### PR TITLE
[BEAM-2762] Generate Python coverage reports during pre-commit

### DIFF
--- a/.test-infra/jenkins/CommonJobProperties.groovy
+++ b/.test-infra/jenkins/CommonJobProperties.groovy
@@ -90,6 +90,7 @@ class CommonJobProperties {
         env('SPARK_LOCAL_IP', '127.0.0.1')
       }
       credentialsBinding {
+        string("CODECOV_TOKEN", "beam-codecov-token")
         string("COVERALLS_REPO_TOKEN", "beam-coveralls-token")
         string("SLACK_WEBHOOK_URL", "beam-slack-webhook-url")
       }

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -193,8 +193,6 @@ REQUIRED_TEST_PACKAGES = [
     'requests_mock>=1.7,<2.0',
     'tenacity>=5.0.2,<6.0',
     'pytest>=4.4.0,<5.0',
-    # More recent versions of pytest-cov do not support pytest 4.4.0
-    'pytest-cov==2.9.0',
     'pytest-xdist>=1.29.0,<2',
     'pytest-timeout>=1.3.3,<2',
     'rsa<4.1; python_version < "3.0"',

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -193,6 +193,8 @@ REQUIRED_TEST_PACKAGES = [
     'requests_mock>=1.7,<2.0',
     'tenacity>=5.0.2,<6.0',
     'pytest>=4.4.0,<5.0',
+    # More recent versions of pytest-cov do not support pytest 4.4.0
+    'pytest-cov==2.9.0',
     'pytest-xdist>=1.29.0,<2',
     'pytest-timeout>=1.3.3,<2',
     'rsa<4.1; python_version < "3.0"',

--- a/sdks/python/test-suites/tox/common.gradle
+++ b/sdks/python/test-suites/tox/common.gradle
@@ -30,7 +30,3 @@ test.dependsOn "testPy${pythonVersionSuffix}Cython"
 project.task("preCommitPy${pythonVersionSuffix}") {
       dependsOn = ["testPy${pythonVersionSuffix}Cloud", "testPy${pythonVersionSuffix}Cython"]
 }
-
-project.task("preCommitPy38") {
-      dependsOn = ["testPy38Cloud", "testPy38CloudCoverage"]
-}

--- a/sdks/python/test-suites/tox/common.gradle
+++ b/sdks/python/test-suites/tox/common.gradle
@@ -28,5 +28,9 @@ toxTask "testPy${pythonVersionSuffix}Cython", "py${pythonVersionSuffix}-cython"
 test.dependsOn "testPy${pythonVersionSuffix}Cython"
 
 project.task("preCommitPy${pythonVersionSuffix}") {
-      dependsOn = ["testPy${pythonVersionSuffix}Cloud", "testPy${pythonVersionSuffix}Cython"]
+      if (pythonVersionSuffix.equals('38') {
+          dependsOn = ["testPy${pythonVersionSuffix}CloudCoverage", "testPy${pythonVersionSuffix}Cython"]
+      } else {
+          dependsOn = ["testPy${pythonVersionSuffix}Cloud", "testPy${pythonVersionSuffix}Cython"]
+      }
 }

--- a/sdks/python/test-suites/tox/common.gradle
+++ b/sdks/python/test-suites/tox/common.gradle
@@ -30,3 +30,7 @@ test.dependsOn "testPy${pythonVersionSuffix}Cython"
 project.task("preCommitPy${pythonVersionSuffix}") {
       dependsOn = ["testPy${pythonVersionSuffix}Cloud", "testPy${pythonVersionSuffix}Cython"]
 }
+
+project.task("preCommitPy38") {
+      dependsOn = ["testPy38Cloud", "testPy38CloudCoverage"]
+}

--- a/sdks/python/test-suites/tox/common.gradle
+++ b/sdks/python/test-suites/tox/common.gradle
@@ -31,6 +31,7 @@ toxTask "testPy38CloudCoverage", "py38-cloudcoverage"
 test.dependsOn "testPy38CloudCoverage"
 
 project.task("preCommitPy${pythonVersionSuffix}") {
+      // Generates coverage reports only once, in Py38, to remove duplicated work
       if (pythonVersionSuffix.equals('38')) {
           dependsOn = ["testPy38CloudCoverage", "testPy38Cython"]
       } else {

--- a/sdks/python/test-suites/tox/common.gradle
+++ b/sdks/python/test-suites/tox/common.gradle
@@ -28,7 +28,7 @@ toxTask "testPy${pythonVersionSuffix}Cython", "py${pythonVersionSuffix}-cython"
 test.dependsOn "testPy${pythonVersionSuffix}Cython"
 
 project.task("preCommitPy${pythonVersionSuffix}") {
-      if (pythonVersionSuffix.equals('38') {
+      if (pythonVersionSuffix.equals('38')) {
           dependsOn = ["testPy${pythonVersionSuffix}CloudCoverage", "testPy${pythonVersionSuffix}Cython"]
       } else {
           dependsOn = ["testPy${pythonVersionSuffix}Cloud", "testPy${pythonVersionSuffix}Cython"]

--- a/sdks/python/test-suites/tox/common.gradle
+++ b/sdks/python/test-suites/tox/common.gradle
@@ -27,6 +27,9 @@ test.dependsOn "testPy${pythonVersionSuffix}Cloud"
 toxTask "testPy${pythonVersionSuffix}Cython", "py${pythonVersionSuffix}-cython"
 test.dependsOn "testPy${pythonVersionSuffix}Cython"
 
+toxTask "testPy38CloudCoverage", "py38-cloudcoverage"
+test.dependsOn "testPy38CloudCoverage"
+
 project.task("preCommitPy${pythonVersionSuffix}") {
       if (pythonVersionSuffix.equals('38')) {
           dependsOn = ["testPy${pythonVersionSuffix}CloudCoverage", "testPy${pythonVersionSuffix}Cython"]

--- a/sdks/python/test-suites/tox/common.gradle
+++ b/sdks/python/test-suites/tox/common.gradle
@@ -32,7 +32,7 @@ test.dependsOn "testPy38CloudCoverage"
 
 project.task("preCommitPy${pythonVersionSuffix}") {
       if (pythonVersionSuffix.equals('38')) {
-          dependsOn = ["testPy${pythonVersionSuffix}CloudCoverage", "testPy${pythonVersionSuffix}Cython"]
+          dependsOn = ["testPy38CloudCoverage", "testPy38Cython"]
       } else {
           dependsOn = ["testPy${pythonVersionSuffix}Cloud", "testPy${pythonVersionSuffix}Cython"]
       }

--- a/sdks/python/test-suites/tox/py38/build.gradle
+++ b/sdks/python/test-suites/tox/py38/build.gradle
@@ -32,13 +32,6 @@ check.dependsOn formatter
 toxTask "testPy38CloudCoverage", "py38-cloudcoverage"
 test.dependsOn "testPy38CloudCoverage"
 
-task python38CloudCoverage() {
-  dependsOn 'sdks:python:test-suites:tox:py38:testPy38CloudCoverage'
-}
-
-toxTask "testPy38Cython"
-test.dependsOn "testPy38CloudCoverage"
-
 apply from: "../common.gradle"
 
 // TODO(BEAM-8954): Remove this once tox uses isolated builds.

--- a/sdks/python/test-suites/tox/py38/build.gradle
+++ b/sdks/python/test-suites/tox/py38/build.gradle
@@ -29,7 +29,10 @@ pythonVersion = '3.8'
 toxTask "formatter", "py3-yapf-check"
 check.dependsOn formatter
 
+toxTask "testPy38CloudCoverage", "py38-cloudcoverage"
+test.dependsOn "testPy38CloudCoverage"
+
 apply from: "../common.gradle"
 
 // TODO(BEAM-8954): Remove this once tox uses isolated builds.
-testPy38Cython.mustRunAfter testPython38, testPy38Cloud
+testPy38Cython.mustRunAfter testPython38, testPy38Cloud, testPy38CloudCoverage

--- a/sdks/python/test-suites/tox/py38/build.gradle
+++ b/sdks/python/test-suites/tox/py38/build.gradle
@@ -32,4 +32,4 @@ check.dependsOn formatter
 apply from: "../common.gradle"
 
 // TODO(BEAM-8954): Remove this once tox uses isolated builds.
-testPy38Cython.mustRunAfter testPython38, python38CloudCoverage
+testPy38Cython.mustRunAfter testPython38, testPy38CloudCoverage

--- a/sdks/python/test-suites/tox/py38/build.gradle
+++ b/sdks/python/test-suites/tox/py38/build.gradle
@@ -32,7 +32,11 @@ check.dependsOn formatter
 toxTask "testPy38CloudCoverage", "py38-cloudcoverage"
 test.dependsOn "testPy38CloudCoverage"
 
+task python38CloudCoverage() {
+  dependsOn 'sdks:python:test-suites:tox:py38:testPy38CloudCoverage'
+}
+
 apply from: "../common.gradle"
 
 // TODO(BEAM-8954): Remove this once tox uses isolated builds.
-testPy38Cython.mustRunAfter testPython38, testPy38Cloud, testPy38CloudCoverage
+testPy38Cython.mustRunAfter testPython38, python38CloudCoverage

--- a/sdks/python/test-suites/tox/py38/build.gradle
+++ b/sdks/python/test-suites/tox/py38/build.gradle
@@ -29,9 +29,6 @@ pythonVersion = '3.8'
 toxTask "formatter", "py3-yapf-check"
 check.dependsOn formatter
 
-toxTask "testPy38CloudCoverage", "py38-cloudcoverage"
-test.dependsOn "testPy38CloudCoverage"
-
 apply from: "../common.gradle"
 
 // TODO(BEAM-8954): Remove this once tox uses isolated builds.

--- a/sdks/python/test-suites/tox/py38/build.gradle
+++ b/sdks/python/test-suites/tox/py38/build.gradle
@@ -36,6 +36,9 @@ task python38CloudCoverage() {
   dependsOn 'sdks:python:test-suites:tox:py38:testPy38CloudCoverage'
 }
 
+toxTask "testPy38Cython"
+test.dependsOn "testPy38CloudCoverage"
+
 apply from: "../common.gradle"
 
 // TODO(BEAM-8954): Remove this once tox uses isolated builds.

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -181,7 +181,7 @@ passenv = GIT_* BUILD_* ghprb* CHANGE_ID BRANCH_NAME JENKINS_* CODECOV_*
 extras = test,gcp,interactive,aws
 commands =
   {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}" --cov=apache_beam
-  codecov -t CODECOV_TOKEN
+  codecov
 
 [testenv:py27-lint]
 # Checks for py2 syntax errors

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -17,7 +17,7 @@
 
 [tox]
 # new environments will be excluded by default unless explicitly added to envlist.
-envlist = py27,py35,py36,py37,py27-{cloud,cython,lint,lint3},py35-{cloud,cython},py36-{cloud,cython},py37-{cloud,cython,lint,mypy},py38-{cloud,cython,docs}
+envlist = py27,py35,py36,py37,py27-{cloud,cython,lint,lint3},py35-{cloud,cython},py36-{cloud,cython},py37-{cloud,cython,lint,mypy},py38-{cloud,cython,docs,cloud-coverage}
 toxworkdir = {toxinidir}/target/{env:ENV_NAME:.tox}
 
 [pycodestyle]
@@ -238,19 +238,6 @@ deps =
   sphinx_rtd_theme==0.4.3
 commands =
   time {toxinidir}/scripts/generate_pydoc.sh
-
-[testenv:cover]
-# This is not included in envlist which is defined in [tox].
-deps =
-  coverage==4.4.1
-commands =
-  # Clean up previously collected data.
-  coverage erase
-  coverage run setup.py test
-  # Print coverage report to STDOUT
-  coverage report --skip-covered
-  # Generate report in xml format
-  coverage xml
 
 [testenv:hdfs_integration_test]
 # Used by hdfs_integration_test.sh. Do not run this directly, as it depends on

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -168,12 +168,19 @@ commands =
   {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"
 
 [testenv:py38-cloud]
+extras = test,gcp,interactive,aws
+commands =
+  {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"
+
+[testenv:py38-cloud-coverage]
+# More recent versions of pytest-cov do not support pytest 4.4.0
+deps =
+  codecov
+  pytest-cov==2.9.0
 passenv = GIT_* BUILD_* ghprb* CHANGE_ID BRANCH_NAME JENKINS_* CODECOV_*
 extras = test,gcp,interactive,aws
-# More recent versions of pytest-cov do not support pytest 4.4.0
-deps= codecov, pytest-cov==2.9.0
 commands =
-  {toxinidir}/scripts/run_pytest.sh {envname} "--cov=apache_beam"
+  {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}" --cov=apache_beam
   codecov -t CODECOV_TOKEN
 
 [testenv:py27-lint]

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -170,7 +170,8 @@ commands =
 [testenv:py38-cloud]
 passenv = GIT_* BUILD_* ghprb* CHANGE_ID BRANCH_NAME JENKINS_* CODECOV_*
 extras = test,gcp,interactive,aws
-deps=codecov
+# More recent versions of pytest-cov do not support pytest 4.4.0
+deps= codecov, pytest-cov==2.9.0
 commands =
   {toxinidir}/scripts/run_pytest.sh {envname} "--cov=apache_beam"
   codecov -t CODECOV_TOKEN

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -169,7 +169,8 @@ commands =
 
 [testenv:py38-cloud]
 passenv = GIT_* BUILD_* ghprb* CHANGE_ID BRANCH_NAME JENKINS_* CODECOV_*
-extras = test,gcp,interactive,aws,codecov
+extras = test,gcp,interactive,aws
+deps=codecov
 commands =
   {toxinidir}/scripts/run_pytest.sh {envname} "--cov=apache_beam"
   codecov -t CODECOV_TOKEN

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -17,7 +17,7 @@
 
 [tox]
 # new environments will be excluded by default unless explicitly added to envlist.
-envlist = py27,py35,py36,py37,py27-{cloud,cython,lint,lint3},py35-{cloud,cython},py36-{cloud,cython},py37-{cloud,cython,lint,mypy},py38-{cloud,cython,docs,cloud-coverage}
+envlist = py27,py35,py36,py37,py27-{cloud,cython,lint,lint3},py35-{cloud,cython},py36-{cloud,cython},py37-{cloud,cython,lint,mypy},py38-{cloud,cython,docs,cloudcoverage}
 toxworkdir = {toxinidir}/target/{env:ENV_NAME:.tox}
 
 [pycodestyle]
@@ -172,7 +172,7 @@ extras = test,gcp,interactive,aws
 commands =
   {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"
 
-[testenv:py38-cloud-coverage]
+[testenv:py38-cloudcoverage]
 # More recent versions of pytest-cov do not support pytest 4.4.0
 deps =
   codecov

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -168,9 +168,11 @@ commands =
   {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"
 
 [testenv:py38-cloud]
-extras = test,gcp,interactive,aws
+passenv = GIT_* BUILD_* ghprb* CHANGE_ID BRANCH_NAME JENKINS_* CODECOV_*
+extras = test,gcp,interactive,aws,codecov
 commands =
-  {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"
+  {toxinidir}/scripts/run_pytest.sh {envname} "--cov=apache_beam"
+  codecov -t CODECOV_TOKEN
 
 [testenv:py27-lint]
 # Checks for py2 syntax errors


### PR DESCRIPTION
This PR enables the generation of Python coverage reports during pre-commit in the `py38-cloud` Tox environment.
 

- The resultant reports are uploaded to `codecov.io`, as can be seen [here](https://codecov.io/gh/saavannanavati/beam/tree/7e9d684698adbe2654fb59a734553c4f1682c356/sdks/python/apache_beam).

- To work on the live testing infrastructure, an environment variable `CODECOV_TOKEN` must be defined on Jenkins with a value that can be found [here](https://codecov.io/gh/apache/beam/).

The full design document related to this PR can be found [here](https://docs.google.com/document/d/1K6zEJnDNvk7TkqDEPwoIa7NTj5KxtUIdq-TGewUgpmo/edit).

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
