### PR TITLE
[BEAM-10308] Make component ID assignments consistent across PipelineContext instances

### DIFF
--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -58,6 +58,7 @@ import sys
 import tempfile
 from builtins import object
 from builtins import zip
+from collections import defaultdict
 from typing import TYPE_CHECKING
 from typing import Dict
 from typing import FrozenSet
@@ -221,12 +222,11 @@ class Pipeline(object):
     # then the transform will have to be cloned with a new label.
     self.applied_labels = set()  # type: Set[str]
 
-    # Create a context for assigning IDs to components. Ensures that any
+    # Create a ComponentIdMap for assigning IDs to components. Ensures that any
     # components that receive an ID during pipeline construction (for example in
     # ExternalTransform), will receive the same component ID when generating the
     # full pipeline proto.
-    from apache_beam.runners import pipeline_context
-    self._component_id_context = pipeline_context.ComponentIdContext()
+    self.component_id_map = ComponentIdMap()
 
 
   @property  # type: ignore[misc]  # decorated property not supported
@@ -819,7 +819,7 @@ class Pipeline(object):
     if context is None:
       context = pipeline_context.PipelineContext(
           use_fake_coders=use_fake_coders,
-          component_id_context=self._component_id_context,
+          component_id_map=self.component_id_map,
           default_environment=default_environment)
     elif default_environment is not None:
       raise ValueError(
@@ -1347,6 +1347,32 @@ class PTransformOverride(with_metaclass(abc.ABCMeta,
     """
     # Returns a PTransformReplacement
     raise NotImplementedError
+
+
+class ComponentIdMap(object):
+  """A utility for assigning unique component ids to Beam components.
+
+  Component ID assignments are only guaranteed to be unique and consistent
+  within the scope of a ComponentIdMap instance.
+  """
+  def __init__(self, namespace="ref"):
+    self.namespace = namespace
+    self._counters = defaultdict(lambda: 0)  # type: Dict[type, int]
+    self._obj_to_id = {}  # type: Dict[Any, str]
+
+  def get_or_assign(self, obj=None, obj_type=None, label=None):
+    if obj not in self._obj_to_id:
+      self._obj_to_id[obj] = self._unique_ref(obj, obj_type, label)
+
+    return self._obj_to_id[obj]
+
+  def _unique_ref(self, obj=None, obj_type=None, label=None):
+    self._counters[obj_type] += 1
+    return "%s_%s_%s_%d" % (
+        self.namespace,
+        obj_type.__name__,
+        label or type(obj).__name__,
+        self._counters[obj_type])
 
 
 if sys.version_info >= (3, ):

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -221,6 +221,14 @@ class Pipeline(object):
     # then the transform will have to be cloned with a new label.
     self.applied_labels = set()  # type: Set[str]
 
+    # Create a context for assigning IDs to components. Ensures that any
+    # components that receive an ID during pipeline construction (for example in
+    # ExternalTransform), will receive the same component ID when generating the
+    # full pipeline proto.
+    from apache_beam.runners import pipeline_context
+    self._component_id_context = pipeline_context.ComponentIdContext()
+
+
   @property  # type: ignore[misc]  # decorated property not supported
   @deprecated(
       since='First stable release',
@@ -811,6 +819,7 @@ class Pipeline(object):
     if context is None:
       context = pipeline_context.PipelineContext(
           use_fake_coders=use_fake_coders,
+          component_id_context=self._component_id_context,
           default_environment=default_environment)
     elif default_environment is not None:
       raise ValueError(

--- a/sdks/python/apache_beam/runners/pipeline_context.py
+++ b/sdks/python/apache_beam/runners/pipeline_context.py
@@ -65,6 +65,7 @@ class _UniqueRefAssigner(object):
 
   def get_or_assign(self, obj=None, label=None):
     # type: (Optional[Any], Optional[str]) -> str
+
     """Retrieve the unique ref for the given object.
 
     Generates and assigns a unique ref if one hasn't been assigned yet. label
@@ -82,6 +83,7 @@ class _UniqueRefAssigner(object):
   @classmethod
   def with_base(cls, base):
     # type: (str) -> _UniqueRefAssigner
+
     """Return the _UniqueRefAssigner with the given base string.
 
     Creates a new instance if one doesn't already exist for this base string."""

--- a/sdks/python/apache_beam/runners/pipeline_context.py
+++ b/sdks/python/apache_beam/runners/pipeline_context.py
@@ -104,7 +104,7 @@ class _PipelineContextMap(object):
     assert isinstance(obj, self._obj_type)
     id = self._pipeline_context.component_id_context.get_or_assign(
         obj, self._obj_type, label)
-    if obj not in self._id_to_obj.values():
+    if obj not in set(self._id_to_obj.values()):
       self._id_to_obj[id] = obj
       self._id_to_proto[id] = obj.to_runner_api(self._pipeline_context)
     return id

--- a/sdks/python/apache_beam/runners/pipeline_context.py
+++ b/sdks/python/apache_beam/runners/pipeline_context.py
@@ -64,12 +64,12 @@ class _UniqueRefAssigner(object):
     self._obj_to_id = {}  # type: Dict[Any, str]
 
   def get_or_assign(self, obj=None, label=None):
+    # type: (Optional[Any], Optional[str]) -> str
     """Retrieve the unique ref for the given object.
 
     Generates and assigns a unique ref if one hasn't been assigned yet. label
     will be incorporated into the unique ref when assigning a new unique ref,
     otherwise it is ignored."""
-    # type: (Optional[Any], Optional[str]) -> str
     if obj not in self._obj_to_id:
       self._obj_to_id[obj] = self._unique_ref(obj, label)
 
@@ -81,10 +81,10 @@ class _UniqueRefAssigner(object):
 
   @classmethod
   def with_base(cls, base):
+    # type: (str) -> _UniqueRefAssigner
     """Return the _UniqueRefAssigner with the given base string.
 
-    Creates one if it doesn't already exist."""
-    # type: (str) -> _UniqueRefAssigner
+    Creates a new instance if one doesn't already exist for this base string."""
     if not base in cls._INSTANCES:
       cls._INSTANCES[base] = _UniqueRefAssigner(base)
 

--- a/sdks/python/apache_beam/runners/pipeline_context.py
+++ b/sdks/python/apache_beam/runners/pipeline_context.py
@@ -91,6 +91,7 @@ class _PipelineContextMap(object):
     self._pipeline_context = context
     self._obj_type = obj_type
     self._namespace = namespace
+    self._obj_to_id = {}  # type: Dict[Any, str]
     self._id_to_obj = {}  # type: Dict[str, Any]
     self._id_to_proto = dict(proto_map) if proto_map else {}
 
@@ -101,13 +102,13 @@ class _PipelineContextMap(object):
 
   def get_id(self, obj, label=None):
     # type: (Any, Optional[str]) -> str
-    assert isinstance(obj, self._obj_type)
-    id = self._pipeline_context.component_id_context.get_or_assign(
-        obj, self._obj_type, label)
-    if obj not in set(self._id_to_obj.values()):
+    if obj not in self._obj_to_id:
+      id = self._pipeline_context.component_id_context.get_or_assign(
+          obj, self._obj_type, label)
       self._id_to_obj[id] = obj
+      self._obj_to_id[obj] = id
       self._id_to_proto[id] = obj.to_runner_api(self._pipeline_context)
-    return id
+    return self._obj_to_id[obj]
 
   def get_proto(self, obj, label=None):
     # type: (Any, Optional[str]) -> message.Message

--- a/sdks/python/apache_beam/runners/pipeline_context.py
+++ b/sdks/python/apache_beam/runners/pipeline_context.py
@@ -56,7 +56,6 @@ class ComponentIdContext(object):
   Component ID assignments are only guaranteed to be unique and consistent
   within the scope of a ComponentIdContext instance.
   """
-
   def __init__(self, namespace="ref"):
     self.namespace = namespace
     self._counters = defaultdict(lambda: 0)  # type: Dict[type, int]

--- a/sdks/python/apache_beam/runners/pipeline_context_test.py
+++ b/sdks/python/apache_beam/runners/pipeline_context_test.py
@@ -53,12 +53,12 @@ class PipelineContextTest(unittest.TestCase):
     self.assertEqual(
         coders.BytesCoder(), context2.coders.get_by_id(bytes_coder_ref))
 
-  def test_id_assignment_spans_multiple_instances(self):
+  def test_common_id_assignment(self):
     context = pipeline_context.PipelineContext()
     float_coder_ref = context.coders.get_id(coders.FloatCoder())
     bytes_coder_ref = context.coders.get_id(coders.BytesCoder())
     context2 = pipeline_context.PipelineContext(
-        component_id_context=context.component_id_context)
+        component_id_map=context.component_id_map)
 
     bytes_coder_ref2 = context2.coders.get_id(coders.BytesCoder())
     float_coder_ref2 = context2.coders.get_id(coders.FloatCoder())

--- a/sdks/python/apache_beam/runners/pipeline_context_test.py
+++ b/sdks/python/apache_beam/runners/pipeline_context_test.py
@@ -53,6 +53,18 @@ class PipelineContextTest(unittest.TestCase):
     self.assertEqual(
         coders.BytesCoder(), context2.coders.get_by_id(bytes_coder_ref))
 
+  def test_ref_assignment_spans_multiple_instances(self):
+    context = pipeline_context.PipelineContext()
+    float_coder_ref = context.coders.get_id(coders.FloatCoder())
+    bytes_coder_ref = context.coders.get_id(coders.BytesCoder())
+    context2 = pipeline_context.PipelineContext()
+
+    bytes_coder_ref2 = context2.coders.get_id(coders.BytesCoder())
+    float_coder_ref2 = context2.coders.get_id(coders.FloatCoder())
+
+    self.assertEqual(bytes_coder_ref, bytes_coder_ref2)
+    self.assertEqual(float_coder_ref, float_coder_ref2)
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/sdks/python/apache_beam/runners/pipeline_context_test.py
+++ b/sdks/python/apache_beam/runners/pipeline_context_test.py
@@ -53,11 +53,12 @@ class PipelineContextTest(unittest.TestCase):
     self.assertEqual(
         coders.BytesCoder(), context2.coders.get_by_id(bytes_coder_ref))
 
-  def test_ref_assignment_spans_multiple_instances(self):
+  def test_id_assignment_spans_multiple_instances(self):
     context = pipeline_context.PipelineContext()
     float_coder_ref = context.coders.get_id(coders.FloatCoder())
     bytes_coder_ref = context.coders.get_id(coders.BytesCoder())
-    context2 = pipeline_context.PipelineContext()
+    context2 = pipeline_context.PipelineContext(
+        component_id_context=context.component_id_context)
 
     bytes_coder_ref2 = context2.coders.get_id(coders.BytesCoder())
     float_coder_ref2 = context2.coders.get_id(coders.FloatCoder())

--- a/sdks/python/apache_beam/transforms/external.py
+++ b/sdks/python/apache_beam/transforms/external.py
@@ -286,7 +286,8 @@ class ExternalTransform(ptransform.PTransform):
     pipeline = (
         next(iter(self._inputs.values())).pipeline
         if self._inputs else pvalueish.pipeline)
-    context = pipeline_context.PipelineContext()
+    context = pipeline_context.PipelineContext(
+        component_id_context=pipeline._component_id_context)
     transform_proto = beam_runner_api_pb2.PTransform(
         unique_name=pipeline._current_transform().full_label,
         spec=beam_runner_api_pb2.FunctionSpec(

--- a/sdks/python/apache_beam/transforms/external.py
+++ b/sdks/python/apache_beam/transforms/external.py
@@ -287,7 +287,7 @@ class ExternalTransform(ptransform.PTransform):
         next(iter(self._inputs.values())).pipeline
         if self._inputs else pvalueish.pipeline)
     context = pipeline_context.PipelineContext(
-        component_id_context=pipeline._component_id_context)
+        component_id_map=pipeline.component_id_map)
     transform_proto = beam_runner_api_pb2.PTransform(
         unique_name=pipeline._current_transform().full_label,
         spec=beam_runner_api_pb2.FunctionSpec(


### PR DESCRIPTION
This PR creates a global cache for component ID assignments made in PipelineContext instances. See BEAM-10308 and BEAM-10143 for motivation.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark
--- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
