### PR TITLE
Add relational GroupBy transform to Python.

### DIFF
--- a/sdks/python/apache_beam/coders/row_coder.py
+++ b/sdks/python/apache_beam/coders/row_coder.py
@@ -90,6 +90,7 @@ class RowCoder(FastCoder):
       try:
         schema = named_fields_to_schema(type_hint._fields)
       except ValueError:
+        # TODO(BEAM-10570): Consider a pythonsdk logical type.
         return typecoders.registry.get_coder(object)
     else:
       schema = named_tuple_to_schema(type_hint)

--- a/sdks/python/apache_beam/coders/row_coder.py
+++ b/sdks/python/apache_beam/coders/row_coder.py
@@ -87,7 +87,10 @@ class RowCoder(FastCoder):
   @staticmethod
   def from_type_hint(type_hint, registry):
     if isinstance(type_hint, row_type.RowTypeConstraint):
-      schema = named_fields_to_schema(type_hint._fields)
+      try:
+        schema = named_fields_to_schema(type_hint._fields)
+      except ValueError:
+        return typecoders.registry.get_coder(object)
     else:
       schema = named_tuple_to_schema(type_hint)
     return RowCoder(schema)

--- a/sdks/python/apache_beam/pvalue.py
+++ b/sdks/python/apache_beam/pvalue.py
@@ -675,3 +675,10 @@ class Row(object):
 
   def __ne__(self, other):
     return not self == other
+
+  def __reduce__(self):
+    return _make_Row, tuple(sorted(self.__dict__.items()))
+
+
+def _make_Row(*items):
+  return Row(**dict(items))

--- a/sdks/python/apache_beam/pvalue.py
+++ b/sdks/python/apache_beam/pvalue.py
@@ -659,3 +659,19 @@ class Row(object):
   """
   def __init__(self, **kwargs):
     self.__dict__.update(kwargs)
+
+  def __iter__(self):
+    for _, value in sorted(self.__dict__.items()):
+      yield value
+
+  def __repr__(self):
+    return 'Row(%s)' % ', '.join('%s=%r' % kv for kv in sorted(self.__dict__.items()))
+
+  def __hash__(self):
+    return hash(type(sorted(self.__dict__.items())))
+
+  def __eq__(self, other):
+    return type(self) == type(other) and self.__dict__ == other.__dict__
+
+  def __ne__(self, other):
+    return not self == other

--- a/sdks/python/apache_beam/pvalue.py
+++ b/sdks/python/apache_beam/pvalue.py
@@ -665,7 +665,8 @@ class Row(object):
       yield value
 
   def __repr__(self):
-    return 'Row(%s)' % ', '.join('%s=%r' % kv for kv in sorted(self.__dict__.items()))
+    return 'Row(%s)' % ', '.join(
+        '%s=%r' % kv for kv in sorted(self.__dict__.items()))
 
   def __hash__(self):
     return hash(type(sorted(self.__dict__.items())))

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -2302,7 +2302,7 @@ class GroupBy(PTransform):
         # pylint: disable=dict-items-not-iterating
         kwargs_items = sorted(kwargs.items())
       else:
-        kwargs_items = kwargs.items()
+        kwargs_items = kwargs.items()  # pylint: disable=dict-items-not-iterating
       for name, expr in kwargs_items:
         key_fields.append((name, _expr_to_callable(expr, name)))
     self._key_fields = key_fields

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -2267,7 +2267,7 @@ class GroupBy(PTransform):
 
       beam.Map(lambda v: (expr(v), v)) | beam.GroupByKey()
 
-  but provides several conviniences, e.g.
+  but provides several conveniences, e.g.
 
       * Several arguments may be provided, as positional or keyword arguments,
         resulting in a tuple-like key. For example `GroupBy(a=expr1, b=expr2)`

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -2264,7 +2264,7 @@ class GroupBy(PTransform):
 
   `GroupBy(expr)` is roughly equivalent to
 
-      beam.Map(lambda v: (expr(v), v)) | GroupByKey()
+      beam.Map(lambda v: (expr(v), v)) | beam.GroupByKey()
 
   but provides several conviniences, e.g.
 

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -2299,6 +2299,7 @@ class GroupBy(PTransform):
       if sys.version_info < (3, 6):
         # Before PEP 468, these are randomly ordered.
         # At least provide deterministic behavior here.
+        # pylint: disable=dict-items-not-iterating
         kwargs_items = sorted(kwargs.items())
       else:
         kwargs_items = kwargs.items()

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -2382,14 +2382,6 @@ class _GroupAndAggregate(PTransform):
 
   def expand(self, pcoll):
     from apache_beam.transforms.combiners import TupleCombineFn
-
-    # TODO(Py3): Use {**a, **b} syntax once Python 2 is gone.
-    def union_dicts(a, b):
-      result = {}
-      result.update(a)
-      result.update(b)
-      return result
-
     key_func = self._grouping.force_tuple_keys(True)._key_func()
     value_exprs = [expr for expr, _, __ in self._aggregations]
     value_func = lambda element: [expr(element) for expr in value_exprs]

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -25,6 +25,7 @@ import copy
 import inspect
 import logging
 import random
+import sys
 import types
 import typing
 from builtins import map
@@ -2295,7 +2296,13 @@ class GroupBy(PTransform):
       for ix, field in enumerate(fields):
         name = field if isinstance(field, str) else 'key%d' % ix
         key_fields.append((name, _expr_to_callable(field, ix)))
-      for name, expr in kwargs.items():
+      if sys.version_info < (3, 6):
+        # Before PEP 468, these are randomly ordered.
+        # At least provide deterministic behavior here.
+        kwargs_items = sorted(kwargs.items())
+      else:
+        kwargs_items = kwargs.items()
+      for name, expr in kwargs_items:
         key_fields.append((name, _expr_to_callable(expr, name)))
     self._key_fields = key_fields
     field_names = tuple(name for name, _ in key_fields)

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -796,6 +796,85 @@ class PTransformTest(unittest.TestCase):
     self.assertEqual(sorted(res2), [1, 2, 4, 8])
 
 
+class TestGroupBy(unittest.TestCase):
+  def test_lambdas(self):
+    def normalize(key, values):
+      return tuple(key), sorted(values)
+
+    with TestPipeline() as p:
+      pcoll = p | beam.Create(range(6))
+      assert_that(
+          pcoll | beam.GroupBy() | beam.MapTuple(normalize),
+          equal_to([((), [0, 1, 2, 3, 4, 5])]),
+          'GroupAll')
+      assert_that(
+          pcoll | beam.GroupBy(lambda x: x % 2)
+          | 'n2' >> beam.MapTuple(normalize),
+          equal_to([((0, ), [0, 2, 4]), ((1, ), [1, 3, 5])]),
+          'GroupOne')
+      assert_that(
+          pcoll | beam.GroupBy(a=lambda x: x % 2, b=lambda x: x < 4)
+          | 'n3' >> beam.MapTuple(normalize),
+          equal_to([((0, True), [0, 2]), ((1, True), [1, 3]), ((0, False), [4]),
+                    ((1, False), [5])]),
+          'GroupTwo')
+
+  def test_fields(self):
+    def normalize(key, values):
+      return key, sorted(v.value for v in values)
+
+    with TestPipeline() as p:
+      pcoll = p | beam.Create(range(-2, 3)) | beam.Map(
+          lambda x: beam.Row(
+              value=x, square=x * x, sign=x // abs(x) if x else 0))
+      assert_that(
+          pcoll | beam.GroupBy('square') | beam.MapTuple(normalize),
+          equal_to([
+              (beam.Row(square=0), [0]),
+              (beam.Row(square=1), [-1, 1]),
+              (beam.Row(square=4), [-2, 2]),
+          ]),
+          'GroupSquare')
+      assert_that(
+          pcoll | beam.GroupBy('square', 'sign')
+          | 'n2' >> beam.MapTuple(normalize),
+          equal_to([
+              (beam.Row(square=0, sign=0), [0]),
+              (beam.Row(square=1, sign=1), [1]),
+              (beam.Row(square=4, sign=1), [2]),
+              (beam.Row(square=1, sign=-1), [-1]),
+              (beam.Row(square=4, sign=-1), [-2]),
+          ]),
+          'GroupSquareSign')
+      assert_that(
+          pcoll | beam.GroupBy('square', big=lambda x: x.value > 1)
+          | 'n3' >> beam.MapTuple(normalize),
+          equal_to([
+              (beam.Row(square=0, big=False), [0]),
+              (beam.Row(square=1, big=False), [-1, 1]),
+              (beam.Row(square=4, big=False), [-2]),
+              (beam.Row(square=4, big=True), [2]),
+          ]),
+          'GroupSquareNonzero')
+
+  def test_aggregate(self):
+    with TestPipeline() as p:
+      pcoll = p | beam.Create(range(-2, 3)) | beam.Map(
+          lambda x: beam.Row(
+              value=x, square=x * x, sign=x // abs(x) if x else 0))
+
+      assert_that(
+          pcoll | beam.GroupBy('square', big=lambda x: x.value > 1)
+            .aggregate_field('value', sum, 'sum')
+            .aggregate_field(lambda x: x.sign == 1, all, 'positive'),
+          equal_to([
+              beam.Row(square=0, big=False, sum=0, positive=False),   # [0],
+              beam.Row(square=1, big=False, sum=0, positive=False),   # [-1, 1]
+              beam.Row(square=4, big=False, sum=-2, positive=False),  # [-2]
+              beam.Row(square=4, big=True, sum=2, positive=True),     # [2]
+          ]))
+
+
 @beam.ptransform_fn
 def SamplePTransform(pcoll):
   """Sample transform using the @ptransform_fn decorator."""

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -824,7 +824,7 @@ class TestGroupBy(unittest.TestCase):
       return key, sorted(v.value for v in values)
 
     with TestPipeline() as p:
-      pcoll = p | beam.Create(range(-2, 3)) | beam.Map(
+      pcoll = p | beam.Create(range(-2, 3)) | beam.Map(int) | beam.Map(
           lambda x: beam.Row(
               value=x, square=x * x, sign=x // abs(x) if x else 0))
       assert_that(

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -799,7 +799,7 @@ class PTransformTest(unittest.TestCase):
 class TestGroupBy(unittest.TestCase):
   def test_lambdas(self):
     def normalize(key, values):
-      return tuple(key) if isinstance(key, beam.Row) else key, sorted(values)
+      return tuple(key) if isinstance(key, tuple) else key, sorted(values)
 
     with TestPipeline() as p:
       pcoll = p | beam.Create(range(6))

--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -85,7 +85,7 @@ def _safe_issubclass(derived, parent):
   """
   try:
     return issubclass(derived, parent)
-  except TypeError:
+  except (TypeError, AttributeError):
     if hasattr(derived, '__origin__'):
       try:
         return issubclass(derived.__origin__, parent)


### PR DESCRIPTION

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
