### PR TITLE
[BEAM-10283] Add new overloads of withKeyRanges and withRowFilter met…

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,8 @@
   is experimental. It reads data from BigQuery by exporting data to Avro files, and reading those files. It also supports
   reading data by exporting to JSON files. This has small differences in behavior for Time and Date-related fields. See
   Pydoc for more information.
+* New overloads for BigtableIO.Read.withKeyRange() and BigtableIO.Read.withRowFilter()
+  methods that take ValueProvider as a parameter (Java) ([BEAM-10283](https://issues.apache.org/jira/browse/BEAM-10283)).
 
 ## New Features / Improvements
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -47,6 +47,19 @@
 * Fixed X (Java/Python) ([BEAM-X](https://issues.apache.org/jira/browse/BEAM-X)).
 -->
 
+# [2.24.0] - Unreleased
+
+## Highlights
+
+## I/Os
+
+* New overloads for BigtableIO.Read.withKeyRange() and BigtableIO.Read.withRowFilter()
+  methods that take ValueProvider as a parameter (Java) ([BEAM-10283](https://issues.apache.org/jira/browse/BEAM-10283)).
+
+## New Features / Improvements
+
+## Breaking Changes
+
 # [2.23.0] - Unreleased
 
 ## Highlights
@@ -63,8 +76,6 @@
   is experimental. It reads data from BigQuery by exporting data to Avro files, and reading those files. It also supports
   reading data by exporting to JSON files. This has small differences in behavior for Time and Date-related fields. See
   Pydoc for more information.
-* New overloads for BigtableIO.Read.withKeyRange() and BigtableIO.Read.withRowFilter()
-  methods that take ValueProvider as a parameter (Java) ([BEAM-10283](https://issues.apache.org/jira/browse/BEAM-10283)).
 
 ## New Features / Improvements
 
@@ -76,7 +87,6 @@
 
 ## Deprecations
 
-* X behavior is deprecated and will be removed in X versions ([BEAM-X](https://issues.apache.org/jira/browse/BEAM-X)).
 * Remove Gearpump runner. ([BEAM-9999](https://issues.apache.org/jira/browse/BEAM-9999))
 * Remove Apex runner. ([BEAM-9999](https://issues.apache.org/jira/browse/BEAM-9999))
 * RedisIO.readAll() is deprecated and will be removed in 2 versions, users must use RedisIO.readKeyPatterns() as a replacement ([BEAM-9747](https://issues.apache.org/jira/browse/BEAM-9747)).

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
@@ -968,7 +968,8 @@ public class BigtableIO {
         counter++;
       }
       if (size > 0) {
-        reducedSplits.add(new BigtableSource(config, readOptions.withKeyRanges(previousSourceRanges), size));
+        reducedSplits
+            .add(new BigtableSource(config, readOptions.withKeyRanges(previousSourceRanges), size));
       }
       return reducedSplits;
     }
@@ -1189,7 +1190,8 @@ public class BigtableIO {
       builder.add(DisplayData.item("tableId", config.getTableId()).withLabel("Table ID"));
 
       if (getRowFilter() != null) {
-        builder.add(DisplayData.item("rowFilter", getRowFilter().toString()).withLabel("Table Row Filter"));
+        builder.add(
+            DisplayData.item("rowFilter", getRowFilter().toString()).withLabel("Table Row Filter"));
       }
     }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
@@ -231,16 +231,15 @@ public class BigtableIO {
 
     static Read create() {
       BigtableConfig config =
-          BigtableConfig.builder()
-              .setTableId(StaticValueProvider.of(""))
-              .setValidate(true)
-              .build();
+          BigtableConfig.builder().setTableId(StaticValueProvider.of("")).setValidate(true).build();
 
       return new AutoValue_BigtableIO_Read.Builder()
           .setBigtableConfig(config)
-          .setBigtableReadOptions(BigtableReadOptions.builder()
-              .setKeyRanges(StaticValueProvider
-                  .of(Collections.singletonList(ByteKeyRange.ALL_KEYS))).build())
+          .setBigtableReadOptions(
+              BigtableReadOptions.builder()
+                  .setKeyRanges(
+                      StaticValueProvider.of(Collections.singletonList(ByteKeyRange.ALL_KEYS)))
+                  .build())
           .build();
     }
 
@@ -872,9 +871,7 @@ public class BigtableIO {
 
   static class BigtableSource extends BoundedSource<Row> {
     public BigtableSource(
-        BigtableConfig config,
-        BigtableReadOptions readOptions,
-        @Nullable Long estimatedSizeBytes) {
+        BigtableConfig config, BigtableReadOptions readOptions, @Nullable Long estimatedSizeBytes) {
       this.config = config;
       this.readOptions = readOptions;
       this.estimatedSizeBytes = estimatedSizeBytes;
@@ -968,8 +965,8 @@ public class BigtableIO {
         counter++;
       }
       if (size > 0) {
-        reducedSplits
-            .add(new BigtableSource(config, readOptions.withKeyRanges(previousSourceRanges), size));
+        reducedSplits.add(
+            new BigtableSource(config, readOptions.withKeyRanges(previousSourceRanges), size));
       }
       return reducedSplits;
     }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableReadOptions.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableReadOptions.java
@@ -70,7 +70,8 @@ abstract class BigtableReadOptions implements Serializable {
   }
 
   void populateDisplayData(DisplayData.Builder builder) {
-    builder.addIfNotNull(DisplayData.item("rowFilter", getRowFilter()).withLabel("Row Filter"))
+    builder
+        .addIfNotNull(DisplayData.item("rowFilter", getRowFilter()).withLabel("Row Filter"))
         .addIfNotNull(DisplayData.item("keyRanges", getKeyRanges()).withLabel("Key Ranges"));
   }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableReadOptions.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableReadOptions.java
@@ -16,7 +16,7 @@ import org.apache.beam.sdk.transforms.display.DisplayData;
 @AutoValue
 abstract class BigtableReadOptions implements Serializable {
 
-  /** Returns the Row filter to use. */
+  /** Returns the row filter to use. */
   @Nullable
   abstract ValueProvider<RowFilter> getRowFilter();
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableReadOptions.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableReadOptions.java
@@ -1,0 +1,73 @@
+package org.apache.beam.sdk.io.gcp.bigtable;
+
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+
+import com.google.auto.value.AutoValue;
+import com.google.bigtable.v2.RowFilter;
+import java.io.Serializable;
+import java.util.Collections;
+import java.util.List;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.io.range.ByteKeyRange;
+import org.apache.beam.sdk.options.ValueProvider;
+import org.apache.beam.sdk.transforms.display.DisplayData;
+
+/** Configuration for which values to read from Bigtable. */
+@AutoValue
+abstract class BigtableReadOptions implements Serializable {
+
+  /** Returns the Row filter to use. */
+  @Nullable
+  abstract ValueProvider<RowFilter> getRowFilter();
+
+  /** Returns the key ranges to read. */
+  @Nullable
+  abstract ValueProvider<List<ByteKeyRange>> getKeyRanges();
+
+  abstract Builder toBuilder();
+
+  static BigtableReadOptions.Builder builder() {
+    return new AutoValue_BigtableReadOptions.Builder();
+  }
+
+  @AutoValue.Builder
+  abstract static class Builder {
+
+    abstract Builder setRowFilter(ValueProvider<RowFilter> rowFilter);
+
+    abstract Builder setKeyRanges(ValueProvider<List<ByteKeyRange>> keyRanges);
+
+    abstract BigtableReadOptions build();
+  }
+
+  BigtableReadOptions withRowFilter(RowFilter rowFilter) {
+    return toBuilder().setRowFilter(ValueProvider.StaticValueProvider.of(rowFilter)).build();
+  }
+
+  BigtableReadOptions withKeyRanges(List<ByteKeyRange> keyRanges) {
+    return toBuilder().setKeyRanges(ValueProvider.StaticValueProvider.of(keyRanges)).build();
+  }
+
+  BigtableReadOptions withKeyRange(ByteKeyRange keyRange) {
+    return withKeyRanges(Collections.singletonList(keyRange));
+  }
+
+  void populateDisplayData(DisplayData.Builder builder) {
+    builder.addIfNotNull(DisplayData.item("rowFilter", getRowFilter()).withLabel("Row Filter"))
+        .addIfNotNull(DisplayData.item("keyRanges", getKeyRanges()).withLabel("Key Ranges"));
+  }
+
+  void validate() {
+    if (getRowFilter() != null && getRowFilter().isAccessible()) {
+      checkArgument(getRowFilter().get() != null, "rowFilter can not be null");
+    }
+
+    if (getKeyRanges() != null && getKeyRanges().isAccessible()) {
+      checkArgument(getKeyRanges().get() != null, "keyRanges can not be null");
+      checkArgument(!getKeyRanges().get().isEmpty(), "keyRanges can not be empty");
+      for (ByteKeyRange range : getKeyRanges().get()) {
+        checkArgument(range != null, "keyRanges cannot hold null range");
+      }
+    }
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableReadOptions.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableReadOptions.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.beam.sdk.io.gcp.bigtable;
 
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
@@ -185,8 +185,8 @@ public class BigtableIOTest {
   private static final SerializableFunction<BigtableOptions.Builder, BigtableOptions.Builder>
       PORT_CONFIGURATOR = input -> input.setPort(1234);
 
-  private static final ValueProvider<List<ByteKeyRange>> ALL_KEY_RANGE = StaticValueProvider
-      .of(Collections.singletonList(ByteKeyRange.ALL_KEYS));
+  private static final ValueProvider<List<ByteKeyRange>> ALL_KEY_RANGE =
+      StaticValueProvider.of(Collections.singletonList(ByteKeyRange.ALL_KEYS));
 
   @Before
   public void setup() throws Exception {
@@ -518,7 +518,8 @@ public class BigtableIOTest {
   }
 
   private void runReadTest(BigtableIO.Read read, List<Row> expected) {
-    PCollection<Row> rows = p.apply(read.getTableId() + "_" + read.getBigtableReadOptions().getKeyRanges(), read);
+    PCollection<Row> rows =
+        p.apply(read.getTableId() + "_" + read.getBigtableReadOptions().getKeyRanges(), read);
     PAssert.that(rows).containsInAnyOrder(expected);
     p.run();
   }
@@ -568,9 +569,7 @@ public class BigtableIOTest {
     assertThat(suffixRows, hasItems(middleRows.toArray(new Row[] {})));
   }
 
-  /**
-   * Tests reading key ranges specified through a ValueProvider.
-   */
+  /** Tests reading key ranges specified through a ValueProvider. */
   @Test
   public void testReadingWithRuntimeParameterizedKeyRange() throws Exception {
     final String table = "TEST-KEY-RANGE-TABLE";
@@ -583,7 +582,11 @@ public class BigtableIOTest {
 
     final ByteKeyRange middleRange = ByteKeyRange.of(startKey, endKey);
     List<Row> middleRows = filterToRange(testRows, middleRange);
-    runReadTest(defaultRead.withTableId(table).withKeyRanges(StaticValueProvider.of(Collections.singletonList(middleRange))), middleRows);
+    runReadTest(
+        defaultRead
+            .withTableId(table)
+            .withKeyRanges(StaticValueProvider.of(Collections.singletonList(middleRange))),
+        middleRows);
 
     assertThat(middleRows, allOf(hasSize(lessThan(numRows)), hasSize(greaterThan(0))));
   }
@@ -965,7 +968,9 @@ public class BigtableIOTest {
         new BigtableSource(
             config.withTableId(StaticValueProvider.of(table)),
             BigtableReadOptions.builder()
-                .setKeyRanges(StaticValueProvider.of(Collections.singletonList(service.getTableRange(table)))).build(), null /*size*/);
+                .setKeyRanges(
+                    StaticValueProvider.of(Collections.singletonList(service.getTableRange(table))))
+                .build(), null /*size*/);
     List<BigtableSource> splits = // 10,000
         source.split(numRows * bytesPerRow / numSamples, null /* options */);
 
@@ -1099,7 +1104,8 @@ public class BigtableIOTest {
 
     assertThat(displayData, hasDisplayItem("rowFilter", rowFilter.toString()));
 
-    assertThat(displayData, hasDisplayItem("keyRanges", "[ByteKeyRange{startKey=[], endKey=[abcd]}]"));
+    assertThat(displayData,
+        hasDisplayItem("keyRanges", "[ByteKeyRange{startKey=[], endKey=[abcd]}]"));
 
     // BigtableIO adds user-agent to options; assert only on key and not value.
     assertThat(displayData, hasDisplayItem("bigtableOptions"));

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
@@ -1141,7 +1141,7 @@ public class BigtableIOTest {
             .withBigtableOptions(BIGTABLE_OPTIONS)
             .withProjectId(options.getBigtableProject())
             .withInstanceId(options.getBigtableInstanceId())
-            .withTableId(options.getBigtableTableId())
+            .withTableId(options.getBigtableTableId());
     DisplayData displayData = DisplayData.from(read);
     assertThat(
         displayData,

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
@@ -683,7 +683,8 @@ public class BigtableIOTest {
             BigtableReadOptions.builder()
                 .setKeyRanges(
                     StaticValueProvider.of(Collections.singletonList(service.getTableRange(table))))
-                .build(), null);
+                .build(),
+            null);
     assertSplitAtFractionExhaustive(source, null);
   }
 
@@ -703,7 +704,8 @@ public class BigtableIOTest {
             BigtableReadOptions.builder()
                 .setKeyRanges(
                     StaticValueProvider.of(Collections.singletonList(service.getTableRange(table))))
-                .build(), null);
+                .build(),
+            null);
     // With 0 items read, all split requests will fail.
     assertSplitAtFractionFails(source, 0, 0.1, null /* options */);
     assertSplitAtFractionFails(source, 0, 1.0, null /* options */);
@@ -734,8 +736,9 @@ public class BigtableIOTest {
     // Generate source and split it.
     BigtableSource source =
         new BigtableSource(
-            config.withTableId(StaticValueProvider.of(table)),BigtableReadOptions.builder()
-            .setKeyRanges(ALL_KEY_RANGE).build(), null /*size*/);
+            config.withTableId(StaticValueProvider.of(table)),
+            BigtableReadOptions.builder().setKeyRanges(ALL_KEY_RANGE).build(),
+            null /*size*/);
     List<BigtableSource> splits =
         source.split(numRows * bytesPerRow / numSamples, null /* options */);
 
@@ -801,8 +804,8 @@ public class BigtableIOTest {
     BigtableSource source =
         new BigtableSource(
             config.withTableId(StaticValueProvider.of(table)),
-            BigtableReadOptions.builder()
-                .setKeyRanges(StaticValueProvider.of(keyRanges)).build(), null /*size*/);
+            BigtableReadOptions.builder().setKeyRanges(StaticValueProvider.of(keyRanges)).build(),
+            null /*size*/);
 
     List<BigtableSource> splits = new ArrayList<>();
     for (ByteKeyRange range : keyRanges) {
@@ -851,8 +854,8 @@ public class BigtableIOTest {
     BigtableSource source =
         new BigtableSource(
             config.withTableId(StaticValueProvider.of(table)),
-            BigtableReadOptions.builder()
-                .setKeyRanges(StaticValueProvider.of(keyRanges)).build(), null /*size*/);
+            BigtableReadOptions.builder().setKeyRanges(StaticValueProvider.of(keyRanges)).build(),
+            null /*size*/);
 
     List<BigtableSource> splits = new ArrayList<>();
     for (ByteKeyRange range : keyRanges) {
@@ -892,7 +895,8 @@ public class BigtableIOTest {
     BigtableSource source =
         new BigtableSource(
             config.withTableId(StaticValueProvider.of(table)),
-            BigtableReadOptions.builder().setKeyRanges(ALL_KEY_RANGE).build(), null /*size*/);
+            BigtableReadOptions.builder().setKeyRanges(ALL_KEY_RANGE).build(),
+            null /*size*/);
     List<BigtableSource> splits = new ArrayList<>();
     List<ByteKeyRange> keyRanges =
         Arrays.asList(
@@ -962,15 +966,16 @@ public class BigtableIOTest {
     BigtableSource source =
         new BigtableSource(
             config.withTableId(StaticValueProvider.of(table)),
-            BigtableReadOptions.builder()
-                .setKeyRanges(StaticValueProvider.of(keyRanges)).build(), null /*size*/);
+            BigtableReadOptions.builder().setKeyRanges(StaticValueProvider.of(keyRanges)).build(),
+            null /*size*/);
     BigtableSource referenceSource =
         new BigtableSource(
             config.withTableId(StaticValueProvider.of(table)),
             BigtableReadOptions.builder()
                 .setKeyRanges(
                     StaticValueProvider.of(Collections.singletonList(service.getTableRange(table))))
-                .build(), null /*size*/);
+                .build(),
+            null /*size*/);
     List<BigtableSource> splits = // 10,000
         source.split(numRows * bytesPerRow / numSamples, null /* options */);
 
@@ -996,7 +1001,8 @@ public class BigtableIOTest {
     BigtableSource source =
         new BigtableSource(
             config.withTableId(StaticValueProvider.of(table)),
-            BigtableReadOptions.builder().setKeyRanges(ALL_KEY_RANGE).build(), null /*size*/);
+            BigtableReadOptions.builder().setKeyRanges(ALL_KEY_RANGE).build(),
+            null /*size*/);
     List<BigtableSource> splits = source.split(numRows * bytesPerRow / numSplits, null);
 
     // Test num splits and split equality.
@@ -1037,15 +1043,16 @@ public class BigtableIOTest {
     BigtableSource source =
         new BigtableSource(
             config.withTableId(StaticValueProvider.of(table)),
-            BigtableReadOptions.builder()
-                .setKeyRanges(StaticValueProvider.of(keyRanges)).build(),
+            BigtableReadOptions.builder().setKeyRanges(StaticValueProvider.of(keyRanges)).build(),
             null /*size*/);
     BigtableSource referenceSource =
         new BigtableSource(
             config.withTableId(StaticValueProvider.of(table)),
             BigtableReadOptions.builder()
-                .setKeyRanges(StaticValueProvider
-                    .of(ImmutableList.of(service.getTableRange(table)))).build(), null /*size*/);
+                .setKeyRanges(
+                    StaticValueProvider.of(ImmutableList.of(service.getTableRange(table))))
+                .build(),
+            null /*size*/);
     List<BigtableSource> splits = source.split(numRows * bytesPerRow / numSplits, null);
 
     // Test num splits and split equality.
@@ -1074,7 +1081,9 @@ public class BigtableIOTest {
             config.withTableId(StaticValueProvider.of(table)),
             BigtableReadOptions.builder()
                 .setRowFilter(StaticValueProvider.of(filter))
-                .setKeyRanges(ALL_KEY_RANGE).build(), null /*size*/);
+                .setKeyRanges(ALL_KEY_RANGE)
+                .build(),
+            null /*size*/);
     List<BigtableSource> splits = source.split(numRows * bytesPerRow / numSplits, null);
 
     // Test num splits and split equality.
@@ -1104,8 +1113,8 @@ public class BigtableIOTest {
 
     assertThat(displayData, hasDisplayItem("rowFilter", rowFilter.toString()));
 
-    assertThat(displayData,
-        hasDisplayItem("keyRanges", "[ByteKeyRange{startKey=[], endKey=[abcd]}]"));
+    assertThat(
+        displayData, hasDisplayItem("keyRanges", "[ByteKeyRange{startKey=[], endKey=[abcd]}]"));
 
     // BigtableIO adds user-agent to options; assert only on key and not value.
     assertThat(displayData, hasDisplayItem("bigtableOptions"));
@@ -1408,7 +1417,8 @@ public class BigtableIOTest {
     BigtableSource source =
         new BigtableSource(
             config.withTableId(StaticValueProvider.of(table)),
-            BigtableReadOptions.builder().setKeyRanges(ALL_KEY_RANGE).build(), null);
+            BigtableReadOptions.builder().setKeyRanges(ALL_KEY_RANGE).build(),
+            null);
 
     BoundedReader<Row> reader = source.createReader(TestPipeline.testingPipelineOptions());
 


### PR DESCRIPTION
…hods that take ValueProvider as a parameter.

This will allow passing runtime parameters from a dataflow template to these methods.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark
--- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
