### PR TITLE
[BEAM-9615] Add string coder utility functions.

### DIFF
--- a/sdks/go/pkg/beam/core/graph/coder/stringutf8.go
+++ b/sdks/go/pkg/beam/core/graph/coder/stringutf8.go
@@ -1,0 +1,68 @@
+package coder
+
+import (
+	"io"
+	"strings"
+
+	"github.com/apache/beam/sdks/go/pkg/beam/core/util/ioutilx"
+)
+
+const bufCap = 64
+
+// EncodeStringUTF8LP encodes a UTF string with a length prefix.
+func EncodeStringUTF8LP(s string, w io.Writer) error {
+	if err := EncodeVarInt(int64(len(s)), w); err != nil {
+		return err
+	}
+	return encodeStringUTF8(s, w)
+}
+
+// encodeStringUTF8 encodes a string.
+func encodeStringUTF8(s string, w io.Writer) error {
+	l := len(s)
+	var b [bufCap]byte
+	i := 0
+	for l-i > bufCap {
+		n := i + bufCap
+		copy(b[:], s[i:n])
+		if _, err := ioutilx.WriteUnsafe(w, b[:]); err != nil {
+			return err
+		}
+		i = n
+	}
+	n := l - i
+	copy(b[:n], s[i:])
+	ioutilx.WriteUnsafe(w, b[:n])
+	return nil
+}
+
+// decodeStringUTF8 reads l bytes and produces a string.
+func decodeStringUTF8(l int64, r io.Reader) (string, error) {
+	var builder strings.Builder
+	var b [bufCap]byte
+	i := l
+	for i > bufCap {
+		err := ioutilx.ReadNBufUnsafe(r, b[:])
+		if err != nil {
+			return "", err
+		}
+		i -= bufCap
+		builder.Write(b[:])
+	}
+	err := ioutilx.ReadNBufUnsafe(r, b[:i])
+	if err != nil {
+		return "", err
+	}
+	builder.Write(b[:i])
+
+	return builder.String(), nil
+}
+
+// DecodeStringUTF8LP decodes a length prefixed utf8 string.
+func DecodeStringUTF8LP(r io.Reader) (string, error) {
+	l, err := DecodeVarInt(r)
+	if err != nil {
+		return "", err
+	}
+	return decodeStringUTF8(l, r)
+}

--- a/sdks/go/pkg/beam/core/graph/coder/stringutf8_test.go
+++ b/sdks/go/pkg/beam/core/graph/coder/stringutf8_test.go
@@ -1,0 +1,107 @@
+package coder
+
+import (
+	"bytes"
+	"encoding/base64"
+	"io"
+	"strings"
+	"testing"
+	"unicode/utf8"
+)
+
+var testValues = []string{
+	"",
+	"a",
+	"13",
+	"hello",
+	"a longer string with spaces and all that",
+	"a string with a \n newline",
+	"スタリング",
+	"I am the very model of a modern major general.\nI've information animal, vegetable, and mineral",
+}
+
+// Base64 encoded versions of the above strings, without the length prefix.
+var testEncodings = []string{
+	"",
+	"YQ",
+	"MTM",
+	"aGVsbG8",
+	"YSBsb25nZXIgc3RyaW5nIHdpdGggc3BhY2VzIGFuZCBhbGwgdGhhdA",
+	"YSBzdHJpbmcgd2l0aCBhIAogbmV3bGluZQ",
+	"44K544K_44Oq44Oz44Kw",
+	"SSBhbSB0aGUgdmVyeSBtb2RlbCBvZiBhIG1vZGVybiBtYWpvciBnZW5lcmFsLgpJJ3ZlIGluZm9ybWF0aW9uIGFuaW1hbCwgdmVnZXRhYmxlLCBhbmQgbWluZXJhbA",
+}
+
+// TestLen serves as a verification that string lengths
+// match their equivalent byte lengths, and not their rune
+// representation.
+func TestLen(t *testing.T) {
+	runeCount := []int{0, 1, 2, 5, 40, 25, 5, 94}
+	for i, s := range testValues {
+		if got, want := len(s), len([]byte(s)); got != want {
+			t.Errorf("string and []byte len do not match. got %v, want %v", got, want)
+		}
+		if got, want := utf8.RuneCountInString(s), runeCount[i]; got != want {
+			t.Errorf("Rune count of %q change len do not match. got %v, want %v", s, got, want)
+		}
+	}
+}
+
+func TestEncodeStringUTF8(t *testing.T) {
+	for i, s := range testValues {
+		s := s
+		want := testEncodings[i]
+		t.Run(s, func(t *testing.T) {
+			var b strings.Builder
+			base64enc := base64.NewEncoder(base64.RawURLEncoding, &b)
+
+			if err := encodeStringUTF8(s, base64enc); err != nil {
+				t.Fatal(err)
+			}
+			base64enc.Close()
+			got := b.String()
+			if got != want {
+				t.Errorf("encodeStringUTF8(%q) = %q, want %q", s, got, want)
+			}
+		})
+	}
+}
+
+func TestDecodeStringUTF8(t *testing.T) {
+	for i, s := range testEncodings {
+		s := s
+		want := testValues[i]
+		t.Run(want, func(t *testing.T) {
+			b := bytes.NewBufferString(s)
+			base64dec := base64.NewDecoder(base64.RawURLEncoding, b)
+
+			got, err := decodeStringUTF8(int64(len(want)), base64dec)
+			if err != nil && err != io.EOF {
+				t.Fatal(err)
+			}
+			if got != want {
+				t.Errorf("decodeStringUTF8(%q) = %q, want %q", s, got, want)
+			}
+		})
+	}
+}
+
+func TestEncodeDecodeStringUTF8LP(t *testing.T) {
+	for _, s := range testValues {
+		want := s
+		t.Run(want, func(t *testing.T) {
+			var build strings.Builder
+			if err := EncodeStringUTF8LP(want, &build); err != nil {
+				t.Fatal(err)
+			}
+			buf := bytes.NewBufferString(build.String())
+			got, err := DecodeStringUTF8LP(buf)
+			if err != nil && err != io.EOF {
+				t.Fatal(err)
+			}
+			if got != want {
+				t.Errorf("decodeStringUTF8(%q) = %q, want %q", s, got, want)
+			}
+		})
+	}
+}


### PR DESCRIPTION
This adds initial utility functions for encoding and decoding utf8 strings in the Go SDK.

Doesn't make use of them yet. In practice this is already how strings are encoded in the Go SDK, but marked as "custom" coders rather than the built in URN.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
