### PR TITLE
[BEAM-9322] Modify the TestStream to output a dict when no output_tags are specified

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/caching/streaming_cache.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/streaming_cache.py
@@ -304,18 +304,6 @@ class StreamingCache(CacheManager):
       return iter([]), -1
     return StreamingCache.Reader([header], [reader]).read(), 1
 
-  @staticmethod
-  def sentinel_label():
-    """Returns a label that marks an unused PCollection.
-
-    This is used to always use a TestStream with multiple outputs. The reason is
-    that the TestStream does not allow for control over output tags if there is
-    only a single output. This allows for the InteractiveRunner to use the
-    output tags as cache keys.
-    """
-    from apache_beam.runners.interactive.pipeline_instrument import CacheKey
-    return repr(CacheKey('synthetic_sentinel', '0', '0', '0'))
-
   def read_multiple(self, labels):
     """Returns a generator to read all records from file.
 
@@ -327,7 +315,6 @@ class StreamingCache(CacheManager):
         StreamingCacheSource(self._cache_dir, l,
                              self._is_cache_complete).read(tail=True)
         for l in labels
-        if not [sub_l for sub_l in l if self.sentinel_label() in sub_l]
     ]
     headers = [next(r) for r in readers]
     return StreamingCache.Reader(headers, readers).read()

--- a/sdks/python/apache_beam/runners/interactive/caching/streaming_cache_test.py
+++ b/sdks/python/apache_beam/runners/interactive/caching/streaming_cache_test.py
@@ -251,8 +251,7 @@ class StreamingCacheTest(unittest.TestCase):
 
     # Units here are in seconds.
     test_stream = (
-        TestStream(output_tags=(CACHED_RECORDS,
-                                StreamingCache.sentinel_label()))
+        TestStream(output_tags=(CACHED_RECORDS))
                    .advance_watermark_to(0, tag=CACHED_RECORDS)
                    .advance_processing_time(5)
                    .add_elements(['a', 'b', 'c'], tag=CACHED_RECORDS)

--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument.py
@@ -720,7 +720,6 @@ class PipelineInstrument(object):
       # the output tags for the TestStream. This is to remember what cache-key
       # is associated with which PCollection.
       output_tags = v.unbounded_pcolls
-      output_tags.add(self._cache_manager.sentinel_label())
 
       # Take the PCollections that will be read from the TestStream and insert
       # them back into the dictionary of cached PCollections. The next step will

--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument.py
@@ -720,6 +720,7 @@ class PipelineInstrument(object):
       # the output tags for the TestStream. This is to remember what cache-key
       # is associated with which PCollection.
       output_tags = v.unbounded_pcolls
+      output_tags.add(self._cache_manager.sentinel_label())
 
       # Take the PCollections that will be read from the TestStream and insert
       # them back into the dictionary of cached PCollections. The next step will
@@ -728,11 +729,8 @@ class PipelineInstrument(object):
       if output_tags:
         output_pcolls = pipeline | test_stream.TestStream(
             output_tags=output_tags, coder=self._cache_manager._default_pcoder)
-        if len(output_tags) == 1:
-          self._cached_pcoll_read[list(output_tags)[0]] = output_pcolls
-        else:
-          for tag, pcoll in output_pcolls.items():
-            self._cached_pcoll_read[tag] = pcoll
+        for tag, pcoll in output_pcolls.items():
+          self._cached_pcoll_read[tag] = pcoll
 
     class ReadCacheWireVisitor(PipelineVisitor):
       """Visitor wires cache read as inputs to replace corresponding original

--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
@@ -31,7 +31,7 @@ from apache_beam.runners.interactive import interactive_beam as ib
 from apache_beam.runners.interactive import interactive_environment as ie
 from apache_beam.runners.interactive import pipeline_instrument as instr
 from apache_beam.runners.interactive import interactive_runner
-from apache_beam.runners.interactive.caching import streaming_cache
+from apache_beam.runners.interactive.caching.streaming_cache import StreamingCache
 from apache_beam.runners.interactive.testing.pipeline_assertion import assert_pipeline_equal
 from apache_beam.runners.interactive.testing.pipeline_assertion import assert_pipeline_proto_contain_top_level_transform
 from apache_beam.runners.interactive.testing.pipeline_assertion import assert_pipeline_proto_equal
@@ -162,7 +162,7 @@ class PipelineInstrumentTest(unittest.TestCase):
     self.assertFalse(instr.has_unbounded_sources(p))
 
   def test_background_caching_pipeline_proto(self):
-    ie.new_env(cache_manager=streaming_cache.StreamingCache(cache_dir=None))
+    ie.new_env(cache_manager=StreamingCache(cache_dir=None))
     p = beam.Pipeline(interactive_runner.InteractiveRunner())
 
     # Test that the two ReadFromPubSub are correctly cut out.
@@ -309,7 +309,7 @@ class PipelineInstrumentTest(unittest.TestCase):
     """Tests that the instrumenter works for a single unbounded source.
     """
     # Create a new interactive environment to make the test idempotent.
-    ie.new_env(cache_manager=streaming_cache.StreamingCache(cache_dir=None))
+    ie.new_env(cache_manager=StreamingCache(cache_dir=None))
 
     # Create the pipeline that will be instrumented.
     p_original = beam.Pipeline(interactive_runner.InteractiveRunner())
@@ -340,9 +340,10 @@ class PipelineInstrumentTest(unittest.TestCase):
     p_expected = beam.Pipeline()
     test_stream = (
         p_expected
-        | TestStream(output_tags=[self.cache_key_of('source_1', source_1)]))
+        | TestStream(
+            output_tags=[source_1_cache_key, StreamingCache.sentinel_label()]))
     # pylint: disable=expression-not-assigned
-    test_stream | 'square1' >> beam.Map(lambda x: x * x)
+    test_stream[source_1_cache_key] | 'square1' >> beam.Map(lambda x: x * x)
 
     # Test that the TestStream is outputting to the correct PCollection.
     class TestStreamVisitor(PipelineVisitor):
@@ -359,7 +360,8 @@ class PipelineInstrumentTest(unittest.TestCase):
 
     v = TestStreamVisitor()
     actual_pipeline.visit(v)
-    expected_output_tags = set([source_1_cache_key])
+    expected_output_tags = set(
+        [source_1_cache_key, StreamingCache.sentinel_label()])
     actual_output_tags = v.output_tags
     self.assertSetEqual(expected_output_tags, actual_output_tags)
 
@@ -377,7 +379,7 @@ class PipelineInstrumentTest(unittest.TestCase):
     is taken care of.
     """
     # Create a new interactive environment to make the test idempotent.
-    ie.new_env(cache_manager=streaming_cache.StreamingCache(cache_dir=None))
+    ie.new_env(cache_manager=StreamingCache(cache_dir=None))
 
     # Create the pipeline that will be instrumented.
     from apache_beam.options.pipeline_options import StandardOptions
@@ -425,10 +427,14 @@ class PipelineInstrumentTest(unittest.TestCase):
 
     test_stream = (
         p_expected
-        | TestStream(output_tags=[intermediate_source_pcoll_cache_key]))
+        | TestStream(
+            output_tags=[
+                intermediate_source_pcoll_cache_key,
+                StreamingCache.sentinel_label()
+            ]))
     # pylint: disable=expression-not-assigned
     (
-        test_stream
+        test_stream[intermediate_source_pcoll_cache_key]
         | 'square1' >> beam.Map(lambda e: e)
         | 'reify' >> beam.Map(lambda _: _)
         | cache.WriteCache(ie.current_env().cache_manager(), 'unused'))
@@ -448,7 +454,8 @@ class PipelineInstrumentTest(unittest.TestCase):
 
     v = TestStreamVisitor()
     actual_pipeline.visit(v)
-    expected_output_tags = set([intermediate_source_pcoll_cache_key])
+    expected_output_tags = set(
+        [intermediate_source_pcoll_cache_key, StreamingCache.sentinel_label()])
     actual_output_tags = v.output_tags
     self.assertSetEqual(expected_output_tags, actual_output_tags)
 
@@ -465,7 +472,7 @@ class PipelineInstrumentTest(unittest.TestCase):
     TestStream.
     """
     # Create a new interactive environment to make the test idempotent.
-    ie.new_env(cache_manager=streaming_cache.StreamingCache(cache_dir=None))
+    ie.new_env(cache_manager=StreamingCache(cache_dir=None))
 
     # Create the pipeline that will be instrumented.
     from apache_beam.options.pipeline_options import StandardOptions
@@ -505,7 +512,12 @@ class PipelineInstrumentTest(unittest.TestCase):
 
     test_stream = (
         p_expected
-        | TestStream(output_tags=[source_1_cache_key, source_2_cache_key]))
+        | TestStream(
+            output_tags=[
+                source_1_cache_key,
+                source_2_cache_key,
+                StreamingCache.sentinel_label()
+            ]))
     # pylint: disable=expression-not-assigned
     ((
         test_stream[self.cache_key_of('source_1', source_1)],
@@ -530,7 +542,9 @@ class PipelineInstrumentTest(unittest.TestCase):
 
     v = TestStreamVisitor()
     actual_pipeline.visit(v)
-    expected_output_tags = set([source_1_cache_key, source_2_cache_key])
+    expected_output_tags = set([
+        source_1_cache_key, source_2_cache_key, StreamingCache.sentinel_label()
+    ])
     actual_output_tags = v.output_tags
     self.assertSetEqual(expected_output_tags, actual_output_tags)
 
@@ -544,7 +558,7 @@ class PipelineInstrumentTest(unittest.TestCase):
     """Tests that the it caches PCollections from a source.
     """
     # Create a new interactive environment to make the test idempotent.
-    ie.new_env(cache_manager=streaming_cache.StreamingCache(cache_dir=None))
+    ie.new_env(cache_manager=StreamingCache(cache_dir=None))
 
     # Create the pipeline that will be instrumented.
     from apache_beam.options.pipeline_options import StandardOptions
@@ -576,7 +590,11 @@ class PipelineInstrumentTest(unittest.TestCase):
     # pylint: disable=unused-variable
     test_stream = (
         p_expected
-        | TestStream(output_tags=[self.cache_key_of('source_1', source_1)]))
+        | TestStream(
+            output_tags=[
+                self.cache_key_of('source_1', source_1),
+                StreamingCache.sentinel_label()
+            ]))
 
     # Test that the TestStream is outputting to the correct PCollection.
     class TestStreamVisitor(PipelineVisitor):
@@ -593,7 +611,8 @@ class PipelineInstrumentTest(unittest.TestCase):
 
     v = TestStreamVisitor()
     actual_pipeline.visit(v)
-    expected_output_tags = set([source_1_cache_key])
+    expected_output_tags = set(
+        [source_1_cache_key, StreamingCache.sentinel_label()])
     actual_output_tags = v.output_tags
     self.assertSetEqual(expected_output_tags, actual_output_tags)
 
@@ -607,7 +626,7 @@ class PipelineInstrumentTest(unittest.TestCase):
     """Tests that the instrumenter works when the PCollection is not cached.
     """
     # Create a new interactive environment to make the test idempotent.
-    ie.new_env(cache_manager=streaming_cache.StreamingCache(cache_dir=None))
+    ie.new_env(cache_manager=StreamingCache(cache_dir=None))
 
     # Create the pipeline that will be instrumented.
     from apache_beam.options.pipeline_options import StandardOptions
@@ -638,10 +657,11 @@ class PipelineInstrumentTest(unittest.TestCase):
     p_expected = beam.Pipeline()
     test_stream = (
         p_expected
-        | TestStream(output_tags=[self.cache_key_of('source_1', source_1)]))
+        | TestStream(
+            output_tags=[source_1_cache_key, StreamingCache.sentinel_label()]))
     # pylint: disable=expression-not-assigned
     (
-        test_stream
+        test_stream[source_1_cache_key]
         | 'square1' >> beam.Map(lambda x: x * x)
         | 'reify' >> beam.Map(lambda _: _)
         | cache.WriteCache(ie.current_env().cache_manager(), 'unused'))
@@ -661,7 +681,8 @@ class PipelineInstrumentTest(unittest.TestCase):
 
     v = TestStreamVisitor()
     actual_pipeline.visit(v)
-    expected_output_tags = set([source_1_cache_key])
+    expected_output_tags = set(
+        [source_1_cache_key, StreamingCache.sentinel_label()])
     actual_output_tags = v.output_tags
     self.assertSetEqual(expected_output_tags, actual_output_tags)
 
@@ -675,7 +696,7 @@ class PipelineInstrumentTest(unittest.TestCase):
     """Tests that the instrumenter works for multiple unbounded sources.
     """
     # Create a new interactive environment to make the test idempotent.
-    ie.new_env(cache_manager=streaming_cache.StreamingCache(cache_dir=None))
+    ie.new_env(cache_manager=StreamingCache(cache_dir=None))
 
     # Create the pipeline that will be instrumented.
     p_original = beam.Pipeline(interactive_runner.InteractiveRunner())
@@ -714,7 +735,8 @@ class PipelineInstrumentTest(unittest.TestCase):
         | TestStream(
             output_tags=[
                 self.cache_key_of('source_1', source_1),
-                self.cache_key_of('source_2', source_2)
+                self.cache_key_of('source_2', source_2),
+                StreamingCache.sentinel_label(),
             ]))
     # pylint: disable=expression-not-assigned
     test_stream[source_1_cache_key] | 'square1' >> beam.Map(lambda x: x * x)
@@ -736,7 +758,9 @@ class PipelineInstrumentTest(unittest.TestCase):
 
     v = TestStreamVisitor()
     actual_pipeline.visit(v)
-    expected_output_tags = set([source_1_cache_key, source_2_cache_key])
+    expected_output_tags = set([
+        source_1_cache_key, source_2_cache_key, StreamingCache.sentinel_label()
+    ])
     actual_output_tags = v.output_tags
     self.assertSetEqual(expected_output_tags, actual_output_tags)
 

--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
@@ -338,9 +338,7 @@ class PipelineInstrumentTest(unittest.TestCase):
     # a TestStream.
     source_1_cache_key = self.cache_key_of('source_1', source_1)
     p_expected = beam.Pipeline()
-    test_stream = (
-        p_expected
-        | TestStream(output_tags=[source_1_cache_key]))
+    test_stream = (p_expected | TestStream(output_tags=[source_1_cache_key]))
     # pylint: disable=expression-not-assigned
     test_stream[source_1_cache_key] | 'square1' >> beam.Map(lambda x: x * x)
 
@@ -636,9 +634,7 @@ class PipelineInstrumentTest(unittest.TestCase):
     # a TestStream.
     source_1_cache_key = self.cache_key_of('source_1', source_1)
     p_expected = beam.Pipeline()
-    test_stream = (
-        p_expected
-        | TestStream(output_tags=[source_1_cache_key]))
+    test_stream = (p_expected | TestStream(output_tags=[source_1_cache_key]))
     # pylint: disable=expression-not-assigned
     (
         test_stream[source_1_cache_key]

--- a/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
+++ b/sdks/python/apache_beam/runners/interactive/pipeline_instrument_test.py
@@ -340,8 +340,7 @@ class PipelineInstrumentTest(unittest.TestCase):
     p_expected = beam.Pipeline()
     test_stream = (
         p_expected
-        | TestStream(
-            output_tags=[source_1_cache_key, StreamingCache.sentinel_label()]))
+        | TestStream(output_tags=[source_1_cache_key]))
     # pylint: disable=expression-not-assigned
     test_stream[source_1_cache_key] | 'square1' >> beam.Map(lambda x: x * x)
 
@@ -360,8 +359,7 @@ class PipelineInstrumentTest(unittest.TestCase):
 
     v = TestStreamVisitor()
     actual_pipeline.visit(v)
-    expected_output_tags = set(
-        [source_1_cache_key, StreamingCache.sentinel_label()])
+    expected_output_tags = set([source_1_cache_key])
     actual_output_tags = v.output_tags
     self.assertSetEqual(expected_output_tags, actual_output_tags)
 
@@ -427,11 +425,7 @@ class PipelineInstrumentTest(unittest.TestCase):
 
     test_stream = (
         p_expected
-        | TestStream(
-            output_tags=[
-                intermediate_source_pcoll_cache_key,
-                StreamingCache.sentinel_label()
-            ]))
+        | TestStream(output_tags=[intermediate_source_pcoll_cache_key]))
     # pylint: disable=expression-not-assigned
     (
         test_stream[intermediate_source_pcoll_cache_key]
@@ -454,8 +448,7 @@ class PipelineInstrumentTest(unittest.TestCase):
 
     v = TestStreamVisitor()
     actual_pipeline.visit(v)
-    expected_output_tags = set(
-        [intermediate_source_pcoll_cache_key, StreamingCache.sentinel_label()])
+    expected_output_tags = set([intermediate_source_pcoll_cache_key])
     actual_output_tags = v.output_tags
     self.assertSetEqual(expected_output_tags, actual_output_tags)
 
@@ -512,12 +505,7 @@ class PipelineInstrumentTest(unittest.TestCase):
 
     test_stream = (
         p_expected
-        | TestStream(
-            output_tags=[
-                source_1_cache_key,
-                source_2_cache_key,
-                StreamingCache.sentinel_label()
-            ]))
+        | TestStream(output_tags=[source_1_cache_key, source_2_cache_key]))
     # pylint: disable=expression-not-assigned
     ((
         test_stream[self.cache_key_of('source_1', source_1)],
@@ -542,9 +530,7 @@ class PipelineInstrumentTest(unittest.TestCase):
 
     v = TestStreamVisitor()
     actual_pipeline.visit(v)
-    expected_output_tags = set([
-        source_1_cache_key, source_2_cache_key, StreamingCache.sentinel_label()
-    ])
+    expected_output_tags = set([source_1_cache_key, source_2_cache_key])
     actual_output_tags = v.output_tags
     self.assertSetEqual(expected_output_tags, actual_output_tags)
 
@@ -590,11 +576,7 @@ class PipelineInstrumentTest(unittest.TestCase):
     # pylint: disable=unused-variable
     test_stream = (
         p_expected
-        | TestStream(
-            output_tags=[
-                self.cache_key_of('source_1', source_1),
-                StreamingCache.sentinel_label()
-            ]))
+        | TestStream(output_tags=[self.cache_key_of('source_1', source_1)]))
 
     # Test that the TestStream is outputting to the correct PCollection.
     class TestStreamVisitor(PipelineVisitor):
@@ -611,8 +593,7 @@ class PipelineInstrumentTest(unittest.TestCase):
 
     v = TestStreamVisitor()
     actual_pipeline.visit(v)
-    expected_output_tags = set(
-        [source_1_cache_key, StreamingCache.sentinel_label()])
+    expected_output_tags = set([source_1_cache_key])
     actual_output_tags = v.output_tags
     self.assertSetEqual(expected_output_tags, actual_output_tags)
 
@@ -657,8 +638,7 @@ class PipelineInstrumentTest(unittest.TestCase):
     p_expected = beam.Pipeline()
     test_stream = (
         p_expected
-        | TestStream(
-            output_tags=[source_1_cache_key, StreamingCache.sentinel_label()]))
+        | TestStream(output_tags=[source_1_cache_key]))
     # pylint: disable=expression-not-assigned
     (
         test_stream[source_1_cache_key]
@@ -681,8 +661,7 @@ class PipelineInstrumentTest(unittest.TestCase):
 
     v = TestStreamVisitor()
     actual_pipeline.visit(v)
-    expected_output_tags = set(
-        [source_1_cache_key, StreamingCache.sentinel_label()])
+    expected_output_tags = set([source_1_cache_key])
     actual_output_tags = v.output_tags
     self.assertSetEqual(expected_output_tags, actual_output_tags)
 
@@ -735,8 +714,7 @@ class PipelineInstrumentTest(unittest.TestCase):
         | TestStream(
             output_tags=[
                 self.cache_key_of('source_1', source_1),
-                self.cache_key_of('source_2', source_2),
-                StreamingCache.sentinel_label(),
+                self.cache_key_of('source_2', source_2)
             ]))
     # pylint: disable=expression-not-assigned
     test_stream[source_1_cache_key] | 'square1' >> beam.Map(lambda x: x * x)
@@ -758,9 +736,7 @@ class PipelineInstrumentTest(unittest.TestCase):
 
     v = TestStreamVisitor()
     actual_pipeline.visit(v)
-    expected_output_tags = set([
-        source_1_cache_key, source_2_cache_key, StreamingCache.sentinel_label()
-    ])
+    expected_output_tags = set([source_1_cache_key, source_2_cache_key])
     actual_output_tags = v.output_tags
     self.assertSetEqual(expected_output_tags, actual_output_tags)
 

--- a/sdks/python/apache_beam/testing/test_stream.py
+++ b/sdks/python/apache_beam/testing/test_stream.py
@@ -291,10 +291,10 @@ class TestStream(PTransform):
     assert isinstance(pbegin, pvalue.PBegin)
     self.pipeline = pbegin.pipeline
     if not self.output_tags:
-      self.output_tags = set([None])
+      self.output_tags = {None}
 
     # For backwards compatibility return a single PCollection.
-    if len(self.output_tags) == 1:
+    if self.output_tags == {None}:
       return pvalue.PCollection(
           self.pipeline, is_bounded=False, tag=list(self.output_tags)[0])
     return {


### PR DESCRIPTION
Change-Id: I6a8eba4e323bf0fff318a56e44e512916c06266f

https://github.com/apache/beam/pull/11765 removes the ability to set the output id on TestStreams with single outputs. This PR allows for setting the tags on single outputs by returning a dict in the expand when output_tags is not specified, i.e. when output_tags = {NONE}.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
