### PR TITLE
Revert "[BEAM-9890] Support BIT_AND aggregation function in Beam SQL"

### DIFF
--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamBuiltinAggregations.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamBuiltinAggregations.java
@@ -58,7 +58,6 @@ public class BeamBuiltinAggregations {
               .put("$SUM0", BeamBuiltinAggregations::createSum)
               .put("AVG", BeamBuiltinAggregations::createAvg)
               .put("BIT_OR", BeamBuiltinAggregations::createBitOr)
-              .put("BIT_AND", BeamBuiltinAggregations::createBitAnd)
               .put("VAR_POP", t -> VarianceFn.newPopulation(t.getTypeName()))
               .put("VAR_SAMP", t -> VarianceFn.newSample(t.getTypeName()))
               .put("COVAR_POP", t -> CovarianceFn.newPopulation(t.getTypeName()))
@@ -184,14 +183,6 @@ public class BeamBuiltinAggregations {
     }
     throw new UnsupportedOperationException(
         String.format("[%s] is not supported in BIT_OR", fieldType));
-  }
-
-  static CombineFn createBitAnd(Schema.FieldType fieldType) {
-    if (fieldType.getTypeName() == TypeName.INT64) {
-      return new BitAnd();
-    }
-    throw new UnsupportedOperationException(
-        String.format("[%s] is not supported in BIT_AND", fieldType));
   }
 
   static class CustMax<T extends Comparable<T>> extends Combine.BinaryCombineFn<T> {
@@ -383,32 +374,6 @@ public class BeamBuiltinAggregations {
       Long merged = createAccumulator();
       for (Long accum : accums) {
         merged = merged | accum;
-      }
-      return merged;
-    }
-
-    @Override
-    public Long extractOutput(Long accum) {
-      return accum;
-    }
-  }
-
-  static class BitAnd<T extends Number> extends CombineFn<T, Long, Long> {
-    @Override
-    public Long createAccumulator() {
-      return -1L;
-    }
-
-    @Override
-    public Long addInput(Long accum, T input) {
-      return accum & input.longValue();
-    }
-
-    @Override
-    public Long mergeAccumulators(Iterable<Long> accums) {
-      Long merged = createAccumulator();
-      for (long accum : accums) {
-        merged = merged & accum;
       }
       return merged;
     }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslAggregationTest.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/BeamSqlDslAggregationTest.java
@@ -314,39 +314,7 @@ public class BeamSqlDslAggregationTest extends BeamSqlDslBase {
     PCollection<Row> inputRows =
         pipeline.apply("longVals", Create.of(rowsInTableA).withRowSchema(schemaInTableA));
     PCollection<Row> result = inputRows.apply("sql", SqlTransform.query(sql));
-
     PAssert.that(result).containsInAnyOrder(rowResult);
-
-    pipeline.run().waitUntilFinish();
-  }
-
-  @Test
-  public void testBitAndFunction() throws Exception {
-    pipeline.enableAbandonedNodeEnforcement(false);
-
-    Schema schemaInTableA =
-        Schema.builder().addInt64Field("f_long").addInt32Field("f_int2").build();
-
-    Schema resultType = Schema.builder().addInt64Field("finalAnswer").build();
-
-    List<Row> rowsInTableA =
-        TestUtils.RowsBuilder.of(schemaInTableA)
-            .addRows(
-                0xF001L, 0,
-                0x00A1L, 0)
-            .getRows();
-
-    String sql = "SELECT bit_and(f_long) as bitand " + "FROM PCOLLECTION GROUP BY f_int2";
-
-    Row rowResult = Row.withSchema(resultType).addValues(1L).build();
-
-    PCollection<Row> inputRows =
-        pipeline.apply("longVals", Create.of(rowsInTableA).withRowSchema(schemaInTableA));
-    PCollection<Row> result = inputRows.apply("sql", SqlTransform.query(sql));
-
-    PAssert.that(result).containsInAnyOrder(rowResult);
-
-    pipeline.run().waitUntilFinish();
   }
 
   private static class CheckerBigDecimalDivide

--- a/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/SqlStdOperatorMappingTable.java
+++ b/sdks/java/extensions/sql/zetasql/src/main/java/org/apache/beam/sdk/extensions/sql/zetasql/SqlStdOperatorMappingTable.java
@@ -35,7 +35,6 @@ public class SqlStdOperatorMappingTable {
           FunctionSignatureId.FN_ANY_VALUE,
           FunctionSignatureId.FN_STRING_AGG_STRING,
           FunctionSignatureId.FN_BIT_OR_INT64,
-          FunctionSignatureId.FN_BIT_AND_INT64,
           FunctionSignatureId.FN_OR,
           FunctionSignatureId.FN_NOT,
           FunctionSignatureId.FN_MULTIPLY_DOUBLE,
@@ -239,7 +238,7 @@ public class SqlStdOperatorMappingTable {
           // .put("array_agg", )
           // .put("array_concat_agg")
           .put("string_agg", SqlOperators.STRING_AGG_STRING_FN) // NULL values not supported
-          .put("bit_and", SqlStdOperatorTable.BIT_AND)
+          // .put("bit_and")
           // .put("bit_xor")
           // .put("logical_and")
           // .put("logical_or")

--- a/sdks/java/extensions/sql/zetasql/src/test/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSQLDialectSpecTest.java
+++ b/sdks/java/extensions/sql/zetasql/src/test/java/org/apache/beam/sdk/extensions/sql/zetasql/ZetaSQLDialectSpecTest.java
@@ -4892,23 +4892,6 @@ public class ZetaSQLDialectSpecTest extends ZetaSQLTestBase {
   }
 
   @Test
-  public void testZetaSQLBitAnd() {
-    String sql = "SELECT BIT_AND(row_id) FROM table_all_types GROUP BY bool_col";
-
-    ZetaSQLQueryPlanner zetaSQLQueryPlanner = new ZetaSQLQueryPlanner(config);
-    BeamRelNode beamRelNode = zetaSQLQueryPlanner.convertToBeamRel(sql);
-    PCollection<Row> stream = BeamSqlRelUtils.toPCollection(pipeline, beamRelNode);
-
-    final Schema schema = Schema.builder().addInt64Field("field1").build();
-    PAssert.that(stream)
-        .containsInAnyOrder(
-            Row.withSchema(schema).addValue(1L).build(),
-            Row.withSchema(schema).addValue(0L).build());
-
-    pipeline.run().waitUntilFinish(Duration.standardMinutes(PIPELINE_EXECUTION_WAITTIME_MINUTES));
-  }
-
-  @Test
   public void testSimpleTableName() {
     String sql = "SELECT Key FROM KeyValue";
 


### PR DESCRIPTION
Reverts apache/beam#12079



It turns out that on direct runner, NULL will not be passed to CombineFn thus all NULL inputs are ignored. And then if there is any non-null inputs, bit_and will be applied on them only, which leads to a non-null result, which is not correct.

Before we can figure out the root cause and propose a fix, we should revert this implementation. 