### PR TITLE
[BEAM-10097, BEAM-5982, BEAM-3080] Use primitive views directly instead of transforming KV<Void, Iterable<T>> to the view type via a naive mapping.

### DIFF
--- a/runners/apex/src/test/java/org/apache/beam/runners/apex/translation/ParDoTranslatorTest.java
+++ b/runners/apex/src/test/java/org/apache/beam/runners/apex/translation/ParDoTranslatorTest.java
@@ -220,7 +220,7 @@ public class ParDoTranslatorTest {
     operator.beginWindow(0);
     WindowedValue<Integer> wv1 = WindowedValue.valueInGlobalWindow(1);
     WindowedValue<Iterable<?>> sideInput =
-        WindowedValue.valueInGlobalWindow(materializeValuesFor(View.asSingleton(), 22));
+        WindowedValue.valueInGlobalWindow(materializeValuesFor(options, View.asSingleton(), 22));
     operator.input.process(ApexStreamTuple.DataTuple.of(wv1)); // pushed back input
 
     final List<Object> results = Lists.newArrayList();

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PCollectionViewTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PCollectionViewTranslation.java
@@ -22,7 +22,6 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import java.io.IOException;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.sdk.coders.Coder;
-import org.apache.beam.sdk.transforms.Materializations;
 import org.apache.beam.sdk.transforms.ViewFn;
 import org.apache.beam.sdk.transforms.windowing.WindowMappingFn;
 import org.apache.beam.sdk.util.SerializableUtils;
@@ -53,12 +52,7 @@ public class PCollectionViewTranslation {
     TupleTag<?> tag = new TupleTag<>(localName);
     WindowMappingFn<?> windowMappingFn = windowMappingFnFromProto(sideInput.getWindowMappingFn());
     ViewFn<?, ?> viewFn = viewFnFromProto(sideInput.getViewFn());
-
     WindowingStrategy<?, ?> windowingStrategy = pCollection.getWindowingStrategy().fixDefaults();
-    checkArgument(
-        sideInput.getAccessPattern().getUrn().equals(Materializations.MULTIMAP_MATERIALIZATION_URN),
-        "Unknown View Materialization URN %s",
-        sideInput.getAccessPattern().getUrn());
 
     PCollectionView<?> view =
         new RunnerPCollectionView<>(

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SideInputHandler.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SideInputHandler.java
@@ -34,11 +34,13 @@ import org.apache.beam.sdk.state.CombiningState;
 import org.apache.beam.sdk.state.ValueState;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.Materializations;
+import org.apache.beam.sdk.transforms.Materializations.IterableView;
 import org.apache.beam.sdk.transforms.Materializations.MultimapView;
 import org.apache.beam.sdk.transforms.ViewFn;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
 
 /**
  * Generic side input handler that uses {@link StateInternals} to store all data. Both the actual
@@ -57,6 +59,10 @@ import org.apache.beam.sdk.values.PCollectionView;
  * reach the GC horizon.
  */
 public class SideInputHandler implements ReadyCheckingSideInputReader {
+  private static final Set<String> SUPPORTED_MATERIALIZATIONS =
+      ImmutableSet.of(
+          Materializations.ITERABLE_MATERIALIZATION_URN,
+          Materializations.MULTIMAP_MATERIALIZATION_URN);
 
   /** The list of side inputs that we're handling. */
   protected final Collection<PCollectionView<?>> sideInputs;
@@ -93,11 +99,10 @@ public class SideInputHandler implements ReadyCheckingSideInputReader {
 
     for (PCollectionView<?> sideInput : sideInputs) {
       checkArgument(
-          Materializations.MULTIMAP_MATERIALIZATION_URN.equals(
-              sideInput.getViewFn().getMaterialization().getUrn()),
+          SUPPORTED_MATERIALIZATIONS.contains(sideInput.getViewFn().getMaterialization().getUrn()),
           "This handler is only capable of dealing with %s materializations "
               + "but was asked to handle %s for PCollectionView with tag %s.",
-          Materializations.MULTIMAP_MATERIALIZATION_URN,
+          SUPPORTED_MATERIALIZATIONS,
           sideInput.getViewFn().getMaterialization().getUrn(),
           sideInput.getTagInternal().getId());
 
@@ -147,15 +152,26 @@ public class SideInputHandler implements ReadyCheckingSideInputReader {
   @Nullable
   @Override
   public <T> T get(PCollectionView<T> view, BoundedWindow window) {
-
     Iterable<?> elements = getIterable(view, window);
-    // TODO: Add support for choosing which representation is contained based upon the
-    // side input materialization. We currently can assume that we always have a multimap
-    // materialization as that is the only supported type within the Java SDK.
-    ViewFn<MultimapView, T> viewFn = (ViewFn<MultimapView, T>) view.getViewFn();
-    Coder<?> keyCoder = ((KvCoder<?, ?>) view.getCoderInternal()).getKeyCoder();
-    return (T)
-        viewFn.apply(InMemoryMultimapSideInputView.fromIterable(keyCoder, (Iterable) elements));
+    switch (view.getViewFn().getMaterialization().getUrn()) {
+      case Materializations.ITERABLE_MATERIALIZATION_URN:
+        {
+          ViewFn<IterableView, T> viewFn = (ViewFn<IterableView, T>) view.getViewFn();
+          return viewFn.apply(() -> elements);
+        }
+      case Materializations.MULTIMAP_MATERIALIZATION_URN:
+        {
+          ViewFn<MultimapView, T> viewFn = (ViewFn<MultimapView, T>) view.getViewFn();
+          Coder<?> keyCoder = ((KvCoder<?, ?>) view.getCoderInternal()).getKeyCoder();
+          return viewFn.apply(
+              InMemoryMultimapSideInputView.fromIterable(keyCoder, (Iterable) elements));
+        }
+      default:
+        throw new IllegalStateException(
+            String.format(
+                "Unknown side input materialization format requested '%s'",
+                view.getViewFn().getMaterialization().getUrn()));
+    }
   }
 
   /**

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SideInputHandlerTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SideInputHandlerTest.java
@@ -103,7 +103,9 @@ public class SideInputHandlerTest {
     sideInputHandler.addSideInputValue(
         view1,
         valuesInWindow(
-            materializeValuesFor(View.asIterable(), "Hello"), new Instant(0), firstWindow));
+            materializeValuesFor(view1.getPipeline().getOptions(), View.asIterable(), "Hello"),
+            new Instant(0),
+            firstWindow));
 
     // now side input should be ready
     assertTrue(sideInputHandler.isReady(view1, firstWindow));
@@ -127,7 +129,10 @@ public class SideInputHandlerTest {
     // add a first value for view1
     sideInputHandler.addSideInputValue(
         view1,
-        valuesInWindow(materializeValuesFor(View.asIterable(), "Hello"), new Instant(0), window));
+        valuesInWindow(
+            materializeValuesFor(view1.getPipeline().getOptions(), View.asIterable(), "Hello"),
+            new Instant(0),
+            window));
 
     assertThat(sideInputHandler.get(view1, window), contains("Hello"));
 
@@ -135,7 +140,10 @@ public class SideInputHandlerTest {
     sideInputHandler.addSideInputValue(
         view1,
         valuesInWindow(
-            materializeValuesFor(View.asIterable(), "Ciao", "Buongiorno"), new Instant(0), window));
+            materializeValuesFor(
+                view1.getPipeline().getOptions(), View.asIterable(), "Ciao", "Buongiorno"),
+            new Instant(0),
+            window));
 
     assertThat(sideInputHandler.get(view1, window), contains("Ciao", "Buongiorno"));
   }
@@ -154,7 +162,9 @@ public class SideInputHandlerTest {
     sideInputHandler.addSideInputValue(
         view1,
         valuesInWindow(
-            materializeValuesFor(View.asIterable(), "Hello"), new Instant(0), firstWindow));
+            materializeValuesFor(view1.getPipeline().getOptions(), View.asIterable(), "Hello"),
+            new Instant(0),
+            firstWindow));
 
     assertThat(sideInputHandler.get(view1, firstWindow), contains("Hello"));
 
@@ -162,7 +172,10 @@ public class SideInputHandlerTest {
     sideInputHandler.addSideInputValue(
         view1,
         valuesInWindow(
-            materializeValuesFor(View.asIterable(), "Arrivederci"), new Instant(0), secondWindow));
+            materializeValuesFor(
+                view1.getPipeline().getOptions(), View.asIterable(), "Arrivederci"),
+            new Instant(0),
+            secondWindow));
 
     assertThat(sideInputHandler.get(view1, secondWindow), contains("Arrivederci"));
 
@@ -183,7 +196,9 @@ public class SideInputHandlerTest {
     sideInputHandler.addSideInputValue(
         view1,
         valuesInWindow(
-            materializeValuesFor(View.asIterable(), "Hello"), new Instant(0), firstWindow));
+            materializeValuesFor(view1.getPipeline().getOptions(), View.asIterable(), "Hello"),
+            new Instant(0),
+            firstWindow));
 
     assertThat(sideInputHandler.get(view1, firstWindow), contains("Hello"));
 
@@ -194,7 +209,9 @@ public class SideInputHandlerTest {
     sideInputHandler.addSideInputValue(
         view2,
         valuesInWindow(
-            materializeValuesFor(View.asIterable(), "Salut"), new Instant(0), firstWindow));
+            materializeValuesFor(view2.getPipeline().getOptions(), View.asIterable(), "Salut"),
+            new Instant(0),
+            firstWindow));
 
     assertTrue(sideInputHandler.isReady(view2, firstWindow));
     assertThat(sideInputHandler.get(view2, firstWindow), contains("Salut"));

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/EvaluationContextTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/EvaluationContextTest.java
@@ -137,12 +137,14 @@ public class EvaluationContextTest {
     BoundedWindow window = new TestBoundedWindow(new Instant(1024L));
     BoundedWindow second = new TestBoundedWindow(new Instant(899999L));
     ImmutableList.Builder<WindowedValue<?>> valuesBuilder = ImmutableList.builder();
-    for (Object materializedValue : materializeValuesFor(View.asIterable(), 1)) {
+    for (Object materializedValue :
+        materializeValuesFor(view.getPipeline().getOptions(), View.asIterable(), 1)) {
       valuesBuilder.add(
           WindowedValue.of(
               materializedValue, new Instant(1222), window, PaneInfo.ON_TIME_AND_ONLY_FIRING));
     }
-    for (Object materializedValue : materializeValuesFor(View.asIterable(), 2)) {
+    for (Object materializedValue :
+        materializeValuesFor(view.getPipeline().getOptions(), View.asIterable(), 2)) {
       valuesBuilder.add(
           WindowedValue.of(
               materializedValue,
@@ -157,7 +159,8 @@ public class EvaluationContextTest {
     assertThat(reader.get(view, second), containsInAnyOrder(2));
 
     ImmutableList.Builder<WindowedValue<?>> overwrittenValuesBuilder = ImmutableList.builder();
-    for (Object materializedValue : materializeValuesFor(View.asIterable(), 4444)) {
+    for (Object materializedValue :
+        materializeValuesFor(view.getPipeline().getOptions(), View.asIterable(), 4444)) {
       overwrittenValuesBuilder.add(
           WindowedValue.of(
               materializedValue,

--- a/runners/direct-java/src/test/java/org/apache/beam/runners/direct/SideInputContainerTest.java
+++ b/runners/direct-java/src/test/java/org/apache/beam/runners/direct/SideInputContainerTest.java
@@ -123,12 +123,14 @@ public class SideInputContainerTest {
   @Test
   public void getAfterWriteReturnsPaneInWindow() throws Exception {
     ImmutableList.Builder<WindowedValue<?>> valuesBuilder = ImmutableList.builder();
-    for (Object materializedValue : materializeValuesFor(View.asMap(), KV.of("one", 1))) {
+    for (Object materializedValue :
+        materializeValuesFor(mapView.getPipeline().getOptions(), View.asMap(), KV.of("one", 1))) {
       valuesBuilder.add(
           WindowedValue.of(
               materializedValue, new Instant(1L), FIRST_WINDOW, PaneInfo.ON_TIME_AND_ONLY_FIRING));
     }
-    for (Object materializedValue : materializeValuesFor(View.asMap(), KV.of("two", 2))) {
+    for (Object materializedValue :
+        materializeValuesFor(mapView.getPipeline().getOptions(), View.asMap(), KV.of("two", 2))) {
       valuesBuilder.add(
           WindowedValue.of(
               materializedValue, new Instant(20L), FIRST_WINDOW, PaneInfo.ON_TIME_AND_ONLY_FIRING));
@@ -145,7 +147,8 @@ public class SideInputContainerTest {
   @Test
   public void getReturnsLatestPaneInWindow() throws Exception {
     ImmutableList.Builder<WindowedValue<?>> valuesBuilder = ImmutableList.builder();
-    for (Object materializedValue : materializeValuesFor(View.asMap(), KV.of("one", 1))) {
+    for (Object materializedValue :
+        materializeValuesFor(mapView.getPipeline().getOptions(), View.asMap(), KV.of("one", 1))) {
       valuesBuilder.add(
           WindowedValue.of(
               materializedValue,
@@ -153,7 +156,8 @@ public class SideInputContainerTest {
               SECOND_WINDOW,
               PaneInfo.createPane(true, false, Timing.EARLY)));
     }
-    for (Object materializedValue : materializeValuesFor(View.asMap(), KV.of("two", 2))) {
+    for (Object materializedValue :
+        materializeValuesFor(mapView.getPipeline().getOptions(), View.asMap(), KV.of("two", 2))) {
       valuesBuilder.add(
           WindowedValue.of(
               materializedValue,
@@ -170,7 +174,8 @@ public class SideInputContainerTest {
     assertThat(viewContents.size(), is(2));
 
     ImmutableList.Builder<WindowedValue<?>> overwriteValuesBuilder = ImmutableList.builder();
-    for (Object materializedValue : materializeValuesFor(View.asMap(), KV.of("three", 3))) {
+    for (Object materializedValue :
+        materializeValuesFor(mapView.getPipeline().getOptions(), View.asMap(), KV.of("three", 3))) {
       overwriteValuesBuilder.add(
           WindowedValue.of(
               materializedValue,
@@ -224,7 +229,8 @@ public class SideInputContainerTest {
   @Test
   public void writeForMultipleElementsInDifferentWindowsSucceeds() throws Exception {
     ImmutableList.Builder<WindowedValue<?>> valuesBuilder = ImmutableList.builder();
-    for (Object materializedValue : materializeValuesFor(View.asSingleton(), 2.875)) {
+    for (Object materializedValue :
+        materializeValuesFor(singletonView.getPipeline().getOptions(), View.asSingleton(), 2.875)) {
       valuesBuilder.add(
           WindowedValue.of(
               materializedValue,
@@ -232,7 +238,8 @@ public class SideInputContainerTest {
               FIRST_WINDOW,
               PaneInfo.ON_TIME_AND_ONLY_FIRING));
     }
-    for (Object materializedValue : materializeValuesFor(View.asSingleton(), 4.125)) {
+    for (Object materializedValue :
+        materializeValuesFor(singletonView.getPipeline().getOptions(), View.asSingleton(), 4.125)) {
       valuesBuilder.add(
           WindowedValue.of(
               materializedValue,
@@ -256,7 +263,8 @@ public class SideInputContainerTest {
   @Test
   public void writeForMultipleIdenticalElementsInSameWindowSucceeds() throws Exception {
     ImmutableList.Builder<WindowedValue<?>> valuesBuilder = ImmutableList.builder();
-    for (Object materializedValue : materializeValuesFor(View.asIterable(), 44, 44)) {
+    for (Object materializedValue :
+        materializeValuesFor(iterableView.getPipeline().getOptions(), View.asIterable(), 44, 44)) {
       valuesBuilder.add(
           WindowedValue.of(
               materializedValue,
@@ -276,7 +284,8 @@ public class SideInputContainerTest {
   @Test
   public void writeForElementInMultipleWindowsSucceeds() throws Exception {
     ImmutableList.Builder<WindowedValue<?>> valuesBuilder = ImmutableList.builder();
-    for (Object materializedValue : materializeValuesFor(View.asSingleton(), 2.875)) {
+    for (Object materializedValue :
+        materializeValuesFor(singletonView.getPipeline().getOptions(), View.asSingleton(), 2.875)) {
       valuesBuilder.add(
           WindowedValue.of(
               materializedValue,
@@ -300,7 +309,8 @@ public class SideInputContainerTest {
   @Test
   public void finishDoesNotOverwriteWrittenElements() throws Exception {
     ImmutableList.Builder<WindowedValue<?>> valuesBuilder = ImmutableList.builder();
-    for (Object materializedValue : materializeValuesFor(View.asMap(), KV.of("one", 1))) {
+    for (Object materializedValue :
+        materializeValuesFor(mapView.getPipeline().getOptions(), View.asMap(), KV.of("one", 1))) {
       valuesBuilder.add(
           WindowedValue.of(
               materializedValue,
@@ -308,7 +318,8 @@ public class SideInputContainerTest {
               SECOND_WINDOW,
               PaneInfo.createPane(true, false, Timing.EARLY)));
     }
-    for (Object materializedValue : materializeValuesFor(View.asMap(), KV.of("two", 2))) {
+    for (Object materializedValue :
+        materializeValuesFor(mapView.getPipeline().getOptions(), View.asMap(), KV.of("two", 2))) {
       valuesBuilder.add(
           WindowedValue.of(
               materializedValue,
@@ -358,7 +369,8 @@ public class SideInputContainerTest {
   @Test
   public void isReadyForSomeNotReadyViewsFalseUntilElements() {
     ImmutableList.Builder<WindowedValue<?>> mapValuesBuilder = ImmutableList.builder();
-    for (Object materializedValue : materializeValuesFor(View.asMap(), KV.of("one", 1))) {
+    for (Object materializedValue :
+        materializeValuesFor(mapView.getPipeline().getOptions(), View.asMap(), KV.of("one", 1))) {
       mapValuesBuilder.add(
           WindowedValue.of(
               materializedValue,
@@ -376,7 +388,8 @@ public class SideInputContainerTest {
     assertThat(reader.isReady(singletonView, SECOND_WINDOW), is(false));
 
     ImmutableList.Builder<WindowedValue<?>> newMapValuesBuilder = ImmutableList.builder();
-    for (Object materializedValue : materializeValuesFor(View.asMap(), KV.of("too", 2))) {
+    for (Object materializedValue :
+        materializeValuesFor(mapView.getPipeline().getOptions(), View.asMap(), KV.of("too", 2))) {
       newMapValuesBuilder.add(
           WindowedValue.of(
               materializedValue,
@@ -389,7 +402,8 @@ public class SideInputContainerTest {
     assertThat(reader.isReady(mapView, FIRST_WINDOW), is(false));
 
     ImmutableList.Builder<WindowedValue<?>> singletonValuesBuilder = ImmutableList.builder();
-    for (Object materializedValue : materializeValuesFor(View.asSingleton(), 1.25)) {
+    for (Object materializedValue :
+        materializeValuesFor(singletonView.getPipeline().getOptions(), View.asSingleton(), 1.25)) {
       singletonValuesBuilder.add(
           WindowedValue.of(
               materializedValue,

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkSideInputReader.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkSideInputReader.java
@@ -20,22 +20,31 @@ package org.apache.beam.runners.flink.translation.functions;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.Map;
+import java.util.Set;
 import javax.annotation.Nullable;
 import org.apache.beam.runners.core.InMemoryMultimapSideInputView;
 import org.apache.beam.runners.core.SideInputReader;
 import org.apache.beam.sdk.transforms.Materializations;
+import org.apache.beam.sdk.transforms.Materializations.IterableView;
 import org.apache.beam.sdk.transforms.Materializations.MultimapView;
 import org.apache.beam.sdk.transforms.ViewFn;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.WindowingStrategy;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
 import org.apache.flink.api.common.functions.RuntimeContext;
 
 /** A {@link SideInputReader} for the Flink Batch Runner. */
 public class FlinkSideInputReader implements SideInputReader {
+  private static final Set<String> SUPPORTED_MATERIALIZATIONS =
+      ImmutableSet.of(
+          Materializations.ITERABLE_MATERIALIZATION_URN,
+          Materializations.MULTIMAP_MATERIALIZATION_URN);
+
   private final Map<TupleTag<?>, WindowingStrategy<?, ?>> sideInputs;
 
   private RuntimeContext runtimeContext;
@@ -44,11 +53,10 @@ public class FlinkSideInputReader implements SideInputReader {
       Map<PCollectionView<?>, WindowingStrategy<?, ?>> indexByView, RuntimeContext runtimeContext) {
     for (PCollectionView<?> view : indexByView.keySet()) {
       checkArgument(
-          Materializations.MULTIMAP_MATERIALIZATION_URN.equals(
-              view.getViewFn().getMaterialization().getUrn()),
+          SUPPORTED_MATERIALIZATIONS.contains(view.getViewFn().getMaterialization().getUrn()),
           "This handler is only capable of dealing with %s materializations "
               + "but was asked to handle %s for PCollectionView with tag %s.",
-          Materializations.MULTIMAP_MATERIALIZATION_URN,
+          SUPPORTED_MATERIALIZATIONS,
           view.getViewFn().getMaterialization().getUrn(),
           view.getTagInternal().getId());
     }
@@ -71,8 +79,23 @@ public class FlinkSideInputReader implements SideInputReader {
             tag.getId(), new SideInputInitializer<>(view));
     T result = sideInputs.get(window);
     if (result == null) {
-      ViewFn<MultimapView, T> viewFn = (ViewFn<MultimapView, T>) view.getViewFn();
-      result = viewFn.apply(InMemoryMultimapSideInputView.empty());
+      switch (view.getViewFn().getMaterialization().getUrn()) {
+        case Materializations.ITERABLE_MATERIALIZATION_URN:
+          {
+            ViewFn<IterableView, T> viewFn = (ViewFn<IterableView, T>) view.getViewFn();
+            return viewFn.apply(() -> Collections.emptyList());
+          }
+        case Materializations.MULTIMAP_MATERIALIZATION_URN:
+          {
+            ViewFn<MultimapView, T> viewFn = (ViewFn<MultimapView, T>) view.getViewFn();
+            return viewFn.apply(InMemoryMultimapSideInputView.empty());
+          }
+        default:
+          throw new IllegalStateException(
+              String.format(
+                  "Unknown side input materialization format requested '%s'",
+                  view.getViewFn().getMaterialization().getUrn()));
+      }
     }
     return result;
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/SideInputInitializer.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/SideInputInitializer.java
@@ -23,17 +23,19 @@ import java.util.ArrayList;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.beam.runners.core.InMemoryMultimapSideInputView;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.transforms.Materializations;
+import org.apache.beam.sdk.transforms.Materializations.IterableView;
 import org.apache.beam.sdk.transforms.Materializations.MultimapView;
 import org.apache.beam.sdk.transforms.ViewFn;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.WindowedValue;
-import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
 import org.apache.flink.api.common.functions.BroadcastVariableInitializer;
 
 /**
@@ -42,16 +44,19 @@ import org.apache.flink.api.common.functions.BroadcastVariableInitializer;
  */
 public class SideInputInitializer<ViewT>
     implements BroadcastVariableInitializer<WindowedValue<?>, Map<BoundedWindow, ViewT>> {
+  private static final Set<String> SUPPORTED_MATERIALIZATIONS =
+      ImmutableSet.of(
+          Materializations.ITERABLE_MATERIALIZATION_URN,
+          Materializations.MULTIMAP_MATERIALIZATION_URN);
 
   PCollectionView<ViewT> view;
 
   public SideInputInitializer(PCollectionView<ViewT> view) {
     checkArgument(
-        Materializations.MULTIMAP_MATERIALIZATION_URN.equals(
-            view.getViewFn().getMaterialization().getUrn()),
+        SUPPORTED_MATERIALIZATIONS.contains(view.getViewFn().getMaterialization().getUrn()),
         "This handler is only capable of dealing with %s materializations "
             + "but was asked to handle %s for PCollectionView with tag %s.",
-        Materializations.MULTIMAP_MATERIALIZATION_URN,
+        SUPPORTED_MATERIALIZATIONS,
         view.getViewFn().getMaterialization().getUrn(),
         view.getTagInternal().getId());
     this.view = view;
@@ -62,11 +67,10 @@ public class SideInputInitializer<ViewT>
       Iterable<WindowedValue<?>> inputValues) {
 
     // first partition into windows
-    Map<BoundedWindow, List<WindowedValue<KV<?, ?>>>> partitionedElements = new HashMap<>();
-    for (WindowedValue<KV<?, ?>> value :
-        (Iterable<WindowedValue<KV<?, ?>>>) (Iterable) inputValues) {
+    Map<BoundedWindow, List<WindowedValue<?>>> partitionedElements = new HashMap<>();
+    for (WindowedValue<?> value : inputValues) {
       for (BoundedWindow window : value.getWindows()) {
-        List<WindowedValue<KV<?, ?>>> windowedValues =
+        List<WindowedValue<?>> windowedValues =
             partitionedElements.computeIfAbsent(window, k -> new ArrayList<>());
         windowedValues.add(value);
       }
@@ -74,21 +78,42 @@ public class SideInputInitializer<ViewT>
 
     Map<BoundedWindow, ViewT> resultMap = new HashMap<>();
 
-    for (Map.Entry<BoundedWindow, List<WindowedValue<KV<?, ?>>>> elements :
+    for (Map.Entry<BoundedWindow, List<WindowedValue<?>>> elements :
         partitionedElements.entrySet()) {
-
-      ViewFn<MultimapView, ViewT> viewFn = (ViewFn<MultimapView, ViewT>) view.getViewFn();
-      Coder keyCoder = ((KvCoder<?, ?>) view.getCoderInternal()).getKeyCoder();
-      resultMap.put(
-          elements.getKey(),
-          (ViewT)
-              viewFn.apply(
-                  InMemoryMultimapSideInputView.fromIterable(
-                      keyCoder,
-                      (Iterable)
-                          elements.getValue().stream()
-                              .map(WindowedValue::getValue)
-                              .collect(Collectors.toList()))));
+      switch (view.getViewFn().getMaterialization().getUrn()) {
+        case Materializations.ITERABLE_MATERIALIZATION_URN:
+          {
+            ViewFn<IterableView, ViewT> viewFn = (ViewFn<IterableView, ViewT>) view.getViewFn();
+            resultMap.put(
+                elements.getKey(),
+                viewFn.apply(
+                    () ->
+                        elements.getValue().stream()
+                            .map(WindowedValue::getValue)
+                            .collect(Collectors.toList())));
+          }
+          break;
+        case Materializations.MULTIMAP_MATERIALIZATION_URN:
+          {
+            ViewFn<MultimapView, ViewT> viewFn = (ViewFn<MultimapView, ViewT>) view.getViewFn();
+            Coder<?> keyCoder = ((KvCoder<?, ?>) view.getCoderInternal()).getKeyCoder();
+            resultMap.put(
+                elements.getKey(),
+                viewFn.apply(
+                    InMemoryMultimapSideInputView.fromIterable(
+                        keyCoder,
+                        (Iterable)
+                            elements.getValue().stream()
+                                .map(WindowedValue::getValue)
+                                .collect(Collectors.toList()))));
+          }
+          break;
+        default:
+          throw new IllegalStateException(
+              String.format(
+                  "Unknown side input materialization format requested '%s'",
+                  view.getViewFn().getMaterialization().getUrn()));
+      }
     }
 
     return resultMap;

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperatorTest.java
@@ -57,6 +57,7 @@ import org.apache.beam.sdk.state.Timer;
 import org.apache.beam.sdk.state.TimerSpec;
 import org.apache.beam.sdk.state.TimerSpecs;
 import org.apache.beam.sdk.state.ValueState;
+import org.apache.beam.sdk.testing.PCollectionViewTesting;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.DoFnSchemaInformation;
@@ -696,11 +697,20 @@ public class DoFnOperatorTest {
         new StreamRecord<>(
             new RawUnionValue(
                 1,
-                valuesInWindow(ImmutableList.of("hello", "ciao"), new Instant(0), firstWindow))));
+                valuesInWindow(
+                    PCollectionViewTesting.materializeValuesFor(
+                        view1.getPipeline().getOptions(), View.asIterable(), "hello", "ciao"),
+                    new Instant(0),
+                    firstWindow))));
     testHarness.processElement2(
         new StreamRecord<>(
             new RawUnionValue(
-                2, valuesInWindow(ImmutableList.of("foo", "bar"), new Instant(0), secondWindow))));
+                2,
+                valuesInWindow(
+                    PCollectionViewTesting.materializeValuesFor(
+                        view2.getPipeline().getOptions(), View.asIterable(), "foo", "bar"),
+                    new Instant(0),
+                    secondWindow))));
 
     // push in a regular elements
     WindowedValue<String> helloElement = valueInWindow("Hello", new Instant(0), firstWindow);
@@ -714,12 +724,19 @@ public class DoFnOperatorTest {
             new RawUnionValue(
                 1,
                 valuesInWindow(
-                    ImmutableList.of("hello", "ciao"), new Instant(1000), firstWindow))));
+                    PCollectionViewTesting.materializeValuesFor(
+                        view1.getPipeline().getOptions(), View.asIterable(), "hello", "ciao"),
+                    new Instant(1000),
+                    firstWindow))));
     testHarness.processElement2(
         new StreamRecord<>(
             new RawUnionValue(
                 2,
-                valuesInWindow(ImmutableList.of("foo", "bar"), new Instant(1000), secondWindow))));
+                valuesInWindow(
+                    PCollectionViewTesting.materializeValuesFor(
+                        view2.getPipeline().getOptions(), View.asIterable(), "foo", "bar"),
+                    new Instant(1000),
+                    secondWindow))));
 
     assertThat(
         stripStreamRecordFromWindowedValue(testHarness.getOutput()),
@@ -921,7 +938,8 @@ public class DoFnOperatorTest {
             new RawUnionValue(
                 1,
                 valuesInWindow(
-                    ImmutableList.of(KV.of((Void) null, "hello"), KV.of((Void) null, "ciao")),
+                    PCollectionViewTesting.materializeValuesFor(
+                        view1.getPipeline().getOptions(), View.asIterable(), "hello", "ciao"),
                     new Instant(0),
                     firstWindow))));
     testHarness.processElement2(
@@ -929,7 +947,8 @@ public class DoFnOperatorTest {
             new RawUnionValue(
                 2,
                 valuesInWindow(
-                    ImmutableList.of(KV.of((Void) null, "foo"), KV.of((Void) null, "bar")),
+                    PCollectionViewTesting.materializeValuesFor(
+                        view2.getPipeline().getOptions(), View.asIterable(), "foo", "bar"),
                     new Instant(0),
                     secondWindow))));
 
@@ -1074,7 +1093,8 @@ public class DoFnOperatorTest {
             new RawUnionValue(
                 1,
                 valuesInWindow(
-                    ImmutableList.of(KV.of((Void) null, "hello"), KV.of((Void) null, "ciao")),
+                    PCollectionViewTesting.materializeValuesFor(
+                        view1.getPipeline().getOptions(), View.asIterable(), "hello", "ciao"),
                     new Instant(0),
                     firstWindow))));
     testHarness.processElement2(
@@ -1082,7 +1102,8 @@ public class DoFnOperatorTest {
             new RawUnionValue(
                 2,
                 valuesInWindow(
-                    ImmutableList.of(KV.of((Void) null, "foo"), KV.of((Void) null, "bar")),
+                    PCollectionViewTesting.materializeValuesFor(
+                        view2.getPipeline().getOptions(), View.asIterable(), "foo", "bar"),
                     new Instant(0),
                     secondWindow))));
 

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -118,6 +118,7 @@ import org.apache.beam.sdk.runners.AppliedPTransform;
 import org.apache.beam.sdk.runners.PTransformMatcher;
 import org.apache.beam.sdk.runners.PTransformOverride;
 import org.apache.beam.sdk.runners.PTransformOverrideFactory;
+import org.apache.beam.sdk.runners.PTransformOverrideFactory.PTransformReplacement;
 import org.apache.beam.sdk.runners.TransformHierarchy;
 import org.apache.beam.sdk.runners.TransformHierarchy.Node;
 import org.apache.beam.sdk.state.MapState;

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslatorTest.java
@@ -999,11 +999,12 @@ public class DataflowPipelineTranslatorTest implements Serializable {
 
     @SuppressWarnings("unchecked")
     List<Map<String, Object>> toIsmRecordOutputs =
-        (List<Map<String, Object>>) steps.get(7).getProperties().get(PropertyNames.OUTPUT_INFO);
+        (List<Map<String, Object>>)
+            steps.get(steps.size() - 2).getProperties().get(PropertyNames.OUTPUT_INFO);
     assertTrue(
         Structs.getBoolean(Iterables.getOnlyElement(toIsmRecordOutputs), "use_indexed_format"));
 
-    Step collectionToSingletonStep = steps.get(8);
+    Step collectionToSingletonStep = steps.get(steps.size() - 1);
     assertEquals("CollectionToSingleton", collectionToSingletonStep.getKind());
   }
 
@@ -1034,11 +1035,12 @@ public class DataflowPipelineTranslatorTest implements Serializable {
 
     @SuppressWarnings("unchecked")
     List<Map<String, Object>> toIsmRecordOutputs =
-        (List<Map<String, Object>>) steps.get(1).getProperties().get(PropertyNames.OUTPUT_INFO);
+        (List<Map<String, Object>>)
+            steps.get(steps.size() - 2).getProperties().get(PropertyNames.OUTPUT_INFO);
     assertTrue(
         Structs.getBoolean(Iterables.getOnlyElement(toIsmRecordOutputs), "use_indexed_format"));
 
-    Step collectionToSingletonStep = steps.get(2);
+    Step collectionToSingletonStep = steps.get(steps.size() - 1);
     assertEquals("CollectionToSingleton", collectionToSingletonStep.getKind());
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StateFetcherTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StateFetcherTest.java
@@ -78,9 +78,7 @@ public class StateFetcherTest {
     ByteString encodedIterable = stream.toByteString();
 
     PCollectionView<String> view =
-        TestPipeline.create()
-            .apply(Create.empty(StringUtf8Coder.of()))
-            .apply(View.<String>asSingleton());
+        TestPipeline.create().apply(Create.empty(StringUtf8Coder.of())).apply(View.asSingleton());
 
     String tag = view.getTagInternal().getId();
 
@@ -133,7 +131,7 @@ public class StateFetcherTest {
     ByteString encodedIterable = stream.toByteString();
 
     PCollectionView<Void> view =
-        TestPipeline.create().apply(Create.empty(VoidCoder.of())).apply(View.<Void>asSingleton());
+        TestPipeline.create().apply(Create.empty(VoidCoder.of())).apply(View.asSingleton());
 
     String tag = view.getTagInternal().getId();
 
@@ -194,14 +192,10 @@ public class StateFetcherTest {
     StateFetcher fetcher = new StateFetcher(server, cache);
 
     PCollectionView<String> view1 =
-        TestPipeline.create()
-            .apply(Create.empty(StringUtf8Coder.of()))
-            .apply(View.<String>asSingleton());
+        TestPipeline.create().apply(Create.empty(StringUtf8Coder.of())).apply(View.asSingleton());
 
     PCollectionView<String> view2 =
-        TestPipeline.create()
-            .apply(Create.empty(StringUtf8Coder.of()))
-            .apply(View.<String>asSingleton());
+        TestPipeline.create().apply(Create.empty(StringUtf8Coder.of())).apply(View.asSingleton());
 
     String tag1 = view1.getTagInternal().getId();
     String tag2 = view2.getTagInternal().getId();

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/graph/InsertFetchAndFilterStreamingSideInputNodesTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/graph/InsertFetchAndFilterStreamingSideInputNodesTest.java
@@ -88,7 +88,7 @@ public class InsertFetchAndFilterStreamingSideInputNodesTest {
   public void testSdkParDoWithSideInput() throws Exception {
     Pipeline p = Pipeline.create();
     PCollection<String> pc = p.apply(Create.of("a", "b", "c"));
-    PCollectionView<Iterable<String>> pcView = pc.apply(View.asIterable());
+    PCollectionView<List<String>> pcView = pc.apply(View.asList());
     pc.apply(ParDo.of(new TestDoFn(pcView)).withSideInputs(pcView));
     RunnerApi.Pipeline pipeline = PipelineTranslation.toProto(p);
 
@@ -175,9 +175,9 @@ public class InsertFetchAndFilterStreamingSideInputNodesTest {
   }
 
   private static class TestDoFn extends DoFn<String, Iterable<String>> {
-    @Nullable private final PCollectionView<Iterable<String>> pCollectionView;
+    @Nullable private final PCollectionView<List<String>> pCollectionView;
 
-    private TestDoFn(@Nullable PCollectionView<Iterable<String>> pCollectionView) {
+    private TestDoFn(@Nullable PCollectionView<List<String>> pCollectionView) {
       this.pCollectionView = pCollectionView;
     }
 

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.fnexecution.control;
 
+import static org.apache.beam.sdk.options.ExperimentalOptions.addExperiment;
 import static org.apache.beam.sdk.util.WindowedValue.valueInGlobalWindow;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkState;
 import static org.hamcrest.MatcherAssert.assertThat;
@@ -100,6 +101,7 @@ import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.fn.stream.OutboundObserverFactory;
 import org.apache.beam.sdk.fn.test.InProcessManagedChannelFactory;
 import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.beam.sdk.options.ExperimentalOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.state.BagState;
 import org.apache.beam.sdk.state.ReadableState;
@@ -399,6 +401,9 @@ public class RemoteExecutionTest implements Serializable {
   @Test
   public void testExecutionWithSideInput() throws Exception {
     Pipeline p = Pipeline.create();
+    addExperiment(p.getOptions().as(ExperimentalOptions.class), "beam_fn_api");
+    // TODO(BEAM-10097): Remove experiment once all portable runners support this view type
+    addExperiment(p.getOptions().as(ExperimentalOptions.class), "use_runner_v2");
     PCollection<String> input =
         p.apply("impulse", Impulse.create())
             .apply(
@@ -464,7 +469,6 @@ public class RemoteExecutionTest implements Serializable {
               (Coder<WindowedValue<?>>) remoteOutputCoder.getValue(), outputContents::add));
     }
 
-    Iterable<String> sideInputData = Arrays.asList("A", "B", "C");
     StateRequestHandler stateRequestHandler =
         StateRequestHandlers.forSideInputHandlerFactory(
             descriptor.getSideInputSpecs(),
@@ -476,7 +480,17 @@ public class RemoteExecutionTest implements Serializable {
                       String sideInputId,
                       Coder<V> elementCoder,
                       Coder<W> windowCoder) {
-                throw new UnsupportedOperationException();
+                return new IterableSideInputHandler<V, W>() {
+                  @Override
+                  public Iterable<V> get(W window) {
+                    return (Iterable) Arrays.asList("A", "B", "C");
+                  }
+
+                  @Override
+                  public Coder<V> elementCoder() {
+                    return elementCoder;
+                  }
+                };
               }
 
               @Override
@@ -486,27 +500,7 @@ public class RemoteExecutionTest implements Serializable {
                       String sideInputId,
                       KvCoder<K, V> elementCoder,
                       Coder<W> windowCoder) {
-                return new MultimapSideInputHandler<K, V, W>() {
-                  @Override
-                  public Iterable<K> get(W window) {
-                    throw new UnsupportedOperationException();
-                  }
-
-                  @Override
-                  public Iterable<V> get(K key, W window) {
-                    return (Iterable) sideInputData;
-                  }
-
-                  @Override
-                  public Coder<K> keyCoder() {
-                    return elementCoder.getKeyCoder();
-                  }
-
-                  @Override
-                  public Coder<V> valueCoder() {
-                    return elementCoder.getValueCoder();
-                  }
-                };
+                throw new UnsupportedOperationException();
               }
             });
     BundleProgressHandler progressHandler = BundleProgressHandler.ignored();

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/functions/SparkSideInputReader.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/functions/SparkSideInputReader.java
@@ -25,6 +25,7 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Set;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
 import org.apache.beam.runners.core.InMemoryMultimapSideInputView;
@@ -34,30 +35,22 @@ import org.apache.beam.runners.spark.structuredstreaming.translation.helpers.Sid
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.transforms.Materializations;
+import org.apache.beam.sdk.transforms.Materializations.IterableView;
 import org.apache.beam.sdk.transforms.Materializations.MultimapView;
 import org.apache.beam.sdk.transforms.ViewFn;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.WindowedValue;
-import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.WindowingStrategy;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
 
 /** A {@link SideInputReader} for the Spark Batch Runner. */
 public class SparkSideInputReader implements SideInputReader {
-  /** A {@link Materializations.MultimapView} which always returns an empty iterable. */
-  private static final Materializations.MultimapView EMPTY_MULTIMAP_VIEW =
-      new MultimapView() {
-        @Override
-        public Iterable get() {
-          return Collections.EMPTY_LIST;
-        }
-
-        @Override
-        public Iterable get(@Nullable Object o) {
-          return Collections.EMPTY_LIST;
-        }
-      };
+  private static final Set<String> SUPPORTED_MATERIALIZATIONS =
+      ImmutableSet.of(
+          Materializations.ITERABLE_MATERIALIZATION_URN,
+          Materializations.MULTIMAP_MATERIALIZATION_URN);
 
   private final Map<TupleTag<?>, WindowingStrategy<?, ?>> sideInputs;
   private final SideInputBroadcast broadcastStateData;
@@ -67,11 +60,10 @@ public class SparkSideInputReader implements SideInputReader {
       SideInputBroadcast broadcastStateData) {
     for (PCollectionView<?> view : indexByView.keySet()) {
       checkArgument(
-          Materializations.MULTIMAP_MATERIALIZATION_URN.equals(
-              view.getViewFn().getMaterialization().getUrn()),
+          SUPPORTED_MATERIALIZATIONS.contains(view.getViewFn().getMaterialization().getUrn()),
           "This handler is only capable of dealing with %s materializations "
               + "but was asked to handle %s for PCollectionView with tag %s.",
-          Materializations.MULTIMAP_MATERIALIZATION_URN,
+          SUPPORTED_MATERIALIZATIONS,
           view.getViewFn().getMaterialization().getUrn(),
           view.getTagInternal().getId());
     }
@@ -101,9 +93,23 @@ public class SparkSideInputReader implements SideInputReader {
     Map<BoundedWindow, T> sideInputs = initializeBroadcastVariable(decodedValues, view);
     T result = sideInputs.get(window);
     if (result == null) {
-      ViewFn<Materializations.MultimapView, T> viewFn =
-          (ViewFn<Materializations.MultimapView, T>) view.getViewFn();
-      result = viewFn.apply(EMPTY_MULTIMAP_VIEW);
+      switch (view.getViewFn().getMaterialization().getUrn()) {
+        case Materializations.ITERABLE_MATERIALIZATION_URN:
+          {
+            ViewFn<IterableView, T> viewFn = (ViewFn<IterableView, T>) view.getViewFn();
+            return viewFn.apply(() -> Collections.emptyList());
+          }
+        case Materializations.MULTIMAP_MATERIALIZATION_URN:
+          {
+            ViewFn<MultimapView, T> viewFn = (ViewFn<MultimapView, T>) view.getViewFn();
+            return viewFn.apply(InMemoryMultimapSideInputView.empty());
+          }
+        default:
+          throw new IllegalStateException(
+              String.format(
+                  "Unknown side input materialization format requested '%s'",
+                  view.getViewFn().getMaterialization().getUrn()));
+      }
     }
     return result;
   }
@@ -122,11 +128,10 @@ public class SparkSideInputReader implements SideInputReader {
       Iterable<WindowedValue<?>> inputValues, PCollectionView<T> view) {
 
     // first partition into windows
-    Map<BoundedWindow, List<WindowedValue<KV<?, ?>>>> partitionedElements = new HashMap<>();
-    for (WindowedValue<KV<?, ?>> value :
-        (Iterable<WindowedValue<KV<?, ?>>>) (Iterable) inputValues) {
+    Map<BoundedWindow, List<WindowedValue<?>>> partitionedElements = new HashMap<>();
+    for (WindowedValue<?> value : inputValues) {
       for (BoundedWindow window : value.getWindows()) {
-        List<WindowedValue<KV<?, ?>>> windowedValues =
+        List<WindowedValue<?>> windowedValues =
             partitionedElements.computeIfAbsent(window, k -> new ArrayList<>());
         windowedValues.add(value);
       }
@@ -134,22 +139,43 @@ public class SparkSideInputReader implements SideInputReader {
 
     Map<BoundedWindow, T> resultMap = new HashMap<>();
 
-    for (Map.Entry<BoundedWindow, List<WindowedValue<KV<?, ?>>>> elements :
+    for (Map.Entry<BoundedWindow, List<WindowedValue<?>>> elements :
         partitionedElements.entrySet()) {
 
-      ViewFn<Materializations.MultimapView, T> viewFn =
-          (ViewFn<Materializations.MultimapView, T>) view.getViewFn();
-      Coder keyCoder = ((KvCoder<?, ?>) view.getCoderInternal()).getKeyCoder();
-      resultMap.put(
-          elements.getKey(),
-          (T)
-              viewFn.apply(
-                  InMemoryMultimapSideInputView.fromIterable(
-                      keyCoder,
-                      (Iterable)
-                          elements.getValue().stream()
-                              .map(WindowedValue::getValue)
-                              .collect(Collectors.toList()))));
+      switch (view.getViewFn().getMaterialization().getUrn()) {
+        case Materializations.ITERABLE_MATERIALIZATION_URN:
+          {
+            ViewFn<IterableView, T> viewFn = (ViewFn<IterableView, T>) view.getViewFn();
+            resultMap.put(
+                elements.getKey(),
+                viewFn.apply(
+                    () ->
+                        elements.getValue().stream()
+                            .map(WindowedValue::getValue)
+                            .collect(Collectors.toList())));
+          }
+          break;
+        case Materializations.MULTIMAP_MATERIALIZATION_URN:
+          {
+            ViewFn<MultimapView, T> viewFn = (ViewFn<MultimapView, T>) view.getViewFn();
+            Coder<?> keyCoder = ((KvCoder<?, ?>) view.getCoderInternal()).getKeyCoder();
+            resultMap.put(
+                elements.getKey(),
+                viewFn.apply(
+                    InMemoryMultimapSideInputView.fromIterable(
+                        keyCoder,
+                        (Iterable)
+                            elements.getValue().stream()
+                                .map(WindowedValue::getValue)
+                                .collect(Collectors.toList()))));
+          }
+          break;
+        default:
+          throw new IllegalStateException(
+              String.format(
+                  "Unknown side input materialization format requested '%s'",
+                  view.getViewFn().getMaterialization().getUrn()));
+      }
     }
 
     return resultMap;

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/util/SparkSideInputReader.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/util/SparkSideInputReader.java
@@ -27,6 +27,8 @@ import org.apache.beam.runners.core.InMemoryMultimapSideInputView;
 import org.apache.beam.runners.core.SideInputReader;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.transforms.Materializations;
+import org.apache.beam.sdk.transforms.Materializations.IterableView;
 import org.apache.beam.sdk.transforms.Materializations.MultimapView;
 import org.apache.beam.sdk.transforms.ViewFn;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
@@ -61,9 +63,9 @@ public class SparkSideInputReader implements SideInputReader {
     // --- match the appropriate sideInput window.
     // a tag will point to all matching sideInputs, that is all windows.
     // now that we've obtained the appropriate sideInputWindow, all that's left is to filter by it.
-    Iterable<WindowedValue<KV<?, ?>>> availableSideInputs =
-        (Iterable<WindowedValue<KV<?, ?>>>) windowedBroadcastHelper.getValue().getValue();
-    Iterable<KV<?, ?>> sideInputForWindow =
+    Iterable<WindowedValue<?>> availableSideInputs =
+        (Iterable<WindowedValue<?>>) windowedBroadcastHelper.getValue().getValue();
+    Iterable<?> sideInputForWindow =
         StreamSupport.stream(availableSideInputs.spliterator(), false)
             .filter(
                 sideInputCandidate -> {
@@ -77,10 +79,25 @@ public class SparkSideInputReader implements SideInputReader {
             .map(WindowedValue::getValue)
             .collect(Collectors.toList());
 
-    ViewFn<MultimapView, T> viewFn = (ViewFn<MultimapView, T>) view.getViewFn();
-    Coder keyCoder = ((KvCoder<?, ?>) view.getCoderInternal()).getKeyCoder();
-    return viewFn.apply(
-        InMemoryMultimapSideInputView.fromIterable(keyCoder, (Iterable) sideInputForWindow));
+    switch (view.getViewFn().getMaterialization().getUrn()) {
+      case Materializations.ITERABLE_MATERIALIZATION_URN:
+        {
+          ViewFn<IterableView, T> viewFn = (ViewFn<IterableView, T>) view.getViewFn();
+          return viewFn.apply(() -> sideInputForWindow);
+        }
+      case Materializations.MULTIMAP_MATERIALIZATION_URN:
+        {
+          ViewFn<MultimapView, T> viewFn = (ViewFn<MultimapView, T>) view.getViewFn();
+          Coder<?> keyCoder = ((KvCoder<?, ?>) view.getCoderInternal()).getKeyCoder();
+          return viewFn.apply(
+              InMemoryMultimapSideInputView.fromIterable(keyCoder, (Iterable) sideInputForWindow));
+        }
+      default:
+        throw new IllegalStateException(
+            String.format(
+                "Unknown side input materialization format requested '%s'",
+                view.getViewFn().getMaterialization().getUrn()));
+    }
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/View.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/View.java
@@ -17,22 +17,31 @@
  */
 package org.apache.beam.sdk.transforms;
 
+import static org.apache.beam.sdk.options.ExperimentalOptions.hasExperiment;
+
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.concurrent.ThreadLocalRandom;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.PipelineRunner;
 import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.sdk.coders.BigEndianLongCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.VoidCoder;
+import org.apache.beam.sdk.io.range.OffsetRange;
 import org.apache.beam.sdk.runners.TransformHierarchy.Node;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.PCollectionViews;
 import org.apache.beam.sdk.values.PCollectionViews.TypeDescriptorSupplier;
+import org.apache.beam.sdk.values.PCollectionViews.ValueOrMetadata;
+import org.apache.beam.sdk.values.PCollectionViews.ValueOrMetadataCoder;
 
 /**
  * Transforms for creating {@link PCollectionView PCollectionViews} from {@link PCollection
@@ -157,7 +166,10 @@ public class View {
    * PCollectionView} mapping each window to a {@link List} containing all of the elements in the
    * window.
    *
-   * <p>Unlike with {@link #asIterable}, the resulting list is required to fit in memory.
+   * <p>This view should only be used if random access and/or size of the PCollection is required.
+   * {@link #asIterable()} will perform significantly better for sequential access.
+   *
+   * <p>Some runners may require that the view fits in memory.
    */
   public static <T> AsList<T> asList() {
     return new AsList<>();
@@ -168,9 +180,7 @@ public class View {
    * produces a {@link PCollectionView} mapping each window to an {@link Iterable} of the values in
    * that window.
    *
-   * <p>The values of the {@link Iterable} for a window are not required to fit in memory, but they
-   * may also not be effectively cached. If it is known that every window fits in memory, and
-   * stronger caching is desired, use {@link #asList}.
+   * <p>Some runners may require that the view fits in memory.
    */
   public static <T> AsIterable<T> asIterable() {
     return new AsIterable<>();
@@ -191,7 +201,7 @@ public class View {
    *     .apply(View.<K, OutputT>asMap());
    * }</pre>
    *
-   * <p>Currently, the resulting map is required to fit into memory.
+   * <p>Some runners may require that the view fits in memory.
    */
   public static <K, V> AsMap<K, V> asMap() {
     return new AsMap<>();
@@ -208,6 +218,8 @@ public class View {
    * PCollection<KV<K, V>> input = ... // maybe more than one occurrence of a some keys
    * PCollectionView<Map<K, Iterable<V>>> output = input.apply(View.<K, V>asMultimap());
    * }</pre>
+   *
+   * <p>Some runners may require that the view fits in memory.
    */
   public static <K, V> AsMultimap<K, V> asMultimap() {
     return new AsMultimap<>();
@@ -232,16 +244,85 @@ public class View {
         throw new IllegalStateException("Unable to create a side-input view from input", e);
       }
 
+      /**
+       * The materialized format uses {@link Materializations#MULTIMAP_MATERIALIZATION_URN multimap}
+       * access pattern where the key is a position and the index of the value in the iterable is a
+       * sub-position. All keys are {@code long}s and all sub-positions are also considered {@code
+       * long}s. A mapping from {@code [0, size)} to {@code (position, sub-position)} is used to
+       * provide an ordering over all values in the {@link PCollection} per {@link BoundedWindow
+       * window}. A total ordering is done by taking {@code (position, sub-position)} and ordering
+       * first by {@code position} and then by {@code sub-position} where the smallest value in such
+       * an ordering represents the index 0, and the next smallest 1, and so forth. The {@link
+       * Long#MIN_VALUE} key is used to store all known {@link OffsetRange ranges} allowing us to
+       * compute such an ordering.
+       */
+
+      // TODO(BEAM-10097): Make this the default expansion for all portable runners.
+      if (hasExperiment(input.getPipeline().getOptions(), "beam_fn_api")
+          && (hasExperiment(input.getPipeline().getOptions(), "use_runner_v2")
+              || hasExperiment(input.getPipeline().getOptions(), "use_unified_worker"))) {
+        Coder<T> inputCoder = input.getCoder();
+        PCollection<KV<Long, ValueOrMetadata<T, OffsetRange>>> materializationInput =
+            input
+                .apply("IndexElements", ParDo.of(new ToListViewDoFn<>()))
+                .setCoder(
+                    KvCoder.of(
+                        BigEndianLongCoder.of(),
+                        ValueOrMetadataCoder.create(inputCoder, OffsetRange.Coder.of())));
+        PCollectionView<List<T>> view =
+            PCollectionViews.listView(
+                materializationInput,
+                (TypeDescriptorSupplier<T>) inputCoder::getEncodedTypeDescriptor,
+                input.getWindowingStrategy());
+        materializationInput.apply(CreatePCollectionView.of(view));
+        return view;
+      }
+
       PCollection<KV<Void, T>> materializationInput =
           input.apply(new VoidKeyToMultimapMaterialization<>());
       Coder<T> inputCoder = input.getCoder();
       PCollectionView<List<T>> view =
-          PCollectionViews.listView(
+          PCollectionViews.listViewUsingVoidKey(
               materializationInput,
               (TypeDescriptorSupplier<T>) inputCoder::getEncodedTypeDescriptor,
               materializationInput.getWindowingStrategy());
       materializationInput.apply(CreatePCollectionView.of(view));
       return view;
+    }
+  }
+
+  /**
+   * Provides an index to value mapping using a random starting index and also provides an offset
+   * range for each window seen. We use random offset ranges to minimize the chance that two ranges
+   * overlap increasing the odds that each "key" represents a single index.
+   */
+  private static class ToListViewDoFn<T>
+      extends DoFn<T, KV<Long, ValueOrMetadata<T, OffsetRange>>> {
+    private Map<BoundedWindow, OffsetRange> windowsToOffsets = new HashMap<>();
+
+    private OffsetRange generateRange(BoundedWindow window) {
+      long offset =
+          ThreadLocalRandom.current()
+              .nextLong(Long.MIN_VALUE + 1, Long.MAX_VALUE - Integer.MAX_VALUE);
+      return new OffsetRange(offset, offset);
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext c, BoundedWindow window) {
+      OffsetRange range = windowsToOffsets.computeIfAbsent(window, this::generateRange);
+      c.output(KV.of(range.getTo(), ValueOrMetadata.create(c.element())));
+      windowsToOffsets.put(window, new OffsetRange(range.getFrom(), range.getTo() + 1));
+    }
+
+    @FinishBundle
+    public void finishBundle(FinishBundleContext c) {
+      for (Map.Entry<BoundedWindow, OffsetRange> entry : windowsToOffsets.entrySet()) {
+        c.output(
+            KV.of(Long.MIN_VALUE, ValueOrMetadata.createMetadata(entry.getValue())),
+            entry.getKey().maxTimestamp(),
+            entry.getKey());
+      }
+      windowsToOffsets.clear();
     }
   }
 
@@ -265,11 +346,25 @@ public class View {
         throw new IllegalStateException("Unable to create a side-input view from input", e);
       }
 
+      // TODO(BEAM-10097): Make this the default expansion for all portable runners.
+      if (hasExperiment(input.getPipeline().getOptions(), "beam_fn_api")
+          && (hasExperiment(input.getPipeline().getOptions(), "use_runner_v2")
+              || hasExperiment(input.getPipeline().getOptions(), "use_unified_worker"))) {
+        Coder<T> inputCoder = input.getCoder();
+        PCollectionView<Iterable<T>> view =
+            PCollectionViews.iterableView(
+                input,
+                (TypeDescriptorSupplier<T>) inputCoder::getEncodedTypeDescriptor,
+                input.getWindowingStrategy());
+        input.apply(CreatePCollectionView.of(view));
+        return view;
+      }
+
       PCollection<KV<Void, T>> materializationInput =
           input.apply(new VoidKeyToMultimapMaterialization<>());
       Coder<T> inputCoder = input.getCoder();
       PCollectionView<Iterable<T>> view =
-          PCollectionViews.iterableView(
+          PCollectionViews.iterableViewUsingVoidKey(
               materializationInput,
               (TypeDescriptorSupplier<T>) inputCoder::getEncodedTypeDescriptor,
               materializationInput.getWindowingStrategy());
@@ -409,13 +504,30 @@ public class View {
         throw new IllegalStateException("Unable to create a side-input view from input", e);
       }
 
+      // TODO(BEAM-10097): Make this the default expansion for all portable runners.
+      if (hasExperiment(input.getPipeline().getOptions(), "beam_fn_api")
+          && (hasExperiment(input.getPipeline().getOptions(), "use_runner_v2")
+              || hasExperiment(input.getPipeline().getOptions(), "use_unified_worker"))) {
+        KvCoder<K, V> kvCoder = (KvCoder<K, V>) input.getCoder();
+        Coder<K> keyCoder = kvCoder.getKeyCoder();
+        Coder<V> valueCoder = kvCoder.getValueCoder();
+        PCollectionView<Map<K, Iterable<V>>> view =
+            PCollectionViews.multimapView(
+                input,
+                (TypeDescriptorSupplier<K>) keyCoder::getEncodedTypeDescriptor,
+                (TypeDescriptorSupplier<V>) valueCoder::getEncodedTypeDescriptor,
+                input.getWindowingStrategy());
+        input.apply(CreatePCollectionView.of(view));
+        return view;
+      }
+
       KvCoder<K, V> kvCoder = (KvCoder<K, V>) input.getCoder();
       Coder<K> keyCoder = kvCoder.getKeyCoder();
       Coder<V> valueCoder = kvCoder.getValueCoder();
       PCollection<KV<Void, KV<K, V>>> materializationInput =
           input.apply(new VoidKeyToMultimapMaterialization<>());
       PCollectionView<Map<K, Iterable<V>>> view =
-          PCollectionViews.multimapView(
+          PCollectionViews.multimapViewUsingVoidKey(
               materializationInput,
               (TypeDescriptorSupplier<K>) keyCoder::getEncodedTypeDescriptor,
               (TypeDescriptorSupplier<V>) valueCoder::getEncodedTypeDescriptor,
@@ -451,6 +563,24 @@ public class View {
         throw new IllegalStateException("Unable to create a side-input view from input", e);
       }
 
+      // TODO(BEAM-10097): Make this the default expansion for all portable runners.
+      if (hasExperiment(input.getPipeline().getOptions(), "beam_fn_api")
+          && (hasExperiment(input.getPipeline().getOptions(), "use_runner_v2")
+              || hasExperiment(input.getPipeline().getOptions(), "use_unified_worker"))) {
+        KvCoder<K, V> kvCoder = (KvCoder<K, V>) input.getCoder();
+        Coder<K> keyCoder = kvCoder.getKeyCoder();
+        Coder<V> valueCoder = kvCoder.getValueCoder();
+
+        PCollectionView<Map<K, V>> view =
+            PCollectionViews.mapView(
+                input,
+                (TypeDescriptorSupplier<K>) keyCoder::getEncodedTypeDescriptor,
+                (TypeDescriptorSupplier<V>) valueCoder::getEncodedTypeDescriptor,
+                input.getWindowingStrategy());
+        input.apply(CreatePCollectionView.of(view));
+        return view;
+      }
+
       KvCoder<K, V> kvCoder = (KvCoder<K, V>) input.getCoder();
       Coder<K> keyCoder = kvCoder.getKeyCoder();
       Coder<V> valueCoder = kvCoder.getValueCoder();
@@ -458,7 +588,7 @@ public class View {
       PCollection<KV<Void, KV<K, V>>> materializationInput =
           input.apply(new VoidKeyToMultimapMaterialization<>());
       PCollectionView<Map<K, V>> view =
-          PCollectionViews.mapView(
+          PCollectionViews.mapViewUsingVoidKey(
               materializationInput,
               (TypeDescriptorSupplier<K>) keyCoder::getEncodedTypeDescriptor,
               (TypeDescriptorSupplier<V>) valueCoder::getEncodedTypeDescriptor,
@@ -474,8 +604,8 @@ public class View {
   /**
    * A {@link PTransform} which converts all values into {@link KV}s with {@link Void} keys.
    *
-   * <p>TODO: Replace this materialization with specializations that optimize the various SDK
-   * requested views.
+   * <p>TODO(BEAM-10097): Replace this materialization with specializations that optimize the
+   * various SDK requested views.
    */
   @Internal
   static class VoidKeyToMultimapMaterialization<T>

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionViews.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionViews.java
@@ -17,35 +17,63 @@
  */
 package org.apache.beam.sdk.values;
 
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkState;
+
 import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
 import java.io.Serializable;
+import java.util.AbstractList;
+import java.util.AbstractMap;
+import java.util.AbstractSet;
 import java.util.ArrayList;
+import java.util.Arrays;
 import java.util.Collections;
+import java.util.Comparator;
 import java.util.HashMap;
+import java.util.Iterator;
 import java.util.List;
+import java.util.ListIterator;
 import java.util.Map;
 import java.util.NoSuchElementException;
 import java.util.Objects;
+import java.util.PriorityQueue;
+import java.util.RandomAccess;
+import java.util.Set;
+import java.util.SortedMap;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.sdk.coders.BooleanCoder;
 import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.coders.StructuredCoder;
+import org.apache.beam.sdk.io.range.OffsetRange;
 import org.apache.beam.sdk.transforms.Materialization;
 import org.apache.beam.sdk.transforms.Materializations;
+import org.apache.beam.sdk.transforms.Materializations.IterableView;
 import org.apache.beam.sdk.transforms.Materializations.MultimapView;
 import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.View;
 import org.apache.beam.sdk.transforms.ViewFn;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.InvalidWindows;
 import org.apache.beam.sdk.transforms.windowing.WindowMappingFn;
 import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Suppliers;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ArrayListMultimap;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.FluentIterable;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSortedMap;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Multimap;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.primitives.Ints;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.primitives.Longs;
 
 /**
  * <b>For internal use only; no backwards compatibility guarantees.</b>
@@ -64,6 +92,30 @@ public class PCollectionViews {
    * defaultValue} for any empty windows.
    */
   public static <T, W extends BoundedWindow> PCollectionView<T> singletonView(
+      PCollection<T> pCollection,
+      TypeDescriptorSupplier<T> typeDescriptorSupplier,
+      WindowingStrategy<?, W> windowingStrategy,
+      boolean hasDefault,
+      @Nullable T defaultValue,
+      Coder<T> defaultValueCoder) {
+    return new SimplePCollectionView<>(
+        pCollection,
+        new SingletonViewFn2<>(hasDefault, defaultValue, defaultValueCoder, typeDescriptorSupplier),
+        windowingStrategy.getWindowFn().getDefaultWindowMappingFn(),
+        windowingStrategy);
+  }
+
+  /**
+   * Returns a {@code PCollectionView<T>} capable of processing elements windowed using the provided
+   * {@link WindowingStrategy}.
+   *
+   * <p>If {@code hasDefault} is {@code true}, then the view will take on the value {@code
+   * defaultValue} for any empty windows.
+   *
+   * @deprecated See {@link #singletonView}.
+   */
+  @Deprecated
+  public static <T, W extends BoundedWindow> PCollectionView<T> singletonViewUsingVoidKey(
       PCollection<KV<Void, T>> pCollection,
       TypeDescriptorSupplier<T> typeDescriptorSupplier,
       WindowingStrategy<?, W> windowingStrategy,
@@ -72,7 +124,7 @@ public class PCollectionViews {
       Coder<T> defaultValueCoder) {
     return new SimplePCollectionView<>(
         pCollection,
-        new SingletonViewFn<T>(hasDefault, defaultValue, defaultValueCoder, typeDescriptorSupplier),
+        new SingletonViewFn<>(hasDefault, defaultValue, defaultValueCoder, typeDescriptorSupplier),
         windowingStrategy.getWindowFn().getDefaultWindowMappingFn(),
         windowingStrategy);
   }
@@ -82,12 +134,30 @@ public class PCollectionViews {
    * the provided {@link WindowingStrategy}.
    */
   public static <T, W extends BoundedWindow> PCollectionView<Iterable<T>> iterableView(
+      PCollection<T> pCollection,
+      TypeDescriptorSupplier<T> typeDescriptorSupplier,
+      WindowingStrategy<?, W> windowingStrategy) {
+    return new SimplePCollectionView<>(
+        pCollection,
+        new IterableViewFn2<>(typeDescriptorSupplier),
+        windowingStrategy.getWindowFn().getDefaultWindowMappingFn(),
+        windowingStrategy);
+  }
+
+  /**
+   * Returns a {@code PCollectionView<Iterable<T>>} capable of processing elements windowed using
+   * the provided {@link WindowingStrategy}.
+   *
+   * @deprecated See {@link #iterableView}.
+   */
+  @Deprecated
+  public static <T, W extends BoundedWindow> PCollectionView<Iterable<T>> iterableViewUsingVoidKey(
       PCollection<KV<Void, T>> pCollection,
       TypeDescriptorSupplier<T> typeDescriptorSupplier,
       WindowingStrategy<?, W> windowingStrategy) {
     return new SimplePCollectionView<>(
         pCollection,
-        new IterableViewFn<T>(typeDescriptorSupplier),
+        new IterableViewFn<>(typeDescriptorSupplier),
         windowingStrategy.getWindowFn().getDefaultWindowMappingFn(),
         windowingStrategy);
   }
@@ -97,6 +167,24 @@ public class PCollectionViews {
    * provided {@link WindowingStrategy}.
    */
   public static <T, W extends BoundedWindow> PCollectionView<List<T>> listView(
+      PCollection<KV<Long, ValueOrMetadata<T, OffsetRange>>> pCollection,
+      TypeDescriptorSupplier<T> typeDescriptorSupplier,
+      WindowingStrategy<?, W> windowingStrategy) {
+    return new SimplePCollectionView<>(
+        pCollection,
+        new ListViewFn2<>(typeDescriptorSupplier),
+        windowingStrategy.getWindowFn().getDefaultWindowMappingFn(),
+        windowingStrategy);
+  }
+
+  /**
+   * Returns a {@code PCollectionView<List<T>>} capable of processing elements windowed using the
+   * provided {@link WindowingStrategy}.
+   *
+   * @deprecated See {@link #listView}.
+   */
+  @Deprecated
+  public static <T, W extends BoundedWindow> PCollectionView<List<T>> listViewUsingVoidKey(
       PCollection<KV<Void, T>> pCollection,
       TypeDescriptorSupplier<T> typeDescriptorSupplier,
       WindowingStrategy<?, W> windowingStrategy) {
@@ -106,11 +194,31 @@ public class PCollectionViews {
         windowingStrategy.getWindowFn().getDefaultWindowMappingFn(),
         windowingStrategy);
   }
+
   /**
    * Returns a {@code PCollectionView<Map<K, V>>} capable of processing elements windowed using the
    * provided {@link WindowingStrategy}.
    */
   public static <K, V, W extends BoundedWindow> PCollectionView<Map<K, V>> mapView(
+      PCollection<KV<K, V>> pCollection,
+      TypeDescriptorSupplier<K> keyTypeDescriptorSupplier,
+      TypeDescriptorSupplier<V> valueTypeDescriptorSupplier,
+      WindowingStrategy<?, W> windowingStrategy) {
+    return new SimplePCollectionView<>(
+        pCollection,
+        new MapViewFn2<>(keyTypeDescriptorSupplier, valueTypeDescriptorSupplier),
+        windowingStrategy.getWindowFn().getDefaultWindowMappingFn(),
+        windowingStrategy);
+  }
+
+  /**
+   * Returns a {@code PCollectionView<Map<K, V>>} capable of processing elements windowed using the
+   * provided {@link WindowingStrategy}.
+   *
+   * @deprecated See {@link #mapView}.
+   */
+  @Deprecated
+  public static <K, V, W extends BoundedWindow> PCollectionView<Map<K, V>> mapViewUsingVoidKey(
       PCollection<KV<Void, KV<K, V>>> pCollection,
       TypeDescriptorSupplier<K> keyTypeDescriptorSupplier,
       TypeDescriptorSupplier<V> valueTypeDescriptorSupplier,
@@ -127,10 +235,30 @@ public class PCollectionViews {
    * using the provided {@link WindowingStrategy}.
    */
   public static <K, V, W extends BoundedWindow> PCollectionView<Map<K, Iterable<V>>> multimapView(
-      PCollection<KV<Void, KV<K, V>>> pCollection,
+      PCollection<KV<K, V>> pCollection,
       TypeDescriptorSupplier<K> keyTypeDescriptorSupplier,
       TypeDescriptorSupplier<V> valueTypeDescriptorSupplier,
       WindowingStrategy<?, W> windowingStrategy) {
+    return new SimplePCollectionView<>(
+        pCollection,
+        new MultimapViewFn2<>(keyTypeDescriptorSupplier, valueTypeDescriptorSupplier),
+        windowingStrategy.getWindowFn().getDefaultWindowMappingFn(),
+        windowingStrategy);
+  }
+
+  /**
+   * Returns a {@code PCollectionView<Map<K, Iterable<V>>>} capable of processing elements windowed
+   * using the provided {@link WindowingStrategy}.
+   *
+   * @deprecated See {@link #multimapView}.
+   */
+  @Deprecated
+  public static <K, V, W extends BoundedWindow>
+      PCollectionView<Map<K, Iterable<V>>> multimapViewUsingVoidKey(
+          PCollection<KV<Void, KV<K, V>>> pCollection,
+          TypeDescriptorSupplier<K> keyTypeDescriptorSupplier,
+          TypeDescriptorSupplier<V> valueTypeDescriptorSupplier,
+          WindowingStrategy<?, W> windowingStrategy) {
     return new SimplePCollectionView<>(
         pCollection,
         new MultimapViewFn<>(keyTypeDescriptorSupplier, valueTypeDescriptorSupplier),
@@ -151,12 +279,104 @@ public class PCollectionViews {
   }
 
   /**
-   * Implementation which is able to adapt a multimap materialization to a {@code T}.
+   * Implementation which is able to adapt an iterable materialization to a {@code T}.
    *
    * <p>For internal use only.
    *
    * <p>Instantiate via {@link PCollectionViews#singletonView}.
+   *
+   * <p>{@link SingletonViewFn} is meant to be removed in the future and replaced with this class.
    */
+  @Experimental(Kind.CORE_RUNNERS_ONLY)
+  private static class SingletonViewFn2<T> extends ViewFn<IterableView<T>, T> {
+    @Nullable private byte[] encodedDefaultValue;
+    @Nullable private transient T defaultValue;
+    @Nullable private Coder<T> valueCoder;
+    private boolean hasDefault;
+    private TypeDescriptorSupplier<T> typeDescriptorSupplier;
+
+    private SingletonViewFn2(
+        boolean hasDefault,
+        T defaultValue,
+        Coder<T> valueCoder,
+        TypeDescriptorSupplier<T> typeDescriptorSupplier) {
+      this.hasDefault = hasDefault;
+      this.defaultValue = defaultValue;
+      this.valueCoder = valueCoder;
+      this.typeDescriptorSupplier = typeDescriptorSupplier;
+      if (hasDefault) {
+        try {
+          this.encodedDefaultValue = CoderUtils.encodeToByteArray(valueCoder, defaultValue);
+        } catch (IOException e) {
+          throw new RuntimeException("Unexpected IOException: ", e);
+        }
+      }
+    }
+
+    /** Returns if a default value was specified. */
+    @Internal
+    public boolean hasDefault() {
+      return hasDefault;
+    }
+
+    /**
+     * Returns the default value that was specified.
+     *
+     * <p>For internal use only.
+     *
+     * @throws NoSuchElementException if no default was specified.
+     */
+    public T getDefaultValue() {
+      if (!hasDefault) {
+        throw new NoSuchElementException("Empty PCollection accessed as a singleton view.");
+      }
+      // Lazily decode the default value once
+      synchronized (this) {
+        if (encodedDefaultValue != null) {
+          try {
+            defaultValue = CoderUtils.decodeFromByteArray(valueCoder, encodedDefaultValue);
+            // Clear the encoded default value to free the reference once we have the object
+            // version. Also, this will guarantee that the value will only be decoded once.
+            encodedDefaultValue = null;
+          } catch (IOException e) {
+            throw new RuntimeException("Unexpected IOException: ", e);
+          }
+        }
+        return defaultValue;
+      }
+    }
+
+    @Override
+    public Materialization<IterableView<T>> getMaterialization() {
+      return Materializations.iterable();
+    }
+
+    @Override
+    public T apply(IterableView<T> primitiveViewT) {
+      try {
+        return Iterables.getOnlyElement(primitiveViewT.get());
+      } catch (NoSuchElementException exc) {
+        return getDefaultValue();
+      } catch (IllegalArgumentException exc) {
+        throw new IllegalArgumentException(
+            "PCollection with more than one element accessed as a singleton view.");
+      }
+    }
+
+    @Override
+    public TypeDescriptor<T> getTypeDescriptor() {
+      return typeDescriptorSupplier.get();
+    }
+  }
+
+  /**
+   * Implementation which is able to adapt a multimap materialization to a {@code T}.
+   *
+   * <p>For internal use only.
+   *
+   * @deprecated See {@link SingletonViewFn2}.
+   */
+  @Deprecated
   @Experimental(Kind.CORE_RUNNERS_ONLY)
   public static class SingletonViewFn<T> extends ViewFn<MultimapView<Void, T>, T> {
     @Nullable private byte[] encodedDefaultValue;
@@ -240,12 +460,46 @@ public class PCollectionViews {
   }
 
   /**
-   * Implementation which is able to adapt a multimap materialization to a {@code Iterable<T>}.
+   * Implementation which is able to adapt an iterable materialization to a {@code Iterable<T>}.
    *
    * <p>For internal use only.
    *
    * <p>Instantiate via {@link PCollectionViews#iterableView}.
+   *
+   * <p>{@link IterableViewFn} is meant to be removed in the future and replaced with this class.
    */
+  @Experimental(Kind.CORE_RUNNERS_ONLY)
+  private static class IterableViewFn2<T> extends ViewFn<IterableView<T>, Iterable<T>> {
+    private TypeDescriptorSupplier<T> typeDescriptorSupplier;
+
+    public IterableViewFn2(TypeDescriptorSupplier<T> typeDescriptorSupplier) {
+      this.typeDescriptorSupplier = typeDescriptorSupplier;
+    }
+
+    @Override
+    public Materialization<IterableView<T>> getMaterialization() {
+      return Materializations.iterable();
+    }
+
+    @Override
+    public Iterable<T> apply(IterableView<T> primitiveViewT) {
+      return Iterables.unmodifiableIterable(primitiveViewT.get());
+    }
+
+    @Override
+    public TypeDescriptor<Iterable<T>> getTypeDescriptor() {
+      return TypeDescriptors.iterables(typeDescriptorSupplier.get());
+    }
+  }
+
+  /**
+   * Implementation which is able to adapt a multimap materialization to a {@code Iterable<T>}.
+   *
+   * <p>For internal use only.
+   *
+   * @deprecated See {@link IterableViewFn2}.
+   */
+  @Deprecated
   @Experimental(Kind.CORE_RUNNERS_ONLY)
   public static class IterableViewFn<T> extends ViewFn<MultimapView<Void, T>, Iterable<T>> {
     private TypeDescriptorSupplier<T> typeDescriptorSupplier;
@@ -276,7 +530,406 @@ public class PCollectionViews {
    * <p>For internal use only.
    *
    * <p>Instantiate via {@link PCollectionViews#listView}.
+   *
+   * <p>{@link ListViewFn} is meant to be removed in the future and replaced with this class.
    */
+  @Experimental(Kind.CORE_RUNNERS_ONLY)
+  @VisibleForTesting
+  static class ListViewFn2<T>
+      extends ViewFn<MultimapView<Long, ValueOrMetadata<T, OffsetRange>>, List<T>> {
+    private TypeDescriptorSupplier<T> typeDescriptorSupplier;
+
+    public ListViewFn2(TypeDescriptorSupplier<T> typeDescriptorSupplier) {
+      this.typeDescriptorSupplier = typeDescriptorSupplier;
+    }
+
+    @Override
+    public Materialization<MultimapView<Long, ValueOrMetadata<T, OffsetRange>>>
+        getMaterialization() {
+      return Materializations.multimap();
+    }
+
+    @Override
+    public List<T> apply(MultimapView<Long, ValueOrMetadata<T, OffsetRange>> primitiveViewT) {
+      return Collections.unmodifiableList(new ListOverMultimapView<>(primitiveViewT));
+    }
+
+    @Override
+    public TypeDescriptor<List<T>> getTypeDescriptor() {
+      return TypeDescriptors.lists(typeDescriptorSupplier.get());
+    }
+
+    /**
+     * A {@link List} adapter over a {@link MultimapView}.
+     *
+     * <p>See {@link View.AsList} for a description of the materialized format and {@code index} to
+     * {@code (position, sub-position)} mapping details.
+     */
+    private static class ListOverMultimapView<T> extends AbstractList<T> implements RandomAccess {
+      private final MultimapView<Long, ValueOrMetadata<T, OffsetRange>> primitiveView;
+      /**
+       * A mapping from non over-lapping ranges to the number of elements at each position within
+       * that range. Ranges not specified in the mapping implicitly have 0 elements at those
+       * positions.
+       *
+       * <p>Used to quickly compute the {@code index} -> {@code (position, sub-position} within the
+       * map.
+       */
+      private final Supplier<SortedMap<OffsetRange, Integer>>
+          nonOverlappingRangesToNumElementsPerPosition;
+
+      private final Supplier<Integer> size;
+
+      private ListOverMultimapView(
+          MultimapView<Long, ValueOrMetadata<T, OffsetRange>> primitiveView) {
+        this.primitiveView = primitiveView;
+        this.nonOverlappingRangesToNumElementsPerPosition =
+            Suppliers.memoize(
+                () ->
+                    computeOverlappingRanges(
+                        Iterables.transform(
+                            primitiveView.get(Long.MIN_VALUE), (value) -> value.getMetadata())));
+        this.size =
+            Suppliers.memoize(
+                () -> computeTotalNumElements(nonOverlappingRangesToNumElementsPerPosition.get()));
+      }
+
+      @Override
+      public T get(int index) {
+        if (index < 0 || index >= size.get()) {
+          throw new IndexOutOfBoundsException();
+        }
+        KV<Long, Integer> position =
+            computePositionForIndex(nonOverlappingRangesToNumElementsPerPosition.get(), index);
+        return Iterables.get(primitiveView.get(position.getKey()), position.getValue()).get();
+      }
+
+      @Override
+      public int size() {
+        return size.get();
+      }
+
+      @Override
+      public Iterator<T> iterator() {
+        return listIterator();
+      }
+
+      @Override
+      public ListIterator<T> listIterator() {
+        return super.listIterator();
+      }
+
+      /** A {@link ListIterator} over {@link MultimapView} adapter. */
+      private class ListIteratorOverMultimapView implements ListIterator<T> {
+        private int position;
+
+        @Override
+        public boolean hasNext() {
+          return position < size();
+        }
+
+        @Override
+        public T next() {
+          if (!hasNext()) {
+            throw new NoSuchElementException();
+          }
+          T rval = get(position);
+          position += 1;
+          return rval;
+        }
+
+        @Override
+        public boolean hasPrevious() {
+          return position > 0;
+        }
+
+        @Override
+        public T previous() {
+          if (!hasPrevious()) {
+            throw new NoSuchElementException();
+          }
+          position -= 1;
+          return get(position);
+        }
+
+        @Override
+        public int nextIndex() {
+          return position;
+        }
+
+        @Override
+        public int previousIndex() {
+          return position - 1;
+        }
+
+        @Override
+        public void remove() {
+          throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void set(T e) {
+          throw new UnsupportedOperationException();
+        }
+
+        @Override
+        public void add(T e) {
+          throw new UnsupportedOperationException();
+        }
+      }
+    }
+  }
+
+  /**
+   * Compares {@link OffsetRange}s such that ranges are ordered by the smallest {@code from} and in
+   * case of a tie the smallest {@code to}.
+   */
+  @VisibleForTesting
+  static class OffsetRangeComparator implements Comparator<OffsetRange> {
+    private static final OffsetRangeComparator INSTANCE = new OffsetRangeComparator();
+
+    @Override
+    public int compare(OffsetRange o1, OffsetRange o2) {
+      int fromComparison = Longs.compare(o1.getFrom(), o2.getFrom());
+      if (fromComparison != 0) {
+        return fromComparison;
+      }
+      return Longs.compare(o1.getTo(), o2.getTo());
+    }
+  }
+
+  @VisibleForTesting
+  static SortedMap<OffsetRange, Integer> computeOverlappingRanges(Iterable<OffsetRange> ranges) {
+    ImmutableSortedMap.Builder<OffsetRange, Integer> rval =
+        ImmutableSortedMap.orderedBy(OffsetRangeComparator.INSTANCE);
+    List<OffsetRange> sortedRanges = Lists.newArrayList(ranges);
+    if (sortedRanges.isEmpty()) {
+      return rval.build();
+    }
+    Collections.sort(sortedRanges, OffsetRangeComparator.INSTANCE);
+
+    // Stores ranges in smallest 'from' and then smallest 'to' order
+    // e.g. [2, 7), [3, 4), [3, 5), [3, 5), [3, 6), [4, 0)
+    PriorityQueue<OffsetRange> rangesWithSameFrom =
+        new PriorityQueue<>(OffsetRangeComparator.INSTANCE);
+    Iterator<OffsetRange> iterator = sortedRanges.iterator();
+
+    // Stored in reverse sorted order so that when we iterate and re-add them back to
+    // overlappingRanges they are stored in sorted order from smallest to largest range.to
+    List<OffsetRange> rangesToProcess = new ArrayList<>();
+    while (iterator.hasNext()) {
+      OffsetRange current = iterator.next();
+      // Skip empty ranges
+      if (current.getFrom() == current.getTo()) {
+        continue;
+      }
+
+      // If the current range has a different 'from' then a prior range then we must produce
+      // ranges in [rangesWithSameFrom.from, current.from)
+      while (!rangesWithSameFrom.isEmpty()
+          && rangesWithSameFrom.peek().getFrom() != current.getFrom()) {
+        rangesToProcess.addAll(rangesWithSameFrom);
+        Collections.sort(rangesToProcess, OffsetRangeComparator.INSTANCE);
+        rangesWithSameFrom.clear();
+
+        int i = 0;
+        long lastTo = rangesToProcess.get(i).getFrom();
+        // Output all the ranges that are strictly less then current.from
+        // e.g. current.to := 7 for [3, 4), [3, 5), [3, 5), [3, 6) will produce
+        // [3, 4) := 4
+        // [4, 5) := 3
+        // [5, 6) := 1
+        for (; i < rangesToProcess.size(); ++i) {
+          if (rangesToProcess.get(i).getTo() > current.getFrom()) {
+            break;
+          }
+          // Output only the first of any subsequent duplicate ranges
+          if (i == 0 || rangesToProcess.get(i - 1).getTo() != rangesToProcess.get(i).getTo()) {
+            rval.put(
+                new OffsetRange(lastTo, rangesToProcess.get(i).getTo()),
+                rangesToProcess.size() - i);
+            lastTo = rangesToProcess.get(i).getTo();
+          }
+        }
+
+        // We exitted the loop with 'to' > current.from, we must add the range [lastTo,
+        // current.from) if it is non-empty
+        if (lastTo < current.getFrom() && i != rangesToProcess.size()) {
+          rval.put(new OffsetRange(lastTo, current.getFrom()), rangesToProcess.size() - i);
+        }
+
+        // The remaining ranges have a 'to' that is greater then 'current.from' and will overlap
+        // with current so add them back to rangesWithSameFrom with the updated 'from'
+        for (; i < rangesToProcess.size(); ++i) {
+          rangesWithSameFrom.add(
+              new OffsetRange(current.getFrom(), rangesToProcess.get(i).getTo()));
+        }
+
+        rangesToProcess.clear();
+      }
+      rangesWithSameFrom.add(current);
+    }
+
+    // Process the last chunk of overlapping ranges
+    while (!rangesWithSameFrom.isEmpty()) {
+      // This range always represents the range with with the smallest 'to'
+      OffsetRange current = rangesWithSameFrom.remove();
+
+      rangesToProcess.addAll(rangesWithSameFrom);
+      Collections.sort(rangesToProcess, OffsetRangeComparator.INSTANCE);
+      rangesWithSameFrom.clear();
+
+      rval.put(current, rangesToProcess.size() + 1 /* include current */);
+
+      // Shorten all the remaining ranges such that they start with current.to
+      for (OffsetRange rangeWithDifferentFrom : rangesToProcess) {
+        // Skip any duplicates of current
+        if (rangeWithDifferentFrom.getTo() > current.getTo()) {
+          rangesWithSameFrom.add(new OffsetRange(current.getTo(), rangeWithDifferentFrom.getTo()));
+        }
+      }
+      rangesToProcess.clear();
+    }
+    return rval.build();
+  }
+
+  @VisibleForTesting
+  static int computeTotalNumElements(
+      Map<OffsetRange, Integer> nonOverlappingRangesToNumElementsPerPosition) {
+    long sum = 0;
+    for (Map.Entry<OffsetRange, Integer> range :
+        nonOverlappingRangesToNumElementsPerPosition.entrySet()) {
+      sum +=
+          Math.multiplyExact(
+              Math.subtractExact(range.getKey().getTo(), range.getKey().getFrom()),
+              range.getValue());
+    }
+    return Ints.checkedCast(sum);
+  }
+
+  @VisibleForTesting
+  static KV<Long, Integer> computePositionForIndex(
+      Map<OffsetRange, Integer> nonOverlappingRangesToNumElementsPerPosition, int index) {
+    if (index < 0) {
+      throw new IndexOutOfBoundsException(
+          String.format(
+              "Position %s was out of bounds for ranges %s.",
+              index, nonOverlappingRangesToNumElementsPerPosition));
+    }
+    for (Map.Entry<OffsetRange, Integer> range :
+        nonOverlappingRangesToNumElementsPerPosition.entrySet()) {
+      int numElementsInRange =
+          Ints.checkedCast(
+              Math.multiplyExact(
+                  Math.subtractExact(range.getKey().getTo(), range.getKey().getFrom()),
+                  range.getValue()));
+      if (numElementsInRange <= index) {
+        index -= numElementsInRange;
+        continue;
+      }
+      long position = range.getKey().getFrom() + index / range.getValue();
+      int subPosition = index % range.getValue();
+      return KV.of(position, subPosition);
+    }
+    throw new IndexOutOfBoundsException(
+        String.format(
+            "Position %s was out of bounds for ranges %s.",
+            index, nonOverlappingRangesToNumElementsPerPosition));
+  }
+
+  /** Stores values or metadata about values. */
+  public static class ValueOrMetadata<T, MetaT> {
+    private final T value;
+    private final boolean isMetadata;
+    private final MetaT metadata;
+
+    public static <T, MetaT> ValueOrMetadata<T, MetaT> create(T value) {
+      return new ValueOrMetadata(false, value, null);
+    }
+
+    public static <T, MetaT> ValueOrMetadata<T, MetaT> createMetadata(MetaT metadata) {
+      return new ValueOrMetadata(true, null, metadata);
+    }
+
+    public ValueOrMetadata(boolean isMetadata, T value, MetaT metadata) {
+      this.isMetadata = isMetadata;
+      this.value = value;
+      this.metadata = metadata;
+    }
+
+    public T get() {
+      checkState(!isMetadata);
+      return value;
+    }
+
+    public boolean isMetadata() {
+      return isMetadata;
+    }
+
+    public MetaT getMetadata() {
+      checkState(isMetadata);
+      return metadata;
+    }
+  }
+
+  /** A coder for {@link ValueOrMetadata}. */
+  public static class ValueOrMetadataCoder<T, MetaT>
+      extends StructuredCoder<ValueOrMetadata<T, MetaT>> {
+    public static <T, MetaT> ValueOrMetadataCoder<T, MetaT> create(
+        Coder<T> valueCoder, Coder<MetaT> metadataCoder) {
+      return new ValueOrMetadataCoder<>(valueCoder, metadataCoder);
+    }
+
+    private final Coder<T> valueCoder;
+    private final Coder<MetaT> metadataCoder;
+
+    private ValueOrMetadataCoder(Coder<T> valueCoder, Coder<MetaT> metadataCoder) {
+      this.valueCoder = valueCoder;
+      this.metadataCoder = metadataCoder;
+    }
+
+    @Override
+    public void encode(ValueOrMetadata<T, MetaT> value, OutputStream outStream)
+        throws CoderException, IOException {
+      BooleanCoder.of().encode(value.isMetadata(), outStream);
+      if (value.isMetadata()) {
+        metadataCoder.encode(value.getMetadata(), outStream);
+      } else {
+        valueCoder.encode(value.get(), outStream);
+      }
+    }
+
+    @Override
+    public ValueOrMetadata<T, MetaT> decode(InputStream inStream)
+        throws CoderException, IOException {
+      boolean isMetadata = BooleanCoder.of().decode(inStream);
+      if (isMetadata) {
+        return ValueOrMetadata.createMetadata(metadataCoder.decode(inStream));
+      } else {
+        return ValueOrMetadata.create(valueCoder.decode(inStream));
+      }
+    }
+
+    @Override
+    public List<? extends Coder<?>> getCoderArguments() {
+      return Arrays.asList(valueCoder, metadataCoder);
+    }
+
+    @Override
+    public void verifyDeterministic() throws NonDeterministicException {
+      verifyDeterministic(valueCoder, "value coder");
+      verifyDeterministic(metadataCoder, "metadata coder");
+    }
+  }
+
+  /**
+   * Implementation which is able to adapt a multimap materialization to a {@code List<T>}.
+   *
+   * <p>For internal use only.
+   *
+   * @deprecated See {@link ListViewFn2}.
+   */
+  @Deprecated
   @Experimental(Kind.CORE_RUNNERS_ONLY)
   public static class ListViewFn<T> extends ViewFn<MultimapView<Void, T>, List<T>> {
     private TypeDescriptorSupplier<T> typeDescriptorSupplier;
@@ -322,7 +975,49 @@ public class PCollectionViews {
    * <p>For internal use only.
    *
    * <p>Instantiate via {@link PCollectionViews#multimapView}.
+   *
+   * <p>{@link MultimapViewFn} is meant to be removed in the future and replaced with this class.
    */
+  @Experimental(Kind.CORE_RUNNERS_ONLY)
+  private static class MultimapViewFn2<K, V>
+      extends ViewFn<MultimapView<K, V>, Map<K, Iterable<V>>> {
+    private TypeDescriptorSupplier<K> keyTypeDescriptorSupplier;
+    private TypeDescriptorSupplier<V> valueTypeDescriptorSupplier;
+
+    public MultimapViewFn2(
+        TypeDescriptorSupplier<K> keyTypeDescriptorSupplier,
+        TypeDescriptorSupplier<V> valueTypeDescriptorSupplier) {
+      this.keyTypeDescriptorSupplier = keyTypeDescriptorSupplier;
+      this.valueTypeDescriptorSupplier = valueTypeDescriptorSupplier;
+    }
+
+    @Override
+    public Materialization<MultimapView<K, V>> getMaterialization() {
+      return Materializations.multimap();
+    }
+
+    @Override
+    public Map<K, Iterable<V>> apply(MultimapView<K, V> primitiveViewT) {
+      return Collections.unmodifiableMap(new MultimapViewToMultimapAdapter<>(primitiveViewT));
+    }
+
+    @Override
+    public TypeDescriptor<Map<K, Iterable<V>>> getTypeDescriptor() {
+      return TypeDescriptors.maps(
+          keyTypeDescriptorSupplier.get(),
+          TypeDescriptors.iterables(valueTypeDescriptorSupplier.get()));
+    }
+  }
+
+  /**
+   * Implementation which is able to adapt a multimap materialization to a {@code Map<K,
+   * Iterable<V>>}.
+   *
+   * <p>For internal use only.
+   *
+   * @deprecated See {@link MultimapViewFn2}.
+   */
+  @Deprecated
   @Experimental(Kind.CORE_RUNNERS_ONLY)
   public static class MultimapViewFn<K, V>
       extends ViewFn<MultimapView<Void, KV<K, V>>, Map<K, Iterable<V>>> {
@@ -369,7 +1064,45 @@ public class PCollectionViews {
    * <p>For internal use only.
    *
    * <p>Instantiate via {@link PCollectionViews#mapView}.
+   *
+   * <p>{@link MapViewFn} is meant to be removed in the future and replaced with this class.
    */
+  private static class MapViewFn2<K, V> extends ViewFn<MultimapView<K, V>, Map<K, V>> {
+    private TypeDescriptorSupplier<K> keyTypeDescriptorSupplier;
+    private TypeDescriptorSupplier<V> valueTypeDescriptorSupplier;
+
+    public MapViewFn2(
+        TypeDescriptorSupplier<K> keyTypeDescriptorSupplier,
+        TypeDescriptorSupplier<V> valueTypeDescriptorSupplier) {
+      this.keyTypeDescriptorSupplier = keyTypeDescriptorSupplier;
+      this.valueTypeDescriptorSupplier = valueTypeDescriptorSupplier;
+    }
+
+    @Override
+    public Materialization<MultimapView<K, V>> getMaterialization() {
+      return Materializations.multimap();
+    }
+
+    @Override
+    public Map<K, V> apply(MultimapView<K, V> primitiveViewT) {
+      return Collections.unmodifiableMap(new MultimapViewToMapAdapter<>(primitiveViewT));
+    }
+
+    @Override
+    public TypeDescriptor<Map<K, V>> getTypeDescriptor() {
+      return TypeDescriptors.maps(
+          keyTypeDescriptorSupplier.get(), valueTypeDescriptorSupplier.get());
+    }
+  }
+
+  /**
+   * Implementation which is able to adapt a multimap materialization to a {@code Map<K, V>}.
+   *
+   * <p>For internal use only.
+   *
+   * @deprecated See {@link MapViewFn2}.
+   */
+  @Deprecated
   @Experimental(Kind.CORE_RUNNERS_ONLY)
   public static class MapViewFn<K, V> extends ViewFn<MultimapView<Void, KV<K, V>>, Map<K, V>> {
     private TypeDescriptorSupplier<K> keyTypeDescriptorSupplier;
@@ -531,6 +1264,143 @@ public class PCollectionViews {
     @Override
     public Map<TupleTag<?>, PValue> expand() {
       return Collections.singletonMap(tag, pCollection);
+    }
+  }
+
+  /** A {@link MultimapView} to {@link Map Map<K, V>} adapter. */
+  private static class MultimapViewToMapAdapter<K, V> extends AbstractMap<K, V> {
+    private final MultimapView<K, V> primitiveViewT;
+    private final Supplier<Integer> size;
+
+    private MultimapViewToMapAdapter(MultimapView<K, V> primitiveViewT) {
+      this.primitiveViewT = primitiveViewT;
+      this.size = Suppliers.memoize(() -> Iterables.size(primitiveViewT.get()));
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+      return primitiveViewT.get((K) key).iterator().hasNext();
+    }
+
+    @Override
+    public V get(Object key) {
+      Iterator<V> iterator = primitiveViewT.get((K) key).iterator();
+      if (!iterator.hasNext()) {
+        return null;
+      }
+      V value = iterator.next();
+      if (iterator.hasNext()) {
+        throw new IllegalArgumentException("Duplicate values for " + key);
+      }
+      return value;
+    }
+
+    @Override
+    public int size() {
+      return size.get();
+    }
+
+    @Override
+    public Set<Entry<K, V>> entrySet() {
+      return new AbstractSet<Entry<K, V>>() {
+        @Override
+        public Iterator<Entry<K, V>> iterator() {
+          return FluentIterable.from(primitiveViewT.get())
+              .<Entry<K, V>>transform((K key) -> new SimpleEntry<>(key, get(key)))
+              .iterator();
+        }
+
+        @Override
+        public boolean contains(Object o) {
+          if (!(o instanceof Entry)) {
+            return false;
+          }
+          Entry<?, ?> entry = (Entry<?, ?>) o;
+          // We treat the absence of the key in the map as a difference in these abstract sets. The
+          // underlying primitive view represents missing keys as empty iterables so we use this
+          // to check if the map contains the key first before comparing values.
+          Iterable<V> value = primitiveViewT.get((K) entry.getKey());
+          if (value.iterator().hasNext()) {
+            return false;
+          }
+          return Objects.equals(entry.getValue(), value);
+        }
+
+        @Override
+        public int size() {
+          return size.get();
+        }
+      };
+    }
+  }
+
+  /** A {@link MultimapView} to {@link Map Map<K, Iterable<V>>} adapter. */
+  private static class MultimapViewToMultimapAdapter<K, V> extends AbstractMap<K, Iterable<V>> {
+    private final MultimapView<K, V> primitiveViewT;
+    private final Supplier<Integer> size;
+
+    private MultimapViewToMultimapAdapter(MultimapView<K, V> primitiveViewT) {
+      this.primitiveViewT = primitiveViewT;
+      this.size = Suppliers.memoize(() -> Iterables.size(primitiveViewT.get()));
+    }
+
+    @Override
+    public boolean containsKey(Object key) {
+      return primitiveViewT.get((K) key).iterator().hasNext();
+    }
+
+    @Override
+    public Iterable<V> get(Object key) {
+      Iterable<V> values = primitiveViewT.get((K) key);
+      // The only way for the values iterable to be empty is for us to have never seen such a key
+      // during materialization and hence we return 'null' to satisfy Java's Map contract.
+      if (values.iterator().hasNext()) {
+        return values;
+      } else {
+        return null;
+      }
+    }
+
+    @Override
+    public int size() {
+      return size.get();
+    }
+
+    @Override
+    public Set<Entry<K, Iterable<V>>> entrySet() {
+      return new AbstractSet<Entry<K, Iterable<V>>>() {
+        @Override
+        public Iterator<Entry<K, Iterable<V>>> iterator() {
+          return FluentIterable.from(primitiveViewT.get())
+              .<Entry<K, Iterable<V>>>transform(
+                  (K key) -> new SimpleEntry<>(key, primitiveViewT.get(key)))
+              .iterator();
+        }
+
+        @Override
+        public boolean contains(Object o) {
+          if (!(o instanceof Entry)) {
+            return false;
+          }
+          Entry<?, ?> entry = (Entry<?, ?>) o;
+          if (!(entry.getValue() instanceof Iterable)) {
+            return false;
+          }
+          // We treat the absence of the key in the map as a difference in these abstract sets. The
+          // underlying primitive view represents missing keys as empty iterables so we use this
+          // to check if the map contains the key first before comparing values.
+          Iterable<V> value = primitiveViewT.get((K) entry.getKey());
+          if (value.iterator().hasNext()) {
+            return false;
+          }
+          return Iterables.elementsEqual((Iterable<?>) entry.getValue(), value);
+        }
+
+        @Override
+        public int size() {
+          return size.get();
+        }
+      };
     }
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/PCollectionViewTesting.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/PCollectionViewTesting.java
@@ -17,55 +17,107 @@
  */
 package org.apache.beam.sdk.testing;
 
+import static org.apache.beam.sdk.options.ExperimentalOptions.hasExperiment;
+
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import org.apache.beam.sdk.io.range.OffsetRange;
+import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.View;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.PCollectionViews.ValueOrMetadata;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
 
 /** Methods for testing {@link PCollectionView}s. */
 public final class PCollectionViewTesting {
   public static List<Object> materializeValuesFor(
-      PTransform<?, ? extends PCollectionView<?>> viewTransformClass, Object... values) {
+      PipelineOptions options,
+      PTransform<?, ? extends PCollectionView<?>> viewTransformClass,
+      Object... values) {
     List<Object> rval = new ArrayList<>();
-    // Currently all view materializations are the same where the data is shared underneath
-    // the void/null key. Once this changes, these materializations will differ but test code
-    // should not worry about what these look like if they are relying on the ViewFn to "undo"
-    // the conversion.
-    if (View.AsSingleton.class.equals(viewTransformClass.getClass())) {
-      for (Object value : values) {
-        rval.add(KV.of(null, value));
-      }
-    } else if (View.AsIterable.class.equals(viewTransformClass.getClass())) {
-      for (Object value : values) {
-        rval.add(KV.of(null, value));
-      }
-    } else if (View.AsList.class.equals(viewTransformClass.getClass())) {
-      for (Object value : values) {
-        rval.add(KV.of(null, value));
-      }
-    } else if (View.AsMap.class.equals(viewTransformClass.getClass())) {
-      for (Object value : values) {
-        rval.add(KV.of(null, value));
-      }
-    } else if (View.AsMultimap.class.equals(viewTransformClass.getClass())) {
-      for (Object value : values) {
-        rval.add(KV.of(null, value));
+    // Map values to the materialized format that is expected by each view type. These
+    // materializations will differ but test code should not worry about what these look like if
+    // they are relying on the ViewFn to "undo" the conversion.
+
+    // TODO(BEAM-10097): Make this the default case once all portable runners can support
+    // the iterable access pattern.
+    if (hasExperiment(options, "beam_fn_api")
+        && (hasExperiment(options, "use_runner_v2")
+            || hasExperiment(options, "use_unified_worker"))) {
+      if (View.AsSingleton.class.equals(viewTransformClass.getClass())) {
+        for (Object value : values) {
+          rval.add(value);
+        }
+      } else if (View.AsIterable.class.equals(viewTransformClass.getClass())) {
+        for (Object value : values) {
+          rval.add(value);
+        }
+      } else if (View.AsList.class.equals(viewTransformClass.getClass())) {
+        if (values.length > 0) {
+          rval.add(
+              KV.of(
+                  Long.MIN_VALUE,
+                  ValueOrMetadata.createMetadata(new OffsetRange(0, values.length))));
+          for (int i = 0; i < values.length; ++i) {
+            rval.add(KV.of((long) i, ValueOrMetadata.create(values[i])));
+          }
+        }
+      } else if (View.AsMap.class.equals(viewTransformClass.getClass())) {
+        for (Object value : values) {
+          rval.add(value);
+        }
+      } else if (View.AsMultimap.class.equals(viewTransformClass.getClass())) {
+        for (Object value : values) {
+          rval.add(value);
+        }
+      } else {
+        throw new IllegalArgumentException(
+            String.format(
+                "Unknown type of view %s. Supported views are %s.",
+                viewTransformClass.getClass(),
+                ImmutableSet.of(
+                    View.AsSingleton.class,
+                    View.AsIterable.class,
+                    View.AsList.class,
+                    View.AsMap.class,
+                    View.AsMultimap.class)));
       }
     } else {
-      throw new IllegalArgumentException(
-          String.format(
-              "Unknown type of view %s. Supported views are %s.",
-              viewTransformClass.getClass(),
-              ImmutableSet.of(
-                  View.AsSingleton.class,
-                  View.AsIterable.class,
-                  View.AsList.class,
-                  View.AsMap.class,
-                  View.AsMultimap.class)));
+      if (View.AsSingleton.class.equals(viewTransformClass.getClass())) {
+        for (Object value : values) {
+          rval.add(KV.of(null, value));
+        }
+      } else if (View.AsIterable.class.equals(viewTransformClass.getClass())) {
+        for (Object value : values) {
+          rval.add(KV.of(null, value));
+        }
+      } else if (View.AsList.class.equals(viewTransformClass.getClass())) {
+        for (Object value : values) {
+          rval.add(KV.of(null, value));
+        }
+      } else if (View.AsMap.class.equals(viewTransformClass.getClass())) {
+        for (Object value : values) {
+          rval.add(KV.of(null, value));
+        }
+      } else if (View.AsMultimap.class.equals(viewTransformClass.getClass())) {
+        for (Object value : values) {
+          rval.add(KV.of(null, value));
+        }
+      } else {
+        throw new IllegalArgumentException(
+            String.format(
+                "Unknown type of view %s. Supported views are %s.",
+                viewTransformClass.getClass(),
+                ImmutableSet.of(
+                    View.AsSingleton.class,
+                    View.AsIterable.class,
+                    View.AsList.class,
+                    View.AsMap.class,
+                    View.AsMultimap.class)));
+      }
     }
     return Collections.unmodifiableList(rval);
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ViewTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ViewTest.java
@@ -1236,7 +1236,8 @@ public class ViewTest implements Serializable {
                             c.output(
                                 KV.of(
                                     c.element(),
-                                    c.sideInput(view).get(c.element().substring(0, 1))));
+                                    c.sideInput(view)
+                                        .getOrDefault(c.element().substring(0, 1), 0)));
                           }
                         })
                     .withSideInputs(view));

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/values/PCollectionViewsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/values/PCollectionViewsTest.java
@@ -1,0 +1,270 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.values;
+
+import static org.apache.beam.sdk.values.PCollectionViews.computeOverlappingRanges;
+import static org.apache.beam.sdk.values.PCollectionViews.computePositionForIndex;
+import static org.apache.beam.sdk.values.PCollectionViews.computeTotalNumElements;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+import static org.junit.Assert.assertThrows;
+
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Random;
+import java.util.TreeSet;
+import java.util.stream.IntStream;
+import org.apache.beam.sdk.io.range.OffsetRange;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ArrayListMultimap;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ListMultimap;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link PCollectionViews}. */
+@RunWith(JUnit4.class)
+public class PCollectionViewsTest {
+  @Test
+  public void testEmpty() {
+    Iterable<OffsetRange> ranges = Collections.emptyList();
+
+    Map<OffsetRange, Integer> nonOverlappingRangesToNumElementsPerPosition =
+        computeOverlappingRanges(ranges);
+    assertEquals(nonOverlappingRangesToNumElementsPerPosition, Collections.emptyMap());
+    assertEquals(0, computeTotalNumElements(nonOverlappingRangesToNumElementsPerPosition));
+    assertThrows(
+        IndexOutOfBoundsException.class,
+        () -> computePositionForIndex(nonOverlappingRangesToNumElementsPerPosition, 0));
+  }
+
+  @Test
+  public void testNoOverlapping() {
+    Iterable<OffsetRange> ranges = Arrays.asList(range(0, 2), range(4, 6));
+
+    Map<OffsetRange, Integer> nonOverlappingRangesToNumElementsPerPosition =
+        computeOverlappingRanges(ranges);
+    assertEquals(
+        ImmutableMap.of(range(0, 2), 1, range(4, 6), 1),
+        nonOverlappingRangesToNumElementsPerPosition);
+    assertNonEmptyRangesAndPositions(ranges, nonOverlappingRangesToNumElementsPerPosition);
+  }
+
+  @Test
+  public void testOnlyTouchingRanges() {
+    Iterable<OffsetRange> ranges = Arrays.asList(range(0, 4), range(4, 8), range(8, 12));
+
+    Map<OffsetRange, Integer> nonOverlappingRangesToNumElementsPerPosition =
+        computeOverlappingRanges(ranges);
+    assertEquals(
+        ImmutableMap.of(range(0, 4), 1, range(4, 8), 1, range(8, 12), 1),
+        nonOverlappingRangesToNumElementsPerPosition);
+    assertNonEmptyRangesAndPositions(ranges, nonOverlappingRangesToNumElementsPerPosition);
+  }
+
+  @Test
+  public void testRangesWithAtMostOneOverlap() {
+    Iterable<OffsetRange> ranges = Arrays.asList(range(0, 6), range(4, 10), range(8, 12));
+
+    Map<OffsetRange, Integer> nonOverlappingRangesToNumElementsPerPosition =
+        computeOverlappingRanges(ranges);
+    assertEquals(
+        ImmutableMap.builder()
+            .put(range(0, 4), 1)
+            .put(range(4, 6), 2)
+            .put(range(6, 8), 1)
+            .put(range(8, 10), 2)
+            .put(range(10, 12), 1)
+            .build(),
+        nonOverlappingRangesToNumElementsPerPosition);
+    assertNonEmptyRangesAndPositions(ranges, nonOverlappingRangesToNumElementsPerPosition);
+  }
+
+  @Test
+  public void testOverlappingFroms() {
+    Iterable<OffsetRange> ranges = Arrays.asList(range(0, 4), range(0, 8), range(0, 12));
+
+    Map<OffsetRange, Integer> nonOverlappingRangesToNumElementsPerPosition =
+        computeOverlappingRanges(ranges);
+    assertEquals(
+        ImmutableMap.builder().put(range(0, 4), 3).put(range(4, 8), 2).put(range(8, 12), 1).build(),
+        nonOverlappingRangesToNumElementsPerPosition);
+    assertNonEmptyRangesAndPositions(ranges, nonOverlappingRangesToNumElementsPerPosition);
+  }
+
+  @Test
+  public void testOverlappingTos() {
+    Iterable<OffsetRange> ranges = Arrays.asList(range(0, 12), range(4, 12), range(8, 12));
+
+    Map<OffsetRange, Integer> nonOverlappingRangesToNumElementsPerPosition =
+        computeOverlappingRanges(ranges);
+    assertEquals(
+        ImmutableMap.builder().put(range(0, 4), 1).put(range(4, 8), 2).put(range(8, 12), 3).build(),
+        nonOverlappingRangesToNumElementsPerPosition);
+    assertNonEmptyRangesAndPositions(ranges, nonOverlappingRangesToNumElementsPerPosition);
+  }
+
+  @Test
+  public void testOverlappingFromsAndTos() {
+    Iterable<OffsetRange> ranges = Arrays.asList(range(0, 4), range(0, 4), range(0, 4));
+
+    Map<OffsetRange, Integer> nonOverlappingRangesToNumElementsPerPosition =
+        computeOverlappingRanges(ranges);
+    assertEquals(
+        ImmutableMap.builder().put(range(0, 4), 3).build(),
+        nonOverlappingRangesToNumElementsPerPosition);
+    assertNonEmptyRangesAndPositions(ranges, nonOverlappingRangesToNumElementsPerPosition);
+  }
+
+  @Test
+  public void testMultipleOverlapsForTheSameRange() {
+    Iterable<OffsetRange> ranges =
+        Arrays.asList(
+            range(0, 4),
+            range(0, 8),
+            range(0, 12),
+            range(0, 12),
+            range(4, 12),
+            range(8, 12),
+            range(0, 4),
+            range(0, 8),
+            range(0, 12),
+            range(0, 12),
+            range(4, 12),
+            range(8, 12));
+
+    Map<OffsetRange, Integer> nonOverlappingRangesToNumElementsPerPosition =
+        computeOverlappingRanges(ranges);
+    assertEquals(
+        ImmutableMap.builder().put(range(0, 4), 8).put(range(4, 8), 8).put(range(8, 12), 8).build(),
+        nonOverlappingRangesToNumElementsPerPosition);
+    assertNonEmptyRangesAndPositions(ranges, nonOverlappingRangesToNumElementsPerPosition);
+  }
+
+  @Test
+  public void testIncreasingOverlaps() {
+    Iterable<OffsetRange> ranges =
+        Arrays.asList(range(0, 4), range(1, 5), range(2, 6), range(3, 7), range(4, 8), range(5, 9));
+
+    Map<OffsetRange, Integer> nonOverlappingRangesToNumElementsPerPosition =
+        computeOverlappingRanges(ranges);
+    assertEquals(
+        ImmutableMap.builder()
+            .put(range(0, 1), 1)
+            .put(range(1, 2), 2)
+            .put(range(2, 3), 3)
+            .put(range(3, 4), 4)
+            .put(range(4, 5), 4)
+            .put(range(5, 6), 4)
+            .put(range(6, 7), 3)
+            .put(range(7, 8), 2)
+            .put(range(8, 9), 1)
+            .build(),
+        nonOverlappingRangesToNumElementsPerPosition);
+    assertNonEmptyRangesAndPositions(ranges, nonOverlappingRangesToNumElementsPerPosition);
+  }
+
+  @Test
+  public void testNestedOverlaps() {
+    Iterable<OffsetRange> ranges =
+        Arrays.asList(range(0, 8), range(1, 7), range(2, 6), range(3, 5));
+
+    Map<OffsetRange, Integer> nonOverlappingRangesToNumElementsPerPosition =
+        computeOverlappingRanges(ranges);
+    assertEquals(
+        ImmutableMap.builder()
+            .put(range(0, 1), 1)
+            .put(range(1, 2), 2)
+            .put(range(2, 3), 3)
+            .put(range(3, 5), 4)
+            .put(range(5, 6), 3)
+            .put(range(6, 7), 2)
+            .put(range(7, 8), 1)
+            .build(),
+        nonOverlappingRangesToNumElementsPerPosition);
+    assertNonEmptyRangesAndPositions(ranges, nonOverlappingRangesToNumElementsPerPosition);
+  }
+
+  @Test
+  public void testRandomRanges() {
+    Random random =
+        new Random(123892154890L); // use an arbitrary seed to make this test deterministic
+    for (int i = 0; i < 1000; ++i) {
+      List<OffsetRange> ranges = new ArrayList<>();
+      for (int j = 0; j < 20; ++j) {
+        long start = random.nextInt(10);
+        ranges.add(range(start, start + random.nextInt(10) + 1));
+        Map<OffsetRange, Integer> nonOverlappingRangesToNumElementsPerPosition =
+            computeOverlappingRanges(ranges);
+        assertNonEmptyRangesAndPositions(ranges, nonOverlappingRangesToNumElementsPerPosition);
+      }
+    }
+  }
+
+  private static OffsetRange range(long from, long to) {
+    return new OffsetRange(from, to);
+  }
+
+  private static void assertNonEmptyRangesAndPositions(
+      Iterable<OffsetRange> ranges,
+      Map<OffsetRange, Integer> nonOverlappingRangesToNumElementsPerPosition) {
+    for (Map.Entry<OffsetRange, Integer> entry :
+        nonOverlappingRangesToNumElementsPerPosition.entrySet()) {
+      assertNotEquals(0, (int) entry.getValue());
+    }
+
+    ListMultimap<Long, Integer> positions = ArrayListMultimap.create();
+    for (OffsetRange range : ranges) {
+      for (long i = range.getFrom(); i < range.getTo(); ++i) {
+        positions.put(i, 0);
+      }
+    }
+
+    int position = 0;
+    for (Long key : new TreeSet<>(positions.keySet())) {
+      int size = positions.get(key).size();
+      positions.replaceValues(
+          key, Lists.newArrayList(IntStream.range(position, position + size).iterator()));
+      position += size;
+    }
+
+    for (int i = 0; i < position; ++i) {
+      KV<Long, Integer> computedPosition =
+          computePositionForIndex(nonOverlappingRangesToNumElementsPerPosition, i);
+      assertEquals(
+          i, (int) positions.get(computedPosition.getKey()).get(computedPosition.getValue()));
+    }
+
+    assertThrows(
+        IndexOutOfBoundsException.class,
+        () -> computePositionForIndex(nonOverlappingRangesToNumElementsPerPosition, -1));
+
+    int totalNumberOfElements =
+        computeTotalNumElements(nonOverlappingRangesToNumElementsPerPosition);
+    assertEquals(position, totalNumberOfElements);
+    assertThrows(
+        IndexOutOfBoundsException.class,
+        () ->
+            computePositionForIndex(
+                nonOverlappingRangesToNumElementsPerPosition, totalNumberOfElements));
+  }
+}

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/IterableSideInput.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/IterableSideInput.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.fn.harness.state;
+
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.StateRequest;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.fn.stream.DataStreams;
+import org.apache.beam.sdk.transforms.Materializations.IterableView;
+import org.apache.beam.vendor.grpc.v1p26p0.com.google.protobuf.ByteString;
+
+/**
+ * An implementation of a iterable side input that utilizes the Beam Fn State API to fetch values.
+ *
+ * <p>TODO: Support block level caching and prefetch.
+ */
+public class IterableSideInput<T> implements IterableView<T> {
+
+  private final BeamFnStateClient beamFnStateClient;
+  private final String instructionId;
+  private final String ptransformId;
+  private final String sideInputId;
+  private final ByteString encodedWindow;
+  private final Coder<T> valueCoder;
+
+  public IterableSideInput(
+      BeamFnStateClient beamFnStateClient,
+      String instructionId,
+      String ptransformId,
+      String sideInputId,
+      ByteString encodedWindow,
+      Coder<T> valueCoder) {
+    this.beamFnStateClient = beamFnStateClient;
+    this.instructionId = instructionId;
+    this.ptransformId = ptransformId;
+    this.sideInputId = sideInputId;
+    this.encodedWindow = encodedWindow;
+    this.valueCoder = valueCoder;
+  }
+
+  @Override
+  public Iterable<T> get() {
+    StateRequest.Builder requestBuilder = StateRequest.newBuilder();
+    requestBuilder
+        .setInstructionId(instructionId)
+        .getStateKeyBuilder()
+        .getIterableSideInputBuilder()
+        .setTransformId(ptransformId)
+        .setSideInputId(sideInputId)
+        .setWindow(encodedWindow);
+
+    return new LazyCachingIteratorToIterable<>(
+        new DataStreams.DataStreamDecoder(
+            valueCoder,
+            DataStreams.inbound(
+                StateFetchingIterators.readAllStartingFrom(
+                    beamFnStateClient, requestBuilder.build()))));
+  }
+}

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/SideInputSpec.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/SideInputSpec.java
@@ -24,20 +24,24 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.WindowMappingFn;
 
 /**
- * A specification for side inputs containing a value {@link Coder}, the window {@link Coder},
- * {@link ViewFn}, and the {@link WindowMappingFn}.
+ * A specification for side inputs containing the access pattern, a value {@link Coder}, the window
+ * {@link Coder}, the {@link ViewFn}, and the {@link WindowMappingFn}.
  *
  * @param <W>
  */
 @AutoValue
 public abstract class SideInputSpec<W extends BoundedWindow> {
   public static <W extends BoundedWindow> SideInputSpec create(
+      String accessPattern,
       Coder<?> coder,
       Coder<W> windowCoder,
       ViewFn<?, ?> viewFn,
       WindowMappingFn<W> windowMappingFn) {
-    return new AutoValue_SideInputSpec<>(coder, windowCoder, viewFn, windowMappingFn);
+    return new AutoValue_SideInputSpec<>(
+        accessPattern, coder, windowCoder, viewFn, windowMappingFn);
   }
+
+  abstract String getAccessPattern();
 
   abstract Coder<?> getCoder();
 

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
@@ -1609,6 +1609,9 @@ public class FnApiDoFnRunnerTest implements Serializable {
   @Test
   public void testProcessElementForWindowedSizedElementAndRestriction() throws Exception {
     Pipeline p = Pipeline.create();
+    addExperiment(p.getOptions().as(ExperimentalOptions.class), "beam_fn_api");
+    // TODO(BEAM-10097): Remove experiment once all portable runners support this view type
+    addExperiment(p.getOptions().as(ExperimentalOptions.class), "use_runner_v2");
     PCollection<String> valuePCollection = p.apply(Create.of("unused"));
     PCollectionView<String> singletonSideInputView = valuePCollection.apply(View.asSingleton());
     TestSplittableDoFn doFn = new TestSplittableDoFn(singletonSideInputView);
@@ -1665,7 +1668,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
 
     ImmutableMap<StateKey, ByteString> stateData =
         ImmutableMap.of(
-            multimapSideInputKey(singletonSideInputView.getTagInternal().getId(), ByteString.EMPTY),
+            iterableSideInputKey(singletonSideInputView.getTagInternal().getId(), ByteString.EMPTY),
             encode("8"));
 
     FakeBeamFnStateClient fakeClient = new FakeBeamFnStateClient(stateData);


### PR DESCRIPTION
This only impacts Dataflow runner v2 since the new expansions are guarded by the experiment "beam_fn_api" and "use_runner_v2".

This currently has little benefit for portable runners since they still treat all views as in memory iterables of values but opens the door for them once we can remove the requirement on the "use_runner_v2" experiment. I did the pre-work to fill in the iterable support for non-Dataflow portable runners but it isn't exercised.

This builds on prior work for exposing iterable and multimap views to runners in BEAM-3419

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
