### PR TITLE
[BEAM-10313] Add without_defaults to built-in Combiners in Python

### DIFF
--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -64,7 +64,7 @@ TimestampType = Union[int, float, Timestamp, Duration]
 
 
 class CombinerWithoutDefaults(ptransform.PTransform):
-  """Parent class to inherit  without_defaults to built-in Combiners"""
+  """Parent class to inherit without_defaults to built-in Combiners"""
   def __init__(self, has_defaults=True):
     self.has_defaults = has_defaults
 

--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -64,6 +64,7 @@ TimestampType = Union[int, float, Timestamp, Duration]
 
 
 class CombinerWithoutDefaults(ptransform.PTransform):
+  """Parent class to inherit  without_defaults to built-in Combiners"""
   def __init__(self, has_defaults=True):
     self.has_defaults = has_defaults
 

--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -64,7 +64,7 @@ TimestampType = Union[int, float, Timestamp, Duration]
 
 
 class CombinerWithoutDefaults(ptransform.PTransform):
-  """Parent class to inherit without_defaults to built-in Combiners"""
+  """Super class to inherit without_defaults to built-in Combiners."""
   def __init__(self, has_defaults=True):
     self.has_defaults = has_defaults
 

--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -68,9 +68,9 @@ class CombinerWithoutDefaults(ptransform.PTransform):
     self.has_defaults = has_defaults
 
   def with_defaults(self, has_defaults=True):
-      new = copy.copy(self)
-      new.has_defaults = has_defaults
-      return new
+    new = copy.copy(self)
+    new.has_defaults = has_defaults
+    return new
 
   def without_defaults(self):
     return self.with_defaults(False)

--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -78,10 +78,6 @@ class Mean(object):
   """Combiners for computing arithmetic means of elements."""
   class Globally(CombinerWithoutDefaults):
     """combiners.Mean.Globally computes the arithmetic mean of the elements."""
-    def __init__(self, has_defaults=True):
-      super(Mean.Globally, self).__init__()
-      self.has_defaults = has_defaults
-
     def expand(self, pcoll):
       if self.has_defaults:
         return pcoll | core.CombineGlobally(MeanCombineFn())

--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -62,9 +62,21 @@ V = TypeVar('V')
 TimestampType = Union[int, float, Timestamp, Duration]
 
 
+class CombinerWithoutDefaults(ptransform.PTransform):
+  def __init__(self, has_defaults=True):
+    self.has_defaults = has_defaults
+
+  def with_defaults(self, has_defaults=True):
+    self.has_defaults = has_defaults
+    return self
+
+  def without_defaults(self):
+    return self.with_defaults(False)
+
+
 class Mean(object):
   """Combiners for computing arithmetic means of elements."""
-  class Globally(ptransform.PTransform):
+  class Globally(CombinerWithoutDefaults):
     """combiners.Mean.Globally computes the arithmetic mean of the elements."""
     def __init__(self, has_defaults=True):
       super(Mean.Globally, self).__init__()
@@ -75,12 +87,6 @@ class Mean(object):
         return pcoll | core.CombineGlobally(MeanCombineFn())
       else:
         return pcoll | core.CombineGlobally(MeanCombineFn()).without_defaults()
-
-    def with_defaults(self, has_defaults=True):
-      return Mean.Globally(has_defaults=has_defaults)
-
-    def without_defaults(self):
-      return self.with_defaults(False)
 
   class PerKey(ptransform.PTransform):
     """combiners.Mean.PerKey finds the means of the values for each key."""
@@ -121,10 +127,13 @@ class MeanCombineFn(core.CombineFn):
 
 class Count(object):
   """Combiners for counting elements."""
-  class Globally(ptransform.PTransform):
+  class Globally(CombinerWithoutDefaults):
     """combiners.Count.Globally counts the total number of elements."""
     def expand(self, pcoll):
-      return pcoll | core.CombineGlobally(CountCombineFn())
+      if self.has_defaults:
+        return pcoll | core.CombineGlobally(CountCombineFn())
+      else:
+        return pcoll | core.CombineGlobally(CountCombineFn()).without_defaults()
 
   class PerKey(ptransform.PTransform):
     """combiners.Count.PerKey counts how many elements each unique key has."""
@@ -169,7 +178,7 @@ class Top(object):
 
   # pylint: disable=no-self-argument
 
-  class Of(ptransform.PTransform):
+  class Of(CombinerWithoutDefaults):
     """Obtain a list of the compare-most N elements in a PCollection.
 
     This transform will retrieve the n greatest elements in the PCollection
@@ -193,6 +202,7 @@ class Top(object):
         *args: as described above.
         **kwargs: as described above.
       """
+      super(Top.Of, self).__init__()
       if compare:
         warnings.warn(
             'Compare not available in Python 3, use key instead.',
@@ -252,10 +262,16 @@ class Top(object):
                 | core.GroupByKey()
                 | core.ParDo(_MergeTopPerBundle(self._n, compare, self._key)))
       else:
-        return pcoll | core.CombineGlobally(
-            TopCombineFn(self._n, compare, self._key, self._reverse),
-            *self._args,
-            **self._kwargs)
+        if self.has_defaults:
+          return pcoll | core.CombineGlobally(
+              TopCombineFn(self._n, compare, self._key, self._reverse),
+              *self._args,
+              **self._kwargs)
+        else:
+          return pcoll | core.CombineGlobally(
+              TopCombineFn(self._n, compare, self._key, self._reverse),
+              *self._args,
+              **self._kwargs).without_defaults()
 
   class PerKey(ptransform.PTransform):
     """Identifies the compare-most N elements associated with each key.
@@ -338,15 +354,21 @@ class Top(object):
 
   @staticmethod
   @ptransform.ptransform_fn
-  def Largest(pcoll, n):
+  def Largest(pcoll, n, has_defaults=True):
     """Obtain a list of the greatest N elements in a PCollection."""
-    return pcoll | Top.Of(n)
+    if has_defaults:
+      return pcoll | Top.Of(n)
+    else:
+      return pcoll | Top.Of(n).without_defaults()
 
   @staticmethod
   @ptransform.ptransform_fn
-  def Smallest(pcoll, n):
+  def Smallest(pcoll, n, has_defaults=True):
     """Obtain a list of the least N elements in a PCollection."""
-    return pcoll | Top.Of(n, reverse=True)
+    if has_defaults:
+      return pcoll | Top.Of(n, reverse=True)
+    else:
+      return pcoll | Top.Of(n, reverse=True).without_defaults()
 
   @staticmethod
   @ptransform.ptransform_fn
@@ -633,13 +655,18 @@ class Sample(object):
 
   # pylint: disable=no-self-argument
 
-  class FixedSizeGlobally(ptransform.PTransform):
+  class FixedSizeGlobally(CombinerWithoutDefaults):
     """Sample n elements from the input PCollection without replacement."""
     def __init__(self, n):
+      super(Sample.FixedSizeGlobally, self).__init__()
       self._n = n
 
     def expand(self, pcoll):
-      return pcoll | core.CombineGlobally(SampleCombineFn(self._n))
+      if self.has_defaults:
+        return pcoll | core.CombineGlobally(SampleCombineFn(self._n))
+      else:
+        return pcoll | core.CombineGlobally(SampleCombineFn(
+            self._n)).without_defaults()
 
     def display_data(self):
       return {'n': self._n}
@@ -754,13 +781,17 @@ class SingleInputTupleCombineFn(_TupleCombineFnBase):
     ]
 
 
-class ToList(ptransform.PTransform):
+class ToList(CombinerWithoutDefaults):
   """A global CombineFn that condenses a PCollection into a single list."""
   def __init__(self, label='ToList'):  # pylint: disable=useless-super-delegation
     super(ToList, self).__init__(label)
 
   def expand(self, pcoll):
-    return pcoll | self.label >> core.CombineGlobally(ToListCombineFn())
+    if self.has_defaults:
+      return pcoll | self.label >> core.CombineGlobally(ToListCombineFn())
+    else:
+      return pcoll | self.label >> core.CombineGlobally(
+          ToListCombineFn()).without_defaults()
 
 
 @with_input_types(T)
@@ -781,7 +812,7 @@ class ToListCombineFn(core.CombineFn):
     return accumulator
 
 
-class ToDict(ptransform.PTransform):
+class ToDict(CombinerWithoutDefaults):
   """A global CombineFn that condenses a PCollection into a single dict.
 
   PCollections should consist of 2-tuples, notionally (key, value) pairs.
@@ -792,7 +823,11 @@ class ToDict(ptransform.PTransform):
     super(ToDict, self).__init__(label)
 
   def expand(self, pcoll):
-    return pcoll | self.label >> core.CombineGlobally(ToDictCombineFn())
+    if self.has_defaults:
+      return pcoll | self.label >> core.CombineGlobally(ToDictCombineFn())
+    else:
+      return pcoll | self.label >> core.CombineGlobally(
+          ToDictCombineFn()).without_defaults()
 
 
 @with_input_types(Tuple[K, V])
@@ -817,13 +852,17 @@ class ToDictCombineFn(core.CombineFn):
     return accumulator
 
 
-class ToSet(ptransform.PTransform):
+class ToSet(CombinerWithoutDefaults):
   """A global CombineFn that condenses a PCollection into a set."""
   def __init__(self, label='ToSet'):  # pylint: disable=useless-super-delegation
     super(ToSet, self).__init__(label)
 
   def expand(self, pcoll):
-    return pcoll | self.label >> core.CombineGlobally(ToSetCombineFn())
+    if self.has_defaults:
+      return pcoll | self.label >> core.CombineGlobally(ToSetCombineFn())
+    else:
+      return pcoll | self.label >> core.CombineGlobally(
+          ToSetCombineFn()).without_defaults()
 
 
 @with_input_types(T)
@@ -918,7 +957,7 @@ class Latest(object):
   """Combiners for computing the latest element"""
   @with_input_types(T)
   @with_output_types(T)
-  class Globally(ptransform.PTransform):
+  class Globally(CombinerWithoutDefaults):
     """Compute the element with the latest timestamp from a
     PCollection."""
     @staticmethod
@@ -926,11 +965,18 @@ class Latest(object):
       return [(element, timestamp)]
 
     def expand(self, pcoll):
-      return (
-          pcoll
-          | core.ParDo(self.add_timestamp).with_output_types(
-              Tuple[T, TimestampType])  # type: ignore[misc]
-          | core.CombineGlobally(LatestCombineFn()))
+      if self.has_defaults:
+        return (
+            pcoll
+            | core.ParDo(self.add_timestamp).with_output_types(
+                Tuple[T, TimestampType])  # type: ignore[misc]
+            | core.CombineGlobally(LatestCombineFn()))
+      else:
+        return (
+            pcoll
+            | core.ParDo(self.add_timestamp).with_output_types(
+                Tuple[T, TimestampType])  # type: ignore[misc]
+            | core.CombineGlobally(LatestCombineFn()).without_defaults())
 
   @with_input_types(Tuple[K, V])
   @with_output_types(Tuple[K, V])

--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -22,6 +22,7 @@
 from __future__ import absolute_import
 from __future__ import division
 
+import copy
 import heapq
 import operator
 import random
@@ -67,8 +68,9 @@ class CombinerWithoutDefaults(ptransform.PTransform):
     self.has_defaults = has_defaults
 
   def with_defaults(self, has_defaults=True):
-    self.has_defaults = has_defaults
-    return self
+      new = copy.copy(self)
+      new.has_defaults = has_defaults
+      return new
 
   def without_defaults(self):
     return self.with_defaults(False)

--- a/sdks/python/scripts/generate_pydoc.sh
+++ b/sdks/python/scripts/generate_pydoc.sh
@@ -166,6 +166,7 @@ ignore_identifiers = [
   'apache_beam.pvalue.PValue',
   'apache_beam.runners.direct.executor.CallableTask',
   'apache_beam.testing.synthetic_pipeline._Random',
+  'apache_beam.transforms.combiners.CombinerWithoutDefaults',
   'apache_beam.transforms.core.CallableWrapperCombineFn',
   'apache_beam.transforms.ptransform.PTransformWithSideInputs',
   'apache_beam.transforms.trigger._ParallelTriggerFn',


### PR DESCRIPTION
Following with [BEAM-10209](https://issues.apache.org/jira/browse/BEAM-10209) that fixed `Mean`

When need Windows and built-in combiners in a Globally way, we cannot specify `without_defaults()`, forcing us to use the workaround as `CombineGlobally(CountCombineFn()).without_defaults()`. This PR fix this, adding the `without_defaults()` to built-in Combiners in Python
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark
--- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
