### PR TITLE
[BEAM-9615] Add bytes, bool, and iterable coders

### DIFF
--- a/sdks/go/pkg/beam/core/graph/coder/bool.go
+++ b/sdks/go/pkg/beam/core/graph/coder/bool.go
@@ -1,0 +1,57 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coder
+
+import (
+	"io"
+
+	"github.com/apache/beam/sdks/go/pkg/beam/core/util/ioutilx"
+	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
+)
+
+// EncodeBool encodes a boolean according to the beam protocol.
+func EncodeBool(v bool, w io.Writer) error {
+	// Encoding: false = 0, true = 1
+	var err error
+	if v {
+		_, err = ioutilx.WriteUnsafe(w, []byte{1})
+	} else {
+		_, err = ioutilx.WriteUnsafe(w, []byte{0})
+	}
+	if err != nil {
+		return errors.Wrap(err, "error encoding bool")
+	}
+	return nil
+}
+
+// DecodeBool decodes a boolean according to the beam protocol.
+func DecodeBool(r io.Reader) (bool, error) {
+	// Encoding: false = 0, true = 1
+	var b [1]byte
+	if err := ioutilx.ReadNBufUnsafe(r, b[:]); err != nil {
+		if err == io.EOF {
+			return false, err
+		}
+		return false, errors.Wrap(err, "error decoding bool")
+	}
+	switch b[0] {
+	case 0:
+		return false, nil
+	case 1:
+		return true, nil
+	}
+	return false, errors.Errorf("error decoding bool: received invalid value %v", b[0])
+}

--- a/sdks/go/pkg/beam/core/graph/coder/bool_test.go
+++ b/sdks/go/pkg/beam/core/graph/coder/bool_test.go
@@ -1,0 +1,79 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coder
+
+import (
+	"bytes"
+	"fmt"
+	"testing"
+
+	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestEncodeBool(t *testing.T) {
+	tests := []struct {
+		v    bool
+		want []byte
+	}{
+		{v: false, want: []byte{0}},
+		{v: true, want: []byte{1}},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(fmt.Sprintf("%v", test.v), func(t *testing.T) {
+			var buf bytes.Buffer
+			err := EncodeBool(test.v, &buf)
+			if err != nil {
+				t.Fatalf("EncodeBool(%v) = %v", test.v, err)
+			}
+			if d := cmp.Diff(test.want, buf.Bytes()); d != "" {
+				t.Errorf("EncodeBool(%v) = %v, want %v diff(-want,+got):\n %v", test.v, buf.Bytes(), test.want, d)
+			}
+		})
+	}
+}
+
+func TestDecodeBool(t *testing.T) {
+	tests := []struct {
+		b    []byte
+		want bool
+		err  error
+	}{
+		{want: false, b: []byte{0}},
+		{want: true, b: []byte{1}},
+		{b: []byte{42}, err: errors.Errorf("error decoding bool: received invalid value %v", 42)},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(fmt.Sprintf("%v", test.want), func(t *testing.T) {
+			buf := bytes.NewBuffer(test.b)
+			got, err := DecodeBool(buf)
+			if test.err != nil && err != nil {
+				if d := cmp.Diff(test.err.Error(), err.Error()); d != "" {
+					t.Errorf("DecodeBool(%v) = %v, want %v diff(-want,+got):\n %v", test.b, err, test.err, d)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("DecodeBool(%v) = %v", test.b, err)
+			}
+			if d := cmp.Diff(test.want, got); d != "" {
+				t.Errorf("DecodeBool(%v) = %v, want %v diff(-want,+got):\n %v", test.b, got, test.want, d)
+			}
+		})
+	}
+}

--- a/sdks/go/pkg/beam/core/graph/coder/bytes.go
+++ b/sdks/go/pkg/beam/core/graph/coder/bytes.go
@@ -1,0 +1,68 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coder
+
+import (
+	"fmt"
+	"io"
+
+	"github.com/apache/beam/sdks/go/pkg/beam/core/util/ioutilx"
+	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
+)
+
+// EncodeByte encodes a single byte.
+func EncodeByte(v byte, w io.Writer) error {
+	// Encoding: raw byte.
+	if _, err := ioutilx.WriteUnsafe(w, []byte{v}); err != nil {
+		return fmt.Errorf("error encoding byte: %v", err)
+	}
+	return nil
+}
+
+// DecodeByte decodes a single byte.
+func DecodeByte(r io.Reader) (byte, error) {
+	// Encoding: raw byte
+	var b [1]byte
+	if err := ioutilx.ReadNBufUnsafe(r, b[:]); err != nil {
+		if err == io.EOF {
+			return 0, err
+		}
+		return 0, errors.Wrap(err, "error decoding byte")
+	}
+	return b[0], nil
+}
+
+// EncodeBytes encodes a []byte with a length prefix per the beam protocol.
+func EncodeBytes(v []byte, w io.Writer) error {
+	// Encoding: size (varint) + raw data
+	size := len(v)
+	if err := EncodeVarInt((int64)(size), w); err != nil {
+		return err
+	}
+	_, err := w.Write(v)
+	return err
+
+}
+
+// DecodeBytes decodes a length prefixed []byte according to the beam protocol.
+func DecodeBytes(r io.Reader) ([]byte, error) {
+	// Encoding: size (varint) + raw data
+	size, err := DecodeVarInt(r)
+	if err != nil {
+		return nil, err
+	}
+	return ioutilx.ReadN(r, (int)(size))
+}

--- a/sdks/go/pkg/beam/core/graph/coder/bytes_test.go
+++ b/sdks/go/pkg/beam/core/graph/coder/bytes_test.go
@@ -1,0 +1,61 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coder
+
+import (
+	"bytes"
+	"fmt"
+	"strings"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestEncodeDecodeBytes(t *testing.T) {
+	longString := strings.Repeat(" this sentence is 32 characters.", 8) // 256 characters to ensure LP works.
+	tests := []struct {
+		v       []byte
+		encoded []byte
+	}{
+		{v: []byte{}, encoded: []byte{0}},
+		{v: []byte{42}, encoded: []byte{1, 42}},
+		{v: []byte{42, 23}, encoded: []byte{2, 42, 23}},
+		{v: []byte(longString), encoded: append([]byte{128, 2}, []byte(longString)...)},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(fmt.Sprintf("encode %q", test.v), func(t *testing.T) {
+			var buf bytes.Buffer
+			err := EncodeBytes(test.v, &buf)
+			if err != nil {
+				t.Fatalf("EncodeBytes(%q) = %v", test.v, err)
+			}
+			if d := cmp.Diff(test.encoded, buf.Bytes()); d != "" {
+				t.Errorf("EncodeBytes(%q) = %v, want %v diff(-want,+got):\n %v", test.v, buf.Bytes(), test.encoded, d)
+			}
+		})
+		t.Run(fmt.Sprintf("decode %v", test.v), func(t *testing.T) {
+			buf := bytes.NewBuffer(test.encoded)
+			got, err := DecodeBytes(buf)
+			if err != nil {
+				t.Fatalf("DecodeBytes(%q) = %v", test.encoded, err)
+			}
+			if d := cmp.Diff(test.v, got); d != "" {
+				t.Errorf("DecodeBytes(%q) = %q, want %v diff(-want,+got):\n %v", test.encoded, got, test.v, d)
+			}
+		})
+	}
+}

--- a/sdks/go/pkg/beam/core/graph/coder/iterable.go
+++ b/sdks/go/pkg/beam/core/graph/coder/iterable.go
@@ -16,7 +16,6 @@
 package coder
 
 import (
-	"fmt"
 	"io"
 	"reflect"
 
@@ -68,7 +67,6 @@ func iterableDecoderForSlice(rt reflect.Type, decodeToElem func(reflect.Value, i
 			}
 			rv := reflect.MakeSlice(rt, 0, int(chunk))
 			for chunk != 0 {
-				fmt.Printf("chunk: %d\n", chunk)
 				rvi := reflect.MakeSlice(rt, int(chunk), int(chunk))
 				if err := decodeToIterable(rvi, r, decodeToElem); err != nil {
 					return err

--- a/sdks/go/pkg/beam/core/graph/coder/iterable.go
+++ b/sdks/go/pkg/beam/core/graph/coder/iterable.go
@@ -1,0 +1,124 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coder
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+
+	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
+)
+
+// TODO(lostluck): 2020.06.29 export these for use for others?
+
+// iterableEncoder reflectively encodes a slice or array type using
+// the beam fixed length iterable encoding.
+func iterableEncoder(rt reflect.Type, encode func(reflect.Value, io.Writer) error) func(reflect.Value, io.Writer) error {
+	return func(rv reflect.Value, w io.Writer) error {
+		size := rv.Len()
+		if err := EncodeInt32((int32)(size), w); err != nil {
+			return err
+		}
+		for i := 0; i < size; i++ {
+			if err := encode(rv.Index(i), w); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// iterableDecoderForSlice can decode from both the fixed sized and
+// multi-chunk variants of the beam iterable protocol.
+// Returns an error for other protocols (such as state backed).
+func iterableDecoderForSlice(rt reflect.Type, decodeToElem func(reflect.Value, io.Reader) error) func(reflect.Value, io.Reader) error {
+	return func(ret reflect.Value, r io.Reader) error {
+		// (1) Read count prefixed encoded data
+		size, err := DecodeInt32(r)
+		if err != nil {
+			return err
+		}
+		n := int(size)
+		switch {
+		case n >= 0:
+			rv := reflect.MakeSlice(rt, n, n)
+			if err := decodeToIterable(rv, r, decodeToElem); err != nil {
+				return err
+			}
+			ret.Set(rv)
+			return nil
+		case n == -1:
+			chunk, err := DecodeVarInt(r)
+			if err != nil {
+				return err
+			}
+			rv := reflect.MakeSlice(rt, 0, int(chunk))
+			for chunk != 0 {
+				fmt.Printf("chunk: %d\n", chunk)
+				rvi := reflect.MakeSlice(rt, int(chunk), int(chunk))
+				if err := decodeToIterable(rvi, r, decodeToElem); err != nil {
+					return err
+				}
+				rv = reflect.AppendSlice(rv, rvi)
+				chunk, err = DecodeVarInt(r)
+				if err != nil {
+					return err
+				}
+			}
+			ret.Set(rv)
+			return nil
+		default:
+			return errors.Errorf("unable to decode slice iterable with size: %d", n)
+		}
+	}
+}
+
+// iterableDecoderForArray can decode from only the fixed sized and
+// multi-chunk variant of the beam iterable protocol.
+// Returns an error for other protocols (such as state backed).
+func iterableDecoderForArray(rt reflect.Type, decodeToElem func(reflect.Value, io.Reader) error) func(reflect.Value, io.Reader) error {
+	return func(ret reflect.Value, r io.Reader) error {
+		// (1) Read count prefixed encoded data
+		size, err := DecodeInt32(r)
+		if err != nil {
+			return err
+		}
+		n := int(size)
+		if rt.Len() != n {
+			return errors.Errorf("len mismatch decoding a %v: want %d got %d", rt, rt.Len(), n)
+		}
+		switch {
+		case n >= 0:
+			if err := decodeToIterable(ret, r, decodeToElem); err != nil {
+				return err
+			}
+			return nil
+		default:
+			return errors.Errorf("unable to decode array iterable with size: %d", n)
+		}
+	}
+}
+
+func decodeToIterable(rv reflect.Value, r io.Reader, decodeTo func(reflect.Value, io.Reader) error) error {
+	for i := 0; i < rv.Len(); i++ {
+		err := decodeTo(rv.Index(i), r)
+		if err != nil {
+			return err
+		}
+	}
+	return nil
+}

--- a/sdks/go/pkg/beam/core/graph/coder/iterable_test.go
+++ b/sdks/go/pkg/beam/core/graph/coder/iterable_test.go
@@ -1,0 +1,113 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coder
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestEncodeDecodeIterable(t *testing.T) {
+	stringEnc := func(rv reflect.Value, w io.Writer) error {
+		return EncodeStringUTF8(rv.String(), w)
+	}
+	stringDec := func(rv reflect.Value, r io.Reader) error {
+		v, err := DecodeStringUTF8(r)
+		if err != nil {
+			return nil
+		}
+		t.Log(v)
+		rv.SetString(v)
+		return nil
+	}
+
+	tests := []struct {
+		v          interface{}
+		encElm     func(reflect.Value, io.Writer) error
+		decElm     func(reflect.Value, io.Reader) error
+		encoded    []byte
+		decodeOnly bool
+	}{
+		{
+			v: [4]byte{1, 2, 3, 4},
+			encElm: func(rv reflect.Value, w io.Writer) error {
+				return EncodeByte(byte(rv.Uint()), w)
+			},
+			decElm: func(rv reflect.Value, r io.Reader) error {
+				b, err := DecodeByte(r)
+				if err != nil {
+					return nil
+				}
+				rv.SetUint(uint64(b))
+				return nil
+			},
+			encoded: []byte{0, 0, 0, 4, 1, 2, 3, 4},
+		},
+		{
+			v:       []string{"my", "gopher"},
+			encElm:  stringEnc,
+			decElm:  stringDec,
+			encoded: []byte{0, 0, 0, 2, 2, 'm', 'y', 6, 'g', 'o', 'p', 'h', 'e', 'r'},
+		},
+		{
+			v:          []string{"my", "gopher", "rocks"},
+			encElm:     stringEnc,
+			decElm:     stringDec,
+			encoded:    []byte{255, 255, 255, 255, 1, 2, 'm', 'y', 2, 6, 'g', 'o', 'p', 'h', 'e', 'r', 5, 'r', 'o', 'c', 'k', 's', 0},
+			decodeOnly: true,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		if !test.decodeOnly {
+			t.Run(fmt.Sprintf("encode %q", test.v), func(t *testing.T) {
+				var buf bytes.Buffer
+				err := iterableEncoder(reflect.TypeOf(test.v), test.encElm)(reflect.ValueOf(test.v), &buf)
+				if err != nil {
+					t.Fatalf("EncodeBytes(%q) = %v", test.v, err)
+				}
+				if d := cmp.Diff(test.encoded, buf.Bytes()); d != "" {
+					t.Errorf("EncodeBytes(%q) = %v, want %v diff(-want,+got):\n %v", test.v, buf.Bytes(), test.encoded, d)
+				}
+			})
+		}
+		t.Run(fmt.Sprintf("decode %v", test.v), func(t *testing.T) {
+			buf := bytes.NewBuffer(test.encoded)
+			rt := reflect.TypeOf(test.v)
+			var dec func(reflect.Value, io.Reader) error
+			switch rt.Kind() {
+			case reflect.Slice:
+				dec = iterableDecoderForSlice(rt, test.decElm)
+			case reflect.Array:
+				dec = iterableDecoderForArray(rt, test.decElm)
+			}
+			rv := reflect.New(rt).Elem()
+			err := dec(rv, buf)
+			if err != nil {
+				t.Fatalf("DecodeBytes(%q) = %v", test.encoded, err)
+			}
+			got := rv.Interface()
+			if d := cmp.Diff(test.v, got); d != "" {
+				t.Errorf("DecodeBytes(%q) = %q, want %v diff(-want,+got):\n %v", test.encoded, got, test.v, d)
+			}
+		})
+	}
+}


### PR DESCRIPTION
Add bytes, bool, and iterable coders to the graph/coders package.

This is in preparation of the next PR which has the first pass at the row encoder, so these building blocks can be reviewed separately. 
The bool and bytes coders are code migrated from the exec package, but it was striking me as odd to have so much encoding implementation living in exec/coder.go when much of it was in this graph/coder package. Those implementations will be replaced with the ones in this PR as appropriate (eg. iterables will necessarily be implemented in the Datasource package as well to support Large CoGBKs via the state channel for example.)

Iterables demonstrate how to handle reflective encoding with nested types, in this case, with a nested coder. As much as possible, it's best to avoid swapping back and forth through reflect.Values as that adds extensive overhead, which is why these are implemented in terms of reflect.Value. This doesn't matter for the primitive types which have efficient extraction methods from the reflect.Value containers.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
