### PR TITLE
[BEAM-10135] Add Python wrapper for Jdbc Write external transform

### DIFF
--- a/sdks/python/apache_beam/io/external/jdbc.py
+++ b/sdks/python/apache_beam/io/external/jdbc.py
@@ -61,9 +61,9 @@ WriteToJdbcSchema = typing.NamedTuple(
         ('jdbc_url', unicode),
         ('username', unicode),
         ('password', unicode),
-        ('statement', unicode),
-        ('connection_properties', unicode),
+        ('connection_properties', typing.Optional[unicode]),
         ('connection_init_sqls', typing.Optional[typing.List[unicode]]),
+        ('statement', unicode),
     ],
 )
 
@@ -101,10 +101,7 @@ class WriteToJdbc(ExternalTransform):
       username,
       password,
       statement,
-      connection_properties='',
-      connection_init_sqls=None,
-      expansion_service=None,
-  ):
+      **kwargs):
     """
     Initializes a write operation to Jdbc.
 
@@ -117,6 +114,10 @@ class WriteToJdbc(ExternalTransform):
     :param connection_init_sqls: required only for MySql and MariaDB
     :param expansion_service: The address (host:port) of the ExpansionService.
     """
+    connection_properties = kwargs.get('connection_properties')
+    connection_init_sqls = kwargs.get('connection_init_sqls')
+    expansion_service = kwargs.get('expansion_service')
+
     super(WriteToJdbc, self).__init__(
         self.URN,
         NamedTupleBasedPayloadBuilder(

--- a/sdks/python/apache_beam/io/external/jdbc.py
+++ b/sdks/python/apache_beam/io/external/jdbc.py
@@ -1,0 +1,134 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""
+  PTransforms for supporting Jdbc in Python pipelines. These transforms do not
+  run a Jdbc client in Python. Instead, they expand to ExternalTransforms
+  which the Expansion Service resolves to the Java SDK's JdbcIO.
+
+  Note: To use these transforms, you need to start a Java Expansion Service.
+  Please refer to the portability documentation on how to do that. Flink Users
+  can use the built-in Expansion Service of the Flink Runner's Job Server. The
+  expansion service address has to be provided when instantiating the
+  transforms.
+
+  If you start Flink's Job Server, the expansion service will be started on
+  port 8097. This is also the configured default for this transform. For a
+  different address, please set the expansion_service parameter.
+
+  For more information see:
+  - https://beam.apache.org/documentation/runners/flink/
+  - https://beam.apache.org/roadmap/portability/
+"""
+
+# pytype: skip-file
+
+from __future__ import absolute_import
+
+import typing
+
+from past.builtins import unicode
+
+from apache_beam.transforms.external import BeamJarExpansionService
+from apache_beam.transforms.external import ExternalTransform
+from apache_beam.transforms.external import NamedTupleBasedPayloadBuilder
+
+__all__ = ['WriteToJdbc']
+
+
+def default_io_expansion_service():
+  return BeamJarExpansionService('sdks:java:io:expansion-service:shadowJar')
+
+
+WriteToJdbcSchema = typing.NamedTuple(
+    'WriteToJdbcSchema',
+    [
+        ('driver_class_name', unicode),
+        ('jdbc_url', unicode),
+        ('username', unicode),
+        ('password', unicode),
+        ('statement', unicode),
+        ('connection_properties', unicode),
+        ('connection_init_sqls', typing.Optional[typing.List[unicode]]),
+    ],
+)
+
+
+class WriteToJdbc(ExternalTransform):
+  """
+  An external PTransform which writes Rows to the specified database.
+
+  This transform receives Rows defined as NamedTuple type and registered in
+  the coders registry to use RowCoder, e.g.
+
+    import typing
+    from apache_beam import coders
+
+    ExampleRow = typing.NamedTuple(
+      "ExampleRow",
+      [
+        ("id", int),
+        ("name", unicode),
+        ("budget", float),
+      ],
+    )
+    coders.registry.register_coder(ExampleRow, coders.RowCoder)
+
+  Experimental; no backwards compatibility guarantees.  It requires special
+  preparation of the Java SDK.  See BEAM-7870.
+  """
+
+  URN = 'beam:external:java:jdbc:write:v1'
+
+  def __init__(
+      self,
+      driver_class_name,
+      jdbc_url,
+      username,
+      password,
+      statement,
+      connection_properties='',
+      connection_init_sqls=None,
+      expansion_service=None,
+  ):
+    """
+    Initializes a write operation to Jdbc.
+
+    :param driver_class_name: name of the jdbc driver class
+    :param jdbc_url: full jdbc url to the database.
+    :param username: database username
+    :param password: database password
+    :param statement: sql statement to be executed
+    :param connection_properties: properties of the jdbc connection
+    :param connection_init_sqls: required only for MySql and MariaDB
+    :param expansion_service: The address (host:port) of the ExpansionService.
+    """
+    super(WriteToJdbc, self).__init__(
+        self.URN,
+        NamedTupleBasedPayloadBuilder(
+            WriteToJdbcSchema(
+                driver_class_name=driver_class_name,
+                jdbc_url=jdbc_url,
+                username=username,
+                password=password,
+                statement=statement,
+                connection_properties=connection_properties,
+                connection_init_sqls=connection_init_sqls,
+            ),
+        ),
+        expansion_service or default_io_expansion_service(),
+    )

--- a/sdks/python/apache_beam/io/external/xlang_jdbcio_it_test.py
+++ b/sdks/python/apache_beam/io/external/xlang_jdbcio_it_test.py
@@ -78,13 +78,6 @@ class JdbcExternalTransformTest(unittest.TestCase):
   """
   ROW_COUNT = 10
 
-  pipeline_options = {
-      'runner': 'FlinkRunner',
-      'flink_version': '1.10',
-      'experiment': 'beam_fn_api',
-      'environment_type': 'LOOPBACK'
-  }
-
   def test_xlang_jdbc_write(self):
     table_name = 'jdbc_external_test_write'
     self.engine.execute(

--- a/sdks/python/apache_beam/io/external/xlang_jdbcio_it_test.py
+++ b/sdks/python/apache_beam/io/external/xlang_jdbcio_it_test.py
@@ -23,6 +23,7 @@ import logging
 import typing
 import unittest
 
+from nose.plugins.attrib import attr
 from past.builtins import unicode
 
 import apache_beam as beam
@@ -55,7 +56,7 @@ JdbcTestRow = typing.NamedTuple(
 
 coders.registry.register_coder(JdbcTestRow, coders.RowCoder)
 
-
+@attr('UsesCrossLanguageTransforms')
 @unittest.skipIf(sqlalchemy is None, "sql alchemy package is not installed.")
 @unittest.skipIf(
     PostgresContainer is None, "testcontainers package is not installed")

--- a/sdks/python/apache_beam/io/external/xlang_jdbcio_it_test.py
+++ b/sdks/python/apache_beam/io/external/xlang_jdbcio_it_test.py
@@ -1,0 +1,138 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+# pytype: skip-file
+
+from __future__ import absolute_import
+
+import logging
+import typing
+import unittest
+
+from past.builtins import unicode
+
+import apache_beam as beam
+from apache_beam import coders
+from apache_beam.io.external.jdbc import WriteToJdbc
+from apache_beam.testing.test_pipeline import TestPipeline
+
+# pylint: disable=wrong-import-order, wrong-import-position, ungrouped-imports
+try:
+  import sqlalchemy
+except ImportError:
+  sqlalchemy = None
+# pylint: enable=wrong-import-order, wrong-import-position, ungrouped-imports
+
+# pylint: disable=wrong-import-order, wrong-import-position, ungrouped-imports
+try:
+  from testcontainers.postgres import PostgresContainer
+except ImportError:
+  PostgresContainer = None
+# pylint: enable=wrong-import-order, wrong-import-position, ungrouped-imports
+
+JdbcTestRow = typing.NamedTuple(
+    "JdbcTestRow",
+    [
+        ("f_id", int),
+        ("f_real", float),
+        ("f_string", unicode),
+    ],
+)
+
+coders.registry.register_coder(JdbcTestRow, coders.RowCoder)
+
+
+@unittest.skipIf(sqlalchemy is None, "sql alchemy package is not installed.")
+@unittest.skipIf(
+    PostgresContainer is None, "testcontainers package is not installed")
+class JdbcExternalTransformTest(unittest.TestCase):
+  """Tests that exercise the cross-language JdbcIO Transform
+   (implemented in java).
+
+  It is required to have testcontainers package installed.
+  You can do that e.g. via:
+    pip install testcontainers
+
+  To run with the local expansion service, flink job server you need to
+  build it, e.g. via command:
+    ./gradlew :sdks:java:io:expansion-service:shadowJar
+    ./gradlew :runners:flink:1.10:job-server:shadowJar
+
+  Also, beam java sdk container is necessary. You can build it via:
+    ./gradlew :sdks:java:container:docker
+  """
+  ROW_COUNT = 10
+
+  pipeline_options = {
+      'runner': 'FlinkRunner',
+      'flink_version': '1.10',
+      'experiment': 'beam_fn_api',
+      'environment_type': 'LOOPBACK'
+  }
+
+  def test_xlang_jdbc_write(self):
+    table_name = 'jdbc_external_test_write'
+    self.engine.execute(
+        "CREATE TABLE {}(f_id INTEGER, f_real REAL, f_string VARCHAR)".format(
+            table_name))
+    inserted_rows = [
+        JdbcTestRow(i, float(i + 0.1), str(i)) for i in range(self.ROW_COUNT)
+    ]
+    with TestPipeline() as p:
+      p.not_use_test_runner_api = True
+      _ = (
+          p
+          | beam.Create(inserted_rows).with_output_types(JdbcTestRow)
+          | 'Write to jdbc' >> WriteToJdbc(
+              driver_class_name=self.driver_class_name,
+              jdbc_url=self.jdbc_url,
+              username=self.username,
+              password=self.password,
+              statement='insert into {}(f_id, f_real, f_string) values(?, ?, ?)'
+              .format(table_name),
+          ))
+    fetched_data = self.engine.execute("select * from {}".format(table_name))
+    fetched_rows = [
+        JdbcTestRow(int(row[0]), float(row[1]), str(row[2]))
+        for row in fetched_data
+    ]
+
+    self.assertEqual(
+        set(fetched_rows),
+        set(inserted_rows),
+        'Inserted data does not fit data fetched from table')
+
+  def setUp(self):
+    self.postgres = PostgresContainer('postgres:latest')
+    self.postgres.start()
+    self.engine = sqlalchemy.create_engine(self.postgres.get_connection_url())
+    self.username = 'test'
+    self.password = 'test'
+    self.host = self.postgres.get_container_host_ip()
+    self.port = self.postgres.get_exposed_port(5432)
+    self.database_name = 'test'
+    self.driver_class_name = 'org.postgresql.Driver'
+    self.jdbc_url = 'jdbc:postgresql://{}:{}/{}'.format(
+        self.host, self.port, self.database_name)
+
+  def tearDown(self):
+    self.postgres.stop()
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.DEBUG)
+  unittest.main()

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -195,6 +195,8 @@ REQUIRED_TEST_PACKAGES = [
     'pytest-xdist>=1.29.0,<2',
     'pytest-timeout>=1.3.3,<2',
     'rsa<4.1; python_version < "3.0"',
+    'sqlalchemy>=1.3,<2.0; python_version >= "3.5"',
+    'testcontainers>=3.0.3,<4.0.0; python_version >= "3.5"',
     ]
 
 GCP_REQUIREMENTS = [


### PR DESCRIPTION
Add python wrapper for jdbc write transform

Note: This is a very limited transform - it can't insert timestamp, boolean, bytes as the actual row_coder is the limitation here.

This PR is dependent on #12022

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Samza | Spark
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) 
Portable | --- | [![Build Status](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
