### PR TITLE
[BEAM-10303] Add support for the non-window observing optimization to DoFn execution in portable Beam Java

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
@@ -43,6 +43,7 @@ import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.Restrictio
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.SchemaElementParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.SideInputParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.StateParameter;
+import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.TimerFamilyParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.TimerParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.WindowParameter;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
@@ -247,6 +248,7 @@ public abstract class DoFnSignature {
               Predicates.or(
                       Predicates.instanceOf(WindowParameter.class),
                       Predicates.instanceOf(TimerParameter.class),
+                      Predicates.instanceOf(TimerFamilyParameter.class),
                       Predicates.instanceOf(StateParameter.class))
                   ::apply);
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
@@ -234,6 +234,23 @@ public abstract class DoFnSignature {
      */
     List<Parameter> extraParameters();
 
+    /**
+     * Whether this method observes - directly or indirectly - the window that an element resides
+     * in.
+     *
+     * <p>{@link State} and {@link Timer} parameters indirectly observe the window, because they are
+     * each scoped to a single window.
+     */
+    default boolean observesWindow() {
+      return extraParameters().stream()
+          .anyMatch(
+              Predicates.or(
+                      Predicates.instanceOf(WindowParameter.class),
+                      Predicates.instanceOf(TimerParameter.class),
+                      Predicates.instanceOf(StateParameter.class))
+                  ::apply);
+    }
+
     /** The type of window expected by this method, if any. */
     @Nullable
     TypeDescriptor<? extends BoundedWindow> windowT();
@@ -991,23 +1008,6 @@ public abstract class DoFnSignature {
           watermarkEstimatorT,
           windowT,
           hasReturnValue);
-    }
-
-    /**
-     * Whether this {@link DoFn} observes - directly or indirectly - the window that an element
-     * resides in.
-     *
-     * <p>{@link State} and {@link Timer} parameters indirectly observe the window, because they are
-     * each scoped to a single window.
-     */
-    public boolean observesWindow() {
-      return extraParameters().stream()
-          .anyMatch(
-              Predicates.or(
-                      Predicates.instanceOf(WindowParameter.class),
-                      Predicates.instanceOf(TimerParameter.class),
-                      Predicates.instanceOf(StateParameter.class))
-                  ::apply);
     }
 
     @Nullable

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -482,7 +482,8 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
         }
         break;
       case PTransformTranslation.SPLITTABLE_SPLIT_AND_SIZE_RESTRICTIONS_URN:
-        if (doFnSignature.splitRestriction().observesWindow()
+        if ((doFnSignature.splitRestriction() != null
+                && doFnSignature.splitRestriction().observesWindow())
             || (doFnSignature.newTracker() != null && doFnSignature.newTracker().observesWindow())
             || (doFnSignature.getSize() != null && doFnSignature.getSize().observesWindow())
             || !sideInputMapping.isEmpty()) {

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
@@ -363,7 +363,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
   }
 
   @Test
-  public void testBasicWithSideInputsAndOutputs() throws Exception {
+  public void testProcessElementWithSideInputsAndOutputs() throws Exception {
     Pipeline p = Pipeline.create();
     addExperiment(p.getOptions().as(ExperimentalOptions.class), "beam_fn_api");
     // TODO(BEAM-10097): Remove experiment once all portable runners support this view type
@@ -491,6 +491,141 @@ public class FnApiDoFnRunnerTest implements Serializable {
 
     // Assert that state data did not change
     assertEquals(stateData, fakeClient.getData());
+  }
+
+  private static class TestNonWindowObservingDoFn extends DoFn<String, String> {
+    private final TupleTag<String> additionalOutput;
+
+    private TestNonWindowObservingDoFn(TupleTag<String> additionalOutput) {
+      this.additionalOutput = additionalOutput;
+    }
+
+    @ProcessElement
+    public void processElement(ProcessContext context) {
+      context.output(context.element() + ":main");
+      context.output(additionalOutput, context.element() + ":additional");
+    }
+  }
+
+  @Test
+  public void testProcessElementWithNonWindowObservingOptimization() throws Exception {
+    Pipeline p = Pipeline.create();
+    addExperiment(p.getOptions().as(ExperimentalOptions.class), "beam_fn_api");
+    // TODO(BEAM-10097): Remove experiment once all portable runners support this view type
+    addExperiment(p.getOptions().as(ExperimentalOptions.class), "use_runner_v2");
+    PCollection<String> valuePCollection =
+        p.apply(Create.of("unused"))
+            .apply(Window.into(FixedWindows.of(Duration.standardMinutes(1))));
+    TupleTag<String> mainOutput = new TupleTag<String>("main") {};
+    TupleTag<String> additionalOutput = new TupleTag<String>("additional") {};
+    PCollectionTuple outputPCollection =
+        valuePCollection.apply(
+            TEST_TRANSFORM_ID,
+            ParDo.of(new TestNonWindowObservingDoFn(additionalOutput))
+                .withOutputTags(mainOutput, TupleTagList.of(additionalOutput)));
+
+    SdkComponents sdkComponents = SdkComponents.create(p.getOptions());
+    RunnerApi.Pipeline pProto = PipelineTranslation.toProto(p, sdkComponents, true);
+    String inputPCollectionId = sdkComponents.registerPCollection(valuePCollection);
+    String outputPCollectionId =
+        sdkComponents.registerPCollection(outputPCollection.get(mainOutput));
+    String additionalPCollectionId =
+        sdkComponents.registerPCollection(outputPCollection.get(additionalOutput));
+
+    RunnerApi.PTransform pTransform =
+        pProto.getComponents().getTransformsOrThrow(TEST_TRANSFORM_ID);
+
+    List<WindowedValue<String>> mainOutputValues = new ArrayList<>();
+    List<WindowedValue<String>> additionalOutputValues = new ArrayList<>();
+    MetricsContainerStepMap metricsContainerRegistry = new MetricsContainerStepMap();
+    PCollectionConsumerRegistry consumers =
+        new PCollectionConsumerRegistry(
+            metricsContainerRegistry, mock(ExecutionStateTracker.class));
+    consumers.register(
+        outputPCollectionId,
+        TEST_TRANSFORM_ID,
+        (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add);
+    consumers.register(
+        additionalPCollectionId,
+        TEST_TRANSFORM_ID,
+        (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) additionalOutputValues::add);
+    PTransformFunctionRegistry startFunctionRegistry =
+        new PTransformFunctionRegistry(
+            mock(MetricsContainerStepMap.class), mock(ExecutionStateTracker.class), "start");
+    PTransformFunctionRegistry finishFunctionRegistry =
+        new PTransformFunctionRegistry(
+            mock(MetricsContainerStepMap.class), mock(ExecutionStateTracker.class), "finish");
+    List<ThrowingRunnable> teardownFunctions = new ArrayList<>();
+
+    new FnApiDoFnRunner.Factory<>()
+        .createRunnerForPTransform(
+            PipelineOptionsFactory.create(),
+            null /* beamFnDataClient */,
+            null /* beamFnStateClient */,
+            null /* beamFnTimerClient */,
+            TEST_TRANSFORM_ID,
+            pTransform,
+            Suppliers.ofInstance("57L")::get,
+            pProto.getComponents().getPcollectionsMap(),
+            pProto.getComponents().getCodersMap(),
+            pProto.getComponents().getWindowingStrategiesMap(),
+            consumers,
+            startFunctionRegistry,
+            finishFunctionRegistry,
+            teardownFunctions::add,
+            null /* addProgressRequestCallback */,
+            null /* splitListener */,
+            null /* bundleFinalizer */);
+
+    Iterables.getOnlyElement(startFunctionRegistry.getFunctions()).run();
+    mainOutputValues.clear();
+
+    assertThat(
+        consumers.keySet(),
+        containsInAnyOrder(inputPCollectionId, outputPCollectionId, additionalPCollectionId));
+
+    FnDataReceiver<WindowedValue<?>> mainInput =
+        consumers.getMultiplexingConsumer(inputPCollectionId);
+    mainInput.accept(
+        valueInWindows(
+            "X",
+            new IntervalWindow(new Instant(0L), Duration.standardMinutes(1)),
+            new IntervalWindow(new Instant(10L), Duration.standardMinutes(1))));
+    mainInput.accept(
+        valueInWindows(
+            "Y",
+            new IntervalWindow(new Instant(1000L), Duration.standardMinutes(1)),
+            new IntervalWindow(new Instant(1010L), Duration.standardMinutes(1))));
+    // Ensure that each output element is in all the windows and not one per window.
+    assertThat(
+        mainOutputValues,
+        contains(
+            valueInWindows(
+                "X:main",
+                new IntervalWindow(new Instant(0L), Duration.standardMinutes(1)),
+                new IntervalWindow(new Instant(10L), Duration.standardMinutes(1))),
+            valueInWindows(
+                "Y:main",
+                new IntervalWindow(new Instant(1000L), Duration.standardMinutes(1)),
+                new IntervalWindow(new Instant(1010L), Duration.standardMinutes(1)))));
+    assertThat(
+        additionalOutputValues,
+        contains(
+            valueInWindows(
+                "X:additional",
+                new IntervalWindow(new Instant(0L), Duration.standardMinutes(1)),
+                new IntervalWindow(new Instant(10L), Duration.standardMinutes(1))),
+            valueInWindows(
+                "Y:additional",
+                new IntervalWindow(new Instant(1000L), Duration.standardMinutes(1)),
+                new IntervalWindow(new Instant(1010L), Duration.standardMinutes(1)))));
+    mainOutputValues.clear();
+
+    Iterables.getOnlyElement(finishFunctionRegistry.getFunctions()).run();
+    assertThat(mainOutputValues, empty());
+
+    Iterables.getOnlyElement(teardownFunctions).run();
+    assertThat(mainOutputValues, empty());
   }
 
   private static class TestSideInputIsAccessibleForDownstreamCallersDoFn
@@ -1191,28 +1326,33 @@ public class FnApiDoFnRunnerTest implements Serializable {
 
   /**
    * The trySplit testing of this splittable DoFn is done when processing the {@link
-   * TestSplittableDoFn#SPLIT_ELEMENT}.
+   * NonWindowObservingTestSplittableDoFn#SPLIT_ELEMENT}. Always checkpoints at element {@link
+   * NonWindowObservingTestSplittableDoFn#CHECKPOINT_UPPER_BOUND}.
    *
    * <p>The expected thread flow is:
    *
    * <ul>
-   *   <li>splitting thread: {@link TestSplittableDoFn#waitForSplitElementToBeProcessed()}
-   *   <li>process element thread: {@link TestSplittableDoFn#enableAndWaitForTrySplitToHappen()}
+   *   <li>splitting thread: {@link
+   *       NonWindowObservingTestSplittableDoFn#waitForSplitElementToBeProcessed()}
+   *   <li>process element thread: {@link
+   *       NonWindowObservingTestSplittableDoFn#enableAndWaitForTrySplitToHappen()}
    *   <li>splitting thread: perform try split
-   *   <li>splitting thread: {@link TestSplittableDoFn#releaseWaitingProcessElementThread()}
+   *   <li>splitting thread: {@link
+   *       NonWindowObservingTestSplittableDoFn#releaseWaitingProcessElementThread()}
    * </ul>
    */
-  static class TestSplittableDoFn extends DoFn<String, String> {
+  static class NonWindowObservingTestSplittableDoFn extends DoFn<String, String> {
     private static final ConcurrentMap<String, KV<CountDownLatch, CountDownLatch>>
         DOFN_INSTANCE_TO_LOCK = new ConcurrentHashMap<>();
     private static final long SPLIT_ELEMENT = 3;
+    private static final long CHECKPOINT_UPPER_BOUND = 8;
 
     private KV<CountDownLatch, CountDownLatch> getLatches() {
       return DOFN_INSTANCE_TO_LOCK.computeIfAbsent(
           this.uuid, (uuid) -> KV.of(new CountDownLatch(1), new CountDownLatch(1)));
     }
 
-    private void enableAndWaitForTrySplitToHappen() throws Exception {
+    public void enableAndWaitForTrySplitToHappen() throws Exception {
       KV<CountDownLatch, CountDownLatch> latches = getLatches();
       latches.getKey().countDown();
       if (!latches.getValue().await(30, TimeUnit.SECONDS)) {
@@ -1220,23 +1360,21 @@ public class FnApiDoFnRunnerTest implements Serializable {
       }
     }
 
-    private void waitForSplitElementToBeProcessed() throws Exception {
+    public void waitForSplitElementToBeProcessed() throws Exception {
       KV<CountDownLatch, CountDownLatch> latches = getLatches();
       if (!latches.getKey().await(30, TimeUnit.SECONDS)) {
         fail("Failed to wait for split element to be processed.");
       }
     }
 
-    private void releaseWaitingProcessElementThread() {
+    public void releaseWaitingProcessElementThread() {
       KV<CountDownLatch, CountDownLatch> latches = getLatches();
       latches.getValue().countDown();
     }
 
-    private final PCollectionView<String> singletonSideInput;
     private final String uuid;
 
-    private TestSplittableDoFn(PCollectionView<String> singletonSideInput) {
-      this.singletonSideInput = singletonSideInput;
+    private NonWindowObservingTestSplittableDoFn() {
       this.uuid = UUID.randomUUID().toString();
     }
 
@@ -1246,7 +1384,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
         RestrictionTracker<OffsetRange, Long> tracker,
         ManualWatermarkEstimator<Instant> watermarkEstimator)
         throws Exception {
-      long checkpointUpperBound = Long.parseLong(context.sideInput(singletonSideInput));
+      long checkpointUpperBound = CHECKPOINT_UPPER_BOUND;
       long position = tracker.currentRestriction().getFrom();
       boolean claimStatus;
       while (true) {
@@ -1299,6 +1437,51 @@ public class FnApiDoFnRunnerTest implements Serializable {
     }
   }
 
+  /**
+   * A window observing variant of {@link NonWindowObservingTestSplittableDoFn} which uses the side
+   * inputs to choose the checkpoint upper bound.
+   */
+  static class WindowObservingTestSplittableDoFn extends NonWindowObservingTestSplittableDoFn {
+
+    private final PCollectionView<String> singletonSideInput;
+
+    private WindowObservingTestSplittableDoFn(PCollectionView<String> singletonSideInput) {
+      this.singletonSideInput = singletonSideInput;
+    }
+
+    @Override
+    @ProcessElement
+    public ProcessContinuation processElement(
+        ProcessContext context,
+        RestrictionTracker<OffsetRange, Long> tracker,
+        ManualWatermarkEstimator<Instant> watermarkEstimator)
+        throws Exception {
+      long checkpointUpperBound = Long.parseLong(context.sideInput(singletonSideInput));
+      long position = tracker.currentRestriction().getFrom();
+      boolean claimStatus;
+      while (true) {
+        claimStatus = (tracker.tryClaim(position));
+        if (!claimStatus) {
+          break;
+        } else if (position == NonWindowObservingTestSplittableDoFn.SPLIT_ELEMENT) {
+          enableAndWaitForTrySplitToHappen();
+        }
+        context.outputWithTimestamp(
+            context.element() + ":" + position, GlobalWindow.TIMESTAMP_MIN_VALUE.plus(position));
+        watermarkEstimator.setWatermark(GlobalWindow.TIMESTAMP_MIN_VALUE.plus(position));
+        position += 1L;
+        if (position == checkpointUpperBound) {
+          break;
+        }
+      }
+      if (!claimStatus) {
+        return ProcessContinuation.stop();
+      } else {
+        return ProcessContinuation.resume().withResumeDelay(Duration.millis(54321L));
+      }
+    }
+  }
+
   @Test
   public void testProcessElementForSizedElementAndRestriction() throws Exception {
     Pipeline p = Pipeline.create();
@@ -1307,7 +1490,8 @@ public class FnApiDoFnRunnerTest implements Serializable {
     addExperiment(p.getOptions().as(ExperimentalOptions.class), "use_runner_v2");
     PCollection<String> valuePCollection = p.apply(Create.of("unused"));
     PCollectionView<String> singletonSideInputView = valuePCollection.apply(View.asSingleton());
-    TestSplittableDoFn doFn = new TestSplittableDoFn(singletonSideInputView);
+    WindowObservingTestSplittableDoFn doFn =
+        new WindowObservingTestSplittableDoFn(singletonSideInputView);
     valuePCollection.apply(
         TEST_TRANSFORM_ID, ParDo.of(doFn).withSideInputs(singletonSideInputView));
 
@@ -1614,7 +1798,8 @@ public class FnApiDoFnRunnerTest implements Serializable {
     addExperiment(p.getOptions().as(ExperimentalOptions.class), "use_runner_v2");
     PCollection<String> valuePCollection = p.apply(Create.of("unused"));
     PCollectionView<String> singletonSideInputView = valuePCollection.apply(View.asSingleton());
-    TestSplittableDoFn doFn = new TestSplittableDoFn(singletonSideInputView);
+    WindowObservingTestSplittableDoFn doFn =
+        new WindowObservingTestSplittableDoFn(singletonSideInputView);
 
     valuePCollection
         .apply(Window.into(SlidingWindows.of(Duration.standardSeconds(1))))
@@ -2003,7 +2188,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
     PCollectionView<String> singletonSideInputView = valuePCollection.apply(View.asSingleton());
     valuePCollection.apply(
         TEST_TRANSFORM_ID,
-        ParDo.of(new TestSplittableDoFn(singletonSideInputView))
+        ParDo.of(new WindowObservingTestSplittableDoFn(singletonSideInputView))
             .withSideInputs(singletonSideInputView));
 
     RunnerApi.Pipeline pProto =
@@ -2098,7 +2283,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
         .apply(Window.into(SlidingWindows.of(Duration.standardSeconds(1))))
         .apply(
             TEST_TRANSFORM_ID,
-            ParDo.of(new TestSplittableDoFn(singletonSideInputView))
+            ParDo.of(new WindowObservingTestSplittableDoFn(singletonSideInputView))
                 .withSideInputs(singletonSideInputView));
 
     RunnerApi.Pipeline pProto =
@@ -2205,13 +2390,117 @@ public class FnApiDoFnRunnerTest implements Serializable {
   }
 
   @Test
+  public void testProcessElementForWindowedPairWithRestrictionWithNonWindowObservingOptimization()
+      throws Exception {
+    Pipeline p = Pipeline.create();
+    PCollection<String> valuePCollection = p.apply(Create.of("unused"));
+    PCollectionView<String> singletonSideInputView = valuePCollection.apply(View.asSingleton());
+    valuePCollection
+        .apply(Window.into(SlidingWindows.of(Duration.standardSeconds(1))))
+        .apply(TEST_TRANSFORM_ID, ParDo.of(new NonWindowObservingTestSplittableDoFn()));
+
+    RunnerApi.Pipeline pProto =
+        ProtoOverrides.updateTransform(
+            PTransformTranslation.PAR_DO_TRANSFORM_URN,
+            PipelineTranslation.toProto(p, SdkComponents.create(p.getOptions()), true),
+            SplittableParDoExpander.createSizedReplacement());
+    String expandedTransformId =
+        Iterables.find(
+                pProto.getComponents().getTransformsMap().entrySet(),
+                entry ->
+                    entry
+                            .getValue()
+                            .getSpec()
+                            .getUrn()
+                            .equals(PTransformTranslation.SPLITTABLE_PAIR_WITH_RESTRICTION_URN)
+                        && entry.getValue().getUniqueName().contains(TEST_TRANSFORM_ID))
+            .getKey();
+    RunnerApi.PTransform pTransform =
+        pProto.getComponents().getTransformsOrThrow(expandedTransformId);
+    String inputPCollectionId =
+        pTransform.getInputsOrThrow(ParDoTranslation.getMainInputName(pTransform));
+    String outputPCollectionId = Iterables.getOnlyElement(pTransform.getOutputsMap().values());
+
+    FakeBeamFnStateClient fakeClient = new FakeBeamFnStateClient(ImmutableMap.of());
+
+    List<WindowedValue<KV<String, OffsetRange>>> mainOutputValues = new ArrayList<>();
+    MetricsContainerStepMap metricsContainerRegistry = new MetricsContainerStepMap();
+    PCollectionConsumerRegistry consumers =
+        new PCollectionConsumerRegistry(
+            metricsContainerRegistry, mock(ExecutionStateTracker.class));
+    consumers.register(outputPCollectionId, TEST_TRANSFORM_ID, ((List) mainOutputValues)::add);
+    PTransformFunctionRegistry startFunctionRegistry =
+        new PTransformFunctionRegistry(
+            mock(MetricsContainerStepMap.class), mock(ExecutionStateTracker.class), "start");
+    PTransformFunctionRegistry finishFunctionRegistry =
+        new PTransformFunctionRegistry(
+            mock(MetricsContainerStepMap.class), mock(ExecutionStateTracker.class), "finish");
+    List<ThrowingRunnable> teardownFunctions = new ArrayList<>();
+
+    new FnApiDoFnRunner.Factory<>()
+        .createRunnerForPTransform(
+            PipelineOptionsFactory.create(),
+            null /* beamFnDataClient */,
+            fakeClient,
+            null /* beamFnTimerClient */,
+            TEST_TRANSFORM_ID,
+            pTransform,
+            Suppliers.ofInstance("57L")::get,
+            pProto.getComponents().getPcollectionsMap(),
+            pProto.getComponents().getCodersMap(),
+            pProto.getComponents().getWindowingStrategiesMap(),
+            consumers,
+            startFunctionRegistry,
+            finishFunctionRegistry,
+            teardownFunctions::add,
+            null /* addProgressRequestCallback */,
+            null /* bundleSplitListener */,
+            null /* bundleFinalizer */);
+
+    assertTrue(startFunctionRegistry.getFunctions().isEmpty());
+    mainOutputValues.clear();
+
+    assertThat(consumers.keySet(), containsInAnyOrder(inputPCollectionId, outputPCollectionId));
+
+    FnDataReceiver<WindowedValue<?>> mainInput =
+        consumers.getMultiplexingConsumer(inputPCollectionId);
+    IntervalWindow window1 = new IntervalWindow(new Instant(5), new Instant(10));
+    IntervalWindow window2 = new IntervalWindow(new Instant(6), new Instant(11));
+    WindowedValue<?> firstValue = valueInWindows("5", window1, window2);
+    WindowedValue<?> secondValue = valueInWindows("2", window1, window2);
+    mainInput.accept(firstValue);
+    mainInput.accept(secondValue);
+    // Ensure that each output element is in all the windows and not one per window.
+    assertThat(
+        mainOutputValues,
+        contains(
+            WindowedValue.of(
+                KV.of("5", KV.of(new OffsetRange(0, 5), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                firstValue.getTimestamp(),
+                ImmutableList.of(window1, window2),
+                firstValue.getPane()),
+            WindowedValue.of(
+                KV.of("2", KV.of(new OffsetRange(0, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                secondValue.getTimestamp(),
+                ImmutableList.of(window1, window2),
+                secondValue.getPane())));
+    mainOutputValues.clear();
+
+    assertTrue(finishFunctionRegistry.getFunctions().isEmpty());
+    assertThat(mainOutputValues, empty());
+
+    Iterables.getOnlyElement(teardownFunctions).run();
+    assertThat(mainOutputValues, empty());
+  }
+
+  @Test
   public void testProcessElementForSplitAndSizeRestriction() throws Exception {
     Pipeline p = Pipeline.create();
     PCollection<String> valuePCollection = p.apply(Create.of("unused"));
     PCollectionView<String> singletonSideInputView = valuePCollection.apply(View.asSingleton());
     valuePCollection.apply(
         TEST_TRANSFORM_ID,
-        ParDo.of(new TestSplittableDoFn(singletonSideInputView))
+        ParDo.of(new WindowObservingTestSplittableDoFn(singletonSideInputView))
             .withSideInputs(singletonSideInputView));
 
     RunnerApi.Pipeline pProto =
@@ -2323,7 +2612,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
         .apply(Window.into(SlidingWindows.of(Duration.standardSeconds(1))))
         .apply(
             TEST_TRANSFORM_ID,
-            ParDo.of(new TestSplittableDoFn(singletonSideInputView))
+            ParDo.of(new WindowObservingTestSplittableDoFn(singletonSideInputView))
                 .withSideInputs(singletonSideInputView));
 
     RunnerApi.Pipeline pProto =
@@ -2464,6 +2753,136 @@ public class FnApiDoFnRunnerTest implements Serializable {
                     1.0),
                 firstValue.getTimestamp(),
                 window2,
+                firstValue.getPane())));
+    mainOutputValues.clear();
+
+    assertTrue(finishFunctionRegistry.getFunctions().isEmpty());
+    assertThat(mainOutputValues, empty());
+
+    Iterables.getOnlyElement(teardownFunctions).run();
+    assertThat(mainOutputValues, empty());
+  }
+
+  @Test
+  public void
+      testProcessElementForWindowedSplitAndSizeRestrictionWithNonWindowObservingOptimization()
+          throws Exception {
+    Pipeline p = Pipeline.create();
+    PCollection<String> valuePCollection = p.apply(Create.of("unused"));
+    PCollectionView<String> singletonSideInputView = valuePCollection.apply(View.asSingleton());
+    valuePCollection
+        .apply(Window.into(SlidingWindows.of(Duration.standardSeconds(1))))
+        .apply(TEST_TRANSFORM_ID, ParDo.of(new NonWindowObservingTestSplittableDoFn()));
+
+    RunnerApi.Pipeline pProto =
+        ProtoOverrides.updateTransform(
+            PTransformTranslation.PAR_DO_TRANSFORM_URN,
+            PipelineTranslation.toProto(p, SdkComponents.create(p.getOptions()), true),
+            SplittableParDoExpander.createSizedReplacement());
+    String expandedTransformId =
+        Iterables.find(
+                pProto.getComponents().getTransformsMap().entrySet(),
+                entry ->
+                    entry
+                            .getValue()
+                            .getSpec()
+                            .getUrn()
+                            .equals(
+                                PTransformTranslation.SPLITTABLE_SPLIT_AND_SIZE_RESTRICTIONS_URN)
+                        && entry.getValue().getUniqueName().contains(TEST_TRANSFORM_ID))
+            .getKey();
+    RunnerApi.PTransform pTransform =
+        pProto.getComponents().getTransformsOrThrow(expandedTransformId);
+    String inputPCollectionId =
+        pTransform.getInputsOrThrow(ParDoTranslation.getMainInputName(pTransform));
+    String outputPCollectionId = Iterables.getOnlyElement(pTransform.getOutputsMap().values());
+
+    List<WindowedValue<KV<KV<String, OffsetRange>, Double>>> mainOutputValues = new ArrayList<>();
+    MetricsContainerStepMap metricsContainerRegistry = new MetricsContainerStepMap();
+    PCollectionConsumerRegistry consumers =
+        new PCollectionConsumerRegistry(
+            metricsContainerRegistry, mock(ExecutionStateTracker.class));
+    consumers.register(outputPCollectionId, TEST_TRANSFORM_ID, ((List) mainOutputValues)::add);
+    PTransformFunctionRegistry startFunctionRegistry =
+        new PTransformFunctionRegistry(
+            mock(MetricsContainerStepMap.class), mock(ExecutionStateTracker.class), "start");
+    PTransformFunctionRegistry finishFunctionRegistry =
+        new PTransformFunctionRegistry(
+            mock(MetricsContainerStepMap.class), mock(ExecutionStateTracker.class), "finish");
+    List<ThrowingRunnable> teardownFunctions = new ArrayList<>();
+
+    new FnApiDoFnRunner.Factory<>()
+        .createRunnerForPTransform(
+            PipelineOptionsFactory.create(),
+            null /* beamFnDataClient */,
+            null /* beamFnStateClient */,
+            null /* beamFnTimerClient */,
+            TEST_TRANSFORM_ID,
+            pTransform,
+            Suppliers.ofInstance("57L")::get,
+            pProto.getComponents().getPcollectionsMap(),
+            pProto.getComponents().getCodersMap(),
+            pProto.getComponents().getWindowingStrategiesMap(),
+            consumers,
+            startFunctionRegistry,
+            finishFunctionRegistry,
+            teardownFunctions::add,
+            null /* addProgressRequestCallback */,
+            null /* bundleSplitListener */,
+            null /* bundleFinalizer */);
+
+    assertTrue(startFunctionRegistry.getFunctions().isEmpty());
+    mainOutputValues.clear();
+
+    assertThat(consumers.keySet(), containsInAnyOrder(inputPCollectionId, outputPCollectionId));
+
+    FnDataReceiver<WindowedValue<?>> mainInput =
+        consumers.getMultiplexingConsumer(inputPCollectionId);
+    IntervalWindow window1 = new IntervalWindow(new Instant(5), new Instant(10));
+    IntervalWindow window2 = new IntervalWindow(new Instant(6), new Instant(11));
+    WindowedValue<?> firstValue =
+        valueInWindows(
+            KV.of("5", KV.of(new OffsetRange(0, 5), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+            window1,
+            window2);
+    WindowedValue<?> secondValue =
+        valueInWindows(
+            KV.of("2", KV.of(new OffsetRange(0, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+            window1,
+            window2);
+    mainInput.accept(firstValue);
+    mainInput.accept(secondValue);
+    // Ensure that each output element is in all the windows and not one per window.
+    assertThat(
+        mainOutputValues,
+        contains(
+            WindowedValue.of(
+                KV.of(
+                    KV.of("5", KV.of(new OffsetRange(0, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                    2.0),
+                firstValue.getTimestamp(),
+                ImmutableList.of(window1, window2),
+                firstValue.getPane()),
+            WindowedValue.of(
+                KV.of(
+                    KV.of("5", KV.of(new OffsetRange(2, 5), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                    3.0),
+                firstValue.getTimestamp(),
+                ImmutableList.of(window1, window2),
+                firstValue.getPane()),
+            WindowedValue.of(
+                KV.of(
+                    KV.of("2", KV.of(new OffsetRange(0, 1), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                    1.0),
+                firstValue.getTimestamp(),
+                ImmutableList.of(window1, window2),
+                firstValue.getPane()),
+            WindowedValue.of(
+                KV.of(
+                    KV.of("2", KV.of(new OffsetRange(1, 2), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                    1.0),
+                firstValue.getTimestamp(),
+                ImmutableList.of(window1, window2),
                 firstValue.getPane())));
     mainOutputValues.clear();
 


### PR DESCRIPTION
The idea for the optimization is that if we don't observe the window then we don't need to process each element in each individual window.

We could make this better by making it dynamically figured out instead of statically during initialization but this change brings us up to what is implemented in the non-portable Java runner libraries.

This covers all but the splittable DoFn processElements call since I wanted to limit the size of the change and that one will be more involved.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark
--- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/)
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/)
XLang | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/)

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
