### PR TITLE
[BEAM-9987] added instruction for converting maven project to gradle

### DIFF
--- a/website/www/site/content/en/get-started/quickstart-java.md
+++ b/website/www/site/content/en/get-started/quickstart-java.md
@@ -106,12 +106,30 @@ For a detailed introduction to the Beam concepts used in these examples, see the
 
 ## Optional: Convert from Maven to Gradle Project
 
-To convert this from a Maven project into Gradle, execute `gradle init` while in the same directory as the `pom.xml` file.
+Ensure you are in the same directory as the `pom.xml` file generated from the previous step. Automatically convert your project from Maven to Gradle by running:
+{{< highlight >}}
+$ gradle init
+{{< /highlight >}}
 
 After you have converted the project to Gradle:
 
-1. Edit the generated `build.gradle` by adding `mavenCentral()` under `repositories`.
-1. Rebuild your project by running `gradle build`.
+1. Edit the generated `build.gradle` file by adding `mavenCentral()` under `repositories`:
+{{< highlight >}}
+repositories {
+    mavenCentral()
+    maven {
+        url = uri('https://repository.apache.org/content/repositories/snapshots/')
+    }
+
+    maven {
+        url = uri('http://repo.maven.apache.org/maven2')
+    }
+}
+{{< /highlight >}}
+1. Rebuild your project by running:
+{{< highlight >}}
+$ gradle build
+{{< /highlight >}}
 
 ## Run WordCount
 

--- a/website/www/site/content/en/get-started/quickstart-java.md
+++ b/website/www/site/content/en/get-started/quickstart-java.md
@@ -33,6 +33,7 @@ If you're interested in contributing to the Apache Beam Java codebase, see the [
 
 1. Download and install [Apache Maven](https://maven.apache.org/download.cgi) by following Maven's [installation guide](https://maven.apache.org/install.html) for your specific operating system.
 
+1. Optional: Install [Gradle](https://gradle.org/install/) if you would like to convert your Maven project into Gradle.
 
 ## Get the WordCount Code
 
@@ -103,6 +104,14 @@ d-----        7/19/2018  11:00 PM                subprocess
 
 For a detailed introduction to the Beam concepts used in these examples, see the [WordCount Example Walkthrough](/get-started/wordcount-example). Here, we'll just focus on executing `WordCount.java`.
 
+## Optional: Convert from Maven to Gradle Project
+
+To convert this from a Maven project into Gradle, execute `gradle init` while in the same directory as the `pom.xml` file.
+
+After you have converted the project to Gradle:
+
+1. Edit the generated `build.gradle` by adding `mavenCentral()` under `repositories`.
+1. Rebuild your project by running `gradle build`.
 
 ## Run WordCount
 

--- a/website/www/site/content/en/get-started/quickstart-java.md
+++ b/website/www/site/content/en/get-started/quickstart-java.md
@@ -126,6 +126,15 @@ repositories {
     }
 }
 {{< /highlight >}}
+1. Add the following task in `build.gradle` to allow you to execute pipelines with Gradle:
+{{< highlight >}}
+task execute (type:JavaExec) {
+    main = System.getProperty("mainClass")
+    classpath = sourceSets.main.runtimeClasspath
+    systemProperties System.getProperties()
+    args System.getProperty("exec.args").split()
+}
+{{< /highlight >}}
 1. Rebuild your project by running:
 {{< highlight >}}
 $ gradle build
@@ -143,6 +152,8 @@ After you've chosen which runner you'd like to use:
     1. Adding any runner-specific required options
     1. Choosing input files and an output location are accessible on the chosen runner. (For example, you can't access a local file if you are running the pipeline on an external cluster.)
 1.  Run your first WordCount pipeline.
+
+### Run WordCount Using Maven
 
 For Unix shells:
 
@@ -258,6 +269,50 @@ PS> java -cp target/word-count-beam-bundled-0.1.jar org.apache.beam.examples.Wor
 PS> mvn package -P jet-runner
 PS> java -cp target/word-count-beam-bundled-0.1.jar org.apache.beam.examples.WordCount `
       --runner=JetRunner --jetLocalMode=3 --inputFile=$pwd/pom.xml --output=counts
+{{< /highlight >}}
+
+### Run WordCount Using Gradle
+
+For Unix shells (Instructions currently only available for Direct, Spark, and Dataflow):
+
+{{< highlight class="runner-direct">}}
+$ gradle clean execute -DmainClass=org.apache.beam.examples.WordCount \
+    -Dexec.args="--inputFile=pom.xml --output=counts" -Pdirect-runner
+{{< /highlight >}}
+
+{{< highlight class="runner-apex">}}
+We are working on adding the instruction for this runner!
+{{< /highlight >}}
+
+{{< highlight class="runner-flink-local">}}
+We are working on adding the instruction for this runner!
+{{< /highlight >}}
+
+{{< highlight class="runner-flink-cluster">}}
+We are working on adding the instruction for this runner!
+{{< /highlight >}}
+
+{{< highlight class="runner-spark" >}}
+$ gradle clean execute -DmainClass=org.apache.beam.examples.WordCount \
+    -Dexec.args="--inputFile=pom.xml --output=counts" -Pspark-runner
+{{< /highlight >}}
+
+{{< highlight class="runner-dataflow" >}}
+$ gradle clean execute -DmainClass=org.apache.beam.examples.WordCount \
+    -Dexec.args="--project=<your-gcp-project> --inputFile=gs://apache-beam-samples/shakespeare/* \
+    --output=gs://<your-gcs-bucket>/counts" -Pdataflow-runner
+{{< /highlight >}}
+
+{{< highlight class="runner-samza-local">}}
+We are working on adding the instruction for this runner!
+{{< /highlight >}}
+
+{{< highlight class="runner-nemo">}}
+We are working on adding the instruction for this runner!
+{{< /highlight >}}
+
+{{< highlight class="runner-jet">}}
+We are working on adding the instruction for this runner!
 {{< /highlight >}}
 
 ## Inspect the results


### PR DESCRIPTION
Added instructions for converting the example WordCount Maven project generated using the generate:archetype into a Gradle project. I've attached images of what it looks like when I run it locally. I don't have much experience writing instructions like this so please let me know if there are any suggestions on how the phrasing/formatting could be better!

Added to setting up development environment:
![gradleinstructions1](https://user-images.githubusercontent.com/6096872/84213475-49f54c00-aab0-11ea-927d-f1870610d4e4.png)

Instructions:
![instruction2](https://user-images.githubusercontent.com/6096872/84451328-4f829b80-ac42-11ea-8987-2719717d787f.png)

Instructions for Executing (currently only instructions for runners: Direct, Dataflow, Spark):
![instruction3](https://user-images.githubusercontent.com/6096872/84451146-b3589480-ac41-11ea-9930-1df2fad39790.png)

View for when a runner is selected that does not have current instructions:
![instruction4](https://user-images.githubusercontent.com/6096872/84451159-bd7a9300-ac41-11ea-8b1f-7f8dc89f8ccc.png)

Please let me know if this could be better displayed in an alternate way. If I only include highlight tabs for the ones with current instructions (Direct, Dataflow, and Spark) then the entire runner-switcher under "Run WordCount Using Gradle" disappears if a user clicks on another runner option under "Run WordCount Using Maven". I thought it would make more sense to include the others as placeholders and just mark them as to be added so the whole switcher does not disappear and it's clear where the instruction will be added in the future. 


------------------------

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Gearpump | Samza | Spark
--- | --- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Gearpump/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
