### PR TITLE
[BEAM-10051] Scope instruction data. 

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/harness/datamgr.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/datamgr.go
@@ -38,8 +38,6 @@ type ScopedDataManager struct {
 	mgr    *DataChannelManager
 	instID instructionID
 
-	// TODO(herohde) 7/20/2018: capture and force close open reads/writes. However,
-	// we would need the underlying Close to be idempotent or a separate method.
 	closed bool
 	mu     sync.Mutex
 }
@@ -82,9 +80,10 @@ func (s *ScopedDataManager) open(ctx context.Context, port exec.Port) (*DataChan
 // Close prevents new IO for this instruction.
 func (s *ScopedDataManager) Close() error {
 	s.mu.Lock()
+	defer s.mu.Unlock()
 	s.closed = true
+	s.mgr.closeInstruction(s.instID)
 	s.mgr = nil
-	s.mu.Unlock()
 	return nil
 }
 
@@ -125,6 +124,14 @@ func (m *DataChannelManager) Open(ctx context.Context, port exec.Port) (*DataCha
 	return ch, nil
 }
 
+func (m *DataChannelManager) closeInstruction(instID instructionID) {
+	m.mu.Lock()
+	defer m.mu.Unlock()
+	for _, ch := range m.ports {
+		ch.removeInstruction(instID)
+	}
+}
+
 // clientID identifies a client of a connected channel.
 type clientID struct {
 	ptransformID string
@@ -148,8 +155,13 @@ type DataChannel struct {
 	id     string
 	client dataClient
 
-	writers map[clientID]*dataWriter
-	readers map[clientID]*dataReader
+	writers map[instructionID]map[string]*dataWriter
+	readers map[instructionID]map[string]*dataReader
+
+	// recently terminated instructions
+	endedInstructions map[instructionID]struct{}
+	rmQueue           []instructionID
+
 	// readErr indicates a client.Recv error and is used to prevent new readers.
 	readErr error
 
@@ -178,11 +190,12 @@ func newDataChannel(ctx context.Context, port exec.Port) (*DataChannel, error) {
 
 func makeDataChannel(ctx context.Context, id string, client dataClient, cancelFn context.CancelFunc) *DataChannel {
 	ret := &DataChannel{
-		id:       id,
-		client:   client,
-		writers:  make(map[clientID]*dataWriter),
-		readers:  make(map[clientID]*dataReader),
-		cancelFn: cancelFn,
+		id:                id,
+		client:            client,
+		writers:           make(map[instructionID]map[string]*dataWriter),
+		readers:           make(map[instructionID]map[string]*dataReader),
+		endedInstructions: make(map[instructionID]struct{}),
+		cancelFn:          cancelFn,
 	}
 	go ret.read(ctx)
 
@@ -227,14 +240,16 @@ func (c *DataChannel) read(ctx context.Context) {
 			// close the r.buf channels twice, or send on a closed channel.
 			// Any other approach is racy, and may cause one of the above
 			// panics.
-			for _, r := range c.readers {
-				log.Errorf(ctx, "DataChannel.read %v reader %v closing due to error on channel", c.id, r.id)
-				if !r.completed {
-					r.completed = true
-					r.err = err
-					close(r.buf)
+			for _, m := range c.readers {
+				for _, r := range m {
+					log.Errorf(ctx, "DataChannel.read %v reader %v closing due to error on channel", c.id, r.id)
+					if !r.completed {
+						r.completed = true
+						r.err = err
+						close(r.buf)
+					}
+					delete(cache, r.id)
 				}
-				delete(cache, r.id)
 			}
 			c.terminateStreamOnError(err)
 			c.mu.Unlock()
@@ -319,31 +334,95 @@ func (r *errReader) Close() error {
 
 // makeReader creates a dataReader. It expects to be called while c.mu is held.
 func (c *DataChannel) makeReader(ctx context.Context, id clientID) *dataReader {
-	if r, ok := c.readers[id]; ok {
+	var m map[string]*dataReader
+	var ok bool
+	if m, ok = c.readers[id.instID]; !ok {
+		m = make(map[string]*dataReader)
+		c.readers[id.instID] = m
+	}
+
+	if r, ok := m[id.ptransformID]; ok {
 		return r
 	}
 
 	r := &dataReader{id: id, buf: make(chan []byte, bufElements), done: make(chan bool, 1), channel: c}
-	c.readers[id] = r
+
+	// Just in case initial data for an instructionsarrives *after* an instructon has ended.
+	// eg. it was blocked by another reader being slow, or the other instruction failed.
+	// So we provide a pre-completed reader, and do not cache it, as there's no further cleanup for it.
+	if _, ok := c.endedInstructions[id.instID]; ok {
+		r.completed = true
+		close(r.buf)
+		r.err = io.EOF // In of any actual data readers, so they terminate without error.
+		return r
+	}
+
+	m[id.ptransformID] = r
 	return r
 }
 
 func (c *DataChannel) removeReader(id clientID) {
 	c.mu.Lock()
-	delete(c.readers, id)
+	if m, ok := c.readers[id.instID]; ok {
+		delete(m, id.ptransformID)
+	}
 	c.mu.Unlock()
+}
+
+const endedInstructionCap = 32
+
+// removeInstruction closes all readers and writers registered for the instruction
+// and deletes this instruction from the channel's reader and writer maps.
+func (c *DataChannel) removeInstruction(instID instructionID) {
+	c.mu.Lock()
+
+	// We don't want to leak memory, so cap the endedInstructions list.
+	if len(c.rmQueue) >= endedInstructionCap {
+		toRemove := c.rmQueue[0]
+		c.rmQueue = c.rmQueue[1:]
+		delete(c.endedInstructions, toRemove)
+	}
+	c.endedInstructions[instID] = struct{}{}
+	c.rmQueue = append(c.rmQueue, instID)
+
+	rs := c.readers[instID]
+	ws := c.writers[instID]
+
+	// Prevent other users while we iterate.
+	delete(c.readers, instID)
+	delete(c.writers, instID)
+	c.mu.Unlock()
+
+	// Close grabs the channel lock, so this must be outside the critical section.
+	for _, r := range rs {
+		r.Close()
+	}
+	for _, w := range ws {
+		w.Close()
+	}
 }
 
 func (c *DataChannel) makeWriter(ctx context.Context, id clientID) *dataWriter {
 	c.mu.Lock()
 	defer c.mu.Unlock()
 
-	if w, ok := c.writers[id]; ok {
+	var m map[string]*dataWriter
+	var ok bool
+	if m, ok = c.writers[id.instID]; !ok {
+		m = make(map[string]*dataWriter)
+		c.writers[id.instID] = m
+	}
+
+	if w, ok := m[id.ptransformID]; ok {
 		return w
 	}
 
+	// We don't check for ended instructions for writers, as writers
+	// can only be created if an instruction is in scope, and aren't
+	// runner or user directed.
+
 	w := &dataWriter{ch: c, id: id}
-	c.writers[id] = w
+	m[id.ptransformID] = w
 	return w
 }
 
@@ -389,9 +468,6 @@ func (r *dataReader) Read(buf []byte) (int, error) {
 	return n, nil
 }
 
-// TODO(herohde) 7/20/2018: we should probably either not be tracking writers or
-// make dataWriter threadsafe. Either case is likely a corruption generator.
-
 type dataWriter struct {
 	buf []byte
 
@@ -431,7 +507,7 @@ func (w *dataWriter) Close() error {
 	// Now acquire the locks since we're sending.
 	w.ch.mu.Lock()
 	defer w.ch.mu.Unlock()
-	delete(w.ch.writers, w.id)
+	delete(w.ch.writers[w.id.instID], w.id.ptransformID)
 	msg := &fnpb.Elements{
 		Data: []*fnpb.Elements_Data{
 			{

--- a/sdks/go/pkg/beam/core/runtime/harness/datamgr.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/datamgr.go
@@ -347,13 +347,13 @@ func (c *DataChannel) makeReader(ctx context.Context, id clientID) *dataReader {
 
 	r := &dataReader{id: id, buf: make(chan []byte, bufElements), done: make(chan bool, 1), channel: c}
 
-	// Just in case initial data for an instructionsarrives *after* an instructon has ended.
+	// Just in case initial data for an instruction arrives *after* an instructon has ended.
 	// eg. it was blocked by another reader being slow, or the other instruction failed.
 	// So we provide a pre-completed reader, and do not cache it, as there's no further cleanup for it.
 	if _, ok := c.endedInstructions[id.instID]; ok {
 		r.completed = true
 		close(r.buf)
-		r.err = io.EOF // In of any actual data readers, so they terminate without error.
+		r.err = io.EOF // In case of any actual data readers, so they terminate without error.
 		return r
 	}
 


### PR DESCRIPTION
Make DataChannels instruction scope aware so that whenever data arrives, it will either be used, or safely dropped.

In particular, the start of an instruction isn't coupled to when the data will arrive. So there are a few cases that needed particular handling.

* Happy Path: Instruction starts processing, creating a reader, and starts to read data before any data arrives.
   * This case was handled very well already.
* Initial data arrives before instruction start, and reader creation.
  * This case was also handled well, data would be cached, and eventually cause push back until the instruction requests a reader, at which point it's the same as the happy path.
* Initial data arrives and instruction never creates a reader.
  * This can happen if there are issues initializing a DoFn in Setup or StartBundle. This can cause the worker to be hung for other bundles.
* Initial data arrives after instruction ends.
  * Similarly to the never creates a reader case, this can cause a hung worker. The data channel needs to be aware at least temporarily that the instruction is over and shouldn't create readers for it.

When the ScopedDataManager is closed, all channels are notified to remove the instruction and close the readers and writers. 
At the point in the stack where ScopedDataMana

ger is closed, readers needed to be handled carefully, but writers do not. Writers are only created by the DataSink node, and managed by the framework. In particular, if the writer was already closed, it would have removed themselves from the writer map on the Close call, preventing the ScopedDataManager from a double close. Otherwise, the writer would be in the map (such as due to a panic preventing the ordinary close), and need closing.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
