### PR TITLE
[BEAM-9615] Add String UTF8 coder.

### DIFF
--- a/sdks/go/pkg/beam/coder.go
+++ b/sdks/go/pkg/beam/coder.go
@@ -163,20 +163,13 @@ func inferCoder(t FullType) (*coder.Coder, error) {
 			return &coder.Coder{Kind: coder.Double, T: t}, nil
 
 		case reflectx.String:
-			c, err := coderx.NewString()
-			if err != nil {
-				return nil, err
-			}
-			return &coder.Coder{Kind: coder.Custom, T: t, Custom: c}, nil
+			return &coder.Coder{Kind: coder.String, T: t}, nil
 
 		case reflectx.ByteSlice:
 			return &coder.Coder{Kind: coder.Bytes, T: t}, nil
 
 		case reflectx.Bool:
 			return &coder.Coder{Kind: coder.Bool, T: t}, nil
-
-		case reflectx.String:
-			return &coder.Coder{Kind: coder.String, T: t}, nil
 
 		default:
 			et := t.Type()

--- a/sdks/go/pkg/beam/coder.go
+++ b/sdks/go/pkg/beam/coder.go
@@ -175,6 +175,9 @@ func inferCoder(t FullType) (*coder.Coder, error) {
 		case reflectx.Bool:
 			return &coder.Coder{Kind: coder.Bool, T: t}, nil
 
+		case reflectx.String:
+			return &coder.Coder{Kind: coder.String, T: t}, nil
+
 		default:
 			et := t.Type()
 			if c := coder.LookupCustomCoder(et); c != nil {

--- a/sdks/go/pkg/beam/core/graph/coder/coder.go
+++ b/sdks/go/pkg/beam/core/graph/coder/coder.go
@@ -164,6 +164,7 @@ type Kind string
 const (
 	Custom        Kind = "Custom" // Implicitly length-prefixed
 	Bytes         Kind = "bytes"  // Implicitly length-prefixed as part of the encoding
+	String        Kind = "string" // Implicitly length-prefixed as part of the encoding.
 	Bool          Kind = "bool"
 	VarInt        Kind = "varint"
 	Double        Kind = "double"
@@ -277,6 +278,11 @@ func NewVarInt() *Coder {
 // NewDouble returns a new double coder using the built-in scheme.
 func NewDouble() *Coder {
 	return &Coder{Kind: Double, T: typex.New(reflectx.Float64)}
+}
+
+// NewString returns a new string coder using the built-in scheme.
+func NewString() *Coder {
+	return &Coder{Kind: String, T: typex.New(reflectx.String)}
 }
 
 // IsW returns true iff the coder is for a WindowedValue.

--- a/sdks/go/pkg/beam/core/runtime/coderx/string.go
+++ b/sdks/go/pkg/beam/core/runtime/coderx/string.go
@@ -23,6 +23,8 @@ import (
 
 // NewString returns a coder for the string type. It uses the native
 // []byte to string conversion.
+//
+// Only for custom coder test use.
 func NewString() (*coder.CustomCoder, error) {
 	return coder.NewCustomCoder("string", reflectx.String, encString, decString)
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/coder_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/coder_test.go
@@ -46,6 +46,9 @@ func TestCoders(t *testing.T) {
 			coder: coder.NewDouble(),
 			val:   &FullValue{Elm: float64(12.9)},
 		}, {
+			coder: coder.NewString(),
+			val:   &FullValue{Elm: "myString"},
+		}, {
 			coder: func() *coder.Coder {
 				c, _ := coderx.NewString()
 				return &coder.Coder{Kind: coder.Custom, Custom: c, T: typex.New(reflectx.String)}

--- a/sdks/go/pkg/beam/core/runtime/exec/hash.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/hash.go
@@ -42,6 +42,9 @@ func makeElementHasher(c *coder.Coder) elementHasher {
 	case coder.VarInt:
 		return &numberHasher{}
 
+	case coder.String:
+		return &stringHasher{hash: hasher}
+
 	case coder.Custom:
 		// Shortcut for primitives where we know we can do better.
 		switch c.Custom.Type {
@@ -49,8 +52,6 @@ func makeElementHasher(c *coder.Coder) elementHasher {
 			reflectx.Uint, reflectx.Uint8, reflectx.Uint16, reflectx.Uint32, reflectx.Uint64,
 			reflectx.Float32, reflectx.Float64:
 			return &numberHasher{}
-		case reflectx.String:
-			return &stringHasher{hash: hasher}
 		}
 		// TODO(lostluck): 2019.02.07 - consider supporting encoders that
 		// take in a io.Writer instead.

--- a/sdks/go/pkg/beam/core/runtime/graphx/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/coder.go
@@ -35,6 +35,7 @@ const (
 	urnBoolCoder                = "beam:coder:bool:v1"
 	urnVarIntCoder              = "beam:coder:varint:v1"
 	urnDoubleCoder              = "beam:coder:double:v1"
+	urnStringCoder              = "beam:coder:string_utf8:v1"
 	urnLengthPrefixCoder        = "beam:coder:length_prefix:v1"
 	urnKVCoder                  = "beam:coder:kv:v1"
 	urnIterableCoder            = "beam:coder:iterable:v1"
@@ -56,6 +57,7 @@ func knownStandardCoders() []string {
 		urnBoolCoder,
 		urnVarIntCoder,
 		urnDoubleCoder,
+		urnStringCoder,
 		urnLengthPrefixCoder,
 		urnKVCoder,
 		urnIterableCoder,
@@ -183,6 +185,9 @@ func (b *CoderUnmarshaller) makeCoder(c *pipepb.Coder) (*coder.Coder, error) {
 
 	case urnDoubleCoder:
 		return coder.NewDouble(), nil
+
+	case urnStringCoder:
+		return coder.NewString(), nil
 
 	case urnKVCoder:
 		if len(components) != 2 {
@@ -402,6 +407,9 @@ func (b *CoderMarshaller) Add(c *coder.Coder) string {
 
 	case coder.Double:
 		return b.internBuiltInCoder(urnDoubleCoder)
+
+	case coder.String:
+		return b.internBuiltInCoder(urnStringCoder)
 
 	default:
 		panic(fmt.Sprintf("Failed to marshal custom coder %v, unexpected coder kind: %v", c, c.Kind))

--- a/sdks/go/pkg/beam/core/runtime/graphx/coder_test.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/coder_test.go
@@ -58,6 +58,10 @@ func TestMarshalUnmarshalCoders(t *testing.T) {
 			coder.NewDouble(),
 		},
 		{
+			"string",
+			coder.NewString(),
+		},
+		{
 			"foo",
 			foo,
 		},
@@ -95,6 +99,23 @@ func TestMarshalUnmarshalCoders(t *testing.T) {
 			}
 			if len(coders) != 1 || !test.c.Equals(coders[0]) {
 				t.Errorf("Unmarshal(Marshal(%v)) = %v, want identity", test.c, coders)
+			}
+		})
+	}
+
+	// These tests cover the pure dataflow to dataflow coder cases.
+	for _, test := range tests {
+		t.Run("dataflow:"+test.name, func(t *testing.T) {
+			ref, err := graphx.EncodeCoderRef(test.c)
+			if err != nil {
+				t.Fatalf("EncodeCoderRef(%v) failed: %v", test.c, err)
+			}
+			got, err := graphx.DecodeCoderRef(ref)
+			if err != nil {
+				t.Fatalf("DecodeCoderRef(EncodeCoderRef(%v)) failed: %v", test.c, err)
+			}
+			if !test.c.Equals(got) {
+				t.Errorf("DecodeCoderRef(EncodeCoderRef(%v)) = %v, want identity", test.c, got)
 			}
 		})
 	}

--- a/sdks/go/pkg/beam/core/runtime/graphx/dataflow.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/dataflow.go
@@ -52,6 +52,7 @@ const (
 	intervalWindowType = "kind:interval_window"
 
 	cogbklistType = "kind:cogbklist" // CoGBK representation. Not a coder.
+	stringType    = "kind:string"    // Not a classical Dataflow kind.
 )
 
 // WrapIterable adds an iterable (stream) coder for Dataflow side input.
@@ -150,7 +151,6 @@ func EncodeCoderRef(c *coder.Coder) (*CoderRef, error) {
 		return &CoderRef{Type: windowedValueType, Components: []*CoderRef{elm, w}, IsWrapper: true}, nil
 
 	case coder.Bytes:
-		// TODO(herohde) 6/27/2017: add length-prefix and not assume nested by context?
 		return &CoderRef{Type: bytesType}, nil
 
 	case coder.Bool:
@@ -161,6 +161,10 @@ func EncodeCoderRef(c *coder.Coder) (*CoderRef, error) {
 
 	case coder.Double:
 		return &CoderRef{Type: doubleType}, nil
+
+	case coder.String:
+		// IncludePipelineProtoCoderID since this isn't "known" to dataflow.
+		return &CoderRef{Type: stringType, PipelineProtoCoderID: c.ID}, nil
 
 	default:
 		return nil, errors.Errorf("bad coder kind: %v", c.Kind)
@@ -194,6 +198,9 @@ func DecodeCoderRef(c *CoderRef) (*coder.Coder, error) {
 
 	case doubleType:
 		return coder.NewDouble(), nil
+
+	case stringType:
+		return coder.NewString(), nil
 
 	case pairType:
 		if len(c.Components) != 2 {

--- a/sdks/go/pkg/beam/core/runtime/harness/harness.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/harness.go
@@ -175,7 +175,7 @@ func (c *control) getOrCreatePlan(bdID bundleDescriptorID) (*exec.Plan, error) {
 			c.mu.Unlock() // Unlock to make the lookup.
 			newDesc, err := c.lookupDesc(bdID)
 			if err != nil {
-				return nil, errors.Wrapf(err, "execution plan for %v not found", bdID)
+				return nil, errors.WithContextf(err, "execution plan for %v not found", bdID)
 			}
 			c.mu.Lock()
 			c.descriptors[bdID] = newDesc
@@ -184,7 +184,7 @@ func (c *control) getOrCreatePlan(bdID bundleDescriptorID) (*exec.Plan, error) {
 		newPlan, err := exec.UnmarshalPlan(desc)
 		if err != nil {
 			c.mu.Unlock()
-			return nil, errors.Wrapf(err, "invalid bundle desc %v: %v", bdID, desc)
+			return nil, errors.WithContextf(err, "invalid bundle desc: %v", bdID)
 		}
 		plan = newPlan
 	}


### PR DESCRIPTION
Adds support for the StringUTF8 beam coder to the Go SDK.
This is functionally how strings were encoded before, but now we use the standard URN rather than a custom coder to wrap it.

* This PR also changes harness Bundle Descriptor Plan errors to put the root error first and then have all the PB proto print outs afterwards which makes those errors easier to read.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Samza | Spark
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
