### PR TITLE
[BEAM-10496] Improve nullability analysis for :sdks:java:core

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
@@ -378,7 +378,7 @@ public class PipelineOptionsFactory {
               "Multiple matches found for %s: %s.%n",
               helpOption,
               StreamSupport.stream(matches.spliterator(), false)
-                  .map(ReflectHelpers.CLASS_NAME::apply)
+                  .map(Class::getName)
                   .collect(Collectors.toList()));
           printHelp(printStream);
         }
@@ -1104,12 +1104,12 @@ public class PipelineOptionsFactory {
       Iterable<String> getterClassNames =
           getters.stream()
               .map(MethodToDeclaringClassFunction.INSTANCE)
-              .map(ReflectHelpers.CLASS_NAME)
+              .map(Class::getName)
               .collect(Collectors.toList());
       Iterable<String> gettersWithTheAnnotationClassNames =
           gettersWithTheAnnotation.stream()
               .map(MethodToDeclaringClassFunction.INSTANCE)
-              .map(ReflectHelpers.CLASS_NAME)
+              .map(Class::getName)
               .collect(Collectors.toList());
 
       if (!(gettersWithTheAnnotation.isEmpty()
@@ -1144,7 +1144,7 @@ public class PipelineOptionsFactory {
       Iterable<String> settersWithTheAnnotationClassNames =
           settersWithTheAnnotation.stream()
               .map(MethodToDeclaringClassFunction.INSTANCE)
-              .map(ReflectHelpers.CLASS_NAME)
+              .map(Class::getName)
               .collect(Collectors.toList());
 
       if (!settersWithTheAnnotation.isEmpty()) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
@@ -1089,9 +1089,8 @@ public class PipelineOptionsFactory {
                                     annotation ->
                                         String.format(
                                             "[%s on %s]",
-                                            ReflectHelpers.ANNOTATION_FORMATTER.apply(annotation),
-                                            ReflectHelpers.CLASS_AND_METHOD_FORMATTER.apply(
-                                                method))))
+                                            ReflectHelpers.formatAnnotation(annotation),
+                                            ReflectHelpers.formatMethodWithClass(method))))
                     .collect(Collectors.joining(", "))));
       }
 
@@ -1230,9 +1229,7 @@ public class PipelineOptionsFactory {
     checkArgument(
         unknownMethods.isEmpty(),
         "Methods [%s] on [%s] do not conform to being bean properties.",
-        unknownMethods.stream()
-            .map(ReflectHelpers.METHOD_FORMATTER)
-            .collect(Collectors.joining(",")),
+        unknownMethods.stream().map(ReflectHelpers::formatMethod).collect(Collectors.joining(",")),
         iface.getName());
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsValidator.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsValidator.java
@@ -110,7 +110,7 @@ public class PipelineOptionsValidator {
                 + requiredGroup
                 + "]. At least one of the following properties "
                 + Collections2.transform(
-                    requiredGroups.get(requiredGroup), ReflectHelpers.METHOD_FORMATTER)
+                    requiredGroups.get(requiredGroup), ReflectHelpers::formatMethod)
                 + " required. Run with --help="
                 + klass.getSimpleName()
                 + " for more information.");

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
@@ -2319,7 +2319,7 @@ public class DoFnSignatures {
   }
 
   private static String format(Class<?> kls) {
-    return ReflectHelpers.CLASS_SIMPLE_NAME.apply(kls);
+    return kls.getSimpleName();
   }
 
   static class ErrorReporter {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
@@ -2311,11 +2311,11 @@ public class DoFnSignatures {
   }
 
   private static String format(Method method) {
-    return ReflectHelpers.METHOD_FORMATTER.apply(method);
+    return ReflectHelpers.formatMethod(method);
   }
 
   private static String format(TypeDescriptor<?> t) {
-    return ReflectHelpers.TYPE_SIMPLE_DESCRIPTION.apply(t.getType());
+    return ReflectHelpers.simpleTypeDescription(t.getType());
   }
 
   private static String format(Class<?> kls) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/common/ReflectHelpers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/common/ReflectHelpers.java
@@ -59,7 +59,7 @@ public class ReflectHelpers {
         public String apply(@Nonnull Method input) {
           String parameterTypes =
               FluentIterable.from(asList(input.getParameterTypes()))
-                  .transform(CLASS_SIMPLE_NAME)
+                  .transform(Class::getSimpleName)
                   .join(COMMA_SEPARATOR);
           return String.format("%s(%s)", input.getName(), parameterTypes);
         }
@@ -74,15 +74,9 @@ public class ReflectHelpers {
         @Override
         public String apply(@Nonnull Method input) {
           return String.format(
-              "%s#%s", CLASS_NAME.apply(input.getDeclaringClass()), METHOD_FORMATTER.apply(input));
+              "%s#%s", input.getDeclaringClass().getName(), METHOD_FORMATTER.apply(input));
         }
       };
-
-  /** A {@link Function} with returns the classes name. */
-  public static final Function<Class<?>, String> CLASS_NAME = Class::getName;
-
-  /** A {@link Function} with returns the classes name. */
-  public static final Function<Class<?>, String> CLASS_SIMPLE_NAME = Class::getSimpleName;
 
   /** A {@link Function} that returns a concise string for a {@link Annotation}. */
   public static final Function<Annotation, String> ANNOTATION_FORMATTER =

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/common/ReflectHelpers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/common/ReflectHelpers.java
@@ -21,7 +21,6 @@ import static java.util.Arrays.asList;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
 
-import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.GenericArrayType;
 import java.lang.reflect.Method;
@@ -35,8 +34,6 @@ import java.util.Collection;
 import java.util.Comparator;
 import java.util.Queue;
 import java.util.ServiceLoader;
-import javax.annotation.Nonnull;
-import javax.annotation.Nullable;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Function;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Joiner;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.FluentIterable;
@@ -49,119 +46,95 @@ public class ReflectHelpers {
 
   private static final Joiner COMMA_SEPARATOR = Joiner.on(", ");
 
-  /** A {@link Function} that turns a method into a simple method signature. */
-  public static final Function<Method, String> METHOD_FORMATTER =
-      new Function<Method, String>() {
-        @SuppressFBWarnings(
-            value = "NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION",
-            justification = "https://github.com/google/guava/issues/920")
-        @Override
-        public String apply(@Nonnull Method input) {
-          String parameterTypes =
-              FluentIterable.from(asList(input.getParameterTypes()))
-                  .transform(Class::getSimpleName)
-                  .join(COMMA_SEPARATOR);
-          return String.format("%s(%s)", input.getName(), parameterTypes);
-        }
-      };
+  /** Returns a string representation of the signature of a {@link Method}. */
+  public static String formatMethod(Method input) {
+    String parameterTypes =
+        FluentIterable.from(asList(input.getParameterTypes()))
+            .transform(Class::getSimpleName)
+            .join(COMMA_SEPARATOR);
+    return String.format("%s(%s)", input.getName(), parameterTypes);
+  }
 
-  /** A {@link Function} that turns a method into the declaring class + method signature. */
-  public static final Function<Method, String> CLASS_AND_METHOD_FORMATTER =
-      new Function<Method, String>() {
-        @SuppressFBWarnings(
-            value = "NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION",
-            justification = "https://github.com/google/guava/issues/920")
-        @Override
-        public String apply(@Nonnull Method input) {
-          return String.format(
-              "%s#%s", input.getDeclaringClass().getName(), METHOD_FORMATTER.apply(input));
-        }
-      };
+  /** Returns a string representation of the class + method signature for a {@link Method}. */
+  public static String formatMethodWithClass(Method input) {
+    return String.format("%s#%s", input.getDeclaringClass().getName(), formatMethod(input));
+  }
 
   /** A {@link Function} that returns a concise string for a {@link Annotation}. */
-  public static final Function<Annotation, String> ANNOTATION_FORMATTER =
-      annotation -> {
-        String annotationName = annotation.annotationType().getName();
-        String annotationNameWithoutPackage =
-            annotationName.substring(annotationName.lastIndexOf('.') + 1).replace('$', '.');
-        String annotationToString = annotation.toString();
-        String values = annotationToString.substring(annotationToString.indexOf('('));
-        return String.format("%s%s", annotationNameWithoutPackage, values);
-      };
+  public static String formatAnnotation(Annotation annotation) {
+    String annotationName = annotation.annotationType().getName();
+    String annotationNameWithoutPackage =
+        annotationName.substring(annotationName.lastIndexOf('.') + 1).replace('$', '.');
+    String annotationToString = annotation.toString();
+    String values = annotationToString.substring(annotationToString.indexOf('('));
+    return String.format("%s%s", annotationNameWithoutPackage, values);
+  }
 
   /** A {@link Function} that formats types. */
-  public static final Function<Type, String> TYPE_SIMPLE_DESCRIPTION =
-      new Function<Type, String>() {
-        @SuppressFBWarnings(
-            value = "NP_METHOD_PARAMETER_TIGHTENS_ANNOTATION",
-            justification = "https://github.com/google/guava/issues/920")
-        @Override
-        @Nullable
-        public String apply(@Nonnull Type input) {
-          StringBuilder builder = new StringBuilder();
-          format(builder, input);
-          return builder.toString();
-        }
+  public static String simpleTypeDescription(Type input) {
+    StringBuilder builder = new StringBuilder();
+    format(builder, input);
+    return builder.toString();
+  }
 
-        private void format(StringBuilder builder, Type t) {
-          if (t instanceof Class) {
-            formatClass(builder, (Class<?>) t);
-          } else if (t instanceof TypeVariable) {
-            formatTypeVariable(builder, (TypeVariable<?>) t);
-          } else if (t instanceof WildcardType) {
-            formatWildcardType(builder, (WildcardType) t);
-          } else if (t instanceof ParameterizedType) {
-            formatParameterizedType(builder, (ParameterizedType) t);
-          } else if (t instanceof GenericArrayType) {
-            formatGenericArrayType(builder, (GenericArrayType) t);
-          } else {
-            builder.append(t.toString());
-          }
-        }
+  private static void format(StringBuilder builder, Type t) {
+    if (t instanceof Class) {
+      formatClass(builder, (Class<?>) t);
+    } else if (t instanceof TypeVariable) {
+      formatTypeVariable(builder, (TypeVariable<?>) t);
+    } else if (t instanceof WildcardType) {
+      formatWildcardType(builder, (WildcardType) t);
+    } else if (t instanceof ParameterizedType) {
+      formatParameterizedType(builder, (ParameterizedType) t);
+    } else if (t instanceof GenericArrayType) {
+      formatGenericArrayType(builder, (GenericArrayType) t);
+    } else {
+      builder.append(t.toString());
+    }
+  }
 
-        private void formatClass(StringBuilder builder, Class<?> clazz) {
-          builder.append(clazz.getSimpleName());
-        }
+  private static void formatClass(StringBuilder builder, Class<?> clazz) {
+    builder.append(clazz.getSimpleName());
+  }
 
-        private void formatTypeVariable(StringBuilder builder, TypeVariable<?> t) {
-          builder.append(t.getName());
-        }
+  private static void formatTypeVariable(StringBuilder builder, TypeVariable<?> t) {
+    builder.append(t.getName());
+  }
 
-        private void formatWildcardType(StringBuilder builder, WildcardType t) {
-          builder.append("?");
-          for (Type lowerBound : t.getLowerBounds()) {
-            builder.append(" super ");
-            format(builder, lowerBound);
-          }
-          for (Type upperBound : t.getUpperBounds()) {
-            if (!Object.class.equals(upperBound)) {
-              builder.append(" extends ");
-              format(builder, upperBound);
-            }
-          }
-        }
+  private static void formatWildcardType(StringBuilder builder, WildcardType t) {
+    builder.append("?");
+    for (Type lowerBound : t.getLowerBounds()) {
+      builder.append(" super ");
+      format(builder, lowerBound);
+    }
+    for (Type upperBound : t.getUpperBounds()) {
+      if (!Object.class.equals(upperBound)) {
+        builder.append(" extends ");
+        format(builder, upperBound);
+      }
+    }
+  }
 
-        private void formatParameterizedType(StringBuilder builder, ParameterizedType t) {
-          if (t.getOwnerType() != null) {
-            format(builder, t.getOwnerType());
-            builder.append('.');
-          }
-          format(builder, t.getRawType());
-          if (t.getActualTypeArguments().length > 0) {
-            builder.append('<');
-            COMMA_SEPARATOR.appendTo(
-                builder,
-                FluentIterable.from(asList(t.getActualTypeArguments()))
-                    .transform(TYPE_SIMPLE_DESCRIPTION));
-            builder.append('>');
-          }
-        }
+  private static void formatParameterizedType(StringBuilder builder, ParameterizedType t) {
+    if (t.getOwnerType() != null) {
+      format(builder, t.getOwnerType());
+      builder.append('.');
+    }
+    format(builder, t.getRawType());
+    if (t.getActualTypeArguments().length > 0) {
+      builder.append('<');
+      COMMA_SEPARATOR.appendTo(
+          builder,
+          FluentIterable.from(asList(t.getActualTypeArguments()))
+              .transform(ReflectHelpers::simpleTypeDescription));
+      builder.append('>');
+    }
+  }
 
-        private void formatGenericArrayType(StringBuilder builder, GenericArrayType t) {
-          format(builder, t.getGenericComponentType());
-          builder.append("[]");
-        }
-      };
+  private static void formatGenericArrayType(StringBuilder builder, GenericArrayType t) {
+    format(builder, t.getGenericComponentType());
+    builder.append("[]");
+  }
 
   /** A {@link Comparator} that uses the object's class' canonical name to compare them. */
   public static class ObjectsClassComparator implements Comparator<Object> {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/common/ReflectHelpersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/common/ReflectHelpersTest.java
@@ -39,16 +39,6 @@ import org.junit.runners.JUnit4;
 public class ReflectHelpersTest {
 
   @Test
-  public void testClassName() {
-    assertEquals(getClass().getName(), ReflectHelpers.CLASS_NAME.apply(getClass()));
-  }
-
-  @Test
-  public void testClassSimpleName() {
-    assertEquals(getClass().getSimpleName(), ReflectHelpers.CLASS_SIMPLE_NAME.apply(getClass()));
-  }
-
-  @Test
   public void testMethodFormatter() throws Exception {
     assertEquals(
         "testMethodFormatter()",

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/common/ReflectHelpersTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/common/ReflectHelpersTest.java
@@ -42,14 +42,14 @@ public class ReflectHelpersTest {
   public void testMethodFormatter() throws Exception {
     assertEquals(
         "testMethodFormatter()",
-        ReflectHelpers.METHOD_FORMATTER.apply(getClass().getMethod("testMethodFormatter")));
+        ReflectHelpers.formatMethod(getClass().getMethod("testMethodFormatter")));
 
     assertEquals(
         "oneArg(int)",
-        ReflectHelpers.METHOD_FORMATTER.apply(getClass().getDeclaredMethod("oneArg", int.class)));
+        ReflectHelpers.formatMethod(getClass().getDeclaredMethod("oneArg", int.class)));
     assertEquals(
         "twoArg(String, List)",
-        ReflectHelpers.METHOD_FORMATTER.apply(
+        ReflectHelpers.formatMethod(
             getClass().getDeclaredMethod("twoArg", String.class, List.class)));
   }
 
@@ -57,16 +57,15 @@ public class ReflectHelpersTest {
   public void testClassMethodFormatter() throws Exception {
     assertEquals(
         getClass().getName() + "#testMethodFormatter()",
-        ReflectHelpers.CLASS_AND_METHOD_FORMATTER.apply(
-            getClass().getMethod("testMethodFormatter")));
+        ReflectHelpers.formatMethodWithClass(getClass().getMethod("testMethodFormatter")));
 
     assertEquals(
         getClass().getName() + "#oneArg(int)",
-        ReflectHelpers.CLASS_AND_METHOD_FORMATTER.apply(
-            getClass().getDeclaredMethod("oneArg", int.class)));
+        ReflectHelpers.formatMethodWithClass(getClass().getDeclaredMethod("oneArg", int.class)));
+
     assertEquals(
         getClass().getName() + "#twoArg(String, List)",
-        ReflectHelpers.CLASS_AND_METHOD_FORMATTER.apply(
+        ReflectHelpers.formatMethodWithClass(
             getClass().getDeclaredMethod("twoArg", String.class, List.class)));
   }
 
@@ -78,32 +77,30 @@ public class ReflectHelpersTest {
 
   @Test
   public void testTypeFormatterOnClasses() throws Exception {
-    assertEquals("Integer", ReflectHelpers.TYPE_SIMPLE_DESCRIPTION.apply(Integer.class));
-    assertEquals("int", ReflectHelpers.TYPE_SIMPLE_DESCRIPTION.apply(int.class));
-    assertEquals("Map", ReflectHelpers.TYPE_SIMPLE_DESCRIPTION.apply(Map.class));
-    assertEquals(
-        getClass().getSimpleName(), ReflectHelpers.TYPE_SIMPLE_DESCRIPTION.apply(getClass()));
+    assertEquals("Integer", ReflectHelpers.simpleTypeDescription(Integer.class));
+    assertEquals("int", ReflectHelpers.simpleTypeDescription(int.class));
+    assertEquals("Map", ReflectHelpers.simpleTypeDescription(Map.class));
+    assertEquals(getClass().getSimpleName(), ReflectHelpers.simpleTypeDescription(getClass()));
   }
 
   @Test
   public void testTypeFormatterOnArrays() throws Exception {
-    assertEquals("Integer[]", ReflectHelpers.TYPE_SIMPLE_DESCRIPTION.apply(Integer[].class));
-    assertEquals("int[]", ReflectHelpers.TYPE_SIMPLE_DESCRIPTION.apply(int[].class));
+    assertEquals("Integer[]", ReflectHelpers.simpleTypeDescription(Integer[].class));
+    assertEquals("int[]", ReflectHelpers.simpleTypeDescription(int[].class));
   }
 
   @Test
   public void testTypeFormatterWithGenerics() throws Exception {
     assertEquals(
         "Map<Integer, String>",
-        ReflectHelpers.TYPE_SIMPLE_DESCRIPTION.apply(
+        ReflectHelpers.simpleTypeDescription(
             new TypeDescriptor<Map<Integer, String>>() {}.getType()));
     assertEquals(
         "Map<?, String>",
-        ReflectHelpers.TYPE_SIMPLE_DESCRIPTION.apply(
-            new TypeDescriptor<Map<?, String>>() {}.getType()));
+        ReflectHelpers.simpleTypeDescription(new TypeDescriptor<Map<?, String>>() {}.getType()));
     assertEquals(
         "Map<? extends Integer, String>",
-        ReflectHelpers.TYPE_SIMPLE_DESCRIPTION.apply(
+        ReflectHelpers.simpleTypeDescription(
             new TypeDescriptor<Map<? extends Integer, String>>() {}.getType()));
   }
 
@@ -111,14 +108,14 @@ public class ReflectHelpersTest {
   public <T> void testTypeFormatterWithWildcards() throws Exception {
     assertEquals(
         "Map<T, T>",
-        ReflectHelpers.TYPE_SIMPLE_DESCRIPTION.apply(new TypeDescriptor<Map<T, T>>() {}.getType()));
+        ReflectHelpers.simpleTypeDescription(new TypeDescriptor<Map<T, T>>() {}.getType()));
   }
 
   @Test
   public <InputT, OutputT> void testTypeFormatterWithMultipleWildcards() throws Exception {
     assertEquals(
         "Map<? super InputT, ? extends OutputT>",
-        ReflectHelpers.TYPE_SIMPLE_DESCRIPTION.apply(
+        ReflectHelpers.simpleTypeDescription(
             new TypeDescriptor<Map<? super InputT, ? extends OutputT>>() {}.getType()));
   }
 
@@ -132,22 +129,23 @@ public class ReflectHelpersTest {
   }
 
   @Test
-  public void testAnnotationFormatter() throws Exception {
+  public void testFormatAnnotationDefault() throws Exception {
     // Java 11 puts quotes in unparsed string, Java 8 does not.
     // It would be an improvement for our own formatter to make it have the
     // Java 11 behavior even when running on Java 8, but we can just
     // wait it out.
     assertThat(
-        ReflectHelpers.ANNOTATION_FORMATTER.apply(
-            Options.class.getMethod("getString").getAnnotations()[0]),
+        ReflectHelpers.formatAnnotation(Options.class.getMethod("getString").getAnnotations()[0]),
         anyOf(
             equalTo("Default.String(value=package.OuterClass$InnerClass#method())"),
             equalTo("Default.String(value=\"package.OuterClass$InnerClass#method()\")")));
+  }
 
+  @Test
+  public void testFormatAnnotationJsonIgnore() throws Exception {
     assertEquals(
         "JsonIgnore(value=true)",
-        ReflectHelpers.ANNOTATION_FORMATTER.apply(
-            Options.class.getMethod("getObject").getAnnotations()[0]));
+        ReflectHelpers.formatAnnotation(Options.class.getMethod("getObject").getAnnotations()[0]));
   }
 
   @Test


### PR DESCRIPTION
The total number of nullability issues in `:sdks:java:core` is very high. These are some baby steps towards embracing nullability typing. While not discovering any latent NPE this time, it did uncover improvements to the core SDK:

 - inlining completely trivial functions and their trivial tests
 - moving to Java function instead of Guava function
 - moving to Java streams instead of Guava `FluentIterable`
 - moving irrelevant null check out of utility function that has no reason to accept null parameters

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
