### PR TITLE
Make tracking/cleanup of cache and in-environment states per pipeline

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/background_caching_job.py
+++ b/sdks/python/apache_beam/runners/interactive/background_caching_job.py
@@ -202,14 +202,16 @@ def has_source_to_cache(user_pipeline):
   # Add logic for other cacheable sources here when they are available.
   has_cache = instr.has_unbounded_sources(user_pipeline)
   if has_cache:
-    if not isinstance(ie.current_env().cache_manager(),
+    if not isinstance(ie.current_env().get_cache_manager(user_pipeline,
+                                                         create_if_absent=True),
                       streaming_cache.StreamingCache):
 
       ie.current_env().set_cache_manager(
           streaming_cache.StreamingCache(
-              ie.current_env().cache_manager()._cache_dir,
+              ie.current_env().get_cache_manager(user_pipeline)._cache_dir,
               is_cache_complete=is_cache_complete,
-              sample_resolution_sec=1.0))
+              sample_resolution_sec=1.0),
+          user_pipeline)
   return has_cache
 
 

--- a/sdks/python/apache_beam/runners/interactive/background_caching_job_test.py
+++ b/sdks/python/apache_beam/runners/interactive/background_caching_job_test.py
@@ -71,9 +71,9 @@ def _build_an_empty_stream_pipeline():
   return p
 
 
-def _setup_test_streaming_cache():
+def _setup_test_streaming_cache(pipeline):
   cache_manager = StreamingCache(cache_dir=None)
-  ie.current_env().set_cache_manager(cache_manager)
+  ie.current_env().set_cache_manager(cache_manager, pipeline)
   builder = FileRecordsBuilder(tag=_TEST_CACHE_KEY)
   (builder
       .advance_watermark(watermark_secs=0)
@@ -108,7 +108,7 @@ class BackgroundCachingJobTest(unittest.TestCase):
       lambda x: None)
   def test_background_caching_job_starts_when_none_such_job_exists(self):
     p = _build_a_test_stream_pipeline()
-    _setup_test_streaming_cache()
+    _setup_test_streaming_cache(p)
     p.run()
     self.assertIsNotNone(ie.current_env().get_background_caching_job(p))
     expected_cached_source_signature = bcj.extract_source_to_cache_signature(p)
@@ -138,7 +138,7 @@ class BackgroundCachingJobTest(unittest.TestCase):
       lambda x: None)
   def test_background_caching_job_not_start_when_such_job_exists(self):
     p = _build_a_test_stream_pipeline()
-    _setup_test_streaming_cache()
+    _setup_test_streaming_cache(p)
     a_running_background_caching_job = bcj.BackgroundCachingJob(
         runner.PipelineResult(runner.PipelineState.RUNNING), limiters=[])
     ie.current_env().set_background_caching_job(
@@ -162,7 +162,7 @@ class BackgroundCachingJobTest(unittest.TestCase):
       lambda x: None)
   def test_background_caching_job_not_start_when_such_job_is_done(self):
     p = _build_a_test_stream_pipeline()
-    _setup_test_streaming_cache()
+    _setup_test_streaming_cache(p)
     a_done_background_caching_job = bcj.BackgroundCachingJob(
         runner.PipelineResult(runner.PipelineState.DONE), limiters=[])
     ie.current_env().set_background_caching_job(

--- a/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization.py
+++ b/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization.py
@@ -398,7 +398,7 @@ class PCollectionVisualization(object):
 
   def _to_dataframe(self):
     results = []
-    cache_manager = ie.current_env().cache_manager()
+    cache_manager = ie.current_env().get_cache_manager(self._pcoll.pipeline)
     if cache_manager.exists('full', self._cache_key):
       coder = cache_manager.load_pcoder('full', self._cache_key)
       reader, _ = cache_manager.read('full', self._cache_key)

--- a/sdks/python/apache_beam/runners/interactive/interactive_beam.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_beam.py
@@ -499,7 +499,7 @@ def head(pcoll, n=5, include_window_info=False):
     # Read from pcoll cache, then convert to DF
     pipeline_instrument = pi.PipelineInstrument(pcoll.pipeline)
     key = pipeline_instrument.cache_key(pcoll)
-    cache_manager = ie.current_env().cache_manager()
+    cache_manager = ie.current_env().get_cache_manager(user_pipeline)
 
     coder = cache_manager.load_pcoder('full', key)
     reader, _ = cache_manager.read('full', key)
@@ -538,11 +538,12 @@ def show_graph(pipeline):
   pipeline_graph.PipelineGraph(pipeline).display_graph()
 
 
-def evict_captured_data():
-  """Forcefully evicts all captured replayable data.
+def evict_captured_data(pipeline=None):
+  """Forcefully evicts all captured replayable data for the given pipeline. If
+  no pipeline is specified, evicts for all user defined pipelines.
 
   Once invoked, Interactive Beam will capture new data based on the guidance of
   options the next time it evaluates/visualizes PCollections or runs pipelines.
   """
   from apache_beam.runners.interactive.options import capture_control
-  capture_control.evict_captured_data()
+  capture_control.evict_captured_data(pipeline)

--- a/sdks/python/apache_beam/runners/interactive/interactive_environment.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_environment.py
@@ -329,6 +329,7 @@ class InteractiveEnvironment(object):
     """Evicts the cache manager held by current Interactive Environment for the
     given pipeline. Noop if the pipeline is absent from the environment. If no
     pipeline is specified, evicts for all pipelines."""
+    self.cleanup(pipeline)
     if pipeline:
       return self._cache_managers.pop(str(id(pipeline)), None)
     self._cache_managers.clear()

--- a/sdks/python/apache_beam/runners/interactive/interactive_environment.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_environment.py
@@ -29,10 +29,13 @@ from __future__ import absolute_import
 import atexit
 import importlib
 import logging
+import os
 import sys
+import tempfile
 
 import apache_beam as beam
 from apache_beam.runners import runner
+from apache_beam.runners.interactive import cache_manager as cache
 from apache_beam.runners.interactive.messaging.interactive_environment_inspector import InteractiveEnvironmentInspector
 from apache_beam.runners.interactive.utils import register_ipython_log_handler
 from apache_beam.utils.interactive_utils import is_in_ipython
@@ -99,21 +102,21 @@ _HTML_IMPORT_TEMPLATE = """
         }}"""
 
 
-def current_env(cache_manager=None):
+def current_env():
   """Gets current Interactive Beam environment."""
   global _interactive_beam_env
   if not _interactive_beam_env:
-    _interactive_beam_env = InteractiveEnvironment(cache_manager)
+    _interactive_beam_env = InteractiveEnvironment()
   return _interactive_beam_env
 
 
-def new_env(cache_manager=None):
+def new_env():
   """Creates a new Interactive Beam environment to replace current one."""
   global _interactive_beam_env
   if _interactive_beam_env:
     _interactive_beam_env.cleanup()
   _interactive_beam_env = None
-  return current_env(cache_manager)
+  return current_env()
 
 
 class InteractiveEnvironment(object):
@@ -126,11 +129,13 @@ class InteractiveEnvironment(object):
   also visualize and introspect those PCollections in user code since they have
   handles to the variables.
   """
-  def __init__(self, cache_manager=None):
-    self._cache_manager = cache_manager
-    # Register a cleanup routine when kernel is restarted or terminated.
-    if cache_manager:
-      atexit.register(self.cleanup)
+  def __init__(self):
+    # Registers a cleanup routine when system exits.
+    atexit.register(self.cleanup)
+    # Holds cache managers that manage source recording and intermediate
+    # PCollection cache for each pipeline. Each key is a stringified user
+    # defined pipeline instance's id.
+    self._cache_managers = {}
     # Holds class instances, module object, string of module names.
     self._watching_set = set()
     # Holds variables list of (Dict[str, object]).
@@ -245,12 +250,19 @@ class InteractiveEnvironment(object):
     information consumable by other applications."""
     return self._inspector
 
-  def cleanup(self):
-    # Utilizes cache manager to clean up cache from everywhere.
-    if self.cache_manager():
-      self.cache_manager().cleanup()
-    self.evict_computed_pcollections()
-    self.evict_cached_source_signature()
+  def cleanup(self, pipeline=None):
+    """Cleans up cached states for the given pipeline. Cleans up
+    for all pipelines if no specific pipeline is given."""
+    if pipeline:
+      cache_manager = self.get_cache_manager(pipeline)
+      if cache_manager:
+        cache_manager.cleanup()
+    else:
+      for _, cache_manager in self._cache_managers.items():
+        cache_manager.cleanup()
+
+    self.evict_computed_pcollections(pipeline)
+    self.evict_cached_source_signature(pipeline)
 
   def watch(self, watchable):
     """Watches a watchable.
@@ -286,24 +298,40 @@ class InteractiveEnvironment(object):
         watching.append(vars(watchable).items())
     return watching
 
-  def set_cache_manager(self, cache_manager):
-    """Sets the cache manager held by current Interactive Environment."""
-    if self._cache_manager is cache_manager:
+  def set_cache_manager(self, cache_manager, pipeline):
+    """Sets the cache manager held by current Interactive Environment for the
+    given pipeline."""
+    if self.get_cache_manager(pipeline) is cache_manager:
       # NOOP if setting to the same cache_manager.
       return
-    if self._cache_manager:
+    if self.get_cache_manager(pipeline):
       # Invoke cleanup routine when a new cache_manager is forcefully set and
       # current cache_manager is not None.
-      self.cleanup()
-      atexit.unregister(self.cleanup)
-    self._cache_manager = cache_manager
-    if self._cache_manager:
-      # Re-register cleanup routine for the new cache_manager if it's not None.
-      atexit.register(self.cleanup)
+      self.cleanup(pipeline)
+    self._cache_managers[str(id(pipeline))] = cache_manager
 
-  def cache_manager(self):
-    """Gets the cache manager held by current Interactive Environment."""
-    return self._cache_manager
+  def get_cache_manager(self, pipeline, create_if_absent=False):
+    """Gets the cache manager held by current Interactive Environment for the
+    given pipeline. If the pipeline is absent from the environment while
+    create_if_absent is True, creates and returns a new file based cache
+    manager for the pipeline."""
+    cache_manager = self._cache_managers.get(str(id(pipeline)), None)
+    if not cache_manager and create_if_absent:
+      cache_dir = tempfile.mkdtemp(
+          suffix=str(id(pipeline)),
+          prefix='interactive-temp-',
+          dir=os.environ.get('TEST_TMPDIR', None))
+      cache_manager = cache.FileBasedCacheManager(cache_dir)
+      self._cache_managers[str(id(pipeline))] = cache_manager
+    return cache_manager
+
+  def evict_cache_manager(self, pipeline=None):
+    """Evicts the cache manager held by current Interactive Environment for the
+    given pipeline. Noop if the pipeline is absent from the environment. If no
+    pipeline is specified, evicts for all pipelines."""
+    if pipeline:
+      return self._cache_managers.pop(str(id(pipeline)), None)
+    self._cache_managers.clear()
 
   def set_pipeline_result(self, pipeline, result):
     """Sets the pipeline run result. Adds one if absent. Otherwise, replace."""
@@ -390,17 +418,15 @@ class InteractiveEnvironment(object):
     code execution is under ipython due to the possibility that any user-defined
     pipeline can be re-evaluated through notebook cell re-execution at any time.
 
-    Each time this is invoked, the tracked user pipelines are refreshed to
-    remove any pipeline instances that are no longer in watched scope. For
-    example, after a notebook cell re-execution re-evaluating a pipeline
-    creation, the last pipeline reference created by last evaluation will not be
-    in watched scope anymore.
+    Each time this is invoked, it will check if there is a cache manager
+    already created for each user defined pipeline. If not, create one for it.
     """
     self._tracked_user_pipelines = set()
     for watching in self.watching():
       for _, val in watching:
         if isinstance(val, beam.pipeline.Pipeline):
           self._tracked_user_pipelines.add(val)
+          _ = self.get_cache_manager(val, create_if_absent=True)
 
   @property
   def tracked_user_pipelines(self):
@@ -421,13 +447,16 @@ class InteractiveEnvironment(object):
     """
     self._computed_pcolls.update(pcoll for pcoll in pcolls)
 
-  def evict_computed_pcollections(self):
-    """Evicts all computed PCollections.
-
-    Interactive Beam will treat none of the PCollections in any given pipeline
-    as completely computed.
+  def evict_computed_pcollections(self, pipeline=None):
+    """Evicts all computed PCollections for the given pipeline. If no pipeline
+    is specified, evicts for all pipelines.
     """
-    self._computed_pcolls = set()
+    if pipeline:
+      for pcoll in self._computed_pcolls:
+        if pcoll.pipeline is pipeline:
+          self._computed_pcolls.discard(pcoll)
+    else:
+      self._computed_pcolls = set()
 
   @property
   def computed_pcollections(self):

--- a/sdks/python/apache_beam/runners/interactive/interactive_environment_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_environment_test.py
@@ -233,6 +233,19 @@ class InteractiveEnvironmentTest(unittest.TestCase):
         ie.current_env().get_cache_manager(
             dummy_pipeline, create_if_absent=True))
 
+  @patch(
+      'apache_beam.runners.interactive.interactive_environment'
+      '.InteractiveEnvironment.cleanup')
+  def test_cleanup_invoked_when_cache_manager_is_evicted(self, mocked_cleanup):
+    ie._interactive_beam_env = None
+    ie.new_env()
+    dummy_pipeline = 'dummy'
+    ie.current_env().set_cache_manager(
+        cache.FileBasedCacheManager(), dummy_pipeline)
+    mocked_cleanup.assert_not_called()
+    ie.current_env().evict_cache_manager(dummy_pipeline)
+    mocked_cleanup.assert_called_once()
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/sdks/python/apache_beam/runners/interactive/interactive_environment_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_environment_test.py
@@ -32,9 +32,9 @@ from apache_beam.runners.interactive import interactive_environment as ie
 # TODO(BEAM-8288): clean up the work-around of nose tests using Python2 without
 # unittest.mock module.
 try:
-  from unittest.mock import call, patch
+  from unittest.mock import patch
 except ImportError:
-  from mock import call, patch  # type: ignore[misc]
+  from mock import patch  # type: ignore[misc]
 
 # The module name is also a variable in module.
 _module_name = 'apache_beam.runners.interactive.interactive_environment_test'
@@ -168,35 +168,9 @@ class InteractiveEnvironmentTest(unittest.TestCase):
     self.assertIs(ie.current_env().evict_pipeline_result(self._p), None)
 
   @patch('atexit.register')
-  def test_no_cleanup_when_cm_none(self, mocked_atexit):
-    ie.new_env(None)
-    mocked_atexit.assert_not_called()
-
-  @patch('atexit.register')
-  def test_cleanup_when_cm_not_none(self, mocked_atexit):
-    ie.new_env(cache.FileBasedCacheManager())
+  def test_cleanup_registered_when_creating_new_env(self, mocked_atexit):
+    ie.new_env()
     mocked_atexit.assert_called_once()
-
-  @patch('atexit.register')
-  @patch('atexit.unregister')
-  def test_cleanup_unregistered_when_not_none_cm_cleared(
-      self, mocked_unreg, mocked_reg):
-    ie.new_env(cache.FileBasedCacheManager())
-    mocked_reg.assert_called_once()
-    mocked_unreg.assert_not_called()
-    ie.current_env().set_cache_manager(None)
-    mocked_reg.assert_called_once()
-    mocked_unreg.assert_called_once()
-
-  @patch('atexit.register')
-  @patch('atexit.unregister')
-  def test_cleanup_reregistered_when_cm_changed(self, mocked_unreg, mocked_reg):
-    ie.new_env(cache.FileBasedCacheManager())
-    mocked_unreg.assert_not_called()
-    ie.current_env().set_cache_manager(cache.FileBasedCacheManager())
-    mocked_unreg.assert_called_once()
-    mocked_reg.assert_has_calls(
-        [call(ie.current_env().cleanup), call(ie.current_env().cleanup)])
 
   @patch(
       'apache_beam.runners.interactive.interactive_environment'
@@ -204,41 +178,60 @@ class InteractiveEnvironmentTest(unittest.TestCase):
   def test_cleanup_invoked_when_new_env_replace_not_none_env(
       self, mocked_cleanup):
     ie._interactive_beam_env = None
-    ie.new_env(cache.FileBasedCacheManager())
+    ie.new_env()
     mocked_cleanup.assert_not_called()
-    ie.new_env(cache.FileBasedCacheManager())
+    ie.new_env()
     mocked_cleanup.assert_called_once()
 
   @patch(
       'apache_beam.runners.interactive.interactive_environment'
       '.InteractiveEnvironment.cleanup')
-  def test_cleanup_invoked_when_cm_changed(self, mocked_cleanup):
+  def test_cleanup_not_invoked_when_cm_changed_from_none(self, mocked_cleanup):
     ie._interactive_beam_env = None
-    ie.new_env(cache.FileBasedCacheManager())
-    ie.current_env().set_cache_manager(cache.FileBasedCacheManager())
+    ie.new_env()
+    dummy_pipeline = 'dummy'
+    self.assertIsNone(ie.current_env().get_cache_manager(dummy_pipeline))
+    cache_manager = cache.FileBasedCacheManager()
+    ie.current_env().set_cache_manager(cache_manager, dummy_pipeline)
+    mocked_cleanup.assert_not_called()
+    self.assertIs(
+        ie.current_env().get_cache_manager(dummy_pipeline), cache_manager)
+
+  @patch(
+      'apache_beam.runners.interactive.interactive_environment'
+      '.InteractiveEnvironment.cleanup')
+  def test_cleanup_invoked_when_not_none_cm_changed(self, mocked_cleanup):
+    ie._interactive_beam_env = None
+    ie.new_env()
+    dummy_pipeline = 'dummy'
+    ie.current_env().set_cache_manager(
+        cache.FileBasedCacheManager(), dummy_pipeline)
+    mocked_cleanup.assert_not_called()
+    ie.current_env().set_cache_manager(
+        cache.FileBasedCacheManager(), dummy_pipeline)
     mocked_cleanup.assert_called_once()
 
-  @patch('atexit.register')
-  @patch('atexit.unregister')
-  def test_cleanup_registered_when_none_cm_changed(
-      self, mocked_unreg, mocked_reg):
-    ie.new_env(None)
-    mocked_reg.assert_not_called()
-    mocked_unreg.assert_not_called()
-    ie.current_env().set_cache_manager(cache.FileBasedCacheManager())
-    mocked_reg.assert_called_once()
-    mocked_unreg.assert_not_called()
-
-  @patch('atexit.register')
-  @patch('atexit.unregister')
-  def test_noop_when_cm_is_not_changed(self, mocked_unreg, mocked_reg):
+  @patch(
+      'apache_beam.runners.interactive.interactive_environment'
+      '.InteractiveEnvironment.cleanup')
+  def test_noop_when_cm_is_not_changed(self, mocked_cleanup):
+    ie._interactive_beam_env = None
     cache_manager = cache.FileBasedCacheManager()
-    ie.new_env(cache_manager)
-    mocked_unreg.assert_not_called()
-    mocked_reg.assert_called_once()
-    ie.current_env().set_cache_manager(cache_manager)
-    mocked_unreg.assert_not_called()
-    mocked_reg.assert_called_once()
+    dummy_pipeline = 'dummy'
+    ie.new_env()
+    ie.current_env()._cache_managers[str(id(dummy_pipeline))] = cache_manager
+    mocked_cleanup.assert_not_called()
+    ie.current_env().set_cache_manager(cache_manager, dummy_pipeline)
+    mocked_cleanup.assert_not_called()
+
+  def test_get_cache_manager_creates_cache_manager_if_absent(self):
+    ie._interactive_beam_env = None
+    ie.new_env()
+    dummy_pipeline = 'dummy'
+    self.assertIsNone(ie.current_env().get_cache_manager(dummy_pipeline))
+    self.assertIsNotNone(
+        ie.current_env().get_cache_manager(
+            dummy_pipeline, create_if_absent=True))
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/runners/interactive/options/capture_control_test.py
+++ b/sdks/python/apache_beam/runners/interactive/options/capture_control_test.py
@@ -113,14 +113,14 @@ class CaptureControlTest(unittest.TestCase):
     self.assertTrue(ie.current_env().get_cached_source_signature(p) == set())
 
   def test_capture_size_limit_not_reached_when_no_cache(self):
-    self.assertIsNone(ie.current_env().cache_manager())
+    self.assertEqual(len(ie.current_env()._cache_managers), 0)
     limiter = capture_limiters.SizeLimiter(1)
     self.assertFalse(limiter.is_triggered())
 
   def test_capture_size_limit_not_reached_when_no_file(self):
     cache = StreamingCache(cache_dir=None)
     self.assertFalse(cache.exists('my_label'))
-    ie.current_env().set_cache_manager(cache)
+    ie.current_env().set_cache_manager(cache, 'dummy pipeline')
 
     limiter = capture_limiters.SizeLimiter(1)
     self.assertFalse(limiter.is_triggered())
@@ -132,7 +132,7 @@ class CaptureControlTest(unittest.TestCase):
     cache.sink(['my_label'], is_capture=True)
     cache.write([TestStreamFileRecord()], 'my_label')
     self.assertTrue(cache.exists('my_label'))
-    ie.current_env().set_cache_manager(cache)
+    ie.current_env().set_cache_manager(cache, 'dummy pipeline')
 
     limiter = capture_limiters.SizeLimiter(ib.options.capture_size_limit)
     self.assertFalse(limiter.is_triggered())
@@ -154,7 +154,8 @@ class CaptureControlTest(unittest.TestCase):
     ],
                 'my_label')
     self.assertTrue(cache.exists('my_label'))
-    ie.current_env().set_cache_manager(cache)
+    p = _build_an_empty_streaming_pipeline()
+    ie.current_env().set_cache_manager(cache, p)
 
     limiter = capture_limiters.SizeLimiter(1)
     self.assertTrue(limiter.is_triggered())

--- a/sdks/python/apache_beam/runners/interactive/options/capture_limiters.py
+++ b/sdks/python/apache_beam/runners/interactive/options/capture_limiters.py
@@ -45,10 +45,13 @@ class SizeLimiter(Limiter):
     self._size_limit = size_limit
 
   def is_triggered(self):
-    cache_manager = ie.current_env().cache_manager()
-    if hasattr(cache_manager, 'capture_size'):
-      return cache_manager.capture_size >= self._size_limit
-    return False
+    total_capture_size = 0
+    ie.current_env().track_user_pipelines()
+    for user_pipeline in ie.current_env().tracked_user_pipelines:
+      cache_manager = ie.current_env().get_cache_manager(user_pipeline)
+      if hasattr(cache_manager, 'capture_size'):
+        total_capture_size += cache_manager.capture_size
+    return total_capture_size >= self._size_limit
 
 
 class DurationLimiter(Limiter):


### PR DESCRIPTION
1. Interactive Beam now creates 1 cache manager for each user defined pipeline.
2. Cache managers are created lazily when they are used.
3. Cleanup of cache and states are carried out independently for each pipeline.
4. The source recording/capture size limit is applied to the total capture size of all pipelines.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
