### PR TITLE
[BEAM-9754] Add Py 3.8 support to Dataflow runner.

### DIFF
--- a/sdks/python/apache_beam/__init__.py
+++ b/sdks/python/apache_beam/__init__.py
@@ -77,11 +77,16 @@ import os
 import sys
 import warnings
 
-if sys.version_info[0] == 2 and sys.version_info[1] == 7:
+if sys.version_info.major == 2 and sys.version_info.minor == 7:
   warnings.warn(
       'You are using Apache Beam with Python 2. '
       'New releases of Apache Beam will soon support Python 3 only.')
-elif sys.version_info[0] == 3:
+elif sys.version_info.major == 3:
+  if sys.version_info.minor >= 8:
+    warnings.warn(
+        'This version of Apache Beam has not been sufficiently tested on '
+        'Python %s.%s. You may encounter bugs or missing features.' %
+        (sys.version_info.major, sys.version_info.minor))
   pass
 else:
   raise RuntimeError(

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner_test.py
@@ -225,9 +225,6 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
                 capabilities=environments.python_sdk_capabilities())
         ])
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_remote_runner_translation(self):
     remote_runner = DataflowRunner()
     with Pipeline(remote_runner,
@@ -238,9 +235,6 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
           | 'Do' >> ptransform.FlatMap(lambda x: [(x, x)])
           | ptransform.GroupByKey())
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_streaming_create_translation(self):
     remote_runner = DataflowRunner()
     self.default_properties.append("--streaming")
@@ -256,9 +250,6 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
     self.assertEqual(job_dict[u'steps'][1][u'kind'], u'ParallelDo')
     self.assertEqual(job_dict[u'steps'][2][u'kind'], u'ParallelDo')
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_bigquery_read_streaming_fail(self):
     remote_runner = DataflowRunner()
     self.default_properties.append("--streaming")
@@ -268,9 +259,6 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
                     PipelineOptions(self.default_properties)) as p:
         _ = p | beam.io.Read(beam.io.BigQuerySource('some.table'))
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_biqquery_read_fn_api_fail(self):
     remote_runner = DataflowRunner()
     for flag in ['beam_fn_api', 'use_unified_worker', 'use_runner_v2']:
@@ -283,9 +271,6 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
                       PipelineOptions(self.default_properties)) as p:
           _ = p | beam.io.Read(beam.io.BigQuerySource('some.table'))
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_remote_runner_display_data(self):
     remote_runner = DataflowRunner()
     p = Pipeline(
@@ -328,9 +313,6 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
                      }]
     self.assertUnhashableCountEqual(disp_data, expected_data)
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_no_group_by_key_directly_after_bigquery(self):
     remote_runner = DataflowRunner()
     with self.assertRaises(ValueError,
@@ -456,9 +438,6 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
           common_urns.side_inputs.MULTIMAP.urn,
           side_input._side_input_data().access_pattern)
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_min_cpu_platform_flag_is_propagated_to_experiments(self):
     remote_runner = DataflowRunner()
     self.default_properties.append('--min_cpu_platform=Intel Haswell')
@@ -469,9 +448,6 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
         'min_cpu_platform=Intel Haswell',
         remote_runner.job.options.view_as(DebugOptions).experiments)
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_streaming_engine_flag_adds_windmill_experiments(self):
     remote_runner = DataflowRunner()
     self.default_properties.append('--streaming')
@@ -487,9 +463,6 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
     self.assertIn('enable_windmill_service', experiments_for_job)
     self.assertIn('some_other_experiment', experiments_for_job)
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_upload_graph_experiment(self):
     remote_runner = DataflowRunner()
     self.default_properties.append('--experiment=upload_graph')
@@ -501,9 +474,6 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
         remote_runner.job.options.view_as(DebugOptions).experiments)
     self.assertIn('upload_graph', experiments_for_job)
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_dataflow_worker_jar_flag_non_fnapi_noop(self):
     remote_runner = DataflowRunner()
     self.default_properties.append('--experiment=some_other_experiment')
@@ -517,9 +487,6 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
     self.assertIn('some_other_experiment', experiments_for_job)
     self.assertNotIn('use_staged_dataflow_worker_jar', experiments_for_job)
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_dataflow_worker_jar_flag_adds_use_staged_worker_jar_experiment(self):
     remote_runner = DataflowRunner()
     self.default_properties.append('--experiment=beam_fn_api')
@@ -533,9 +500,6 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
     self.assertIn('beam_fn_api', experiments_for_job)
     self.assertIn('use_staged_dataflow_worker_jar', experiments_for_job)
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_use_fastavro_experiment_is_added_on_py3_and_onwards(self):
     remote_runner = DataflowRunner()
 
@@ -547,9 +511,6 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
         remote_runner.job.options.view_as(DebugOptions).lookup_experiment(
             'use_fastavro', False))
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_use_fastavro_experiment_is_not_added_when_use_avro_is_present(self):
     remote_runner = DataflowRunner()
     self.default_properties.append('--experiment=use_avro')
@@ -561,9 +522,6 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
 
     self.assertFalse(debug_options.lookup_experiment('use_fastavro', False))
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_unsupported_fnapi_features(self):
     remote_runner = DataflowRunner()
     self.default_properties.append('--experiment=beam_fn_api')
@@ -617,9 +575,6 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
     result = runner.get_default_gcp_region()
     self.assertIsNone(result)
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_combine_values_translation(self):
     runner = DataflowRunner()
 
@@ -670,9 +625,6 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
     self.assertGreater(len(step[u'properties']['display_data']), 0)
     self.assertEqual(step[u'properties']['output_info'], expected_output_info)
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_read_create_translation(self):
     runner = DataflowRunner()
 
@@ -683,9 +635,6 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
 
     self.expect_correct_override(runner.job, u'Create/Read', u'ParallelRead')
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_read_bigquery_translation(self):
     runner = DataflowRunner()
 
@@ -696,9 +645,6 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
 
     self.expect_correct_override(runner.job, u'Read', u'ParallelRead')
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_read_pubsub_translation(self):
     runner = DataflowRunner()
 
@@ -712,9 +658,6 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
     self.expect_correct_override(
         runner.job, u'ReadFromPubSub/Read', u'ParallelRead')
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_gbk_translation(self):
     runner = DataflowRunner()
     with beam.Pipeline(runner=runner,
@@ -752,9 +695,6 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
     self.assertEqual(
         gbk_step[u'properties']['output_info'], expected_output_info)
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_write_bigquery_translation(self):
     runner = DataflowRunner()
 
@@ -805,9 +745,6 @@ class DataflowRunnerTest(unittest.TestCase, ExtraAssertionsMixin):
     del step_encoding[u'component_encodings'][0][u'@type']
     self.assertEqual(expected_step, write_step)
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_write_bigquery_failed_translation(self):
     """Tests that WriteToBigQuery cannot have any consumers if replaced."""
     runner = DataflowRunner()

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
@@ -1080,6 +1080,8 @@ def get_container_image_from_options(pipeline_options):
     version_suffix = '36'
   elif sys.version_info[0:2] == (3, 7):
     version_suffix = '37'
+  elif sys.version_info[0:2] == (3, 8):
+    version_suffix = '38'
   else:
     raise Exception(
         'Dataflow only supports Python versions 2 and 3.5+, got: %s' %
@@ -1144,7 +1146,7 @@ def get_response_encoding():
 
 
 def _verify_interpreter_version_is_supported(pipeline_options):
-  if sys.version_info[0:2] in [(2, 7), (3, 5), (3, 6), (3, 7)]:
+  if sys.version_info[0:2] in [(2, 7), (3, 5), (3, 6), (3, 7), (3, 8)]:
     return
 
   debug_options = pipeline_options.view_as(DebugOptions)
@@ -1154,7 +1156,7 @@ def _verify_interpreter_version_is_supported(pipeline_options):
 
   raise Exception(
       'Dataflow runner currently supports Python versions '
-      '2.7, 3.5, 3.6, and 3.7. To ignore this requirement and start a job '
+      '2.7, 3.5, 3.6, 3.7 and 3.8. To ignore this requirement and start a job '
       'using a different version of Python 3 interpreter, pass '
       '--experiment ignore_py3_minor_version pipeline option.')
 

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
@@ -61,9 +61,6 @@ class UtilTest(unittest.TestCase):
     pipeline_options = PipelineOptions()
     apiclient.DataflowApplicationClient(pipeline_options)
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_pipeline_url(self):
     pipeline_options = PipelineOptions([
         '--subnetwork',
@@ -95,9 +92,6 @@ class UtilTest(unittest.TestCase):
 
     self.assertEqual(pipeline_url.string_value, FAKE_PIPELINE_URL)
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_set_network(self):
     pipeline_options = PipelineOptions([
         '--network',
@@ -111,9 +105,6 @@ class UtilTest(unittest.TestCase):
                                 FAKE_PIPELINE_URL)
     self.assertEqual(env.proto.workerPools[0].network, 'anetworkname')
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_set_subnetwork(self):
     pipeline_options = PipelineOptions([
         '--subnetwork',
@@ -130,9 +121,6 @@ class UtilTest(unittest.TestCase):
         env.proto.workerPools[0].subnetwork,
         '/regions/MY/subnetworks/SUBNETWORK')
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_flexrs_blank(self):
     pipeline_options = PipelineOptions(
         ['--temp_location', 'gs://any-location/temp'])
@@ -143,9 +131,6 @@ class UtilTest(unittest.TestCase):
                                 FAKE_PIPELINE_URL)
     self.assertEqual(env.proto.flexResourceSchedulingGoal, None)
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_flexrs_cost(self):
     pipeline_options = PipelineOptions([
         '--flexrs_goal',
@@ -164,9 +149,6 @@ class UtilTest(unittest.TestCase):
             dataflow.Environment.FlexResourceSchedulingGoalValueValuesEnum.
             FLEXRS_COST_OPTIMIZED))
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_flexrs_speed(self):
     pipeline_options = PipelineOptions([
         '--flexrs_goal',
@@ -185,9 +167,6 @@ class UtilTest(unittest.TestCase):
             dataflow.Environment.FlexResourceSchedulingGoalValueValuesEnum.
             FLEXRS_SPEED_OPTIMIZED))
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_sdk_harness_container_images_get_set(self):
 
     pipeline_options = PipelineOptions([
@@ -371,9 +350,6 @@ class UtilTest(unittest.TestCase):
     self.assertEqual(
         metric_update.floatingPointMean.count.lowBits, accumulator.count)
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_default_ip_configuration(self):
     pipeline_options = PipelineOptions(
         ['--temp_location', 'gs://any-location/temp'])
@@ -383,9 +359,6 @@ class UtilTest(unittest.TestCase):
                                 FAKE_PIPELINE_URL)
     self.assertEqual(env.proto.workerPools[0].ipConfiguration, None)
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_public_ip_configuration(self):
     pipeline_options = PipelineOptions(
         ['--temp_location', 'gs://any-location/temp', '--use_public_ips'])
@@ -397,9 +370,6 @@ class UtilTest(unittest.TestCase):
         env.proto.workerPools[0].ipConfiguration,
         dataflow.WorkerPool.IpConfigurationValueValuesEnum.WORKER_IP_PUBLIC)
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_private_ip_configuration(self):
     pipeline_options = PipelineOptions(
         ['--temp_location', 'gs://any-location/temp', '--no_use_public_ips'])
@@ -411,9 +381,6 @@ class UtilTest(unittest.TestCase):
         env.proto.workerPools[0].ipConfiguration,
         dataflow.WorkerPool.IpConfigurationValueValuesEnum.WORKER_IP_PRIVATE)
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_number_of_worker_harness_threads(self):
     pipeline_options = PipelineOptions([
         '--temp_location',
@@ -431,9 +398,6 @@ class UtilTest(unittest.TestCase):
       'apache_beam.runners.dataflow.internal.apiclient.'
       'beam_version.__version__',
       '2.2.0')
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_harness_override_default_in_released_sdks(self):
     pipeline_options = PipelineOptions(
         ['--temp_location', 'gs://any-location/temp', '--streaming'])
@@ -452,9 +416,6 @@ class UtilTest(unittest.TestCase):
       'apache_beam.runners.dataflow.internal.apiclient.'
       'beam_version.__version__',
       '2.2.0')
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_harness_override_absent_in_released_sdks_with_runner_v2(self):
     pipeline_options = PipelineOptions([
         '--temp_location',
@@ -475,9 +436,6 @@ class UtilTest(unittest.TestCase):
       'apache_beam.runners.dataflow.internal.apiclient.'
       'beam_version.__version__',
       '2.2.0')
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_harness_override_custom_in_released_sdks(self):
     pipeline_options = PipelineOptions([
         '--temp_location',
@@ -502,9 +460,6 @@ class UtilTest(unittest.TestCase):
       'apache_beam.runners.dataflow.internal.apiclient.'
       'beam_version.__version__',
       '2.2.0')
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_harness_override_custom_in_released_sdks_with_runner_v2(self):
     pipeline_options = PipelineOptions([
         '--temp_location',
@@ -530,9 +485,6 @@ class UtilTest(unittest.TestCase):
       'apache_beam.runners.dataflow.internal.apiclient.'
       'beam_version.__version__',
       '2.2.0.rc1')
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_harness_override_uses_base_version_in_rc_releases(self):
     pipeline_options = PipelineOptions(
         ['--temp_location', 'gs://any-location/temp', '--streaming'])
@@ -551,9 +503,6 @@ class UtilTest(unittest.TestCase):
       'apache_beam.runners.dataflow.internal.apiclient.'
       'beam_version.__version__',
       '2.2.0.dev')
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_harness_override_absent_in_unreleased_sdk(self):
     pipeline_options = PipelineOptions(
         ['--temp_location', 'gs://any-location/temp', '--streaming'])
@@ -569,9 +518,6 @@ class UtilTest(unittest.TestCase):
       'apache_beam.runners.dataflow.internal.apiclient.'
       'beam_version.__version__',
       '2.2.0.dev')
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_pinned_worker_harness_image_tag_used_in_dev_sdk(self):
     # streaming, fnapi pipeline.
     pipeline_options = PipelineOptions(
@@ -634,9 +580,6 @@ class UtilTest(unittest.TestCase):
       'apache_beam.runners.dataflow.internal.apiclient.'
       'beam_version.__version__',
       '2.2.0')
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_worker_harness_image_tag_matches_released_sdk_version(self):
     # streaming, fnapi pipeline.
     pipeline_options = PipelineOptions(
@@ -687,9 +630,6 @@ class UtilTest(unittest.TestCase):
       'apache_beam.runners.dataflow.internal.apiclient.'
       'beam_version.__version__',
       '2.2.0.rc1')
-  @unittest.skipIf(
-      sys.version_info.minor == 8, 'Re-enable once BEAM-9754 is '
-      'resolved')
   def test_worker_harness_image_tag_matches_base_sdk_version_of_an_rc(self):
     # streaming, fnapi pipeline.
     pipeline_options = PipelineOptions(
@@ -736,9 +676,6 @@ class UtilTest(unittest.TestCase):
               names.DATAFLOW_CONTAINER_IMAGE_REPOSITORY + '/python%d%d:2.2.0' %
               (sys.version_info[0], sys.version_info[1])))
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_worker_harness_override_takes_precedence_over_sdk_defaults(self):
     # streaming, fnapi pipeline.
     pipeline_options = PipelineOptions([
@@ -828,9 +765,6 @@ class UtilTest(unittest.TestCase):
     self.assertEqual('key5', job.proto.labels.additionalProperties[4].key)
     self.assertEqual('', job.proto.labels.additionalProperties[4].value)
 
-  @unittest.skipIf(
-      sys.version_info.minor == 8,
-      'Doesn\'t work on Python 3.8, see: BEAM-9754')
   def test_experiment_use_multiple_sdk_containers(self):
     pipeline_options = PipelineOptions([
         '--project',

--- a/sdks/python/apache_beam/runners/dataflow/internal/names.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/names.py
@@ -40,10 +40,10 @@ SERIALIZED_SOURCE_KEY = 'serialized_source'
 
 # Update this version to the next version whenever there is a change that will
 # require changes to legacy Dataflow worker execution environment.
-BEAM_CONTAINER_VERSION = 'beam-master-20200619'
+BEAM_CONTAINER_VERSION = 'beam-master-20200630'
 # Update this version to the next version whenever there is a change that
 # requires changes to SDK harness container or SDK harness launcher.
-BEAM_FNAPI_CONTAINER_VERSION = 'beam-master-20200619'
+BEAM_FNAPI_CONTAINER_VERSION = 'beam-master-20200630'
 
 # TODO(BEAM-5939): Remove these shared names once Dataflow worker is updated.
 PICKLED_MAIN_SESSION_FILE = 'pickled_main_session'

--- a/sdks/python/apache_beam/runners/dataflow/template_runner_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/template_runner_test.py
@@ -22,7 +22,6 @@
 from __future__ import absolute_import
 
 import json
-import sys
 import tempfile
 import unittest
 
@@ -41,8 +40,6 @@ except ImportError:
 
 
 @unittest.skipIf(apiclient is None, 'GCP dependencies are not installed')
-@unittest.skipIf(
-    sys.version_info.minor == 8, 'Doesn\'t work on Python 3.8, see: BEAM-9754')
 class TemplatingDataflowRunnerTest(unittest.TestCase):
   """TemplatingDataflow tests."""
   def test_full_completion(self):

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -259,10 +259,16 @@ def generate_protos_first(original_cmd):
 
 python_requires = '>=2.7,!=3.0.*,!=3.1.*,!=3.2.*,!=3.3.*,!=3.4.*'
 
-if sys.version_info[0] == 2:
+if sys.version_info.major == 2:
   warnings.warn(
       'You are using Apache Beam with Python 2. '
       'New releases of Apache Beam will soon support Python 3 only.')
+
+if sys.version_info.major == 3 and sys.version_info.minor >= 8:
+  warnings.warn(
+      'This version of Apache Beam has not been sufficiently tested on '
+      'Python %s.%s. You may encounter bugs or missing features.' % (
+          sys.version_info.major, sys.version_info.minor))
 
 setuptools.setup(
     name=PACKAGE_NAME,
@@ -312,6 +318,8 @@ setuptools.setup(
         'Programming Language :: Python :: 3.5',
         'Programming Language :: Python :: 3.6',
         'Programming Language :: Python :: 3.7',
+        # When updating vesion classifiers, also update version warnings
+        # above and in apache_beam/__init__.py.
         'Topic :: Software Development :: Libraries',
         'Topic :: Software Development :: Libraries :: Python Modules',
     ],


### PR DESCRIPTION
Adds Py3.8 support to Dataflow runner now that Dataflow provides Py 3.8 containers.
Also add a user warning  for Py3.8 and newer versions  for which Apache Beam does not yet have robust test coverage.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
