### PR TITLE
[BEAM-10291] Adding full thread dump upon lull detection

### DIFF
--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -588,7 +588,6 @@ class SdkWorker(object):
       return True
     return False
 
-
   def process_bundle_progress(self,
                               request,  # type: beam_fn_api_pb2.ProcessBundleProgressRequest
                               instruction_id  # type: str

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -591,7 +591,7 @@ class SdkWorker(object):
     for ident, frame in sys._current_frames().items():  # pylint: disable=protected-access
       stack_trace = ''.join(traceback.format_stack(frame))
       _LOGGER.info(
-        'Thread %s(%d):\n%s', id2name.get(ident, ''), ident, stack_trace)
+          'Thread %s(%d):\n%s', id2name.get(ident, ''), ident, stack_trace)
 
   def process_bundle_progress(self,
                               request,  # type: beam_fn_api_pb2.ProcessBundleProgressRequest

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -65,6 +65,7 @@ from apache_beam.runners.worker.data_plane import PeriodicThread
 from apache_beam.runners.worker.statecache import StateCache
 from apache_beam.runners.worker.worker_id_interceptor import WorkerIdInterceptor
 from apache_beam.runners.worker.worker_status import FnApiWorkerStatusHandler
+from apache_beam.runners.worker.worker_status import thread_dump
 from apache_beam.utils import thread_pool_executor
 
 if TYPE_CHECKING:
@@ -587,11 +588,7 @@ class SdkWorker(object):
     return False
 
   def _log_full_thread_dump(self):
-    id2name = {th.ident: th.name for th in threading.enumerate()}
-    for ident, frame in sys._current_frames().items():  # pylint: disable=protected-access
-      stack_trace = ''.join(traceback.format_stack(frame))
-      _LOGGER.info(
-          'Thread %s(%d):\n%s', id2name.get(ident, ''), ident, stack_trace)
+    thread_dump()
 
   def process_bundle_progress(self,
                               request,  # type: beam_fn_api_pb2.ProcessBundleProgressRequest

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -575,11 +575,11 @@ class SdkWorker(object):
           stack_trace)
 
       if self._should_log_full_thread_dump():
-        id2name = {th.ident:th.name for th in threading.enumerate()}
+        id2name = {th.ident: th.name for th in threading.enumerate()}
         for ident, frame in sys._current_frames().items():  # pylint: disable=protected-access
           stack_trace = ''.join(traceback.format_stack(frame))
-          _LOGGER.info('Thread %s(%d):\n%s', id2name.get(ident, ''), ident,
-                       stack_trace)
+          _LOGGER.info(
+              'Thread %s(%d):\n%s', id2name.get(ident, ''), ident, stack_trace)
 
   def _should_log_full_thread_dump(self):
     now = time.time()

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -575,7 +575,7 @@ class SdkWorker(object):
           stack_trace)
 
       if self._should_log_full_thread_dump():
-        id2name = dict([(th.ident, th.name) for th in threading.enumerate()])
+        id2name = {th.ident:th.name for th in threading.enumerate()}
         for ident, frame in sys._current_frames().items():  # pylint: disable=protected-access
           stack_trace = ''.join(traceback.format_stack(frame))
           _LOGGER.info('Thread %s(%d):\n%s', id2name.get(ident, ''), ident,

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
@@ -25,9 +25,12 @@ from __future__ import print_function
 
 import contextlib
 import logging
+import threading
+import time
 import unittest
 from builtins import range
 from collections import namedtuple
+from unittest import mock
 
 import grpc
 
@@ -38,8 +41,11 @@ from apache_beam.portability.api import beam_runner_api_pb2
 from apache_beam.portability.api import metrics_pb2
 from apache_beam.runners.worker import sdk_worker
 from apache_beam.runners.worker import statecache
+from apache_beam.runners.worker import statesampler
 from apache_beam.runners.worker.sdk_worker import CachingStateHandler
+from apache_beam.runners.worker.sdk_worker import SdkWorker
 from apache_beam.utils import thread_pool_executor
+from apache_beam.utils.counters import CounterName
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -120,6 +126,46 @@ class SdkWorkerTest(unittest.TestCase):
 
   def test_fn_registration(self):
     self._check_fn_registration_multi_request((1, 4), (4, 4))
+
+  def test_log_lull_in_bundle_processor(self):
+    bundle_processor_cache = mock.MagicMock()
+    worker = SdkWorker(bundle_processor_cache)
+
+    sampler_info = statesampler.StateSamplerInfo(
+        CounterName('progress-msecs', 'stage_name', 'step_name'),
+        1,
+        400000000000,
+        threading.current_thread())
+
+    now = time.time()
+    log_full_thread_dump_fn_name = 'apache_beam.runners.worker.sdk_worker.SdkWorker._log_full_thread_dump'
+    with mock.patch('logging.Logger.warning') as warn_mock:
+      with mock.patch(log_full_thread_dump_fn_name) as log_full_thread_dump:
+        with mock.patch('time.time') as time_mock:
+          time_mock.return_value = now
+          worker._log_lull_sampler_info(sampler_info)
+
+          processing_template = warn_mock.call_args[0][1]
+          step_name_template = warn_mock.call_args[0][2]
+          traceback = warn_mock.call_args = warn_mock.call_args[0][3]
+
+          self.assertIn('progress-msecs', processing_template)
+          self.assertIn('step_name', step_name_template)
+          self.assertIn('test_log_lull_in_bundle_processor', traceback)
+
+          log_full_thread_dump.assert_called()
+
+    with mock.patch(log_full_thread_dump_fn_name) as log_full_thread_dump:
+      with mock.patch('time.time') as time_mock:
+        time_mock.return_value = now + 6 * 60  # 6 minutes
+        worker._log_lull_sampler_info(sampler_info)
+        log_full_thread_dump.assert_not_called()
+
+    with mock.patch(log_full_thread_dump_fn_name) as log_full_thread_dump:
+      with mock.patch('time.time') as time_mock:
+        time_mock.return_value = now + 21 * 60  # 21 minutes
+        worker._log_lull_sampler_info(sampler_info)
+        log_full_thread_dump.assert_called()
 
 
 class CachingStateHandlerTest(unittest.TestCase):

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
@@ -25,7 +25,6 @@ from __future__ import print_function
 
 import contextlib
 import logging
-import mock
 import threading
 import time
 import unittest
@@ -33,6 +32,7 @@ from builtins import range
 from collections import namedtuple
 
 import grpc
+import mock
 
 from apache_beam.coders import VarIntCoder
 from apache_beam.portability.api import beam_fn_api_pb2
@@ -160,7 +160,8 @@ class SdkWorkerTest(unittest.TestCase):
       with mock.patch('time.time') as time_mock:
         time_mock.return_value = now + 6 * 60  # 6 minutes
         worker._log_lull_sampler_info(sampler_info)
-        self.assertFalse(log_full_thread_dump.called,
+        self.assertFalse(
+            log_full_thread_dump.called,
             'log_full_thread_dump should not be called.')
 
     with mock.patch(log_full_thread_dump_fn_name) as log_full_thread_dump:

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
@@ -160,7 +160,7 @@ class SdkWorkerTest(unittest.TestCase):
       with mock.patch('time.time') as time_mock:
         time_mock.return_value = now + 6 * 60  # 6 minutes
         worker._log_lull_sampler_info(sampler_info)
-        assert not log_full_thread_dump.called, (
+        self.assertFalse(log_full_thread_dump.called,
             'log_full_thread_dump should not be called.')
 
     with mock.patch(log_full_thread_dump_fn_name) as log_full_thread_dump:

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
@@ -138,7 +138,8 @@ class SdkWorkerTest(unittest.TestCase):
         threading.current_thread())
 
     now = time.time()
-    log_full_thread_dump_fn_name = 'apache_beam.runners.worker.sdk_worker.SdkWorker._log_full_thread_dump'
+    log_full_thread_dump_fn_name = \
+        'apache_beam.runners.worker.sdk_worker.SdkWorker._log_full_thread_dump'
     with mock.patch('logging.Logger.warning') as warn_mock:
       with mock.patch(log_full_thread_dump_fn_name) as log_full_thread_dump:
         with mock.patch('time.time') as time_mock:

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
@@ -25,12 +25,12 @@ from __future__ import print_function
 
 import contextlib
 import logging
+import mock
 import threading
 import time
 import unittest
 from builtins import range
 from collections import namedtuple
-from unittest import mock
 
 import grpc
 
@@ -154,19 +154,20 @@ class SdkWorkerTest(unittest.TestCase):
           self.assertIn('step_name', step_name_template)
           self.assertIn('test_log_lull_in_bundle_processor', traceback)
 
-          log_full_thread_dump.assert_called()
+          log_full_thread_dump.assert_called_once_with()
 
     with mock.patch(log_full_thread_dump_fn_name) as log_full_thread_dump:
       with mock.patch('time.time') as time_mock:
         time_mock.return_value = now + 6 * 60  # 6 minutes
         worker._log_lull_sampler_info(sampler_info)
-        log_full_thread_dump.assert_not_called()
+        assert not log_full_thread_dump.called, (
+            'log_full_thread_dump should not be called.')
 
     with mock.patch(log_full_thread_dump_fn_name) as log_full_thread_dump:
       with mock.patch('time.time') as time_mock:
         time_mock.return_value = now + 21 * 60  # 21 minutes
         worker._log_lull_sampler_info(sampler_info)
-        log_full_thread_dump.assert_called()
+        log_full_thread_dump.assert_called_once_with()
 
 
 class CachingStateHandlerTest(unittest.TestCase):


### PR DESCRIPTION
Adding full thread dump upon lull detection to python fnapi sdk harness
R: @tvalentyn 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
