### PR TITLE
[BEAM-10312] Sub-element progress accounted for during splitting.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/datasource.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasource.go
@@ -302,12 +302,23 @@ func (n *DataSource) Split(splits []int64, frac float64, bufSize int64) (int64, 
 	}
 
 	n.mu.Lock()
+	var currProg float64 // Current element progress.
+	if n.index < 0 {     // Progress is at the end of the non-existant -1st element.
+		currProg = 1.0
+	} else if n.rt == nil { // If this isn't sub-element splittable, estimate some progress.
+		currProg = 0.5
+	} else { // If this is sub-element splittable, get progress of the current element.
+		rt := <-n.rt
+		d, r := rt.GetProgress()
+		currProg = d / (d + r)
+		n.rt <- rt
+	}
 	// Size to split within is the minimum of bufSize or splitIdx so we avoid
 	// including elements we already know won't be processed.
 	if bufSize <= 0 || n.splitIdx < bufSize {
 		bufSize = n.splitIdx
 	}
-	s, err := splitHelper(n.index, bufSize, splits, frac)
+	s, _, err := splitHelper(n.index, bufSize, currProg, splits, frac, false)
 	if err != nil {
 		n.mu.Unlock()
 		return 0, err
@@ -319,58 +330,99 @@ func (n *DataSource) Split(splits []int64, frac float64, bufSize int64) (int64, 
 }
 
 // splitHelper is a helper function that finds a split point in a range.
-// currIdx and splitIdx should match the DataSource's index and splitIdx fields,
-// and represent the start and end of the splittable range respectively. splits
-// is an optional slice of valid split indices, and if nil then all indices are
-// considered valid split points. frac must be between [0, 1], and represents
-// a fraction of the remaining work that the split point aims to be as close
-// as possible to.
-func splitHelper(currIdx, splitIdx int64, splits []int64, frac float64) (int64, error) {
+//
+// currIdx and endIdx should match the DataSource's index and splitIdx fields,
+// and represent the start and end of the splittable range respectively.
+//
+// currProg represents the progress through the current element (currIdx).
+//
+// splits is an optional slice of valid split indices, and if nil then all
+// indices are considered valid split points.
+//
+// frac must be between [0, 1], and represents a fraction of the remaining work
+// that the split point aims to be as close as possible to.
+//
+// splittable indicates that sub-element splitting is possible (i.e. the next
+// unit is an SDF).
+//
+// Returns the element index to split at (first element of residual), and the
+// fraction within that element to split, iff the split point is the current
+// element, the splittable param is set to true, and both the element being
+// split and the following element are valid split points.
+func splitHelper(
+	currIdx, endIdx int64,
+	currProg float64,
+	splits []int64,
+	frac float64,
+	splittable bool) (int64, float64, error) {
 	// Get split index from fraction. Find the closest index to the fraction of
 	// the remainder.
-	var start int64 = 0
-	if currIdx > start {
-		start = currIdx
+	start := float64(currIdx) + currProg
+	safeStart := currIdx + 1 // safeStart avoids splitting at 0, or <= currIdx
+	if safeStart <= 0 {
+		safeStart = 1
 	}
-	// This is the first valid split index, since we should never split at 0 or
-	// at the current element.
-	safeStart := start + 1
-	// The remainder starts at our actual progress (i.e. start), but our final
-	// split index has to be >= our safeStart.
-	fracIdx := start + int64(math.Round(frac*float64(splitIdx-start)))
-	if fracIdx < safeStart {
-		fracIdx = safeStart
-	}
+	var splitFloat = start + frac*(float64(endIdx)-start)
+
+	// Handle simpler cases where all split points are valid first.
 	if len(splits) == 0 {
-		// All split points are valid so just split at fraction.
-		return fracIdx, nil
-	} else {
-		// Find the closest unprocessed split point to our fraction.
-		sort.Slice(splits, func(i, j int) bool { return splits[i] < splits[j] })
-		var prevDiff int64 = math.MaxInt64
-		var bestS int64 = -1
+		if splittable && int64(splitFloat) == currIdx {
+			// Sub-element splitting is valid here, so return fraction.
+			_, f := math.Modf(splitFloat)
+			return int64(splitFloat), f, nil
+		}
+		// All split points are valid so just split at safe index closest to
+		// fraction.
+		splitIdx := int64(math.Round(splitFloat))
+		if splitIdx < safeStart {
+			splitIdx = safeStart
+		}
+		return splitIdx, 0.0, nil
+	}
+
+	// Cases where we have to find a valid split point.
+	sort.Slice(splits, func(i, j int) bool { return splits[i] < splits[j] })
+	if splittable && int64(splitFloat) == currIdx {
+		// Check valid split points to see if we can do a sub-element split.
+		// We need to find the currIdx and currIdx + 1 for it to be valid.
+		c, cp1 := false, false
 		for _, s := range splits {
-			if s >= safeStart && s <= splitIdx {
-				diff := intAbs(fracIdx - s)
-				if diff <= prevDiff {
-					prevDiff = diff
-					bestS = s
-				} else {
-					break // Stop early if the difference starts increasing.
-				}
+			if s == currIdx {
+				c = true
+			} else if s == currIdx+1 {
+				cp1 = true
+				break
+			} else if s > currIdx+1 {
+				break
 			}
 		}
-		if bestS != -1 {
-			return bestS, nil
+		if c && cp1 {
+			// Sub-element splitting is valid here, so return fraction.
+			_, f := math.Modf(splitFloat)
+			return int64(splitFloat), f, nil
 		}
 	}
-	return 0, fmt.Errorf("failed to split DataSource (at index: %v) at requested splits: {%v}", currIdx, splits)
-}
 
-// intAbs implements absolute value for integers via Two's Complement.
-func intAbs(n int64) int64 {
-	y := n >> 63       // y ← x ⟫ 63
-	return (n ^ y) - y // (x ⨁ y) - y
+	// For non-sub-element splitting, find the closest unprocessed split
+	// point to our fraction.
+	var prevDiff = math.MaxFloat64
+	var bestS int64 = -1
+	for _, s := range splits {
+		if s >= safeStart && s <= endIdx {
+			diff := math.Abs(splitFloat - float64(s))
+			if diff <= prevDiff {
+				prevDiff = diff
+				bestS = s
+			} else {
+				break // Stop early if the difference starts increasing.
+			}
+		}
+	}
+	if bestS != -1 {
+		return bestS, 0.0, nil
+	}
+
+	return -1, 0.0, fmt.Errorf("failed to split DataSource (at index: %v) at requested splits: {%v}", currIdx, splits)
 }
 
 type concatReStream struct {


### PR DESCRIPTION
Adding sub-element progress to the splitting logic in DataSource.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
