### PR TITLE
[BEAM-9968] Guarantee that outstanding split/progress requests are handled before bundle completion (and before any final progress/checkpoint data sent to handlers).

### DIFF
--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/RemoteBundle.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/RemoteBundle.java
@@ -49,8 +49,11 @@ public interface RemoteBundle extends AutoCloseable {
   /**
    * Ask the remote bundle for progress.
    *
-   * <p>This method will return after the request has been issue. Any progress reports will be
-   * forwarded to the {@link BundleProgressHandler}.
+   * <p>This method is a no-op if the bundle is complete otherwise it will return after the request
+   * has been issued. Any progress reports will be forwarded to the {@link BundleProgressHandler}.
+   *
+   * <p>All {@link BundleProgressHandler#onProgress} calls are guaranteed to be called before any
+   * {@link BundleProgressHandler#onCompleted}.
    */
   void requestProgress();
 
@@ -58,8 +61,11 @@ public interface RemoteBundle extends AutoCloseable {
    * Ask the remote bundle to split its current processing based upon its knowledge of remaining
    * work. A fraction of 0, is equivalent to asking the SDK to checkpoint.
    *
-   * <p>This method will return after the request has been issued. Any splits will be forwarded to
-   * the {@link BundleSplitHandler}.
+   * <p>This method is a no-op if the bundle is complete otherwise it will return after the request
+   * has been issued. Any splits will be forwarded to the {@link BundleSplitHandler}.
+   *
+   * <p>All {@link BundleSplitHandler#split} calls are guaranteed to be called before any {@link
+   * BundleCheckpointHandler#onCheckpoint}.
    */
   void split(double fractionOfRemainder);
 
@@ -67,7 +73,8 @@ public interface RemoteBundle extends AutoCloseable {
    * Closes this bundle. This causes the input {@link FnDataReceiver} to be closed (future calls to
    * that {@link FnDataReceiver} will throw an exception), and causes the {@link RemoteBundle} to
    * produce any buffered outputs. The call to {@link #close()} will block until all of the outputs
-   * produced by this bundle have been received.
+   * produced by this bundle have been received and all outstanding progress and split requests have
+   * been handled.
    */
   @Override
   void close() throws Exception;

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/SdkHarnessClient.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/SdkHarnessClient.java
@@ -341,7 +341,7 @@ public class SdkHarnessClient implements AutoCloseable {
         // Ensure that we mark when the bundle is completed
         this.response.whenComplete(
             (processBundleResponse, throwable) -> {
-              synchronized (this) {
+              synchronized (ActiveBundle.this) {
                 this.bundleIsCompleted = true;
               }
             });

--- a/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/SdkHarnessClient.java
+++ b/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/SdkHarnessClient.java
@@ -26,6 +26,8 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.CompletionStage;
 import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Phaser;
+import java.util.concurrent.atomic.AtomicBoolean;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.InstructionRequest;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.InstructionResponse;
@@ -310,6 +312,9 @@ public class SdkHarnessClient implements AutoCloseable {
       private final BundleSplitHandler splitHandler;
       private final BundleCheckpointHandler checkpointHandler;
       private final BundleFinalizationHandler finalizationHandler;
+      private final Phaser outstandingRequests;
+      private final AtomicBoolean isClosed;
+      private boolean bundleIsCompleted;
 
       private ActiveBundle(
           String bundleId,
@@ -330,6 +335,16 @@ public class SdkHarnessClient implements AutoCloseable {
         this.splitHandler = splitHandler;
         this.checkpointHandler = checkpointHandler;
         this.finalizationHandler = finalizationHandler;
+        this.outstandingRequests = new Phaser(1);
+        this.isClosed = new AtomicBoolean(false);
+
+        // Ensure that we mark when the bundle is completed
+        this.response.whenComplete(
+            (processBundleResponse, throwable) -> {
+              synchronized (this) {
+                this.bundleIsCompleted = true;
+              }
+            });
       }
 
       /** Returns an id used to represent this bundle. */
@@ -371,6 +386,12 @@ public class SdkHarnessClient implements AutoCloseable {
 
       @Override
       public void requestProgress() {
+        synchronized (this) {
+          if (bundleIsCompleted) {
+            return;
+          }
+          outstandingRequests.register();
+        }
         InstructionRequest request =
             InstructionRequest.newBuilder()
                 .setInstructionId(idGenerator.getId())
@@ -378,19 +399,27 @@ public class SdkHarnessClient implements AutoCloseable {
                     ProcessBundleProgressRequest.newBuilder().setInstructionId(bundleId).build())
                 .build();
         CompletionStage<InstructionResponse> response = fnApiControlClient.handle(request);
-        response.thenAccept(
-            instructionResponse -> {
-              // Don't forward empty responses.
-              if (ProcessBundleProgressResponse.getDefaultInstance()
-                  .equals(instructionResponse.getProcessBundleProgress())) {
-                return;
-              }
-              progressHandler.onProgress(instructionResponse.getProcessBundleProgress());
-            });
+        response
+            .whenComplete(
+                (instructionResponse, throwable) -> {
+                  // Don't forward empty responses.
+                  if (ProcessBundleProgressResponse.getDefaultInstance()
+                      .equals(instructionResponse.getProcessBundleProgress())) {
+                    return;
+                  }
+                  progressHandler.onProgress(instructionResponse.getProcessBundleProgress());
+                })
+            .whenComplete((instructionResponse, throwable) -> outstandingRequests.arrive());
       }
 
       @Override
       public void split(double fractionOfRemainder) {
+        synchronized (this) {
+          if (bundleIsCompleted) {
+            return;
+          }
+          outstandingRequests.register();
+        }
         Map<String, DesiredSplit> splits = new HashMap<>();
         for (Map.Entry<LogicalEndpoint, CloseableFnDataReceiver> ptransformToInput :
             inputReceivers.entrySet()) {
@@ -414,15 +443,17 @@ public class SdkHarnessClient implements AutoCloseable {
                         .build())
                 .build();
         CompletionStage<InstructionResponse> response = fnApiControlClient.handle(request);
-        response.thenAccept(
-            instructionResponse -> {
-              // Don't forward empty responses representing the failure to split.
-              if (ProcessBundleSplitResponse.getDefaultInstance()
-                  .equals(instructionResponse.getProcessBundleSplit())) {
-                return;
-              }
-              splitHandler.split(instructionResponse.getProcessBundleSplit());
-            });
+        response
+            .whenComplete(
+                (instructionResponse, throwable) -> {
+                  // Don't forward empty responses representing the failure to split.
+                  if (ProcessBundleSplitResponse.getDefaultInstance()
+                      .equals(instructionResponse.getProcessBundleSplit())) {
+                    return;
+                  }
+                  splitHandler.split(instructionResponse.getProcessBundleSplit());
+                })
+            .whenComplete((instructionResponse, throwable) -> outstandingRequests.arrive());
       }
 
       /**
@@ -440,6 +471,10 @@ public class SdkHarnessClient implements AutoCloseable {
        */
       @Override
       public void close() throws Exception {
+        if (isClosed.getAndSet(true)) {
+          return;
+        }
+
         Exception exception = null;
         for (CloseableFnDataReceiver<?> inputReceiver : inputReceivers.values()) {
           try {
@@ -456,6 +491,8 @@ public class SdkHarnessClient implements AutoCloseable {
           // We don't have to worry about the completion stage.
           if (exception == null) {
             BeamFnApi.ProcessBundleResponse completedResponse = MoreFutures.get(response);
+            outstandingRequests.arriveAndAwaitAdvance();
+
             progressHandler.onCompleted(completedResponse);
             if (completedResponse.getResidualRootsCount() > 0) {
               checkpointHandler.onCheckpoint(completedResponse);
@@ -663,8 +700,8 @@ public class SdkHarnessClient implements AutoCloseable {
 
     @Override
     public void accept(T input) throws Exception {
-      count += 1;
       delegate.accept(input);
+      count += 1;
     }
 
     @Override

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
@@ -719,7 +719,6 @@ public class RemoteExecutionTest implements Serializable {
           @Override
           public void onCompleted(ProcessBundleResponse response) {
             List<Matcher<MonitoringInfo>> matchers = new ArrayList<>();
-
             // User Counters.
             SimpleMonitoringInfoBuilder builder = new SimpleMonitoringInfoBuilder();
             builder

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/SdkHarnessClientTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/SdkHarnessClientTest.java
@@ -40,11 +40,18 @@ import java.util.Collections;
 import java.util.List;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutionException;
+import java.util.concurrent.Executors;
+import java.util.concurrent.ScheduledExecutorService;
+import java.util.concurrent.TimeUnit;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.BundleApplication;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.DelayedBundleApplication;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.InstructionResponse;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.ProcessBundleDescriptor;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.ProcessBundleProgressResponse;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.ProcessBundleResponse;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.ProcessBundleSplitResponse;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.ProcessBundleSplitResponse.ChannelSplit;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.RemoteGrpcPort;
 import org.apache.beam.model.pipeline.v1.Endpoints.ApiServiceDescriptor;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
@@ -76,6 +83,7 @@ import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.util.WindowedValue.FullWindowedValueCoder;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
+import org.apache.beam.vendor.grpc.v1p26p0.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.junit.Before;
@@ -85,6 +93,7 @@ import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
 import org.mockito.Mock;
 import org.mockito.Mockito;
 import org.mockito.MockitoAnnotations;
@@ -246,6 +255,229 @@ public class SdkHarnessClientTest {
       processBundleResponseFuture.complete(
           BeamFnApi.InstructionResponse.newBuilder().setProcessBundle(response).build());
     }
+  }
+
+  @Test
+  public void testClosingActiveBundleMultipleTimesIsNoop() throws Exception {
+    CompletableFuture<InstructionResponse> processBundleResponseFuture = new CompletableFuture<>();
+    when(fnApiControlClient.handle(any(BeamFnApi.InstructionRequest.class)))
+        .thenReturn(processBundleResponseFuture);
+
+    FullWindowedValueCoder<String> coder =
+        FullWindowedValueCoder.of(StringUtf8Coder.of(), Coder.INSTANCE);
+    BundleProcessor processor =
+        sdkHarnessClient.getProcessor(
+            descriptor,
+            Collections.singletonList(
+                RemoteInputDestination.of(
+                    (FullWindowedValueCoder) coder, SDK_GRPC_READ_TRANSFORM)));
+    when(dataService.send(any(), eq(coder))).thenReturn(mock(CloseableFnDataReceiver.class));
+
+    RemoteBundle activeBundle =
+        processor.newBundle(Collections.emptyMap(), BundleProgressHandler.ignored());
+    // Correlating the request and response is owned by the underlying
+    // FnApiControlClient. The SdkHarnessClient owns just wrapping the request and unwrapping
+    // the response.
+    //
+    // Currently there are no fields so there's nothing to check. This test is formulated
+    // to match the pattern it should have if/when the response is meaningful.
+    BeamFnApi.ProcessBundleResponse response = ProcessBundleResponse.getDefaultInstance();
+    processBundleResponseFuture.complete(
+        BeamFnApi.InstructionResponse.newBuilder().setProcessBundle(response).build());
+    activeBundle.close();
+
+    activeBundle.close();
+  }
+
+  @Test
+  public void testProgressAndSplitCallsAreIgnoredWhenBundleIsComplete() throws Exception {
+    CompletableFuture<InstructionResponse> processBundleResponseFuture = new CompletableFuture<>();
+    when(fnApiControlClient.handle(any(BeamFnApi.InstructionRequest.class)))
+        .thenReturn(processBundleResponseFuture);
+
+    FullWindowedValueCoder<String> coder =
+        FullWindowedValueCoder.of(StringUtf8Coder.of(), Coder.INSTANCE);
+    BundleProcessor processor =
+        sdkHarnessClient.getProcessor(
+            descriptor,
+            Collections.singletonList(
+                RemoteInputDestination.of(
+                    (FullWindowedValueCoder) coder, SDK_GRPC_READ_TRANSFORM)));
+    when(dataService.send(any(), eq(coder))).thenReturn(mock(CloseableFnDataReceiver.class));
+
+    RemoteBundle activeBundle =
+        processor.newBundle(Collections.emptyMap(), BundleProgressHandler.ignored());
+    // Correlating the request and response is owned by the underlying
+    // FnApiControlClient. The SdkHarnessClient owns just wrapping the request and unwrapping
+    // the response.
+    BeamFnApi.ProcessBundleResponse response = ProcessBundleResponse.getDefaultInstance();
+    processBundleResponseFuture.complete(
+        BeamFnApi.InstructionResponse.newBuilder().setProcessBundle(response).build());
+    activeBundle.close();
+
+    verify(fnApiControlClient).registerProcessBundleDescriptor(any(ProcessBundleDescriptor.class));
+    verify(fnApiControlClient).handle(any(BeamFnApi.InstructionRequest.class));
+
+    activeBundle.requestProgress();
+    activeBundle.split(0);
+    verifyNoMoreInteractions(fnApiControlClient);
+  }
+
+  @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
+  public void testProgressHandlerOnCompletedHappensAfterOnProgress() throws Exception {
+    CompletableFuture<InstructionResponse> processBundleResponseFuture = new CompletableFuture<>();
+    CompletableFuture<InstructionResponse> progressResponseFuture = new CompletableFuture<>();
+    when(fnApiControlClient.handle(any(BeamFnApi.InstructionRequest.class)))
+        .thenAnswer(
+            invocationOnMock -> {
+              switch (invocationOnMock
+                  .<BeamFnApi.InstructionRequest>getArgument(0)
+                  .getRequestCase()) {
+                case PROCESS_BUNDLE:
+                  return processBundleResponseFuture;
+                case PROCESS_BUNDLE_PROGRESS:
+                  return progressResponseFuture;
+                default:
+                  throw new IllegalArgumentException(
+                      "Unexpected request "
+                          + invocationOnMock.<BeamFnApi.InstructionRequest>getArgument(0));
+              }
+            });
+
+    FullWindowedValueCoder<String> coder =
+        FullWindowedValueCoder.of(StringUtf8Coder.of(), Coder.INSTANCE);
+    BundleProcessor processor =
+        sdkHarnessClient.getProcessor(
+            descriptor,
+            Collections.singletonList(
+                RemoteInputDestination.of(
+                    (FullWindowedValueCoder) coder, SDK_GRPC_READ_TRANSFORM)));
+    when(dataService.send(any(), eq(coder))).thenReturn(mock(CloseableFnDataReceiver.class));
+
+    BundleProgressHandler mockProgressHandler = mock(BundleProgressHandler.class);
+
+    RemoteBundle activeBundle = processor.newBundle(Collections.emptyMap(), mockProgressHandler);
+    BeamFnApi.ProcessBundleResponse response =
+        ProcessBundleResponse.newBuilder().putMonitoringData("test", ByteString.EMPTY).build();
+    BeamFnApi.ProcessBundleProgressResponse progressResponse =
+        ProcessBundleProgressResponse.newBuilder()
+            .putMonitoringData("test2", ByteString.EMPTY)
+            .build();
+
+    ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+
+    // Correlating the request and response is owned by the underlying
+    // FnApiControlClient. The SdkHarnessClient owns just wrapping the request and unwrapping
+    // the response.
+    //
+    // Schedule the progress response to come in after the bundle response and after the close call.
+    activeBundle.requestProgress();
+    executor.schedule(
+        () ->
+            processBundleResponseFuture.complete(
+                BeamFnApi.InstructionResponse.newBuilder().setProcessBundle(response).build()),
+        1,
+        TimeUnit.SECONDS);
+    executor.schedule(
+        () ->
+            progressResponseFuture.complete(
+                BeamFnApi.InstructionResponse.newBuilder()
+                    .setProcessBundleProgress(progressResponse)
+                    .build()),
+        2,
+        TimeUnit.SECONDS);
+    activeBundle.close();
+
+    InOrder inOrder = Mockito.inOrder(mockProgressHandler);
+    inOrder.verify(mockProgressHandler).onProgress(eq(progressResponse));
+    inOrder.verify(mockProgressHandler).onCompleted(eq(response));
+  }
+
+  @Test
+  @SuppressWarnings("FutureReturnValueIgnored")
+  public void testCheckpointHappensAfterAnySplitCalls() throws Exception {
+    CompletableFuture<InstructionResponse> processBundleResponseFuture = new CompletableFuture<>();
+    CompletableFuture<InstructionResponse> splitResponseFuture = new CompletableFuture<>();
+    when(fnApiControlClient.handle(any(BeamFnApi.InstructionRequest.class)))
+        .thenAnswer(
+            invocationOnMock -> {
+              switch (invocationOnMock
+                  .<BeamFnApi.InstructionRequest>getArgument(0)
+                  .getRequestCase()) {
+                case PROCESS_BUNDLE:
+                  return processBundleResponseFuture;
+                case PROCESS_BUNDLE_SPLIT:
+                  return splitResponseFuture;
+                default:
+                  throw new IllegalArgumentException(
+                      "Unexpected request "
+                          + invocationOnMock.<BeamFnApi.InstructionRequest>getArgument(0));
+              }
+            });
+
+    FullWindowedValueCoder<String> coder =
+        FullWindowedValueCoder.of(StringUtf8Coder.of(), Coder.INSTANCE);
+    BundleProcessor processor =
+        sdkHarnessClient.getProcessor(
+            descriptor,
+            Collections.singletonList(
+                RemoteInputDestination.of(
+                    (FullWindowedValueCoder) coder, SDK_GRPC_READ_TRANSFORM)));
+    when(dataService.send(any(), eq(coder))).thenReturn(mock(CloseableFnDataReceiver.class));
+
+    BundleCheckpointHandler mockCheckpointHandler = mock(BundleCheckpointHandler.class);
+    BundleSplitHandler mockSplitHandler = mock(BundleSplitHandler.class);
+    BundleFinalizationHandler mockFinalizationHandler = mock(BundleFinalizationHandler.class);
+
+    RemoteBundle activeBundle =
+        processor.newBundle(
+            Collections.emptyMap(),
+            Collections.emptyMap(),
+            StateRequestHandler.unsupported(),
+            BundleProgressHandler.ignored(),
+            mockSplitHandler,
+            mockCheckpointHandler,
+            mockFinalizationHandler);
+    BeamFnApi.ProcessBundleResponse response =
+        ProcessBundleResponse.newBuilder()
+            .addResidualRoots(
+                DelayedBundleApplication.newBuilder()
+                    .setApplication(BundleApplication.newBuilder().setTransformId("test").build())
+                    .build())
+            .build();
+    BeamFnApi.ProcessBundleSplitResponse splitResponse =
+        ProcessBundleSplitResponse.newBuilder()
+            .addChannelSplits(ChannelSplit.newBuilder().setTransformId("test2"))
+            .build();
+
+    ScheduledExecutorService executor = Executors.newSingleThreadScheduledExecutor();
+
+    // Correlating the request and response is owned by the underlying
+    // FnApiControlClient. The SdkHarnessClient owns just wrapping the request and unwrapping
+    // the response.
+    //
+    // Schedule the split response to come in after the bundle response and after the close call.
+    activeBundle.split(0.5);
+    executor.schedule(
+        () ->
+            processBundleResponseFuture.complete(
+                BeamFnApi.InstructionResponse.newBuilder().setProcessBundle(response).build()),
+        1,
+        TimeUnit.SECONDS);
+    executor.schedule(
+        () ->
+            splitResponseFuture.complete(
+                BeamFnApi.InstructionResponse.newBuilder()
+                    .setProcessBundleSplit(splitResponse)
+                    .build()),
+        2,
+        TimeUnit.SECONDS);
+    activeBundle.close();
+
+    InOrder inOrder = Mockito.inOrder(mockCheckpointHandler, mockSplitHandler);
+    inOrder.verify(mockSplitHandler).split(eq(splitResponse));
+    inOrder.verify(mockCheckpointHandler).onCheckpoint(eq(response));
   }
 
   @Test

--- a/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/BeamFnDataSizeBasedBufferingOutboundObserver.java
+++ b/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/BeamFnDataSizeBasedBufferingOutboundObserver.java
@@ -64,7 +64,7 @@ public class BeamFnDataSizeBasedBufferingOutboundObserver<T>
   @Override
   public void close() throws Exception {
     if (closed) {
-      throw new IllegalStateException("Already closed.");
+      return;
     }
     closed = true;
     BeamFnApi.Elements.Builder elements = convertBufferForTransmission();

--- a/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/data/BeamFnDataSizeBasedBufferingOutboundObserverTest.java
+++ b/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/data/BeamFnDataSizeBasedBufferingOutboundObserverTest.java
@@ -119,13 +119,8 @@ public class BeamFnDataSizeBasedBufferingOutboundObserverTest {
       // expected
     }
 
-    // Test that we can't close a stream twice.
-    try {
-      consumer.close();
-      fail("Closing twice should be prohibited.");
-    } catch (IllegalStateException exn) {
-      // expected
-    }
+    // Test that we can close a stream twice.
+    consumer.close();
   }
 
   @Test


### PR DESCRIPTION
The test was failing because there was an outstanding split request that was queued in the FnApiControlClient(https://github.com/apache/beam/blob/f7b23ec69fa68f4f0b6386ecec32ab12982e4098/runners/java-fn-execution/src/main/java/org/apache/beam/runners/fnexecution/control/FnApiControlClient.java#L134) which if all outstanding responses haven't returned will throw an error which causes the test to fail because of this exception being unexpected. This should also fix the progress test since it could also see this issue.

During the investigation of the test failure, I also discovered that BeamFnDataSizeBasedBufferingOutboundObserver was throwing an exception if close was called multiple times which is against the contract for CloseableFnDataReceiver and the CountingFnDataReceiver to only increment the count after the delegate accepted the value.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
