### PR TITLE
[BEAM-9615] Add Row coder functions.

### DIFF
--- a/sdks/go/pkg/beam/core/graph/coder/row.go
+++ b/sdks/go/pkg/beam/core/graph/coder/row.go
@@ -1,0 +1,379 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coder
+
+import (
+	"fmt"
+	"io"
+	"reflect"
+
+	"github.com/apache/beam/sdks/go/pkg/beam/core/util/ioutilx"
+	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
+)
+
+type typeDecoderReflect struct {
+	typ    reflect.Type
+	fields []func(reflect.Value, io.Reader) error
+}
+
+// RowEncoderForStruct returns an encoding function that encodes a struct type
+// or a pointer to a struct type using the beam row encoding.
+//
+// Returns an error if the given type is invalid or not encodable to a beam
+// schema row.
+func RowEncoderForStruct(rt reflect.Type) (func(interface{}, io.Writer) error, error) {
+	if err := rowTypeValidation(rt, true); err != nil {
+		return nil, err
+	}
+	return encoderForType(rt), nil
+}
+
+// RowDecoderForStruct returns a decoding function that decodes the beam row encoding
+// into the given type.
+//
+// Returns an error if the given type is invalid or not decodable from a beam
+// schema row.
+func RowDecoderForStruct(rt reflect.Type) (func(io.Reader) (interface{}, error), error) {
+	if err := rowTypeValidation(rt, true); err != nil {
+		return nil, err
+	}
+	return decoderForType(rt), nil
+}
+
+func rowTypeValidation(rt reflect.Type, strictExportedFields bool) error {
+	switch k := rt.Kind(); k {
+	case reflect.Ptr, reflect.Struct:
+	default:
+		return errors.Errorf("can't generate row coder for type %v: must be a struct type or pointer to a struct type", rt)
+	}
+	// TODO exported field validation.
+	return nil
+}
+
+// decoderForType returns a decoder function for the struct or pointer to struct type.
+func decoderForType(t reflect.Type) func(io.Reader) (interface{}, error) {
+	var isPtr bool
+	// Pointers become the value type for decomposition.
+	if t.Kind() == reflect.Ptr {
+		isPtr = true
+		t = t.Elem()
+	}
+	dec := decoderForStructReflect(t)
+
+	if isPtr {
+		return func(r io.Reader) (interface{}, error) {
+			rv := reflect.New(t)
+			err := dec(rv.Elem(), r)
+			return rv.Interface(), err
+		}
+	}
+	return func(r io.Reader) (interface{}, error) {
+		rv := reflect.New(t)
+		err := dec(rv.Elem(), r)
+		return rv.Elem().Interface(), err
+	}
+}
+
+// decoderForSingleTypeReflect returns a reflection based decoder function for the
+// given type.
+func decoderForSingleTypeReflect(t reflect.Type) func(reflect.Value, io.Reader) error {
+	switch t.Kind() {
+	case reflect.Struct:
+		return decoderForStructReflect(t)
+	case reflect.Bool:
+		return func(rv reflect.Value, r io.Reader) error {
+			v, err := DecodeBool(r)
+			if err != nil {
+				return errors.Wrap(err, "error decoding varint field")
+			}
+			rv.SetBool(v)
+			return nil
+		}
+	case reflect.Uint8:
+		return func(rv reflect.Value, r io.Reader) error {
+			b, err := DecodeByte(r)
+			if err != nil {
+				return nil
+			}
+			rv.SetUint(uint64(b))
+			return nil
+		}
+	case reflect.String:
+		return func(rv reflect.Value, r io.Reader) error {
+			v, err := DecodeStringUTF8(r)
+			if err != nil {
+				return errors.Wrap(err, "error decoding string field")
+			}
+			rv.SetString(v)
+			return nil
+		}
+	case reflect.Int, reflect.Int8, reflect.Int16, reflect.Int32, reflect.Int64:
+		return func(rv reflect.Value, r io.Reader) error {
+			v, err := DecodeVarInt(r)
+			if err != nil {
+				return errors.Wrap(err, "error decoding varint field")
+			}
+			rv.SetInt(v)
+			return nil
+		}
+	case reflect.Float32, reflect.Float64:
+		return func(rv reflect.Value, r io.Reader) error {
+			v, err := DecodeDouble(r)
+			if err != nil {
+				return errors.Wrap(err, "error decoding double field")
+			}
+			rv.SetFloat(v)
+			return nil
+		}
+	case reflect.Ptr:
+		decf := decoderForSingleTypeReflect(t.Elem())
+		return func(rv reflect.Value, r io.Reader) error {
+			nv := reflect.New(t.Elem())
+			rv.Set(nv)
+			return decf(nv.Elem(), r)
+		}
+	case reflect.Slice:
+		// Special case handling for byte slices.
+		if t.Elem().Kind() == reflect.Uint8 {
+			return func(rv reflect.Value, r io.Reader) error {
+				b, err := DecodeBytes(r)
+				if err != nil {
+					return err
+				}
+				rv.SetBytes(b)
+				return nil
+			}
+		}
+		decf := decoderForSingleTypeReflect(t.Elem())
+		sdec := iterableDecoderForSlice(t, decf)
+		return func(rv reflect.Value, r io.Reader) error {
+			return sdec(rv, r)
+		}
+	case reflect.Array:
+		decf := decoderForSingleTypeReflect(t.Elem())
+		sdec := iterableDecoderForArray(t, decf)
+		return func(rv reflect.Value, r io.Reader) error {
+			return sdec(rv, r)
+		}
+	}
+	panic(fmt.Sprintf("unimplemented type to decode: %v", t))
+}
+
+// decoderForStructReflect returns a reflection based decoder function for the
+// given struct type.
+func decoderForStructReflect(t reflect.Type) func(reflect.Value, io.Reader) error {
+	var coder typeDecoderReflect
+	for i := 0; i < t.NumField(); i++ {
+		i := i // avoid alias issues in the closures.
+		dec := decoderForSingleTypeReflect(t.Field(i).Type)
+		coder.fields = append(coder.fields, func(rv reflect.Value, r io.Reader) error {
+			return dec(rv.Field(i), r)
+		})
+	}
+
+	return func(rv reflect.Value, r io.Reader) error {
+		nf, nils, err := readRowHeader(rv, r)
+		if err != nil {
+			return err
+		}
+		if nf != len(coder.fields) {
+			return errors.Errorf("schema[%v] changed: got %d fields, want %d fields", "TODO", nf, len(coder.fields))
+		}
+		for i, f := range coder.fields {
+			if isFieldNil(nils, i) {
+				continue
+			}
+			if err := f(rv, r); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// isFieldNil examines the passed in packed bits nils buffer
+// and returns true if the field at that index wasn't encoded
+// and can be skipped in decoding.
+func isFieldNil(nils []byte, f int) bool {
+	i, b := f/8, f%8
+	return len(nils) != 0 && (nils[i]>>b)&0x1 == 1
+}
+
+// encoderForType returns an encoder function for the struct or pointer to struct type.
+func encoderForType(t reflect.Type) func(interface{}, io.Writer) error {
+	var isPtr bool
+	// Pointers become the value type for decomposition.
+	if t.Kind() == reflect.Ptr {
+		isPtr = true
+		t = t.Elem()
+	}
+	enc := encoderForStructReflect(t)
+
+	if isPtr {
+		return func(v interface{}, w io.Writer) error {
+			return enc(reflect.ValueOf(v).Elem(), w)
+		}
+	}
+	return func(v interface{}, w io.Writer) error {
+		return enc(reflect.ValueOf(v), w)
+	}
+}
+
+// Generates coder using reflection for
+func encoderForSingleTypeReflect(t reflect.Type) func(reflect.Value, io.Writer) error {
+	switch t.Kind() {
+	case reflect.Struct:
+		return encoderForStructReflect(t)
+	case reflect.Bool:
+		return func(rv reflect.Value, w io.Writer) error {
+			return EncodeBool(rv.Bool(), w)
+		}
+	case reflect.Uint8:
+		return func(rv reflect.Value, w io.Writer) error {
+			return EncodeByte(byte(rv.Uint()), w)
+		}
+	case reflect.String:
+		return func(rv reflect.Value, w io.Writer) error {
+			return EncodeStringUTF8(rv.String(), w)
+		}
+	case reflect.Int, reflect.Int64, reflect.Int16, reflect.Int32, reflect.Int8:
+		return func(rv reflect.Value, w io.Writer) error {
+			return EncodeVarInt(int64(rv.Int()), w)
+		}
+	case reflect.Float32, reflect.Float64:
+		return func(rv reflect.Value, w io.Writer) error {
+			return EncodeDouble(float64(rv.Float()), w)
+		}
+	case reflect.Ptr:
+		// Nils are handled at the struct field level.
+		encf := encoderForSingleTypeReflect(t.Elem())
+		return func(rv reflect.Value, w io.Writer) error {
+			return encf(rv.Elem(), w)
+		}
+	case reflect.Slice:
+		// Special case handling for byte slices.
+		if t.Elem().Kind() == reflect.Uint8 {
+			return func(rv reflect.Value, w io.Writer) error {
+				return EncodeBytes(rv.Bytes(), w)
+			}
+		}
+		encf := encoderForSingleTypeReflect(t.Elem())
+		return iterableEncoder(t, encf)
+	case reflect.Array:
+		encf := encoderForSingleTypeReflect(t.Elem())
+		return iterableEncoder(t, encf)
+	}
+	panic(fmt.Sprintf("unimplemented type to encode: %v", t))
+}
+
+type typeEncoderReflect struct {
+	fields []func(reflect.Value, io.Writer) error
+}
+
+// encoderForStructReflect generates reflection field access closures for structs.
+func encoderForStructReflect(t reflect.Type) func(reflect.Value, io.Writer) error {
+	var coder typeEncoderReflect
+	for i := 0; i < t.NumField(); i++ {
+		i := i // avoid alias issues in the closures.
+		coder.fields = append(coder.fields, encoderForSingleTypeReflect(t.Field(i).Type))
+	}
+
+	return func(rv reflect.Value, w io.Writer) error {
+		// Row/Structs are prefixed with the number of fields that are encoded in total.
+		if err := writeRowHeader(rv, w); err != nil {
+			return err
+		}
+		for i, f := range coder.fields {
+			rvf := rv.Field(i)
+			switch rvf.Kind() {
+			case reflect.Ptr, reflect.Map, reflect.Slice:
+				if rvf.IsNil() {
+					continue
+				}
+			}
+			if err := f(rvf, w); err != nil {
+				return err
+			}
+		}
+		return nil
+	}
+}
+
+// writeRowHeader handles the field header for row encodings.
+func writeRowHeader(rv reflect.Value, w io.Writer) error {
+	// Row/Structs are prefixed with the number of fields that are encoded in total.
+	if err := EncodeVarInt(int64(rv.NumField()), w); err != nil {
+		return err
+	}
+	// Followed by a packed bit array of the nil fields.
+	var curByte byte
+	var nils bool
+	var bytes = make([]byte, 0, rv.NumField()/8+1)
+	for i := 0; i < rv.NumField(); i++ {
+		shift := i % 8
+		if i != 0 && shift == 0 {
+			bytes = append(bytes, curByte)
+			curByte = 0
+		}
+		rvf := rv.Field(i)
+		switch rvf.Kind() {
+		// Other types can be nil, but they aren't encodable.
+		case reflect.Ptr, reflect.Map, reflect.Slice:
+			if rvf.IsNil() {
+				curByte |= (1 << shift)
+				nils = true
+			}
+		}
+	}
+	if nils {
+		bytes = append(bytes, curByte)
+	} else {
+		// If there are no nils, we write a 0 length byte array instead.
+		bytes = bytes[:0]
+	}
+	if err := EncodeVarInt(int64(len(bytes)), w); err != nil {
+		return err
+	}
+	if _, err := ioutilx.WriteUnsafe(w, bytes); err != nil {
+		return err
+	}
+	return nil
+}
+
+// readRowHeader handles the field header for row decodings.
+//
+// This returns the raw bitpacked byte slice because we only need to
+// examine each bit once, so we may as well do so inline with field checking.
+func readRowHeader(rv reflect.Value, r io.Reader) (int, []byte, error) {
+	nf, err := DecodeVarInt(r) // is for checksum purposes (old vs new versions of a schemas)
+	if err != nil {
+		return 0, nil, err
+	}
+	l, err := DecodeVarInt(r) // read the length prefix for the packed bits.
+	if err != nil {
+		return int(nf), nil, err
+	}
+	if l == 0 {
+		// A zero length byte array means no nils.
+		return int(nf), nil, nil
+	}
+	var buf [32]byte // should get stack allocated?
+	nils := buf[:l]
+	if err := ioutilx.ReadNBufUnsafe(r, nils); err != nil {
+		return int(nf), nil, err
+	}
+	return int(nf), nils, nil
+}

--- a/sdks/go/pkg/beam/core/graph/coder/row.go
+++ b/sdks/go/pkg/beam/core/graph/coder/row.go
@@ -209,7 +209,7 @@ func decoderForStructReflect(t reflect.Type) func(reflect.Value, io.Reader) erro
 // and can be skipped in decoding.
 func isFieldNil(nils []byte, f int) bool {
 	i, b := f/8, f%8
-	return len(nils) != 0 && (nils[i]>>b)&0x1 == 1
+	return len(nils) != 0 && (nils[i]>>uint8(b))&0x1 == 1
 }
 
 // encoderForType returns an encoder function for the struct or pointer to struct type.
@@ -333,7 +333,7 @@ func writeRowHeader(rv reflect.Value, w io.Writer) error {
 		// Other types can be nil, but they aren't encodable.
 		case reflect.Ptr, reflect.Map, reflect.Slice:
 			if rvf.IsNil() {
-				curByte |= (1 << shift)
+				curByte |= (uint8(1) << shift)
 				nils = true
 			}
 		}

--- a/sdks/go/pkg/beam/core/graph/coder/row_test.go
+++ b/sdks/go/pkg/beam/core/graph/coder/row_test.go
@@ -1,0 +1,166 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package coder
+
+import (
+	"bytes"
+	"fmt"
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestReflectionRowCoderGeneration(t *testing.T) {
+	num := 35
+	tests := []struct {
+		want interface{}
+	}{{
+		// Top level value check
+		want: UserType1{
+			A: "cats",
+			B: 24,
+			C: "pjamas",
+		},
+	}, {
+		// Top level pointer check
+		want: &UserType1{
+			A: "marmalade",
+			B: 24,
+			C: "jam",
+		},
+	}, {
+		// Inner pointer check.
+		want: UserType2{
+			A: "dogs",
+			B: &UserType1{
+				A: "cats",
+				B: 24,
+				C: "pjamas",
+			},
+			C: &num,
+		},
+	}, {
+		// nil pointer check.
+		want: UserType2{
+			A: "dogs",
+			B: nil,
+			C: nil,
+		},
+	}, {
+		// All zeroes
+		want: struct {
+			V00 bool
+			V01 byte  // unsupported by spec (same as uint8)
+			V02 uint8 // unsupported by spec
+			V03 int16
+			//	V04 uint16 // unsupported by spec
+			V05 int32
+			//	V06 uint32 // unsupported by spec
+			V07 int64
+			//	V08 uint64 // unsupported by spec
+			V09 int
+			V10 struct{}
+			V11 *struct{}
+			V12 [0]int
+			V13 [2]int
+			V14 []int
+			// V15 map[string]int // not yet a standard coder (BEAM-7996)
+			V16 float32
+			V17 float64
+			V18 []byte
+		}{},
+	}, {
+		want: struct {
+			V00 bool
+			V01 byte
+			V02 uint8
+			V03 int16
+			//	V04 uint16 // unsupported by spec
+			V05 int32
+			//	V06 uint32 // unsupported by spec
+			V07 int64
+			//	V08 uint64 // unsupported by spec
+			V09 int
+			V10 struct{}
+			V11 *struct{}
+			V12 [0]int
+			V13 [2]int
+			V14 []int
+			// V15 map[string]int // not yet a standard coder (BEAM-7996) (encoding unspecified)
+			V16 float32
+			V17 float64
+			V18 []byte
+		}{
+			V00: true,
+			V01: 1,
+			V02: 2,
+			V03: 3,
+			V05: 5,
+			V07: 7,
+			V09: 9,
+			V10: struct{}{},
+			V11: &struct{}{},
+			V12: [0]int{},
+			V13: [2]int{72, 908},
+			V14: []int{12, 9326, 641346, 6},
+			V16: 3.14169,
+			V17: 2.6e100,
+			V18: []byte{21, 17, 65, 255, 0, 16},
+		},
+		// TODO add custom types such as protocol buffers.
+	},
+	}
+	for _, test := range tests {
+		t.Run(fmt.Sprintf("%+v", test.want), func(t *testing.T) {
+			rt := reflect.TypeOf(test.want)
+			enc, err := RowEncoderForStruct(rt)
+			if err != nil {
+				t.Fatalf("RowEncoderForStruct(%v) = %v, want nil error", rt, err)
+			}
+			var buf bytes.Buffer
+			if err := enc(test.want, &buf); err != nil {
+				t.Fatalf("enc(%v) = err, want nil error", err)
+			}
+			dec, err := RowDecoderForStruct(rt)
+			if err != nil {
+				t.Fatalf("RowDecoderForStruct(%v) = %v, want nil error", rt, err)
+			}
+			b := buf.Bytes()
+			r := bytes.NewBuffer(b)
+			got, err := dec(r)
+			if err != nil {
+				t.Fatalf("RowDecoderForStruct(%v) = %v, want nil error", rt, err)
+			}
+			if d := cmp.Diff(test.want, got); d != "" {
+				t.Fatalf("dec(enc(%v)) = %v\ndiff (-want, +got): %v", test.want, got, d)
+			}
+		})
+	}
+
+}
+
+type UserType1 struct {
+	A string
+	B int
+	C string
+}
+
+type UserType2 struct {
+	A string
+	B *UserType1
+	C *int
+}


### PR DESCRIPTION
Adds row encoder and decoder function generators, using reflection. Doesn't provide single element convenience functions for encoding and decoding struct values.

Doesn't support looking up Logical types, or handling Map types at present, but this is sufficient to pass standard_coders.yaml for now.
Subsequent PRs will hook this into framework use.
Remaining work includes:
* Adding reference kinds for this coder in the rest of the coder package.
* Hooking those into graphx/coder.go
* Converting Go types to Schemas and vice versa.
* Validation and restrictions on such types (eg unexported fields).
* Hooking this into the exec package.
* Submitting the standard_coders.yaml validation for the Go SDK.
* Swapping this to default over JSON encoding.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
