### PR TITLE
[BEAM-10310] Adding thread-safe restriction tracker wrapper.

### DIFF
--- a/sdks/go/examples/stringsplit/stringsplit.go
+++ b/sdks/go/examples/stringsplit/stringsplit.go
@@ -71,7 +71,7 @@ func (fn *StringSplitFn) CreateInitialRestriction(s string) offsetrange.Restrict
 
 // SplitRestriction performs initial splits so that each restriction is split
 // into 5.
-func (fn *StringSplitFn) SplitRestriction(s string, rest offsetrange.Restriction) []offsetrange.Restriction {
+func (fn *StringSplitFn) SplitRestriction(_ string, rest offsetrange.Restriction) []offsetrange.Restriction {
 	splits := rest.EvenSplits(5)
 	log.Debugf(context.Background(), "StringSplit SplitRestrictions: %v -> %v", rest, splits)
 	return splits
@@ -79,7 +79,7 @@ func (fn *StringSplitFn) SplitRestriction(s string, rest offsetrange.Restriction
 
 // RestrictionSize returns the size as the difference between the restriction's
 // start and end.
-func (fn *StringSplitFn) RestrictionSize(s string, rest offsetrange.Restriction) float64 {
+func (fn *StringSplitFn) RestrictionSize(_ string, rest offsetrange.Restriction) float64 {
 	size := rest.Size()
 	log.Debugf(context.Background(), "StringSplit RestrictionSize: %v -> %v", rest, size)
 	return size
@@ -103,7 +103,7 @@ func (fn *StringSplitFn) CreateTracker(rest offsetrange.Restriction) *sdf.LockRT
 // following substrings: [100, 200], [200, 300], [300, 400]
 func (fn *StringSplitFn) ProcessElement(ctx context.Context, rt *sdf.LockRTracker, elem string, emit func(string)) {
 	log.Debugf(ctx, "StringSplit ProcessElement: Tracker = %v", rt)
-	i := rt.Rt.(*offsetrange.Tracker).Rest.Start
+	i := rt.GetRestriction().(offsetrange.Restriction).Start
 	if rem := i % fn.BufSize; rem != 0 {
 		i += fn.BufSize - rem // Skip to next multiple of BufSize.
 	}

--- a/sdks/go/pkg/beam/core/graph/fn_test.go
+++ b/sdks/go/pkg/beam/core/graph/fn_test.go
@@ -635,6 +635,9 @@ func (rt *RTrackerT) GetProgress() (float64, float64) {
 func (rt *RTrackerT) IsDone() bool {
 	return true
 }
+func (rt *RTrackerT) GetRestriction() interface{} {
+	return nil
+}
 
 type GoodSdf struct {
 	*GoodDoFn

--- a/sdks/go/pkg/beam/core/runtime/exec/sdf_invokers_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf_invokers_test.go
@@ -262,7 +262,8 @@ func (rt *VetRTracker) TryClaim(interface{}) bool       { return false }
 func (rt *VetRTracker) GetError() error                 { return nil }
 func (rt *VetRTracker) GetProgress() (float64, float64) { return 0, 0 }
 func (rt *VetRTracker) IsDone() bool                    { return true }
-func (rt *VetRTracker) TrySplit(fraction float64) (interface{}, interface{}, error) {
+func (rt *VetRTracker) GetRestriction() interface{}     { return nil }
+func (rt *VetRTracker) TrySplit(_ float64) (interface{}, interface{}, error) {
 	return nil, nil, nil
 }
 

--- a/sdks/go/pkg/beam/core/runtime/graphx/translate_test.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate_test.go
@@ -183,11 +183,12 @@ func TestMarshal(t *testing.T) {
 type testRT struct {
 }
 
-func (rt *testRT) TryClaim(interface{}) bool       { return false }
+func (rt *testRT) TryClaim(_ interface{}) bool     { return false }
 func (rt *testRT) GetError() error                 { return nil }
 func (rt *testRT) GetProgress() (float64, float64) { return 0, 0 }
 func (rt *testRT) IsDone() bool                    { return true }
-func (rt *testRT) TrySplit(fraction float64) (interface{}, interface{}, error) {
+func (rt *testRT) GetRestriction() interface{}     { return nil }
+func (rt *testRT) TrySplit(_ float64) (interface{}, interface{}, error) {
 	return nil, nil, nil
 }
 
@@ -196,12 +197,12 @@ func (rt *testRT) TrySplit(fraction float64) (interface{}, interface{}, error) {
 type splitPickFn struct {
 }
 
-func (fn *splitPickFn) CreateInitialRestriction(i int) int      { return 0 }
-func (fn *splitPickFn) SplitRestriction(i int, rest int) []int  { return []int{0} }
-func (fn *splitPickFn) RestrictionSize(i int, rest int) float64 { return 0.0 }
-func (fn *splitPickFn) CreateTracker(rest int) *testRT          { return &testRT{} }
+func (fn *splitPickFn) CreateInitialRestriction(_ int) int   { return 0 }
+func (fn *splitPickFn) SplitRestriction(_ int, _ int) []int  { return []int{0} }
+func (fn *splitPickFn) RestrictionSize(_ int, _ int) float64 { return 0.0 }
+func (fn *splitPickFn) CreateTracker(_ int) *testRT          { return &testRT{} }
 
 // ProcessElement calls pickFn.
-func (fn *splitPickFn) ProcessElement(rt *testRT, a int, small, big func(int)) {
+func (fn *splitPickFn) ProcessElement(_ *testRT, a int, small, big func(int)) {
 	pickFn(a, small, big)
 }

--- a/sdks/go/pkg/beam/core/sdf/lock.go
+++ b/sdks/go/pkg/beam/core/sdf/lock.go
@@ -1,0 +1,62 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package sdf
+
+import "sync"
+
+// NewLockRTracker creates a LockRTracker initialized with the specified
+// restriction tracker as its underlying restriction tracker.
+func NewLockRTracker(rt RTracker) *LockRTracker {
+	return &LockRTracker{Rt: rt}
+}
+
+// LockRTracker is a restriction tracker that wraps another restriction
+// tracker and adds thread safety to it by locking a mutex in each method,
+// before delegating to the underlying tracker.
+type LockRTracker struct {
+	mu sync.Mutex // Lock on accessing underlying tracker.
+	Rt RTracker
+}
+
+func (rt *LockRTracker) TryClaim(pos interface{}) (ok bool) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return rt.Rt.TryClaim(pos)
+}
+
+func (rt *LockRTracker) GetError() error {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return rt.Rt.GetError()
+}
+
+func (rt *LockRTracker) TrySplit(fraction float64) (interface{}, interface{}, error) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return rt.Rt.TrySplit(fraction)
+}
+
+func (rt *LockRTracker) GetProgress() (float64, float64) {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return rt.Rt.GetProgress()
+}
+
+func (rt *LockRTracker) IsDone() bool {
+	rt.mu.Lock()
+	defer rt.mu.Unlock()
+	return rt.Rt.IsDone()
+}

--- a/sdks/go/pkg/beam/core/sdf/lock.go
+++ b/sdks/go/pkg/beam/core/sdf/lock.go
@@ -27,36 +27,56 @@ func NewLockRTracker(rt RTracker) *LockRTracker {
 // tracker and adds thread safety to it by locking a mutex in each method,
 // before delegating to the underlying tracker.
 type LockRTracker struct {
-	mu sync.Mutex // Lock on accessing underlying tracker.
+	Mu sync.Mutex // Lock on accessing underlying tracker.
+	// The underlying tracker. If accessing directly, consider thread safety.
+	// Lock the mutex if thread safety is needed.
 	Rt RTracker
 }
 
+// TryClaim locks a mutex for thread safety, and then delegates to the
+// underlying tracker's TryClaim.
 func (rt *LockRTracker) TryClaim(pos interface{}) (ok bool) {
-	rt.mu.Lock()
-	defer rt.mu.Unlock()
+	rt.Mu.Lock()
+	defer rt.Mu.Unlock()
 	return rt.Rt.TryClaim(pos)
 }
 
+// GetError locks a mutex for thread safety, and then delegates to the
+// underlying tracker's GetError.
 func (rt *LockRTracker) GetError() error {
-	rt.mu.Lock()
-	defer rt.mu.Unlock()
+	rt.Mu.Lock()
+	defer rt.Mu.Unlock()
 	return rt.Rt.GetError()
 }
 
+// TrySplit locks a mutex for thread safety, and then delegates to the
+// underlying tracker's TrySplit.
 func (rt *LockRTracker) TrySplit(fraction float64) (interface{}, interface{}, error) {
-	rt.mu.Lock()
-	defer rt.mu.Unlock()
+	rt.Mu.Lock()
+	defer rt.Mu.Unlock()
 	return rt.Rt.TrySplit(fraction)
 }
 
+// GetProgress locks a mutex for thread safety, and then delegates to the
+// underlying tracker's GetProgress.
 func (rt *LockRTracker) GetProgress() (float64, float64) {
-	rt.mu.Lock()
-	defer rt.mu.Unlock()
+	rt.Mu.Lock()
+	defer rt.Mu.Unlock()
 	return rt.Rt.GetProgress()
 }
 
+// IsDone locks a mutex for thread safety, and then delegates to the
+// underlying tracker's IsDone.
 func (rt *LockRTracker) IsDone() bool {
-	rt.mu.Lock()
-	defer rt.mu.Unlock()
+	rt.Mu.Lock()
+	defer rt.Mu.Unlock()
 	return rt.Rt.IsDone()
+}
+
+// GetRestriction locks a mutex for thread safety, and then delegates to the
+// underlying tracker's GetRestriction.
+func (rt *LockRTracker) GetRestriction() interface{} {
+	rt.Mu.Lock()
+	defer rt.Mu.Unlock()
+	return rt.Rt.GetRestriction()
 }

--- a/sdks/go/pkg/beam/core/sdf/sdf.go
+++ b/sdks/go/pkg/beam/core/sdf/sdf.go
@@ -80,4 +80,8 @@ type RTracker interface {
 	// correctly processed all work in a restriction before finishing. If this method returns false
 	// then GetError is expected to return a non-nil error.
 	IsDone() bool
+
+	// GetRestriction returns the restriction this tracker is tracking, or nil if the restriction
+	// is unavailable for some reason.
+	GetRestriction() interface{}
 }

--- a/sdks/go/pkg/beam/io/synthetic/source.go
+++ b/sdks/go/pkg/beam/io/synthetic/source.go
@@ -24,6 +24,7 @@ package synthetic
 
 import (
 	"fmt"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/sdf"
 	"math/rand"
 	"reflect"
 	"time"
@@ -106,14 +107,14 @@ func (fn *sourceFn) SplitRestriction(config SourceConfig, rest offsetrange.Restr
 
 // RestrictionSize outputs the size of the restriction as the number of elements
 // that restriction will output.
-func (fn *sourceFn) RestrictionSize(config SourceConfig, rest offsetrange.Restriction) float64 {
+func (fn *sourceFn) RestrictionSize(_ SourceConfig, rest offsetrange.Restriction) float64 {
 	return rest.Size()
 }
 
 // CreateTracker just creates an offset range restriction tracker for the
 // restriction.
-func (fn *sourceFn) CreateTracker(rest offsetrange.Restriction) *offsetrange.Tracker {
-	return offsetrange.NewTracker(rest)
+func (fn *sourceFn) CreateTracker(rest offsetrange.Restriction) *sdf.LockRTracker {
+	return sdf.NewLockRTracker(offsetrange.NewTracker(rest))
 }
 
 // Setup sets up the random number generator.
@@ -124,8 +125,8 @@ func (fn *sourceFn) Setup() {
 // ProcessElement creates a number of random elements based on the restriction
 // tracker received. Each element is a random byte slice key and value, in the
 // form of KV<[]byte, []byte>.
-func (fn *sourceFn) ProcessElement(rt *offsetrange.Tracker, config SourceConfig, emit func([]byte, []byte)) error {
-	for i := rt.Rest.Start; rt.TryClaim(i) == true; i++ {
+func (fn *sourceFn) ProcessElement(rt *sdf.LockRTracker, _ SourceConfig, emit func([]byte, []byte)) error {
+	for i := rt.Rt.(*offsetrange.Tracker).Rest.Start; rt.TryClaim(i) == true; i++ {
 		key := make([]byte, 8)
 		val := make([]byte, 8)
 		if _, err := fn.rng.Read(key); err != nil {

--- a/sdks/go/pkg/beam/io/synthetic/source.go
+++ b/sdks/go/pkg/beam/io/synthetic/source.go
@@ -126,7 +126,7 @@ func (fn *sourceFn) Setup() {
 // tracker received. Each element is a random byte slice key and value, in the
 // form of KV<[]byte, []byte>.
 func (fn *sourceFn) ProcessElement(rt *sdf.LockRTracker, _ SourceConfig, emit func([]byte, []byte)) error {
-	for i := rt.Rt.(*offsetrange.Tracker).Rest.Start; rt.TryClaim(i) == true; i++ {
+	for i := rt.GetRestriction().(offsetrange.Restriction).Start; rt.TryClaim(i) == true; i++ {
 		key := make([]byte, 8)
 		val := make([]byte, 8)
 		if _, err := fn.rng.Read(key); err != nil {

--- a/sdks/go/pkg/beam/io/synthetic/step.go
+++ b/sdks/go/pkg/beam/io/synthetic/step.go
@@ -17,6 +17,7 @@ package synthetic
 
 import (
 	"fmt"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/sdf"
 	"math/rand"
 	"reflect"
 	"time"
@@ -92,7 +93,7 @@ type sdfStepFn struct {
 // CreateInitialRestriction creates an offset range restriction representing
 // the number of elements to emit for this received element, as specified by
 // the output per input configuration in StepConfig.
-func (fn *sdfStepFn) CreateInitialRestriction(key, val []byte) offsetrange.Restriction {
+func (fn *sdfStepFn) CreateInitialRestriction(_, _ []byte) offsetrange.Restriction {
 	return offsetrange.Restriction{
 		Start: 0,
 		End:   int64(fn.cfg.OutputPerInput),
@@ -103,20 +104,20 @@ func (fn *sdfStepFn) CreateInitialRestriction(key, val []byte) offsetrange.Restr
 // initial splits specified in StepConfig. Each restriction output by this
 // method will contain at least one element, so the number of splits will not
 // exceed the number of elements.
-func (fn *sdfStepFn) SplitRestriction(key, val []byte, rest offsetrange.Restriction) (splits []offsetrange.Restriction) {
+func (fn *sdfStepFn) SplitRestriction(_, _ []byte, rest offsetrange.Restriction) (splits []offsetrange.Restriction) {
 	return rest.EvenSplits(int64(fn.cfg.InitialSplits))
 }
 
 // RestrictionSize outputs the size of the restriction as the number of elements
 // that restriction will output.
-func (fn *sdfStepFn) RestrictionSize(key, val []byte, rest offsetrange.Restriction) float64 {
+func (fn *sdfStepFn) RestrictionSize(_, _ []byte, rest offsetrange.Restriction) float64 {
 	return rest.Size()
 }
 
 // CreateTracker creates an offset range restriction tracker for the
 // restriction.
-func (fn *sdfStepFn) CreateTracker(rest offsetrange.Restriction) *offsetrange.Tracker {
-	return offsetrange.NewTracker(rest)
+func (fn *sdfStepFn) CreateTracker(rest offsetrange.Restriction) *sdf.LockRTracker {
+	return sdf.NewLockRTracker(offsetrange.NewTracker(rest))
 }
 
 // Setup sets up the random number generator.
@@ -126,10 +127,10 @@ func (fn *sdfStepFn) Setup() {
 
 // ProcessElement takes an input and either filters it or produces a number of
 // outputs identical to that input based on the restriction size.
-func (fn *sdfStepFn) ProcessElement(rt *offsetrange.Tracker, key, val []byte, emit func([]byte, []byte)) {
+func (fn *sdfStepFn) ProcessElement(rt *sdf.LockRTracker, key, val []byte, emit func([]byte, []byte)) {
 	filtered := fn.cfg.FilterRatio > 0 && fn.rng.Float64() < fn.cfg.FilterRatio
 
-	for i := rt.Rest.Start; rt.TryClaim(i) == true; i++ {
+	for i := rt.Rt.(*offsetrange.Tracker).Rest.Start; rt.TryClaim(i) == true; i++ {
 		if !filtered {
 			emit(key, val)
 		}

--- a/sdks/go/pkg/beam/io/synthetic/step.go
+++ b/sdks/go/pkg/beam/io/synthetic/step.go
@@ -130,7 +130,7 @@ func (fn *sdfStepFn) Setup() {
 func (fn *sdfStepFn) ProcessElement(rt *sdf.LockRTracker, key, val []byte, emit func([]byte, []byte)) {
 	filtered := fn.cfg.FilterRatio > 0 && fn.rng.Float64() < fn.cfg.FilterRatio
 
-	for i := rt.Rt.(*offsetrange.Tracker).Rest.Start; rt.TryClaim(i) == true; i++ {
+	for i := rt.GetRestriction().(offsetrange.Restriction).Start; rt.TryClaim(i) == true; i++ {
 		if !filtered {
 			emit(key, val)
 		}


### PR DESCRIPTION
Pretty self-explanatory. The wrapper was basic enough that I don't think it makes sense to test it with unit tests. You'd basically just be unit testing the mutex. Instead, I'm testing it in practice by replacing existing restriction tracker usage with the thread-safe one.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | --- | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
