### PR TITLE
[BEAM-10137][BEAM-10138] Python wrapper KinesisIO integration tests

### DIFF
--- a/sdks/python/apache_beam/io/external/xlang_kinesisio_it_test.py
+++ b/sdks/python/apache_beam/io/external/xlang_kinesisio_it_test.py
@@ -1,0 +1,118 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Integration test for Python cross-language pipelines for Java KinesisIO."""
+
+# pytype: skip-file
+
+from __future__ import absolute_import
+
+import logging
+import unittest
+
+from testcontainers.core.container import DockerContainer
+
+import apache_beam as beam
+from apache_beam.io.kinesis import InitialPositionInStream
+from apache_beam.io.kinesis import ReadDataFromKinesis
+from apache_beam.io.kinesis import WriteToKinesis
+from apache_beam.testing.test_pipeline import TestPipeline
+from apache_beam.testing.util import assert_that
+from apache_beam.testing.util import equal_to
+from apache_beam.transforms.combiners import Count
+
+MAX_NUM_RECORDS = 10
+MAX_READ_TIME = 120
+INITIAL_POSITION_IN_STREAM = InitialPositionInStream.TRIM_HORIZON
+
+
+class CrossLanguageKinesisIOTest(unittest.TestCase):
+  def setUp(self):
+    self.localstack = DockerContainer('localstack:localstack:0.11.3')\
+      .with_env('SERVICES', 'kinesis')
+    self.service_endpoint = '{}:{}'.format(
+        self.localstack.get_container_host_ip(),
+        self.localstack.get_exposed_port(4568),
+    )
+    self.access_key = 'accesskey'
+    self.secret_key = 'secretkey'
+    self.region = 'us-east-1'
+    self.partition_key = 'a'
+    self.localstack.start()
+
+  def tearDown(self):
+    self.localstack.stop()
+
+  def test_kinesisio(self):
+    self.run_kinesis_write()
+    self.run_kinesis_read_data()
+
+  def run_kinesis_write(self):
+    with TestPipeline() as p:
+      _ = (
+          p
+          | 'Impulse' >> beam.Impulse()
+          | 'Generate' >> beam.FlatMap(lambda x: range(MAX_NUM_RECORDS))  # pylint: disable=range-builtin-not-iterating
+          | 'Make bytes' >>
+          beam.Map(lambda x: str(x).encode()).with_output_types(bytes)
+          | 'WriteToKinesis' >> WriteToKinesis(
+              stream_name=self.stream_name,
+              aws_access_key=self.access_key,
+              aws_secret_key=self.secret_key,
+              region=self.region,
+              partition_key=self.partition_key,
+          ))
+
+  def run_kinesis_read_data(self):
+    with TestPipeline() as p:
+      result = (
+          p
+          | 'ReadFromKinesis' >> ReadDataFromKinesis(
+              stream_name=self.stream_name,
+              aws_access_key=self.aws_access_key,
+              aws_secret_key=self.aws_secret_key,
+              region=self.region,
+              max_num_records=MAX_NUM_RECORDS,
+              max_read_time=MAX_READ_TIME,
+              initial_position_in_stream=INITIAL_POSITION_IN_STREAM,
+          )
+          | 'Count elements' >> Count.Globally())
+
+      # There could already be some records in the stream so we can't ensure
+      # that the ones we read are the ones we've just written so just count
+      # them to verify that requested number of messages's been read.
+      assert_that(result, equal_to([MAX_NUM_RECORDS]))
+
+  def get_kinesis_options(self):
+    p = TestPipeline()
+
+    def get_required_option(option_name):
+      option = p.get_option(option_name)
+      if not option:
+        logging.error('--%s argument is required.', option_name)
+        sys.exit(1)
+      return option
+
+    self.stream_name = get_required_option('stream_name')
+    self.aws_access_key = get_required_option('aws_access_key')
+    self.aws_secret_key = get_required_option('aws_secret_key')
+    self.region = get_required_option('aws_region')
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/sdks/python/apache_beam/io/external/xlang_kinesisio_it_test.py
+++ b/sdks/python/apache_beam/io/external/xlang_kinesisio_it_test.py
@@ -22,37 +22,62 @@
 from __future__ import absolute_import
 
 import logging
+import time
 import unittest
-
-from testcontainers.core.container import DockerContainer
 
 import apache_beam as beam
 from apache_beam.io.kinesis import InitialPositionInStream
 from apache_beam.io.kinesis import ReadDataFromKinesis
 from apache_beam.io.kinesis import WriteToKinesis
+
+from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
 from apache_beam.transforms.combiners import Count
 
+# pylint: disable=wrong-import-order, wrong-import-position, ungrouped-imports
+try:
+  import boto3
+except ImportError:
+  boto3 = None
+# pylint: enable=wrong-import-order, wrong-import-position, ungrouped-imports
+
+# pylint: disable=wrong-import-order, wrong-import-position, ungrouped-imports
+try:
+  from testcontainers.core.container import DockerContainer
+except ImportError:
+  DockerContainer = None
+# pylint: enable=wrong-import-order, wrong-import-position, ungrouped-imports
+
 MAX_NUM_RECORDS = 10
-MAX_READ_TIME = 120
-INITIAL_POSITION_IN_STREAM = InitialPositionInStream.TRIM_HORIZON
 
-
+@unittest.skipIf(DockerContainer is None, 'testcontainers is not installed.')
+@unittest.skipIf(boto3 is None, 'boto3 is not installed.')
+@unittest.skipIf(
+    TestPipeline().get_pipeline_options().view_as(StandardOptions).runner is
+    None,
+    'Do not run this test on precommit suites.')
 class CrossLanguageKinesisIOTest(unittest.TestCase):
   def setUp(self):
-    self.localstack = DockerContainer('localstack:localstack:0.11.3')\
-      .with_env('SERVICES', 'kinesis')
-    self.service_endpoint = '{}:{}'.format(
+    self.localstack = DockerContainer('localstack/localstack:0.8.6')\
+      .with_env('SERVICES', 'kinesis')\
+      .with_env('KINESIS_PORT', '4568')\
+      .with_exposed_ports(4568)
+    self.localstack.start()
+    self.service_endpoint = 'http://{}:{}'.format(
         self.localstack.get_container_host_ip(),
-        self.localstack.get_exposed_port(4568),
+        self.localstack.get_exposed_port('4568'),
     )
     self.access_key = 'accesskey'
     self.secret_key = 'secretkey'
-    self.region = 'us-east-1'
+    self.region = 'US_EAST_1'
+    self.aws_region = 'us-east-1'
     self.partition_key = 'a'
-    self.localstack.start()
+    self.max_read_time = 120  # 2min
+    self.initial_position_in_stream = InitialPositionInStream.TRIM_HORIZON
+    self.stream_name = 'beam'
+    self.create_kinesis_stream()
 
   def tearDown(self):
     self.localstack.stop()
@@ -73,6 +98,7 @@ class CrossLanguageKinesisIOTest(unittest.TestCase):
               stream_name=self.stream_name,
               aws_access_key=self.access_key,
               aws_secret_key=self.secret_key,
+              service_endpoint=self.service_endpoint,
               region=self.region,
               partition_key=self.partition_key,
           ))
@@ -83,35 +109,47 @@ class CrossLanguageKinesisIOTest(unittest.TestCase):
           p
           | 'ReadFromKinesis' >> ReadDataFromKinesis(
               stream_name=self.stream_name,
-              aws_access_key=self.aws_access_key,
-              aws_secret_key=self.aws_secret_key,
+              aws_access_key=self.access_key,
+              aws_secret_key=self.secret_key,
+              service_endpoint=self.service_endpoint,
               region=self.region,
               max_num_records=MAX_NUM_RECORDS,
-              max_read_time=MAX_READ_TIME,
-              initial_position_in_stream=INITIAL_POSITION_IN_STREAM,
+              max_read_time=self.max_read_time,
+              initial_position_in_stream=self.initial_position_in_stream,
           )
           | 'Count elements' >> Count.Globally())
 
-      # There could already be some records in the stream so we can't ensure
-      # that the ones we read are the ones we've just written so just count
-      # them to verify that requested number of messages's been read.
-      assert_that(result, equal_to([MAX_NUM_RECORDS]))
+      assert_that(
+          result, equal_to([str(i).encode() for i in range(MAX_NUM_RECORDS)]))
 
-  def get_kinesis_options(self):
-    p = TestPipeline()
+  def create_kinesis_stream(self):
+    client = boto3.client(
+        service_name='kinesis',
+        region_name='us-east-1',
+        endpoint_url=self.service_endpoint,
+        aws_access_key_id=self.access_key,
+        aws_secret_access_key=self.secret_key,
 
-    def get_required_option(option_name):
-      option = p.get_option(option_name)
-      if not option:
-        logging.error('--%s argument is required.', option_name)
-        sys.exit(1)
-      return option
+    )
+    # localstack could not have initialized yet so try few times
+    retries = 5
+    for i in range(retries):
+      try:
+        client.create_stream(
+            StreamName=self.stream_name,
+            ShardCount=1,
+        )
+        time.sleep(2)
+        break
+      except Exception as e:
+        if i == retries:
+          raise e
 
-    self.stream_name = get_required_option('stream_name')
-    self.aws_access_key = get_required_option('aws_access_key')
-    self.aws_secret_key = get_required_option('aws_secret_key')
-    self.region = get_required_option('aws_region')
-
+    # ensure stream is initialized before proceeding
+    stream = client.describe_stream(StreamName=self.stream_name)
+    while stream['StreamDescription']['StreamStatus'] != 'ACTIVE':
+      time.sleep(2)
+      stream = client.describe_stream(StreamName=self.stream_name)
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)


### PR DESCRIPTION
Add python wrapper for KinesisIO.Read.

Chronology:
1. java write
2. java read
3. python wrapper
4. python integration tests

PR for java external transform for write: [#12234](https://github.com/apache/beam/pull/12234)
PR for python wrapper: [#12235](https://github.com/apache/beam/pull/12235)
PR for java external transform for read: [#12297](https://github.com/apache/beam/pull/12297)

I haven't managed to run this test yet. In the previous version (1st commit) it succeeded on my AWS account. But when I try to run the same pipelines on localstack I get com.amazonaws.services.kinesis.producer.UserRecordFailedException.

Strange thing is that with below code I can use the container, so it works.
```
 client.put_record(
      StreamName='beam',
      Data=b'bytes',
      PartitionKey='a',
)
shard_iterator = client.get_shard_iterator(
    StreamName=self.stream_name,
    ShardId='shardId-000000000000',
    ShardIteratorType='TRIM_HORIZON'
)

response = client.get_records(
      ShardIterator=shard_iterator['ShardIterator'],
      Limit=2
)
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
