### PR TITLE
[BEAM-9615] finish standardizing proto import names

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/translate.go
@@ -25,7 +25,7 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/coder"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/window"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx"
-	v1 "github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx/v1"
+	v1pb "github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx/v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/protox"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/stringx"
@@ -371,7 +371,7 @@ func (b *builder) makeLink(from string, id linkID) (Node, error) {
 		// TODO(herohde) 1/28/2018: Once Dataflow's fully off the old way,
 		// we can simply switch on the ParDo DoFn URN directly.
 
-		var tp v1.TransformPayload
+		var tp v1pb.TransformPayload
 		if err := protox.DecodeBase64(data, &tp); err != nil {
 			return nil, errors.Wrapf(err, "invalid transform payload for %v", transform)
 		}

--- a/sdks/go/pkg/beam/core/runtime/graphx/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/coder.go
@@ -20,11 +20,11 @@ import (
 	"fmt"
 
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/coder"
-	v1 "github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx/v1"
+	v1pb "github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx/v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/protox"
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
+	pipepb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 	"github.com/golang/protobuf/proto"
 )
 
@@ -67,14 +67,14 @@ func knownStandardCoders() []string {
 }
 
 // MarshalCoders marshals a list of coders into model coders.
-func MarshalCoders(coders []*coder.Coder) ([]string, map[string]*pb.Coder) {
+func MarshalCoders(coders []*coder.Coder) ([]string, map[string]*pipepb.Coder) {
 	b := NewCoderMarshaller()
 	ids := b.AddMulti(coders)
 	return ids, b.Build()
 }
 
 // UnmarshalCoders unmarshals coders.
-func UnmarshalCoders(ids []string, m map[string]*pb.Coder) ([]*coder.Coder, error) {
+func UnmarshalCoders(ids []string, m map[string]*pipepb.Coder) ([]*coder.Coder, error) {
 	b := NewCoderUnmarshaller(m)
 
 	var coders []*coder.Coder
@@ -91,14 +91,14 @@ func UnmarshalCoders(ids []string, m map[string]*pb.Coder) ([]*coder.Coder, erro
 // CoderUnmarshaller is an incremental unmarshaller of model coders. Identical
 // coders are shared.
 type CoderUnmarshaller struct {
-	models map[string]*pb.Coder
+	models map[string]*pipepb.Coder
 
 	coders       map[string]*coder.Coder
 	windowCoders map[string]*coder.WindowCoder
 }
 
 // NewCoderUnmarshaller returns a new CoderUnmarshaller.
-func NewCoderUnmarshaller(m map[string]*pb.Coder) *CoderUnmarshaller {
+func NewCoderUnmarshaller(m map[string]*pipepb.Coder) *CoderUnmarshaller {
 	return &CoderUnmarshaller{
 		models:       m,
 		coders:       make(map[string]*coder.Coder),
@@ -167,7 +167,7 @@ func urnToWindowCoder(urn string) *coder.WindowCoder {
 	}
 }
 
-func (b *CoderUnmarshaller) makeCoder(c *pb.Coder) (*coder.Coder, error) {
+func (b *CoderUnmarshaller) makeCoder(c *pipepb.Coder) (*coder.Coder, error) {
 	urn := c.GetSpec().GetUrn()
 	components := c.GetComponentCoderIds()
 
@@ -250,7 +250,7 @@ func (b *CoderUnmarshaller) makeCoder(c *pb.Coder) (*coder.Coder, error) {
 			return nil, errors.Errorf("could not unmarshal length prefix coder from %v, want a custom coder as a sub component but got %v", c, elm)
 		}
 
-		var ref v1.CustomCoder
+		var ref v1pb.CustomCoder
 		if err := protox.DecodeBase64(string(elm.GetSpec().GetPayload()), &ref); err != nil {
 			return nil, err
 		}
@@ -302,7 +302,7 @@ func (b *CoderUnmarshaller) makeCoder(c *pb.Coder) (*coder.Coder, error) {
 	}
 }
 
-func (b *CoderUnmarshaller) peek(id string) (*pb.Coder, error) {
+func (b *CoderUnmarshaller) peek(id string) (*pipepb.Coder, error) {
 	c, ok := b.models[id]
 	if !ok {
 		return nil, errors.Errorf("coder with id %v not found", id)
@@ -331,14 +331,14 @@ func (b *CoderUnmarshaller) isCoGBKList(id string) ([]string, bool) {
 // CoderMarshaller incrementally builds a compact model representation of a set
 // of coders. Identical coders are shared.
 type CoderMarshaller struct {
-	coders   map[string]*pb.Coder
+	coders   map[string]*pipepb.Coder
 	coder2id map[string]string // index of serialized coders to id to deduplicate
 }
 
 // NewCoderMarshaller returns a new CoderMarshaller.
 func NewCoderMarshaller() *CoderMarshaller {
 	return &CoderMarshaller{
-		coders:   make(map[string]*pb.Coder),
+		coders:   make(map[string]*pipepb.Coder),
 		coder2id: make(map[string]string),
 	}
 }
@@ -358,8 +358,8 @@ func (b *CoderMarshaller) Add(c *coder.Coder) string {
 		if err != nil {
 			panic(errors.Wrapf(err, "Failed to marshal custom coder %v", c))
 		}
-		inner := b.internCoder(&pb.Coder{
-			Spec: &pb.FunctionSpec{
+		inner := b.internCoder(&pipepb.Coder{
+			Spec: &pipepb.FunctionSpec{
 				Urn:     urnCustomCoder,
 				Payload: []byte(data),
 			},
@@ -431,20 +431,20 @@ func (b *CoderMarshaller) AddWindowCoder(w *coder.WindowCoder) string {
 
 // Build returns the set of model coders. Note that the map may be larger
 // than the number of coders added, because component coders are included.
-func (b *CoderMarshaller) Build() map[string]*pb.Coder {
+func (b *CoderMarshaller) Build() map[string]*pipepb.Coder {
 	return b.coders
 }
 
 func (b *CoderMarshaller) internBuiltInCoder(urn string, components ...string) string {
-	return b.internCoder(&pb.Coder{
-		Spec: &pb.FunctionSpec{
+	return b.internCoder(&pipepb.Coder{
+		Spec: &pipepb.FunctionSpec{
 			Urn: urn,
 		},
 		ComponentCoderIds: components,
 	})
 }
 
-func (b *CoderMarshaller) internCoder(coder *pb.Coder) string {
+func (b *CoderMarshaller) internCoder(coder *pipepb.Coder) string {
 	key := proto.MarshalTextString(coder)
 	if id, exists := b.coder2id[key]; exists {
 		return id

--- a/sdks/go/pkg/beam/core/runtime/graphx/dataflow.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/dataflow.go
@@ -17,7 +17,7 @@ package graphx
 
 import (
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/coder"
-	v1 "github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx/v1"
+	v1pb "github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx/v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/protox"
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
@@ -243,7 +243,7 @@ func DecodeCoderRef(c *CoderRef) (*coder.Coder, error) {
 			return nil, errors.Errorf("bad length prefix: %+v", c)
 		}
 
-		var ref v1.CustomCoder
+		var ref v1pb.CustomCoder
 		if err := protox.DecodeBase64(c.Components[0].Type, &ref); err != nil {
 			return nil, errors.Wrapf(err, "base64 decode for %v failed", c.Components[0].Type)
 		}

--- a/sdks/go/pkg/beam/core/runtime/graphx/serialize_test.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/serialize_test.go
@@ -21,7 +21,7 @@ import (
 	"testing"
 
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime"
-	v1 "github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx/v1"
+	v1pb "github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx/v1"
 )
 
 func TestEncodeType(t *testing.T) {
@@ -35,7 +35,7 @@ func TestEncodeType(t *testing.T) {
 		if err != nil {
 			t.Fatalf("got error = %v, want nil", err)
 		}
-		if got, want := pbT.Kind, v1.Type_STRUCT; got != want {
+		if got, want := pbT.Kind, v1pb.Type_STRUCT; got != want {
 			t.Fatalf("got pbT.Kind == %v, want %v", got, want)
 		}
 	})
@@ -62,7 +62,7 @@ func TestEncodeType(t *testing.T) {
 		if err != nil {
 			t.Fatalf("got error = %v, want nil", err)
 		}
-		if got, want := pbT.Kind, v1.Type_EXTERNAL; got != want {
+		if got, want := pbT.Kind, v1pb.Type_EXTERNAL; got != want {
 			t.Fatalf("got pbT.Kind == %v, want %v", got, want)
 		}
 	})

--- a/sdks/go/pkg/beam/core/runtime/graphx/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate.go
@@ -22,7 +22,7 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/coder"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/window"
-	v1 "github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx/v1"
+	v1pb "github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx/v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/pipelinex"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/protox"
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
@@ -291,7 +291,7 @@ func (m *marshaller) addMultiEdge(edge NamedEdge) []string {
 				payload := &pipepb.ParDoPayload{
 					DoFn: &pipepb.FunctionSpec{
 						Urn: URNIterableSideInputKey,
-						Payload: []byte(protox.MustEncodeBase64(&v1.TransformPayload{
+						Payload: []byte(protox.MustEncodeBase64(&v1pb.TransformPayload{
 							Urn: URNIterableSideInputKey,
 						})),
 					},
@@ -415,9 +415,9 @@ func (m *marshaller) expandCoGBK(edge NamedEdge) string {
 		payload := &pipepb.ParDoPayload{
 			DoFn: &pipepb.FunctionSpec{
 				Urn: URNInject,
-				Payload: []byte(protox.MustEncodeBase64(&v1.TransformPayload{
+				Payload: []byte(protox.MustEncodeBase64(&v1pb.TransformPayload{
 					Urn:    URNInject,
-					Inject: &v1.InjectPayload{N: (int32)(i)},
+					Inject: &v1pb.InjectPayload{N: (int32)(i)},
 				})),
 			},
 		}
@@ -478,7 +478,7 @@ func (m *marshaller) expandCoGBK(edge NamedEdge) string {
 	payload := &pipepb.ParDoPayload{
 		DoFn: &pipepb.FunctionSpec{
 			Urn: URNExpand,
-			Payload: []byte(protox.MustEncodeBase64(&v1.TransformPayload{
+			Payload: []byte(protox.MustEncodeBase64(&v1pb.TransformPayload{
 				Urn: URNExpand,
 			})),
 		},
@@ -597,7 +597,7 @@ func (m *marshaller) expandReshuffle(edge NamedEdge) string {
 	payload := &pipepb.ParDoPayload{
 		DoFn: &pipepb.FunctionSpec{
 			Urn: URNReshuffleInput,
-			Payload: []byte(protox.MustEncodeBase64(&v1.TransformPayload{
+			Payload: []byte(protox.MustEncodeBase64(&v1pb.TransformPayload{
 				Urn: URNReshuffleInput,
 			})),
 		},
@@ -641,7 +641,7 @@ func (m *marshaller) expandReshuffle(edge NamedEdge) string {
 	outputPayload := &pipepb.ParDoPayload{
 		DoFn: &pipepb.FunctionSpec{
 			Urn: URNReshuffleOutput,
-			Payload: []byte(protox.MustEncodeBase64(&v1.TransformPayload{
+			Payload: []byte(protox.MustEncodeBase64(&v1pb.TransformPayload{
 				Urn: URNReshuffleOutput,
 			})),
 		},
@@ -792,7 +792,7 @@ func mustEncodeMultiEdgeBase64(edge *graph.MultiEdge) string {
 	if err != nil {
 		panic(errors.Wrapf(err, "Failed to serialize %v", edge))
 	}
-	return protox.MustEncodeBase64(&v1.TransformPayload{
+	return protox.MustEncodeBase64(&v1pb.TransformPayload{
 		Urn:  URNDoFn,
 		Edge: ref,
 	})

--- a/sdks/go/pkg/beam/core/runtime/graphx/translate_test.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate_test.go
@@ -16,9 +16,10 @@
 package graphx_test
 
 import (
-	"github.com/google/go-cmp/cmp/cmpopts"
 	"reflect"
 	"testing"
+
+	"github.com/google/go-cmp/cmp/cmpopts"
 
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/coder"
@@ -27,7 +28,7 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
+	pipepb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 )
@@ -155,12 +156,12 @@ func TestMarshal(t *testing.T) {
 				t.Fatal("expected a single edge")
 			}
 
-			payload, err := proto.Marshal(&pb.DockerPayload{ContainerImage: "foo"})
+			payload, err := proto.Marshal(&pipepb.DockerPayload{ContainerImage: "foo"})
 			if err != nil {
 				t.Fatal(err)
 			}
 			p, err := graphx.Marshal(edges,
-				&graphx.Options{Environment: &pb.Environment{Urn: "beam:env:docker:v1", Payload: payload}})
+				&graphx.Options{Environment: &pipepb.Environment{Urn: "beam:env:docker:v1", Payload: payload}})
 			if err != nil {
 				t.Fatal(err)
 			}

--- a/sdks/go/pkg/beam/core/runtime/graphx/user.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/user.go
@@ -24,7 +24,7 @@ import (
 
 	"github.com/apache/beam/sdks/go/pkg/beam/core/funcx"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/coder"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx/v1"
+	v1pb "github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx/v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/protox"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
 )
@@ -44,7 +44,7 @@ func EncodeType(t reflect.Type) (string, error) {
 // guaranteed to be isomorphic to the input with regard to data members.
 // The returned type will have no methods.
 func DecodeType(data string) (reflect.Type, error) {
-	var ref v1.Type
+	var ref v1pb.Type
 	if err := protox.DecodeBase64(data, &ref); err != nil {
 		return nil, err
 	}
@@ -69,7 +69,7 @@ func EncodeFn(fn reflectx.Func) (string, error) {
 // DecodeFn encodes a function. The function symbol must be resolvable via the
 // runtime.GlobalSymbolResolver. The parameter types must be encodable.
 func DecodeFn(data string) (reflectx.Func, error) {
-	var ref v1.UserFn
+	var ref v1pb.UserFn
 	if err := protox.DecodeBase64(data, &ref); err != nil {
 		return nil, err
 	}

--- a/sdks/go/pkg/beam/core/runtime/pipelinex/clone.go
+++ b/sdks/go/pkg/beam/core/runtime/pipelinex/clone.go
@@ -17,11 +17,11 @@ package pipelinex
 
 import (
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
+	pipepb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 )
 
-func shallowClonePipeline(p *pb.Pipeline) *pb.Pipeline {
-	ret := &pb.Pipeline{
+func shallowClonePipeline(p *pipepb.Pipeline) *pipepb.Pipeline {
+	ret := &pipepb.Pipeline{
 		Components:   shallowCloneComponents(p.GetComponents()),
 		Requirements: reflectx.ShallowClone(p.GetRequirements()).([]string),
 	}
@@ -29,23 +29,23 @@ func shallowClonePipeline(p *pb.Pipeline) *pb.Pipeline {
 	return ret
 }
 
-func shallowCloneComponents(comp *pb.Components) *pb.Components {
-	ret := &pb.Components{}
-	ret.Transforms, _ = reflectx.ShallowClone(comp.GetTransforms()).(map[string]*pb.PTransform)
-	ret.Pcollections, _ = reflectx.ShallowClone(comp.GetPcollections()).(map[string]*pb.PCollection)
-	ret.WindowingStrategies, _ = reflectx.ShallowClone(comp.GetWindowingStrategies()).(map[string]*pb.WindowingStrategy)
-	ret.Coders, _ = reflectx.ShallowClone(comp.GetCoders()).(map[string]*pb.Coder)
-	ret.Environments, _ = reflectx.ShallowClone(comp.GetEnvironments()).(map[string]*pb.Environment)
+func shallowCloneComponents(comp *pipepb.Components) *pipepb.Components {
+	ret := &pipepb.Components{}
+	ret.Transforms, _ = reflectx.ShallowClone(comp.GetTransforms()).(map[string]*pipepb.PTransform)
+	ret.Pcollections, _ = reflectx.ShallowClone(comp.GetPcollections()).(map[string]*pipepb.PCollection)
+	ret.WindowingStrategies, _ = reflectx.ShallowClone(comp.GetWindowingStrategies()).(map[string]*pipepb.WindowingStrategy)
+	ret.Coders, _ = reflectx.ShallowClone(comp.GetCoders()).(map[string]*pipepb.Coder)
+	ret.Environments, _ = reflectx.ShallowClone(comp.GetEnvironments()).(map[string]*pipepb.Environment)
 	return ret
 }
 
 // ShallowClonePTransform makes a shallow copy of the given PTransform.
-func ShallowClonePTransform(t *pb.PTransform) *pb.PTransform {
+func ShallowClonePTransform(t *pipepb.PTransform) *pipepb.PTransform {
 	if t == nil {
 		return nil
 	}
 
-	ret := &pb.PTransform{
+	ret := &pipepb.PTransform{
 		UniqueName:  t.UniqueName,
 		Spec:        t.Spec,
 		DisplayData: t.DisplayData,
@@ -58,37 +58,37 @@ func ShallowClonePTransform(t *pb.PTransform) *pb.PTransform {
 }
 
 // ShallowCloneParDoPayload makes a shallow copy of the given ParDoPayload.
-func ShallowCloneParDoPayload(p *pb.ParDoPayload) *pb.ParDoPayload {
+func ShallowCloneParDoPayload(p *pipepb.ParDoPayload) *pipepb.ParDoPayload {
 	if p == nil {
 		return nil
 	}
 
-	ret := &pb.ParDoPayload{
+	ret := &pipepb.ParDoPayload{
 		DoFn:               p.DoFn,
 		RestrictionCoderId: p.RestrictionCoderId,
 	}
-	ret.SideInputs, _ = reflectx.ShallowClone(p.SideInputs).(map[string]*pb.SideInput)
-	ret.StateSpecs, _ = reflectx.ShallowClone(p.StateSpecs).(map[string]*pb.StateSpec)
-	ret.TimerFamilySpecs, _ = reflectx.ShallowClone(p.TimerFamilySpecs).(map[string]*pb.TimerFamilySpec)
+	ret.SideInputs, _ = reflectx.ShallowClone(p.SideInputs).(map[string]*pipepb.SideInput)
+	ret.StateSpecs, _ = reflectx.ShallowClone(p.StateSpecs).(map[string]*pipepb.StateSpec)
+	ret.TimerFamilySpecs, _ = reflectx.ShallowClone(p.TimerFamilySpecs).(map[string]*pipepb.TimerFamilySpec)
 	return ret
 }
 
 // ShallowCloneSideInput makes a shallow copy of the given SideInput.
-func ShallowCloneSideInput(p *pb.SideInput) *pb.SideInput {
+func ShallowCloneSideInput(p *pipepb.SideInput) *pipepb.SideInput {
 	if p == nil {
 		return nil
 	}
-	var ret pb.SideInput
+	var ret pipepb.SideInput
 	ret = *p
 	return &ret
 }
 
 // ShallowCloneFunctionSpec makes a shallow copy of the given FunctionSpec.
-func ShallowCloneFunctionSpec(p *pb.FunctionSpec) *pb.FunctionSpec {
+func ShallowCloneFunctionSpec(p *pipepb.FunctionSpec) *pipepb.FunctionSpec {
 	if p == nil {
 		return nil
 	}
-	var ret pb.FunctionSpec
+	var ret pipepb.FunctionSpec
 	ret = *p
 	return &ret
 }

--- a/sdks/go/pkg/beam/core/runtime/pipelinex/clone_test.go
+++ b/sdks/go/pkg/beam/core/runtime/pipelinex/clone_test.go
@@ -18,16 +18,16 @@ package pipelinex
 import (
 	"testing"
 
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
+	pipepb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 	"github.com/golang/protobuf/proto"
 	"github.com/google/go-cmp/cmp"
 )
 
 func TestShallowClonePTransform(t *testing.T) {
-	tests := []*pb.PTransform{
+	tests := []*pipepb.PTransform{
 		{},
 		{UniqueName: "a"},
-		{Spec: &pb.FunctionSpec{Urn: "foo"}},
+		{Spec: &pipepb.FunctionSpec{Urn: "foo"}},
 		{Subtransforms: []string{"a", "b"}},
 		{Inputs: map[string]string{"a": "b"}},
 		{Outputs: map[string]string{"a": "b"}},

--- a/sdks/go/pkg/beam/runners/dataflow/dataflowlib/execute.go
+++ b/sdks/go/pkg/beam/runners/dataflow/dataflowlib/execute.go
@@ -24,14 +24,14 @@ import (
 
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/protox"
 	"github.com/apache/beam/sdks/go/pkg/beam/log"
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
+	pipepb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/runners/universal/runnerlib"
 	"github.com/golang/protobuf/proto"
 	df "google.golang.org/api/dataflow/v1b3"
 )
 
 // Execute submits a pipeline as a Dataflow job.
-func Execute(ctx context.Context, raw *pb.Pipeline, opts *JobOptions, workerURL, jarURL, modelURL, endpoint string, async bool) (string, error) {
+func Execute(ctx context.Context, raw *pipepb.Pipeline, opts *JobOptions, workerURL, jarURL, modelURL, endpoint string, async bool) (string, error) {
 	// (1) Upload Go binary to GCS.
 
 	bin := opts.Worker

--- a/sdks/go/pkg/beam/runners/dataflow/dataflowlib/fixup.go
+++ b/sdks/go/pkg/beam/runners/dataflow/dataflowlib/fixup.go
@@ -16,10 +16,10 @@
 package dataflowlib
 
 import (
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
+	pipepb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 )
 
 // Fixup proto pipeline with Dataflow quirks.
-func Fixup(p *pb.Pipeline) (*pb.Pipeline, error) {
+func Fixup(p *pipepb.Pipeline) (*pipepb.Pipeline, error) {
 	return p, nil
 }

--- a/sdks/java/container/boot.go
+++ b/sdks/java/container/boot.go
@@ -28,7 +28,7 @@ import (
 
 	"github.com/apache/beam/sdks/go/pkg/beam/artifact"
 	fnpb "github.com/apache/beam/sdks/go/pkg/beam/model/fnexecution_v1"
-	pb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
+	pipepb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/provision"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/execx"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/grpcx"
@@ -108,8 +108,8 @@ func main() {
 
 	os.Setenv("HARNESS_ID", *id)
 	os.Setenv("PIPELINE_OPTIONS", options)
-	os.Setenv("LOGGING_API_SERVICE_DESCRIPTOR", proto.MarshalTextString(&pb.ApiServiceDescriptor{Url: *loggingEndpoint}))
-	os.Setenv("CONTROL_API_SERVICE_DESCRIPTOR", proto.MarshalTextString(&pb.ApiServiceDescriptor{Url: *controlEndpoint}))
+	os.Setenv("LOGGING_API_SERVICE_DESCRIPTOR", proto.MarshalTextString(&pipepb.ApiServiceDescriptor{Url: *loggingEndpoint}))
+	os.Setenv("CONTROL_API_SERVICE_DESCRIPTOR", proto.MarshalTextString(&pipepb.ApiServiceDescriptor{Url: *controlEndpoint}))
 
 	if info.GetStatusEndpoint() != nil {
 		os.Setenv("STATUS_API_SERVICE_DESCRIPTOR", proto.MarshalTextString(info.GetStatusEndpoint()))

--- a/sdks/python/container/boot.go
+++ b/sdks/python/container/boot.go
@@ -28,8 +28,8 @@ import (
 	"time"
 
 	"github.com/apache/beam/sdks/go/pkg/beam/artifact"
-	pbjob "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
-	pbpipeline "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
+	jobpb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
+	pipepb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 	"github.com/apache/beam/sdks/go/pkg/beam/provision"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/execx"
 	"github.com/apache/beam/sdks/go/pkg/beam/util/grpcx"
@@ -154,8 +154,8 @@ func main() {
 	os.Setenv("WORKER_ID", *id)
 	os.Setenv("PIPELINE_OPTIONS", options)
 	os.Setenv("SEMI_PERSISTENT_DIRECTORY", *semiPersistDir)
-	os.Setenv("LOGGING_API_SERVICE_DESCRIPTOR", proto.MarshalTextString(&pbpipeline.ApiServiceDescriptor{Url: *loggingEndpoint}))
-	os.Setenv("CONTROL_API_SERVICE_DESCRIPTOR", proto.MarshalTextString(&pbpipeline.ApiServiceDescriptor{Url: *controlEndpoint}))
+	os.Setenv("LOGGING_API_SERVICE_DESCRIPTOR", proto.MarshalTextString(&pipepb.ApiServiceDescriptor{Url: *loggingEndpoint}))
+	os.Setenv("CONTROL_API_SERVICE_DESCRIPTOR", proto.MarshalTextString(&pipepb.ApiServiceDescriptor{Url: *controlEndpoint}))
 
 	if info.GetStatusEndpoint() != nil {
 		os.Setenv("STATUS_API_SERVICE_DESCRIPTOR", proto.MarshalTextString(info.GetStatusEndpoint()))
@@ -171,7 +171,7 @@ func main() {
 }
 
 // installSetupPackages installs Beam SDK and user dependencies.
-func installSetupPackages(mds []*pbjob.ArtifactMetadata, workDir string) error {
+func installSetupPackages(mds []*jobpb.ArtifactMetadata, workDir string) error {
 	log.Printf("Installing setup packages ...")
 
 	files := make([]string, len(mds))


### PR DESCRIPTION
I noticed that there were several stranglers that were not following the import name conventions, and this PR completes that work.

pipepb, fnpb, jobpb for the Pipeline protos, Fn Execution protos, and Job Management protos respectively, and v1pb for the internal serialization representation for types the Go SDK uses.

This PR is a rote find/replace.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
