### PR TITLE
[BEAM-10409] Add combiner packing to graph optimizer phases

### DIFF
--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -1023,10 +1023,11 @@ class TupleCoder(FastCoder):
     if self.is_kv_coder():
       return common_urns.coders.KV.urn, None, self.coders()
     else:
-      return super(TupleCoder, self).to_runner_api_parameter(context)
+      return python_urns.TUPLE_CODER, None, self.coders()
 
   @staticmethod
   @Coder.register_urn(common_urns.coders.KV.urn, None)
+  @Coder.register_urn(python_urns.TUPLE_CODER, None)
   def from_runner_api_parameter(unused_payload, components, unused_context):
     return TupleCoder(components)
 

--- a/sdks/python/apache_beam/portability/python_urns.py
+++ b/sdks/python/apache_beam/portability/python_urns.py
@@ -33,6 +33,8 @@ IMPULSE_READ_TRANSFORM = "beam:transform:read_from_impulse_python:v1"
 
 GENERIC_COMPOSITE_TRANSFORM = "beam:transform:generic_composite:v1"
 
+PACKED_COMBINE_FN = "beam:combinefn:packed_python:v1"
+
 # Invoke UserFns in process, via direct function calls.
 # Payload: None.
 EMBEDDED_PYTHON = "beam:env:embedded_python:v1"

--- a/sdks/python/apache_beam/portability/python_urns.py
+++ b/sdks/python/apache_beam/portability/python_urns.py
@@ -35,6 +35,10 @@ GENERIC_COMPOSITE_TRANSFORM = "beam:transform:generic_composite:v1"
 
 PACKED_COMBINE_FN = "beam:combinefn:packed_python:v1"
 
+# A coder for a tuple.
+# Components: The coders for the tuple elements, in order.
+TUPLE_CODER = "beam:coder:tuple:v1"
+
 # Invoke UserFns in process, via direct function calls.
 # Payload: None.
 EMBEDDED_PYTHON = "beam:env:embedded_python:v1"

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner.py
@@ -292,7 +292,6 @@ class FnApiRunner(runner.PipelineRunner):
         phases=[
             translations.annotate_downstream_side_inputs,
             translations.fix_side_input_pcoll_coders,
-            translations.eliminate_common_siblings,
             translations.pack_combiners,
             translations.lift_combiners,
             translations.expand_sdf,

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner.py
@@ -292,6 +292,8 @@ class FnApiRunner(runner.PipelineRunner):
         phases=[
             translations.annotate_downstream_side_inputs,
             translations.fix_side_input_pcoll_coders,
+            translations.eliminate_common_siblings,
+            translations.pack_combiners,
             translations.lift_combiners,
             translations.expand_sdf,
             translations.expand_gbk,
@@ -305,7 +307,7 @@ class FnApiRunner(runner.PipelineRunner):
         ],
         known_runner_urns=frozenset([
             common_urns.primitives.FLATTEN.urn,
-            common_urns.primitives.GROUP_BY_KEY.urn
+            common_urns.primitives.GROUP_BY_KEY.urn,
         ]),
         use_state_iterables=self._use_state_iterables,
         is_drain=self._is_drain)

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
@@ -801,8 +801,7 @@ def pack_combiners(stages, context):
     ]
     tuple_accumulator_coder_id = context.add_or_get_coder_id(
         beam_runner_api_pb2.Coder(
-            spec=beam_runner_api_pb2.FunctionSpec(
-                urn=common_urns.coders.KV.urn),
+            spec=beam_runner_api_pb2.FunctionSpec(urn=python_urns.TUPLE_CODER),
             component_coder_ids=accumulator_coder_ids))
 
     # Build packed output coder for (key, (out1, out2, ...))
@@ -819,7 +818,7 @@ def pack_combiners(stages, context):
         for output_kv_coder_id in output_kv_coder_ids
     ]
     pack_output_value_coder = beam_runner_api_pb2.Coder(
-        spec=beam_runner_api_pb2.FunctionSpec(urn=python_urns.tuple.KV.urn),
+        spec=beam_runner_api_pb2.FunctionSpec(urn=python_urns.TUPLE_CODER),
         component_coder_ids=output_value_coder_ids)
     pack_output_value_coder_id = context.add_or_get_coder_id(
         pack_output_value_coder)

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
@@ -22,11 +22,12 @@ import logging
 import unittest
 
 import apache_beam as beam
+from apache_beam.options import pipeline_options
 from apache_beam.portability import common_urns
 from apache_beam.runners.portability.fn_api_runner import translations
 from apache_beam.transforms import combiners
+from apache_beam.transforms import environments
 from apache_beam.transforms.core import Create
-
 
 class TranslationsTest(unittest.TestCase):
 
@@ -37,7 +38,9 @@ class TranslationsTest(unittest.TestCase):
     _ = pcoll | 'mean-perkey' >> combiners.Mean.PerKey()
     _ = pcoll | 'count-perkey' >> combiners.Count.PerKey()
 
-    pipeline_proto = pipeline.to_runner_api()
+    environment = environments.DockerEnvironment.from_options(
+        pipeline_options.PortableOptions(sdk_location='container'))
+    pipeline_proto = pipeline.to_runner_api(default_environment=environment)
     _, stages = translations.create_and_optimize_stages(
         pipeline_proto, [translations.pack_combiners],
         known_runner_urns=frozenset())
@@ -48,6 +51,28 @@ class TranslationsTest(unittest.TestCase):
           combine_per_key_stages.append(stage)
     self.assertEqual(len(combine_per_key_stages), 1)
     self.assertIn('/Pack', combine_per_key_stages[0].name)
+
+  def test_pack_combiners_with_missing_environment_capability(self):
+    pipeline = beam.Pipeline()
+    vals = [6, 3, 1, 1, 9, 1, 5, 2, 0, 6]
+    pcoll = pipeline | 'start-perkey' >> Create([('a', x) for x in vals])
+    _ = pcoll | 'mean-perkey' >> combiners.Mean.PerKey()
+    _ = pcoll | 'count-perkey' >> combiners.Count.PerKey()
+
+    environment = environments.DockerEnvironment(capabilities=())
+    pipeline_proto = pipeline.to_runner_api(default_environment=environment)
+    _, stages = translations.create_and_optimize_stages(
+        pipeline_proto, [translations.pack_combiners],
+        known_runner_urns=frozenset())
+    combine_per_key_stages = []
+    for stage in stages:
+      for transform in stage.transforms:
+        if transform.spec.urn == common_urns.composites.COMBINE_PER_KEY.urn:
+          combine_per_key_stages.append(stage)
+    # Combiner packing should be skipped because the environment is missing
+    # the beam:combinefn:packed_python:v1 capability.
+    self.assertEqual(len(combine_per_key_stages), 2)
+    self.assertNotIn('/Pack', combine_per_key_stages[0].name)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
@@ -1,0 +1,101 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# pytype: skip-file
+
+from __future__ import absolute_import
+
+import logging
+import unittest
+
+import apache_beam as beam
+from apache_beam.portability import common_urns
+from apache_beam.runners.portability.fn_api_runner import translations
+from apache_beam.transforms import combiners
+from apache_beam.transforms.core import Create
+
+
+class TranslationsTest(unittest.TestCase):
+
+  def test_eliminate_common_siblings(self):
+
+    class AddNDoFn(beam.DoFn):
+
+      def process(self, element, addon):
+        return [element + addon]
+
+    pipeline = beam.Pipeline()
+    pcoll = pipeline | 'Start' >> beam.Create([1, 2, 3])
+    _ = pcoll | 'SiblingDoA' >> beam.ParDo(AddNDoFn(), 10)
+    _ = pcoll | 'SiblingDoB' >> beam.ParDo(AddNDoFn(), 10)
+
+    pipeline_proto = pipeline.to_runner_api()
+    _, stages = translations.create_and_optimize_stages(
+        pipeline_proto, [translations.eliminate_common_siblings],
+        known_runner_urns=frozenset())
+    sibling_do_stages = [stage for stage in stages if 'SiblingDo' in stage.name]
+    self.assertEqual(len(sibling_do_stages), 1)
+
+  def test_pack_combiners(self):
+    pipeline = beam.Pipeline()
+    vals = [6, 3, 1, 1, 9, 1, 5, 2, 0, 6]
+    pcoll = pipeline | 'start-perkey' >> Create([('a', x) for x in vals])
+    _ = pcoll | 'mean-perkey' >> combiners.Mean.PerKey()
+    _ = pcoll | 'count-perkey' >> combiners.Count.PerKey()
+
+    pipeline_proto = pipeline.to_runner_api()
+    _, stages = translations.create_and_optimize_stages(
+        pipeline_proto, [translations.pack_combiners],
+        known_runner_urns=frozenset())
+    combine_per_key_stages = []
+    for stage in stages:
+      for transform in stage.transforms:
+        if transform.spec.urn == common_urns.composites.COMBINE_PER_KEY.urn:
+          combine_per_key_stages.append(stage)
+    self.assertEqual(len(combine_per_key_stages), 1)
+    self.assertIn('/Pack', combine_per_key_stages[0].name)
+
+  def test_pack_global_combiners(self):
+    pipeline = beam.Pipeline()
+    vals = [6, 3, 1, 1, 9, 1, 5, 2, 0, 6]
+    pcoll = pipeline | 'start' >> Create(vals)
+    _ = pcoll | 'mean' >> combiners.Mean.Globally()
+    _ = pcoll | 'count' >> combiners.Count.Globally()
+
+    pipeline_proto = pipeline.to_runner_api()
+    _, stages = translations.create_and_optimize_stages(
+        pipeline_proto, [
+            translations.eliminate_common_siblings,
+            translations.pack_combiners,
+        ],
+        known_runner_urns=frozenset())
+    key_with_void_stages = [
+        stage for stage in stages if 'KeyWithVoid' in stage.name
+    ]
+    self.assertEqual(len(key_with_void_stages), 1)
+
+    combine_per_key_stages = []
+    for stage in stages:
+      for transform in stage.transforms:
+        if transform.spec.urn == common_urns.composites.COMBINE_PER_KEY.urn:
+          combine_per_key_stages.append(stage)
+    self.assertEqual(len(combine_per_key_stages), 1)
+    self.assertIn('/Pack', combine_per_key_stages[0].name)
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/sdks/python/apache_beam/runners/portability/portable_runner.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner.py
@@ -332,7 +332,6 @@ class PortableRunner(runner.PipelineRunner):
                 translations.annotate_downstream_side_inputs,
                 translations.annotate_stateful_dofns_as_roots,
                 translations.fix_side_input_pcoll_coders,
-                translations.eliminate_common_siblings,
                 translations.pack_combiners,
                 translations.lift_combiners,
                 translations.expand_sdf,

--- a/sdks/python/apache_beam/runners/portability/portable_runner.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner.py
@@ -332,6 +332,8 @@ class PortableRunner(runner.PipelineRunner):
                 translations.annotate_downstream_side_inputs,
                 translations.annotate_stateful_dofns_as_roots,
                 translations.fix_side_input_pcoll_coders,
+                translations.eliminate_common_siblings,
+                translations.pack_combiners,
                 translations.lift_combiners,
                 translations.expand_sdf,
                 translations.fix_flatten_coders,

--- a/sdks/python/apache_beam/transforms/environments.py
+++ b/sdks/python/apache_beam/transforms/environments.py
@@ -594,6 +594,7 @@ def _python_sdk_capabilities_iter():
       yield urn_spec.urn
   yield common_urns.protocols.LEGACY_PROGRESS_REPORTING.urn
   yield common_urns.protocols.WORKER_STATUS.urn
+  yield python_urns.PACKED_COMBINE_FN
   yield 'beam:version:sdk_base:' + DockerEnvironment.default_docker_image()
   #TODO(BEAM-10530): Add truncate capability.
   # yield common_urns.sdf_components.TRUNCATE_SIZED_RESTRICTION.urn


### PR DESCRIPTION
Adds `pack_combiners` graph optimization phases to the translations module. This allows  packs compatible CombinePerKey stages with a common input into a single stage. This improves performance for use cases of Beam that create thousands of Combine stages with a common input.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
