### PR TITLE
[BEAM 7624] Added Null Behavior in JsonToRow

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/JsonToRow.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/JsonToRow.java
@@ -92,7 +92,7 @@ public class JsonToRow {
   static class JsonToRowFn extends PTransform<PCollection<String>, PCollection<Row>> {
     private transient volatile @Nullable ObjectMapper objectMapper;
     private Schema schema;
-    private volatile NullBehavior nullBehavior = NullBehavior.REQUIRE_NULL;
+    private volatile NullBehavior nullBehavior = NullBehavior.ACCEPT_MISSING_OR_NULL;
 
     static JsonToRowFn forSchema(Schema rowSchema) {
       // Throw exception if this schema is not supported by RowJson

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/JsonToRow.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/JsonToRow.java
@@ -104,6 +104,7 @@ public class JsonToRow {
       this.schema = schema;
     }
 
+    /** Sets the behavior of the deserializer according to {@link NullBehavior}. */
     public JsonToRowFn withNullBehavior(NullBehavior nullBehavior) {
       this.nullBehavior = nullBehavior;
       return this;
@@ -260,7 +261,7 @@ public class JsonToRow {
     }
 
     /**
-     * Sets the missing field behavior.
+     * Sets the behavior of the deserializer according to {@link NullBehavior}.
      *
      * @return {@link JsonToRow}
      */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/JsonToRow.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/JsonToRow.java
@@ -221,7 +221,7 @@ public class JsonToRow {
       RowJson.verifySchemaSupported(rowSchema);
       return new AutoValue_JsonToRow_JsonToRowWithErrFn.Builder()
           .setSchema(rowSchema)
-          .setNullBehavior(NullBehavior.REQUIRE_NULL)
+          .setNullBehavior(NullBehavior.ACCEPT_MISSING_OR_NULL)
           .setExtendedErrorInfo(false)
           .setLineFieldName(LINE_FIELD_NAME)
           .setErrorFieldName(ERROR_FIELD_NAME)

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/JsonToRowTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/JsonToRowTest.java
@@ -146,8 +146,9 @@ public class JsonToRowTest implements Serializable {
     PCollection<Row> personRows =
         jsonPersons
             .apply(
-                ((JsonToRowFn) JsonToRow.withSchema(PERSON_SCHEMA_WITH_NULLABLE_FIELD))
-                    .withNullBehavior(NullBehavior.ACCEPT_MISSING_OR_NULL))
+                ((JsonToRowFn)
+                    JsonToRow.withSchemaAndNullBehavior(
+                        PERSON_SCHEMA_WITH_NULLABLE_FIELD, NullBehavior.ACCEPT_MISSING_OR_NULL)))
             .setRowSchema(PERSON_SCHEMA_WITH_NULLABLE_FIELD);
 
     PAssert.that(personRows).containsInAnyOrder(PERSON_ROWS_WITH_NULLS);

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/JsonToRowTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/JsonToRowTest.java
@@ -27,8 +27,10 @@ import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.UsesSchema;
+import org.apache.beam.sdk.transforms.JsonToRow.JsonToRowFn;
 import org.apache.beam.sdk.transforms.JsonToRow.JsonToRowWithErrFn;
 import org.apache.beam.sdk.transforms.JsonToRow.ParseResult;
+import org.apache.beam.sdk.util.RowJson.RowJsonDeserializer.NullBehavior;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
@@ -70,6 +72,29 @@ public class JsonToRowTest implements Serializable {
           row(PERSON_SCHEMA, "person3", 60, true),
           row(PERSON_SCHEMA, "person4", 50, false),
           row(PERSON_SCHEMA, "person5", 40, true));
+
+  private static final Schema PERSON_SCHEMA_WITH_NULLABLE_FIELD =
+      Schema.builder()
+          .addStringField("name")
+          .addInt32Field("height")
+          .addNullableField("knowsJavascript", FieldType.BOOLEAN)
+          .build();
+
+  private static final ImmutableList<String> JSON_PERSON_WITH_IMPLICIT_NULLS =
+      ImmutableList.of(
+          jsonPerson("person1", "80"),
+          jsonPerson("person2", "70", "false"),
+          jsonPerson("person3", "60"),
+          jsonPerson("person4", "50", "false"),
+          jsonPerson("person5", "40", "true"));
+
+  private static final ImmutableList<Row> PERSON_ROWS_WITH_NULLS =
+      ImmutableList.of(
+          row(PERSON_SCHEMA_WITH_NULLABLE_FIELD, "person1", 80, null),
+          row(PERSON_SCHEMA_WITH_NULLABLE_FIELD, "person2", 70, false),
+          row(PERSON_SCHEMA_WITH_NULLABLE_FIELD, "person3", 60, null),
+          row(PERSON_SCHEMA_WITH_NULLABLE_FIELD, "person4", 50, false),
+          row(PERSON_SCHEMA_WITH_NULLABLE_FIELD, "person5", 40, true));
 
   private static final ImmutableList<String> JSON_PERSON_WITH_ERR =
       ImmutableList.copyOf(
@@ -113,6 +138,25 @@ public class JsonToRowTest implements Serializable {
 
   @Test
   @Category(NeedsRunner.class)
+  public void testParsesRowsMissing() throws Exception {
+
+    PCollection<String> jsonPersons =
+        pipeline.apply("jsonPersons", Create.of(JSON_PERSON_WITH_IMPLICIT_NULLS));
+
+    PCollection<Row> personRows =
+        jsonPersons
+            .apply(
+                ((JsonToRowFn) JsonToRow.withSchema(PERSON_SCHEMA_WITH_NULLABLE_FIELD))
+                    .withNullBehavior(NullBehavior.ACCEPT_MISSING_OR_NULL))
+            .setRowSchema(PERSON_SCHEMA_WITH_NULLABLE_FIELD);
+
+    PAssert.that(personRows).containsInAnyOrder(PERSON_ROWS_WITH_NULLS);
+
+    pipeline.run();
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
   public void testParsesRowsDeadLetterNoErrors() throws Exception {
 
     PCollection<String> jsonPersons = pipeline.apply("jsonPersons", Create.of(JSON_PERSON));
@@ -123,6 +167,28 @@ public class JsonToRowTest implements Serializable {
     PCollection<Row> errors = results.getFailedToParseLines();
 
     PAssert.that(personRows).containsInAnyOrder(PERSON_ROWS);
+
+    PAssert.that(errors).empty();
+
+    pipeline.run();
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testParsesRowsDeadLetterWithMissingFieldsNoErrors() throws Exception {
+
+    PCollection<String> jsonPersons =
+        pipeline.apply("jsonPersons", Create.of(JSON_PERSON_WITH_IMPLICIT_NULLS));
+
+    ParseResult results =
+        jsonPersons.apply(
+            JsonToRow.withExceptionReporting(PERSON_SCHEMA_WITH_NULLABLE_FIELD)
+                .withNullBehavior(NullBehavior.ACCEPT_MISSING_OR_NULL));
+
+    PCollection<Row> personRows = results.getResults();
+    PCollection<Row> errors = results.getFailedToParseLines();
+
+    PAssert.that(personRows).containsInAnyOrder(PERSON_ROWS_WITH_NULLS);
 
     PAssert.that(errors).empty();
 
@@ -181,6 +247,33 @@ public class JsonToRowTest implements Serializable {
 
   @Test
   @Category(NeedsRunner.class)
+  public void testParsesErrorWithErrorMsgWithMissingFieldsDeadLetter() throws Exception {
+    PCollection<String> jsonPersons =
+        pipeline.apply("jsonPersons", Create.of(JSON_PERSON_WITH_IMPLICIT_NULLS));
+
+    ParseResult results =
+        jsonPersons.apply(
+            JsonToRow.withExceptionReporting(PERSON_SCHEMA_WITH_NULLABLE_FIELD)
+                .withExtendedErrorInfo());
+
+    PCollection<Row> errorsWithMsg = results.getFailedToParseLines();
+
+    PAssert.that(errorsWithMsg)
+        .containsInAnyOrder(
+            row(
+                JsonToRowWithErrFn.ERROR_ROW_WITH_ERR_MSG_SCHEMA,
+                jsonPerson("person1", "80"),
+                "Field 'knowsJavascript' is not present in the JSON object."),
+            row(
+                JsonToRowWithErrFn.ERROR_ROW_WITH_ERR_MSG_SCHEMA,
+                jsonPerson("person3", "60"),
+                "Field 'knowsJavascript' is not present in the JSON object."));
+
+    pipeline.run();
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
   public void testParsesErrorWithErrorMsgRowsDeadLetterWithCustomFieldNames() throws Exception {
     PCollection<String> jsonPersons =
         pipeline.apply("jsonPersons", Create.of(JSON_PERSON_WITH_ERR));
@@ -226,6 +319,10 @@ public class JsonToRowTest implements Serializable {
         + knowsJs
         + "\n"
         + "}";
+  }
+
+  private static String jsonPerson(String name, String height) {
+    return "{\n" + "  \"name\": \"" + name + "\",\n" + "  \"height\": " + height + "}";
   }
 
   private static Row row(Schema schema, Object... values) {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/JsonToRowTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/JsonToRowTest.java
@@ -247,14 +247,15 @@ public class JsonToRowTest implements Serializable {
 
   @Test
   @Category(NeedsRunner.class)
-  public void testParsesErrorWithErrorMsgWithMissingFieldsDeadLetter() throws Exception {
+  public void testParsesErrorWithErrorMsgWithRequireNullDeadLetter() throws Exception {
     PCollection<String> jsonPersons =
         pipeline.apply("jsonPersons", Create.of(JSON_PERSON_WITH_IMPLICIT_NULLS));
 
     ParseResult results =
         jsonPersons.apply(
             JsonToRow.withExceptionReporting(PERSON_SCHEMA_WITH_NULLABLE_FIELD)
-                .withExtendedErrorInfo());
+                .withExtendedErrorInfo()
+                .withNullBehavior(NullBehavior.REQUIRE_NULL));
 
     PCollection<Row> errorsWithMsg = results.getFailedToParseLines();
 


### PR DESCRIPTION
Added support for changing the null read behavior of JsonToRow using the changes done in RowJson. 

Added NullBehavior to JsonToRow, and some corresponding tests. 


Notes:
I needed to add the volatile flag on the NullBehavior on JsonToRowFn because spotbugs would complain about threading issues if I didn't. 

Didn't end up doing anything with the BeamSQL Json stuff as I don't have any experience with BeamSQL and looked like quite a lot of internal code surrounding it. 


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
