### PR TITLE
GH-Actions workflow checks are GCP variables set [depends on BEAM-10599]

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -36,6 +36,21 @@ env:
 
 jobs:
 
+  check-gcp-variables:
+    timeout-minutes: 5
+    name: "Check are GCP variables set"
+    runs-on: ubuntu-latest
+    outputs:
+      run-tests: ${{ steps.check-gcp-variables.outputs.are-gcp-variables-set }}
+    steps:
+      - uses: actions/checkout@v2
+      - name: "Check are GCP variables set"
+        run: "./scripts/ci/ci_check_are_gcp_variables_set.sh"
+        id: check-gcp-variables
+        env:
+          GCP_SA_EMAIL: ${{ secrets.GCP_SA_EMAIL }}
+          GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
+
   build_source:
     runs-on: ubuntu-latest
     name: Build python source distribution
@@ -78,9 +93,11 @@ jobs:
 
   prepare_gcs:
     name: Prepare GCS
-    needs: build_source
+    needs:
+      - build_source
+      - check-gcp-variables
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'apache' && github.event_name != 'pull_request'
+    if: needs.check-gcp-variables.outputs.are-gcp-variables-set == 'true' && github.event_name != 'pull_request'
     steps:
       - name: Authenticate on GCP
         uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
@@ -92,9 +109,11 @@ jobs:
 
   upload_source_to_gcs:
     name: Upload python source distribution to GCS bucket
-    needs: prepare_gcs
+    needs:
+      - prepare_gcs
+      - check-gcp-variables
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'apache'
+    if: needs.check-gcp-variables.outputs.are-gcp-variables-set == 'true'
     steps:
       - name: Download compressed sources from artifacts
         uses: actions/download-artifact@v2
@@ -156,10 +175,12 @@ jobs:
         path: apache-beam-source/wheelhouse/
 
   upload_wheels_to_gcs:
-    name: Upload python wheels to GCS bucket
-    needs: build_wheels
+    name: Upload wheels to GCS bucket
+    needs:
+      - build_wheels
+      - check-gcp-variables
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'apache' && github.event_name != 'pull_request'
+    if: needs.check-gcp-variables.outputs.are-gcp-variables-set == 'true' && github.event_name != 'pull_request'
     strategy:
       matrix:
         os : [ubuntu-latest, macos-latest, windows-latest]
@@ -199,9 +220,11 @@ jobs:
 
   list_files_on_gcs:
     name: List files on Google Cloud Storage Bucket
-    needs: upload_wheels_to_gcs
+    needs:
+     - upload_wheels_to_gcs
+     - check-gcp-variables
     runs-on: ubuntu-latest
-    if: github.repository_owner == 'apache' && github.event_name != 'pull_request'
+    if: needs.check-gcp-variables.outputs.are-gcp-variables-set == 'true' && github.event_name != 'pull_request'
     steps:
     - name: Authenticate on GCP
       uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
@@ -218,7 +241,7 @@ jobs:
       - build_wheels
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    if: github.repository_owner == 'apache' && github.event_name == 'schedule'
+    if: github.event_name == 'schedule'
     steps:
       - name: Checkout code on master branch
         uses: actions/checkout@master

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -241,7 +241,7 @@ jobs:
       - build_wheels
     runs-on: ubuntu-latest
     timeout-minutes: 60
-    if: github.event_name == 'schedule'
+    if: github.repository_owner == 'apache' && github.event_name == 'schedule'
     steps:
       - name: Checkout code on master branch
         uses: actions/checkout@master

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -36,17 +36,17 @@ env:
 
 jobs:
 
-  check-gcp-variables:
+  check_gcp_variables:
     timeout-minutes: 5
     name: "Check are GCP variables set"
     runs-on: ubuntu-latest
     outputs:
-      run-tests: ${{ steps.check-gcp-variables.outputs.are-gcp-variables-set }}
+      run-tests: ${{ steps.check_gcp_variables.outputs.are-gcp-variables-set }}
     steps:
       - uses: actions/checkout@v2
       - name: "Check are GCP variables set"
         run: "./scripts/ci/ci_check_are_gcp_variables_set.sh"
-        id: check-gcp-variables
+        id: check_gcp_variables
         env:
           GCP_SA_EMAIL: ${{ secrets.GCP_SA_EMAIL }}
           GCP_SA_KEY: ${{ secrets.GCP_SA_KEY }}
@@ -95,9 +95,9 @@ jobs:
     name: Prepare GCS
     needs:
       - build_source
-      - check-gcp-variables
+      - check_gcp_variables
     runs-on: ubuntu-latest
-    if: needs.check-gcp-variables.outputs.are-gcp-variables-set == 'true' && github.event_name != 'pull_request'
+    if: needs.check_gcp_variables.outputs.are-gcp-variables-set == 'true' && github.event_name != 'pull_request'
     steps:
       - name: Authenticate on GCP
         uses: GoogleCloudPlatform/github-actions/setup-gcloud@master
@@ -111,9 +111,9 @@ jobs:
     name: Upload python source distribution to GCS bucket
     needs:
       - prepare_gcs
-      - check-gcp-variables
+      - check_gcp_variables
     runs-on: ubuntu-latest
-    if: needs.check-gcp-variables.outputs.are-gcp-variables-set == 'true'
+    if: needs.check_gcp_variables.outputs.are-gcp-variables-set == 'true'
     steps:
       - name: Download compressed sources from artifacts
         uses: actions/download-artifact@v2
@@ -178,9 +178,9 @@ jobs:
     name: Upload wheels to GCS bucket
     needs:
       - build_wheels
-      - check-gcp-variables
+      - check_gcp_variables
     runs-on: ubuntu-latest
-    if: needs.check-gcp-variables.outputs.are-gcp-variables-set == 'true' && github.event_name != 'pull_request'
+    if: needs.check_gcp_variables.outputs.are-gcp-variables-set == 'true' && github.event_name != 'pull_request'
     strategy:
       matrix:
         os : [ubuntu-latest, macos-latest, windows-latest]
@@ -222,9 +222,9 @@ jobs:
     name: List files on Google Cloud Storage Bucket
     needs:
      - upload_wheels_to_gcs
-     - check-gcp-variables
+     - check_gcp_variables
     runs-on: ubuntu-latest
-    if: needs.check-gcp-variables.outputs.are-gcp-variables-set == 'true' && github.event_name != 'pull_request'
+    if: needs.check_gcp_variables.outputs.are-gcp-variables-set == 'true' && github.event_name != 'pull_request'
     steps:
     - name: Authenticate on GCP
       uses: GoogleCloudPlatform/github-actions/setup-gcloud@master

--- a/scripts/ci/ci_check_are_gcp_variables_set.sh
+++ b/scripts/ci/ci_check_are_gcp_variables_set.sh
@@ -18,11 +18,8 @@
 
 set -e
 
-echo "This script checks of presence of veriables required to perform operations on Google Cloud Platform. They should be stored as secrets."
-echo "\"GCP_SA_EMAIL\" - Service account email address. This is usually of the format <name>@<project-id>.iam.gserviceaccount.com"
-echo "\"GCP_SA_KEY\" - Service account key. This key should be created and encoded as a Base64 string (eg. cat my-key.json | base64 on macOS)"
-echo "Service Account shall have following permissions:"
-echo " - Storage Object Admin (roles/storage.objectAdmin)"
+echo "This script checks of presence of variables required to perform operations on Google Cloud Platform. They should be stored as secrets."
+echo "More detailed information can be found in CI.md"
 
 function check_vars() {
   ret=true

--- a/scripts/ci/ci_check_are_gcp_variables_set.sh
+++ b/scripts/ci/ci_check_are_gcp_variables_set.sh
@@ -19,7 +19,7 @@
 set -e
 
 echo "This script checks of presence of variables required to perform operations on Google Cloud Platform. They should be stored as secrets."
-echo "More detailed information can be found in CI.md"
+echo "More detailed information about Google Cloud Platform Credentials can be found in CI.md"
 
 function check_vars() {
   ret=true

--- a/scripts/ci/ci_check_are_gcp_variables_set.sh
+++ b/scripts/ci/ci_check_are_gcp_variables_set.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/env bash
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+set -e
+
+echo "This script checks of presence of veriables required to perform operations on Google Cloud Platform. They should be stored as secrets."
+echo "\"GCP_SA_EMAIL\" - Service account email address. This is usually of the format <name>@<project-id>.iam.gserviceaccount.com"
+echo "\"GCP_SA_KEY\" - Service account key. This key should be created and encoded as a Base64 string (eg. cat my-key.json | base64 on macOS)"
+echo "Service Account shall have following permissions:"
+echo " - Storage Object Admin (roles/storage.objectAdmin)"
+
+function check_vars() {
+  ret=true
+  for var in "$@"; do
+    if [ -n "${!var}" ]; then
+      echo "$var is set"
+    else
+      echo >&2 "$var is not set"
+      ret=false
+    fi
+  done
+  $ret
+}
+
+if ! check_vars "GCP_SA_EMAIL" "GCP_SA_KEY"; then
+  echo "::set-output name=are-gcp-variables-set::false"
+  echo >&2 "!!! WARNING !!!"
+  echo >&2 "Not all GCP variables are set. Jobs which require them will be skipped."
+else
+  echo "::set-output name=are-gcp-variables-set::true"
+fi


### PR DESCRIPTION
I want to propose a different approach for making GitHub Actions workflow runnable on the forks.
Some of the jobs requires GCP variables stored as secrets to perform operations like uploading wheels to GCS.
Currently these jobs are filtered based on the condition `github.repository_owner == 'apache'`.
I introduced shell script which checks are these variables are set and echos some information about them.
Later job filtering is based on the output returned by this check.

PR which introduced gating:
[Gate GH actions so it only runs in main/upstream repo](https://github.com/apache/beam/pull/12222)

Inspired by Apache Airflow ci workflow:
https://github.com/apache/airflow/blob/master/.github/workflows/ci.yml#L111

Depends on depends on https://github.com/apache/beam/pull/12405

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
