### PR TITLE
[BEAM-10072] Fix RequiresTimeSortedInput for stateless DoFns

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformMatchers.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformMatchers.java
@@ -228,6 +228,35 @@ public class PTransformMatchers {
   }
 
   /**
+   * A {@link PTransformMatcher} that matches a {@link ParDo.SingleOutput} or {@link
+   * ParDo.MultiOutput} whose {@link DoFn.ProcessElement} is annotated by {@link
+   * DoFn.RequiresTimeSortedInput}
+   */
+  public static PTransformMatcher timeSortedParDo() {
+    return new PTransformMatcher() {
+      @Override
+      public boolean matches(AppliedPTransform<?, ?, ?> application) {
+        PTransform<?, ?> transform = application.getTransform();
+        final DoFn<?, ?> fn;
+        if (transform instanceof ParDo.SingleOutput) {
+          fn = ((ParDo.SingleOutput<?, ?>) transform).getFn();
+        } else if (transform instanceof ParDo.MultiOutput) {
+          fn = ((ParDo.MultiOutput<?, ?>) transform).getFn();
+        } else {
+          return false;
+        }
+        DoFnSignature signature = DoFnSignatures.signatureForDoFn(fn);
+        return signature.processElement().requiresTimeSortedInput();
+      }
+
+      @Override
+      public String toString() {
+        return MoreObjects.toStringHelper("TimeSortedParDoMatcher").toString();
+      }
+    };
+  }
+
+  /**
    * A {@link PTransformMatcher} that matches a {@link ParDo.MultiOutput} containing a {@link DoFn}
    * that is splittable, as signified by {@link ProcessElementMethod#isSplittable()}.
    */

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ParDoTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ParDoTranslation.java
@@ -309,9 +309,7 @@ public class ParDoTranslation {
 
           @Override
           public boolean isStateful() {
-            return !signature.stateDeclarations().isEmpty()
-                || !signature.timerDeclarations().isEmpty()
-                || !signature.timerFamilyDeclarations().isEmpty();
+            return DoFnSignatures.isStateful(doFn);
           }
 
           @Override
@@ -739,7 +737,9 @@ public class ParDoTranslation {
 
   public static boolean usesStateOrTimers(AppliedPTransform<?, ?, ?> transform) throws IOException {
     ParDoPayload payload = getParDoPayload(transform);
-    return payload.getStateSpecsCount() > 0 || payload.getTimerFamilySpecsCount() > 0;
+    return payload.getStateSpecsCount() > 0
+        || payload.getTimerFamilySpecsCount() > 0
+        || payload.getRequiresTimeSortedInput();
   }
 
   public static boolean isSplittable(AppliedPTransform<?, ?, ?> transform) throws IOException {

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ParDoTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ParDoTranslation.java
@@ -737,9 +737,7 @@ public class ParDoTranslation {
 
   public static boolean usesStateOrTimers(AppliedPTransform<?, ?, ?> transform) throws IOException {
     ParDoPayload payload = getParDoPayload(transform);
-    return payload.getStateSpecsCount() > 0
-        || payload.getTimerFamilySpecsCount() > 0
-        || payload.getRequiresTimeSortedInput();
+    return payload.getStateSpecsCount() > 0 || payload.getTimerFamilySpecsCount() > 0;
   }
 
   public static boolean isSplittable(AppliedPTransform<?, ?, ?> transform) throws IOException {

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PTransformMatchersTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PTransformMatchersTest.java
@@ -210,6 +210,12 @@ public class PTransformMatchersTest implements Serializable {
           context.output(42);
         }
       };
+  private DoFn<KV<String, Integer>, Integer> doFnTimeSorted =
+      new DoFn<KV<String, Integer>, Integer>() {
+        @RequiresTimeSortedInput
+        @ProcessElement
+        public void process(ProcessContext context) {}
+      };
 
   /** Demonstrates that a {@link ParDo.SingleOutput} does not match any ParDo matcher. */
   @Test
@@ -310,6 +316,14 @@ public class PTransformMatchersTest implements Serializable {
         getAppliedTransform(
             ParDo.of(splittableDoFn).withOutputTags(new TupleTag<>(), TupleTagList.empty()));
     assertThat(PTransformMatchers.stateOrTimerParDo().matches(splittableApplication), is(false));
+  }
+
+  @Test
+  public void parDoTimeSorted() {
+    AppliedPTransform<?, ?, ?> timeSortedApplication =
+        getAppliedTransform(ParDo.of(doFnTimeSorted));
+    assertThat(PTransformMatchers.stateOrTimerParDo().matches(timeSortedApplication), is(false));
+    assertThat(PTransformMatchers.timeSortedParDo().matches(timeSortedApplication), is(true));
   }
 
   @Test

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectRunner.java
@@ -267,6 +267,10 @@ public class DirectRunner extends PipelineRunner<DirectPipelineResult> {
             .add(
                 PTransformOverride.of(
                     PTransformMatchers.stateOrTimerParDo(), new ParDoMultiOverrideFactory()))
+            // time sorted ParDo wrapped in StatefulDoFnRunner
+            .add(
+                PTransformOverride.of(
+                    PTransformMatchers.timeSortedParDo(), new ParDoMultiOverrideFactory()))
             .add(
                 PTransformOverride.of(
                     PTransformMatchers.urnEqualTo(

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoEvaluator.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoEvaluator.java
@@ -96,7 +96,7 @@ class ParDoEvaluator<InputT> implements TransformEvaluator<InputT> {
               windowingStrategy,
               doFnSchemaInformation,
               sideInputMapping);
-      if (DoFnSignatures.signatureForDoFn(fn).usesState()) {
+      if (DoFnSignatures.isStateful(fn)) {
         // the coder specified on the input PCollection doesn't match type
         // of elements processed by the StatefulDoFnRunner
         // that is internal detail of how DirectRunner processes stateful DoFns

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoMultiOverrideFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoMultiOverrideFactory.java
@@ -102,9 +102,7 @@ public class ParDoMultiOverrideFactory<InputT, OutputT>
 
     if (signature.processElement().isSplittable()) {
       return SplittableParDo.forAppliedParDo((AppliedPTransform) application);
-    } else if (signature.stateDeclarations().size() > 0
-        || signature.timerDeclarations().size() > 0
-        || signature.timerFamilyDeclarations().size() > 0) {
+    } else if (DoFnSignatures.isStateful(fn)) {
       return new GbkThenStatefulParDo(
           fn,
           ParDoTranslation.getMainOutputTag(application),

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/StatefulParDoEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/StatefulParDoEvaluatorFactory.java
@@ -131,7 +131,7 @@ final class StatefulParDoEvaluatorFactory<K, InputT, OutputT> implements Transfo
     // If the DoFn is stateful, schedule state clearing.
     // It is semantically correct to schedule any number of redundant clear tasks; the
     // cache is used to limit the number of tasks to avoid performance degradation.
-    if (signature.stateDeclarations().size() > 0) {
+    if (DoFnSignatures.isStateful(doFn)) {
       for (final WindowedValue<?> element : inputBundle.getElements()) {
         for (final BoundedWindow window : element.getWindows()) {
           cleanupRegistry.get(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -812,8 +812,8 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    * ascending order. The time ordering is defined by element's timestamp, ordering of elements with
    * equal timestamps is not defined.
    *
-   * <p>Note that this annotation makes sense only for stateful {@code ParDo}s, because outcome of
-   * stateless functions cannot depend on the ordering.
+   * <p>Note that this annotation makes a {@link DoFn} stateful, requiring to be keyed (typed of
+   * {@code KV<K, V>}.
    *
    * <p>This annotation respects specified <i>allowedLateness</i> defined in {@link
    * WindowingStrategy}. All data is emitted <b>after</b> input watermark passes element's timestamp

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
@@ -146,7 +146,7 @@ public abstract class DoFnSignature {
   /** @deprecated use {@link #usesState()}, it's cleaner */
   @Deprecated
   public boolean isStateful() {
-    return stateDeclarations().size() > 0;
+    return usesState();
   }
 
   /** Whether the {@link DoFn} described by this signature uses state. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
@@ -2430,7 +2430,7 @@ public class DoFnSignatures {
   }
 
   public static boolean isStateful(DoFn<?, ?> doFn) {
-    return usesState(doFn) || usesTimers(doFn);
+    return usesState(doFn) || usesTimers(doFn) || requiresTimeSortedInput(doFn);
   }
 
   public static boolean usesMapState(DoFn<?, ?> doFn) {
@@ -2442,23 +2442,23 @@ public class DoFnSignatures {
   }
 
   public static boolean usesValueState(DoFn<?, ?> doFn) {
-    return usesGivenStateClass(doFn, ValueState.class) || requiresTimeSortedInput(doFn);
+    return usesGivenStateClass(doFn, ValueState.class);
   }
 
   public static boolean usesBagState(DoFn<?, ?> doFn) {
-    return usesGivenStateClass(doFn, BagState.class) || requiresTimeSortedInput(doFn);
+    return usesGivenStateClass(doFn, BagState.class);
   }
 
   public static boolean usesWatermarkHold(DoFn<?, ?> doFn) {
-    return usesGivenStateClass(doFn, WatermarkHoldState.class) || requiresTimeSortedInput(doFn);
+    return usesGivenStateClass(doFn, WatermarkHoldState.class);
   }
 
   public static boolean usesTimers(DoFn<?, ?> doFn) {
-    return signatureForDoFn(doFn).usesTimers() || requiresTimeSortedInput(doFn);
+    return signatureForDoFn(doFn).usesTimers();
   }
 
   public static boolean usesState(DoFn<?, ?> doFn) {
-    return signatureForDoFn(doFn).usesState() || requiresTimeSortedInput(doFn);
+    return signatureForDoFn(doFn).usesState();
   }
 
   public static boolean requiresTimeSortedInput(DoFn<?, ?> doFn) {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesTest.java
@@ -1483,13 +1483,13 @@ public class DoFnSignaturesTest {
     public void test() {
       assertThat(DoFnSignatures.isSplittable(this), SerializableMatchers.equalTo(false));
       assertThat(DoFnSignatures.isStateful(this), SerializableMatchers.equalTo(true));
-      assertThat(DoFnSignatures.usesTimers(this), SerializableMatchers.equalTo(true));
-      assertThat(DoFnSignatures.usesState(this), SerializableMatchers.equalTo(true));
-      assertThat(DoFnSignatures.usesBagState(this), SerializableMatchers.equalTo(true));
+      assertThat(DoFnSignatures.usesTimers(this), SerializableMatchers.equalTo(false));
+      assertThat(DoFnSignatures.usesState(this), SerializableMatchers.equalTo(false));
+      assertThat(DoFnSignatures.usesBagState(this), SerializableMatchers.equalTo(false));
       assertThat(DoFnSignatures.usesMapState(this), SerializableMatchers.equalTo(false));
       assertThat(DoFnSignatures.usesSetState(this), SerializableMatchers.equalTo(false));
-      assertThat(DoFnSignatures.usesValueState(this), SerializableMatchers.equalTo(true));
-      assertThat(DoFnSignatures.usesWatermarkHold(this), SerializableMatchers.equalTo(true));
+      assertThat(DoFnSignatures.usesValueState(this), SerializableMatchers.equalTo(false));
+      assertThat(DoFnSignatures.usesWatermarkHold(this), SerializableMatchers.equalTo(false));
       assertThat(DoFnSignatures.requiresTimeSortedInput(this), SerializableMatchers.equalTo(true));
     }
   }


### PR DESCRIPTION
Fix for BEAM-10072

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
