### PR TITLE
[BEAM-10165] Cache and return error messages on pipeline failure.

### DIFF
--- a/sdks/python/apache_beam/runners/portability/local_job_service.py
+++ b/sdks/python/apache_beam/runners/portability/local_job_service.py
@@ -284,11 +284,12 @@ class BeamJob(abstract_job_service.AbstractBeamJob):
         self.set_state(beam_job_api_pb2.JobState.DONE)
         self.result = result
       except:  # pylint: disable=bare-except
-        self._log_queues.put(beam_job_api_pb2.JobMessage(
-              message_id=log_handler._next_id(),
-              time=time.strftime('%Y-%m-%d %H:%M:%S.'),
-              importance=beam_job_api_pb2.JobMessage.JOB_MESSAGE_ERROR,
-              message_text=traceback.format_exc()))
+        self._log_queues.put(
+            beam_job_api_pb2.JobMessage(
+                message_id=log_handler._next_id(),
+                time=time.strftime('%Y-%m-%d %H:%M:%S.'),
+                importance=beam_job_api_pb2.JobMessage.JOB_MESSAGE_ERROR,
+                message_text=traceback.format_exc()))
         _LOGGER.exception('Error running pipeline.')
         self.set_state(beam_job_api_pb2.JobState.FAILED)
         raise
@@ -327,7 +328,8 @@ class BeamJob(abstract_job_service.AbstractBeamJob):
     self._log_queues.append(log_queue)
     self._state_queues.append(log_queue)
 
-    for msg in itertools.chain(self._log_queues.cache(), self.with_state_history(_iter_queue(log_queue))):
+    for msg in itertools.chain(self._log_queues.cache(),
+                               self.with_state_history(_iter_queue(log_queue))):
       if isinstance(msg, tuple):
         assert len(msg) == 2 and isinstance(msg[0], int)
         current_state = msg[0]

--- a/sdks/python/apache_beam/runners/portability/local_job_service.py
+++ b/sdks/python/apache_beam/runners/portability/local_job_service.py
@@ -19,6 +19,7 @@
 from __future__ import absolute_import
 
 import concurrent.futures
+import itertools
 import logging
 import os
 import queue
@@ -167,8 +168,9 @@ class LocalJobServicer(abstract_job_service.AbstractJobServiceServicer):
 
     result = self._jobs[request.job_id].result
     monitoring_info_list = []
-    for mi in result._monitoring_infos_by_stage.values():
-      monitoring_info_list.extend(mi)
+    if result is not None:
+      for mi in result._monitoring_infos_by_stage.values():
+        monitoring_info_list.extend(mi)
 
     # Filter out system metrics
     user_monitoring_info_list = [
@@ -247,7 +249,7 @@ class BeamJob(abstract_job_service.AbstractBeamJob):
     self._artifact_staging_endpoint = artifact_staging_endpoint
     self._artifact_service = artifact_service
     self._state_queues = []  # type: List[queue.Queue]
-    self._log_queues = []  # type: List[queue.Queue]
+    self._log_queues = JobLogQueues()
     self.daemon = True
     self.result = None
 
@@ -272,7 +274,7 @@ class BeamJob(abstract_job_service.AbstractBeamJob):
 
   def _run_job(self):
     self.set_state(beam_job_api_pb2.JobState.RUNNING)
-    with JobLogHandler(self._log_queues):
+    with JobLogHandler(self._log_queues) as log_handler:
       self._update_dependencies()
       try:
         result = fn_runner.FnApiRunner(
@@ -282,8 +284,12 @@ class BeamJob(abstract_job_service.AbstractBeamJob):
         self.set_state(beam_job_api_pb2.JobState.DONE)
         self.result = result
       except:  # pylint: disable=bare-except
+        self._log_queues.put(beam_job_api_pb2.JobMessage(
+              message_id=log_handler._next_id(),
+              time=time.strftime('%Y-%m-%d %H:%M:%S.'),
+              importance=beam_job_api_pb2.JobMessage.JOB_MESSAGE_ERROR,
+              message_text=traceback.format_exc()))
         _LOGGER.exception('Error running pipeline.')
-        _LOGGER.exception(traceback)
         self.set_state(beam_job_api_pb2.JobState.FAILED)
         raise
 
@@ -321,7 +327,7 @@ class BeamJob(abstract_job_service.AbstractBeamJob):
     self._log_queues.append(log_queue)
     self._state_queues.append(log_queue)
 
-    for msg in self.with_state_history(_iter_queue(log_queue)):
+    for msg in itertools.chain(self._log_queues.cache(), self.with_state_history(_iter_queue(log_queue))):
       if isinstance(msg, tuple):
         assert len(msg) == 2 and isinstance(msg[0], int)
         current_state = msg[0]
@@ -338,6 +344,38 @@ class BeamFnLoggingServicer(beam_fn_api_pb2_grpc.BeamFnLoggingServicer):
       for log_entry in log_bundle.log_entries:
         _LOGGER.info('Worker: %s', str(log_entry).replace('\n', ' '))
     return iter([])
+
+
+class JobLogQueues(object):
+  def __init__(self):
+    self._queues = []  # type: List[queue.Queue]
+    self._cache = []
+    self._cache_size = 10
+    self._lock = threading.Lock()
+
+  def cache(self):
+    with self._lock:
+      return list(self._cache)
+
+  def append(self, queue):
+    with self._lock:
+      self._queues.append(queue)
+
+  def put(self, msg):
+    with self._lock:
+      if len(self._cache) < self._cache_size:
+        self._cache.append(msg)
+      else:
+        min_level = min(m.importance for m in self._cache)
+        if msg.importance >= min_level:
+          self._cache.append(msg)
+          for ix, m in enumerate(self._cache):
+            if m.importance == min_level:
+              del self._cache[ix]
+              break
+
+      for queue in self._queues:
+        queue.put(msg)
 
 
 class JobLogHandler(logging.Handler):
@@ -366,6 +404,7 @@ class JobLogHandler(logging.Handler):
     # running pipelines (as Python log handlers are global).
     self._logged_thread = threading.current_thread()
     logging.getLogger().addHandler(self)
+    return self
 
   def __exit__(self, *args):
     self._logged_thread = None
@@ -385,5 +424,4 @@ class JobLogHandler(logging.Handler):
           message_text=self.format(record))
 
       # Inform all message consumers.
-      for queue in self._log_queues:
-        queue.put(msg)
+      self._log_queues.put(msg)

--- a/sdks/python/apache_beam/runners/portability/local_job_service_test.py
+++ b/sdks/python/apache_beam/runners/portability/local_job_service_test.py
@@ -63,6 +63,42 @@ class LocalJobServerTest(unittest.TestCase):
     self.assertEqual([s.state_response.state for s in message_results],
                      expected_states)
 
+  def test_error_messages_after_pipeline_failure(self):
+    job_service = local_job_service.LocalJobServicer()
+    job_service.start_grpc_server()
+
+    plan = TestJobServicePlan(job_service)
+
+    job_id, message_stream, state_stream = plan.submit(
+        beam_runner_api_pb2.Pipeline(requirements=['unsupported_requirement']))
+
+    message_results = list(message_stream)
+    state_results = list(state_stream)
+
+    expected_states = [
+        beam_job_api_pb2.JobState.STOPPED,
+        beam_job_api_pb2.JobState.STARTING,
+        beam_job_api_pb2.JobState.RUNNING,
+        beam_job_api_pb2.JobState.FAILED,
+    ]
+    self.assertEqual([s.state for s in state_results], expected_states)
+    self.assertTrue(
+        any(
+            'unsupported_requirement' in m.message_response.message_text
+            for m in message_results),
+        message_results)
+
+    # Assert we still see the error message if we fetch error messages after
+    # the job has completed.
+    messages_again = list(
+        plan.job_service.GetMessageStream(
+            beam_job_api_pb2.JobMessagesRequest(job_id=job_id)))
+    self.assertTrue(
+        any(
+            'unsupported_requirement' in m.message_response.message_text
+            for m in message_results),
+        messages_again)
+
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)


### PR DESCRIPTION
The Java portable runner only fetches messages and looks for errors after the pipeline returns failure. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
