### PR TITLE
[BEAM-10260] Fix continuation token support with statecache

### DIFF
--- a/sdks/python/apache_beam/runners/portability/flink_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/flink_runner_test.py
@@ -304,7 +304,6 @@ if __name__ == '__main__':
             'stateful.beam.metric:statecache:miss: 0',
             'stateful.beam.metric:statecache:hit: 20',
             'stateful.beam.metric:statecache:put: 0',
-            'stateful.beam.metric:statecache:extend: 10',
             'stateful.beam.metric:statecache:evict: 0',
             # Counters
             # (total of get/hit will be off by 10 due to the cross-bundle
@@ -317,7 +316,6 @@ if __name__ == '__main__':
             'stateful.beam.metric:statecache:miss_total: 20',
             'stateful.beam.metric:statecache:hit_total: 200',
             'stateful.beam.metric:statecache:put_total: 20',
-            'stateful.beam.metric:statecache:extend_total: 110',
             'stateful.beam.metric:statecache:evict_total: 0',
         ])
       else:
@@ -335,14 +333,12 @@ if __name__ == '__main__':
             'stateful).beam.metric:statecache:hit: 11',
             # State is flushed back once per key
             'stateful).beam.metric:statecache:put: 1',
-            'stateful).beam.metric:statecache:extend: 1',
             'stateful).beam.metric:statecache:evict: 0',
             # Counters
             'stateful).beam.metric:statecache:get_total: 120',
             'stateful).beam.metric:statecache:miss_total: 10',
             'stateful).beam.metric:statecache:hit_total: 110',
             'stateful).beam.metric:statecache:put_total: 10',
-            'stateful).beam.metric:statecache:extend_total: 10',
             'stateful).beam.metric:statecache:evict_total: 0',
         ])
       lines_actual = set()

--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -345,8 +345,9 @@ class _StateBackedIterable(object):
 
   def __iter__(self):
     # type: () -> Iterator[Any]
-    return self._state_handler.blocking_get(
-        self._state_key, self._coder_impl, is_cached=self._is_cached)
+    return iter(
+        self._state_handler.blocking_get(
+            self._state_key, self._coder_impl, is_cached=self._is_cached))
 
   def __reduce__(self):
     return list, (list(self), )

--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -332,7 +332,6 @@ class _StateBackedIterable(object):
                state_handler,  # type: sdk_worker.CachingStateHandler
                state_key,  # type: beam_fn_api_pb2.StateKey
                coder_or_impl,  # type: Union[coders.Coder, coder_impl.CoderImpl]
-               is_cached=False
               ):
     # type: (...) -> None
     self._state_handler = state_handler
@@ -341,13 +340,11 @@ class _StateBackedIterable(object):
       self._coder_impl = coder_or_impl.get_impl()
     else:
       self._coder_impl = coder_or_impl
-    self._is_cached = is_cached
 
   def __iter__(self):
     # type: () -> Iterator[Any]
     return iter(
-        self._state_handler.blocking_get(
-            self._state_key, self._coder_impl, is_cached=self._is_cached))
+        self._state_handler.blocking_get(self._state_key, self._coder_impl))
 
   def __reduce__(self):
     return list, (list(self), )
@@ -514,10 +511,7 @@ class SynchronousBagRuntimeState(userstate.BagRuntimeState):
     return _ConcatIterable([] if self._cleared else cast(
         'Iterable[Any]',
         _StateBackedIterable(
-            self._state_handler,
-            self._state_key,
-            self._value_coder,
-            is_cached=True)),
+            self._state_handler, self._state_key, self._value_coder)),
                            self._added_elements)
 
   def add(self, value):
@@ -532,13 +526,10 @@ class SynchronousBagRuntimeState(userstate.BagRuntimeState):
   def commit(self):
     to_await = None
     if self._cleared:
-      to_await = self._state_handler.clear(self._state_key, is_cached=True)
+      to_await = self._state_handler.clear(self._state_key)
     if self._added_elements:
       to_await = self._state_handler.extend(
-          self._state_key,
-          self._value_coder.get_impl(),
-          self._added_elements,
-          is_cached=True)
+          self._state_key, self._value_coder.get_impl(), self._added_elements)
     if to_await:
       # To commit, we need to wait on the last state request future to complete.
       to_await.get()
@@ -562,19 +553,13 @@ class SynchronousSetRuntimeState(userstate.SetRuntimeState):
     accumulator = set(
         _ConcatIterable(
             set() if self._cleared else _StateBackedIterable(
-                self._state_handler,
-                self._state_key,
-                self._value_coder,
-                is_cached=True),
+                self._state_handler, self._state_key, self._value_coder),
             self._added_elements))
 
     if rewrite and accumulator:
-      self._state_handler.clear(self._state_key, is_cached=True)
+      self._state_handler.clear(self._state_key)
       self._state_handler.extend(
-          self._state_key,
-          self._value_coder.get_impl(),
-          accumulator,
-          is_cached=True)
+          self._state_key, self._value_coder.get_impl(), accumulator)
 
       # Since everthing is already committed so we can safely reinitialize
       # added_elements here.
@@ -590,7 +575,7 @@ class SynchronousSetRuntimeState(userstate.SetRuntimeState):
     # type: (Any) -> None
     if self._cleared:
       # This is a good time explicitly clear.
-      self._state_handler.clear(self._state_key, is_cached=True)
+      self._state_handler.clear(self._state_key)
       self._cleared = False
 
     self._added_elements.add(value)
@@ -606,13 +591,10 @@ class SynchronousSetRuntimeState(userstate.SetRuntimeState):
     # type: () -> None
     to_await = None
     if self._cleared:
-      to_await = self._state_handler.clear(self._state_key, is_cached=True)
+      to_await = self._state_handler.clear(self._state_key)
     if self._added_elements:
       to_await = self._state_handler.extend(
-          self._state_key,
-          self._value_coder.get_impl(),
-          self._added_elements,
-          is_cached=True)
+          self._state_key, self._value_coder.get_impl(), self._added_elements)
     if to_await:
       # To commit, we need to wait on the last state request future to complete.
       to_await.get()
@@ -770,7 +752,6 @@ class FnApiUserStateContext(userstate.UserStateContext):
 
   def reset(self):
     # type: () -> None
-    # TODO(BEAM-5428): Implement cross-bundle state caching.
     self._all_states = {}
     self._timer_output_streams = {}
     self._timer_coders_impl = {}

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -26,6 +26,7 @@ from __future__ import print_function
 import abc
 import collections
 import contextlib
+import functools
 import logging
 import queue
 import sys
@@ -915,7 +916,7 @@ class CachingStateHandler(object):
                    coder,  # type: coder_impl.CoderImpl
                    is_cached=False
                   ):
-    # type: (...) -> Iterator[Any]
+    # type: (...) -> Iterable[Any]
     cache_token = self._get_cache_token(state_key, is_cached)
     if not cache_token:
       # Cache disabled / no cache token. Can't do a lookup/store in the cache.
@@ -931,8 +932,14 @@ class CachingStateHandler(object):
       # https://jira.apache.org/jira/browse/BEAM-8297
       materialized = cached_value = (
           self._partially_cached_iterable(state_key, coder))
-      self._state_cache.put(cache_state_key, cache_token, materialized)
-    return iter(cached_value)
+      if isinstance(materialized, (list, self.ContinuationIterable)):
+        self._state_cache.put(cache_state_key, cache_token, materialized)
+      else:
+        _LOGGER.error(
+            "Uncacheable type %s for key %s. Not caching.",
+            materialized,
+            state_key)
+    return cached_value
 
   def extend(self,
              state_key,  # type: beam_fn_api_pb2.StateKey
@@ -945,11 +952,27 @@ class CachingStateHandler(object):
     if cache_token:
       # Update the cache
       cache_key = self._convert_to_cache_key(state_key)
-      if self._state_cache.get(cache_key, cache_token) is None:
-        # We have never cached this key before, first initialize cache
-        self.blocking_get(state_key, coder, is_cached=True)
-      # Now update the values in the cache
-      self._state_cache.extend(cache_key, cache_token, elements)
+      cached_value = self._state_cache.get(cache_key, cache_token)
+      # Keep in mind that the state for this key can be evicted
+      # while executing this function. Either read or write to the cache
+      # but never do both here!
+      if cached_value is None:
+        # We have never cached this key before, first retrieve state
+        cached_value = self.blocking_get(state_key, coder)
+      # Just extend the already cached value
+      if isinstance(cached_value, list):
+        # Materialize provided iterable to ensure reproducible iterations,
+        # here and when writing to the state handler below.
+        elements = list(elements)
+        # The state is fully cached and can be extended
+        cached_value.extend(elements)
+      elif isinstance(cached_value, self.ContinuationIterable):
+        # The state is too large to be fully cached (continuation token used),
+        # only the first part is cached, the rest if enumerated via the runner.
+        pass
+      else:
+        # When a corrupt value made it into the cache, we have to fail.
+        raise Exception("Unexpected cached value: %s" % cached_value)
     # Write to state handler
     out = coder_impl.create_OutputStream()
     for element in elements:
@@ -1018,35 +1041,28 @@ class CachingStateHandler(object):
     while input_stream.size() > 0:
       head.append(coder.decode_from_stream(input_stream, True))
 
-    if continuation_token is None:
+    if not continuation_token:
       return head
     else:
+      return self.ContinuationIterable(
+          head,
+          functools.partial(
+              self._lazy_iterator, state_key, coder, continuation_token))
 
-      def iter_func():
-        for item in head:
-          yield item
-        if continuation_token:
-          for item in self._lazy_iterator(state_key, coder, continuation_token):
-            yield item
+  class ContinuationIterable(object):
+    def __init__(self, head, continue_iterator_fn):
+      self.head = head
+      self.continue_iterator_fn = continue_iterator_fn
 
-      return _IterableFromIterator(iter_func)
+    def __iter__(self):
+      for item in self.head:
+        yield item
+      for item in self.continue_iterator_fn():
+        yield item
 
   @staticmethod
   def _convert_to_cache_key(state_key):
     return state_key.SerializeToString()
-
-
-class _IterableFromIterator(object):
-  """Wraps an iterator as an iterable."""
-  def __init__(self, iter_func):
-    self._iter_func = iter_func
-
-  def __iter__(self):
-    return self._iter_func()
-
-
-coder_impl.FastPrimitivesCoderImpl.register_iterable_like_type(
-    _IterableFromIterator)
 
 
 class _Future(object):

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
@@ -38,6 +38,7 @@ from apache_beam.portability.api import beam_runner_api_pb2
 from apache_beam.portability.api import metrics_pb2
 from apache_beam.runners.worker import sdk_worker
 from apache_beam.runners.worker import statecache
+from apache_beam.runners.worker.sdk_worker import CachingStateHandler
 from apache_beam.utils import thread_pool_executor
 
 _LOGGER = logging.getLogger(__name__)
@@ -229,33 +230,91 @@ class CachingStateHandlerTest(unittest.TestCase):
       self.assertEqual(get_as_list(side2), [502])  # uncached
       self.assertEqual(get_as_list(side2), [502])  # cached on bundle
 
-  def test_extend_fetches_initial_state(self):
+  class UnderlyingStateHandler(object):
+    """Simply returns an incremented counter as the state "value."
+    """
+    def __init__(self):
+      self._encoded_values = []
+      self._continuations = False
+
+    def set_value(self, value, coder):
+      self._encoded_values = [coder.encode(value)]
+
+    def set_values(self, values, coder):
+      self._encoded_values = [coder.encode(value) for value in values]
+
+    def set_continuations(self, continuations):
+      self._continuations = continuations
+
+    def get_raw(self, _state_key, continuation_token=None):
+      if self._continuations and len(self._encoded_values) > 0:
+        if not continuation_token:
+          continuation_token = '0'
+        idx = int(continuation_token)
+        next_token = str(idx +
+                         1) if idx + 1 < len(self._encoded_values) else None
+        return self._encoded_values[idx], next_token
+      else:
+        return b''.join(self._encoded_values), None
+
+    def append_raw(self, _key, bytes):
+      self._encoded_values.append(bytes)
+
+    def clear(self, *args):
+      self._encoded_values = []
+
+    @contextlib.contextmanager
+    def process_instruction_id(self, bundle_id):
+      yield
+
+  def test_append_clear_with_preexisting_state(self):
+    state = beam_fn_api_pb2.StateKey(
+        bag_user_state=beam_fn_api_pb2.StateKey.BagUserState(
+            user_state_id='state1'))
+
+    cache_token = beam_fn_api_pb2.ProcessBundleRequest.CacheToken(
+        token=b'state_token1',
+        user_state=beam_fn_api_pb2.ProcessBundleRequest.CacheToken.UserState())
+
     coder = VarIntCoder()
-    coder_impl = coder.get_impl()
 
-    class UnderlyingStateHandler(object):
-      """Simply returns an incremented counter as the state "value."
-      """
-      def set_value(self, value):
-        self._encoded_values = coder.encode(value)
-
-      def get_raw(self, *args):
-        return self._encoded_values, None
-
-      def append_raw(self, _key, bytes):
-        self._encoded_values += bytes
-
-      def clear(self, *args):
-        self._encoded_values = bytes()
-
-      @contextlib.contextmanager
-      def process_instruction_id(self, bundle_id):
-        yield
-
-    underlying_state_handler = UnderlyingStateHandler()
+    underlying_state_handler = self.UnderlyingStateHandler()
     state_cache = statecache.StateCache(100)
     handler = sdk_worker.CachingStateHandler(
         state_cache, underlying_state_handler)
+
+    def get():
+      return handler.blocking_get(state, coder.get_impl(), True)
+
+    def append(iterable):
+      handler.extend(state, coder.get_impl(), iterable, True)
+
+    def clear():
+      handler.clear(state, True)
+
+    # Initialize state
+    underlying_state_handler.set_value(42, coder)
+    with handler.process_instruction_id('bundle', [cache_token]):
+      # Append without reading beforehand
+      append([43])
+      self.assertEqual(get(), [42, 43])
+      clear()
+      self.assertEqual(get(), [])
+      append([44, 45])
+      self.assertEqual(get(), [44, 45])
+      append((46, 47))
+      self.assertEqual(get(), [44, 45, 46, 47])
+      clear()
+      append(range(1000))
+      self.assertEqual(get(), list(range(1000)))
+
+  def test_continuation_token(self):
+    underlying_state_handler = self.UnderlyingStateHandler()
+    state_cache = statecache.StateCache(100)
+    handler = sdk_worker.CachingStateHandler(
+        state_cache, underlying_state_handler)
+
+    coder = VarIntCoder()
 
     state = beam_fn_api_pb2.StateKey(
         bag_user_state=beam_fn_api_pb2.StateKey.BagUserState(
@@ -265,25 +324,39 @@ class CachingStateHandlerTest(unittest.TestCase):
         token=b'state_token1',
         user_state=beam_fn_api_pb2.ProcessBundleRequest.CacheToken.UserState())
 
-    def get():
-      return list(handler.blocking_get(state, coder_impl, True))
+    def get(materialize=True):
+      result = handler.blocking_get(state, coder.get_impl(), True)
+      return list(result) if materialize else result
 
-    def append(value):
-      handler.extend(state, coder_impl, [value], True)
+    def get_type():
+      return type(get(materialize=False))
+
+    def append(*values):
+      handler.extend(state, coder.get_impl(), values, True)
 
     def clear():
       handler.clear(state, True)
 
-    # Initialize state
-    underlying_state_handler.set_value(42)
+    underlying_state_handler.set_continuations(True)
+    underlying_state_handler.set_values([45, 46, 47], coder)
     with handler.process_instruction_id('bundle', [cache_token]):
-      # Append without reading beforehand
-      append(43)
-      self.assertEqual(get(), [42, 43])
+      self.assertEqual(get_type(), CachingStateHandler.ContinuationIterable)
+      self.assertEqual(get(), [45, 46, 47])
+      append(48, 49)
+      self.assertEqual(get_type(), CachingStateHandler.ContinuationIterable)
+      self.assertEqual(get(), [45, 46, 47, 48, 49])
       clear()
+      self.assertEqual(get_type(), list)
       self.assertEqual(get(), [])
-      append(44)
-      self.assertEqual(get(), [44])
+      append(1)
+      self.assertEqual(get(), [1])
+      append(2, 3)
+      self.assertEqual(get(), [1, 2, 3])
+      clear()
+      for i in range(1000):
+        append(i)
+      self.assertEqual(get_type(), list)
+      self.assertEqual(get(), [i for i in range(1000)])
 
 
 class ShortIdCacheTest(unittest.TestCase):

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
@@ -176,7 +176,7 @@ class CachingStateHandlerTest(unittest.TestCase):
             transform_id='transform', side_input_id='side1'))
 
     def get_as_list(key):
-      return list(caching_state_hander.blocking_get(key, coder_impl, True))
+      return list(caching_state_hander.blocking_get(key, coder_impl))
 
     underlying_state.set_counter(100)
     with caching_state_hander.process_instruction_id('bundle1', []):
@@ -284,13 +284,13 @@ class CachingStateHandlerTest(unittest.TestCase):
         state_cache, underlying_state_handler)
 
     def get():
-      return handler.blocking_get(state, coder.get_impl(), True)
+      return handler.blocking_get(state, coder.get_impl())
 
     def append(iterable):
-      handler.extend(state, coder.get_impl(), iterable, True)
+      handler.extend(state, coder.get_impl(), iterable)
 
     def clear():
-      handler.clear(state, True)
+      handler.clear(state)
 
     # Initialize state
     underlying_state_handler.set_value(42, coder)
@@ -325,17 +325,17 @@ class CachingStateHandlerTest(unittest.TestCase):
         user_state=beam_fn_api_pb2.ProcessBundleRequest.CacheToken.UserState())
 
     def get(materialize=True):
-      result = handler.blocking_get(state, coder.get_impl(), True)
+      result = handler.blocking_get(state, coder.get_impl())
       return list(result) if materialize else result
 
     def get_type():
       return type(get(materialize=False))
 
     def append(*values):
-      handler.extend(state, coder.get_impl(), values, True)
+      handler.extend(state, coder.get_impl(), values)
 
     def clear():
-      handler.clear(state, True)
+      handler.clear(state)
 
     underlying_state_handler.set_continuations(True)
     underlying_state_handler.set_values([45, 46, 47], coder)

--- a/sdks/python/apache_beam/runners/worker/statecache.py
+++ b/sdks/python/apache_beam/runners/worker/statecache.py
@@ -169,27 +169,6 @@ class StateCache(object):
     with self._lock:
       return self._cache.put((state_key, cache_token), value)
 
-  @Metrics.counter("extend")
-  def extend(self, state_key, cache_token, elements):
-    assert cache_token and self.is_cache_enabled()
-    with self._lock:
-      value = self._cache.get((state_key, cache_token))
-      if value is self._missing:
-        value = []
-        self._cache.put((state_key, cache_token), value)
-      if isinstance(value, list):
-        value.extend(elements)
-      else:
-
-        class Extended:
-          def __iter__(self):
-            for item in value:
-              yield item
-            for item in elements:
-              yield item
-
-        self._cache.put((state_key, cache_token), Extended())
-
   @Metrics.counter("clear")
   def clear(self, state_key, cache_token):
     assert cache_token and self.is_cache_enabled()

--- a/sdks/python/apache_beam/runners/worker/statecache_test.py
+++ b/sdks/python/apache_beam/runners/worker/statecache_test.py
@@ -39,7 +39,6 @@ class StateCacheTest(unittest.TestCase):
         {
             'get': 1,
             'put': 0,
-            'extend': 0,
             'miss': 1,
             'hit': 0,
             'clear': 0,
@@ -61,7 +60,6 @@ class StateCacheTest(unittest.TestCase):
         {
             'get': 2,
             'put': 1,
-            'extend': 0,
             'miss': 1,
             'hit': 1,
             'clear': 0,
@@ -69,40 +67,6 @@ class StateCacheTest(unittest.TestCase):
             'size': 1,
             'capacity': 5
         })
-
-  def test_extend(self):
-    cache = self.get_cache(3)
-    cache.put("key", "cache_token", ['val'])
-    # test extend for existing key
-    cache.extend("key", "cache_token", ['yet', 'another', 'val'])
-    self.assertEqual(cache.size(), 1)
-    self.assertEqual(
-        cache.get("key", "cache_token"), ['val', 'yet', 'another', 'val'])
-    # test extend without existing key
-    cache.extend("key2", "cache_token", ['another', 'val'])
-    self.assertEqual(cache.size(), 2)
-    self.assertEqual(cache.get("key2", "cache_token"), ['another', 'val'])
-    self.verify_metrics(
-        cache,
-        {
-            'get': 2,
-            'put': 1,
-            'extend': 2,
-            'miss': 0,
-            'hit': 2,
-            'clear': 0,
-            'evict': 0,
-            'size': 2,
-            'capacity': 3
-        })
-
-  def test_extend_non_list(self):
-    cache = self.get_cache(3)
-    cache.put("key", "cache_token", tuple(['val']))
-    cache.extend("key", "cache_token", ['yet', 'another', 'val'])
-    self.assertEqual(cache.size(), 1)
-    self.assertEqual(
-        list(cache.get("key", "cache_token")), ['val', 'yet', 'another', 'val'])
 
   def test_clear(self):
     cache = self.get_cache(5)
@@ -120,7 +84,6 @@ class StateCacheTest(unittest.TestCase):
         {
             'get': 3,
             'put': 1,
-            'extend': 0,
             'miss': 1,
             'hit': 2,
             'clear': 2,
@@ -143,7 +106,6 @@ class StateCacheTest(unittest.TestCase):
         {
             'get': 0,
             'put': 4,
-            'extend': 0,
             'miss': 0,
             'hit': 0,
             'clear': 0,
@@ -166,7 +128,6 @@ class StateCacheTest(unittest.TestCase):
         {
             'get': 2,
             'put': 2,
-            'extend': 0,
             'miss': 2,
             'hit': 0,
             'clear': 0,
@@ -210,16 +171,15 @@ class StateCacheTest(unittest.TestCase):
     self.assertEqual(cache.size(), 5)
     # least recently used key should be gone ("key4")
     self.assertEqual(cache.get("key4", "cache_token"), None)
-    # make "key5" used by appending to it
-    cache.extend("key5", "cache_token", ["another"])
+    # make "key5" used by writing to it
+    cache.put("key5", "cache_token", "val")
     # least recently used key should be gone ("key6")
     self.assertEqual(cache.get("key6", "cache_token"), None)
     self.verify_metrics(
         cache,
         {
             'get': 10,
-            'put': 11,
-            'extend': 1,
+            'put': 12,
             'miss': 4,
             'hit': 6,
             'clear': 0,


### PR DESCRIPTION
The continuation mode was always-on by mistake. Also, continuation mode would
arbitrarily nest appended state via iterators which would lead to the following
error:

```
RecursionError: maximum recursion depth exceeded while calling a Python object
```

In case of continuations tokens, we do not cache anything anymore after the
continuation. Caching after the continuation token would defeat the purpose of
using continuation tokens for large state. A test was added for continuation
tokens.

The extend operation was removed from the statecache in favor of using only
put/get/clear which avoids any race conditions with the cache eviction.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Samza | Spark
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
