### PR TITLE
[BEAM-10220] Add support for REQUIRE_MISSING in RowJsonDeserializer, Make ACCEPT_MISSING_OR_NULL the default behavior.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -71,7 +71,13 @@
 
 ## Breaking Changes
 
-* X behavior was changed ([BEAM-X](https://issues.apache.org/jira/browse/BEAM-X)).
+* `RowJson.RowJsonDeserializer`, `JsonToRow`, and `PubsubJsonTableProvider` now accept "implicit
+  nulls" by default when deserializing JSON (Java) ([BEAM-10220](https://issues.apache.org/jira/browse/BEAM-10220)).
+  Previously nulls could only be represented with explicit null values, as in
+  `{"foo": "bar", "baz": null}`, whereas an implicit null like `{"foo": "bar"}` would raise an
+  exception. Now both JSON strings will yield the same result by default. This behavior can be
+  overriden with `RowJson.RowJsonDeserializer#withNullBehavior`.
+
 
 ## Deprecations
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/RowJson.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/RowJson.java
@@ -172,6 +172,7 @@ public class RowJson {
      *   <li>If configured with {@code REQUIRE_MISSING}, {@code {"str": "bar"}} would be accepted,
      *       and would yield a {@link Row} with {@code null} for the {@code int} field.
      *   <li>If configured with {@code ALLOW_MISSING_OR_NULL}, either JSON string would be accepted.
+     * </ul>
      */
     public enum NullBehavior {
       /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/RowJson.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/RowJson.java
@@ -223,7 +223,7 @@ public class RowJson {
      * {@link NullBehavior} for a description of the options. Default value is {@code
      * ACCEPT_MISSING_OR_NULL}.
      */
-    public RowJsonDeserializer withMissingFieldBehavior(NullBehavior behavior) {
+    public RowJsonDeserializer withNullBehavior(NullBehavior behavior) {
       this.nullBehavior = behavior;
       return this;
     }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/JsonToRowTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/JsonToRowTest.java
@@ -170,7 +170,7 @@ public class JsonToRowTest implements Serializable {
             row(
                 JsonToRowWithErrFn.ERROR_ROW_WITH_ERR_MSG_SCHEMA,
                 "{}",
-                "Field 'name' is not present in the JSON object"),
+                "Non-nullable field 'name' is not present in the JSON object."),
             row(
                 JsonToRowWithErrFn.ERROR_ROW_WITH_ERR_MSG_SCHEMA,
                 "Is it 42?",
@@ -208,7 +208,7 @@ public class JsonToRowTest implements Serializable {
 
     PAssert.that(errorsWithMsg)
         .containsInAnyOrder(
-            row(customSchema, "{}", "Field 'name' is not present in the JSON object"),
+            row(customSchema, "{}", "Non-nullable field 'name' is not present in the JSON object."),
             row(customSchema, "Is it 42?", "Unable to parse Row"));
 
     pipeline.run();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/RowJsonTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/RowJsonTest.java
@@ -261,36 +261,24 @@ public class RowJsonTest {
     }
 
     @Test
-    public void testRoundTrip_KeepNulls_RequireNulls() throws IOException {
-      ObjectMapper objectMapper =
-          newObjectMapperWith(
-              RowJsonSerializer.forSchema(schema),
-              RowJsonDeserializer.forSchema(schema)
-                  .withMissingFieldBehavior(NullBehavior.REQUIRE_NULL));
-      Row parsedRow = objectMapper.readValue(objectMapper.writeValueAsString(row), Row.class);
-
-      assertThat(row, equalTo(parsedRow));
-    }
-
-    @Test
-    public void testRoundTrip_DropNulls_AllowMissingOrNull() throws IOException {
-      ObjectMapper objectMapper =
-          newObjectMapperWith(
-              RowJsonSerializer.forSchema(schema).withDropNullsOnWrite(true),
-              RowJsonDeserializer.forSchema(schema)
-                  .withMissingFieldBehavior(NullBehavior.ACCEPT_MISSING_OR_NULL));
-      Row parsedRow = objectMapper.readValue(objectMapper.writeValueAsString(row), Row.class);
-
-      assertThat(row, equalTo(parsedRow));
-    }
-
-    @Test
-    public void testRoundTrip_KeepNulls_AllowMissingOrNull() throws IOException {
+    public void testRoundTrip_KeepNulls_AcceptMissingOrNull() throws IOException {
       ObjectMapper objectMapper =
           newObjectMapperWith(
               RowJsonSerializer.forSchema(schema).withDropNullsOnWrite(false),
               RowJsonDeserializer.forSchema(schema)
-                  .withMissingFieldBehavior(NullBehavior.ACCEPT_MISSING_OR_NULL));
+                  .withNullBehavior(NullBehavior.ACCEPT_MISSING_OR_NULL));
+      Row parsedRow = objectMapper.readValue(objectMapper.writeValueAsString(row), Row.class);
+
+      assertThat(row, equalTo(parsedRow));
+    }
+
+    @Test
+    public void testRoundTrip_DropNulls_AcceptMissingOrNull() throws IOException {
+      ObjectMapper objectMapper =
+          newObjectMapperWith(
+              RowJsonSerializer.forSchema(schema).withDropNullsOnWrite(true),
+              RowJsonDeserializer.forSchema(schema)
+                  .withNullBehavior(NullBehavior.ACCEPT_MISSING_OR_NULL));
       Row parsedRow = objectMapper.readValue(objectMapper.writeValueAsString(row), Row.class);
 
       assertThat(row, equalTo(parsedRow));
@@ -301,8 +289,7 @@ public class RowJsonTest {
       ObjectMapper objectMapper =
           newObjectMapperWith(
               RowJsonSerializer.forSchema(schema).withDropNullsOnWrite(true),
-              RowJsonDeserializer.forSchema(schema)
-                  .withMissingFieldBehavior(NullBehavior.REQUIRE_MISSING));
+              RowJsonDeserializer.forSchema(schema).withNullBehavior(NullBehavior.REQUIRE_MISSING));
       Row parsedRow = objectMapper.readValue(objectMapper.writeValueAsString(row), Row.class);
 
       assertThat(row, equalTo(parsedRow));
@@ -313,8 +300,7 @@ public class RowJsonTest {
       ObjectMapper objectMapper =
           newObjectMapperWith(
               RowJsonSerializer.forSchema(schema).withDropNullsOnWrite(false),
-              RowJsonDeserializer.forSchema(schema)
-                  .withMissingFieldBehavior(NullBehavior.REQUIRE_NULL));
+              RowJsonDeserializer.forSchema(schema).withNullBehavior(NullBehavior.REQUIRE_NULL));
       Row parsedRow = objectMapper.readValue(objectMapper.writeValueAsString(row), Row.class);
 
       assertThat(row, equalTo(parsedRow));
@@ -408,7 +394,9 @@ public class RowJsonTest {
       thrown.expect(UnsupportedRowJsonException.class);
       thrown.expectMessage("'f_string'");
 
-      newObjectMapperWith(RowJsonDeserializer.forSchema(schema)).readValue(rowString, Row.class);
+      newObjectMapperWith(
+              RowJsonDeserializer.forSchema(schema).withNullBehavior(NullBehavior.REQUIRE_NULL))
+          .readValue(rowString, Row.class);
     }
 
     @Test
@@ -422,7 +410,8 @@ public class RowJsonTest {
       String rowString = "{\"f_byte\": 12, \"f_string\": null}";
 
       assertThat(
-          newObjectMapperWith(RowJsonDeserializer.forSchema(schema))
+          newObjectMapperWith(
+                  RowJsonDeserializer.forSchema(schema).withNullBehavior(NullBehavior.REQUIRE_NULL))
               .readValue(rowString, Row.class),
           equalTo(
               Row.withSchema(schema)
@@ -445,8 +434,7 @@ public class RowJsonTest {
       thrown.expectMessage("'f_string'");
 
       newObjectMapperWith(
-              RowJsonDeserializer.forSchema(schema)
-                  .withMissingFieldBehavior(NullBehavior.REQUIRE_MISSING))
+              RowJsonDeserializer.forSchema(schema).withNullBehavior(NullBehavior.REQUIRE_MISSING))
           .readValue(rowString, Row.class);
     }
 
@@ -463,7 +451,7 @@ public class RowJsonTest {
       assertThat(
           newObjectMapperWith(
                   RowJsonDeserializer.forSchema(schema)
-                      .withMissingFieldBehavior(NullBehavior.REQUIRE_MISSING))
+                      .withNullBehavior(NullBehavior.REQUIRE_MISSING))
               .readValue(rowString, Row.class),
           equalTo(
               Row.withSchema(schema)

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/RowJsonTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/RowJsonTest.java
@@ -33,6 +33,9 @@ import java.util.Collection;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.logicaltypes.PassThroughLogicalType;
+import org.apache.beam.sdk.util.RowJson.RowJsonDeserializer;
+import org.apache.beam.sdk.util.RowJson.RowJsonDeserializer.NullBehavior;
+import org.apache.beam.sdk.util.RowJson.RowJsonSerializer;
 import org.apache.beam.sdk.util.RowJson.UnsupportedRowJsonException;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
@@ -239,148 +242,83 @@ public class RowJsonTest {
 
     @Test
     public void testDeserialize() throws IOException {
-      Row parsedRow = newObjectMapperFor(schema).readValue(serializedString, Row.class);
-
-      assertThat(row, equalTo(parsedRow));
-    }
-
-    @Test
-    public void testSerialize() throws IOException {
-      String str = newObjectMapperFor(schema).writeValueAsString(row);
-
-      assertThat(str, jsonStringLike(serializedString));
-    }
-
-    @Test
-    public void testRoundTrip() throws IOException {
-      ObjectMapper objectMapper = newObjectMapperFor(schema);
-      Row parsedRow = objectMapper.readValue(objectMapper.writeValueAsString(row), Row.class);
-
-      assertThat(row, equalTo(parsedRow));
-    }
-  }
-
-  @RunWith(Parameterized.class)
-  public static class ValueTestsWithMissingFields {
-    @Parameter(0)
-    public String name;
-
-    @Parameter(1)
-    public Schema schema;
-
-    @Parameter(2)
-    public String serializedString;
-
-    @Parameter(3)
-    public Row row;
-
-    @Parameters(name = "{0}")
-    public static Collection<Object[]> data() {
-      return ImmutableList.of(
-          makeFlatRowWithNullsTestCase(),
-          makeArrayNullTestCase(),
-          makeNestedRowwithNullTestCase(),
-          makeRowisNullTestCase());
-    }
-
-    private static Object[] makeFlatRowWithNullsTestCase() {
-      Schema schema =
-          Schema.builder()
-              .addByteField("f_byte")
-              .addNullableField("f_string", FieldType.STRING)
-              .build();
-
-      String rowString = "{\n" + "\"f_byte\" : 12\n" + "}";
-
-      Row expectedRow = Row.withSchema(schema).addValues((byte) 12, null).build();
-
-      return new Object[] {"Nulls", schema, rowString, expectedRow};
-    }
-
-    private static Object[] makeArrayNullTestCase() {
-
-      Schema schema =
-          Schema.builder()
-              .addInt32Field("f_int32")
-              .addNullableField("f_intArray", FieldType.array(FieldType.INT32))
-              .build();
-
-      String rowString = "{\n" + "\"f_int32\" : 32\n" + "}";
-
-      Row expectedRow = Row.withSchema(schema).addValues(32, null).build();
-
-      return new Object[] {"Array field", schema, rowString, expectedRow};
-    }
-
-    private static Object[] makeNestedRowwithNullTestCase() {
-      Schema nestedRowSchema =
-          Schema.builder()
-              .addInt32Field("f_nestedInt32")
-              .addNullableField("f_nestedString", FieldType.STRING)
-              .build();
-
-      Schema schema =
-          Schema.builder().addInt32Field("f_int32").addRowField("f_row", nestedRowSchema).build();
-
-      String rowString =
-          "{\n"
-              + "\"f_int32\" : 32,\n"
-              + "\"f_row\" : {\n"
-              + "             \"f_nestedInt32\" : 54\n"
-              + "            }\n"
-              + "}";
-
-      Row expectedRow =
-          Row.withSchema(schema)
-              .addValues(32, Row.withSchema(nestedRowSchema).addValues(54, null).build())
-              .build();
-
-      return new Object[] {"Nested row", schema, rowString, expectedRow};
-    }
-
-    private static Object[] makeRowisNullTestCase() {
-      Schema nestedRowSchema =
-          Schema.builder()
-              .addInt32Field("f_nestedInt32")
-              .addNullableField("f_nestedString", FieldType.STRING)
-              .build();
-
-      Schema schema =
-          Schema.builder()
-              .addInt32Field("f_int32")
-              .addNullableField("f_row", FieldType.row(nestedRowSchema))
-              .build();
-
-      String rowString = "{\n" + "\"f_int32\" : 32\n" + "}";
-
-      Row expectedRow = Row.withSchema(schema).addValues(32, null).build();
-
-      return new Object[] {"Nested row which is removed", schema, rowString, expectedRow};
-    }
-
-    @Test
-    public void testDeserialize() throws IOException {
       Row parsedRow =
-          newObjectMapperWithImplicitNullsFor(schema).readValue(serializedString, Row.class);
+          newObjectMapperWith(
+                  RowJsonSerializer.forSchema(schema), RowJsonDeserializer.forSchema(schema))
+              .readValue(serializedString, Row.class);
 
       assertThat(row, equalTo(parsedRow));
     }
 
     @Test
     public void testSerialize() throws IOException {
-      String str = newObjectMapperWithImplicitNullsFor(schema).writeValueAsString(row);
+      String str =
+          newObjectMapperWith(
+                  RowJsonSerializer.forSchema(schema), RowJsonDeserializer.forSchema(schema))
+              .writeValueAsString(row);
 
       assertThat(str, jsonStringLike(serializedString));
     }
 
     @Test
-    public void testRoundTrip() throws IOException {
-      ObjectMapper objectMapper = newObjectMapperWithImplicitNullsFor(schema);
+    public void testRoundTrip_KeepNulls_RequireNulls() throws IOException {
+      ObjectMapper objectMapper =
+          newObjectMapperWith(
+              RowJsonSerializer.forSchema(schema), RowJsonDeserializer.forSchema(schema));
+      Row parsedRow = objectMapper.readValue(objectMapper.writeValueAsString(row), Row.class);
+
+      assertThat(row, equalTo(parsedRow));
+    }
+
+    @Test
+    public void testRoundTrip_DropNulls_AllowMissingOrNull() throws IOException {
+      ObjectMapper objectMapper =
+          newObjectMapperWith(
+              RowJsonSerializer.forSchema(schema).withDropNullsOnWrite(true),
+              RowJsonDeserializer.forSchema(schema)
+                  .withMissingFieldBehavior(NullBehavior.ALLOW_MISSING_OR_NULL));
+      Row parsedRow = objectMapper.readValue(objectMapper.writeValueAsString(row), Row.class);
+
+      assertThat(row, equalTo(parsedRow));
+    }
+
+    @Test
+    public void testRoundTrip_KeepNulls_AllowMissingOrNull() throws IOException {
+      ObjectMapper objectMapper =
+          newObjectMapperWith(
+              RowJsonSerializer.forSchema(schema).withDropNullsOnWrite(false),
+              RowJsonDeserializer.forSchema(schema)
+                  .withMissingFieldBehavior(NullBehavior.ALLOW_MISSING_OR_NULL));
+      Row parsedRow = objectMapper.readValue(objectMapper.writeValueAsString(row), Row.class);
+
+      assertThat(row, equalTo(parsedRow));
+    }
+
+    @Test
+    public void testRoundTrip_DropNulls_RequireMissing() throws IOException {
+      ObjectMapper objectMapper =
+          newObjectMapperWith(
+              RowJsonSerializer.forSchema(schema).withDropNullsOnWrite(true),
+              RowJsonDeserializer.forSchema(schema)
+                  .withMissingFieldBehavior(NullBehavior.REQUIRE_MISSING));
+      Row parsedRow = objectMapper.readValue(objectMapper.writeValueAsString(row), Row.class);
+
+      assertThat(row, equalTo(parsedRow));
+    }
+
+    @Test
+    public void testRoundTrip_KeepNulls_RequireNull() throws IOException {
+      ObjectMapper objectMapper =
+          newObjectMapperWith(
+              RowJsonSerializer.forSchema(schema).withDropNullsOnWrite(false),
+              RowJsonDeserializer.forSchema(schema)
+                  .withMissingFieldBehavior(NullBehavior.REQUIRE_NULL));
       Row parsedRow = objectMapper.readValue(objectMapper.writeValueAsString(row), Row.class);
 
       assertThat(row, equalTo(parsedRow));
     }
   }
+
 
   @RunWith(JUnit4.class)
   public static class DeserializerTests {
@@ -417,7 +355,9 @@ public class RowJsonTest {
       thrown.expect(UnsupportedRowJsonException.class);
       thrown.expectMessage("Expected JSON array");
 
-      newObjectMapperFor(schema).readValue(rowString, Row.class);
+      newObjectMapperWith(
+              RowJsonSerializer.forSchema(schema), RowJsonDeserializer.forSchema(schema))
+          .readValue(rowString, Row.class);
     }
 
     @Test
@@ -437,7 +377,9 @@ public class RowJsonTest {
       thrown.expect(UnsupportedRowJsonException.class);
       thrown.expectMessage("Expected JSON object");
 
-      newObjectMapperFor(schema).readValue(rowString, Row.class);
+      newObjectMapperWith(
+              RowJsonSerializer.forSchema(schema), RowJsonDeserializer.forSchema(schema))
+          .readValue(rowString, Row.class);
     }
 
     @Test
@@ -449,7 +391,84 @@ public class RowJsonTest {
       thrown.expect(UnsupportedRowJsonException.class);
       thrown.expectMessage("'f_string' is not present");
 
-      newObjectMapperFor(schema).readValue(rowString, Row.class);
+      newObjectMapperWith(RowJsonDeserializer.forSchema(schema)).readValue(rowString, Row.class);
+    }
+
+    @Test
+    public void testRequireNullThrowsForMissingNullableField() throws Exception {
+      Schema schema =
+          Schema.builder()
+              .addByteField("f_byte")
+              .addNullableField("f_string", FieldType.STRING)
+              .build();
+
+      String rowString = "{\n" + "\"f_byte\" : 12\n" + "}";
+
+      thrown.expect(UnsupportedRowJsonException.class);
+      thrown.expectMessage("'f_string'");
+
+      newObjectMapperWith(RowJsonDeserializer.forSchema(schema)).readValue(rowString, Row.class);
+    }
+
+    @Test
+    public void testRequireNullAcceptsNullValue() throws Exception {
+      Schema schema =
+          Schema.builder()
+              .addByteField("f_byte")
+              .addNullableField("f_string", FieldType.STRING)
+              .build();
+
+      String rowString = "{\"f_byte\": 12, \"f_string\": null}";
+
+      assertThat(
+          newObjectMapperWith(RowJsonDeserializer.forSchema(schema))
+              .readValue(rowString, Row.class),
+          equalTo(
+              Row.withSchema(schema)
+                  .withFieldValue("f_byte", (byte) 12)
+                  .withFieldValue("f_string", null)
+                  .build()));
+    }
+
+    @Test
+    public void testRequireMissingThrowsForNullValue() throws Exception {
+      Schema schema =
+          Schema.builder()
+              .addByteField("f_byte")
+              .addNullableField("f_string", FieldType.STRING)
+              .build();
+
+      String rowString = "{\"f_byte\": 12, \"f_string\": null}";
+
+      thrown.expect(UnsupportedRowJsonException.class);
+      thrown.expectMessage("'f_string'");
+
+      newObjectMapperWith(
+              RowJsonDeserializer.forSchema(schema)
+                  .withMissingFieldBehavior(NullBehavior.REQUIRE_MISSING))
+          .readValue(rowString, Row.class);
+    }
+
+    @Test
+    public void testRequireMissingAcceptsMissingField() throws Exception {
+      Schema schema =
+          Schema.builder()
+              .addByteField("f_byte")
+              .addNullableField("f_string", FieldType.STRING)
+              .build();
+
+      String rowString = "{\"f_byte\": 12}";
+
+      assertThat(
+          newObjectMapperWith(
+                  RowJsonDeserializer.forSchema(schema)
+                      .withMissingFieldBehavior(NullBehavior.REQUIRE_MISSING))
+              .readValue(rowString, Row.class),
+          equalTo(
+              Row.withSchema(schema)
+                  .withFieldValue("f_byte", (byte) 12)
+                  .withFieldValue("f_string", null)
+                  .build()));
     }
 
     @Test
@@ -563,7 +582,9 @@ public class RowJsonTest {
       String fieldName = "f_" + fieldType.getTypeName().name().toLowerCase();
       Schema schema = schemaWithField(fieldName, fieldType);
       Row expectedRow = Row.withSchema(schema).addValues(expectedRowFieldValue).build();
-      ObjectMapper jsonParser = newObjectMapperFor(schema);
+      ObjectMapper jsonParser =
+          newObjectMapperWith(
+              RowJsonSerializer.forSchema(schema), RowJsonDeserializer.forSchema(schema));
 
       Row parsedRow = jsonParser.readValue(jsonObjectWith(fieldName, jsonFieldValue), Row.class);
 
@@ -651,7 +672,9 @@ public class RowJsonTest {
       String fieldName = "f_" + fieldType.getTypeName().name().toLowerCase();
 
       Schema schema = schemaWithField(fieldName, fieldType);
-      ObjectMapper jsonParser = newObjectMapperFor(schema);
+      ObjectMapper jsonParser =
+          newObjectMapperWith(
+              RowJsonSerializer.forSchema(schema), RowJsonDeserializer.forSchema(schema));
 
       thrown.expectMessage(fieldName);
       thrown.expectCause(unsupportedWithMessage(jsonFieldValue, "out of range"));
@@ -678,24 +701,19 @@ public class RowJsonTest {
         hasProperty("message", stringContainsInOrder(Arrays.asList(message))));
   }
 
-  private static ObjectMapper newObjectMapperFor(Schema schema) {
+  private static ObjectMapper newObjectMapperWith(
+      RowJsonSerializer ser, RowJsonDeserializer deser) {
     SimpleModule simpleModule = new SimpleModule("rowSerializationTesModule");
-    simpleModule.addSerializer(Row.class, RowJson.RowJsonSerializer.forSchema(schema));
-    simpleModule.addDeserializer(Row.class, RowJson.RowJsonDeserializer.forSchema(schema));
+    simpleModule.addSerializer(Row.class, ser);
+    simpleModule.addDeserializer(Row.class, deser);
     ObjectMapper objectMapper = new ObjectMapper();
     objectMapper.registerModule(simpleModule);
     return objectMapper;
   }
 
-  private static ObjectMapper newObjectMapperWithImplicitNullsFor(Schema schema) {
+  private static ObjectMapper newObjectMapperWith(RowJsonDeserializer deser) {
     SimpleModule simpleModule = new SimpleModule("rowSerializationTesModule");
-    simpleModule.addSerializer(
-        Row.class, RowJson.RowJsonSerializer.forSchema(schema).withDropNullsOnWrite(true));
-    simpleModule.addDeserializer(
-        Row.class,
-        RowJson.RowJsonDeserializer.forSchema(schema)
-            .withMissingFieldBehavior(
-                RowJson.RowJsonDeserializer.MissingFieldBehavior.ALLOW_MISSING));
+    simpleModule.addDeserializer(Row.class, deser);
     ObjectMapper objectMapper = new ObjectMapper();
     objectMapper.registerModule(simpleModule);
     return objectMapper;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/RowJsonTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/RowJsonTest.java
@@ -264,7 +264,9 @@ public class RowJsonTest {
     public void testRoundTrip_KeepNulls_RequireNulls() throws IOException {
       ObjectMapper objectMapper =
           newObjectMapperWith(
-              RowJsonSerializer.forSchema(schema), RowJsonDeserializer.forSchema(schema));
+              RowJsonSerializer.forSchema(schema),
+              RowJsonDeserializer.forSchema(schema)
+                  .withMissingFieldBehavior(NullBehavior.REQUIRE_NULL));
       Row parsedRow = objectMapper.readValue(objectMapper.writeValueAsString(row), Row.class);
 
       assertThat(row, equalTo(parsedRow));
@@ -276,7 +278,7 @@ public class RowJsonTest {
           newObjectMapperWith(
               RowJsonSerializer.forSchema(schema).withDropNullsOnWrite(true),
               RowJsonDeserializer.forSchema(schema)
-                  .withMissingFieldBehavior(NullBehavior.ALLOW_MISSING_OR_NULL));
+                  .withMissingFieldBehavior(NullBehavior.ACCEPT_MISSING_OR_NULL));
       Row parsedRow = objectMapper.readValue(objectMapper.writeValueAsString(row), Row.class);
 
       assertThat(row, equalTo(parsedRow));
@@ -288,7 +290,7 @@ public class RowJsonTest {
           newObjectMapperWith(
               RowJsonSerializer.forSchema(schema).withDropNullsOnWrite(false),
               RowJsonDeserializer.forSchema(schema)
-                  .withMissingFieldBehavior(NullBehavior.ALLOW_MISSING_OR_NULL));
+                  .withMissingFieldBehavior(NullBehavior.ACCEPT_MISSING_OR_NULL));
       Row parsedRow = objectMapper.readValue(objectMapper.writeValueAsString(row), Row.class);
 
       assertThat(row, equalTo(parsedRow));

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/RowJsonTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/RowJsonTest.java
@@ -319,7 +319,6 @@ public class RowJsonTest {
     }
   }
 
-
   @RunWith(JUnit4.class)
   public static class DeserializerTests {
     private static final Boolean BOOLEAN_TRUE_VALUE = true;

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubMessageToRowTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubMessageToRowTest.java
@@ -296,11 +296,7 @@ public class PubsubMessageToRowTest implements Serializable {
 
   @Test
   public void testNestedSchemaMessageInvalidElement() {
-    Schema payloadSchema =
-        Schema.builder()
-            .addNullableField("id", FieldType.INT32)
-            .addNullableField("name", FieldType.STRING)
-            .build();
+    Schema payloadSchema = Schema.builder().addInt32Field("id").addStringField("name").build();
 
     Schema messageSchema =
         Schema.builder()


### PR DESCRIPTION
Adds a third option, REQUIRE_MISSING, where we throw an error if there's a null value. Only a missing field can encode an error.

This also tweaks RowJsonTest so we can re-use ValueTest to exercise the new options.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Apex | Dataflow | Flink | Samza | Spark
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Apex/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
