### PR TITLE
[BEAM-10305] Let InMemoryBagUserStateFactory only use a single cache token

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunction.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkExecutableStageFunction.java
@@ -173,7 +173,7 @@ public class FlinkExecutableStageFunction<InputT> extends AbstractRichFunction
 
     final StateRequestHandler userStateHandler;
     if (executableStage.getUserStates().size() > 0) {
-      bagUserStateHandlerFactory = new InMemoryBagUserStateFactory();
+      bagUserStateHandlerFactory = new InMemoryBagUserStateFactory<>();
       userStateHandler =
           StateRequestHandlers.forBagUserStateHandlerFactory(
               processBundleDescriptor, bagUserStateHandlerFactory);

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperatorTest.java
@@ -23,7 +23,6 @@ import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.instanceOf;
 import static org.hamcrest.Matchers.is;
-import static org.hamcrest.Matchers.iterableWithSize;
 import static org.hamcrest.collection.IsIterableContainingInOrder.contains;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotEquals;
@@ -83,7 +82,6 @@ import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.coders.VoidCoder;
-import org.apache.beam.sdk.fn.IdGenerator;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.state.BagState;
@@ -845,72 +843,63 @@ public class ExecutableStageDoFnOperatorTest {
     InMemoryStateInternals test = InMemoryStateInternals.forKey("test");
     KeyedStateBackend<ByteBuffer> stateBackend = FlinkStateInternalsTest.createStateBackend();
 
+    ExecutableStageDoFnOperator.BagUserStateFactory<Integer, GlobalWindow> bagUserStateFactory =
+        new ExecutableStageDoFnOperator.BagUserStateFactory<>(
+            test, stateBackend, NoopLock.get(), null);
+
+    ByteString key1 = ByteString.copyFrom("key1", Charsets.UTF_8);
+    ByteString key2 = ByteString.copyFrom("key2", Charsets.UTF_8);
+
+    Map<String, Map<String, ProcessBundleDescriptors.BagUserStateSpec>> userStateMapMock =
+        Mockito.mock(Map.class);
+    Map<String, ProcessBundleDescriptors.BagUserStateSpec> transformMap = Mockito.mock(Map.class);
+
+    final String userState1 = "userstate1";
+    ProcessBundleDescriptors.BagUserStateSpec bagUserStateSpec1 = mockBagUserState(userState1);
+    when(transformMap.get(userState1)).thenReturn(bagUserStateSpec1);
+
+    final String userState2 = "userstate2";
+    ProcessBundleDescriptors.BagUserStateSpec bagUserStateSpec2 = mockBagUserState(userState2);
+    when(transformMap.get(userState2)).thenReturn(bagUserStateSpec2);
+
+    when(userStateMapMock.get(anyString())).thenReturn(transformMap);
+    when(processBundleDescriptor.getBagUserStateSpecs()).thenReturn(userStateMapMock);
+    StateRequestHandler stateRequestHandler =
+        StateRequestHandlers.forBagUserStateHandlerFactory(
+            processBundleDescriptor, bagUserStateFactory);
+
     // User state the cache token is valid for the lifetime of the operator
-    for (String expectedToken : new String[] {"first token", "second token"}) {
-      final IdGenerator cacheTokenGenerator = () -> expectedToken;
-      ExecutableStageDoFnOperator.BagUserStateFactory<Integer, GlobalWindow> bagUserStateFactory =
-          new ExecutableStageDoFnOperator.BagUserStateFactory<>(
-              cacheTokenGenerator, test, stateBackend, NoopLock.get(), null);
+    final BeamFnApi.ProcessBundleRequest.CacheToken expectedCacheToken =
+        Iterables.getOnlyElement(stateRequestHandler.getCacheTokens());
 
-      ByteString key1 = ByteString.copyFrom("key1", Charsets.UTF_8);
-      ByteString key2 = ByteString.copyFrom("key2", Charsets.UTF_8);
+    // Make a request to generate initial cache token
+    stateRequestHandler.handle(getRequest(key1, userState1));
+    BeamFnApi.ProcessBundleRequest.CacheToken returnedCacheToken =
+        Iterables.getOnlyElement(stateRequestHandler.getCacheTokens());
+    assertThat(returnedCacheToken.hasUserState(), is(true));
+    assertThat(returnedCacheToken, is(expectedCacheToken));
 
-      Map<String, Map<String, ProcessBundleDescriptors.BagUserStateSpec>> userStateMapMock =
-          Mockito.mock(Map.class);
-      Map<String, ProcessBundleDescriptors.BagUserStateSpec> transformMap = Mockito.mock(Map.class);
+    List<RequestGenerator> generators =
+        Arrays.asList(
+            ExecutableStageDoFnOperatorTest::getRequest,
+            ExecutableStageDoFnOperatorTest::getAppend,
+            ExecutableStageDoFnOperatorTest::getClear);
 
-      final String userState1 = "userstate1";
-      ProcessBundleDescriptors.BagUserStateSpec bagUserStateSpec1 = mockBagUserState(userState1);
-      when(transformMap.get(userState1)).thenReturn(bagUserStateSpec1);
+    for (RequestGenerator req : generators) {
+      // For every state read the tokens remains unchanged
+      stateRequestHandler.handle(req.makeRequest(key1, userState1));
+      assertThat(
+          Iterables.getOnlyElement(stateRequestHandler.getCacheTokens()), is(expectedCacheToken));
 
-      final String userState2 = "userstate2";
-      ProcessBundleDescriptors.BagUserStateSpec bagUserStateSpec2 = mockBagUserState(userState2);
-      when(transformMap.get(userState2)).thenReturn(bagUserStateSpec2);
+      // The token is still valid for another key in the same key range
+      stateRequestHandler.handle(req.makeRequest(key2, userState1));
+      assertThat(
+          Iterables.getOnlyElement(stateRequestHandler.getCacheTokens()), is(expectedCacheToken));
 
-      when(userStateMapMock.get(anyString())).thenReturn(transformMap);
-      when(processBundleDescriptor.getBagUserStateSpecs()).thenReturn(userStateMapMock);
-      StateRequestHandler stateRequestHandler =
-          StateRequestHandlers.forBagUserStateHandlerFactory(
-              processBundleDescriptor, bagUserStateFactory);
-
-      // There should be no cache token available before any requests have been made
-      assertThat(stateRequestHandler.getCacheTokens(), iterableWithSize(0));
-
-      // Make a request to generate initial cache token
-      stateRequestHandler.handle(getRequest(key1, userState1));
-      BeamFnApi.ProcessBundleRequest.CacheToken cacheTokenStruct =
-          Iterables.getOnlyElement(stateRequestHandler.getCacheTokens());
-      assertThat(cacheTokenStruct.hasUserState(), is(true));
-      ByteString cacheToken = cacheTokenStruct.getToken();
-      final ByteString expectedCacheToken =
-          ByteString.copyFrom(expectedToken.getBytes(Charsets.UTF_8));
-      assertThat(cacheToken, is(expectedCacheToken));
-
-      List<RequestGenerator> generators =
-          Arrays.asList(
-              ExecutableStageDoFnOperatorTest::getRequest,
-              ExecutableStageDoFnOperatorTest::getAppend,
-              ExecutableStageDoFnOperatorTest::getClear);
-
-      for (RequestGenerator req : generators) {
-        // For every state read the tokens remains unchanged
-        stateRequestHandler.handle(req.makeRequest(key1, userState1));
-        assertThat(
-            Iterables.getOnlyElement(stateRequestHandler.getCacheTokens()).getToken(),
-            is(expectedCacheToken));
-
-        // The token is still valid for another key in the same key range
-        stateRequestHandler.handle(req.makeRequest(key2, userState1));
-        assertThat(
-            Iterables.getOnlyElement(stateRequestHandler.getCacheTokens()).getToken(),
-            is(expectedCacheToken));
-
-        // The token is still valid for another state cell in the same key range
-        stateRequestHandler.handle(req.makeRequest(key2, userState2));
-        assertThat(
-            Iterables.getOnlyElement(stateRequestHandler.getCacheTokens()).getToken(),
-            is(expectedCacheToken));
-      }
+      // The token is still valid for another state cell in the same key range
+      stateRequestHandler.handle(req.makeRequest(key2, userState2));
+      assertThat(
+          Iterables.getOnlyElement(stateRequestHandler.getCacheTokens()), is(expectedCacheToken));
     }
   }
 

--- a/sdks/python/apache_beam/runners/portability/flink_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/flink_runner_test.py
@@ -295,27 +295,17 @@ if __name__ == '__main__':
         lines_expected.update([
             # Gauges for the last finished bundle
             'stateful.beam.metric:statecache:capacity: 123',
-            # These are off by 10 because the first bundle contains all the keys
-            # once. Caching is only initialized after the first bundle. Caching
-            # depends on the cache token which is lazily initialized by the
-            # Runner's StateRequestHandlers.
-            'stateful.beam.metric:statecache:size: 20',
+            'stateful.beam.metric:statecache:size: 10',
             'stateful.beam.metric:statecache:get: 20',
             'stateful.beam.metric:statecache:miss: 0',
             'stateful.beam.metric:statecache:hit: 20',
             'stateful.beam.metric:statecache:put: 0',
             'stateful.beam.metric:statecache:evict: 0',
             # Counters
-            # (total of get/hit will be off by 10 due to the cross-bundle
-            # caching only getting initialized after the first bundle.
-            # Cross-bundle caching depends on the cache token which is lazily
-            # initialized by the Runner's StateRequestHandlers).
-            # If cross-bundle caching is not requested, caching is done
-            # at the bundle level.
             'stateful.beam.metric:statecache:get_total: 220',
-            'stateful.beam.metric:statecache:miss_total: 20',
-            'stateful.beam.metric:statecache:hit_total: 200',
-            'stateful.beam.metric:statecache:put_total: 20',
+            'stateful.beam.metric:statecache:miss_total: 10',
+            'stateful.beam.metric:statecache:hit_total: 210',
+            'stateful.beam.metric:statecache:put_total: 10',
             'stateful.beam.metric:statecache:evict_total: 0',
         ])
       else:

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -870,7 +870,11 @@ class GrpcStateHandler(StateHandler):
 
 
 class CachingStateHandler(object):
-  """ A State handler which retrieves and caches state. """
+  """ A State handler which retrieves and caches state.
+   If caching is activated, caches across bundles using a supplied cache token.
+   If activated but no cache token is supplied, caching is done at the bundle
+   level.
+  """
 
   def __init__(self,
                global_state_cache,  # type: StateCache


### PR DESCRIPTION
When the state cache is enabled in the Python SDK, the batch mode of the Flink
Runner currently only allows a single user state cell because a new cache token
is generated for each state cell; the caching code in the Python SDK Harness
only supports one cache token per user state handler.

Theoretically multiple cache tokens would work but would just be adding to the
payload. We should make sure to just send a single cache token in batch
mode (which is already the case in streaming)

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark
--- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
