### PR TITLE
[BEAM-10259] Use ref-counted connection to Spanner to prevent multiple connections.

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/BatchSpannerRead.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/BatchSpannerRead.java
@@ -93,7 +93,7 @@ abstract class BatchSpannerRead
 
     @Setup
     public void setup() throws Exception {
-      spannerAccessor = SpannerAccessor.create(config);
+      spannerAccessor = SpannerAccessor.getOrCreate(config);
     }
 
     @Teardown
@@ -146,7 +146,7 @@ abstract class BatchSpannerRead
 
     @Setup
     public void setup() throws Exception {
-      spannerAccessor = SpannerAccessor.create(config);
+      spannerAccessor = SpannerAccessor.getOrCreate(config);
     }
 
     @Teardown

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/CreateTransactionFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/CreateTransactionFn.java
@@ -33,7 +33,7 @@ class CreateTransactionFn extends DoFn<Object, Transaction> {
 
   @DoFn.Setup
   public void setup() throws Exception {
-    spannerAccessor = SpannerAccessor.create(config.getSpannerConfig());
+    spannerAccessor = SpannerAccessor.getOrCreate(config.getSpannerConfig());
   }
 
   @Teardown

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/NaiveSpannerRead.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/NaiveSpannerRead.java
@@ -81,7 +81,7 @@ abstract class NaiveSpannerRead
 
     @Setup
     public void setup() throws Exception {
-      spannerAccessor = SpannerAccessor.create(config);
+      spannerAccessor = SpannerAccessor.getOrCreate(config);
     }
 
     @Teardown

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/ReadSpannerSchema.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/ReadSpannerSchema.java
@@ -39,7 +39,7 @@ class ReadSpannerSchema extends DoFn<Void, SpannerSchema> {
 
   @Setup
   public void setup() throws Exception {
-    spannerAccessor = SpannerAccessor.create(config);
+    spannerAccessor = SpannerAccessor.getOrCreate(config);
   }
 
   @Teardown

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerAccessor.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerAccessor.java
@@ -31,33 +31,73 @@ import io.grpc.Channel;
 import io.grpc.ClientCall;
 import io.grpc.ClientInterceptor;
 import io.grpc.MethodDescriptor;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.util.ReleaseInfo;
 import org.joda.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Manages lifecycle of {@link DatabaseClient} and {@link Spanner} instances. */
 class SpannerAccessor implements AutoCloseable {
+  private static final Logger LOG = LoggerFactory.getLogger(SpannerAccessor.class);
+
   // A common user agent token that indicates that this request was originated from Apache Beam.
   private static final String USER_AGENT_PREFIX = "Apache_Beam_Java";
+
+  // Only create one SpannerAccessor for each different SpannerConfig.
+  private static final ConcurrentHashMap<SpannerConfig, SpannerAccessor> spannerAccessors =
+      new ConcurrentHashMap<>();
+
+  // Keep reference counts of each SpannerAccessor's usage so that we can close
+  // it when it is no longer in use.
+  private static final ConcurrentHashMap<SpannerConfig, AtomicInteger> refcounts =
+      new ConcurrentHashMap<>();
 
   private final Spanner spanner;
   private final DatabaseClient databaseClient;
   private final BatchClient batchClient;
   private final DatabaseAdminClient databaseAdminClient;
+  private final SpannerConfig spannerConfig;
 
   private SpannerAccessor(
       Spanner spanner,
       DatabaseClient databaseClient,
       DatabaseAdminClient databaseAdminClient,
-      BatchClient batchClient) {
+      BatchClient batchClient,
+      SpannerConfig spannerConfig) {
     this.spanner = spanner;
     this.databaseClient = databaseClient;
     this.databaseAdminClient = databaseAdminClient;
     this.batchClient = batchClient;
+    this.spannerConfig = spannerConfig;
   }
 
-  static SpannerAccessor create(SpannerConfig spannerConfig) {
+  static SpannerAccessor getOrCreate(SpannerConfig spannerConfig) {
+
+    SpannerAccessor self = spannerAccessors.get(spannerConfig);
+    if (self == null) {
+      synchronized (spannerAccessors) {
+        // Re-check that it has not been created before we got the lock.
+        self = spannerAccessors.get(spannerConfig);
+        if (self == null) {
+          // Connect to spanner for this SpannerConfig.
+          LOG.info("Connecting to {}", spannerConfig);
+          self = SpannerAccessor.createAndConnect(spannerConfig);
+          spannerAccessors.put(spannerConfig, self);
+          refcounts.putIfAbsent(spannerConfig, new AtomicInteger(0));
+        }
+      }
+    }
+    // Add refcount for this spannerConfig.
+    int refcount = refcounts.get(spannerConfig).incrementAndGet();
+    LOG.debug("getOrCreate(): refcount={} for {}", refcount, spannerConfig);
+    return self;
+  }
+
+  private static SpannerAccessor createAndConnect(SpannerConfig spannerConfig) {
     SpannerOptions.Builder builder = SpannerOptions.newBuilder();
 
     ValueProvider<Duration> commitDeadline = spannerConfig.getCommitDeadline();
@@ -107,7 +147,8 @@ class SpannerAccessor implements AutoCloseable {
         spanner.getBatchClient(DatabaseId.of(options.getProjectId(), instanceId, databaseId));
     DatabaseAdminClient databaseAdminClient = spanner.getDatabaseAdminClient();
 
-    return new SpannerAccessor(spanner, databaseClient, databaseAdminClient, batchClient);
+    return new SpannerAccessor(
+        spanner, databaseClient, databaseAdminClient, batchClient, spannerConfig);
   }
 
   DatabaseClient getDatabaseClient() {
@@ -124,7 +165,21 @@ class SpannerAccessor implements AutoCloseable {
 
   @Override
   public void close() {
-    spanner.close();
+    // Only close Spanner when present in map and refcount == 0
+    int refcount = refcounts.getOrDefault(spannerConfig, new AtomicInteger(0)).decrementAndGet();
+    LOG.debug("close(): refcount={} for {}", refcount, spannerConfig);
+
+    if (refcount == 0) {
+      synchronized (spannerAccessors) {
+        // Re-check refcount in case it has increased outside the lock.
+        if (refcounts.get(spannerConfig).get() <= 0) {
+          spannerAccessors.remove(spannerConfig);
+          refcounts.remove(spannerConfig);
+          LOG.info("Closing {} ", spannerConfig);
+          spanner.close();
+        }
+      }
+    }
   }
 
   private static class CommitDeadlineSettingInterceptor implements ClientInterceptor {

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/SpannerAccessorTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/SpannerAccessorTest.java
@@ -1,0 +1,103 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.spanner;
+
+import static com.sun.tools.doclint.Entity.times;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+
+import com.google.cloud.spanner.DatabaseId;
+import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class SpannerAccessorTest {
+
+  private FakeServiceFactory serviceFactory;
+
+  @Before
+  public void setUp() throws Exception {
+
+    serviceFactory = new FakeServiceFactory();
+  }
+
+  @Test
+  public void testCreateOnlyOnce() {
+    SpannerConfig config1 =
+        SpannerConfig.create()
+            .toBuilder()
+            .setServiceFactory(serviceFactory)
+            .setProjectId(StaticValueProvider.of("project"))
+            .setInstanceId(StaticValueProvider.of("test1"))
+            .setDatabaseId(StaticValueProvider.of("test1"))
+            .build();
+
+    SpannerAccessor acc1 = SpannerAccessor.getOrCreate(config1);
+    SpannerAccessor acc2 = SpannerAccessor.getOrCreate(config1);
+    SpannerAccessor acc3 = SpannerAccessor.getOrCreate(config1);
+
+    acc1.close();
+    acc2.close();
+    acc3.close();
+
+    // getDatabaseClient and close() only called once.
+    verify(serviceFactory.mockSpanner(), times(1))
+        .getDatabaseClient(DatabaseId.of("project", "test1", "test1"));
+    verify(serviceFactory.mockSpanner(), times(1)).close();
+  }
+
+  @Test
+  public void testRefCountedSpannerAccessorDifferentDbsOnlyOnce() {
+    SpannerConfig config1 =
+        SpannerConfig.create()
+            .toBuilder()
+            .setServiceFactory(serviceFactory)
+            .setProjectId(StaticValueProvider.of("project"))
+            .setInstanceId(StaticValueProvider.of("test1"))
+            .setDatabaseId(StaticValueProvider.of("test1"))
+            .build();
+    SpannerConfig config2 =
+        config1
+            .toBuilder()
+            .setInstanceId(StaticValueProvider.of("test2"))
+            .setDatabaseId(StaticValueProvider.of("test2"))
+            .build();
+
+    SpannerAccessor acc1a = SpannerAccessor.getOrCreate(config1);
+    SpannerAccessor acc1b = SpannerAccessor.getOrCreate(config1);
+
+    SpannerAccessor acc2a = SpannerAccessor.getOrCreate(config2);
+    SpannerAccessor acc2b = SpannerAccessor.getOrCreate(config2);
+
+    acc1a.close();
+    acc2a.close();
+    acc1b.close();
+    acc2b.close();
+
+    // getDatabaseClient called once each for the separate instances.
+    verify(serviceFactory.mockSpanner(), times(1))
+        .getDatabaseClient(eq(DatabaseId.of("project", "test1", "test1")));
+    verify(serviceFactory.mockSpanner(), times(1))
+        .getDatabaseClient(eq(DatabaseId.of("project", "test2", "test2")));
+    verify(serviceFactory.mockSpanner(), times(2)).close();
+  }
+}


### PR DESCRIPTION
In a multi-threaded runner, WriteToSpannerFn.setup() is called for
each instance on each thread, causing multiple session pools to be
created.

Use a ref-counted SpannerAccessor per database to ensure that there
is only one session pool per database per process.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Samza | Spark
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
