### PR TITLE
[BEAM-10188] Add instructions to programmatically publish release to Github

### DIFF
--- a/release/src/main/scripts/publish_github_release_notes.sh
+++ b/release/src/main/scripts/publish_github_release_notes.sh
@@ -42,11 +42,25 @@ REQUEST_JSON="$(cat <<-EOF
 EOF
 )"
 
-## Send request to Github API
-curl https://api.github.com/repos/apache/beam/releases \
--X POST \
--H "Authorization: token ${GITHUB_TOKEN}" \
--H "Content-Type:application/json" \
--d "${REQUEST_JSON}"
+echo -e "Below is the request JSON about to be sent to the Github API:\n\n ${REQUEST_JSON}\n\n"
 
-echo -e "\nView the release on Github: https://github.com/apache/beam/releases/tag/v${RELEASE_VER}"
+read -r -p "Would you like to proceed and submit the request to the Github API? [Y/n] " input
+
+case $input in
+  [yY][eE][sS]|[yY])
+    ## Send request to Github API
+    curl https://api.github.com/repos/apache/beam/releases \
+    -X POST \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    -H "Content-Type:application/json" \
+    -d "${REQUEST_JSON}"
+    ;;
+
+  *)
+    echo "Aborting..."
+    exit 1
+    ;;
+esac
+
+
+echo -e "\n\nView the release on Github: https://github.com/apache/beam/releases/tag/v${RELEASE_VER}"

--- a/release/src/main/scripts/publish_github_release_notes.sh
+++ b/release/src/main/scripts/publish_github_release_notes.sh
@@ -17,6 +17,9 @@ set -e
 #    limitations under the License.
 #
 
+# Load environment variables
+. script.config
+
 # Get this script's absolute path
 SCRIPT_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
 

--- a/release/src/main/scripts/publish_github_release_notes.sh
+++ b/release/src/main/scripts/publish_github_release_notes.sh
@@ -1,0 +1,52 @@
+#!/bin/bash
+set -e
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+
+# Get this script's absolute path
+SCRIPT_PATH=$( cd "$( dirname "${BASH_SOURCE[0]}" )" && pwd )
+
+# Extract release notes from the blog post
+POST_PATH=$(echo "${SCRIPT_PATH}/../../../../website/www/site/content/en/blog/beam-${RELEASE_VER}.md")
+RELEASE_NOTES=$(
+    cat ${POST_PATH} |                               # Read post's content
+    sed -n '/<!--/,$p' |                             # Remove post's metadata
+    sed -e :a -Ee 's/<!--.*-->.*//g;/<!--/N;//ba' |  # Remove license
+    sed '/./,$!d'                                    # Remove leading whitespace
+)
+
+# Escape notes' content to work with JSON
+ESCAPED_NOTES=$(printf '%s' "${RELEASE_NOTES}" | python -c 'import json,sys; print(json.dumps(sys.stdin.read()))')
+
+# Build JSON for the API request
+REQUEST_JSON="$(cat <<-EOF
+{
+  "tag_name": "v${RELEASE_VER}",
+  "name": "Beam ${RELEASE_VER} release",
+  "body": ${ESCAPED_NOTES}
+}
+EOF
+)"
+
+## Send request to Github API
+curl https://api.github.com/repos/apache/beam/releases \
+-X POST \
+-H "Authorization: token ${GITHUB_TOKEN}" \
+-H "Content-Type:application/json" \
+-d "${REQUEST_JSON}"
+
+echo -e "\nView the release on Github: https://github.com/apache/beam/releases/tag/v${RELEASE_VER}"

--- a/release/src/main/scripts/publish_github_release_notes.sh
+++ b/release/src/main/scripts/publish_github_release_notes.sh
@@ -57,6 +57,8 @@ case $input in
     -H "Authorization: token ${GITHUB_TOKEN}" \
     -H "Content-Type:application/json" \
     -d "${REQUEST_JSON}"
+
+    echo -e "\n\nView the release on Github: https://github.com/apache/beam/releases/tag/v${RELEASE_VER}"
     ;;
 
   *)
@@ -64,6 +66,3 @@ case $input in
     exit 1
     ;;
 esac
-
-
-echo -e "\n\nView the release on Github: https://github.com/apache/beam/releases/tag/v${RELEASE_VER}"

--- a/website/www/site/content/en/contribute/release-guide.md
+++ b/website/www/site/content/en/contribute/release-guide.md
@@ -1134,29 +1134,9 @@ Create and push a new signed tag for the released version by copying the tag for
     git tag -s "$VERSION_TAG" "$RC_TAG"
     git push upstream "$VERSION_TAG"
 
-After the tag is uploaded, publish the release by calling the Github API (Make sure that the `GITHUB_TOKEN` variable is set):
+After the tag is uploaded, publish the release notes to Github:
 
-    json_escape () {
-        printf '%s' "$1" | python -c 'import json,sys; print(json.dumps(sys.stdin.read()))'
-    }
-    
-    RELEASE_NOTES=$(sed -n '/^We are happy/,$p' website/www/site/content/en/blog/beam-${RELEASE}.md)
-    ESCAPED_NOTES=$(json_escape ${RELEASE_NOTES})
-    
-    RELEASE_JSON="$(cat <<-EOF
-    {
-      "tag_name": "${VERSION_TAG}",
-      "name": "Beam ${RELEASE} release",
-      "body": ${ESCAPED_NOTES}
-    }
-    EOF
-    )"
-    
-    curl https://api.github.com/repos/jphalip/beam/releases \
-    -X POST \
-    -H "Authorization: token ${GITHUB_TOKEN}" \
-    -H "Content-Type:application/json" \
-    -d ${RELEASE_JSON}
+    ./beam/release/src/main/scripts/publish_github_release_notes.sh
 
 ### Merge website pull request
 

--- a/website/www/site/content/en/contribute/release-guide.md
+++ b/website/www/site/content/en/contribute/release-guide.md
@@ -1134,12 +1134,29 @@ Create and push a new signed tag for the released version by copying the tag for
     git tag -s "$VERSION_TAG" "$RC_TAG"
     git push upstream "$VERSION_TAG"
 
-After the tag is uploaded, publish the release in the Github UI.
-1. Navigate to `https://github.com/apache/beam/releases/tag/$VERSION_TAG`.
-1. Click the "Edit tag" button.
-1. Give the release a title, such as `Beam 2.21.0`.
-1. For the release description, copy the current version's changes from `CHANGES.md`. (You may want to touch up the formatting a bit.)
-1. Click the "Publish release" button.
+After the tag is uploaded, publish the release by calling the Github API (Make sure that the `GITHUB_TOKEN` variable is set):
+
+    json_escape () {
+        printf '%s' "$1" | python -c 'import json,sys; print(json.dumps(sys.stdin.read()))'
+    }
+    
+    RELEASE_NOTES=$(sed -n '/^We are happy/,$p' website/www/site/content/en/blog/beam-${RELEASE}.md)
+    ESCAPED_NOTES=$(json_escape ${RELEASE_NOTES})
+    
+    RELEASE_JSON="$(cat <<-EOF
+    {
+      "tag_name": "${VERSION_TAG}",
+      "name": "Beam ${RELEASE} release",
+      "body": ${ESCAPED_NOTES}
+    }
+    EOF
+    )"
+    
+    curl https://api.github.com/repos/jphalip/beam/releases \
+    -X POST \
+    -H "Authorization: token ${GITHUB_TOKEN}" \
+    -H "Content-Type:application/json" \
+    -d ${RELEASE_JSON}
 
 ### Merge website pull request
 


### PR DESCRIPTION
This fixes BEAM-10188.

See discussion in the dev@ list: https://lists.apache.org/thread.html/re367d262333078501c47856e9b8a0fc3fd7db60c2d2ebb181275481a%40%3Cdev.beam.apache.org%3E

This assumes that the blog post starts with "We are happy", which has been the case in most recent posts. But perhaps you'd like to tweak that?