### PR TITLE
[BEAM-10341] Support drain in python and java SDF

### DIFF
--- a/model/pipeline/src/main/proto/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/beam_runner_api.proto
@@ -384,8 +384,10 @@ message StandardPTransforms {
     // Input: KV(KV(element, restriction), size); output: DoFn's output.
     PROCESS_SIZED_ELEMENTS_AND_RESTRICTIONS = 2 [(beam_urn) = "beam:transform:sdf_process_sized_element_and_restrictions:v1"];
 
-    // Truncates the restriction of each element/restriction pair and returns the
-    // finite restriction which is going to be processed when drain starts.
+    // Truncates the restriction of each element/restriction pair and returns
+    // the finite restriction which will be processed when a pipeline is
+    // drained: https://docs.google.com/document/d/1NExwHlj-2q2WUGhSO4jTu8XGhDPmm3cllSN8IMmWci8/edit#.
+    //
     // Input: KV(KV(element, restriction), size);
     // Output: KV(KV(element, restriction), size).
     TRUNCATE_SIZED_RESTRICTION = 3 [(beam_urn) = "beam:transform:sdf_truncate_sized_restrictions:v1"];

--- a/model/pipeline/src/main/proto/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/beam_runner_api.proto
@@ -383,6 +383,12 @@ message StandardPTransforms {
     //
     // Input: KV(KV(element, restriction), size); output: DoFn's output.
     PROCESS_SIZED_ELEMENTS_AND_RESTRICTIONS = 2 [(beam_urn) = "beam:transform:sdf_process_sized_element_and_restrictions:v1"];
+
+    // Truncates the restriction of each element/restriction pair and returns the
+    // finite restriction which is going to be processed when drain starts.
+    // Input: KV(KV(element, restriction), size);
+    // Output: KV(KV(element, restriction), size).
+    TRUNCATE_SIZED_RESTRICTION = 3 [(beam_urn) = "beam:transform:sdf_truncate_sized_restrictions:v1"];
   }
 }
 

--- a/model/pipeline/src/main/proto/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/beam_runner_api.proto
@@ -386,7 +386,9 @@ message StandardPTransforms {
 
     // Truncates the restriction of each element/restriction pair and returns
     // the finite restriction which will be processed when a pipeline is
-    // drained: https://docs.google.com/document/d/1NExwHlj-2q2WUGhSO4jTu8XGhDPmm3cllSN8IMmWci8/edit#.
+    // drained. See
+    // https://docs.google.com/document/d/1NExwHlj-2q2WUGhSO4jTu8XGhDPmm3cllSN8IMmWci8/edit#.
+    // for additional details about drain.
     //
     // Input: KV(KV(element, restriction), size);
     // Output: KV(KV(element, restriction), size).

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/Environments.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/Environments.java
@@ -40,7 +40,6 @@ import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
 import org.apache.beam.model.pipeline.v1.RunnerApi.ProcessPayload;
 import org.apache.beam.model.pipeline.v1.RunnerApi.StandardArtifacts;
 import org.apache.beam.model.pipeline.v1.RunnerApi.StandardEnvironments;
-import org.apache.beam.model.pipeline.v1.RunnerApi.StandardPTransforms.SplittableParDoComponents;
 import org.apache.beam.model.pipeline.v1.RunnerApi.StandardProtocols;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PortablePipelineOptions;

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/Environments.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/Environments.java
@@ -315,7 +315,8 @@ public class Environments {
     capabilities.add(BeamUrns.getUrn(StandardProtocols.Enum.MULTI_CORE_BUNDLE_PROCESSING));
     capabilities.add(BeamUrns.getUrn(StandardProtocols.Enum.PROGRESS_REPORTING));
     capabilities.add("beam:version:sdk_base:" + JAVA_SDK_HARNESS_CONTAINER_URL);
-    capabilities.add(BeamUrns.getUrn(SplittableParDoComponents.TRUNCATE_SIZED_RESTRICTION));
+    // TODO(BEAM-BEAM-10505): Add the capability back.
+    // capabilities.add(BeamUrns.getUrn(SplittableParDoComponents.TRUNCATE_SIZED_RESTRICTION));
     return capabilities.build();
   }
 

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/Environments.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/Environments.java
@@ -40,6 +40,7 @@ import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
 import org.apache.beam.model.pipeline.v1.RunnerApi.ProcessPayload;
 import org.apache.beam.model.pipeline.v1.RunnerApi.StandardArtifacts;
 import org.apache.beam.model.pipeline.v1.RunnerApi.StandardEnvironments;
+import org.apache.beam.model.pipeline.v1.RunnerApi.StandardPTransforms.SplittableParDoComponents;
 import org.apache.beam.model.pipeline.v1.RunnerApi.StandardProtocols;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PortablePipelineOptions;
@@ -314,6 +315,7 @@ public class Environments {
     capabilities.add(BeamUrns.getUrn(StandardProtocols.Enum.MULTI_CORE_BUNDLE_PROCESSING));
     capabilities.add(BeamUrns.getUrn(StandardProtocols.Enum.PROGRESS_REPORTING));
     capabilities.add("beam:version:sdk_base:" + JAVA_SDK_HARNESS_CONTAINER_URL);
+    capabilities.add(BeamUrns.getUrn(SplittableParDoComponents.TRUNCATE_SIZED_RESTRICTION));
     return capabilities.build();
   }
 

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/Environments.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/Environments.java
@@ -314,7 +314,7 @@ public class Environments {
     capabilities.add(BeamUrns.getUrn(StandardProtocols.Enum.MULTI_CORE_BUNDLE_PROCESSING));
     capabilities.add(BeamUrns.getUrn(StandardProtocols.Enum.PROGRESS_REPORTING));
     capabilities.add("beam:version:sdk_base:" + JAVA_SDK_HARNESS_CONTAINER_URL);
-    // TODO(BEAM-BEAM-10505): Add the capability back.
+    // TODO(BEAM-10505): Add the capability back.
     // capabilities.add(BeamUrns.getUrn(SplittableParDoComponents.TRUNCATE_SIZED_RESTRICTION));
     return capabilities.build();
   }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformTranslation.java
@@ -113,6 +113,8 @@ public class PTransformTranslation {
   // SplittableParDoComponents
   public static final String SPLITTABLE_PAIR_WITH_RESTRICTION_URN =
       "beam:transform:sdf_pair_with_restriction:v1";
+  public static final String SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN =
+      "beam:transform:sdf_truncate_sized_restrictions:v1";
   /**
    * @deprecated runners should move away from using `SplittableProcessKeyedElements` and prefer to
    *     internalize any necessary SplittableDoFn expansion.

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformTranslation.java
@@ -195,6 +195,9 @@ public class PTransformTranslation {
     checkState(
         SPLITTABLE_PROCESS_SIZED_ELEMENTS_AND_RESTRICTIONS_URN.equals(
             getUrn(SplittableParDoComponents.PROCESS_SIZED_ELEMENTS_AND_RESTRICTIONS)));
+    checkState(
+        SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN.equals(
+            getUrn(SplittableParDoComponents.TRUNCATE_SIZED_RESTRICTION)));
   }
 
   private static final Collection<TransformTranslator<?>> KNOWN_TRANSLATORS =

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ParDoTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ParDoTranslation.java
@@ -23,6 +23,7 @@ import static org.apache.beam.runners.core.construction.PTransformTranslation.SP
 import static org.apache.beam.runners.core.construction.PTransformTranslation.SPLITTABLE_PROCESS_ELEMENTS_URN;
 import static org.apache.beam.runners.core.construction.PTransformTranslation.SPLITTABLE_PROCESS_SIZED_ELEMENTS_AND_RESTRICTIONS_URN;
 import static org.apache.beam.runners.core.construction.PTransformTranslation.SPLITTABLE_SPLIT_AND_SIZE_RESTRICTIONS_URN;
+import static org.apache.beam.runners.core.construction.PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN;
 import static org.apache.beam.sdk.transforms.reflect.DoFnSignatures.getStateSpecOrThrow;
 import static org.apache.beam.sdk.transforms.reflect.DoFnSignatures.getTimerSpecOrThrow;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
@@ -491,6 +492,7 @@ public class ParDoTranslation {
         PAR_DO_TRANSFORM_URN.equals(ptransform.getSpec().getUrn())
             || SPLITTABLE_PAIR_WITH_RESTRICTION_URN.equals(ptransform.getSpec().getUrn())
             || SPLITTABLE_SPLIT_AND_SIZE_RESTRICTIONS_URN.equals(ptransform.getSpec().getUrn())
+            || SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN.equals(ptransform.getSpec().getUrn())
             || SPLITTABLE_PROCESS_ELEMENTS_URN.equals(ptransform.getSpec().getUrn())
             || SPLITTABLE_PROCESS_SIZED_ELEMENTS_AND_RESTRICTIONS_URN.equals(
                 ptransform.getSpec().getUrn()),
@@ -507,6 +509,7 @@ public class ParDoTranslation {
         PAR_DO_TRANSFORM_URN.equals(ptransform.getSpec().getUrn())
             || SPLITTABLE_PAIR_WITH_RESTRICTION_URN.equals(ptransform.getSpec().getUrn())
             || SPLITTABLE_SPLIT_AND_SIZE_RESTRICTIONS_URN.equals(ptransform.getSpec().getUrn())
+            || SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN.equals(ptransform.getSpec().getUrn())
             || SPLITTABLE_PROCESS_ELEMENTS_URN.equals(ptransform.getSpec().getUrn())
             || SPLITTABLE_PROCESS_SIZED_ELEMENTS_AND_RESTRICTIONS_URN.equals(
                 ptransform.getSpec().getUrn()),

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/SplittableParDoExpander.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/SplittableParDoExpander.java
@@ -85,7 +85,7 @@ public class SplittableParDoExpander {
    * sideInputA ---------\---------------------\----------------------\--------------------------\
    * sideInputB ---------V---------------------V----------------------V--------------------------V
    * mainInput ---> PairWithRestriction --> SplitAndSize --> TruncateAndSize --> ProcessSizedElementsAndRestriction --> outputA
-   *                                                                                                               \-> outputB
+   *                                                                                                                \-> outputB
    * }</pre>
    */
   public static TransformReplacement createTruncateReplacement() {

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/SplittableParDoExpander.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/SplittableParDoExpander.java
@@ -297,8 +297,8 @@ public class SplittableParDoExpander {
     return prefix + i;
   }
 
-  /** See {@link #createTruncateReplacement()} ()} for details. */
-  private static class TruncateReplacement extends SizedReplacement {
+  /** See {@link #createTruncateReplacement} for details. */
+  private static class TruncateReplacement implements TransformReplacement {
     private static final TruncateReplacement INSTANCE = new TruncateReplacement();
 
     @Override

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/SplittableParDoExpander.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/SplittableParDoExpander.java
@@ -69,6 +69,29 @@ public class SplittableParDoExpander {
     return SizedReplacement.INSTANCE;
   }
 
+  /**
+   * Returns a transform replacement in drain mode which expands a splittable ParDo from:
+   *
+   * <pre>{@code
+   * sideInputA ---------\
+   * sideInputB ---------V
+   * mainInput ---> SplittableParDo --> outputA
+   *                                \-> outputB
+   * }</pre>
+   *
+   * into:
+   *
+   * <pre>{@code
+   * sideInputA ---------\---------------------\----------------------\--------------------------\
+   * sideInputB ---------V---------------------V----------------------V--------------------------V
+   * mainInput ---> PairWithRestriction --> SplitAndSize --> TruncateAndSize --> ProcessSizedElementsAndRestriction --> outputA
+   *                                                                                                               \-> outputB
+   * }</pre>
+   */
+  public static TransformReplacement createTruncateReplacement() {
+    return TruncateReplacement.INSTANCE;
+  }
+
   /** See {@link #createSizedReplacement()} for details. */
   private static class SizedReplacement implements TransformReplacement {
 
@@ -272,5 +295,212 @@ public class SplittableParDoExpander {
       i += 1;
     }
     return prefix + i;
+  }
+
+  /** See {@link #createTruncateReplacement()} ()} for details. */
+  private static class TruncateReplacement extends SizedReplacement {
+    private static final TruncateReplacement INSTANCE = new TruncateReplacement();
+
+    @Override
+    public MessageWithComponents getReplacement(
+        String transformId, ComponentsOrBuilder existingComponents) {
+      try {
+        MessageWithComponents.Builder rval = MessageWithComponents.newBuilder();
+
+        PTransform splittableParDo = existingComponents.getTransformsOrThrow(transformId);
+        ParDoPayload payload = ParDoPayload.parseFrom(splittableParDo.getSpec().getPayload());
+        // Only perform the expansion if this is a splittable DoFn.
+        if (payload.getRestrictionCoderId() == null || payload.getRestrictionCoderId().isEmpty()) {
+          return null;
+        }
+
+        String mainInputName = ParDoTranslation.getMainInputName(splittableParDo);
+        String mainInputPCollectionId = splittableParDo.getInputsOrThrow(mainInputName);
+        PCollection mainInputPCollection =
+            existingComponents.getPcollectionsOrThrow(mainInputPCollectionId);
+        Map<String, String> sideInputs =
+            Maps.filterKeys(
+                splittableParDo.getInputsMap(), input -> payload.containsSideInputs(input));
+
+        String pairWithRestrictionOutCoderId =
+            generateUniqueId(
+                mainInputPCollection.getCoderId() + "/PairWithRestriction",
+                existingComponents::containsCoders);
+        rval.getComponentsBuilder()
+            .putCoders(
+                pairWithRestrictionOutCoderId,
+                ModelCoders.kvCoder(
+                    mainInputPCollection.getCoderId(), payload.getRestrictionCoderId()));
+
+        String pairWithRestrictionOutId =
+            generateUniqueId(
+                mainInputPCollectionId + "/PairWithRestriction",
+                existingComponents::containsPcollections);
+        rval.getComponentsBuilder()
+            .putPcollections(
+                pairWithRestrictionOutId,
+                PCollection.newBuilder()
+                    .setCoderId(pairWithRestrictionOutCoderId)
+                    .setIsBounded(mainInputPCollection.getIsBounded())
+                    .setWindowingStrategyId(mainInputPCollection.getWindowingStrategyId())
+                    .setUniqueName(
+                        generateUniquePCollectonName(
+                            mainInputPCollection.getUniqueName() + "/PairWithRestriction",
+                            existingComponents))
+                    .build());
+
+        String splitAndSizeOutCoderId =
+            generateUniqueId(
+                mainInputPCollection.getCoderId() + "/SplitAndSize",
+                existingComponents::containsCoders);
+        rval.getComponentsBuilder()
+            .putCoders(
+                splitAndSizeOutCoderId,
+                ModelCoders.kvCoder(
+                    pairWithRestrictionOutCoderId, getOrAddDoubleCoder(existingComponents, rval)));
+
+        String splitAndSizeOutId =
+            generateUniqueId(
+                mainInputPCollectionId + "/SplitAndSize", existingComponents::containsPcollections);
+        rval.getComponentsBuilder()
+            .putPcollections(
+                splitAndSizeOutId,
+                PCollection.newBuilder()
+                    .setCoderId(splitAndSizeOutCoderId)
+                    .setIsBounded(mainInputPCollection.getIsBounded())
+                    .setWindowingStrategyId(mainInputPCollection.getWindowingStrategyId())
+                    .setUniqueName(
+                        generateUniquePCollectonName(
+                            mainInputPCollection.getUniqueName() + "/SplitAndSize",
+                            existingComponents))
+                    .build());
+
+        String truncateAndSizeCoderId =
+            generateUniqueId(
+                mainInputPCollection.getCoderId() + "/TruncateAndSize",
+                existingComponents::containsCoders);
+        rval.getComponentsBuilder()
+            .putCoders(
+                truncateAndSizeCoderId,
+                ModelCoders.kvCoder(
+                    splitAndSizeOutCoderId, getOrAddDoubleCoder(existingComponents, rval)));
+        String truncateAndSizeOutId =
+            generateUniqueId(
+                mainInputPCollectionId + "/TruncateAndSize",
+                existingComponents::containsPcollections);
+
+        rval.getComponentsBuilder()
+            .putPcollections(
+                truncateAndSizeOutId,
+                PCollection.newBuilder()
+                    .setCoderId(truncateAndSizeCoderId)
+                    .setIsBounded(mainInputPCollection.getIsBounded())
+                    .setWindowingStrategyId(mainInputPCollection.getWindowingStrategyId())
+                    .setUniqueName(
+                        generateUniquePCollectonName(
+                            mainInputPCollection.getUniqueName() + "/TruncateAndSize",
+                            existingComponents))
+                    .build());
+
+        String pairWithRestrictionId =
+            generateUniqueId(
+                transformId + "/PairWithRestriction", existingComponents::containsTransforms);
+        {
+          PTransform.Builder pairWithRestriction = PTransform.newBuilder();
+          pairWithRestriction.putAllInputs(splittableParDo.getInputsMap());
+          pairWithRestriction.putOutputs("out", pairWithRestrictionOutId);
+          pairWithRestriction.setUniqueName(
+              generateUniquePCollectonName(
+                  splittableParDo.getUniqueName() + "/PairWithRestriction", existingComponents));
+          pairWithRestriction.setSpec(
+              FunctionSpec.newBuilder()
+                  .setUrn(PTransformTranslation.SPLITTABLE_PAIR_WITH_RESTRICTION_URN)
+                  .setPayload(splittableParDo.getSpec().getPayload()));
+          pairWithRestriction.setEnvironmentId(splittableParDo.getEnvironmentId());
+          rval.getComponentsBuilder()
+              .putTransforms(pairWithRestrictionId, pairWithRestriction.build());
+        }
+
+        String splitAndSizeId =
+            generateUniqueId(transformId + "/SplitAndSize", existingComponents::containsTransforms);
+        {
+          PTransform.Builder splitAndSize = PTransform.newBuilder();
+          splitAndSize.putInputs(mainInputName, pairWithRestrictionOutId);
+          splitAndSize.putAllInputs(sideInputs);
+          splitAndSize.putOutputs("out", splitAndSizeOutId);
+          splitAndSize.setUniqueName(
+              generateUniquePCollectonName(
+                  splittableParDo.getUniqueName() + "/SplitAndSize", existingComponents));
+          splitAndSize.setSpec(
+              FunctionSpec.newBuilder()
+                  .setUrn(PTransformTranslation.SPLITTABLE_SPLIT_AND_SIZE_RESTRICTIONS_URN)
+                  .setPayload(splittableParDo.getSpec().getPayload()));
+          splitAndSize.setEnvironmentId(splittableParDo.getEnvironmentId());
+          rval.getComponentsBuilder().putTransforms(splitAndSizeId, splitAndSize.build());
+        }
+
+        String truncateAndSizeId =
+            generateUniqueId(
+                transformId + "/TruncateAndSize", existingComponents::containsTransforms);
+        {
+          PTransform.Builder truncateAndSize = PTransform.newBuilder();
+          truncateAndSize.putInputs(mainInputName, splitAndSizeOutId);
+          truncateAndSize.putAllInputs(sideInputs);
+          truncateAndSize.putOutputs("out", truncateAndSizeOutId);
+          truncateAndSize.setUniqueName(
+              generateUniquePCollectonName(
+                  splittableParDo.getUniqueName() + "/TruncateAndSize", existingComponents));
+          truncateAndSize.setSpec(
+              FunctionSpec.newBuilder()
+                  .setUrn(PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN)
+                  .setPayload(splittableParDo.getSpec().getPayload()));
+          truncateAndSize.setEnvironmentId(splittableParDo.getEnvironmentId());
+          rval.getComponentsBuilder().putTransforms(truncateAndSizeId, truncateAndSize.build());
+        }
+
+        String processSizedElementsAndRestrictionsId =
+            generateUniqueId(
+                transformId + "/ProcessSizedElementsAndRestrictions",
+                existingComponents::containsTransforms);
+        {
+          PTransform.Builder processSizedElementsAndRestrictions = PTransform.newBuilder();
+          processSizedElementsAndRestrictions.putInputs(mainInputName, truncateAndSizeOutId);
+          processSizedElementsAndRestrictions.putAllInputs(sideInputs);
+          processSizedElementsAndRestrictions.putAllOutputs(splittableParDo.getOutputsMap());
+          processSizedElementsAndRestrictions.setUniqueName(
+              generateUniquePCollectonName(
+                  splittableParDo.getUniqueName() + "/ProcessSizedElementsAndRestrictions",
+                  existingComponents));
+          processSizedElementsAndRestrictions.setSpec(
+              FunctionSpec.newBuilder()
+                  .setUrn(
+                      PTransformTranslation.SPLITTABLE_PROCESS_SIZED_ELEMENTS_AND_RESTRICTIONS_URN)
+                  .setPayload(splittableParDo.getSpec().getPayload()));
+          processSizedElementsAndRestrictions.setEnvironmentId(splittableParDo.getEnvironmentId());
+          rval.getComponentsBuilder()
+              .putTransforms(
+                  processSizedElementsAndRestrictionsId,
+                  processSizedElementsAndRestrictions.build());
+        }
+
+        PTransform.Builder newCompositeRoot =
+            splittableParDo
+                .toBuilder()
+                // Clear the original splittable ParDo spec and add all the new transforms as
+                // children.
+                .clearSpec()
+                .addAllSubtransforms(
+                    Arrays.asList(
+                        pairWithRestrictionId,
+                        splitAndSizeId,
+                        truncateAndSizeId,
+                        processSizedElementsAndRestrictionsId));
+        rval.setPtransform(newCompositeRoot);
+
+        return rval.build();
+      } catch (IOException e) {
+        throw new RuntimeException("Unable to perform expansion for transform " + transformId, e);
+      }
+    }
   }
 }

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/EnvironmentsTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/EnvironmentsTest.java
@@ -104,12 +104,13 @@ public class EnvironmentsTest implements Serializable {
     assertThat(
         Environments.getJavaCapabilities(),
         hasItem(BeamUrns.getUrn(RunnerApi.StandardProtocols.Enum.MULTI_CORE_BUNDLE_PROCESSING)));
-    assertThat(
-        Environments.getJavaCapabilities(),
-        hasItem(
-            BeamUrns.getUrn(
-                RunnerApi.StandardPTransforms.SplittableParDoComponents
-                    .TRUNCATE_SIZED_RESTRICTION)));
+    // TODO(BEAM-BEAM-10505): Add the check back.
+    // assertThat(
+    //     Environments.getJavaCapabilities(),
+    //     hasItem(
+    //         BeamUrns.getUrn(
+    //             RunnerApi.StandardPTransforms.SplittableParDoComponents
+    //                 .TRUNCATE_SIZED_RESTRICTION)));
   }
 
   @Test

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/EnvironmentsTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/EnvironmentsTest.java
@@ -104,6 +104,12 @@ public class EnvironmentsTest implements Serializable {
     assertThat(
         Environments.getJavaCapabilities(),
         hasItem(BeamUrns.getUrn(RunnerApi.StandardProtocols.Enum.MULTI_CORE_BUNDLE_PROCESSING)));
+    assertThat(
+        Environments.getJavaCapabilities(),
+        hasItem(
+            BeamUrns.getUrn(
+                RunnerApi.StandardPTransforms.SplittableParDoComponents
+                    .TRUNCATE_SIZED_RESTRICTION)));
   }
 
   @Test

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/EnvironmentsTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/EnvironmentsTest.java
@@ -104,7 +104,7 @@ public class EnvironmentsTest implements Serializable {
     assertThat(
         Environments.getJavaCapabilities(),
         hasItem(BeamUrns.getUrn(RunnerApi.StandardProtocols.Enum.MULTI_CORE_BUNDLE_PROCESSING)));
-    // TODO(BEAM-BEAM-10505): Add the check back.
+    // TODO(BEAM-10505): Add the check back.
     // assertThat(
     //     Environments.getJavaCapabilities(),
     //     hasItem(

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/SplittableParDoTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/SplittableParDoTest.java
@@ -77,8 +77,8 @@ public class SplittableParDoTest {
     public void checkDone() {}
 
     @Override
-    public RestrictionBoundness isBounded() {
-      return RestrictionBoundness.IS_BOUNDED;
+    public IsBounded isBounded() {
+      return IsBounded.BOUNDED;
     }
   }
 

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/SplittableParDoTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/SplittableParDoTest.java
@@ -75,6 +75,11 @@ public class SplittableParDoTest {
 
     @Override
     public void checkDone() {}
+
+    @Override
+    public RestrictionBoundness isBounded() {
+      return RestrictionBoundness.IS_BOUNDED;
+    }
   }
 
   private static class BoundedFakeFn extends DoFn<Integer, String> {

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SplittableParDoProcessFnTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SplittableParDoProcessFnTest.java
@@ -115,6 +115,11 @@ public class SplittableParDoProcessFnTest {
 
     @Override
     public void checkDone() {}
+
+    @Override
+    public RestrictionBoundness isBounded() {
+      return RestrictionBoundness.IS_BOUNDED;
+    }
   }
 
   @Rule public TestPipeline pipeline = TestPipeline.create();

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SplittableParDoProcessFnTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SplittableParDoProcessFnTest.java
@@ -117,8 +117,8 @@ public class SplittableParDoProcessFnTest {
     public void checkDone() {}
 
     @Override
-    public RestrictionBoundness isBounded() {
-      return RestrictionBoundness.IS_BOUNDED;
+    public IsBounded isBounded() {
+      return IsBounded.IS_BOUNDED;
     }
   }
 

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/SplittableParDoProcessFnTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/SplittableParDoProcessFnTest.java
@@ -117,8 +117,8 @@ public class SplittableParDoProcessFnTest {
     public void checkDone() {}
 
     @Override
-    public IsBounded isBounded() {
-      return IsBounded.IS_BOUNDED;
+    public RestrictionTracker.IsBounded isBounded() {
+      return RestrictionTracker.IsBounded.BOUNDED;
     }
   }
 

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
@@ -1348,8 +1348,8 @@ public class RemoteExecutionTest implements Serializable {
     }
 
     @Override
-    public RestrictionBoundness isBounded() {
-      return RestrictionBoundness.IS_BOUNDED;
+    public IsBounded isBounded() {
+      return IsBounded.BOUNDED;
     }
   }
 

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
@@ -1346,6 +1346,11 @@ public class RemoteExecutionTest implements Serializable {
     public void checkDone() throws IllegalStateException {
       checkState(!needsSplitting(), "Expected for this restriction to have been split.");
     }
+
+    @Override
+    public RestrictionBoundness isBounded() {
+      return RestrictionBoundness.IS_BOUNDED;
+    }
   }
 
   @Test(timeout = 60000L)

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Read.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Read.java
@@ -432,8 +432,8 @@ public class Read {
       }
 
       @Override
-      public boolean isBounded() {
-        return true;
+      public RestrictionBoundness isBounded() {
+        return RestrictionBoundness.IS_BOUNDED;
       }
     }
   }
@@ -870,8 +870,8 @@ public class Read {
       }
 
       @Override
-      public boolean isBounded() {
-        return false;
+      public RestrictionBoundness isBounded() {
+        return RestrictionBoundness.IS_UNBOUNDED;
       }
 
       @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Read.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Read.java
@@ -505,19 +505,6 @@ public class Read {
       return new UnboundedSourceAsSDFRestrictionTracker(restriction, pipelineOptions);
     }
 
-    @TruncateSizedRestriction
-    public void truncateSizedRestriction(
-        @Restriction UnboundedSourceRestriction<OutputT, CheckpointT> restriction,
-        OutputReceiver<UnboundedSourceRestriction<OutputT, CheckpointT>> receiver) {
-      try {
-        restriction.getCheckpoint().finalizeCheckpoint();
-      } catch (Exception e) {
-        LOG.warn("Failed to finalize CheckpointMark {}", restriction.getWatermark());
-      } finally {
-        receiver.output(null);
-      }
-    }
-
     @ProcessElement
     public ProcessContinuation processElement(
         RestrictionTracker<UnboundedSourceRestriction<OutputT, CheckpointT>, UnboundedSourceValue[]>

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Read.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/Read.java
@@ -57,7 +57,6 @@ import org.apache.beam.sdk.util.NameUtils;
 import org.apache.beam.sdk.util.SerializableUtils;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollection.IsBounded;
 import org.apache.beam.sdk.values.TimestampedValue;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.sdk.values.ValueWithRecordId;
@@ -154,7 +153,7 @@ public class Read {
       return PCollection.createPrimitiveOutputInternal(
           input.getPipeline(),
           WindowingStrategy.globalDefault(),
-          IsBounded.BOUNDED,
+          PCollection.IsBounded.BOUNDED,
           source.getOutputCoder());
     }
 
@@ -244,7 +243,7 @@ public class Read {
       return PCollection.createPrimitiveOutputInternal(
           input.getPipeline(),
           WindowingStrategy.globalDefault(),
-          IsBounded.UNBOUNDED,
+          PCollection.IsBounded.UNBOUNDED,
           source.getOutputCoder());
     }
 
@@ -432,8 +431,8 @@ public class Read {
       }
 
       @Override
-      public RestrictionBoundness isBounded() {
-        return RestrictionBoundness.IS_BOUNDED;
+      public IsBounded isBounded() {
+        return IsBounded.BOUNDED;
       }
     }
   }
@@ -870,8 +869,8 @@ public class Read {
       }
 
       @Override
-      public RestrictionBoundness isBounded() {
-        return RestrictionBoundness.IS_UNBOUNDED;
+      public IsBounded isBounded() {
+        return IsBounded.UNBOUNDED;
       }
 
       @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -1071,9 +1071,6 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    * <p>This method must satisfy the following constraints:
    *
    * <ul>
-   *   <li>If one of the arguments is of type {@link OutputReceiver}, then it will be passed an
-   *       output receiver for outputting the truncated restrictions. All truncated restrictions
-   *       must be output through this parameter.
    *   <li>If one of its arguments is tagged with the {@link Element} annotation, then it will be
    *       passed the current element being processed; the argument must be of type {@code InputT}.
    *       Note that automatic conversion of {@link Row}s and {@link FieldAccess} parameters are

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -1094,6 +1094,8 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    *       options for the current pipeline.
    * </ul>
    *
+   * <p>Returns a truncated restriction representing a bounded amount of work that must be processed before the pipeline can be drained or {@code null} if no work is necessary.
+   *
    * <p>The default behavior when a pipeline is being drained is that {@link
    * org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.IsBounded#BOUNDED}
    * restrictions process entirely while {@link

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -1066,7 +1066,7 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    * <p>This method is used to perform truncation of the restriction while it is not actively being
    * processed.
    *
-   * <p>Signature: {@code TruncateResult<RestrictionT> truncateRestriction(<arguments>);}
+   * <p>Signature: {@code @Nullable TruncateResult<RestrictionT> truncateRestriction(<arguments>);}
    *
    * <p>This method must satisfy the following constraints:
    *

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -1066,7 +1066,7 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    * <p>This method is used to perform truncation of the restriction while it is not actively being
    * processed.
    *
-   * <p>Signature: {@code Optional<RestrictionT> truncateRestriction(<arguments>);}
+   * <p>Signature: {@code TruncateResult<RestrictionT> truncateRestriction(<arguments>);}
    *
    * <p>This method must satisfy the following constraints:
    *

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -1064,7 +1064,7 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    * <p>This method is used to perform truncation of the restriction while it is not actively being
    * processed.
    *
-   * <p>Signature: {@code void truncateRestriction(<arguments>);}
+   * <p>Signature: {@code Optional<RestrictionT> truncateRestriction(<arguments>);}
    *
    * <p>This method must satisfy the following constraints:
    *

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -1034,6 +1034,9 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    *   <li>If one of its arguments is tagged with the {@link Timestamp} annotation, then it will be
    *       passed the timestamp of the current element being processed; the argument must be of type
    *       {@link Instant}.
+   *   <li>If one of its arguments is a {@link RestrictionTracker}, then it will be passed a tracker
+   *       that is initialized for the current {@link Restriction}. The argument must be of the
+   *       exact type {@code RestrictionTracker<RestrictionT, PositionT>}.
    *   <li>If one of its arguments is a subtype of {@link BoundedWindow}, then it will be passed the
    *       window of the current element. When applied by {@link ParDo} the subtype of {@link
    *       BoundedWindow} must match the type of windows on the input {@link PCollection}. If the
@@ -1057,7 +1060,7 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    *
    * <p>This method is used to perform truncating the restriction before actual processing.
    *
-   * <p>Signature: {@code void truncateSizedRestriction(<arguments>);}
+   * <p>Signature: {@code void truncateRestriction(<arguments>);}
    *
    * <p>This method must satisfy the following constraints:
    *
@@ -1092,7 +1095,7 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.METHOD)
   @Experimental(Kind.SPLITTABLE_DO_FN)
-  public @interface TruncateSizedRestriction {}
+  public @interface TruncateRestriction {}
 
   /**
    * Annotation for the method that creates a new {@link RestrictionTracker} for the restriction of

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -672,6 +672,9 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    *       perform bulk splitting initially allowing for a rapid increase in parallelism. See {@link
    *       RestrictionTracker#trySplit} for details about splitting when the current element and
    *       restriction are actively being processed.
+   *   <li>It <i>may</i> define a {@link TruncateRestriction} method to override the default
+   *       implementation {@code DefaultTruncateRestriction}, This method truncates a given
+   *       restriction into a bounded restriction when pipeline is draining.
    *   <li>It <i>may</i> define a {@link NewTracker} method returning a subtype of {@code
    *       RestrictionTracker<R>} where {@code R} is the restriction type returned by {@link
    *       GetInitialRestriction}. This method is optional only if the restriction type returned by
@@ -1054,11 +1057,12 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
   public @interface SplitRestriction {}
 
   /**
-   * Annotation for the method that truncates restriction of a <a
-   * href="https://s.apache.org/splittable-do-fn">splittable</a> {@link DoFn} into bounded one to be
-   * processed when pipeline starts to drain.
+   * Annotation for the method that truncates the restriction of a <a
+   * href="https://s.apache.org/splittable-do-fn">splittable</a> {@link DoFn} into a bounded one to
+   * be processed when pipeline starts to drain.
    *
-   * <p>This method is used to perform truncating the restriction before actual processing.
+   * <p>This method is used to perform truncation of the restriction while it is not actively being
+   * processed.
    *
    * <p>Signature: {@code void truncateRestriction(<arguments>);}
    *
@@ -1066,8 +1070,8 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    *
    * <ul>
    *   <li>If one of the arguments is of type {@link OutputReceiver}, then it will be passed an
-   *       output receiver for outputting the splits. All splits must be output through this
-   *       parameter.
+   *       output receiver for outputting the truncated restrictions. All truncated restrictions
+   *       must be output through this parameter.
    *   <li>If one of its arguments is tagged with the {@link Element} annotation, then it will be
    *       passed the current element being processed; the argument must be of type {@code InputT}.
    *       Note that automatic conversion of {@link Row}s and {@link FieldAccess} parameters are

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -1034,6 +1034,47 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
    *   <li>If one of its arguments is tagged with the {@link Timestamp} annotation, then it will be
    *       passed the timestamp of the current element being processed; the argument must be of type
    *       {@link Instant}.
+   *   <li>If one of its arguments is a subtype of {@link BoundedWindow}, then it will be passed the
+   *       window of the current element. When applied by {@link ParDo} the subtype of {@link
+   *       BoundedWindow} must match the type of windows on the input {@link PCollection}. If the
+   *       window is not accessed a runner may perform additional optimizations.
+   *   <li>If one of its arguments is of type {@link PaneInfo}, then it will be passed information
+   *       about the current triggering pane.
+   *   <li>If one of the parameters is of type {@link PipelineOptions}, then it will be passed the
+   *       options for the current pipeline.
+   * </ul>
+   */
+  @Documented
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target(ElementType.METHOD)
+  @Experimental(Kind.SPLITTABLE_DO_FN)
+  public @interface SplitRestriction {}
+
+  /**
+   * Annotation for the method that truncates restriction of a <a
+   * href="https://s.apache.org/splittable-do-fn">splittable</a> {@link DoFn} into bounded one to be
+   * processed when pipeline starts to drain.
+   *
+   * <p>This method is used to perform truncating the restriction before actual processing.
+   *
+   * <p>Signature: {@code void truncateSizedRestriction(<arguments>);}
+   *
+   * <p>This method must satisfy the following constraints:
+   *
+   * <ul>
+   *   <li>If one of the arguments is of type {@link OutputReceiver}, then it will be passed an
+   *       output receiver for outputting the splits. All splits must be output through this
+   *       parameter.
+   *   <li>If one of its arguments is tagged with the {@link Element} annotation, then it will be
+   *       passed the current element being processed; the argument must be of type {@code InputT}.
+   *       Note that automatic conversion of {@link Row}s and {@link FieldAccess} parameters are
+   *       currently unsupported.
+   *   <li>If one of its arguments is tagged with the {@link Restriction} annotation, then it will
+   *       be passed the current restriction being processed; the argument must be of type {@code
+   *       RestrictionT}.
+   *   <li>If one of its arguments is tagged with the {@link Timestamp} annotation, then it will be
+   *       passed the timestamp of the current element being processed; the argument must be of type
+   *       {@link Instant}.
    *   <li>If one of its arguments is a {@link RestrictionTracker}, then it will be passed a tracker
    *       that is initialized for the current {@link Restriction}. The argument must be of the
    *       exact type {@code RestrictionTracker<RestrictionT, PositionT>}.
@@ -1051,7 +1092,7 @@ public abstract class DoFn<InputT, OutputT> implements Serializable, HasDisplayD
   @Retention(RetentionPolicy.RUNTIME)
   @Target(ElementType.METHOD)
   @Experimental(Kind.SPLITTABLE_DO_FN)
-  public @interface SplitRestriction {}
+  public @interface TruncateSizedRestriction {}
 
   /**
    * Annotation for the method that creates a new {@link RestrictionTracker} for the restriction of

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/PeriodicSequence.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/PeriodicSequence.java
@@ -146,6 +146,11 @@ public class PeriodicSequence
     }
 
     @Override
+    public RestrictionBoundness isBounded() {
+      return RestrictionBoundness.IS_BOUNDED;
+    }
+
+    @Override
     public String toString() {
       return MoreObjects.toStringHelper(this)
           .add("range", range)

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/PeriodicSequence.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/PeriodicSequence.java
@@ -146,8 +146,8 @@ public class PeriodicSequence
     }
 
     @Override
-    public RestrictionBoundness isBounded() {
-      return RestrictionBoundness.IS_BOUNDED;
+    public IsBounded isBounded() {
+      return IsBounded.BOUNDED;
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Watch.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Watch.java
@@ -1104,11 +1104,11 @@ public class Watch {
     }
 
     @Override
-    public RestrictionBoundness isBounded() {
+    public IsBounded isBounded() {
       if (state == EMPTY_STATE || state instanceof NonPollingGrowthState) {
-        return RestrictionBoundness.IS_BOUNDED;
+        return IsBounded.BOUNDED;
       }
-      return RestrictionBoundness.IS_UNBOUNDED;
+      return IsBounded.UNBOUNDED;
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Watch.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Watch.java
@@ -1104,6 +1104,14 @@ public class Watch {
     }
 
     @Override
+    public RestrictionBoundness isBounded() {
+      if (state == EMPTY_STATE || state instanceof NonPollingGrowthState) {
+        return RestrictionBoundness.IS_BOUNDED;
+      }
+      return RestrictionBoundness.IS_UNBOUNDED;
+    }
+
+    @Override
     public boolean tryClaim(KV<Growth.PollResult<OutputT>, TerminationStateT> pollResult) {
       if (shouldStop) {
         return false;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
@@ -27,7 +27,6 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
@@ -65,6 +64,7 @@ import org.apache.beam.sdk.transforms.splittabledofn.HasDefaultWatermarkEstimato
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.HasProgress;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.IsBounded;
+import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.TruncateResult;
 import org.apache.beam.sdk.transforms.splittabledofn.WatermarkEstimator;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.util.UserCodeException;
@@ -314,12 +314,12 @@ class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
 
     /** Output the current restriction if it is bounded. Otherwise, return null. */
     @SuppressWarnings("unused")
-    public static Optional<?> invokeTruncateRestriction(
+    public static TruncateResult<?> invokeTruncateRestriction(
         DoFnInvoker.ArgumentProvider argumentProvider) {
       if (argumentProvider.restrictionTracker().isBounded() == IsBounded.BOUNDED) {
-        return Optional.of(argumentProvider.restriction());
+        return TruncateResult.of(argumentProvider.restriction());
       }
-      return Optional.empty();
+      return null;
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
@@ -27,6 +27,7 @@ import java.util.ArrayList;
 import java.util.LinkedHashMap;
 import java.util.List;
 import java.util.Map;
+import java.util.Optional;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
@@ -313,10 +314,12 @@ class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
 
     /** Return the current restriction if it's bounded.Otherwise, return null. */
     @SuppressWarnings("unused")
-    public static void invokeTruncateRestriction(DoFnInvoker.ArgumentProvider argumentProvider) {
+    public static Optional<?> invokeTruncateRestriction(
+        DoFnInvoker.ArgumentProvider argumentProvider) {
       if (argumentProvider.restrictionTracker().isBounded() == RestrictionBoundness.IS_BOUNDED) {
-        argumentProvider.outputReceiver(null).output(argumentProvider.restriction());
+        return Optional.of(argumentProvider.restriction());
       }
+      return Optional.empty();
     }
   }
 
@@ -476,7 +479,8 @@ class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
             .method(ElementMatchers.named("invokeSplitRestriction"))
             .intercept(splitRestrictionDelegation(clazzDescription, signature.splitRestriction()))
             .method(ElementMatchers.named("invokeTruncateRestriction"))
-            .intercept(truncateRestrictionDelegation(clazzDescription, signature.truncateRestriction()))
+            .intercept(
+                truncateRestrictionDelegation(clazzDescription, signature.truncateRestriction()))
             .method(ElementMatchers.named("invokeGetRestrictionCoder"))
             .intercept(getRestrictionCoderDelegation(clazzDescription, signature))
             .method(ElementMatchers.named("invokeNewTracker"))

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
@@ -312,7 +312,7 @@ class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
   /** Default implementation of {@link TruncateRestriction}, for delegation by bytebuddy. */
   public static class DefaultTruncateRestriction {
 
-    /** Return the current restriction if it's bounded.Otherwise, return null. */
+    /** Output the current restriction if it is bounded. Otherwise, return null. */
     @SuppressWarnings("unused")
     public static Optional<?> invokeTruncateRestriction(
         DoFnInvoker.ArgumentProvider argumentProvider) {
@@ -331,7 +331,6 @@ class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
       this.restrictionType = restrictionType;
     }
 
-    /** Doesn't split the restriction. */
     @SuppressWarnings({"unused", "unchecked"})
     public <RestrictionT> Coder<RestrictionT> invokeGetRestrictionCoder(CoderRegistry registry)
         throws CannotProvideCoderException {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
@@ -64,7 +64,7 @@ import org.apache.beam.sdk.transforms.splittabledofn.HasDefaultTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.HasDefaultWatermarkEstimator;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.HasProgress;
-import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.RestrictionBoundness;
+import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.IsBounded;
 import org.apache.beam.sdk.transforms.splittabledofn.WatermarkEstimator;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.util.UserCodeException;
@@ -316,7 +316,7 @@ class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
     @SuppressWarnings("unused")
     public static Optional<?> invokeTruncateRestriction(
         DoFnInvoker.ArgumentProvider argumentProvider) {
-      if (argumentProvider.restrictionTracker().isBounded() == RestrictionBoundness.IS_BOUNDED) {
+      if (argumentProvider.restrictionTracker().isBounded() == IsBounded.BOUNDED) {
         return Optional.of(argumentProvider.restriction());
       }
       return Optional.empty();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
@@ -476,7 +476,7 @@ class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
             .method(ElementMatchers.named("invokeSplitRestriction"))
             .intercept(splitRestrictionDelegation(clazzDescription, signature.splitRestriction()))
             .method(ElementMatchers.named("invokeTruncateRestriction"))
-            .intercept(truncateRestrictionDelegation(clazzDescription, signature))
+            .intercept(truncateRestrictionDelegation(clazzDescription, signature.truncateRestriction()))
             .method(ElementMatchers.named("invokeGetRestrictionCoder"))
             .intercept(getRestrictionCoderDelegation(clazzDescription, signature))
             .method(ElementMatchers.named("invokeNewTracker"))

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/ByteBuddyDoFnInvokerFactory.java
@@ -549,11 +549,11 @@ class ByteBuddyDoFnInvokerFactory implements DoFnInvokerFactory {
   }
 
   private static Implementation truncateRestrictionDelegation(
-      TypeDescription doFnType, DoFnSignature signature) {
-    if (signature.truncateRestriction() == null) {
+      TypeDescription doFnType, DoFnSignature.TruncateRestrictionMethod signature) {
+    if (signature == null) {
       return MethodDelegation.to(DefaultTruncateRestriction.class);
     } else {
-      return new DoFnMethodWithExtraParametersDelegation(doFnType, signature.truncateRestriction());
+      return new DoFnMethodWithExtraParametersDelegation(doFnType, signature);
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.sdk.transforms.reflect;
 
-import java.util.Optional;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderRegistry;
@@ -38,6 +37,7 @@ import org.apache.beam.sdk.transforms.DoFn.TimerId;
 import org.apache.beam.sdk.transforms.DoFn.TruncateRestriction;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.HasProgress;
+import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.TruncateResult;
 import org.apache.beam.sdk.transforms.splittabledofn.WatermarkEstimator;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
@@ -96,7 +96,7 @@ public interface DoFnInvoker<InputT, OutputT> {
   void invokeSplitRestriction(ArgumentProvider<InputT, OutputT> arguments);
 
   /** Invoke the {@link TruncateRestriction} method on the bound {@link DoFn}. */
-  <RestrictionT> Optional<RestrictionT> invokeTruncateRestriction(
+  <RestrictionT> TruncateResult<RestrictionT> invokeTruncateRestriction(
       ArgumentProvider<InputT, OutputT> arguments);
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
@@ -34,6 +34,7 @@ import org.apache.beam.sdk.transforms.DoFn.ProcessElement;
 import org.apache.beam.sdk.transforms.DoFn.StartBundle;
 import org.apache.beam.sdk.transforms.DoFn.StateId;
 import org.apache.beam.sdk.transforms.DoFn.TimerId;
+import org.apache.beam.sdk.transforms.DoFn.TruncateRestriction;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.HasProgress;
 import org.apache.beam.sdk.transforms.splittabledofn.WatermarkEstimator;
@@ -93,8 +94,8 @@ public interface DoFnInvoker<InputT, OutputT> {
   /** Invoke the {@link DoFn.SplitRestriction} method on the bound {@link DoFn}. */
   void invokeSplitRestriction(ArgumentProvider<InputT, OutputT> arguments);
 
-  /** Invoke the {@link DoFn.TruncateSizedRestriction} method on the bound {@link DoFn}. */
-  void invokeTruncateSizedRestriction(ArgumentProvider<InputT, OutputT> arguments);
+  /** Invoke the {@link TruncateRestriction} method on the bound {@link DoFn}. */
+  void invokeTruncateRestriction(ArgumentProvider<InputT, OutputT> arguments);
 
   /**
    * Invoke the {@link DoFn.GetSize} method on the bound {@link DoFn}. Falls back to:

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.transforms.reflect;
 
+import java.util.Optional;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderRegistry;
@@ -95,7 +96,8 @@ public interface DoFnInvoker<InputT, OutputT> {
   void invokeSplitRestriction(ArgumentProvider<InputT, OutputT> arguments);
 
   /** Invoke the {@link TruncateRestriction} method on the bound {@link DoFn}. */
-  void invokeTruncateRestriction(ArgumentProvider<InputT, OutputT> arguments);
+  <RestrictionT> Optional<RestrictionT> invokeTruncateRestriction(
+      ArgumentProvider<InputT, OutputT> arguments);
 
   /**
    * Invoke the {@link DoFn.GetSize} method on the bound {@link DoFn}. Falls back to:

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
@@ -93,6 +93,9 @@ public interface DoFnInvoker<InputT, OutputT> {
   /** Invoke the {@link DoFn.SplitRestriction} method on the bound {@link DoFn}. */
   void invokeSplitRestriction(ArgumentProvider<InputT, OutputT> arguments);
 
+  /** Invoke the {@link DoFn.TruncateSizedRestriction} method on the bound {@link DoFn}. */
+  void invokeTruncateSizedRestriction(ArgumentProvider<InputT, OutputT> arguments);
+
   /**
    * Invoke the {@link DoFn.GetSize} method on the bound {@link DoFn}. Falls back to:
    *

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
@@ -112,6 +112,10 @@ public abstract class DoFnSignature {
   @Nullable
   public abstract SplitRestrictionMethod splitRestriction();
 
+  /** Details about this {@link DoFn}'s {@link DoFn.TruncateSizedRestriction} method. */
+  @Nullable
+  public abstract TruncateSizedRestrictionMethod truncateSizedRestriction();
+
   /** Details about this {@link DoFn}'s {@link DoFn.GetRestrictionCoder} method. */
   @Nullable
   public abstract GetRestrictionCoderMethod getRestrictionCoder();
@@ -185,6 +189,9 @@ public abstract class DoFnSignature {
     abstract Builder setGetInitialRestriction(GetInitialRestrictionMethod getInitialRestriction);
 
     abstract Builder setSplitRestriction(SplitRestrictionMethod splitRestriction);
+
+    abstract Builder setTruncateSizedRestriction(
+        TruncateSizedRestrictionMethod truncateSizedRestriction);
 
     abstract Builder setGetRestrictionCoder(GetRestrictionCoderMethod getRestrictionCoder);
 
@@ -1325,6 +1332,31 @@ public abstract class DoFnSignature {
         TypeDescriptor<? extends BoundedWindow> windowT,
         List<Parameter> extraParameters) {
       return new AutoValue_DoFnSignature_SplitRestrictionMethod(
+          targetMethod, windowT, extraParameters);
+    }
+  }
+
+  /** Describes a {@link DoFn.TruncateSizedRestriction} method. */
+  @AutoValue
+  public abstract static class TruncateSizedRestrictionMethod implements MethodWithExtraParameters {
+    /** The annotated method itself. */
+    @Override
+    public abstract Method targetMethod();
+
+    /** The window type used by this method, if any. */
+    @Nullable
+    @Override
+    public abstract TypeDescriptor<? extends BoundedWindow> windowT();
+
+    /** Types of parameters of the annotated method, in the order they appear. */
+    @Override
+    public abstract List<Parameter> extraParameters();
+
+    static TruncateSizedRestrictionMethod create(
+        Method targetMethod,
+        TypeDescriptor<? extends BoundedWindow> windowT,
+        List<Parameter> extraParameters) {
+      return new AutoValue_DoFnSignature_TruncateSizedRestrictionMethod(
           targetMethod, windowT, extraParameters);
     }
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
@@ -38,6 +38,7 @@ import org.apache.beam.sdk.transforms.DoFn.MultiOutputReceiver;
 import org.apache.beam.sdk.transforms.DoFn.ProcessContinuation;
 import org.apache.beam.sdk.transforms.DoFn.StateId;
 import org.apache.beam.sdk.transforms.DoFn.TimerId;
+import org.apache.beam.sdk.transforms.DoFn.TruncateRestriction;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.OutputReceiverParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.RestrictionTrackerParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.SchemaElementParameter;
@@ -112,9 +113,9 @@ public abstract class DoFnSignature {
   @Nullable
   public abstract SplitRestrictionMethod splitRestriction();
 
-  /** Details about this {@link DoFn}'s {@link DoFn.TruncateSizedRestriction} method. */
+  /** Details about this {@link DoFn}'s {@link TruncateRestriction} method. */
   @Nullable
-  public abstract TruncateSizedRestrictionMethod truncateSizedRestriction();
+  public abstract TruncateRestrictionMethod truncateRestriction();
 
   /** Details about this {@link DoFn}'s {@link DoFn.GetRestrictionCoder} method. */
   @Nullable
@@ -190,8 +191,7 @@ public abstract class DoFnSignature {
 
     abstract Builder setSplitRestriction(SplitRestrictionMethod splitRestriction);
 
-    abstract Builder setTruncateSizedRestriction(
-        TruncateSizedRestrictionMethod truncateSizedRestriction);
+    abstract Builder setTruncateRestriction(TruncateRestrictionMethod truncateRestriction);
 
     abstract Builder setGetRestrictionCoder(GetRestrictionCoderMethod getRestrictionCoder);
 
@@ -1336,9 +1336,9 @@ public abstract class DoFnSignature {
     }
   }
 
-  /** Describes a {@link DoFn.TruncateSizedRestriction} method. */
+  /** Describes a {@link TruncateRestriction} method. */
   @AutoValue
-  public abstract static class TruncateSizedRestrictionMethod implements MethodWithExtraParameters {
+  public abstract static class TruncateRestrictionMethod implements MethodWithExtraParameters {
     /** The annotated method itself. */
     @Override
     public abstract Method targetMethod();
@@ -1352,11 +1352,11 @@ public abstract class DoFnSignature {
     @Override
     public abstract List<Parameter> extraParameters();
 
-    static TruncateSizedRestrictionMethod create(
+    static TruncateRestrictionMethod create(
         Method targetMethod,
         TypeDescriptor<? extends BoundedWindow> windowT,
         List<Parameter> extraParameters) {
-      return new AutoValue_DoFnSignature_TruncateSizedRestrictionMethod(
+      return new AutoValue_DoFnSignature_TruncateRestrictionMethod(
           targetMethod, windowT, extraParameters);
     }
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
@@ -83,6 +83,7 @@ import org.apache.beam.sdk.transforms.splittabledofn.HasDefaultTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.HasDefaultWatermarkEstimator;
 import org.apache.beam.sdk.transforms.splittabledofn.ManualWatermarkEstimator;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
+import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.TruncateResult;
 import org.apache.beam.sdk.transforms.splittabledofn.WatermarkEstimator;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
@@ -1832,10 +1833,9 @@ public class DoFnSignatures {
       FnAnalysisContext fnContext) {
     // Method is of the form:
     // @TruncateRestriction
-    // Optional<RestrictionT> truncateRestriction(... parameters ...);
+    // TruncateResult<RestrictionT> truncateRestriction(... parameters ...);
     errors.checkArgument(
-        Optional.class.equals(m.getReturnType()), "Must return Optional<Restriction>");
-
+        TruncateResult.class.equals(m.getReturnType()), "Must return TruncateResult<Restriction>");
     Type[] params = m.getGenericParameterTypes();
     MethodAnalysisContext methodContext = MethodAnalysisContext.create();
     TypeDescriptor<? extends BoundedWindow> windowT = getWindowType(fnT, m);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
@@ -221,7 +221,6 @@ public class DoFnSignatures {
               Parameter.ElementParameter.class,
               Parameter.RestrictionParameter.class,
               Parameter.RestrictionTrackerParameter.class,
-              Parameter.OutputReceiverParameter.class,
               Parameter.WindowParameter.class,
               Parameter.TimestampParameter.class,
               Parameter.PaneInfoParameter.class,
@@ -739,7 +738,6 @@ public class DoFnSignatures {
                 fnT,
                 truncateRestrictionMethod,
                 inputT,
-                outputT,
                 restrictionT,
                 fnContext));
       }
@@ -1830,13 +1828,13 @@ public class DoFnSignatures {
       TypeDescriptor<? extends DoFn<?, ?>> fnT,
       Method m,
       TypeDescriptor<?> inputT,
-      TypeDescriptor<?> outputT,
       TypeDescriptor<?> restrictionT,
       FnAnalysisContext fnContext) {
     // Method is of the form:
     // @TruncateRestriction
-    // void truncateRestriction(... parameters ...);
-    errors.checkArgument(void.class.equals(m.getReturnType()), "Must return void");
+    // Optional<RestrictionT> truncateRestriction(... parameters ...);
+    errors.checkArgument(
+        Optional.class.equals(m.getReturnType()), "Must return Optional<Restriction>");
 
     Type[] params = m.getGenericParameterTypes();
     MethodAnalysisContext methodContext = MethodAnalysisContext.create();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
@@ -215,6 +215,18 @@ public class DoFnSignatures {
           Parameter.PaneInfoParameter.class,
           Parameter.PipelineOptionsParameter.class);
 
+  private static final Collection<Class<? extends Parameter>>
+      ALLOWED_TRUNCATE_RESTRICTION_PARAMETERS =
+          ImmutableList.of(
+              Parameter.ElementParameter.class,
+              Parameter.RestrictionParameter.class,
+              Parameter.RestrictionTrackerParameter.class,
+              Parameter.OutputReceiverParameter.class,
+              Parameter.WindowParameter.class,
+              Parameter.TimestampParameter.class,
+              Parameter.PaneInfoParameter.class,
+              Parameter.PipelineOptionsParameter.class);
+
   private static final Collection<Class<? extends Parameter>> ALLOWED_NEW_TRACKER_PARAMETERS =
       ImmutableList.of(
           Parameter.ElementParameter.class,
@@ -1859,7 +1871,7 @@ public class DoFnSignatures {
     }
 
     for (Parameter parameter : methodContext.getExtraParameters()) {
-      checkParameterOneOf(errors, parameter, ALLOWED_SPLIT_RESTRICTION_PARAMETERS);
+      checkParameterOneOf(errors, parameter, ALLOWED_TRUNCATE_RESTRICTION_PARAMETERS);
     }
 
     return DoFnSignature.TruncateRestrictionMethod.create(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
@@ -61,6 +61,7 @@ import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
 import org.apache.beam.sdk.transforms.DoFn.SideInput;
 import org.apache.beam.sdk.transforms.DoFn.StateId;
 import org.apache.beam.sdk.transforms.DoFn.TimerId;
+import org.apache.beam.sdk.transforms.DoFn.TruncateRestriction;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.FieldAccessDeclaration;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.GetInitialRestrictionMethod;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.GetInitialWatermarkEstimatorStateMethod;
@@ -520,8 +521,8 @@ public class DoFnSignatures {
         findAnnotatedMethod(errors, DoFn.GetInitialRestriction.class, fnClass, false);
     Method splitRestrictionMethod =
         findAnnotatedMethod(errors, DoFn.SplitRestriction.class, fnClass, false);
-    Method truncateSizedRestrictionMethod =
-        findAnnotatedMethod(errors, DoFn.TruncateSizedRestriction.class, fnClass, false);
+    Method truncateRestrictionMethod =
+        findAnnotatedMethod(errors, TruncateRestriction.class, fnClass, false);
     Method getRestrictionCoderMethod =
         findAnnotatedMethod(errors, DoFn.GetRestrictionCoder.class, fnClass, false);
     Method newTrackerMethod = findAnnotatedMethod(errors, DoFn.NewTracker.class, fnClass, false);
@@ -719,13 +720,12 @@ public class DoFnSignatures {
                 fnContext));
       }
 
-      if (truncateSizedRestrictionMethod != null) {
-        signatureBuilder.setTruncateSizedRestriction(
-            analyzeTruncateSizedRestrictionMethod(
-                errors.forMethod(
-                    DoFn.TruncateSizedRestriction.class, truncateSizedRestrictionMethod),
+      if (truncateRestrictionMethod != null) {
+        signatureBuilder.setTruncateRestriction(
+            analyzeTruncateRestrictionMethod(
+                errors.forMethod(TruncateRestriction.class, truncateRestrictionMethod),
                 fnT,
-                truncateSizedRestrictionMethod,
+                truncateRestrictionMethod,
                 inputT,
                 outputT,
                 restrictionT,
@@ -793,8 +793,8 @@ public class DoFnSignatures {
       if (splitRestrictionMethod != null) {
         forbiddenMethods.add("@" + format(DoFn.SplitRestriction.class));
       }
-      if (truncateSizedRestrictionMethod != null) {
-        forbiddenMethods.add("@" + format(DoFn.TruncateSizedRestriction.class));
+      if (truncateRestrictionMethod != null) {
+        forbiddenMethods.add("@" + format(TruncateRestriction.class));
       }
       if (newTrackerMethod != null) {
         forbiddenMethods.add("@" + format(DoFn.NewTracker.class));
@@ -1813,7 +1813,7 @@ public class DoFnSignatures {
   }
 
   @VisibleForTesting
-  static DoFnSignature.TruncateSizedRestrictionMethod analyzeTruncateSizedRestrictionMethod(
+  static DoFnSignature.TruncateRestrictionMethod analyzeTruncateRestrictionMethod(
       ErrorReporter errors,
       TypeDescriptor<? extends DoFn<?, ?>> fnT,
       Method m,
@@ -1822,8 +1822,8 @@ public class DoFnSignatures {
       TypeDescriptor<?> restrictionT,
       FnAnalysisContext fnContext) {
     // Method is of the form:
-    // @TruncateSizedRestriction
-    // void truncateSizedRestriction(... parameters ...);
+    // @TruncateRestriction
+    // void truncateRestriction(... parameters ...);
     errors.checkArgument(void.class.equals(m.getReturnType()), "Must return void");
 
     Type[] params = m.getGenericParameterTypes();
@@ -1844,7 +1844,7 @@ public class DoFnSignatures {
         errors.throwIllegalArgument(
             "Schema @%s are not supported for @%s method. Found %s, did you mean to use %s?",
             format(DoFn.Element.class),
-            format(DoFn.TruncateSizedRestriction.class),
+            format(TruncateRestriction.class),
             format(((SchemaElementParameter) extraParam).elementT()),
             format(inputT));
       } else if (extraParam instanceof RestrictionParameter) {
@@ -1862,7 +1862,7 @@ public class DoFnSignatures {
       checkParameterOneOf(errors, parameter, ALLOWED_SPLIT_RESTRICTION_PARAMETERS);
     }
 
-    return DoFnSignature.TruncateSizedRestrictionMethod.create(
+    return DoFnSignature.TruncateRestrictionMethod.create(
         m, windowT, methodContext.getExtraParameters());
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/ByteKeyRangeTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/ByteKeyRangeTracker.java
@@ -204,6 +204,11 @@ public class ByteKeyRangeTracker extends RestrictionTracker<ByteKeyRange, ByteKe
   }
 
   @Override
+  public boolean isBounded() {
+    return true;
+  }
+
+  @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("range", range)

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/ByteKeyRangeTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/ByteKeyRangeTracker.java
@@ -204,8 +204,8 @@ public class ByteKeyRangeTracker extends RestrictionTracker<ByteKeyRange, ByteKe
   }
 
   @Override
-  public RestrictionBoundness isBounded() {
-    return RestrictionBoundness.IS_BOUNDED;
+  public IsBounded isBounded() {
+    return IsBounded.BOUNDED;
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/ByteKeyRangeTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/ByteKeyRangeTracker.java
@@ -204,8 +204,8 @@ public class ByteKeyRangeTracker extends RestrictionTracker<ByteKeyRange, ByteKe
   }
 
   @Override
-  public boolean isBounded() {
-    return true;
+  public RestrictionBoundness isBounded() {
+    return RestrictionBoundness.IS_BOUNDED;
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/GrowableOffsetRangeTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/GrowableOffsetRangeTracker.java
@@ -143,6 +143,10 @@ public class GrowableOffsetRangeTracker extends OffsetRangeTracker {
 
   @Override
   public boolean isBounded() {
-    return false;
+    // If current range has been done, the range should be bounded.
+    if (lastAttemptedOffset != null && lastAttemptedOffset == Long.MAX_VALUE) {
+      return true;
+    }
+    return range.getTo() == Long.MAX_VALUE ? false : true;
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/GrowableOffsetRangeTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/GrowableOffsetRangeTracker.java
@@ -140,4 +140,9 @@ public class GrowableOffsetRangeTracker extends OffsetRangeTracker {
         totalWork.subtract(workRemaining, MathContext.DECIMAL128).doubleValue(),
         workRemaining.doubleValue());
   }
+
+  @Override
+  public boolean isBounded() {
+    return false;
+  }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/GrowableOffsetRangeTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/GrowableOffsetRangeTracker.java
@@ -142,11 +142,13 @@ public class GrowableOffsetRangeTracker extends OffsetRangeTracker {
   }
 
   @Override
-  public boolean isBounded() {
+  public RestrictionBoundness isBounded() {
     // If current range has been done, the range should be bounded.
     if (lastAttemptedOffset != null && lastAttemptedOffset == Long.MAX_VALUE) {
-      return true;
+      return RestrictionBoundness.IS_BOUNDED;
     }
-    return range.getTo() == Long.MAX_VALUE ? false : true;
+    return range.getTo() == Long.MAX_VALUE
+        ? RestrictionBoundness.IS_UNBOUNDED
+        : RestrictionBoundness.IS_BOUNDED;
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/GrowableOffsetRangeTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/GrowableOffsetRangeTracker.java
@@ -142,13 +142,11 @@ public class GrowableOffsetRangeTracker extends OffsetRangeTracker {
   }
 
   @Override
-  public RestrictionBoundness isBounded() {
+  public IsBounded isBounded() {
     // If current range has been done, the range should be bounded.
     if (lastAttemptedOffset != null && lastAttemptedOffset == Long.MAX_VALUE) {
-      return RestrictionBoundness.IS_BOUNDED;
+      return IsBounded.BOUNDED;
     }
-    return range.getTo() == Long.MAX_VALUE
-        ? RestrictionBoundness.IS_UNBOUNDED
-        : RestrictionBoundness.IS_BOUNDED;
+    return range.getTo() == Long.MAX_VALUE ? IsBounded.UNBOUNDED : IsBounded.BOUNDED;
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/OffsetRangeTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/OffsetRangeTracker.java
@@ -124,8 +124,8 @@ public class OffsetRangeTracker extends RestrictionTracker<OffsetRange, Long>
   }
 
   @Override
-  public RestrictionBoundness isBounded() {
-    return RestrictionBoundness.IS_BOUNDED;
+  public IsBounded isBounded() {
+    return IsBounded.BOUNDED;
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/OffsetRangeTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/OffsetRangeTracker.java
@@ -124,8 +124,8 @@ public class OffsetRangeTracker extends RestrictionTracker<OffsetRange, Long>
   }
 
   @Override
-  public boolean isBounded() {
-    return true;
+  public RestrictionBoundness isBounded() {
+    return RestrictionBoundness.IS_BOUNDED;
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/OffsetRangeTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/OffsetRangeTracker.java
@@ -124,6 +124,11 @@ public class OffsetRangeTracker extends RestrictionTracker<OffsetRange, Long>
   }
 
   @Override
+  public boolean isBounded() {
+    return true;
+  }
+
+  @Override
   public String toString() {
     return MoreObjects.toStringHelper(this)
         .add("range", range)

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
@@ -175,4 +175,16 @@ public abstract class RestrictionTracker<RestrictionT, PositionT> {
     /** The known amount of work remaining. */
     public abstract double getWorkRemaining();
   }
+
+  /** A representation of the truncate result. */
+  @AutoValue
+  public abstract static class TruncateResult<RestrictionT> {
+    /** Returns a {@link TruncateResult} for the given restriction. */
+    public static <RestrictionT> TruncateResult of(RestrictionT restriction) {
+      return new AutoValue_RestrictionTracker_TruncateResult(restriction);
+    }
+
+    @Nullable
+    public abstract RestrictionT getTruncatedRestriction();
+  }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
@@ -110,6 +110,9 @@ public abstract class RestrictionTracker<RestrictionT, PositionT> {
    * Return the boundedness of the current restriction. If the current restriction represents a
    * finite amount of work, it should return {@link IsBounded#BOUNDED}. Otherwise, it should return
    * {@link IsBounded#UNBOUNDED}.
+   *
+   * <p>It is valid to return {@link IsBounded#BOUNDED} after returning {@link IsBounded#UNBOUNDED} once
+   * the end of a restriction is discovered. It is not valid to return {@link IsBounded#UNBOUNDED} after returning {@link IsBounded#BOUNDED}.
    */
   public abstract IsBounded isBounded();
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
@@ -99,23 +99,19 @@ public abstract class RestrictionTracker<RestrictionT, PositionT> {
    */
   public abstract void checkDone() throws IllegalStateException;
 
-  public enum RestrictionBoundness {
-    IS_BOUNDED,
-    IS_UNBOUNDED
+  public enum IsBounded {
+    /** Indicates that a {@code Restriction} represents a bounded amount of work. */
+    BOUNDED,
+    /** Indicates that a {@code Restriction} represents an unbounded amount of work. */
+    UNBOUNDED
   }
 
   /**
-   * Return the boundedness of current tracking restriction. If the current restriction produces
-   * finite output, it should return {@link RestrictionBoundness#IS_BOUNDED}. Otherwise, it should
-   * return {@link RestrictionBoundness#IS_UNBOUNDED}.
-   *
-   * <p>The API is called by the system when the pipeline starts to drain and there is no
-   * implementation of {@link DoFn.TruncateRestriction}. Based on the boundness of the restriction,
-   * the system will give the default behavior of truncating restrictions.
-   *
-   * <p>The API is required to be implemented.
+   * Return the boundedness of the current restriction. If the current restriction represents a
+   * finite amount of work, it should return {@link IsBounded#BOUNDED}. Otherwise, it should return
+   * {@link IsBounded#UNBOUNDED}.
    */
-  public abstract RestrictionBoundness isBounded();
+  public abstract IsBounded isBounded();
 
   /**
    * All {@link RestrictionTracker}s SHOULD implement this interface to improve auto-scaling and

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
@@ -22,6 +22,7 @@ import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.commons.lang3.NotImplementedException;
 
 /**
  * Manages access to the restriction and keeps track of its claimed part for a <a
@@ -98,6 +99,10 @@ public abstract class RestrictionTracker<RestrictionT, PositionT> {
    * work remaining in the restriction.
    */
   public abstract void checkDone() throws IllegalStateException;
+
+  public boolean isBounded() throws NotImplementedException {
+    throw new NotImplementedException("isBounded is not implemented.");
+  }
 
   /**
    * All {@link RestrictionTracker}s SHOULD implement this interface to improve auto-scaling and

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/RestrictionTracker.java
@@ -22,7 +22,6 @@ import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.transforms.DoFn;
-import org.apache.commons.lang3.NotImplementedException;
 
 /**
  * Manages access to the restriction and keeps track of its claimed part for a <a
@@ -100,9 +99,23 @@ public abstract class RestrictionTracker<RestrictionT, PositionT> {
    */
   public abstract void checkDone() throws IllegalStateException;
 
-  public boolean isBounded() throws NotImplementedException {
-    throw new NotImplementedException("isBounded is not implemented.");
+  public enum RestrictionBoundness {
+    IS_BOUNDED,
+    IS_UNBOUNDED
   }
+
+  /**
+   * Return the boundedness of current tracking restriction. If the current restriction produces
+   * finite output, it should return {@link RestrictionBoundness#IS_BOUNDED}. Otherwise, it should
+   * return {@link RestrictionBoundness#IS_UNBOUNDED}.
+   *
+   * <p>The API is called by the system when the pipeline starts to drain and there is no
+   * implementation of {@link DoFn.TruncateRestriction}. Based on the boundness of the restriction,
+   * the system will give the default behavior of truncating restrictions.
+   *
+   * <p>The API is required to be implemented.
+   */
+  public abstract RestrictionBoundness isBounded();
 
   /**
    * All {@link RestrictionTracker}s SHOULD implement this interface to improve auto-scaling and

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
@@ -943,7 +943,7 @@ public class DoFnInvokersTest {
                 return "foo";
               }
             });
-    assertNull(result.getTruncatedRestriction());
+    assertNull(result);
     assertEquals(stop(), invoker.invokeProcessElement(mockArgumentProvider));
     assertThat(
         invoker.invokeNewWatermarkEstimator(

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
@@ -26,7 +26,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
 import static org.junit.Assert.assertThat;
-import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 import static org.mockito.ArgumentMatchers.any;
 import static org.mockito.Matchers.eq;
@@ -42,7 +41,6 @@ import java.io.OutputStream;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.List;
-import java.util.Optional;
 import org.apache.beam.sdk.coders.AtomicCoder;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.CoderProviders;
@@ -67,6 +65,7 @@ import org.apache.beam.sdk.transforms.reflect.testhelper.DoFnInvokersTestHelper;
 import org.apache.beam.sdk.transforms.splittabledofn.HasDefaultTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.HasDefaultWatermarkEstimator;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
+import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.TruncateResult;
 import org.apache.beam.sdk.transforms.splittabledofn.SplitResult;
 import org.apache.beam.sdk.transforms.splittabledofn.WatermarkEstimator;
 import org.apache.beam.sdk.transforms.splittabledofn.WatermarkEstimators;
@@ -848,7 +847,7 @@ public class DoFnInvokersTest {
               }
             });
     assertThat(tracker, instanceOf(BoundedDefaultTracker.class));
-    Optional result =
+    TruncateResult<?> result =
         invoker.invokeTruncateRestriction(
             new FakeArgumentProvider<String, String>() {
               @Override
@@ -866,8 +865,7 @@ public class DoFnInvokersTest {
                 return "foo";
               }
             });
-    assertTrue(result.isPresent());
-    assertEquals("foo", result.get());
+    assertEquals("foo", result.getTruncatedRestriction());
     assertEquals(stop(), invoker.invokeProcessElement(mockArgumentProvider));
     assertThat(
         invoker.invokeNewWatermarkEstimator(
@@ -927,7 +925,7 @@ public class DoFnInvokersTest {
               }
             });
     assertThat(tracker, instanceOf(UnboundedDefaultTracker.class));
-    Optional result =
+    TruncateResult<?> result =
         invoker.invokeTruncateRestriction(
             new FakeArgumentProvider<String, String>() {
               @Override
@@ -945,7 +943,7 @@ public class DoFnInvokersTest {
                 return "foo";
               }
             });
-    assertFalse(result.isPresent());
+    assertNull(result.getTruncatedRestriction());
     assertEquals(stop(), invoker.invokeProcessElement(mockArgumentProvider));
     assertThat(
         invoker.invokeNewWatermarkEstimator(

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
@@ -624,8 +624,8 @@ public class DoFnInvokersTest {
     public void checkDone() throws IllegalStateException {}
 
     @Override
-    public RestrictionBoundness isBounded() {
-      return RestrictionBoundness.IS_BOUNDED;
+    public IsBounded isBounded() {
+      return IsBounded.BOUNDED;
     }
   }
 
@@ -651,8 +651,8 @@ public class DoFnInvokersTest {
     public void checkDone() throws IllegalStateException {}
 
     @Override
-    public RestrictionBoundness isBounded() {
-      return RestrictionBoundness.IS_UNBOUNDED;
+    public IsBounded isBounded() {
+      return IsBounded.UNBOUNDED;
     }
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
@@ -594,7 +594,8 @@ public class DoFnInvokersTest {
   }
 
   private static class RestrictionWithUnboundedDefaultTracker
-      implements HasDefaultTracker<RestrictionWithUnboundedDefaultTracker, UnboundedDefaultTracker> {
+      implements HasDefaultTracker<
+          RestrictionWithUnboundedDefaultTracker, UnboundedDefaultTracker> {
     @Override
     public UnboundedDefaultTracker newTracker() {
       return new UnboundedDefaultTracker();
@@ -627,7 +628,8 @@ public class DoFnInvokersTest {
     }
   }
 
-  private static class UnboundedDefaultTracker extends RestrictionTracker<RestrictionWithUnboundedDefaultTracker, Void>  {
+  private static class UnboundedDefaultTracker
+      extends RestrictionTracker<RestrictionWithUnboundedDefaultTracker, Void> {
     @Override
     public boolean tryClaim(Void position) {
       throw new UnsupportedOperationException();
@@ -639,7 +641,8 @@ public class DoFnInvokersTest {
     }
 
     @Override
-    public SplitResult<RestrictionWithUnboundedDefaultTracker> trySplit(double fractionOfRemainder) {
+    public SplitResult<RestrictionWithUnboundedDefaultTracker> trySplit(
+        double fractionOfRemainder) {
       throw new UnsupportedOperationException();
     }
 
@@ -647,12 +650,13 @@ public class DoFnInvokersTest {
     public void checkDone() throws IllegalStateException {}
 
     @Override
-    public RestrictionBoundness isBounded(){
+    public RestrictionBoundness isBounded() {
       return RestrictionBoundness.IS_UNBOUNDED;
     }
   }
 
-  private static class CoderForDefaultTracker extends AtomicCoder<RestrictionWithBoundedDefaultTracker> {
+  private static class CoderForDefaultTracker
+      extends AtomicCoder<RestrictionWithBoundedDefaultTracker> {
     public static CoderForDefaultTracker of() {
       return new CoderForDefaultTracker();
     }
@@ -813,7 +817,7 @@ public class DoFnInvokersTest {
 
       @GetInitialWatermarkEstimatorState
       public WatermarkEstimatorStateWithDefaultWatermarkEstimator
-      getInitialWatermarkEstimatorState() {
+          getInitialWatermarkEstimatorState() {
         return null;
       }
     }
@@ -834,13 +838,14 @@ public class DoFnInvokersTest {
     assertThat(
         invoker.invokeGetWatermarkEstimatorStateCoder(coderRegistry),
         instanceOf(CoderForWatermarkEstimatorStateWithDefaultWatermarkEstimator.class));
-    RestrictionTracker tracker =        invoker.invokeNewTracker(
-        new FakeArgumentProvider<String, String>() {
-          @Override
-          public Object restriction() {
-            return new RestrictionWithBoundedDefaultTracker();
-          }
-        });
+    RestrictionTracker tracker =
+        invoker.invokeNewTracker(
+            new FakeArgumentProvider<String, String>() {
+              @Override
+              public Object restriction() {
+                return new RestrictionWithBoundedDefaultTracker();
+              }
+            });
     assertThat(tracker, instanceOf(BoundedDefaultTracker.class));
     invoker.invokeTruncateRestriction(
         new FakeArgumentProvider<String, String>() {
@@ -909,7 +914,7 @@ public class DoFnInvokersTest {
 
       @GetInitialWatermarkEstimatorState
       public WatermarkEstimatorStateWithDefaultWatermarkEstimator
-      getInitialWatermarkEstimatorState() {
+          getInitialWatermarkEstimatorState() {
         return null;
       }
     }
@@ -930,21 +935,22 @@ public class DoFnInvokersTest {
     assertThat(
         invoker.invokeGetWatermarkEstimatorStateCoder(coderRegistry),
         instanceOf(CoderForWatermarkEstimatorStateWithDefaultWatermarkEstimator.class));
-    RestrictionTracker tracker =         invoker.invokeNewTracker(
-        new FakeArgumentProvider<String, String>() {
-          @Override
-          public Object restriction() {
-            return new RestrictionWithUnboundedDefaultTracker();
-          }
-        });
-    assertThat(tracker,
-        instanceOf(UnboundedDefaultTracker.class));
+    RestrictionTracker tracker =
+        invoker.invokeNewTracker(
+            new FakeArgumentProvider<String, String>() {
+              @Override
+              public Object restriction() {
+                return new RestrictionWithUnboundedDefaultTracker();
+              }
+            });
+    assertThat(tracker, instanceOf(UnboundedDefaultTracker.class));
     invoker.invokeTruncateRestriction(
         new FakeArgumentProvider<String, String>() {
           @Override
           public RestrictionTracker restrictionTracker() {
             return tracker;
           }
+
           @Override
           public String element(DoFn<String, String> doFn) {
             return "blah";
@@ -986,13 +992,13 @@ public class DoFnInvokersTest {
         instanceOf(DefaultWatermarkEstimator.class));
   }
 
-
   @Test
   public void testDefaultWatermarkEstimatorStateAndCoder() throws Exception {
     class MockFn extends DoFn<String, String> {
       @ProcessElement
       public void processElement(
-          ProcessContext c, RestrictionTracker<RestrictionWithBoundedDefaultTracker, Void> tracker) {}
+          ProcessContext c,
+          RestrictionTracker<RestrictionWithBoundedDefaultTracker, Void> tracker) {}
 
       @GetInitialRestriction
       public RestrictionWithBoundedDefaultTracker getInitialRestriction(@Element String element) {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnInvokersTest.java
@@ -611,6 +611,11 @@ public class DoFnInvokersTest {
 
     @Override
     public void checkDone() throws IllegalStateException {}
+
+    @Override
+    public RestrictionBoundness isBounded() {
+      throw new UnsupportedOperationException();
+    }
   }
 
   private static class CoderForDefaultTracker extends AtomicCoder<RestrictionWithDefaultTracker> {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesSplittableDoFnTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesSplittableDoFnTest.java
@@ -25,7 +25,6 @@ import static org.junit.Assert.assertTrue;
 
 import java.lang.reflect.Method;
 import java.util.List;
-import java.util.Optional;
 import org.apache.beam.sdk.coders.InstantCoder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
@@ -1009,11 +1008,11 @@ public class DoFnSignaturesSplittableDoFnTest {
         errors(),
         TypeDescriptor.of(FakeDoFn.class),
         new AnonymousMethod() {
-          Optional<SomeRestriction> method(
+          TruncateResult<SomeRestriction> method(
               @Element Integer element,
               @Restriction SomeRestriction restriction,
               DoFn.OutputReceiver<SomeRestriction> receiver) {
-            return Optional.empty();
+            return null;
           }
         }.getMethod(),
         TypeDescriptor.of(Integer.class),
@@ -1029,9 +1028,9 @@ public class DoFnSignaturesSplittableDoFnTest {
         errors(),
         TypeDescriptor.of(FakeDoFn.class),
         new AnonymousMethod() {
-          Optional<SomeRestriction> method(
+          TruncateResult<SomeRestriction> method(
               @Element String element, @Restriction SomeRestriction restriction) {
-            return Optional.empty();
+            return null;
           }
         }.getMethod(),
         TypeDescriptor.of(Integer.class),
@@ -1046,9 +1045,9 @@ public class DoFnSignaturesSplittableDoFnTest {
         errors(),
         TypeDescriptor.of(FakeDoFn.class),
         new AnonymousMethod() {
-          private Optional<SomeRestriction> method(
+          private TruncateResult<SomeRestriction> method(
               @Element Integer element, @Restriction SomeRestriction restriction, Object extra) {
-            return Optional.empty();
+            return null;
           }
         }.getMethod(),
         TypeDescriptor.of(Integer.class),

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesSplittableDoFnTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesSplittableDoFnTest.java
@@ -49,6 +49,7 @@ import org.apache.beam.sdk.transforms.splittabledofn.HasDefaultTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.HasDefaultWatermarkEstimator;
 import org.apache.beam.sdk.transforms.splittabledofn.ManualWatermarkEstimator;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
+import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.TruncateResult;
 import org.apache.beam.sdk.transforms.splittabledofn.WatermarkEstimator;
 import org.apache.beam.sdk.transforms.splittabledofn.WatermarkEstimators;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
@@ -306,7 +307,7 @@ public class DoFnSignaturesSplittableDoFnTest {
           @Timestamp Instant timestamp) {}
 
       @TruncateRestriction
-      public Optional<SomeRestriction> truncateRestriction(
+      public TruncateResult<SomeRestriction> truncateRestriction(
           @Element Integer element,
           @Restriction SomeRestriction restriction,
           RestrictionTracker<SomeRestriction, Void> restrictionTracker,
@@ -314,7 +315,7 @@ public class DoFnSignaturesSplittableDoFnTest {
           BoundedWindow boundedWindow,
           PaneInfo paneInfo,
           @Timestamp Instant timestamp) {
-        return Optional.empty();
+        return TruncateResult.of(null);
       }
 
       @NewTracker
@@ -450,8 +451,9 @@ public class DoFnSignaturesSplittableDoFnTest {
           @Restriction RestrictionT restriction, OutputReceiver<RestrictionT> receiver) {}
 
       @TruncateRestriction
-      public Optional<RestrictionT> truncateRestriction(@Restriction RestrictionT restriction) {
-        return Optional.empty();
+      public TruncateResult<RestrictionT> truncateRestriction(
+          @Restriction RestrictionT restriction) {
+        return TruncateResult.of(null);
       }
 
       @NewTracker
@@ -988,7 +990,7 @@ public class DoFnSignaturesSplittableDoFnTest {
 
   @Test
   public void testTruncateRestrictionReturnsWrongType() throws Exception {
-    thrown.expectMessage("Must return Optional<Restriction>");
+    thrown.expectMessage("Must return TruncateResult<Restriction>");
     DoFnSignatures.analyzeTruncateRestrictionMethod(
         errors(),
         TypeDescriptor.of(FakeDoFn.class),
@@ -1074,9 +1076,9 @@ public class DoFnSignaturesSplittableDoFnTest {
       }
 
       @DoFn.TruncateRestriction
-      public Optional<OtherRestriction> truncateRestriction(
+      public TruncateResult<OtherRestriction> truncateRestriction(
           @Element Integer element, @Restriction OtherRestriction restriction) {
-        return Optional.empty();
+        return TruncateResult.of(null);
       }
     }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesSplittableDoFnTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/reflect/DoFnSignaturesSplittableDoFnTest.java
@@ -389,7 +389,7 @@ public class DoFnSignaturesSplittableDoFnTest {
     assertEquals(
         SomeRestriction.class,
         getParameterOfType(
-            signature.truncateRestriction().extraParameters(), RestrictionParameter.class)
+                signature.truncateRestriction().extraParameters(), RestrictionParameter.class)
             .restrictionT()
             .getRawType());
     assertEquals(SomeRestrictionTracker.class, signature.newTracker().trackerT().getRawType());
@@ -509,7 +509,7 @@ public class DoFnSignaturesSplittableDoFnTest {
     assertEquals(
         SomeRestriction.class,
         getParameterOfType(
-            signature.truncateRestriction().extraParameters(), RestrictionParameter.class)
+                signature.truncateRestriction().extraParameters(), RestrictionParameter.class)
             .restrictionT()
             .getRawType());
     assertEquals(RestrictionTracker.class, signature.newTracker().trackerT().getRawType());

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/splittabledofn/GrowableOffsetRangeTrackerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/splittabledofn/GrowableOffsetRangeTrackerTest.java
@@ -25,8 +25,8 @@ import static org.junit.Assert.assertTrue;
 import java.math.BigDecimal;
 import java.math.MathContext;
 import org.apache.beam.sdk.io.range.OffsetRange;
+import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.IsBounded;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.Progress;
-import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.RestrictionBoundness;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -258,18 +258,18 @@ public class GrowableOffsetRangeTrackerTest {
   public void testIsBounded() throws Exception {
     SimpleEstimator simpleEstimator = new SimpleEstimator();
     GrowableOffsetRangeTracker tracker = new GrowableOffsetRangeTracker(0L, simpleEstimator);
-    assertEquals(RestrictionBoundness.IS_UNBOUNDED, tracker.isBounded());
+    assertEquals(IsBounded.UNBOUNDED, tracker.isBounded());
     assertTrue(tracker.tryClaim(0L));
-    assertEquals(RestrictionBoundness.IS_UNBOUNDED, tracker.isBounded());
+    assertEquals(IsBounded.UNBOUNDED, tracker.isBounded());
 
     // After split, the restriction should be bounded.
     simpleEstimator.setEstimateRangeEnd(16L);
     tracker.trySplit(0.5);
-    assertEquals(RestrictionBoundness.IS_BOUNDED, tracker.isBounded());
+    assertEquals(IsBounded.BOUNDED, tracker.isBounded());
 
     // The restriction should be bounded after all the work has been claimed.
     tracker = new GrowableOffsetRangeTracker(0L, simpleEstimator);
     tracker.tryClaim(Long.MAX_VALUE);
-    assertEquals(RestrictionBoundness.IS_BOUNDED, tracker.isBounded());
+    assertEquals(IsBounded.BOUNDED, tracker.isBounded());
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/splittabledofn/GrowableOffsetRangeTrackerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/splittabledofn/GrowableOffsetRangeTrackerTest.java
@@ -252,4 +252,23 @@ public class GrowableOffsetRangeTrackerTest {
     assertEquals(new OffsetRange(123456789012345681L, 123456789012345682L), res.getPrimary());
     assertEquals(new OffsetRange(123456789012345682L, Long.MAX_VALUE), res.getResidual());
   }
+
+  @Test
+  public void testIsBounded() throws Exception {
+    SimpleEstimator simpleEstimator = new SimpleEstimator();
+    GrowableOffsetRangeTracker tracker = new GrowableOffsetRangeTracker(0L, simpleEstimator);
+    assertFalse(tracker.isBounded());
+    assertTrue(tracker.tryClaim(0L));
+    assertFalse(tracker.isBounded());
+
+    // After split, the restriction should be bounded.
+    simpleEstimator.setEstimateRangeEnd(16L);
+    tracker.trySplit(0.5);
+    assertTrue(tracker.isBounded());
+
+    // The restriction should be bounded after all the work has been claimed.
+    tracker = new GrowableOffsetRangeTracker(0L, simpleEstimator);
+    tracker.tryClaim(Long.MAX_VALUE);
+    assertTrue(tracker.isBounded());
+  }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/splittabledofn/GrowableOffsetRangeTrackerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/splittabledofn/GrowableOffsetRangeTrackerTest.java
@@ -26,6 +26,7 @@ import java.math.BigDecimal;
 import java.math.MathContext;
 import org.apache.beam.sdk.io.range.OffsetRange;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.Progress;
+import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.RestrictionBoundness;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
@@ -257,18 +258,18 @@ public class GrowableOffsetRangeTrackerTest {
   public void testIsBounded() throws Exception {
     SimpleEstimator simpleEstimator = new SimpleEstimator();
     GrowableOffsetRangeTracker tracker = new GrowableOffsetRangeTracker(0L, simpleEstimator);
-    assertFalse(tracker.isBounded());
+    assertEquals(RestrictionBoundness.IS_UNBOUNDED, tracker.isBounded());
     assertTrue(tracker.tryClaim(0L));
-    assertFalse(tracker.isBounded());
+    assertEquals(RestrictionBoundness.IS_UNBOUNDED, tracker.isBounded());
 
     // After split, the restriction should be bounded.
     simpleEstimator.setEstimateRangeEnd(16L);
     tracker.trySplit(0.5);
-    assertTrue(tracker.isBounded());
+    assertEquals(RestrictionBoundness.IS_BOUNDED, tracker.isBounded());
 
     // The restriction should be bounded after all the work has been claimed.
     tracker = new GrowableOffsetRangeTracker(0L, simpleEstimator);
     tracker.tryClaim(Long.MAX_VALUE);
-    assertTrue(tracker.isBounded());
+    assertEquals(RestrictionBoundness.IS_BOUNDED, tracker.isBounded());
   }
 }

--- a/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/splittabledofn/RestrictionTrackers.java
+++ b/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/splittabledofn/RestrictionTrackers.java
@@ -78,7 +78,7 @@ public class RestrictionTrackers {
     }
 
     @Override
-    public RestrictionBoundness isBounded() {
+    public IsBounded isBounded() {
       return delegate.isBounded();
     }
   }

--- a/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/splittabledofn/RestrictionTrackers.java
+++ b/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/splittabledofn/RestrictionTrackers.java
@@ -78,7 +78,7 @@ public class RestrictionTrackers {
     }
 
     @Override
-    public boolean isBounded() {
+    public RestrictionBoundness isBounded() {
       return delegate.isBounded();
     }
   }

--- a/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/splittabledofn/RestrictionTrackers.java
+++ b/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/splittabledofn/RestrictionTrackers.java
@@ -76,6 +76,11 @@ public class RestrictionTrackers {
     public synchronized void checkDone() throws IllegalStateException {
       delegate.checkDone();
     }
+
+    @Override
+    public boolean isBounded() {
+      return delegate.isBounded();
+    }
   }
 
   /**

--- a/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/splittabledofn/RestrictionTrackersTest.java
+++ b/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/splittabledofn/RestrictionTrackersTest.java
@@ -110,6 +110,11 @@ public class RestrictionTrackersTest {
 
     @Override
     public void checkDone() throws IllegalStateException {}
+
+    @Override
+    public RestrictionBoundness isBounded() {
+      return RestrictionBoundness.IS_BOUNDED;
+    }
   }
 
   @Test

--- a/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/splittabledofn/RestrictionTrackersTest.java
+++ b/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/splittabledofn/RestrictionTrackersTest.java
@@ -61,8 +61,8 @@ public class RestrictionTrackersTest {
           }
 
           @Override
-          public RestrictionBoundness isBounded() {
-            return RestrictionBoundness.IS_BOUNDED;
+          public IsBounded isBounded() {
+            return IsBounded.BOUNDED;
           }
         };
 
@@ -117,8 +117,8 @@ public class RestrictionTrackersTest {
     public void checkDone() throws IllegalStateException {}
 
     @Override
-    public RestrictionBoundness isBounded() {
-      return RestrictionBoundness.IS_BOUNDED;
+    public IsBounded isBounded() {
+      return IsBounded.BOUNDED;
     }
   }
 

--- a/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/splittabledofn/RestrictionTrackersTest.java
+++ b/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/splittabledofn/RestrictionTrackersTest.java
@@ -59,6 +59,11 @@ public class RestrictionTrackersTest {
           public void checkDone() throws IllegalStateException {
             throw new UnsupportedOperationException();
           }
+
+          @Override
+          public RestrictionBoundness isBounded() {
+            return RestrictionBoundness.IS_BOUNDED;
+          }
         };
 
     List<String> positionsObserved = new ArrayList<>();

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -33,7 +33,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
-import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -99,6 +98,7 @@ import org.apache.beam.sdk.transforms.reflect.DoFnSignatures;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.HasProgress;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.Progress;
+import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.TruncateResult;
 import org.apache.beam.sdk.transforms.splittabledofn.SplitResult;
 import org.apache.beam.sdk.transforms.splittabledofn.TimestampObservingWatermarkEstimator;
 import org.apache.beam.sdk.transforms.splittabledofn.WatermarkEstimator;
@@ -843,10 +843,10 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
               public void onClaimFailed(PositionT position) {}
             });
     try {
-      Optional<OutputT> truncatedRestriction =
+      TruncateResult<OutputT> truncatedRestriction =
           doFnInvoker.invokeTruncateRestriction(processContext);
-      if (truncatedRestriction.isPresent()) {
-        processContext.output(truncatedRestriction.get());
+      if (truncatedRestriction != null) {
+        processContext.output(truncatedRestriction.getTruncatedRestriction());
       }
     } finally {
       currentTracker = null;
@@ -879,10 +879,10 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                   @Override
                   public void onClaimFailed(PositionT position) {}
                 });
-        Optional<OutputT> truncatedRestriction =
+        TruncateResult<OutputT> truncatedRestriction =
             doFnInvoker.invokeTruncateRestriction(processContext);
-        if (truncatedRestriction.isPresent()) {
-          processContext.output(truncatedRestriction.get());
+        if (truncatedRestriction != null) {
+          processContext.output(truncatedRestriction.getTruncatedRestriction());
         }
       }
     } finally {

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -492,185 +492,32 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
             || (doFnSignature.getSize() != null && doFnSignature.getSize().observesWindow())
             || !sideInputMapping.isEmpty()) {
           mainInputConsumer = this::processElementForWindowObservingSplitRestriction;
-          // OutputT == RestrictionT
           this.processContext =
-              new WindowObservingProcessBundleContext() {
-                @Override
-                public void outputWithTimestamp(OutputT output, Instant timestamp) {
-                  double size =
-                      doFnInvoker.invokeGetSize(
-                          new DelegatingArgumentProvider<InputT, OutputT>(
-                              this,
-                              PTransformTranslation.SPLITTABLE_SPLIT_AND_SIZE_RESTRICTIONS_URN
-                                  + "/GetSize") {
-                            @Override
-                            public Object restriction() {
-                              return output;
-                            }
+              new SizedRestrictionWindowObservingProcessBundleContext(
+                  PTransformTranslation.SPLITTABLE_SPLIT_AND_SIZE_RESTRICTIONS_URN);
 
-                            @Override
-                            public Instant timestamp(DoFn<InputT, OutputT> doFn) {
-                              return timestamp;
-                            }
-
-                            @Override
-                            public RestrictionTracker<?, ?> restrictionTracker() {
-                              return doFnInvoker.invokeNewTracker(this);
-                            }
-                          });
-
-                  outputTo(
-                      mainOutputConsumers,
-                      (WindowedValue<OutputT>)
-                          WindowedValue.of(
-                              KV.of(
-                                  KV.of(
-                                      currentElement.getValue(),
-                                      KV.of(output, currentWatermarkEstimatorState)),
-                                  size),
-                              timestamp,
-                              currentWindow,
-                              currentElement.getPane()));
-                }
-              };
         } else {
           mainInputConsumer = this::processElementForSplitRestriction;
-          // OutputT == RestrictionT
           this.processContext =
-              new NonWindowObservingProcessBundleContext() {
-                @Override
-                public void outputWithTimestamp(OutputT output, Instant timestamp) {
-                  double size =
-                      doFnInvoker.invokeGetSize(
-                          new DelegatingArgumentProvider<InputT, OutputT>(
-                              this,
-                              PTransformTranslation.SPLITTABLE_SPLIT_AND_SIZE_RESTRICTIONS_URN
-                                  + "/GetSize") {
-                            @Override
-                            public Object restriction() {
-                              return output;
-                            }
-
-                            @Override
-                            public Instant timestamp(DoFn<InputT, OutputT> doFn) {
-                              return timestamp;
-                            }
-
-                            @Override
-                            public RestrictionTracker<?, ?> restrictionTracker() {
-                              return doFnInvoker.invokeNewTracker(this);
-                            }
-                          });
-
-                  outputTo(
-                      mainOutputConsumers,
-                      (WindowedValue<OutputT>)
-                          WindowedValue.of(
-                              KV.of(
-                                  KV.of(
-                                      currentElement.getValue(),
-                                      KV.of(output, currentWatermarkEstimatorState)),
-                                  size),
-                              timestamp,
-                              currentElement.getWindows(),
-                              currentElement.getPane()));
-                }
-              };
+              new SizedRestrictionNonWindowObservingProcessBundleContext(
+                  PTransformTranslation.SPLITTABLE_SPLIT_AND_SIZE_RESTRICTIONS_URN);
         }
         break;
       case PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN:
-        if ((doFnSignature.truncateSizedRestriction() != null
-                && doFnSignature.truncateSizedRestriction().observesWindow())
+        if ((doFnSignature.truncateRestriction() != null
+                && doFnSignature.truncateRestriction().observesWindow())
             || (doFnSignature.newTracker() != null && doFnSignature.newTracker().observesWindow())
             || (doFnSignature.getSize() != null && doFnSignature.getSize().observesWindow())
             || !sideInputMapping.isEmpty()) {
-          mainInputConsumer = this::processElementForWindowObservingTruncateSizedRestriction;
-          // OutputT == RestrictionT
+          mainInputConsumer = this::processElementForWindowObservingTruncateRestriction;
           this.processContext =
-              new WindowObservingProcessBundleContext() {
-                @Override
-                public void outputWithTimestamp(OutputT output, Instant timestamp) {
-                  double size =
-                      output == null
-                          ? 0.0
-                          : doFnInvoker.invokeGetSize(
-                              new DelegatingArgumentProvider<InputT, OutputT>(
-                                  this,
-                                  PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN
-                                      + "/GetSize") {
-                                @Override
-                                public Object restriction() {
-                                  return output;
-                                }
-
-                                @Override
-                                public Instant timestamp(DoFn<InputT, OutputT> doFn) {
-                                  return timestamp;
-                                }
-
-                                @Override
-                                public RestrictionTracker<?, ?> restrictionTracker() {
-                                  return doFnInvoker.invokeNewTracker(this);
-                                }
-                              });
-
-                  outputTo(
-                      mainOutputConsumers,
-                      (WindowedValue<OutputT>)
-                          WindowedValue.of(
-                              KV.of(
-                                  KV.of(
-                                      currentElement.getValue(),
-                                      KV.of(output, currentWatermarkEstimatorState)),
-                                  size),
-                              timestamp,
-                              currentWindow,
-                              currentElement.getPane()));
-                }
-              };
+              new SizedRestrictionWindowObservingProcessBundleContext(
+                  PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN);
         } else {
-          mainInputConsumer = this::processElementForTruncateSizedRestriction;
-          // OutputT == RestrictionT
+          mainInputConsumer = this::processElementForTruncateRestriction;
           this.processContext =
-              new NonWindowObservingProcessBundleContext() {
-                @Override
-                public void outputWithTimestamp(OutputT output, Instant timestamp) {
-                  double size =
-                      doFnInvoker.invokeGetSize(
-                          new DelegatingArgumentProvider<InputT, OutputT>(
-                              this,
-                              PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN
-                                  + "/GetSize") {
-                            @Override
-                            public Object restriction() {
-                              return output;
-                            }
-
-                            @Override
-                            public Instant timestamp(DoFn<InputT, OutputT> doFn) {
-                              return timestamp;
-                            }
-
-                            @Override
-                            public RestrictionTracker<?, ?> restrictionTracker() {
-                              return doFnInvoker.invokeNewTracker(this);
-                            }
-                          });
-
-                  outputTo(
-                      mainOutputConsumers,
-                      (WindowedValue<OutputT>)
-                          WindowedValue.of(
-                              KV.of(
-                                  KV.of(
-                                      currentElement.getValue(),
-                                      KV.of(output, currentWatermarkEstimatorState)),
-                                  size),
-                              timestamp,
-                              currentElement.getWindows(),
-                              currentElement.getPane()));
-                }
-              };
+              new SizedRestrictionNonWindowObservingProcessBundleContext(
+                  PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN);
         }
         break;
       case PTransformTranslation.SPLITTABLE_PROCESS_SIZED_ELEMENTS_AND_RESTRICTIONS_URN:
@@ -884,12 +731,23 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
     currentElement = elem.withValue(elem.getValue().getKey());
     currentRestriction = elem.getValue().getValue().getKey();
     currentWatermarkEstimatorState = elem.getValue().getValue().getValue();
+    currentTracker =
+        RestrictionTrackers.observe(
+            doFnInvoker.invokeNewTracker(processContext),
+            new ClaimObserver<PositionT>() {
+              @Override
+              public void onClaimed(PositionT position) {}
+
+              @Override
+              public void onClaimFailed(PositionT position) {}
+            });
     try {
       doFnInvoker.invokeSplitRestriction(processContext);
     } finally {
       currentElement = null;
       currentRestriction = null;
       currentWatermarkEstimatorState = null;
+      currentTracker = null;
     }
 
     // TODO(BEAM-10212): Support caching state data across bundle boundaries.
@@ -906,6 +764,16 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
           (Iterator<BoundedWindow>) elem.getWindows().iterator();
       while (windowIterator.hasNext()) {
         currentWindow = windowIterator.next();
+        currentTracker =
+            RestrictionTrackers.observe(
+                doFnInvoker.invokeNewTracker(processContext),
+                new ClaimObserver<PositionT>() {
+                  @Override
+                  public void onClaimed(PositionT position) {}
+
+                  @Override
+                  public void onClaimFailed(PositionT position) {}
+                });
         doFnInvoker.invokeSplitRestriction(processContext);
       }
     } finally {
@@ -913,13 +781,14 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
       currentRestriction = null;
       currentWatermarkEstimatorState = null;
       currentWindow = null;
+      currentTracker = null;
     }
 
     // TODO(BEAM-10212): Support caching state data across bundle boundaries.
     this.stateAccessor.finalizeState();
   }
 
-  private void processElementForTruncateSizedRestriction(
+  private void processElementForTruncateRestriction(
       WindowedValue<KV<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>, Double>> elem) {
     currentElement = elem.withValue(elem.getValue().getKey().getKey());
     currentRestriction = elem.getValue().getKey().getValue().getKey();
@@ -935,7 +804,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
               public void onClaimFailed(PositionT position) {}
             });
     try {
-      doFnInvoker.invokeTruncateSizedRestriction(processContext);
+      doFnInvoker.invokeTruncateRestriction(processContext);
     } finally {
       currentTracker = null;
       currentElement = null;
@@ -947,7 +816,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
     this.stateAccessor.finalizeState();
   }
 
-  private void processElementForWindowObservingTruncateSizedRestriction(
+  private void processElementForWindowObservingTruncateRestriction(
       WindowedValue<KV<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>, Double>> elem) {
     currentElement = elem.withValue(elem.getValue().getKey().getKey());
     currentRestriction = elem.getValue().getKey().getValue().getKey();
@@ -967,7 +836,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                   @Override
                   public void onClaimFailed(PositionT position) {}
                 });
-        doFnInvoker.invokeTruncateSizedRestriction(processContext);
+        doFnInvoker.invokeTruncateRestriction(processContext);
       }
     } finally {
       currentTracker = null;
@@ -1010,10 +879,6 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
   private void processElementForWindowObservingSizedElementAndRestriction(
       WindowedValue<KV<KV<InputT, KV<RestrictionT, WatermarkEstimatorStateT>>, Double>> elem) {
     currentElement = elem.withValue(elem.getValue().getKey().getKey());
-    // No need to process if current restriction is null.
-    if (elem.getValue().getKey().getValue().getKey() == null) {
-      return;
-    }
     try {
       currentWindowIterator =
           currentElement.getWindows() instanceof List
@@ -1789,6 +1654,96 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
       }
       outputTo(
           consumers, WindowedValue.of(output, timestamp, currentWindow, currentElement.getPane()));
+    }
+  }
+
+  private class SizedRestrictionWindowObservingProcessBundleContext
+      extends WindowObservingProcessBundleContext {
+    private final String errorContextPrefix;
+
+    SizedRestrictionWindowObservingProcessBundleContext(String errorContextPrefix) {
+      this.errorContextPrefix = errorContextPrefix;
+    }
+
+    @Override
+    // OutputT == RestrictionT
+    public void outputWithTimestamp(OutputT output, Instant timestamp) {
+      double size =
+          doFnInvoker.invokeGetSize(
+              new DelegatingArgumentProvider<InputT, OutputT>(
+                  this, this.errorContextPrefix + "/GetSize") {
+                @Override
+                public Object restriction() {
+                  return output;
+                }
+
+                @Override
+                public Instant timestamp(DoFn<InputT, OutputT> doFn) {
+                  return timestamp;
+                }
+
+                @Override
+                public RestrictionTracker<?, ?> restrictionTracker() {
+                  return doFnInvoker.invokeNewTracker(this);
+                }
+              });
+
+      outputTo(
+          mainOutputConsumers,
+          (WindowedValue<OutputT>)
+              WindowedValue.of(
+                  KV.of(
+                      KV.of(
+                          currentElement.getValue(), KV.of(output, currentWatermarkEstimatorState)),
+                      size),
+                  timestamp,
+                  currentWindow,
+                  currentElement.getPane()));
+    }
+  }
+
+  private class SizedRestrictionNonWindowObservingProcessBundleContext
+      extends NonWindowObservingProcessBundleContext {
+    private final String errorContextPrefix;
+
+    SizedRestrictionNonWindowObservingProcessBundleContext(String errorContextPrefix) {
+      this.errorContextPrefix = errorContextPrefix;
+    }
+
+    @Override
+    // OutputT == RestrictionT
+    public void outputWithTimestamp(OutputT output, Instant timestamp) {
+      double size =
+          doFnInvoker.invokeGetSize(
+              new DelegatingArgumentProvider<InputT, OutputT>(
+                  this, errorContextPrefix + "/GetSize") {
+                @Override
+                public Object restriction() {
+                  return output;
+                }
+
+                @Override
+                public Instant timestamp(DoFn<InputT, OutputT> doFn) {
+                  return timestamp;
+                }
+
+                @Override
+                public RestrictionTracker<?, ?> restrictionTracker() {
+                  return doFnInvoker.invokeNewTracker(this);
+                }
+              });
+
+      outputTo(
+          mainOutputConsumers,
+          (WindowedValue<OutputT>)
+              WindowedValue.of(
+                  KV.of(
+                      KV.of(
+                          currentElement.getValue(), KV.of(output, currentWatermarkEstimatorState)),
+                      size),
+                  timestamp,
+                  currentElement.getWindows(),
+                  currentElement.getPane()));
     }
   }
 

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -1704,7 +1704,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
     }
   }
 
-  /** This context outputs KV<KV<Element, <Restriction, WatemarkEstimatorState>>, size> */
+  /** This context outputs KV<KV<Element, <Restriction, WatemarkEstimatorState>>, size>. */
   private class SizedRestrictionWindowObservingProcessBundleContext
       extends WindowObservingProcessBundleContext {
     private final String errorContextPrefix;
@@ -1750,7 +1750,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
     }
   }
 
-  /** This context outputs KV<KV<Element, <Restriction, WatemarkEstimatorState>>, size> */
+  /** This context outputs KV<KV<Element, <Restriction, WatermarkEstimatorState>>, size>. */
   private class SizedRestrictionNonWindowObservingProcessBundleContext
       extends NonWindowObservingProcessBundleContext {
     private final String errorContextPrefix;

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -1704,7 +1704,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
     }
   }
 
-  /** This context outputs KV<KV<Element, <Restriction, WatemarkEstimatorState>>, size>. */
+  /** This context outputs KV<KV<Element, KV<Restriction, WatemarkEstimatorState>>, Size>. */
   private class SizedRestrictionWindowObservingProcessBundleContext
       extends WindowObservingProcessBundleContext {
     private final String errorContextPrefix;
@@ -1750,7 +1750,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
     }
   }
 
-  /** This context outputs KV<KV<Element, <Restriction, WatermarkEstimatorState>>, size>. */
+  /** This context outputs KV<KV<Element, KV<Restriction, WatermarkEstimatorState>>, Size>. */
   private class SizedRestrictionNonWindowObservingProcessBundleContext
       extends NonWindowObservingProcessBundleContext {
     private final String errorContextPrefix;

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -1657,6 +1657,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
     }
   }
 
+  /** This context outputs KV<KV<Element, <Restriction, WatemarkEstimatorState>>, size> */
   private class SizedRestrictionWindowObservingProcessBundleContext
       extends WindowObservingProcessBundleContext {
     private final String errorContextPrefix;
@@ -1702,6 +1703,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
     }
   }
 
+  /** This context outputs KV<KV<Element, <Restriction, WatemarkEstimatorState>>, size> */
   private class SizedRestrictionNonWindowObservingProcessBundleContext
       extends NonWindowObservingProcessBundleContext {
     private final String errorContextPrefix;

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -591,26 +591,28 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                 @Override
                 public void outputWithTimestamp(OutputT output, Instant timestamp) {
                   double size =
-                      doFnInvoker.invokeGetSize(
-                          new DelegatingArgumentProvider<InputT, OutputT>(
-                              this,
-                              PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN
-                                  + "/GetSize") {
-                            @Override
-                            public Object restriction() {
-                              return output;
-                            }
+                      output == null
+                          ? 0.0
+                          : doFnInvoker.invokeGetSize(
+                              new DelegatingArgumentProvider<InputT, OutputT>(
+                                  this,
+                                  PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN
+                                      + "/GetSize") {
+                                @Override
+                                public Object restriction() {
+                                  return output;
+                                }
 
-                            @Override
-                            public Instant timestamp(DoFn<InputT, OutputT> doFn) {
-                              return timestamp;
-                            }
+                                @Override
+                                public Instant timestamp(DoFn<InputT, OutputT> doFn) {
+                                  return timestamp;
+                                }
 
-                            @Override
-                            public RestrictionTracker<?, ?> restrictionTracker() {
-                              return doFnInvoker.invokeNewTracker(this);
-                            }
-                          });
+                                @Override
+                                public RestrictionTracker<?, ?> restrictionTracker() {
+                                  return doFnInvoker.invokeNewTracker(this);
+                                }
+                              });
 
                   outputTo(
                       mainOutputConsumers,

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -33,6 +33,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
@@ -804,7 +805,11 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
               public void onClaimFailed(PositionT position) {}
             });
     try {
-      doFnInvoker.invokeTruncateRestriction(processContext);
+      Optional<OutputT> truncatedRestriction =
+          doFnInvoker.invokeTruncateRestriction(processContext);
+      if (truncatedRestriction.isPresent()) {
+        processContext.output(truncatedRestriction.get());
+      }
     } finally {
       currentTracker = null;
       currentElement = null;
@@ -836,7 +841,11 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
                   @Override
                   public void onClaimFailed(PositionT position) {}
                 });
-        doFnInvoker.invokeTruncateRestriction(processContext);
+        Optional<OutputT> truncatedRestriction =
+            doFnInvoker.invokeTruncateRestriction(processContext);
+        if (truncatedRestriction.isPresent()) {
+          processContext.output(truncatedRestriction.get());
+        }
       }
     } finally {
       currentTracker = null;

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
@@ -38,7 +38,6 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
-import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -112,6 +111,7 @@ import org.apache.beam.sdk.transforms.View;
 import org.apache.beam.sdk.transforms.splittabledofn.ManualWatermarkEstimator;
 import org.apache.beam.sdk.transforms.splittabledofn.OffsetRangeTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
+import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker.TruncateResult;
 import org.apache.beam.sdk.transforms.splittabledofn.WatermarkEstimators;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
@@ -1428,8 +1428,8 @@ public class FnApiDoFnRunnerTest implements Serializable {
     }
 
     @TruncateRestriction
-    public Optional<OffsetRange> truncateRestriction(@Restriction OffsetRange range) {
-      return Optional.of(new OffsetRange(range.getFrom(), range.getTo() / 2));
+    public TruncateResult<OffsetRange> truncateRestriction(@Restriction OffsetRange range) {
+      return TruncateResult.of(new OffsetRange(range.getFrom(), range.getTo() / 2));
     }
 
     @GetInitialWatermarkEstimatorState

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
@@ -38,6 +38,7 @@ import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Collections;
 import java.util.List;
+import java.util.Optional;
 import java.util.ServiceLoader;
 import java.util.UUID;
 import java.util.concurrent.ConcurrentHashMap;
@@ -47,6 +48,7 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import org.apache.beam.fn.harness.HandlesSplits.SplitResult;
 import org.apache.beam.fn.harness.PTransformRunnerFactory.ProgressRequestCallback;
 import org.apache.beam.fn.harness.control.BundleSplitListener;
 import org.apache.beam.fn.harness.data.FakeBeamFnTimerClient;
@@ -1423,6 +1425,11 @@ public class FnApiDoFnRunnerTest implements Serializable {
     public void splitRange(@Restriction OffsetRange range, OutputReceiver<OffsetRange> receiver) {
       receiver.output(new OffsetRange(range.getFrom(), (range.getFrom() + range.getTo()) / 2));
       receiver.output(new OffsetRange((range.getFrom() + range.getTo()) / 2, range.getTo()));
+    }
+
+    @TruncateRestriction
+    public Optional<OffsetRange> truncateRestriction(@Restriction OffsetRange range) {
+      return Optional.of(new OffsetRange(range.getFrom(), range.getTo() / 2));
     }
 
     @GetInitialWatermarkEstimatorState
@@ -2880,6 +2887,494 @@ public class FnApiDoFnRunnerTest implements Serializable {
             WindowedValue.of(
                 KV.of(
                     KV.of("2", KV.of(new OffsetRange(1, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                    1.0),
+                firstValue.getTimestamp(),
+                ImmutableList.of(window1, window2),
+                firstValue.getPane())));
+    mainOutputValues.clear();
+
+    assertTrue(finishFunctionRegistry.getFunctions().isEmpty());
+    assertThat(mainOutputValues, empty());
+
+    Iterables.getOnlyElement(teardownFunctions).run();
+    assertThat(mainOutputValues, empty());
+  }
+
+  private static SplitResult createSplitResult(double fractionOfRemainder) {
+    ByteString.Output primaryBytes = ByteString.newOutput();
+    ByteString.Output residualBytes = ByteString.newOutput();
+    try {
+      DoubleCoder.of().encode(fractionOfRemainder, primaryBytes);
+      DoubleCoder.of().encode(1 - fractionOfRemainder, residualBytes);
+    } catch (Exception e) {
+      // No-op.
+    }
+    return SplitResult.of(
+        ImmutableList.of(
+            BundleApplication.newBuilder().setElement(primaryBytes.toByteString()).build()),
+        ImmutableList.of(
+            DelayedBundleApplication.newBuilder()
+                .setApplication(
+                    BundleApplication.newBuilder().setElement(residualBytes.toByteString()).build())
+                .build()));
+  }
+
+  private static class SplittableFnDataReceiver
+      implements HandlesSplits, FnDataReceiver<WindowedValue> {
+    SplittableFnDataReceiver(
+        List<WindowedValue<KV<KV<String, OffsetRange>, Double>>> mainOutputValues) {
+      this.mainOutputValues = mainOutputValues;
+    }
+
+    private final List<WindowedValue<KV<KV<String, OffsetRange>, Double>>> mainOutputValues;
+
+    @Override
+    public SplitResult trySplit(double fractionOfRemainder) {
+      return createSplitResult(fractionOfRemainder);
+    }
+
+    @Override
+    public double getProgress() {
+      return 0.7;
+    }
+
+    @Override
+    public void accept(WindowedValue input) throws Exception {
+      mainOutputValues.add(input);
+    }
+  }
+
+  @Test
+  public void testProcessElementForTruncateAndSizeRestrictionForwardSplitAndProgress()
+      throws Exception {
+    Pipeline p = Pipeline.create();
+    PCollection<String> valuePCollection = p.apply(Create.of("unused"));
+    PCollectionView<String> singletonSideInputView = valuePCollection.apply(View.asSingleton());
+    valuePCollection.apply(
+        TEST_TRANSFORM_ID,
+        ParDo.of(new WindowObservingTestSplittableDoFn(singletonSideInputView))
+            .withSideInputs(singletonSideInputView));
+
+    RunnerApi.Pipeline pProto =
+        ProtoOverrides.updateTransform(
+            PTransformTranslation.PAR_DO_TRANSFORM_URN,
+            PipelineTranslation.toProto(p, SdkComponents.create(p.getOptions()), true),
+            SplittableParDoExpander.createTruncateReplacement());
+    String expandedTransformId =
+        Iterables.find(
+                pProto.getComponents().getTransformsMap().entrySet(),
+                entry ->
+                    entry
+                            .getValue()
+                            .getSpec()
+                            .getUrn()
+                            .equals(PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN)
+                        && entry.getValue().getUniqueName().contains(TEST_TRANSFORM_ID))
+            .getKey();
+    RunnerApi.PTransform pTransform =
+        pProto.getComponents().getTransformsOrThrow(expandedTransformId);
+    String inputPCollectionId =
+        pTransform.getInputsOrThrow(ParDoTranslation.getMainInputName(pTransform));
+    String outputPCollectionId = Iterables.getOnlyElement(pTransform.getOutputsMap().values());
+
+    FakeBeamFnStateClient fakeClient = new FakeBeamFnStateClient(ImmutableMap.of());
+
+    List<WindowedValue<KV<KV<String, OffsetRange>, Double>>> mainOutputValues = new ArrayList<>();
+    MetricsContainerStepMap metricsContainerRegistry = new MetricsContainerStepMap();
+    PCollectionConsumerRegistry consumers =
+        new PCollectionConsumerRegistry(
+            metricsContainerRegistry, mock(ExecutionStateTracker.class));
+    consumers.register(
+        outputPCollectionId,
+        TEST_TRANSFORM_ID,
+        (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues));
+    PTransformFunctionRegistry startFunctionRegistry =
+        new PTransformFunctionRegistry(
+            mock(MetricsContainerStepMap.class), mock(ExecutionStateTracker.class), "start");
+    PTransformFunctionRegistry finishFunctionRegistry =
+        new PTransformFunctionRegistry(
+            mock(MetricsContainerStepMap.class), mock(ExecutionStateTracker.class), "finish");
+    List<ThrowingRunnable> teardownFunctions = new ArrayList<>();
+
+    new FnApiDoFnRunner.Factory<>()
+        .createRunnerForPTransform(
+            PipelineOptionsFactory.create(),
+            null /* beamFnDataClient */,
+            fakeClient,
+            null /* beamFnTimerClient */,
+            TEST_TRANSFORM_ID,
+            pTransform,
+            Suppliers.ofInstance("57L")::get,
+            pProto.getComponents().getPcollectionsMap(),
+            pProto.getComponents().getCodersMap(),
+            pProto.getComponents().getWindowingStrategiesMap(),
+            consumers,
+            startFunctionRegistry,
+            finishFunctionRegistry,
+            teardownFunctions::add,
+            null /* addProgressRequestCallback */,
+            null /* bundleSplitListener */,
+            null /* bundleFinalizer */);
+    FnDataReceiver<WindowedValue<?>> mainInput =
+        consumers.getMultiplexingConsumer(inputPCollectionId);
+    assertThat(mainInput, instanceOf(HandlesSplits.class));
+
+    assertEquals(0.7, ((HandlesSplits) mainInput).getProgress(), 0.0);
+    double fractionOfRemainder = 0.4;
+    assertEquals(createSplitResult(0.4), ((HandlesSplits) mainInput).trySplit(0.4));
+  }
+
+  @Test
+  public void testProcessElementForTruncateAndSizeRestriction() throws Exception {
+    Pipeline p = Pipeline.create();
+    PCollection<String> valuePCollection = p.apply(Create.of("unused"));
+    PCollectionView<String> singletonSideInputView = valuePCollection.apply(View.asSingleton());
+    valuePCollection.apply(
+        TEST_TRANSFORM_ID,
+        ParDo.of(new WindowObservingTestSplittableDoFn(singletonSideInputView))
+            .withSideInputs(singletonSideInputView));
+
+    RunnerApi.Pipeline pProto =
+        ProtoOverrides.updateTransform(
+            PTransformTranslation.PAR_DO_TRANSFORM_URN,
+            PipelineTranslation.toProto(p, SdkComponents.create(p.getOptions()), true),
+            SplittableParDoExpander.createTruncateReplacement());
+    String expandedTransformId =
+        Iterables.find(
+                pProto.getComponents().getTransformsMap().entrySet(),
+                entry ->
+                    entry
+                            .getValue()
+                            .getSpec()
+                            .getUrn()
+                            .equals(PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN)
+                        && entry.getValue().getUniqueName().contains(TEST_TRANSFORM_ID))
+            .getKey();
+    RunnerApi.PTransform pTransform =
+        pProto.getComponents().getTransformsOrThrow(expandedTransformId);
+    String inputPCollectionId =
+        pTransform.getInputsOrThrow(ParDoTranslation.getMainInputName(pTransform));
+    String outputPCollectionId = Iterables.getOnlyElement(pTransform.getOutputsMap().values());
+
+    FakeBeamFnStateClient fakeClient = new FakeBeamFnStateClient(ImmutableMap.of());
+
+    List<WindowedValue<KV<KV<String, OffsetRange>, Double>>> mainOutputValues = new ArrayList<>();
+    MetricsContainerStepMap metricsContainerRegistry = new MetricsContainerStepMap();
+    PCollectionConsumerRegistry consumers =
+        new PCollectionConsumerRegistry(
+            metricsContainerRegistry, mock(ExecutionStateTracker.class));
+    consumers.register(
+        outputPCollectionId,
+        TEST_TRANSFORM_ID,
+        (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues));
+    PTransformFunctionRegistry startFunctionRegistry =
+        new PTransformFunctionRegistry(
+            mock(MetricsContainerStepMap.class), mock(ExecutionStateTracker.class), "start");
+    PTransformFunctionRegistry finishFunctionRegistry =
+        new PTransformFunctionRegistry(
+            mock(MetricsContainerStepMap.class), mock(ExecutionStateTracker.class), "finish");
+    List<ThrowingRunnable> teardownFunctions = new ArrayList<>();
+
+    new FnApiDoFnRunner.Factory<>()
+        .createRunnerForPTransform(
+            PipelineOptionsFactory.create(),
+            null /* beamFnDataClient */,
+            fakeClient,
+            null /* beamFnTimerClient */,
+            TEST_TRANSFORM_ID,
+            pTransform,
+            Suppliers.ofInstance("57L")::get,
+            pProto.getComponents().getPcollectionsMap(),
+            pProto.getComponents().getCodersMap(),
+            pProto.getComponents().getWindowingStrategiesMap(),
+            consumers,
+            startFunctionRegistry,
+            finishFunctionRegistry,
+            teardownFunctions::add,
+            null /* addProgressRequestCallback */,
+            null /* bundleSplitListener */,
+            null /* bundleFinalizer */);
+
+    assertTrue(startFunctionRegistry.getFunctions().isEmpty());
+    mainOutputValues.clear();
+
+    assertThat(consumers.keySet(), containsInAnyOrder(inputPCollectionId, outputPCollectionId));
+
+    FnDataReceiver<WindowedValue<?>> mainInput =
+        consumers.getMultiplexingConsumer(inputPCollectionId);
+    assertThat(mainInput, instanceOf(HandlesSplits.class));
+
+    mainInput.accept(
+        valueInGlobalWindow(
+            KV.of(
+                KV.of("5", KV.of(new OffsetRange(0, 5), GlobalWindow.TIMESTAMP_MIN_VALUE)), 5.0)));
+    mainInput.accept(
+        valueInGlobalWindow(
+            KV.of(
+                KV.of("2", KV.of(new OffsetRange(0, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)), 2.0)));
+    assertThat(
+        mainOutputValues,
+        contains(
+            valueInGlobalWindow(
+                KV.of(
+                    KV.of("5", KV.of(new OffsetRange(0, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                    2.0)),
+            valueInGlobalWindow(
+                KV.of(
+                    KV.of("2", KV.of(new OffsetRange(0, 1), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                    1.0))));
+    mainOutputValues.clear();
+
+    assertTrue(finishFunctionRegistry.getFunctions().isEmpty());
+    assertThat(mainOutputValues, empty());
+
+    Iterables.getOnlyElement(teardownFunctions).run();
+    assertThat(mainOutputValues, empty());
+  }
+
+  @Test
+  public void testProcessElementForWindowedTruncateAndSizeRestriction() throws Exception {
+    Pipeline p = Pipeline.create();
+    PCollection<String> valuePCollection = p.apply(Create.of("unused"));
+    PCollectionView<String> singletonSideInputView = valuePCollection.apply(View.asSingleton());
+    valuePCollection
+        .apply(Window.into(SlidingWindows.of(Duration.standardSeconds(1))))
+        .apply(
+            TEST_TRANSFORM_ID,
+            ParDo.of(new WindowObservingTestSplittableDoFn(singletonSideInputView))
+                .withSideInputs(singletonSideInputView));
+
+    RunnerApi.Pipeline pProto =
+        ProtoOverrides.updateTransform(
+            PTransformTranslation.PAR_DO_TRANSFORM_URN,
+            PipelineTranslation.toProto(p, SdkComponents.create(p.getOptions()), true),
+            SplittableParDoExpander.createTruncateReplacement());
+    String expandedTransformId =
+        Iterables.find(
+                pProto.getComponents().getTransformsMap().entrySet(),
+                entry ->
+                    entry
+                            .getValue()
+                            .getSpec()
+                            .getUrn()
+                            .equals(PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN)
+                        && entry.getValue().getUniqueName().contains(TEST_TRANSFORM_ID))
+            .getKey();
+    RunnerApi.PTransform pTransform =
+        pProto.getComponents().getTransformsOrThrow(expandedTransformId);
+    String inputPCollectionId =
+        pTransform.getInputsOrThrow(ParDoTranslation.getMainInputName(pTransform));
+    String outputPCollectionId = Iterables.getOnlyElement(pTransform.getOutputsMap().values());
+
+    FakeBeamFnStateClient fakeClient = new FakeBeamFnStateClient(ImmutableMap.of());
+
+    List<WindowedValue<KV<KV<String, OffsetRange>, Double>>> mainOutputValues = new ArrayList<>();
+    MetricsContainerStepMap metricsContainerRegistry = new MetricsContainerStepMap();
+    PCollectionConsumerRegistry consumers =
+        new PCollectionConsumerRegistry(
+            metricsContainerRegistry, mock(ExecutionStateTracker.class));
+    consumers.register(
+        outputPCollectionId,
+        TEST_TRANSFORM_ID,
+        (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues));
+    PTransformFunctionRegistry startFunctionRegistry =
+        new PTransformFunctionRegistry(
+            mock(MetricsContainerStepMap.class), mock(ExecutionStateTracker.class), "start");
+    PTransformFunctionRegistry finishFunctionRegistry =
+        new PTransformFunctionRegistry(
+            mock(MetricsContainerStepMap.class), mock(ExecutionStateTracker.class), "finish");
+    List<ThrowingRunnable> teardownFunctions = new ArrayList<>();
+
+    new FnApiDoFnRunner.Factory<>()
+        .createRunnerForPTransform(
+            PipelineOptionsFactory.create(),
+            null /* beamFnDataClient */,
+            fakeClient,
+            null /* beamFnTimerClient */,
+            TEST_TRANSFORM_ID,
+            pTransform,
+            Suppliers.ofInstance("57L")::get,
+            pProto.getComponents().getPcollectionsMap(),
+            pProto.getComponents().getCodersMap(),
+            pProto.getComponents().getWindowingStrategiesMap(),
+            consumers,
+            startFunctionRegistry,
+            finishFunctionRegistry,
+            teardownFunctions::add,
+            null /* addProgressRequestCallback */,
+            null /* bundleSplitListener */,
+            null /* bundleFinalizer */);
+
+    assertTrue(startFunctionRegistry.getFunctions().isEmpty());
+    mainOutputValues.clear();
+
+    assertThat(consumers.keySet(), containsInAnyOrder(inputPCollectionId, outputPCollectionId));
+
+    FnDataReceiver<WindowedValue<?>> mainInput =
+        consumers.getMultiplexingConsumer(inputPCollectionId);
+    assertThat(mainInput, instanceOf(HandlesSplits.class));
+
+    IntervalWindow window1 = new IntervalWindow(new Instant(5), new Instant(10));
+    IntervalWindow window2 = new IntervalWindow(new Instant(6), new Instant(11));
+    WindowedValue<?> firstValue =
+        valueInWindows(
+            KV.of(KV.of("5", KV.of(new OffsetRange(0, 5), GlobalWindow.TIMESTAMP_MIN_VALUE)), 5.0),
+            window1,
+            window2);
+    WindowedValue<?> secondValue =
+        valueInWindows(
+            KV.of(KV.of("2", KV.of(new OffsetRange(0, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)), 2.0),
+            window1,
+            window2);
+    mainInput.accept(firstValue);
+    mainInput.accept(secondValue);
+    assertThat(
+        mainOutputValues,
+        contains(
+            WindowedValue.of(
+                KV.of(
+                    KV.of("5", KV.of(new OffsetRange(0, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                    2.0),
+                firstValue.getTimestamp(),
+                window1,
+                firstValue.getPane()),
+            WindowedValue.of(
+                KV.of(
+                    KV.of("5", KV.of(new OffsetRange(0, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                    2.0),
+                firstValue.getTimestamp(),
+                window2,
+                firstValue.getPane()),
+            WindowedValue.of(
+                KV.of(
+                    KV.of("2", KV.of(new OffsetRange(0, 1), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                    1.0),
+                firstValue.getTimestamp(),
+                window1,
+                firstValue.getPane()),
+            WindowedValue.of(
+                KV.of(
+                    KV.of("2", KV.of(new OffsetRange(0, 1), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                    1.0),
+                firstValue.getTimestamp(),
+                window2,
+                firstValue.getPane())));
+    mainOutputValues.clear();
+
+    assertTrue(finishFunctionRegistry.getFunctions().isEmpty());
+    assertThat(mainOutputValues, empty());
+
+    Iterables.getOnlyElement(teardownFunctions).run();
+    assertThat(mainOutputValues, empty());
+  }
+
+  @Test
+  public void
+      testProcessElementForWindowedTruncateAndSizeRestrictionWithNonWindowObservingOptimization()
+          throws Exception {
+    Pipeline p = Pipeline.create();
+    PCollection<String> valuePCollection = p.apply(Create.of("unused"));
+    PCollectionView<String> singletonSideInputView = valuePCollection.apply(View.asSingleton());
+    valuePCollection
+        .apply(Window.into(SlidingWindows.of(Duration.standardSeconds(1))))
+        .apply(TEST_TRANSFORM_ID, ParDo.of(new NonWindowObservingTestSplittableDoFn()));
+
+    RunnerApi.Pipeline pProto =
+        ProtoOverrides.updateTransform(
+            PTransformTranslation.PAR_DO_TRANSFORM_URN,
+            PipelineTranslation.toProto(p, SdkComponents.create(p.getOptions()), true),
+            SplittableParDoExpander.createTruncateReplacement());
+    String expandedTransformId =
+        Iterables.find(
+                pProto.getComponents().getTransformsMap().entrySet(),
+                entry ->
+                    entry
+                            .getValue()
+                            .getSpec()
+                            .getUrn()
+                            .equals(PTransformTranslation.SPLITTABLE_TRUNCATE_SIZED_RESTRICTION_URN)
+                        && entry.getValue().getUniqueName().contains(TEST_TRANSFORM_ID))
+            .getKey();
+    RunnerApi.PTransform pTransform =
+        pProto.getComponents().getTransformsOrThrow(expandedTransformId);
+    String inputPCollectionId =
+        pTransform.getInputsOrThrow(ParDoTranslation.getMainInputName(pTransform));
+    String outputPCollectionId = Iterables.getOnlyElement(pTransform.getOutputsMap().values());
+
+    List<WindowedValue<KV<KV<String, OffsetRange>, Double>>> mainOutputValues = new ArrayList<>();
+    MetricsContainerStepMap metricsContainerRegistry = new MetricsContainerStepMap();
+    PCollectionConsumerRegistry consumers =
+        new PCollectionConsumerRegistry(
+            metricsContainerRegistry, mock(ExecutionStateTracker.class));
+    consumers.register(
+        outputPCollectionId,
+        TEST_TRANSFORM_ID,
+        (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues));
+    PTransformFunctionRegistry startFunctionRegistry =
+        new PTransformFunctionRegistry(
+            mock(MetricsContainerStepMap.class), mock(ExecutionStateTracker.class), "start");
+    PTransformFunctionRegistry finishFunctionRegistry =
+        new PTransformFunctionRegistry(
+            mock(MetricsContainerStepMap.class), mock(ExecutionStateTracker.class), "finish");
+    List<ThrowingRunnable> teardownFunctions = new ArrayList<>();
+
+    new FnApiDoFnRunner.Factory<>()
+        .createRunnerForPTransform(
+            PipelineOptionsFactory.create(),
+            null /* beamFnDataClient */,
+            null /* beamFnStateClient */,
+            null /* beamFnTimerClient */,
+            TEST_TRANSFORM_ID,
+            pTransform,
+            Suppliers.ofInstance("57L")::get,
+            pProto.getComponents().getPcollectionsMap(),
+            pProto.getComponents().getCodersMap(),
+            pProto.getComponents().getWindowingStrategiesMap(),
+            consumers,
+            startFunctionRegistry,
+            finishFunctionRegistry,
+            teardownFunctions::add,
+            null /* addProgressRequestCallback */,
+            null /* bundleSplitListener */,
+            null /* bundleFinalizer */);
+
+    assertTrue(startFunctionRegistry.getFunctions().isEmpty());
+    mainOutputValues.clear();
+
+    assertThat(consumers.keySet(), containsInAnyOrder(inputPCollectionId, outputPCollectionId));
+
+    FnDataReceiver<WindowedValue<?>> mainInput =
+        consumers.getMultiplexingConsumer(inputPCollectionId);
+    assertThat(mainInput, instanceOf(HandlesSplits.class));
+
+    IntervalWindow window1 = new IntervalWindow(new Instant(5), new Instant(10));
+    IntervalWindow window2 = new IntervalWindow(new Instant(6), new Instant(11));
+    WindowedValue<?> firstValue =
+        valueInWindows(
+            KV.of(KV.of("5", KV.of(new OffsetRange(0, 5), GlobalWindow.TIMESTAMP_MIN_VALUE)), 5.0),
+            window1,
+            window2);
+    WindowedValue<?> secondValue =
+        valueInWindows(
+            KV.of(KV.of("2", KV.of(new OffsetRange(0, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)), 2.0),
+            window1,
+            window2);
+    mainInput.accept(firstValue);
+    mainInput.accept(secondValue);
+    // Ensure that each output element is in all the windows and not one per window.
+    assertThat(
+        mainOutputValues,
+        contains(
+            WindowedValue.of(
+                KV.of(
+                    KV.of("5", KV.of(new OffsetRange(0, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                    2.0),
+                firstValue.getTimestamp(),
+                ImmutableList.of(window1, window2),
+                firstValue.getPane()),
+            WindowedValue.of(
+                KV.of(
+                    KV.of("2", KV.of(new OffsetRange(0, 1), GlobalWindow.TIMESTAMP_MIN_VALUE)),
                     1.0),
                 firstValue.getTimestamp(),
                 ImmutableList.of(window1, window2),

--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -1249,7 +1249,7 @@ class RestrictionTracker(object):
 
     The boundedness of the restriction is used to determine the default behavior
     of how to truncate restrictions when a pipeline is being
-    `drained <https://docs.google.com/document/d/1NExwHlj-2q2WUGhSO4jTu8XGhDPmm3cllSN8IMmWci8/edit#>`_.
+    `drained <https://docs.google.com/document/d/1NExwHlj-2q2WUGhSO4jTu8XGhDPmm3cllSN8IMmWci8/edit#>`_.  # pylint: disable=line-too-long
     If the restriction is bounded, then the entire restriction will be processed
     otherwise the restriction will be processed till a checkpoint is possible.
 

--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -1243,6 +1243,17 @@ class RestrictionTracker(object):
     """
     raise NotImplementedError
 
+  def is_bounded(self):
+    """Identify whether the output produced by the current restriction is
+    bounded.
+
+    The value is important for the default behavior of truncate when the
+    pipeline starts to drain in streaming. If the current restriction is
+    bounded, it will be processed completely by default. If the restriction is
+    unbounded, it will be truncated into null and finish processing immediately.
+    """
+    raise NotImplementedError
+
 
 class WatermarkEstimator(object):
   """A WatermarkEstimator which is used for estimating output_watermark based on
@@ -1436,6 +1447,9 @@ class _SDFBoundedSourceWrapper(ptransform.PTransform):
 
     def check_done(self):
       return self.restriction.range_tracker().fraction_consumed() >= 1.0
+
+    def is_bounded(self):
+      return True
 
   class _SDFBoundedSourceRestrictionProvider(core.RestrictionProvider):
     """A `RestrictionProvider` that is used by SDF for `BoundedSource`."""

--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -1248,9 +1248,11 @@ class RestrictionTracker(object):
     bounded.
 
     The value is important for the default behavior of truncate when the
-    pipeline starts to drain in streaming. If the current restriction is
+    pipeline starts to drain. If the current restriction is
     bounded, it will be processed completely by default. If the restriction is
     unbounded, it will be truncated into null and finish processing immediately.
+
+    The API is required to be implemented.
     """
     raise NotImplementedError
 

--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -1244,15 +1244,19 @@ class RestrictionTracker(object):
     raise NotImplementedError
 
   def is_bounded(self):
-    """Identify whether the output produced by the current restriction is
-    bounded.
+    """Returns whether the amount of work represented by the current restriction
+    is bounded.
 
-    The value is important for the default behavior of truncate when the
-    pipeline starts to drain. If the current restriction is
-    bounded, it will be processed completely by default. If the restriction is
-    unbounded, it will be truncated into null and finish processing immediately.
+    The boundedness of the restriction is used to determine the default behavior
+    of how to truncate restrictions when a pipeline is being
+    `drained <https://docs.google.com/document/d/1NExwHlj-2q2WUGhSO4jTu8XGhDPmm3cllSN8IMmWci8/edit#>`_.
+    If the restriction is bounded, then the entire restriction will be processed
+    otherwise the restriction will be processed till a checkpoint is possible.
 
     The API is required to be implemented.
+
+    Returns: ``True`` if the restriction represents a finite amount of work.
+    Otherwise, returns ``False``.
     """
     raise NotImplementedError
 

--- a/sdks/python/apache_beam/io/restriction_trackers.py
+++ b/sdks/python/apache_beam/io/restriction_trackers.py
@@ -156,3 +156,6 @@ class OffsetRestrictionTracker(RestrictionTracker):
           self._checkpointed = True
         self._range, residual_range = self._range.split_at(split_point)
         return self._range, residual_range
+
+  def is_bounded(self):
+    return True

--- a/sdks/python/apache_beam/runners/common.pxd
+++ b/sdks/python/apache_beam/runners/common.pxd
@@ -44,6 +44,7 @@ cdef class MethodWrapper(object):
   cdef object restriction_provider_arg_name
   cdef object watermark_estimator_provider
   cdef object watermark_estimator_provider_arg_name
+  cdef bint unbounded_per_element
 
 
 cdef class DoFnSignature(object):

--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -195,8 +195,11 @@ class MethodWrapper(object):
     self.restriction_provider_arg_name = None
     self.watermark_estimator_provider = None
     self.watermark_estimator_provider_arg_name = None
-    self.unbounded_per_element = getattr(
-        self.method_value, 'unbounded_per_element', False)
+
+    if hasattr(self.method_value, 'unbounded_per_element'):
+      self.unbounded_per_element = True
+    else:
+      self.unbounded_per_element = False
 
     for kw, v in zip(self.args[-len(self.defaults):], self.defaults):
       if isinstance(v, core.DoFn.StateParam):

--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -973,8 +973,6 @@ class DoFnRunner:
     (element, (restriction, estimator_state)), _ = windowed_value.value
     watermark_estimator = (
         self.do_fn_invoker.invoke_create_watermark_estimator(estimator_state))
-    if restriction is None:
-      return
 
     return self.do_fn_invoker.invoke_process(
         windowed_value.with_value(element),

--- a/sdks/python/apache_beam/runners/common_test.py
+++ b/sdks/python/apache_beam/runners/common_test.py
@@ -62,6 +62,21 @@ class DoFnSignatureTest(unittest.TestCase):
     with self.assertRaises(ValueError):
       DoFnSignature(MyDoFn())
 
+  def test_unbounded_element_process_fn(self):
+    class UnboundedDoFn(DoFn):
+      @DoFn.unbounded_per_element()
+      def process(self, element):
+        pass
+
+    class BoundedDoFn(DoFn):
+      def process(self, element):
+        pass
+
+    signature = DoFnSignature(UnboundedDoFn())
+    self.assertTrue(signature.is_unbounded_per_element())
+    signature = DoFnSignature(BoundedDoFn())
+    self.assertFalse(signature.is_unbounded_per_element())
+
 
 class DoFnProcessTest(unittest.TestCase):
   # pylint: disable=expression-not-assigned

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/execution.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/execution.py
@@ -685,7 +685,7 @@ class BundleContextManager(object):
       if (proto.spec.urn == bundle_processor.DATA_INPUT_URN and
           input_pcoll in proto.outputs.values()):
         return read_id
-      # The GrpcRead is follwoed by the SDF/Truncate -> SDF/Process.
+      # The GrpcRead is followed by the SDF/Truncate -> SDF/Process.
       if (proto.spec.urn ==
           common_urns.sdf_components.TRUNCATE_SIZED_RESTRICTION.urn and
           input_pcoll in proto.outputs.values()):

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/execution.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/execution.py
@@ -681,7 +681,21 @@ class BundleContextManager(object):
     input_pcoll = self.process_bundle_descriptor.transforms[
         transform_id].inputs[input_id]
     for read_id, proto in self.process_bundle_descriptor.transforms.items():
+      # The GrpcRead is followed by the SDF/Process.
       if (proto.spec.urn == bundle_processor.DATA_INPUT_URN and
           input_pcoll in proto.outputs.values()):
         return read_id
+      # The GrpcRead is follwoed by the SDF/Truncate -> SDF/Process.
+      if (proto.spec.urn ==
+          common_urns.sdf_components.TRUNCATE_SIZED_RESTRICTION.urn and
+          input_pcoll in proto.outputs.values()):
+        read_input = list(
+            self.process_bundle_descriptor.transforms[read_id].inputs.values()
+        )[0]
+        for (grpc_read,
+             transform_proto) in self.process_bundle_descriptor.transforms.items():  # pylint: disable=line-too-long
+          if (transform_proto.spec.urn == bundle_processor.DATA_INPUT_URN and
+              read_input in transform_proto.outputs.values()):
+            return grpc_read
+
     raise RuntimeError('No IO transform feeds %s' % transform_id)

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner.py
@@ -92,7 +92,7 @@ class FnApiRunner(runner.PipelineRunner):
       use_state_iterables=False,
       provision_info=None,  # type: Optional[ExtendedProvisionInfo]
       progress_request_frequency=None,
-      is_drain = False):
+      is_drain=False):
     # type: (...) -> None
 
     """Creates a new Fn API Runner.
@@ -106,6 +106,7 @@ class FnApiRunner(runner.PipelineRunner):
       provision_info: provisioning info to make available to workers, or None
       progress_request_frequency: The frequency (in seconds) that the runner
           waits before requesting progress from the SDK.
+      is_drain: identify whether expand the sdf graph in the drain mode.
     """
     super(FnApiRunner, self).__init__()
     self._default_environment = (

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner.py
@@ -91,7 +91,8 @@ class FnApiRunner(runner.PipelineRunner):
       bundle_repeat=0,
       use_state_iterables=False,
       provision_info=None,  # type: Optional[ExtendedProvisionInfo]
-      progress_request_frequency=None):
+      progress_request_frequency=None,
+      is_drain = False):
     # type: (...) -> None
 
     """Creates a new Fn API Runner.
@@ -114,6 +115,7 @@ class FnApiRunner(runner.PipelineRunner):
     self._progress_frequency = progress_request_frequency
     self._profiler_factory = None  # type: Optional[Callable[..., profiler.Profile]]
     self._use_state_iterables = use_state_iterables
+    self._is_drain = is_drain
     self._provision_info = provision_info or ExtendedProvisionInfo(
         beam_provision_api_pb2.ProvisionInfo(
             retrieval_token='unused-retrieval-token'))
@@ -304,7 +306,8 @@ class FnApiRunner(runner.PipelineRunner):
             common_urns.primitives.FLATTEN.urn,
             common_urns.primitives.GROUP_BY_KEY.urn
         ]),
-        use_state_iterables=self._use_state_iterables)
+        use_state_iterables=self._use_state_iterables,
+        is_drain=self._is_drain)
 
   def run_stages(self,
                  stage_context,  # type: translations.TransformContext

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
@@ -1314,6 +1314,9 @@ class FnApiRunnerTestWithMultiWorkers(FnApiRunnerTest):
   def test_sdf_with_sdf_initiated_checkpointing(self):
     raise unittest.SkipTest("This test is for a single worker only.")
 
+  def test_draining_sdf_with_sdf_initiated_checkpointing(self):
+    raise unittest.SkipTest("This test is for a single worker only.")
+
   def test_sdf_with_watermark_tracking(self):
     raise unittest.SkipTest("This test is for a single worker only.")
 
@@ -1333,6 +1336,9 @@ class FnApiRunnerTestWithGrpcAndMultiWorkers(FnApiRunnerTest):
     raise unittest.SkipTest("This test is for a single worker only.")
 
   def test_sdf_with_sdf_initiated_checkpointing(self):
+    raise unittest.SkipTest("This test is for a single worker only.")
+
+  def test_draining_sdf_with_sdf_initiated_checkpointing(self):
     raise unittest.SkipTest("This test is for a single worker only.")
 
   def test_sdf_with_watermark_tracking(self):

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
@@ -1342,7 +1342,7 @@ class FnApiRunnerTestWithGrpcAndMultiWorkers(FnApiRunnerTest):
 class FnApiRunnerTestWithBundleRepeat(FnApiRunnerTest):
   def create_pipeline(self, is_drain=False):
     return beam.Pipeline(
-        runner=fn_api_runner.FnApiRunner(bundle_repeat=3), is_drain=is_drain)
+        runner=fn_api_runner.FnApiRunner(bundle_repeat=3, is_drain=is_drain))
 
   def test_register_finalizations(self):
     raise unittest.SkipTest("TODO: Avoid bundle finalizations on repeat.")
@@ -1365,6 +1365,9 @@ class FnApiRunnerTestWithBundleRepeatAndMultiWorkers(FnApiRunnerTest):
     raise unittest.SkipTest("This test is for a single worker only.")
 
   def test_sdf_with_sdf_initiated_checkpointing(self):
+    raise unittest.SkipTest("This test is for a single worker only.")
+
+  def test_draining_sdf_with_sdf_initiated_checkpointing(self):
     raise unittest.SkipTest("This test is for a single worker only.")
 
   def test_sdf_with_watermark_tracking(self):

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
@@ -1277,25 +1277,28 @@ class FnApiRunnerMetricsTest(unittest.TestCase):
 
 
 class FnApiRunnerTestWithGrpc(FnApiRunnerTest):
-  def create_pipeline(self):
+  def create_pipeline(self, is_drained=False):
     return beam.Pipeline(
         runner=fn_api_runner.FnApiRunner(
-            default_environment=environments.EmbeddedPythonGrpcEnvironment()))
+            default_environment=environments.EmbeddedPythonGrpcEnvironment(),
+            is_drained=is_drained))
 
 
 class FnApiRunnerTestWithDisabledCaching(FnApiRunnerTest):
-  def create_pipeline(self):
+  def create_pipeline(self, is_drained=False):
     return beam.Pipeline(
         runner=fn_api_runner.FnApiRunner(
             default_environment=environments.EmbeddedPythonGrpcEnvironment(
-                state_cache_size=0, data_buffer_time_limit_ms=0)))
+                state_cache_size=0, data_buffer_time_limit_ms=0),
+            is_drained=is_drained))
 
 
 class FnApiRunnerTestWithMultiWorkers(FnApiRunnerTest):
-  def create_pipeline(self):
+  def create_pipeline(self, is_drained=False):
     pipeline_options = PipelineOptions(direct_num_workers=2)
     p = beam.Pipeline(
-        runner=fn_api_runner.FnApiRunner(), options=pipeline_options)
+        runner=fn_api_runner.FnApiRunner(is_drained=is_drained),
+        options=pipeline_options)
     #TODO(BEAM-8444): Fix these tests.
     p._options.view_as(DebugOptions).experiments.remove('beam_fn_api')
     return p
@@ -1311,11 +1314,12 @@ class FnApiRunnerTestWithMultiWorkers(FnApiRunnerTest):
 
 
 class FnApiRunnerTestWithGrpcAndMultiWorkers(FnApiRunnerTest):
-  def create_pipeline(self):
+  def create_pipeline(self, is_drained=False):
     pipeline_options = PipelineOptions(
         direct_num_workers=2, direct_running_mode='multi_threading')
     p = beam.Pipeline(
-        runner=fn_api_runner.FnApiRunner(), options=pipeline_options)
+        runner=fn_api_runner.FnApiRunner(is_drained=is_drained),
+        options=pipeline_options)
     #TODO(BEAM-8444): Fix these tests.
     p._options.view_as(DebugOptions).experiments.remove('beam_fn_api')
     return p
@@ -1331,18 +1335,21 @@ class FnApiRunnerTestWithGrpcAndMultiWorkers(FnApiRunnerTest):
 
 
 class FnApiRunnerTestWithBundleRepeat(FnApiRunnerTest):
-  def create_pipeline(self):
-    return beam.Pipeline(runner=fn_api_runner.FnApiRunner(bundle_repeat=3))
+  def create_pipeline(self, is_drained=False):
+    return beam.Pipeline(
+        runner=fn_api_runner.FnApiRunner(bundle_repeat=3),
+        is_drained=is_drained)
 
   def test_register_finalizations(self):
     raise unittest.SkipTest("TODO: Avoid bundle finalizations on repeat.")
 
 
 class FnApiRunnerTestWithBundleRepeatAndMultiWorkers(FnApiRunnerTest):
-  def create_pipeline(self):
+  def create_pipeline(self, is_drained=False):
     pipeline_options = PipelineOptions(direct_num_workers=2)
     p = beam.Pipeline(
-        runner=fn_api_runner.FnApiRunner(bundle_repeat=3),
+        runner=fn_api_runner.FnApiRunner(
+            bundle_repeat=3, is_drained=is_drained),
         options=pipeline_options)
     #TODO(BEAM-8444): Fix these tests.
     p._options.view_as(DebugOptions).experiments.remove('beam_fn_api')
@@ -1362,12 +1369,13 @@ class FnApiRunnerTestWithBundleRepeatAndMultiWorkers(FnApiRunnerTest):
 
 
 class FnApiRunnerSplitTest(unittest.TestCase):
-  def create_pipeline(self):
+  def create_pipeline(self, is_drained=False):
     # Must be GRPC so we can send data and split requests concurrent
     # to the bundle process request.
     return beam.Pipeline(
         runner=fn_api_runner.FnApiRunner(
-            default_environment=environments.EmbeddedPythonGrpcEnvironment()))
+            default_environment=environments.EmbeddedPythonGrpcEnvironment(),
+            is_drained=is_drained))
 
   def test_checkpoint(self):
     # This split manager will get re-invoked on each smaller split,
@@ -1699,12 +1707,11 @@ class OffsetRangeProviderWithTruncate(OffsetRangeProvider):
 
 
 class FnApiBasedLullLoggingTest(unittest.TestCase):
-  def create_pipeline(self, is_drain=False):
+  def create_pipeline(self):
     return beam.Pipeline(
         runner=fn_api_runner.FnApiRunner(
             default_environment=environments.EmbeddedPythonGrpcEnvironment(),
-            progress_request_frequency=0.5,
-            is_drain=is_drain))
+            progress_request_frequency=0.5))
 
   def test_lull_logging(self):
 

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
@@ -1450,7 +1450,7 @@ class FnApiRunnerSplitTest(unittest.TestCase):
         yield 0
         breakpoint.clear()
 
-      # Everything should be perfectly split.
+    # Everything should be perfectly split.
 
     elements = [2, 3]
     expected_groups = [[(2, 0)], [(2, 1)], [(3, 0)], [(3, 1)], [(3, 2)]]
@@ -1713,7 +1713,7 @@ class ExpandStringsProvider(beam.transforms.core.RestrictionProvider):
     return restriction.size()
 
 
-class SimpleUnboundedOffsetRangeRestrictionTracker(
+class UnboundedOffsetRestrictionTracker(
     restriction_trackers.OffsetRestrictionTracker):
   def is_bounded(self):
     return False
@@ -1729,7 +1729,7 @@ class OffsetRangeProvider(beam.transforms.core.RestrictionProvider):
   def create_tracker(self, restriction):
     if self.use_bounded_offset_range:
       return restriction_trackers.OffsetRestrictionTracker(restriction)
-    return SimpleUnboundedOffsetRangeRestrictionTracker(restriction)
+    return UnboundedOffsetRestrictionTracker(restriction)
 
   def split(self, element, restriction):
     return [restriction]

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
@@ -1277,27 +1277,27 @@ class FnApiRunnerMetricsTest(unittest.TestCase):
 
 
 class FnApiRunnerTestWithGrpc(FnApiRunnerTest):
-  def create_pipeline(self, is_drained=False):
+  def create_pipeline(self, is_drain=False):
     return beam.Pipeline(
         runner=fn_api_runner.FnApiRunner(
             default_environment=environments.EmbeddedPythonGrpcEnvironment(),
-            is_drained=is_drained))
+            is_drain=is_drain))
 
 
 class FnApiRunnerTestWithDisabledCaching(FnApiRunnerTest):
-  def create_pipeline(self, is_drained=False):
+  def create_pipeline(self, is_drain=False):
     return beam.Pipeline(
         runner=fn_api_runner.FnApiRunner(
             default_environment=environments.EmbeddedPythonGrpcEnvironment(
                 state_cache_size=0, data_buffer_time_limit_ms=0),
-            is_drained=is_drained))
+            is_drain=is_drain))
 
 
 class FnApiRunnerTestWithMultiWorkers(FnApiRunnerTest):
-  def create_pipeline(self, is_drained=False):
+  def create_pipeline(self, is_drain=False):
     pipeline_options = PipelineOptions(direct_num_workers=2)
     p = beam.Pipeline(
-        runner=fn_api_runner.FnApiRunner(is_drained=is_drained),
+        runner=fn_api_runner.FnApiRunner(is_drain=is_drain),
         options=pipeline_options)
     #TODO(BEAM-8444): Fix these tests.
     p._options.view_as(DebugOptions).experiments.remove('beam_fn_api')
@@ -1314,11 +1314,11 @@ class FnApiRunnerTestWithMultiWorkers(FnApiRunnerTest):
 
 
 class FnApiRunnerTestWithGrpcAndMultiWorkers(FnApiRunnerTest):
-  def create_pipeline(self, is_drained=False):
+  def create_pipeline(self, is_drain=False):
     pipeline_options = PipelineOptions(
         direct_num_workers=2, direct_running_mode='multi_threading')
     p = beam.Pipeline(
-        runner=fn_api_runner.FnApiRunner(is_drained=is_drained),
+        runner=fn_api_runner.FnApiRunner(is_drain=is_drain),
         options=pipeline_options)
     #TODO(BEAM-8444): Fix these tests.
     p._options.view_as(DebugOptions).experiments.remove('beam_fn_api')
@@ -1335,21 +1335,21 @@ class FnApiRunnerTestWithGrpcAndMultiWorkers(FnApiRunnerTest):
 
 
 class FnApiRunnerTestWithBundleRepeat(FnApiRunnerTest):
-  def create_pipeline(self, is_drained=False):
+  def create_pipeline(self, is_drain=False):
     return beam.Pipeline(
         runner=fn_api_runner.FnApiRunner(bundle_repeat=3),
-        is_drained=is_drained)
+        is_drain=is_drain)
 
   def test_register_finalizations(self):
     raise unittest.SkipTest("TODO: Avoid bundle finalizations on repeat.")
 
 
 class FnApiRunnerTestWithBundleRepeatAndMultiWorkers(FnApiRunnerTest):
-  def create_pipeline(self, is_drained=False):
+  def create_pipeline(self, is_drain=False):
     pipeline_options = PipelineOptions(direct_num_workers=2)
     p = beam.Pipeline(
         runner=fn_api_runner.FnApiRunner(
-            bundle_repeat=3, is_drained=is_drained),
+            bundle_repeat=3, is_drain=is_drain),
         options=pipeline_options)
     #TODO(BEAM-8444): Fix these tests.
     p._options.view_as(DebugOptions).experiments.remove('beam_fn_api')
@@ -1369,13 +1369,13 @@ class FnApiRunnerTestWithBundleRepeatAndMultiWorkers(FnApiRunnerTest):
 
 
 class FnApiRunnerSplitTest(unittest.TestCase):
-  def create_pipeline(self, is_drained=False):
+  def create_pipeline(self, is_drain=False):
     # Must be GRPC so we can send data and split requests concurrent
     # to the bundle process request.
     return beam.Pipeline(
         runner=fn_api_runner.FnApiRunner(
             default_environment=environments.EmbeddedPythonGrpcEnvironment(),
-            is_drained=is_drained))
+            is_drain=is_drain))
 
   def test_checkpoint(self):
     # This split manager will get re-invoked on each smaller split,

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
@@ -1004,6 +1004,8 @@ def expand_sdf(stages, context):
               main_input_id,
               '_truncate_restriction',
               coder_id=sized_coder_id)
+          # Lengthprefix the truncate output.
+          context.length_prefix_pcoll_coders(truncate_pcoll_id)
           truncate_transform_id = copy_like(
               context.components.transforms,
               transform,

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
@@ -69,6 +69,7 @@ PAR_DO_URNS = frozenset([
     common_urns.sdf_components.PAIR_WITH_RESTRICTION.urn,
     common_urns.sdf_components.SPLIT_AND_SIZE_RESTRICTIONS.urn,
     common_urns.sdf_components.PROCESS_SIZED_ELEMENTS_AND_RESTRICTIONS.urn,
+    common_urns.sdf_components.TRUNCATE_SIZED_RESTRICTION.urn,
 ])
 
 IMPULSE_BUFFER = b'impulse'
@@ -343,13 +344,15 @@ class TransformContext(object):
   def __init__(self,
                components,  # type: beam_runner_api_pb2.Components
                known_runner_urns,  # type: FrozenSet[str]
-               use_state_iterables=False
+               use_state_iterables=False,
+               is_drain=False
               ):
     self.components = components
     self.known_runner_urns = known_runner_urns
     self.runner_only_urns = known_runner_urns - frozenset(
         [common_urns.primitives.FLATTEN.urn])
     self.use_state_iterables = use_state_iterables
+    self.is_drain = is_drain
     # ok to pass None for context because BytesCoder has no components
     coder_proto = coders.BytesCoder().to_runner_api(
         None)  # type: ignore[arg-type]
@@ -547,7 +550,8 @@ def pipeline_from_stages(pipeline_proto,  # type: beam_runner_api_pb2.Pipeline
 def create_and_optimize_stages(pipeline_proto,  # type: beam_runner_api_pb2.Pipeline
                                phases,
                                known_runner_urns,  # type: FrozenSet[str]
-                               use_state_iterables=False
+                               use_state_iterables=False,
+    is_drain=False
                               ):
   # type: (...) -> Tuple[TransformContext, List[Stage]]
 
@@ -568,7 +572,8 @@ def create_and_optimize_stages(pipeline_proto,  # type: beam_runner_api_pb2.Pipe
   pipeline_context = TransformContext(
       pipeline_proto.components,
       known_runner_urns,
-      use_state_iterables=use_state_iterables)
+      use_state_iterables=use_state_iterables,
+      is_drain=is_drain)
 
   # Initial set of stages are singleton leaf transforms.
   stages = list(
@@ -973,6 +978,7 @@ def expand_sdf(stages, context):
             inputs=dict(transform.inputs, **{main_input_tag: paired_pcoll_id}),
             outputs={'out': split_pcoll_id})
 
+        reshuffle_stage = None
         if common_urns.composites.RESHUFFLE.urn in context.known_runner_urns:
           reshuffle_pcoll_id = copy_like(
               context.components.pcollections,
@@ -987,25 +993,55 @@ def expand_sdf(stages, context):
               payload=b'',
               inputs=dict(transform.inputs, **{main_input_tag: split_pcoll_id}),
               outputs={'out': reshuffle_pcoll_id})
-          yield make_stage(stage, reshuffle_transform_id)
+          reshuffle_stage = make_stage(stage, reshuffle_transform_id)
         else:
           reshuffle_pcoll_id = split_pcoll_id
           reshuffle_transform_id = None
 
-        process_transform_id = copy_like(
-            context.components.transforms,
-            transform,
-            unique_name=transform.unique_name + '/Process',
-            urn=common_urns.sdf_components.
-            PROCESS_SIZED_ELEMENTS_AND_RESTRICTIONS.urn,
-            inputs=dict(
-                transform.inputs, **{main_input_tag: reshuffle_pcoll_id}))
+        if context.is_drain:
+          truncate_pcoll_id = copy_like(
+              context.components.pcollections,
+              main_input_id,
+              '_truncate_restriction',
+              coder_id=sized_coder_id)
+          truncate_transform_id = copy_like(
+              context.components.transforms,
+              transform,
+              unique_name=transform.unique_name + '/TruncateAndSizeRestriction',
+              urn=common_urns.sdf_components.TRUNCATE_SIZED_RESTRICTION.urn,
+              inputs=dict(
+                  transform.inputs, **{main_input_tag: reshuffle_pcoll_id}),
+              outputs={'out': truncate_pcoll_id})
+          process_transform_id = copy_like(
+              context.components.transforms,
+              transform,
+              unique_name=transform.unique_name + '/Process',
+              urn=common_urns.sdf_components.
+              PROCESS_SIZED_ELEMENTS_AND_RESTRICTIONS.urn,
+              inputs=dict(
+                  transform.inputs, **{main_input_tag: truncate_pcoll_id}))
+        else:
+          process_transform_id = copy_like(
+              context.components.transforms,
+              transform,
+              unique_name=transform.unique_name + '/Process',
+              urn=common_urns.sdf_components.
+              PROCESS_SIZED_ELEMENTS_AND_RESTRICTIONS.urn,
+              inputs=dict(
+                  transform.inputs, **{main_input_tag: reshuffle_pcoll_id}))
 
         yield make_stage(stage, pair_transform_id)
         split_stage = make_stage(stage, split_transform_id)
         yield split_stage
-        yield make_stage(
-            stage, process_transform_id, extra_must_follow=[split_stage])
+        if reshuffle_stage:
+          yield reshuffle_stage
+        if context.is_drain:
+          yield make_stage(
+              stage, truncate_transform_id, extra_must_follow=[split_stage])
+          yield make_stage(stage, process_transform_id)
+        else:
+          yield make_stage(
+              stage, process_transform_id, extra_must_follow=[split_stage])
 
       else:
         yield stage

--- a/sdks/python/apache_beam/runners/portability/portable_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner_test.py
@@ -197,7 +197,7 @@ class PortableRunnerTest(fn_runner_test.FnApiRunnerTest):
         'data_buffer_time_limit_ms=1000')
     return options
 
-  def create_pipeline(self):
+  def create_pipeline(self, unused_is_drain=False):
     return beam.Pipeline(self.get_runner(), self.create_options())
 
   def test_pardo_state_with_custom_key_coder(self):

--- a/sdks/python/apache_beam/runners/portability/portable_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner_test.py
@@ -197,7 +197,7 @@ class PortableRunnerTest(fn_runner_test.FnApiRunnerTest):
         'data_buffer_time_limit_ms=1000')
     return options
 
-  def create_pipeline(self, used_is_drain=False):
+  def create_pipeline(self, is_drain=False):
     return beam.Pipeline(self.get_runner(), self.create_options())
 
   def test_pardo_state_with_custom_key_coder(self):

--- a/sdks/python/apache_beam/runners/portability/portable_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner_test.py
@@ -197,7 +197,7 @@ class PortableRunnerTest(fn_runner_test.FnApiRunnerTest):
         'data_buffer_time_limit_ms=1000')
     return options
 
-  def create_pipeline(self, unused_is_drain=False):
+  def create_pipeline(self, used_is_drain=False):
     return beam.Pipeline(self.get_runner(), self.create_options())
 
   def test_pardo_state_with_custom_key_coder(self):

--- a/sdks/python/apache_beam/runners/portability/portable_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner_test.py
@@ -251,6 +251,9 @@ class PortableRunnerTest(fn_runner_test.FnApiRunnerTest):
   def test_sdf_with_truncate(self):
     raise unittest.SkipTest("Portable runners don't support drain now")
 
+  def test_draining_sdf_with_sdf_initiated_checkpointing(self):
+    raise unittest.SkipTest("Portable runners don't support drain now")
+
 
 @unittest.skip("BEAM-7248")
 class PortableRunnerOptimized(PortableRunnerTest):

--- a/sdks/python/apache_beam/runners/portability/portable_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner_test.py
@@ -242,6 +242,15 @@ class PortableRunnerTest(fn_runner_test.FnApiRunnerTest):
 
   # Inherits all other tests from fn_api_runner_test.FnApiRunnerTest
 
+  def test_sdf_default_truncate_when_bounded(self):
+    raise unittest.SkipTest("Portable runners don't support drain now")
+
+  def test_sdf_default_truncate_when_unbounded(self):
+    raise unittest.SkipTest("Portable runners don't support drain now")
+
+  def test_sdf_with_truncate(self):
+    raise unittest.SkipTest("Portable runners don't support drain now")
+
 
 @unittest.skip("BEAM-7248")
 class PortableRunnerOptimized(PortableRunnerTest):

--- a/sdks/python/apache_beam/runners/portability/portable_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner_test.py
@@ -243,16 +243,16 @@ class PortableRunnerTest(fn_runner_test.FnApiRunnerTest):
   # Inherits all other tests from fn_api_runner_test.FnApiRunnerTest
 
   def test_sdf_default_truncate_when_bounded(self):
-    raise unittest.SkipTest("Portable runners don't support drain now")
+    raise unittest.SkipTest("Portable runners don't support drain yet.")
 
   def test_sdf_default_truncate_when_unbounded(self):
-    raise unittest.SkipTest("Portable runners don't support drain now")
+    raise unittest.SkipTest("Portable runners don't support drain yet.")
 
   def test_sdf_with_truncate(self):
-    raise unittest.SkipTest("Portable runners don't support drain now")
+    raise unittest.SkipTest("Portable runners don't support drain yet.")
 
   def test_draining_sdf_with_sdf_initiated_checkpointing(self):
-    raise unittest.SkipTest("Portable runners don't support drain now")
+    raise unittest.SkipTest("Portable runners don't support drain yet.")
 
 
 @unittest.skip("BEAM-7248")

--- a/sdks/python/apache_beam/runners/sdf_utils.py
+++ b/sdks/python/apache_beam/runners/sdf_utils.py
@@ -151,6 +151,9 @@ class ThreadsafeRestrictionTracker(object):
       return self._deferred_residual, self._deferred_timestamp
     return None
 
+  def is_bounded(self):
+    return self._restriction_tracker.is_bounded()
+
 
 class RestrictionTrackerView(object):
   """A DoFn view of thread-safe RestrictionTracker.
@@ -177,6 +180,9 @@ class RestrictionTrackerView(object):
 
   def defer_remainder(self, deferred_time=None):
     self._threadsafe_restriction_tracker.defer_remainder(deferred_time)
+
+  def is_bounded(self):
+    self._threadsafe_restriction_tracker.is_bounded()
 
 
 class ThreadsafeWatermarkEstimator(object):

--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -1079,12 +1079,6 @@ class BundleProcessor(object):
                                   ):
     # type: (...) -> beam_fn_api_pb2.BundleApplication
     transform_id, main_input_tag, main_input_coder, outputs = op.input_info
-    # The main_input_coder should be the main_input_coder of
-    # SdfTruncateSizedRestrictions if SdfProcessSizedElements is following
-    # SdfTruncateSizedRestrictions.
-    if (isinstance(op, operations.SdfProcessSizedElements) and
-        op.sdf_truncate_op is not None):
-      _, _, main_input_coder, _ = op.sdf_truncate_op.input_info
 
     if output_watermark:
       proto_output_watermark = proto_utils.from_micros(

--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -1437,23 +1437,20 @@ def create_truncate_sized_restriction(*args):
       self.restriction_provider = restriction_provider
       self.dofn_signature = common.DoFnSignature(fn)
 
-    def process(self, element_restrictin, *args, **kwargs):
-      ((element, (restriction, estimator_state)), _) = element_restrictin
+    def process(self, element_restriction, *args, **kwargs):
+      ((element, (restriction, estimator_state)), _) = element_restriction
       try:
-        truncated_restriciton = self.restriction_provider.truncate(
+        truncated_restriction = self.restriction_provider.truncate(
             element, restriction)
-        if truncated_restriciton:
-          truncated_restriciton_size = self.restriction_provider.restriction_size(
-              element, truncated_restriciton)
-        else:
-          truncated_restriciton_size = 0
-        yield ((element, (truncated_restriciton, estimator_state)),
-               truncated_restriciton_size)
+        if truncated_restriction:
+          truncated_restriction_size = (
+              self.restriction_provider.restriction_size(
+                  element, truncated_restriction))
+          yield ((element, (truncated_restriction, estimator_state)),
+                 truncated_restriction_size)
       except NotImplementedError:
-        if self.dofn_signature.is_unbounded_per_element():
-          yield ((element, (None, estimator_state)), 0)
-        else:
-          yield element_restrictin
+        if not self.dofn_signature.is_unbounded_per_element():
+          yield element_restriction
 
   return _create_sdf_operation(TruncateAndSizeRestriction, *args)
 

--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -1435,22 +1435,17 @@ def create_truncate_sized_restriction(*args):
   class TruncateAndSizeRestriction(beam.DoFn):
     def __init__(self, fn, restriction_provider, watermark_estimator_provider):
       self.restriction_provider = restriction_provider
-      self.dofn_signature = common.DoFnSignature(fn)
 
     def process(self, element_restriction, *args, **kwargs):
       ((element, (restriction, estimator_state)), _) = element_restriction
-      try:
-        truncated_restriction = self.restriction_provider.truncate(
-            element, restriction)
-        if truncated_restriction:
-          truncated_restriction_size = (
-              self.restriction_provider.restriction_size(
-                  element, truncated_restriction))
-          yield ((element, (truncated_restriction, estimator_state)),
-                 truncated_restriction_size)
-      except NotImplementedError:
-        if not self.dofn_signature.is_unbounded_per_element():
-          yield element_restriction
+      truncated_restriction = self.restriction_provider.truncate(
+          element, restriction)
+      if truncated_restriction:
+        truncated_restriction_size = (
+            self.restriction_provider.restriction_size(
+                element, truncated_restriction))
+        yield ((element, (truncated_restriction, estimator_state)),
+               truncated_restriction_size)
 
   return _create_sdf_operation(TruncateAndSizeRestriction, *args)
 

--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -759,7 +759,6 @@ class SdfTruncateSizedRestrictions(DoOperation):
     # type: (Operation, int) -> None
     if isinstance(operation, SdfProcessSizedElements):
       self.sdf_process_op = operation
-      self.sdf_process_op.sdf_truncate_op = self
     super(SdfTruncateSizedRestrictions,
           self).add_receiver(operation, output_index)
 
@@ -769,7 +768,6 @@ class SdfProcessSizedElements(DoOperation):
     super(SdfProcessSizedElements, self).__init__(*args, **kwargs)
     self.lock = threading.RLock()
     self.element_start_output_bytes = None  # type: Optional[int]
-    self.sdf_truncate_op = None
 
   def process(self, o):
     # type: (WindowedValue) -> None

--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -753,10 +753,7 @@ class SdfTruncateSizedRestrictions(DoOperation):
     return self.sdf_process_op.current_element_progress()
 
   def try_split(self, fraction_of_remainder):  # type: (...) -> Optional[Any]
-    result = self.sdf_process_op.try_split(fraction_of_remainder)
-    if result is not None:
-      return result
-    return None
+    return self.sdf_process_op.try_split(fraction_of_remainder)
 
   def add_receiver(self, operation, output_index=0):
     # type: (Operation, int) -> None

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -323,7 +323,7 @@ class RestrictionProvider(object):
   def truncate(self, element, restriction):
     """Truncates the provided restriction into a restriction representing a
     finite amount of work when the pipeline is
-    `draining <https://docs.google.com/document/d/1NExwHlj-2q2WUGhSO4jTu8XGhDPmm3cllSN8IMmWci8/edit#> for additional details about drain.>_`.
+    `draining <https://docs.google.com/document/d/1NExwHlj-2q2WUGhSO4jTu8XGhDPmm3cllSN8IMmWci8/edit#> for additional details about drain.>_`.  # pylint: disable=line-too-long
     By default, if the restriction is bounded then the restriction will be
     returned otherwise None will be returned.
 

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -321,13 +321,18 @@ class RestrictionProvider(object):
       yield part, self.restriction_size(element, part)
 
   def truncate(self, element, restriction):
-    """Truncate the given restriction into finite amount of work when the
-    pipeline starts to drain.
+    """Truncates the provided restriction into a restriction representing a
+    finite amount of work when the pipeline is
+    `draining <https://docs.google.com/document/d/1NExwHlj-2q2WUGhSO4jTu8XGhDPmm3cllSN8IMmWci8/edit#> for additional details about drain.>_`.
+    By default, if the restriction is bounded then the restriction will be
+    returned otherwise None will be returned.
 
-    By default, if the restriction is bounded, it will return the entire
-    restriction. If the restriction is unbounded, it will not return anything.
+    This API is optional and should only be implemented if more granularity is
+    required.
 
-    It's recommended to implement this API if more granularity is required.
+    Return a truncated finite restriction if further processing is required
+    otherwise return None to represent that no further processing of this
+    restriction is required.
     """
     restriction_tracker = self.create_tracker(restriction)
     if restriction_tracker.is_bounded():

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -331,7 +331,7 @@ class RestrictionProvider(object):
     """
     restriction_tracker = self.create_tracker(restriction)
     if restriction_tracker.is_bounded():
-      yield restriction
+      return restriction
 
 
 def get_function_arguments(obj, func):

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -334,7 +334,7 @@ class RestrictionProvider(object):
     """
     restriction_tracker = self.create_tracker(restriction)
     if restriction_tracker.is_bounded():
-      return restriction
+      yield restriction
 
 
 def get_function_arguments(obj, func):

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -327,9 +327,6 @@ class RestrictionProvider(object):
     By default, if the restriction is bounded, it will return the entire current
     restriction. If the restriction is unbounded, it will return None.
 
-    The method throws NotImplementError when RestrictionTracker.is_bounded() is
-    not implemented.
-
     It's recommended to implement this API if more granularity is required.
     """
     restriction_tracker = self.create_tracker(restriction)

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -324,8 +324,8 @@ class RestrictionProvider(object):
     """Truncate the given restriction into finite amount of work when the
     pipeline starts to drain.
 
-    By default, if the restriction is bounded, it will return the entire current
-    restriction. If the restriction is unbounded, it will return None.
+    By default, if the restriction is bounded, it will return the entire
+    restriction. If the restriction is unbounded, it will not return anything.
 
     It's recommended to implement this API if more granularity is required.
     """

--- a/sdks/python/apache_beam/transforms/environments.py
+++ b/sdks/python/apache_beam/transforms/environments.py
@@ -595,6 +595,7 @@ def _python_sdk_capabilities_iter():
   yield common_urns.protocols.LEGACY_PROGRESS_REPORTING.urn
   yield common_urns.protocols.WORKER_STATUS.urn
   yield 'beam:version:sdk_base:' + DockerEnvironment.default_docker_image()
+  yield common_urns.sdf_components.TRUNCATE_SIZED_RESTRICTION.urn
 
 
 def python_sdk_dependencies(options, tmp_dir=None):

--- a/sdks/python/apache_beam/transforms/environments_test.py
+++ b/sdks/python/apache_beam/transforms/environments_test.py
@@ -73,6 +73,8 @@ class RunnerApiTest(unittest.TestCase):
     sdk_capabilities = environments.python_sdk_capabilities()
     self.assertIn(common_urns.coders.LENGTH_PREFIX.urn, sdk_capabilities)
     self.assertIn(common_urns.protocols.WORKER_STATUS.urn, sdk_capabilities)
+    self.assertIn(common_urns.sdf_components.TRUNCATE_SIZED_RESTRICTION.urn,
+                  sdk_capabilities)
 
   def test_default_capabilities(self):
     environment = DockerEnvironment.from_options(

--- a/sdks/python/apache_beam/transforms/environments_test.py
+++ b/sdks/python/apache_beam/transforms/environments_test.py
@@ -73,8 +73,9 @@ class RunnerApiTest(unittest.TestCase):
     sdk_capabilities = environments.python_sdk_capabilities()
     self.assertIn(common_urns.coders.LENGTH_PREFIX.urn, sdk_capabilities)
     self.assertIn(common_urns.protocols.WORKER_STATUS.urn, sdk_capabilities)
-    self.assertIn(common_urns.sdf_components.TRUNCATE_SIZED_RESTRICTION.urn,
-                  sdk_capabilities)
+    self.assertIn(
+        common_urns.sdf_components.TRUNCATE_SIZED_RESTRICTION.urn,
+        sdk_capabilities)
 
   def test_default_capabilities(self):
     environment = DockerEnvironment.from_options(


### PR DESCRIPTION
**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Samza | Spark
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
