### PR TITLE
[BEAM-10220] add support for implicit nulls for converting between beam rows and json

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/RowJson.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/RowJson.java
@@ -302,8 +302,6 @@ public class RowJson {
 
     /**
      * Helper class to keep track of schema field type, name, and actual json value for the field.
-     * Also keeps track of whether or not missing fields are valid when reading from the json - in
-     * this case it will be read as null.
      */
     @AutoValue
     abstract static class FieldValue {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/RowJson.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/RowJson.java
@@ -383,7 +383,7 @@ public class RowJson {
       this.schema = schema;
     }
 
-    /** Serializer drops nulls on write if set to true instead of writing fieldName: null */
+    /** Serializer drops nulls on write if set to true instead of writing fieldName: null. */
     public RowJsonSerializer withDropNullsOnWrite(Boolean dropNullsOnWrite) {
       this.dropNullsOnWrite = dropNullsOnWrite;
       return this;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/RowJsonTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/RowJsonTest.java
@@ -260,6 +260,7 @@ public class RowJsonTest {
     }
   }
 
+  @RunWith(Parameterized.class)
   public static class ValueTestsAllowMissing {
     @Parameter(0)
     public String name;
@@ -289,7 +290,7 @@ public class RowJsonTest {
               .addNullableField("f_string", FieldType.STRING)
               .build();
 
-      String rowString = "{\n" + "\"f_byte\" : 12,\n" + "}";
+      String rowString = "{\n" + "\"f_byte\" : 12\n" + "}";
 
       Row expectedRow = Row.withSchema(schema).addValues((byte) 12, null).build();
 
@@ -301,11 +302,11 @@ public class RowJsonTest {
       Schema schema =
           Schema.builder()
               .addInt32Field("f_int32")
-              .addArrayField("f_intArray", FieldType.INT32.withNullable(true))
+              .addNullableField("f_intArray", FieldType.array(FieldType.INT32))
               .build();
 
       String rowString =
-          "{\n" + "\"f_int32\" : 32,\n" + "}";
+          "{\n" + "\"f_int32\" : 32\n" + "}";
 
       Row expectedRow = Row.withSchema(schema).addValues(32, null).build();
 
@@ -323,13 +324,13 @@ public class RowJsonTest {
           "{\n"
               + "\"f_int32\" : 32,\n"
               + "\"f_row\" : {\n"
-              + "             \"f_nestedInt32\" : 54,\n"
+              + "             \"f_nestedInt32\" : 54\n"
               + "            }\n"
               + "}";
 
       Row expectedRow =
           Row.withSchema(schema)
-              .addValues(32, Row.withSchema(nestedRowSchema).addValues(54, "foo").build())
+              .addValues(32, Row.withSchema(nestedRowSchema).addValues(54, null).build())
               .build();
 
       return new Object[] {"Nested row", schema, rowString, expectedRow};
@@ -347,16 +348,16 @@ public class RowJsonTest {
           "{\n"
               + "\"f_int32\" : 32,\n"
               + "\"f_row\" : {\n"
-              + "             \"f_nestedInt32\" : 54,\n"
+              + "             \"f_nestedInt32\" : 54\n"
               + "            }\n"
               + "}";
 
       Row expectedRow =
           Row.withSchema(schema)
-              .addValues(32, Row.withSchema(nestedRowSchema).addValues(54, "foo").build())
+              .addValues(32, Row.withSchema(nestedRowSchema).addValues(54, null).build())
               .build();
 
-      return new Object[] {"Nested row", schema, rowString, expectedRow};
+      return new Object[] {"Nested row with removal", schema, rowString, expectedRow};
     }
 
     @Test
@@ -381,6 +382,7 @@ public class RowJsonTest {
       assertThat(row, equalTo(parsedRow));
     }
   }
+  
   @RunWith(JUnit4.class)
   public static class DeserializerTests {
     private static final Boolean BOOLEAN_TRUE_VALUE = true;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/RowJsonTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/RowJsonTest.java
@@ -351,20 +351,11 @@ public class RowJsonTest {
               .addNullableField("f_row", FieldType.row(nestedRowSchema))
               .build();
 
-      String rowString =
-          "{\n"
-              + "\"f_int32\" : 32,\n"
-              + "\"f_row\" : {\n"
-              + "             \"f_nestedInt32\" : 54\n"
-              + "            }\n"
-              + "}";
+      String rowString = "{\n" + "\"f_int32\" : 32\n" + "}";
 
-      Row expectedRow =
-          Row.withSchema(schema)
-              .addValues(32, Row.withSchema(nestedRowSchema).addValues(54, null).build())
-              .build();
+      Row expectedRow = Row.withSchema(schema).addValues(32, null).build();
 
-      return new Object[] {"Nested row with removal", schema, rowString, expectedRow};
+      return new Object[] {"Nested row which is removed", schema, rowString, expectedRow};
     }
 
     @Test


### PR DESCRIPTION
Currently,  RowJson.java doesn't have support for deserialising JSON with fields missing - it fails, even if the beam schema is nullable. This is often a problem for reading JSON as nulls are very commonly represented by omitting the field. Additionally, for this reason, not writing nulls is a reasonable when converting from Beam rows to JSON.

This would help to allow https://issues.apache.org/jira/browse/BEAM-7624 to be implemented. 

This commit attempts to add support for this type of implicit nulls.


Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.

--
R: @TheNeuralBit 



