### PR TITLE
[BEAM-10420] Add support for per window invocation of beam:transform:sdf_process_sized_element_and_restrictions:v1

### DIFF
--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -70,6 +70,7 @@ __all__ = [
     'BoundedSource',
     'RangeTracker',
     'Read',
+    'RestrictionProgress',
     'RestrictionTracker',
     'WatermarkEstimator',
     'Sink',
@@ -1301,18 +1302,22 @@ class RestrictionProgress(object):
   @property
   def completed_work(self):
     # type: () -> float
-    if self._completed:
+    if self._completed is not None:
       return self._completed
-    elif self._remaining and self._fraction:
+    elif self._remaining is not None and self._fraction:
       return self._remaining * self._fraction / (1 - self._fraction)
+    else:
+      return self._fraction
 
   @property
   def remaining_work(self):
     # type: () -> float
-    if self._remaining:
+    if self._remaining is not None:
       return self._remaining
-    elif self._completed:
+    elif self._completed is not None and self._fraction:
       return self._completed * (1 - self._fraction) / self._fraction
+    else:
+      return 1 - self._fraction
 
   @property
   def total_work(self):

--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -1304,7 +1304,7 @@ class RestrictionProgress(object):
     # type: () -> float
     if self._completed is not None:
       return self._completed
-    elif self._remaining is not None and self._fraction:
+    elif self._remaining is not None and self._fraction is not None:
       return self._remaining * self._fraction / (1 - self._fraction)
     else:
       return self._fraction

--- a/sdks/python/apache_beam/io/restriction_trackers.py
+++ b/sdks/python/apache_beam/io/restriction_trackers.py
@@ -51,6 +51,9 @@ class OffsetRange(object):
   def __hash__(self):
     return hash((type(self), self.start, self.stop))
 
+  def __repr__(self):
+    return 'OffsetRange(start=%s, stop=%s)' % (self.start, self.stop)
+
   def split(self, desired_num_offsets_per_split, min_num_offsets_per_split=1):
     current_split_start = self.start
     max_split_size = max(

--- a/sdks/python/apache_beam/runners/common.pxd
+++ b/sdks/python/apache_beam/runners/common.pxd
@@ -94,6 +94,10 @@ cdef class PerWindowInvoker(DoFnInvoker):
   cdef object threadsafe_restriction_tracker
   cdef object threadsafe_watermark_estimator
   cdef WindowedValue current_windowed_value
+  cdef object restriction
+  cdef object watermark_estimator_state
+  cdef object current_window_index
+  cdef object stop_window_index
   cdef bint is_key_param_required
   cdef object splitting_lock
 

--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -696,7 +696,7 @@ class PerWindowInvoker(DoFnInvoker):
         self.restriction = restriction
         self.watermark_estimator_state = watermark_estimator_state
       try:
-        if self.has_windowed_inputs and len(windowed_value.windows) != 1:
+        if self.has_windowed_inputs and len(windowed_value.windows) > 1:
           for i, w in enumerate(windowed_value.windows):
             if not self._should_process_window_for_sdf(
                 windowed_value, additional_kwargs, i):
@@ -1111,6 +1111,8 @@ class PerWindowInvoker(DoFnInvoker):
     if not current_window_index or not progress:
       return progress
 
+    # stop_window_index should always be set if current_window_index is set,
+    # it is an error otherwise.
     assert stop_window_index
     return PerWindowInvoker._scale_progress(
         progress, current_window_index, stop_window_index)

--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -24,11 +24,13 @@ For internal use only; no backwards-compatibility guarantees.
 # pytype: skip-file
 
 from __future__ import absolute_import
+from __future__ import division
 
 import threading
 import traceback
 from builtins import next
 from builtins import object
+from builtins import round
 from builtins import zip
 from typing import TYPE_CHECKING
 from typing import Any
@@ -466,7 +468,7 @@ class DoFnInvoker(object):
                      additional_args=None,
                      additional_kwargs=None
                     ):
-    # type: (...) -> Optional[SplitResultResidual]
+    # type: (...) -> Iterable[SplitResultResidual]
 
     """Invokes the DoFn.process() function.
 
@@ -591,6 +593,8 @@ class PerWindowInvoker(DoFnInvoker):
     self.is_key_param_required = False
     if self.is_splittable:
       self.splitting_lock = threading.Lock()
+      self.current_window_index = None
+      self.stop_window_index = None
 
     # Try to prepare all the arguments that can just be filled in
     # without any additional work. in the process function.
@@ -674,7 +678,7 @@ class PerWindowInvoker(DoFnInvoker):
                      additional_args=None,
                      additional_kwargs=None
                     ):
-    # type: (...) -> Optional[SplitResultResidual]
+    # type: (...) -> Iterable[SplitResultResidual]
     if not additional_args:
       additional_args = []
     if not additional_kwargs:
@@ -685,46 +689,40 @@ class PerWindowInvoker(DoFnInvoker):
     # or if the process accesses the window parameter. We can just call it once
     # otherwise as none of the arguments are changing
 
+    residuals = []
     if self.is_splittable:
-      restriction_tracker = self.invoke_create_tracker(restriction)
-      watermark_estimator = self.invoke_create_watermark_estimator(
-          watermark_estimator_state)
-
-      if len(windowed_value.windows) > 1 and self.has_windowed_inputs:
-        # Should never get here due to window explosion in
-        # the upstream pair-with-restriction.
-        raise NotImplementedError(
-            'SDFs in multiply-windowed values with windowed arguments.')
       with self.splitting_lock:
-        self.threadsafe_restriction_tracker = ThreadsafeRestrictionTracker(
-            restriction_tracker)
         self.current_windowed_value = windowed_value
-        self.threadsafe_watermark_estimator = (
-            ThreadsafeWatermarkEstimator(watermark_estimator))
-
-      restriction_tracker_param = (
-          self.signature.process_method.restriction_provider_arg_name)
-      if not restriction_tracker_param:
-        raise ValueError(
-            'DoFn is splittable but DoFn does not have a '
-            'RestrictionTrackerParam defined')
-      additional_kwargs[restriction_tracker_param] = (
-          RestrictionTrackerView(self.threadsafe_restriction_tracker))
-      watermark_param = (
-          self.signature.process_method.watermark_estimator_provider_arg_name)
-      # When the watermark_estimator is a NoOpWatermarkEstimator, the system
-      # will not add watermark_param into the DoFn param list.
-      if watermark_param is not None:
-        additional_kwargs[watermark_param] = self.threadsafe_watermark_estimator
+        self.restriction = restriction
+        self.watermark_estimator_state = watermark_estimator_state
       try:
-        return self._invoke_process_per_window(
-            windowed_value, additional_args, additional_kwargs)
+        if self.has_windowed_inputs and len(windowed_value.windows) != 1:
+          for i, w in enumerate(windowed_value.windows):
+            if not self._should_process_window_for_sdf(
+                windowed_value, additional_kwargs, i):
+              break
+            residual = self._invoke_process_per_window(
+                WindowedValue(
+                    windowed_value.value, windowed_value.timestamp, (w, )),
+                additional_args,
+                additional_kwargs)
+            if residual:
+              residuals.append(residual)
+        else:
+          if self._should_process_window_for_sdf(windowed_value,
+                                                 additional_kwargs):
+            residual = self._invoke_process_per_window(
+                windowed_value, additional_args, additional_kwargs)
+            if residual:
+              residuals.append(residual)
       finally:
         with self.splitting_lock:
+          self.current_windowed_value = None
+          self.restriction = None
+          self.watermark_estimator_state = None
+          self.current_window_index = None
           self.threadsafe_restriction_tracker = None
           self.threadsafe_watermark_estimator = None
-          self.current_windowed_value = windowed_value
-
     elif self.has_windowed_inputs and len(windowed_value.windows) != 1:
       for w in windowed_value.windows:
         self._invoke_process_per_window(
@@ -735,7 +733,44 @@ class PerWindowInvoker(DoFnInvoker):
     else:
       self._invoke_process_per_window(
           windowed_value, additional_args, additional_kwargs)
-    return None
+    return residuals
+
+  def _should_process_window_for_sdf(
+      self,
+      windowed_value, # type: WindowedValue
+      additional_kwargs,
+      window_index=None, # type: Optional[int]
+  ):
+    restriction_tracker = self.invoke_create_tracker(self.restriction)
+    watermark_estimator = self.invoke_create_watermark_estimator(
+        self.watermark_estimator_state)
+    with self.splitting_lock:
+      if window_index:
+        self.current_window_index = window_index
+        if window_index == 0:
+          self.stop_window_index = len(windowed_value.windows)
+        if window_index == self.stop_window_index:
+          return False
+      self.threadsafe_restriction_tracker = ThreadsafeRestrictionTracker(
+          restriction_tracker)
+      self.threadsafe_watermark_estimator = (
+          ThreadsafeWatermarkEstimator(watermark_estimator))
+
+    restriction_tracker_param = (
+        self.signature.process_method.restriction_provider_arg_name)
+    if not restriction_tracker_param:
+      raise ValueError(
+          'DoFn is splittable but DoFn does not have a '
+          'RestrictionTrackerParam defined')
+    additional_kwargs[restriction_tracker_param] = (
+        RestrictionTrackerView(self.threadsafe_restriction_tracker))
+    watermark_param = (
+        self.signature.process_method.watermark_estimator_provider_arg_name)
+    # When the watermark_estimator is a NoOpWatermarkEstimator, the system
+    # will not add watermark_param into the DoFn param list.
+    if watermark_param is not None:
+      additional_kwargs[watermark_param] = self.threadsafe_watermark_estimator
+    return True
 
   def _invoke_process_per_window(self,
                                  windowed_value,  # type: WindowedValue
@@ -845,51 +880,240 @@ class PerWindowInvoker(DoFnInvoker):
             deferred_timestamp=deferred_timestamp)
     return None
 
+  @staticmethod
+  def _try_split(fraction,
+      window_index, # type: Optional[int]
+      stop_window_index, # type: Optional[int]
+      windowed_value, # type: WindowedValue
+      restriction,
+      watermark_estimator_state,
+      restriction_provider, # type: RestrictionProvider
+      restriction_tracker, # type: RestrictionTracker
+      watermark_estimator, # type: WatermarkEstimator
+                 ):
+    # type: (...) -> Optional[Tuple[Iterable[SplitResultPrimary], Iterable[SplitResultResidual], Optional[int]]]
+
+    """Try to split returning a primaries, residuals and a new stop index.
+
+    For non-window observing splittable DoFns we split the current restriction
+    and assign the primary and residual to all the windows.
+
+    For window observing splittable DoFns, we:
+    1) return a split at a window boundary if the fraction lies outside of the
+       current window.
+    2) attempt to split the current restriction, if successful then return
+       the primary and residual for the current window and an additional
+       primary and residual for any fully processed and fully unprocessed
+       windows.
+    3) fall back to returning a split at the window boundary if possible
+
+    Args:
+      window_index: the current index of the window being processed or None
+                    if the splittable DoFn is not window observing.
+      stop_window_index: the current index to stop processing at or None
+                         if the splittable DoFn is not window observing.
+      windowed_value: the current windowed value
+      restriction: the initial restriction when processing was started.
+      watermark_estimator_state: the initial watermark estimator state when
+                                 processing was started.
+      restriction_provider: the DoFn's restriction provider
+      restriction_tracker: the current restriction tracker
+      watermark_estimator: the current watermark estimator
+
+    Returns:
+      A tuple containing (primaries, residuals, new_stop_index) or None if
+      splitting was not possible. new_stop_index will only be set if the
+      splittable DoFn is window observing otherwise it will be None.
+    """
+    def compute_whole_window_split(to_index, from_index):
+      restriction_size = restriction_provider.restriction_size(
+          windowed_value, restriction)
+      # The primary and residual both share the same value only differing
+      # by the set of windows they are in.
+      value = ((windowed_value.value, (restriction, watermark_estimator_state)),
+               restriction_size)
+      primary_restriction = SplitResultPrimary(
+          primary_value=WindowedValue(
+              value,
+              windowed_value.timestamp,
+              windowed_value.windows[:to_index])) if to_index > 0 else None
+      # Don't report any updated watermarks for the residual since they have
+      # not processed any part of the restriction.
+      residual_restriction = SplitResultResidual(
+          residual_value=WindowedValue(
+              value,
+              windowed_value.timestamp,
+              windowed_value.windows[from_index:stop_window_index]),
+          current_watermark=None,
+          deferred_timestamp=None) if from_index < stop_window_index else None
+      return (primary_restriction, residual_restriction)
+
+    primary_restrictions = []
+    residual_restrictions = []
+
+    window_observing = window_index is not None
+    # If we are processing each window separately and we aren't on the last
+    # window then compute whether the split lies within the current window
+    # or a future window.
+    if window_observing and window_index != stop_window_index - 1:
+      progress = restriction_tracker.current_progress()
+      if not progress:
+        # Assume no work has been completed for the current window if progress
+        # is unavailable.
+        from apache_beam.io.iobase import RestrictionProgress
+        progress = RestrictionProgress(completed=0, remaining=1)
+
+      scaled_progress = PerWindowInvoker._scale_progress(
+          progress, window_index, stop_window_index)
+      # Compute the fraction of the remainder relative to the scaled progress.
+      # If the value is greater than or equal to progress.remaining_work then we
+      # should split at the closest window boundary.
+      fraction_of_remainder = scaled_progress.remaining_work * fraction
+      if fraction_of_remainder >= progress.remaining_work:
+        # The fraction is outside of the current window and hence we will
+        # split at the closest window boundary. Favor a split and return the
+        # last window if we would have rounded up to the end of the window
+        # based upon the fraction.
+        new_stop_window_index = min(
+            stop_window_index - 1,
+            window_index + max(
+                1,
+                int(
+                    round((
+                        progress.completed_work +
+                        scaled_progress.remaining_work * fraction) /
+                          progress.total_work))))
+        primary, residual = compute_whole_window_split(
+            new_stop_window_index, new_stop_window_index)
+        assert primary is not None
+        assert residual is not None
+        return ([primary], [residual], new_stop_window_index)
+      else:
+        # The fraction is within the current window being processed so compute
+        # the updated fraction based upon the number of windows being processed.
+        new_stop_window_index = window_index + 1
+        fraction = fraction_of_remainder / progress.remaining_work
+        # Attempt to split below, if we can't then we'll compute a split
+        # using only window boundaries
+    else:
+      # We aren't splitting within multiple windows so we don't change our
+      # stop index.
+      new_stop_window_index = stop_window_index
+
+    # Temporary workaround for [BEAM-7473]: get current_watermark before
+    # split, in case watermark gets advanced before getting split results.
+    # In worst case, current_watermark is always stale, which is ok.
+    current_watermark = (watermark_estimator.current_watermark())
+    current_estimator_state = (watermark_estimator.get_estimator_state())
+    split = restriction_tracker.try_split(fraction)
+    if split:
+      primary, residual = split
+      element = windowed_value.value
+      primary_size = restriction_provider.restriction_size(
+          windowed_value.value, primary)
+      residual_size = restriction_provider.restriction_size(
+          windowed_value.value, residual)
+      # We use the watermark estimator state for the original process call
+      # for the primary and the updated watermark estimator state for the
+      # residual for the split.
+      primary_split_value = ((element, (primary, watermark_estimator_state)),
+                             primary_size)
+      residual_split_value = ((element, (residual, current_estimator_state)),
+                              residual_size)
+      windows = (
+          windowed_value.windows[window_index],
+      ) if window_observing else windowed_value.windows
+      primary_restrictions.append(
+          SplitResultPrimary(
+              primary_value=WindowedValue(
+                  primary_split_value, windowed_value.timestamp, windows)))
+      residual_restrictions.append(
+          SplitResultResidual(
+              residual_value=WindowedValue(
+                  residual_split_value, windowed_value.timestamp, windows),
+              current_watermark=current_watermark,
+              deferred_timestamp=None))
+
+      if window_observing:
+        assert new_stop_window_index == window_index + 1
+        primary, residual = compute_whole_window_split(
+            window_index, window_index + 1)
+        if primary:
+          primary_restrictions.append(primary)
+        if residual:
+          residual_restrictions.append(residual)
+      return (
+          primary_restrictions, residual_restrictions, new_stop_window_index)
+    elif new_stop_window_index and new_stop_window_index != stop_window_index:
+      # If we failed to split but have a new stop index then return a split
+      # at the window boundary.
+      primary, residual = compute_whole_window_split(
+          new_stop_window_index, new_stop_window_index)
+      assert primary is not None
+      assert residual is not None
+      return ([primary], [residual], new_stop_window_index)
+    else:
+      return None
+
   def try_split(self, fraction):
-    # type: (...) -> Optional[Tuple[SplitResultPrimary, SplitResultResidual]]
+    # type: (...) -> Optional[Tuple[Iterable[SplitResultPrimary], Iterable[SplitResultResidual]]]
     if not self.is_splittable:
       return None
 
     with self.splitting_lock:
+      if not self.threadsafe_restriction_tracker:
+        return None
+
       # Make a local reference to member variables that change references during
       # processing under lock before attempting to split so we have a consistent
       # view of all the references.
-      current_windowed_value = self.current_windowed_value
-      threadsafe_restriction_tracker = self.threadsafe_restriction_tracker
-      threadsafe_watermark_estimator = self.threadsafe_watermark_estimator
+      result = PerWindowInvoker._try_split(
+          fraction,
+          self.current_window_index,
+          self.stop_window_index,
+          self.current_windowed_value,
+          self.restriction,
+          self.watermark_estimator_state,
+          self.signature.get_restriction_provider(),
+          self.threadsafe_restriction_tracker,
+          self.threadsafe_watermark_estimator)
+      if not result:
+        return None
 
-    if threadsafe_restriction_tracker:
-      # Temporary workaround for [BEAM-7473]: get current_watermark before
-      # split, in case watermark gets advanced before getting split results.
-      # In worst case, current_watermark is always stale, which is ok.
-      current_watermark = (threadsafe_watermark_estimator.current_watermark())
-      estimator_state = (threadsafe_watermark_estimator.get_estimator_state())
-      split = threadsafe_restriction_tracker.try_split(fraction)
-      if split:
-        primary, residual = split
-        element = current_windowed_value.value
-        restriction_provider = self.signature.get_restriction_provider()
-        primary_size = restriction_provider.restriction_size(element, primary)
-        residual_size = restriction_provider.restriction_size(element, residual)
-        primary_value = ((element, (primary, None)), primary_size)
-        residual_value = ((element, (residual, estimator_state)), residual_size)
-        return (
-            SplitResultPrimary(
-                primary_value=current_windowed_value.with_value(primary_value)),
-            SplitResultResidual(
-                residual_value=current_windowed_value.with_value(
-                    residual_value),
-                current_watermark=current_watermark,
-                deferred_timestamp=None))
-    return None
+      residuals, primaries, self.stop_window_index = result
+      return (residuals, primaries)
+
+  @staticmethod
+  def _scale_progress(progress, window_index, stop_window_index):
+    # We scale progress based upon the amount of work we will do for one
+    # window and have it apply for all windows.
+    completed = window_index * progress.total_work + progress.completed_work
+    remaining = (
+        stop_window_index -
+        (window_index + 1)) * progress.total_work + progress.remaining_work
+    from apache_beam.io.iobase import RestrictionProgress
+    return RestrictionProgress(completed=completed, remaining=remaining)
 
   def current_element_progress(self):
     # type: () -> Optional[RestrictionProgress]
-    restriction_tracker = self.threadsafe_restriction_tracker
-    if restriction_tracker:
-      return restriction_tracker.current_progress()
-    else:
+    if not self.is_splittable:
       return None
+
+    with self.splitting_lock:
+      current_window_index = self.current_window_index
+      stop_window_index = self.stop_window_index
+      threadsafe_restriction_tracker = self.threadsafe_restriction_tracker
+
+    if not threadsafe_restriction_tracker:
+      return None
+
+    progress = threadsafe_restriction_tracker.current_progress()
+    if not current_window_index or not progress:
+      return progress
+
+    assert stop_window_index
+    return PerWindowInvoker._scale_progress(
+        progress, current_window_index, stop_window_index)
 
 
 class DoFnRunner:
@@ -974,15 +1198,15 @@ class DoFnRunner:
         bundle_finalizer_param=self.bundle_finalizer_param)
 
   def process(self, windowed_value):
-    # type: (WindowedValue) -> Optional[SplitResultResidual]
+    # type: (WindowedValue) -> Iterable[SplitResultResidual]
     try:
       return self.do_fn_invoker.invoke_process(windowed_value)
     except BaseException as exn:
       self._reraise_augmented(exn)
-      return None
+      return []
 
   def process_with_sized_restriction(self, windowed_value):
-    # type: (WindowedValue) -> Optional[SplitResultResidual]
+    # type: (WindowedValue) -> Iterable[SplitResultResidual]
     (element, (restriction, estimator_state)), _ = windowed_value.value
     return self.do_fn_invoker.invoke_process(
         windowed_value.with_value(element),
@@ -990,7 +1214,7 @@ class DoFnRunner:
         watermark_estimator_state=estimator_state)
 
   def try_split(self, fraction):
-    # type: (...) -> Optional[Tuple[SplitResultPrimary, SplitResultResidual]]
+    # type: (...) -> Optional[Tuple[Iterable[SplitResultPrimary], Iterable[SplitResultResidual]]]
     assert isinstance(self.do_fn_invoker, PerWindowInvoker)
     return self.do_fn_invoker.try_split(fraction)
 

--- a/sdks/python/apache_beam/runners/common_test.py
+++ b/sdks/python/apache_beam/runners/common_test.py
@@ -21,14 +21,26 @@ from __future__ import absolute_import
 
 import unittest
 
+import hamcrest as hc
+
 import apache_beam as beam
+from apache_beam.io.restriction_trackers import OffsetRange
+from apache_beam.io.restriction_trackers import OffsetRestrictionTracker
+from apache_beam.io.watermark_estimators import ManualWatermarkEstimator
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.runners.common import DoFnSignature
+from apache_beam.runners.common import PerWindowInvoker
+from apache_beam.runners.sdf_utils import SplitResultPrimary
+from apache_beam.runners.sdf_utils import SplitResultResidual
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.test_stream import TestStream
 from apache_beam.transforms import trigger
 from apache_beam.transforms import window
 from apache_beam.transforms.core import DoFn
+from apache_beam.transforms.core import RestrictionProvider
+from apache_beam.transforms.window import IntervalWindow
+from apache_beam.utils.timestamp import Timestamp
+from apache_beam.utils.windowed_value import WindowedValue
 
 
 class DoFnSignatureTest(unittest.TestCase):
@@ -109,6 +121,417 @@ class DoFnProcessTest(unittest.TestCase):
          TestPipeline(options=pipeline_options) as p:
       test_stream = (TestStream().advance_watermark_to(10).add_elements([1, 2]))
       (p | test_stream | beam.ParDo(DoFnProcessWithKeyparam()))
+
+
+class TestOffsetRestrictionProvider(RestrictionProvider):
+  def restriction_size(self, element, restriction):
+    return restriction.size()
+
+
+class PerWindowInvokerSplitTest(unittest.TestCase):
+  def setUp(self):
+    self.window1 = IntervalWindow(0, 10)
+    self.window2 = IntervalWindow(10, 20)
+    self.window3 = IntervalWindow(20, 30)
+    self.windowed_value = WindowedValue(
+        'a', 57, (self.window1, self.window2, self.window3))
+    self.restriction = OffsetRange(0, 100)
+    self.watermark_estimator_state = Timestamp(21)
+    self.restriction_provider = TestOffsetRestrictionProvider()
+    self.watermark_estimator = ManualWatermarkEstimator(Timestamp(42))
+    self.maxDiff = None
+
+  def create_split_in_window(self, offset_index, windows):
+    return (
+        SplitResultPrimary(
+            primary_value=WindowedValue(((
+                'a',
+                (OffsetRange(0, offset_index), self.watermark_estimator_state)),
+                                         offset_index),
+                                        57,
+                                        windows)),
+        SplitResultResidual(
+            residual_value=WindowedValue(((
+                'a',
+                (
+                    OffsetRange(offset_index, 100),
+                    self.watermark_estimator.get_estimator_state())),
+                                          100 - offset_index),
+                                         57,
+                                         windows),
+            current_watermark=self.watermark_estimator.current_watermark(),
+            deferred_timestamp=None))
+
+  def create_split_across_windows(self, primary_windows, residual_windows):
+    primary = SplitResultPrimary(
+        primary_value=WindowedValue(
+            (('a', (OffsetRange(0, 100), self.watermark_estimator_state)), 100),
+            57,
+            primary_windows)) if primary_windows else None
+    residual = SplitResultResidual(
+        residual_value=WindowedValue(
+            (('a', (OffsetRange(0, 100), self.watermark_estimator_state)), 100),
+            57,
+            residual_windows),
+        current_watermark=None,
+        deferred_timestamp=None) if residual_windows else None
+    return primary, residual
+
+  def test_non_window_observing_checkpoint(self):
+    # test checkpoint
+    restriction_tracker = OffsetRestrictionTracker(self.restriction)
+    restriction_tracker.try_claim(30)
+    (primaries, residuals, stop_index) = PerWindowInvoker._try_split(
+        0.0,
+        None,
+        None,
+        self.windowed_value,
+        self.restriction,
+        self.watermark_estimator_state,
+        self.restriction_provider,
+        restriction_tracker,
+        self.watermark_estimator)
+    expected_primary_split, expected_residual_split = (
+        self.create_split_in_window(31, self.windowed_value.windows))
+    self.assertEqual([expected_primary_split], primaries)
+    self.assertEqual([expected_residual_split], residuals)
+    # We don't expect the stop index to be set for non window observing splits
+    self.assertIsNone(stop_index)
+
+  def test_non_window_observing_split(self):
+    restriction_tracker = OffsetRestrictionTracker(self.restriction)
+    restriction_tracker.try_claim(30)
+    (primaries, residuals, stop_index) = PerWindowInvoker._try_split(
+        0.1,
+        None,
+        None,
+        self.windowed_value,
+        self.restriction,
+        self.watermark_estimator_state,
+        self.restriction_provider,
+        restriction_tracker,
+        self.watermark_estimator)
+    expected_primary_split, expected_residual_split = (
+        self.create_split_in_window(37, self.windowed_value.windows))
+    self.assertEqual([expected_primary_split], primaries)
+    self.assertEqual([expected_residual_split], residuals)
+    # We don't expect the stop index to be set for non window observing splits
+    self.assertIsNone(stop_index)
+
+  def test_non_window_observing_split_when_restriction_is_done(self):
+    restriction_tracker = OffsetRestrictionTracker(self.restriction)
+    restriction_tracker.try_claim(100)
+    self.assertIsNone(
+        PerWindowInvoker._try_split(
+            0.1,
+            None,
+            None,
+            self.windowed_value,
+            self.restriction,
+            self.watermark_estimator_state,
+            self.restriction_provider,
+            restriction_tracker,
+            self.watermark_estimator))
+
+  def test_window_observing_checkpoint_on_first_window(self):
+    restriction_tracker = OffsetRestrictionTracker(self.restriction)
+    restriction_tracker.try_claim(30)
+    (primaries, residuals, stop_index) = PerWindowInvoker._try_split(
+        0.0,
+        0,
+        3,
+        self.windowed_value,
+        self.restriction,
+        self.watermark_estimator_state,
+        self.restriction_provider,
+        restriction_tracker,
+        self.watermark_estimator)
+    expected_primary_split, expected_residual_split = (
+        self.create_split_in_window(31, (self.window1, )))
+    _, expected_residual_windows = (
+        self.create_split_across_windows(None, (self.window2, self.window3,)))
+    hc.assert_that(primaries, hc.contains_inanyorder(expected_primary_split))
+    hc.assert_that(
+        residuals,
+        hc.contains_inanyorder(
+            expected_residual_split,
+            expected_residual_windows,
+        ))
+    self.assertEqual(stop_index, 1)
+
+  def test_window_observing_checkpoint_on_first_window_after_prior_split(self):
+    restriction_tracker = OffsetRestrictionTracker(self.restriction)
+    restriction_tracker.try_claim(30)
+    (primaries, residuals, stop_index) = PerWindowInvoker._try_split(
+        0.0,
+        0,
+        2,  # stop index < len(windows) representing a prior split had occurred
+        self.windowed_value,
+        self.restriction,
+        self.watermark_estimator_state,
+        self.restriction_provider,
+        restriction_tracker,
+        self.watermark_estimator)
+    expected_primary_split, expected_residual_split = (
+        self.create_split_in_window(31, (self.window1, )))
+    _, expected_residual_windows = (
+        self.create_split_across_windows(None, (self.window2, )))
+    hc.assert_that(primaries, hc.contains_inanyorder(expected_primary_split))
+    hc.assert_that(
+        residuals,
+        hc.contains_inanyorder(
+            expected_residual_split,
+            expected_residual_windows,
+        ))
+    self.assertEqual(stop_index, 1)
+
+  def test_window_observing_split_on_first_window(self):
+    restriction_tracker = OffsetRestrictionTracker(self.restriction)
+    restriction_tracker.try_claim(30)
+    (primaries, residuals, stop_index) = PerWindowInvoker._try_split(
+        0.2,
+        0,
+        3,
+        self.windowed_value,
+        self.restriction,
+        self.watermark_estimator_state,
+        self.restriction_provider,
+        restriction_tracker,
+        self.watermark_estimator)
+    # 20% of 2.7 windows = 20% of 270 offset left = 54 offset
+    # 30 + 54 = 84 split offset
+    expected_primary_split, expected_residual_split = (
+        self.create_split_in_window(84, (self.window1, )))
+    _, expected_residual_windows = (
+        self.create_split_across_windows(None, (self.window2, self.window3, )))
+    hc.assert_that(primaries, hc.contains_inanyorder(expected_primary_split))
+    hc.assert_that(
+        residuals,
+        hc.contains_inanyorder(
+            expected_residual_split,
+            expected_residual_windows,
+        ))
+    self.assertEqual(stop_index, 1)
+
+  def test_window_observing_split_on_middle_window(self):
+    restriction_tracker = OffsetRestrictionTracker(self.restriction)
+    restriction_tracker.try_claim(30)
+    (primaries, residuals, stop_index) = PerWindowInvoker._try_split(
+        0.2,
+        1,
+        3,
+        self.windowed_value,
+        self.restriction,
+        self.watermark_estimator_state,
+        self.restriction_provider,
+        restriction_tracker,
+        self.watermark_estimator)
+    # 20% of 1.7 windows = 20% of 170 offset left = 34 offset
+    # 30 + 34 = 64 split offset
+    expected_primary_split, expected_residual_split = (
+        self.create_split_in_window(64, (self.window2, )))
+    expected_primary_windows, expected_residual_windows = (
+        self.create_split_across_windows((self.window1, ), (self.window3, )))
+    hc.assert_that(
+        primaries,
+        hc.contains_inanyorder(
+            expected_primary_split,
+            expected_primary_windows,
+        ))
+    hc.assert_that(
+        residuals,
+        hc.contains_inanyorder(
+            expected_residual_split,
+            expected_residual_windows,
+        ))
+    self.assertEqual(stop_index, 2)
+
+  def test_window_observing_split_on_last_window(self):
+    restriction_tracker = OffsetRestrictionTracker(self.restriction)
+    restriction_tracker.try_claim(30)
+    (primaries, residuals, stop_index) = PerWindowInvoker._try_split(
+        0.2,
+        2,
+        3,
+        self.windowed_value,
+        self.restriction,
+        self.watermark_estimator_state,
+        self.restriction_provider,
+        restriction_tracker,
+        self.watermark_estimator)
+    # 20% of 0.7 windows = 20% of 70 offset left = 14 offset
+    # 30 + 14 = 44 split offset
+    expected_primary_split, expected_residual_split = (
+        self.create_split_in_window(44, (self.window3, )))
+    expected_primary_windows, _ = (
+        self.create_split_across_windows((self.window1, self.window2, ), None))
+    hc.assert_that(
+        primaries,
+        hc.contains_inanyorder(
+            expected_primary_split,
+            expected_primary_windows,
+        ))
+    hc.assert_that(residuals, hc.contains_inanyorder(expected_residual_split, ))
+    self.assertEqual(stop_index, 3)
+
+  def test_window_observing_split_on_first_window_fallback(self):
+    restriction_tracker = OffsetRestrictionTracker(self.restriction)
+    restriction_tracker.try_claim(100)
+    # We assume that we can't split this fully claimed restriction
+    self.assertIsNone(restriction_tracker.try_split(0))
+    (primaries, residuals, stop_index) = PerWindowInvoker._try_split(
+        0.0,
+        0,
+        3,
+        self.windowed_value,
+        self.restriction,
+        self.watermark_estimator_state,
+        self.restriction_provider,
+        restriction_tracker,
+        self.watermark_estimator)
+    expected_primary_windows, expected_residual_windows = (
+        self.create_split_across_windows(
+            (self.window1, ), (self.window2, self.window3, )))
+    hc.assert_that(
+        primaries, hc.contains_inanyorder(
+            expected_primary_windows,
+        ))
+    hc.assert_that(
+        residuals, hc.contains_inanyorder(
+            expected_residual_windows,
+        ))
+    self.assertEqual(stop_index, 1)
+
+  def test_window_observing_split_on_middle_window_fallback(self):
+    restriction_tracker = OffsetRestrictionTracker(self.restriction)
+    restriction_tracker.try_claim(100)
+    # We assume that we can't split this fully claimed restriction
+    self.assertIsNone(restriction_tracker.try_split(0))
+    (primaries, residuals, stop_index) = PerWindowInvoker._try_split(
+        0.0,
+        1,
+        3,
+        self.windowed_value,
+        self.restriction,
+        self.watermark_estimator_state,
+        self.restriction_provider,
+        restriction_tracker,
+        self.watermark_estimator)
+    expected_primary_windows, expected_residual_windows = (
+        self.create_split_across_windows(
+            (self.window1, self.window2, ), (self.window3, )))
+    hc.assert_that(
+        primaries, hc.contains_inanyorder(
+            expected_primary_windows,
+        ))
+    hc.assert_that(
+        residuals, hc.contains_inanyorder(
+            expected_residual_windows,
+        ))
+    self.assertEqual(stop_index, 2)
+
+  def test_window_observing_split_on_last_window_when_split_not_possible(self):
+    restriction_tracker = OffsetRestrictionTracker(self.restriction)
+    restriction_tracker.try_claim(100)
+    # We assume that we can't split this fully claimed restriction
+    self.assertIsNone(restriction_tracker.try_split(0))
+    self.assertIsNone(
+        PerWindowInvoker._try_split(
+            0.0,
+            2,
+            3,
+            self.windowed_value,
+            self.restriction,
+            self.watermark_estimator_state,
+            self.restriction_provider,
+            restriction_tracker,
+            self.watermark_estimator))
+
+  def test_window_observing_split_on_window_boundary_round_up(self):
+    restriction_tracker = OffsetRestrictionTracker(self.restriction)
+    restriction_tracker.try_claim(30)
+    (primaries, residuals, stop_index) = PerWindowInvoker._try_split(
+        0.6,
+        0,
+        3,
+        self.windowed_value,
+        self.restriction,
+        self.watermark_estimator_state,
+        self.restriction_provider,
+        restriction_tracker,
+        self.watermark_estimator)
+    # 60% of 2.7 windows = 60% of 270 offset left = 162 offset
+    # 30 + 162 = 192 offset --> round to end of window 2
+    expected_primary_windows, expected_residual_windows = (
+        self.create_split_across_windows(
+            (self.window1, self.window2, ), (self.window3, )))
+    hc.assert_that(
+        primaries, hc.contains_inanyorder(
+            expected_primary_windows,
+        ))
+    hc.assert_that(
+        residuals, hc.contains_inanyorder(
+            expected_residual_windows,
+        ))
+    self.assertEqual(stop_index, 2)
+
+  def test_window_observing_split_on_window_boundary_round_down(self):
+    restriction_tracker = OffsetRestrictionTracker(self.restriction)
+    restriction_tracker.try_claim(30)
+    (primaries, residuals, stop_index) = PerWindowInvoker._try_split(
+        0.3,
+        0,
+        3,
+        self.windowed_value,
+        self.restriction,
+        self.watermark_estimator_state,
+        self.restriction_provider,
+        restriction_tracker,
+        self.watermark_estimator)
+    # 30% of 2.7 windows = 30% of 270 offset left = 81 offset
+    # 30 + 81 = 111 offset --> round to end of window 1
+    expected_primary_windows, expected_residual_windows = (
+        self.create_split_across_windows(
+            (self.window1, ), (self.window2, self.window3, )))
+    hc.assert_that(
+        primaries, hc.contains_inanyorder(
+            expected_primary_windows,
+        ))
+    hc.assert_that(
+        residuals, hc.contains_inanyorder(
+            expected_residual_windows,
+        ))
+    self.assertEqual(stop_index, 1)
+
+  def test_window_observing_split_on_window_boundary_round_down_on_last_window(
+      self):
+    restriction_tracker = OffsetRestrictionTracker(self.restriction)
+    restriction_tracker.try_claim(30)
+    (primaries, residuals, stop_index) = PerWindowInvoker._try_split(
+        0.9,
+        0,
+        3,
+        self.windowed_value,
+        self.restriction,
+        self.watermark_estimator_state,
+        self.restriction_provider,
+        restriction_tracker,
+        self.watermark_estimator)
+    # 90% of 2.7 windows = 90% of 270 offset left = 243 offset
+    # 30 + 243 = 273 offset --> prefer a split so round to end of window 2
+    # instead of no split
+    expected_primary_windows, expected_residual_windows = (
+        self.create_split_across_windows(
+            (self.window1, self.window2, ), (self.window3, )))
+    hc.assert_that(
+        primaries, hc.contains_inanyorder(
+            expected_primary_windows,
+        ))
+    hc.assert_that(
+        residuals, hc.contains_inanyorder(
+            expected_residual_windows,
+        ))
+    self.assertEqual(stop_index, 2)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This removes the unused window from pair with restriction allowing for window observing splittable dofns to be exercised.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
