### PR TITLE
[BEAM-10527] Migrate Flink and Spark tests to pytest.

### DIFF
--- a/.test-infra/jenkins/job_PostCommit_Python_ValidatesRunner_Spark.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Python_ValidatesRunner_Spark.groovy
@@ -27,6 +27,11 @@ PostcommitJobBuilder.postCommitJob('beam_PostCommit_Python_VR_Spark',
       // Set common parameters.
       commonJobProperties.setTopLevelMainJobProperties(delegate)
 
+      // Publish all test results to Jenkins.
+      publishers {
+        archiveJunit('**/pytest*.xml')
+      }
+
       // Gradle goals for this job.
       steps {
         gradle {

--- a/.test-infra/jenkins/job_PreCommit_Python_ValidatesRunner_Flink.groovy
+++ b/.test-infra/jenkins/job_PreCommit_Python_ValidatesRunner_Flink.groovy
@@ -39,4 +39,8 @@ PrecommitJobBuilder builder = new PrecommitJobBuilder(
     )
 builder.build {
   previousNames('beam_PreCommit_Python_PVR_Flink')
+  // Publish all test results to Jenkins.
+  publishers {
+    archiveJunit('**/pytest*.xml')
+  }
 }

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -2044,7 +2044,7 @@ class BeamModulePlugin implements Plugin<Project> {
         return argList.join(' ')
       }
 
-      project.ext.toxTask = { name, tox_env ->
+      project.ext.toxTask = { name, tox_env, posargs='' ->
         project.tasks.create(name) {
           dependsOn 'setupVirtualenv'
           dependsOn ':sdks:python:sdist'
@@ -2059,7 +2059,7 @@ class BeamModulePlugin implements Plugin<Project> {
             def distTarBall = "${pythonRootDir}/build/apache-beam.tar.gz"
             project.exec {
               executable 'sh'
-              args '-c', ". ${project.ext.envdir}/bin/activate && cd ${copiedPyRoot} && scripts/run_tox.sh $tox_env $distTarBall"
+              args '-c', ". ${project.ext.envdir}/bin/activate && cd ${copiedPyRoot} && scripts/run_tox.sh $tox_env $distTarBall '$posargs'"
             }
           }
           inputs.files project.pythonSdkDeps

--- a/sdks/python/apache_beam/runners/portability/flink_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/flink_runner_test.py
@@ -21,7 +21,7 @@ from __future__ import print_function
 
 import argparse
 import logging
-import sys
+import shlex
 import typing
 import unittest
 from os import linesep
@@ -30,6 +30,7 @@ from os.path import exists
 from shutil import rmtree
 from tempfile import mkdtemp
 
+import pytest
 from past.builtins import unicode
 
 import apache_beam as beam
@@ -53,361 +54,386 @@ from apache_beam.testing.util import equal_to
 from apache_beam.transforms import userstate
 from apache_beam.transforms.sql import SqlTransform
 
+# Run as
+#
+# pytest flink_runner_test.py \
+#     [--test_pipeline_options "--flink_job_server_jar=/path/to/job_server.jar \
+#                               --environment_type=DOCKER"] \
+#     [FlinkRunnerTest.test_method, ...]
+
 _LOGGER = logging.getLogger(__name__)
 
 Row = typing.NamedTuple("Row", [("col1", int), ("col2", unicode)])
 beam.coders.registry.register_coder(Row, beam.coders.RowCoder)
 
-if __name__ == '__main__':
-  # Run as
-  #
-  # python -m apache_beam.runners.portability.flink_runner_test \
-  #     --flink_job_server_jar=/path/to/job_server.jar \
-  #     --environment_type=docker \
-  #     --extra_experiments=beam_experiments \
-  #     [FlinkRunnerTest.test_method, ...]
 
-  parser = argparse.ArgumentParser(add_help=True)
-  parser.add_argument(
-      '--flink_job_server_jar', help='Job server jar to submit jobs.')
-  parser.add_argument(
-      '--streaming',
-      default=False,
-      action='store_true',
-      help='Job type. batch or streaming')
-  parser.add_argument(
-      '--environment_type',
-      default='loopback',
-      help='Environment type. docker, process, or loopback.')
-  parser.add_argument('--environment_config', help='Environment config.')
-  parser.add_argument(
-      '--extra_experiments',
-      default=[],
-      action='append',
-      help='Beam experiments config.')
-  known_args, args = parser.parse_known_args(sys.argv)
-  sys.argv = args
+class FlinkRunnerTest(portable_runner_test.PortableRunnerTest):
+  _use_grpc = True
+  _use_subprocesses = True
 
-  flink_job_server_jar = (
-      known_args.flink_job_server_jar or
-      job_server.JavaJarJobServer.path_to_beam_jar(
-          ':runners:flink:%s:job-server:shadowJar' %
-          FlinkRunnerOptions.PUBLISHED_FLINK_VERSIONS[-1]))
-  streaming = known_args.streaming
-  environment_type = known_args.environment_type.lower()
-  environment_config = (
-      known_args.environment_config if known_args.environment_config else None)
-  extra_experiments = known_args.extra_experiments
+  conf_dir = None
+  expansion_port = None
+  flink_job_server_jar = None
 
-  # This is defined here to only be run when we invoke this file explicitly.
-  class FlinkRunnerTest(portable_runner_test.PortableRunnerTest):
-    _use_grpc = True
-    _use_subprocesses = True
+  def __init__(self, *args, **kwargs):
+    super(FlinkRunnerTest, self).__init__(*args, **kwargs)
+    self.environment_type = None
+    self.environment_config = None
 
-    conf_dir = None
-    expansion_port = None
+  @pytest.fixture(autouse=True)
+  def parse_options(self, request):
+    if not request.config.option.test_pipeline_options:
+      raise unittest.SkipTest(
+          'Skipping because --test-pipeline-options is not specified.')
+    test_pipeline_options = request.config.option.test_pipeline_options
+    parser = argparse.ArgumentParser(add_help=True)
+    parser.add_argument(
+        '--flink_job_server_jar',
+        help='Job server jar to submit jobs.',
+        action='store')
+    parser.add_argument(
+        '--environment_type',
+        default='LOOPBACK',
+        choices=['DOCKER', 'PROCESS', 'LOOPBACK'],
+        help='Set the environment type for running user code. DOCKER runs '
+        'user code in a container. PROCESS runs user code in '
+        'automatically started processes. LOOPBACK runs user code on '
+        'the same process that originally submitted the job.')
+    parser.add_argument(
+        '--environment_option',
+        '--environment_options',
+        dest='environment_options',
+        action='append',
+        default=None,
+        help=(
+            'Environment configuration for running the user code. '
+            'Recognized options depend on --environment_type.\n '
+            'For DOCKER: docker_container_image (optional)\n '
+            'For PROCESS: process_command (required), process_variables '
+            '(optional, comma-separated)\n '
+            'For EXTERNAL: external_service_address (required)'))
+    known_args, unknown_args = parser.parse_known_args(
+        shlex.split(test_pipeline_options))
+    if unknown_args:
+      _LOGGER.warning('Discarding unrecognized arguments %s' % unknown_args)
+    self.set_flink_job_server_jar(
+        known_args.flink_job_server_jar or
+        job_server.JavaJarJobServer.path_to_beam_jar((
+            ':runners:flink:%s:job-server:shadowJar' %
+            FlinkRunnerOptions.PUBLISHED_FLINK_VERSIONS[-1])))
+    self.environment_type = known_args.environment_type
+    self.environment_options = known_args.environment_options
 
-    @classmethod
-    def tearDownClass(cls):
-      if cls.conf_dir and exists(cls.conf_dir):
-        _LOGGER.info("removing conf dir: %s" % cls.conf_dir)
-        rmtree(cls.conf_dir)
-      super(FlinkRunnerTest, cls).tearDownClass()
+  @classmethod
+  def tearDownClass(cls):
+    if cls.conf_dir and exists(cls.conf_dir):
+      _LOGGER.info("removing conf dir: %s" % cls.conf_dir)
+      rmtree(cls.conf_dir)
+    super(FlinkRunnerTest, cls).tearDownClass()
 
-    @classmethod
-    def _create_conf_dir(cls):
-      """Create (and save a static reference to) a "conf dir", used to provide
-       metrics configs and verify metrics output
+  @classmethod
+  def _create_conf_dir(cls):
+    """Create (and save a static reference to) a "conf dir", used to provide
+     metrics configs and verify metrics output
 
-       It gets cleaned up when the suite is done executing"""
+     It gets cleaned up when the suite is done executing"""
 
-      if hasattr(cls, 'conf_dir'):
-        cls.conf_dir = mkdtemp(prefix='flinktest-conf')
+    if hasattr(cls, 'conf_dir'):
+      cls.conf_dir = mkdtemp(prefix='flinktest-conf')
 
-        # path for a FileReporter to write metrics to
-        cls.test_metrics_path = path.join(cls.conf_dir, 'test-metrics.txt')
+      # path for a FileReporter to write metrics to
+      cls.test_metrics_path = path.join(cls.conf_dir, 'test-metrics.txt')
 
-        # path to write Flink configuration to
-        conf_path = path.join(cls.conf_dir, 'flink-conf.yaml')
-        file_reporter = 'org.apache.beam.runners.flink.metrics.FileReporter'
-        with open(conf_path, 'w') as f:
-          f.write(
-              linesep.join([
-                  'metrics.reporters: file',
-                  'metrics.reporter.file.class: %s' % file_reporter,
-                  'metrics.reporter.file.path: %s' % cls.test_metrics_path,
-                  'metrics.scope.operator: <operator_name>',
-              ]))
+      # path to write Flink configuration to
+      conf_path = path.join(cls.conf_dir, 'flink-conf.yaml')
+      file_reporter = 'org.apache.beam.runners.flink.metrics.FileReporter'
+      with open(conf_path, 'w') as f:
+        f.write(
+            linesep.join([
+                'metrics.reporters: file',
+                'metrics.reporter.file.class: %s' % file_reporter,
+                'metrics.reporter.file.path: %s' % cls.test_metrics_path,
+                'metrics.scope.operator: <operator_name>',
+            ]))
 
-    @classmethod
-    def _subprocess_command(cls, job_port, expansion_port):
-      # will be cleaned up at the end of this method, and recreated and used by
-      # the job server
-      tmp_dir = mkdtemp(prefix='flinktest')
+  @classmethod
+  def _subprocess_command(cls, job_port, expansion_port):
+    # will be cleaned up at the end of this method, and recreated and used by
+    # the job server
+    tmp_dir = mkdtemp(prefix='flinktest')
 
-      cls._create_conf_dir()
-      cls.expansion_port = expansion_port
+    cls._create_conf_dir()
+    cls.expansion_port = expansion_port
 
-      try:
-        return [
-            'java',
-            '-Dorg.slf4j.simpleLogger.defaultLogLevel=warn',
-            '-jar',
-            flink_job_server_jar,
-            '--flink-master',
-            '[local]',
-            '--flink-conf-dir',
-            cls.conf_dir,
-            '--artifacts-dir',
-            tmp_dir,
-            '--job-port',
-            str(job_port),
-            '--artifact-port',
-            '0',
-            '--expansion-port',
-            str(expansion_port),
-        ]
-      finally:
-        rmtree(tmp_dir)
+    try:
+      return [
+          'java',
+          '-Dorg.slf4j.simpleLogger.defaultLogLevel=warn',
+          '-jar',
+          cls.flink_job_server_jar,
+          '--flink-master',
+          '[local]',
+          '--flink-conf-dir',
+          cls.conf_dir,
+          '--artifacts-dir',
+          tmp_dir,
+          '--job-port',
+          str(job_port),
+          '--artifact-port',
+          '0',
+          '--expansion-port',
+          str(expansion_port),
+      ]
+    finally:
+      rmtree(tmp_dir)
 
-    @classmethod
-    def get_runner(cls):
-      return portable_runner.PortableRunner()
+  @classmethod
+  def get_runner(cls):
+    return portable_runner.PortableRunner()
 
-    @classmethod
-    def get_expansion_service(cls):
-      # TODO Move expansion address resides into PipelineOptions
-      return 'localhost:%s' % cls.expansion_port
+  @classmethod
+  def get_expansion_service(cls):
+    # TODO Move expansion address resides into PipelineOptions
+    return 'localhost:%s' % cls.expansion_port
 
-    def create_options(self):
-      options = super(FlinkRunnerTest, self).create_options()
-      options.view_as(
-          DebugOptions).experiments = ['beam_fn_api'] + extra_experiments
-      options._all_options['parallelism'] = 2
-      options.view_as(PortableOptions).environment_type = (
-          environment_type.upper())
-      if environment_config:
-        options.view_as(PortableOptions).environment_config = environment_config
+  @classmethod
+  def set_flink_job_server_jar(cls, flink_job_server_jar):
+    cls.flink_job_server_jar = flink_job_server_jar
 
-      if streaming:
-        options.view_as(StandardOptions).streaming = True
-      return options
+  def create_options(self):
+    options = super(FlinkRunnerTest, self).create_options()
+    options.view_as(DebugOptions).experiments = ['beam_fn_api']
+    options._all_options['parallelism'] = 2
+    options.view_as(PortableOptions).environment_type = self.environment_type
+    options.view_as(
+        PortableOptions).environment_options = self.environment_options
 
-    # Can't read host files from within docker, read a "local" file there.
-    def test_read(self):
+    return options
+
+  # Can't read host files from within docker, read a "local" file there.
+  def test_read(self):
+    print('name:', __name__)
+    with self.create_pipeline() as p:
+      lines = p | beam.io.ReadFromText('/etc/profile')
+      assert_that(lines, lambda lines: len(lines) > 0)
+
+  def test_no_subtransform_composite(self):
+    raise unittest.SkipTest("BEAM-4781")
+
+  def test_external_transform(self):
+    with self.create_pipeline() as p:
+      res = (
+          p
+          | GenerateSequence(
+              start=1, stop=10, expansion_service=self.get_expansion_service()))
+
+      assert_that(res, equal_to([i for i in range(1, 10)]))
+
+  def test_expand_kafka_read(self):
+    # We expect to fail here because we do not have a Kafka cluster handy.
+    # Nevertheless, we check that the transform is expanded by the
+    # ExpansionService and that the pipeline fails during execution.
+    with self.assertRaises(Exception) as ctx:
       with self.create_pipeline() as p:
-        lines = p | beam.io.ReadFromText('/etc/profile')
-        assert_that(lines, lambda lines: len(lines) > 0)
-
-    def test_no_subtransform_composite(self):
-      raise unittest.SkipTest("BEAM-4781")
-
-    def test_external_transform(self):
-      with self.create_pipeline() as p:
-        res = (
-            p
-            | GenerateSequence(
-                start=1,
-                stop=10,
-                expansion_service=self.get_expansion_service()))
-
-        assert_that(res, equal_to([i for i in range(1, 10)]))
-
-    def test_expand_kafka_read(self):
-      # We expect to fail here because we do not have a Kafka cluster handy.
-      # Nevertheless, we check that the transform is expanded by the
-      # ExpansionService and that the pipeline fails during execution.
-      with self.assertRaises(Exception) as ctx:
-        with self.create_pipeline() as p:
-          # pylint: disable=expression-not-assigned
-          (
-              p
-              | ReadFromKafka(
-                  consumer_config={
-                      'bootstrap.servers': 'notvalid1:7777, notvalid2:3531'
-                  },
-                  topics=['topic1', 'topic2'],
-                  key_deserializer='org.apache.kafka.'
-                  'common.serialization.'
-                  'ByteArrayDeserializer',
-                  value_deserializer='org.apache.kafka.'
-                  'common.serialization.'
-                  'LongDeserializer',
-                  expansion_service=self.get_expansion_service()))
-      self.assertTrue(
-          'No resolvable bootstrap urls given in bootstrap.servers' in str(
-              ctx.exception),
-          'Expected to fail due to invalid bootstrap.servers, but '
-          'failed due to:\n%s' % str(ctx.exception))
-
-    def test_expand_kafka_write(self):
-      # We just test the expansion but do not execute.
-      # pylint: disable=expression-not-assigned
-      (
-          self.create_pipeline()
-          | Impulse()
-          | Map(lambda input: (1, input))
-          | WriteToKafka(
-              producer_config={
-                  'bootstrap.servers': 'localhost:9092, notvalid2:3531'
-              },
-              topic='topic1',
-              key_serializer='org.apache.kafka.'
-              'common.serialization.'
-              'LongSerializer',
-              value_serializer='org.apache.kafka.'
-              'common.serialization.'
-              'ByteArraySerializer',
-              expansion_service=self.get_expansion_service()))
-
-    def test_sql(self):
-      with self.create_pipeline() as p:
-        output = (
-            p
-            | 'Create' >> beam.Create([Row(x, str(x)) for x in range(5)])
-            | 'Sql' >> SqlTransform(
-                """SELECT col1, col2 || '*' || col2 as col2,
-                          power(col1, 2) as col3
-                   FROM PCOLLECTION
-                """,
-                expansion_service=self.get_expansion_service()))
-        assert_that(
-            output,
-            equal_to([(x, '{x}*{x}'.format(x=x), x * x) for x in range(5)]))
-
-    def test_flattened_side_input(self):
-      # Blocked on support for transcoding
-      # https://jira.apache.org/jira/browse/BEAM-6523
-      super(FlinkRunnerTest,
-            self).test_flattened_side_input(with_transcoding=False)
-
-    def test_metrics(self):
-      super(FlinkRunnerTest, self).test_metrics(check_gauge=False)
-
-    def test_flink_metrics(self):
-      """Run a simple DoFn that increments a counter and verifies state
-      caching metrics. Verifies that its expected value is written to a
-      temporary file by the FileReporter"""
-
-      counter_name = 'elem_counter'
-      state_spec = userstate.BagStateSpec('state', VarIntCoder())
-
-      class DoFn(beam.DoFn):
-        def __init__(self):
-          self.counter = Metrics.counter(self.__class__, counter_name)
-          _LOGGER.info('counter: %s' % self.counter.metric_name)
-
-        def process(self, kv, state=beam.DoFn.StateParam(state_spec)):
-          # Trigger materialization
-          list(state.read())
-          state.add(1)
-          self.counter.inc()
-
-      options = self.create_options()
-      # Test only supports parallelism of 1
-      options._all_options['parallelism'] = 1
-      # Create multiple bundles to test cache metrics
-      options._all_options['max_bundle_size'] = 10
-      options._all_options['max_bundle_time_millis'] = 95130590130
-      experiments = options.view_as(DebugOptions).experiments or []
-      experiments.append('state_cache_size=123')
-      options.view_as(DebugOptions).experiments = experiments
-      with Pipeline(self.get_runner(), options) as p:
         # pylint: disable=expression-not-assigned
         (
             p
-            | "create" >> beam.Create(list(range(0, 110)))
-            | "mapper" >> beam.Map(lambda x: (x % 10, 'val'))
-            | "stateful" >> beam.ParDo(DoFn()))
+            | ReadFromKafka(
+                consumer_config={
+                    'bootstrap.servers': 'notvalid1:7777, notvalid2:3531'
+                },
+                topics=['topic1', 'topic2'],
+                key_deserializer='org.apache.kafka.'
+                'common.serialization.'
+                'ByteArrayDeserializer',
+                value_deserializer='org.apache.kafka.'
+                'common.serialization.'
+                'LongDeserializer',
+                expansion_service=self.get_expansion_service()))
+    self.assertTrue(
+        'No resolvable bootstrap urls given in bootstrap.servers' in str(
+            ctx.exception),
+        'Expected to fail due to invalid bootstrap.servers, but '
+        'failed due to:\n%s' % str(ctx.exception))
 
-      lines_expected = {'counter: 110'}
-      if streaming:
-        lines_expected.update([
-            # Gauges for the last finished bundle
-            'stateful.beam.metric:statecache:capacity: 123',
-            'stateful.beam.metric:statecache:size: 10',
-            'stateful.beam.metric:statecache:get: 20',
-            'stateful.beam.metric:statecache:miss: 0',
-            'stateful.beam.metric:statecache:hit: 20',
-            'stateful.beam.metric:statecache:put: 0',
-            'stateful.beam.metric:statecache:evict: 0',
-            # Counters
-            'stateful.beam.metric:statecache:get_total: 220',
-            'stateful.beam.metric:statecache:miss_total: 10',
-            'stateful.beam.metric:statecache:hit_total: 210',
-            'stateful.beam.metric:statecache:put_total: 10',
-            'stateful.beam.metric:statecache:evict_total: 0',
-        ])
-      else:
-        # Batch has a different processing model. All values for
-        # a key are processed at once.
-        lines_expected.update([
-            # Gauges
-            'stateful).beam.metric:statecache:capacity: 123',
-            # For the first key, the cache token will not be set yet.
-            # It's lazily initialized after first access in StateRequestHandlers
-            'stateful).beam.metric:statecache:size: 10',
-            # We have 11 here because there are 110 / 10 elements per key
-            'stateful).beam.metric:statecache:get: 12',
-            'stateful).beam.metric:statecache:miss: 1',
-            'stateful).beam.metric:statecache:hit: 11',
-            # State is flushed back once per key
-            'stateful).beam.metric:statecache:put: 1',
-            'stateful).beam.metric:statecache:evict: 0',
-            # Counters
-            'stateful).beam.metric:statecache:get_total: 120',
-            'stateful).beam.metric:statecache:miss_total: 10',
-            'stateful).beam.metric:statecache:hit_total: 110',
-            'stateful).beam.metric:statecache:put_total: 10',
-            'stateful).beam.metric:statecache:evict_total: 0',
-        ])
-      lines_actual = set()
-      with open(self.test_metrics_path, 'r') as f:
-        for line in f:
-          for metric_str in lines_expected:
-            metric_name = metric_str.split()[0]
-            if metric_str in line:
-              lines_actual.add(metric_str)
-            elif metric_name in line:
-              lines_actual.add(line)
-      self.assertSetEqual(lines_actual, lines_expected)
+  def test_expand_kafka_write(self):
+    # We just test the expansion but do not execute.
+    # pylint: disable=expression-not-assigned
+    (
+        self.create_pipeline()
+        | Impulse()
+        | Map(lambda input: (1, input))
+        | WriteToKafka(
+            producer_config={
+                'bootstrap.servers': 'localhost:9092, notvalid2:3531'
+            },
+            topic='topic1',
+            key_serializer='org.apache.kafka.'
+            'common.serialization.'
+            'LongSerializer',
+            value_serializer='org.apache.kafka.'
+            'common.serialization.'
+            'ByteArraySerializer',
+            expansion_service=self.get_expansion_service()))
 
-    def test_sdf_with_watermark_tracking(self):
-      raise unittest.SkipTest("BEAM-2939")
+  def test_sql(self):
+    with self.create_pipeline() as p:
+      output = (
+          p
+          | 'Create' >> beam.Create([Row(x, str(x)) for x in range(5)])
+          | 'Sql' >> SqlTransform(
+              """SELECT col1, col2 || '*' || col2 as col2,
+                    power(col1, 2) as col3
+             FROM PCOLLECTION
+          """,
+              expansion_service=self.get_expansion_service()))
+      assert_that(
+          output,
+          equal_to([(x, '{x}*{x}'.format(x=x), x * x) for x in range(5)]))
 
-    def test_sdf_with_sdf_initiated_checkpointing(self):
-      raise unittest.SkipTest("BEAM-2939")
+  def test_flattened_side_input(self):
+    # Blocked on support for transcoding
+    # https://jira.apache.org/jira/browse/BEAM-6523
+    super(FlinkRunnerTest,
+          self).test_flattened_side_input(with_transcoding=False)
 
-    def test_callbacks_with_exception(self):
-      raise unittest.SkipTest("BEAM-6868")
+  def test_metrics(self):
+    super(FlinkRunnerTest, self).test_metrics(check_gauge=False)
 
-    def test_register_finalizations(self):
-      raise unittest.SkipTest("BEAM-6868")
+  def test_flink_metrics(self):
+    """Run a simple DoFn that increments a counter and verifies state
+    caching metrics. Verifies that its expected value is written to a
+    temporary file by the FileReporter"""
 
-    # Inherits all other tests.
+    counter_name = 'elem_counter'
+    state_spec = userstate.BagStateSpec('state', VarIntCoder())
 
-  class FlinkRunnerTestOptimized(FlinkRunnerTest):
-    # TODO: Remove these tests after resolving BEAM-7248 and enabling
-    #  PortableRunnerOptimized
-    def create_options(self):
-      options = super(FlinkRunnerTestOptimized, self).create_options()
-      options.view_as(DebugOptions).experiments = [
-          'pre_optimize=all'
-      ] + options.view_as(DebugOptions).experiments
-      return options
+    class DoFn(beam.DoFn):
+      def __init__(self):
+        self.counter = Metrics.counter(self.__class__, counter_name)
+        _LOGGER.info('counter: %s' % self.counter.metric_name)
 
-    def test_external_transform(self):
-      raise unittest.SkipTest("BEAM-7252")
+      def process(self, kv, state=beam.DoFn.StateParam(state_spec)):
+        # Trigger materialization
+        list(state.read())
+        state.add(1)
+        self.counter.inc()
 
-    def test_expand_kafka_read(self):
-      raise unittest.SkipTest("BEAM-7252")
+    options = self.create_options()
+    # Test only supports parallelism of 1
+    options._all_options['parallelism'] = 1
+    # Create multiple bundles to test cache metrics
+    options._all_options['max_bundle_size'] = 10
+    options._all_options['max_bundle_time_millis'] = 95130590130
+    experiments = options.view_as(DebugOptions).experiments or []
+    experiments.append('state_cache_size=123')
+    options.view_as(DebugOptions).experiments = experiments
+    with Pipeline(self.get_runner(), options) as p:
+      # pylint: disable=expression-not-assigned
+      (
+          p
+          | "create" >> beam.Create(list(range(0, 110)))
+          | "mapper" >> beam.Map(lambda x: (x % 10, 'val'))
+          | "stateful" >> beam.ParDo(DoFn()))
 
-    def test_expand_kafka_write(self):
-      raise unittest.SkipTest("BEAM-7252")
+    lines_expected = {'counter: 110'}
+    if options.view_as(StandardOptions).streaming:
+      lines_expected.update([
+          # Gauges for the last finished bundle
+          'stateful.beam.metric:statecache:capacity: 123',
+          'stateful.beam.metric:statecache:size: 10',
+          'stateful.beam.metric:statecache:get: 20',
+          'stateful.beam.metric:statecache:miss: 0',
+          'stateful.beam.metric:statecache:hit: 20',
+          'stateful.beam.metric:statecache:put: 0',
+          'stateful.beam.metric:statecache:evict: 0',
+          # Counters
+          'stateful.beam.metric:statecache:get_total: 220',
+          'stateful.beam.metric:statecache:miss_total: 10',
+          'stateful.beam.metric:statecache:hit_total: 210',
+          'stateful.beam.metric:statecache:put_total: 10',
+          'stateful.beam.metric:statecache:evict_total: 0',
+      ])
+    else:
+      # Batch has a different processing model. All values for
+      # a key are processed at once.
+      lines_expected.update([
+          # Gauges
+          'stateful).beam.metric:statecache:capacity: 123',
+          # For the first key, the cache token will not be set yet.
+          # It's lazily initialized after first access in StateRequestHandlers
+          'stateful).beam.metric:statecache:size: 10',
+          # We have 11 here because there are 110 / 10 elements per key
+          'stateful).beam.metric:statecache:get: 12',
+          'stateful).beam.metric:statecache:miss: 1',
+          'stateful).beam.metric:statecache:hit: 11',
+          # State is flushed back once per key
+          'stateful).beam.metric:statecache:put: 1',
+          'stateful).beam.metric:statecache:evict: 0',
+          # Counters
+          'stateful).beam.metric:statecache:get_total: 120',
+          'stateful).beam.metric:statecache:miss_total: 10',
+          'stateful).beam.metric:statecache:hit_total: 110',
+          'stateful).beam.metric:statecache:put_total: 10',
+          'stateful).beam.metric:statecache:evict_total: 0',
+      ])
+    lines_actual = set()
+    with open(self.test_metrics_path, 'r') as f:
+      for line in f:
+        for metric_str in lines_expected:
+          metric_name = metric_str.split()[0]
+          if metric_str in line:
+            lines_actual.add(metric_str)
+          elif metric_name in line:
+            lines_actual.add(line)
+    self.assertSetEqual(lines_actual, lines_expected)
 
-    def test_sql(self):
-      raise unittest.SkipTest("BEAM-7252")
+  def test_sdf_with_watermark_tracking(self):
+    raise unittest.SkipTest("BEAM-2939")
 
+  def test_sdf_with_sdf_initiated_checkpointing(self):
+    raise unittest.SkipTest("BEAM-2939")
+
+  def test_callbacks_with_exception(self):
+    raise unittest.SkipTest("BEAM-6868")
+
+  def test_register_finalizations(self):
+    raise unittest.SkipTest("BEAM-6868")
+
+  # Inherits all other tests.
+
+
+class FlinkRunnerTestOptimized(FlinkRunnerTest):
+  # TODO: Remove these tests after resolving BEAM-7248 and enabling
+  #  PortableRunnerOptimized
+  def create_options(self):
+    options = super(FlinkRunnerTestOptimized, self).create_options()
+    options.view_as(DebugOptions).experiments = [
+        'pre_optimize=all'
+    ] + options.view_as(DebugOptions).experiments
+    return options
+
+  def test_external_transform(self):
+    raise unittest.SkipTest("BEAM-7252")
+
+  def test_expand_kafka_read(self):
+    raise unittest.SkipTest("BEAM-7252")
+
+  def test_expand_kafka_write(self):
+    raise unittest.SkipTest("BEAM-7252")
+
+  def test_sql(self):
+    raise unittest.SkipTest("BEAM-7252")
+
+
+class FlinkRunnerTestStreaming(FlinkRunnerTest):
+  def create_options(self):
+    options = super(FlinkRunnerTestStreaming, self).create_options()
+    options.view_as(StandardOptions).streaming = True
+    return options
+
+
+if __name__ == '__main__':
   # Run the tests.
   logging.getLogger().setLevel(logging.INFO)
   unittest.main()

--- a/sdks/python/apache_beam/runners/portability/portable_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner_test.py
@@ -21,14 +21,10 @@ from __future__ import print_function
 
 import inspect
 import logging
-import platform
-import signal
 import socket
 import subprocess
 import sys
-import threading
 import time
-import traceback
 import unittest
 
 import grpc
@@ -56,37 +52,10 @@ from apache_beam.transforms import userstate
 _LOGGER = logging.getLogger(__name__)
 
 
-# Disable timeout since this test implements its own.
-# TODO(BEAM-9011): Consider using pytest-timeout's mechanism instead.
-@pytest.mark.timeout(0)
 class PortableRunnerTest(fn_runner_test.FnApiRunnerTest):
-
-  TIMEOUT_SECS = 600
 
   # Controls job service interaction, not sdk harness interaction.
   _use_subprocesses = False
-
-  def setUp(self):
-    if platform.system() != 'Windows':
-
-      def handler(signum, frame):
-        msg = 'Timed out after %s seconds.' % self.TIMEOUT_SECS
-        print('=' * 20, msg, '=' * 20)
-        traceback.print_stack(frame)
-        threads_by_id = {th.ident: th for th in threading.enumerate()}
-        for thread_id, stack in sys._current_frames().items():
-          th = threads_by_id.get(thread_id)
-          print()
-          print('# Thread:', th or thread_id)
-          traceback.print_stack(stack)
-        raise BaseException(msg)
-
-      signal.signal(signal.SIGALRM, handler)
-      signal.alarm(self.TIMEOUT_SECS)
-
-  def tearDown(self):
-    if platform.system() != 'Windows':
-      signal.alarm(0)
 
   @classmethod
   def _pick_unused_port(cls):

--- a/sdks/python/apache_beam/runners/portability/spark_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/spark_runner_test.py
@@ -21,141 +21,165 @@ from __future__ import print_function
 
 import argparse
 import logging
-import sys
+import shlex
 import unittest
 from shutil import rmtree
 from tempfile import mkdtemp
 
-from apache_beam.options.pipeline_options import DebugOptions
+import pytest
+
 from apache_beam.options.pipeline_options import PortableOptions
 from apache_beam.runners.portability import job_server
 from apache_beam.runners.portability import portable_runner
 from apache_beam.runners.portability import portable_runner_test
 
+# Run as
+#
+# pytest spark_runner_test.py \
+#     [--test_pipeline_options "--spark_job_server_jar=/path/to/job_server.jar \
+#                               --environment_type=DOCKER"] \
+#     [SparkRunnerTest.test_method, ...]
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class SparkRunnerTest(portable_runner_test.PortableRunnerTest):
+  _use_grpc = True
+  _use_subprocesses = True
+
+  expansion_port = None
+  spark_job_server_jar = None
+
+  @pytest.fixture(autouse=True)
+  def parse_options(self, request):
+    if not request.config.option.test_pipeline_options:
+      raise unittest.SkipTest(
+          'Skipping because --test-pipeline-options is not specified.')
+    test_pipeline_options = request.config.option.test_pipeline_options
+    parser = argparse.ArgumentParser(add_help=True)
+    parser.add_argument(
+        '--spark_job_server_jar',
+        help='Job server jar to submit jobs.',
+        action='store')
+    parser.add_argument(
+        '--environment_type',
+        default='LOOPBACK',
+        choices=['DOCKER', 'PROCESS', 'LOOPBACK'],
+        help='Set the environment type for running user code. DOCKER runs '
+        'user code in a container. PROCESS runs user code in '
+        'automatically started processes. LOOPBACK runs user code on '
+        'the same process that originally submitted the job.')
+    parser.add_argument(
+        '--environment_option',
+        '--environment_options',
+        dest='environment_options',
+        action='append',
+        default=None,
+        help=(
+            'Environment configuration for running the user code. '
+            'Recognized options depend on --environment_type.\n '
+            'For DOCKER: docker_container_image (optional)\n '
+            'For PROCESS: process_command (required), process_variables '
+            '(optional, comma-separated)\n '
+            'For EXTERNAL: external_service_address (required)'))
+    known_args, unknown_args = parser.parse_known_args(
+        shlex.split(test_pipeline_options))
+    if unknown_args:
+      _LOGGER.warning('Discarding unrecognized arguments %s' % unknown_args)
+    self.set_spark_job_server_jar(
+        known_args.spark_job_server_jar or
+        job_server.JavaJarJobServer.path_to_beam_jar(
+            ':runners:job-server:shadowJar'))
+    self.environment_type = known_args.environment_type
+    self.environment_options = known_args.environment_options
+
+  @classmethod
+  def _subprocess_command(cls, job_port, expansion_port):
+    # will be cleaned up at the end of this method, and recreated and used by
+    # the job server
+    tmp_dir = mkdtemp(prefix='sparktest')
+
+    cls.expansion_port = expansion_port
+
+    try:
+      return [
+          'java',
+          '-Dbeam.spark.test.reuseSparkContext=true',
+          '-jar',
+          cls.spark_job_server_jar,
+          '--spark-master-url',
+          'local',
+          '--artifacts-dir',
+          tmp_dir,
+          '--job-port',
+          str(job_port),
+          '--artifact-port',
+          '0',
+          '--expansion-port',
+          str(expansion_port),
+      ]
+    finally:
+      rmtree(tmp_dir)
+
+  @classmethod
+  def get_runner(cls):
+    return portable_runner.PortableRunner()
+
+  @classmethod
+  def get_expansion_service(cls):
+    # TODO Move expansion address resides into PipelineOptions
+    return 'localhost:%s' % cls.expansion_port
+
+  @classmethod
+  def set_spark_job_server_jar(cls, spark_job_server_jar):
+    cls.spark_job_server_jar = spark_job_server_jar
+
+  def create_options(self):
+    options = super(SparkRunnerTest, self).create_options()
+    options.view_as(PortableOptions).environment_type = self.environment_type
+    options.view_as(
+        PortableOptions).environment_options = self.environment_options
+
+    return options
+
+  def test_metrics(self):
+    # Skip until Spark runner supports metrics.
+    raise unittest.SkipTest("BEAM-7219")
+
+  def test_sdf(self):
+    # Skip until Spark runner supports SDF.
+    raise unittest.SkipTest("BEAM-7222")
+
+  def test_sdf_with_watermark_tracking(self):
+    # Skip until Spark runner supports SDF.
+    raise unittest.SkipTest("BEAM-7222")
+
+  def test_sdf_with_sdf_initiated_checkpointing(self):
+    # Skip until Spark runner supports SDF.
+    raise unittest.SkipTest("BEAM-7222")
+
+  def test_sdf_synthetic_source(self):
+    # Skip until Spark runner supports SDF.
+    raise unittest.SkipTest("BEAM-7222")
+
+  def test_callbacks_with_exception(self):
+    # Skip until Spark runner supports bundle finalization.
+    raise unittest.SkipTest("BEAM-7233")
+
+  def test_register_finalizations(self):
+    # Skip until Spark runner supports bundle finalization.
+    raise unittest.SkipTest("BEAM-7233")
+
+  def test_flattened_side_input(self):
+    # Blocked on support for transcoding
+    # https://jira.apache.org/jira/browse/BEAM-7236
+    super(SparkRunnerTest,
+          self).test_flattened_side_input(with_transcoding=False)
+
+  # Inherits all other tests from PortableRunnerTest.
+
+
 if __name__ == '__main__':
-  # Run as
-  #
-  # python -m apache_beam.runners.portability.spark_runner_test \
-  #     --spark_job_server_jar=/path/to/job_server.jar \
-  #     [SparkRunnerTest.test_method, ...]
-
-  parser = argparse.ArgumentParser(add_help=True)
-  parser.add_argument(
-      '--spark_job_server_jar', help='Job server jar to submit jobs.')
-  parser.add_argument(
-      '--environment_type',
-      default='loopback',
-      help='Environment type. docker, process, or loopback')
-  parser.add_argument('--environment_config', help='Environment config.')
-  parser.add_argument(
-      '--environment_cache_millis',
-      help='Environment cache TTL in milliseconds.')
-  parser.add_argument(
-      '--extra_experiments',
-      default=[],
-      action='append',
-      help='Beam experiments config.')
-  known_args, args = parser.parse_known_args(sys.argv)
-  sys.argv = args
-
-  spark_job_server_jar = (
-      known_args.spark_job_server_jar or
-      job_server.JavaJarJobServer.path_to_beam_jar(
-          ':runners:spark:job-server:shadowJar'))
-  environment_type = known_args.environment_type.lower()
-  environment_config = (
-      known_args.environment_config if known_args.environment_config else None)
-  environment_cache_millis = known_args.environment_cache_millis
-  extra_experiments = known_args.extra_experiments
-
-  # This is defined here to only be run when we invoke this file explicitly.
-  class SparkRunnerTest(portable_runner_test.PortableRunnerTest):
-    _use_grpc = True
-    _use_subprocesses = True
-
-    @classmethod
-    def _subprocess_command(cls, job_port, expansion_port):
-      # will be cleaned up at the end of this method, and recreated and used by
-      # the job server
-      tmp_dir = mkdtemp(prefix='sparktest')
-
-      try:
-        return [
-            'java',
-            '-Dbeam.spark.test.reuseSparkContext=true',
-            '-jar',
-            spark_job_server_jar,
-            '--spark-master-url',
-            'local',
-            '--artifacts-dir',
-            tmp_dir,
-            '--job-port',
-            str(job_port),
-            '--artifact-port',
-            '0',
-            '--expansion-port',
-            str(expansion_port),
-        ]
-      finally:
-        rmtree(tmp_dir)
-
-    @classmethod
-    def get_runner(cls):
-      return portable_runner.PortableRunner()
-
-    def create_options(self):
-      options = super(SparkRunnerTest, self).create_options()
-      options.view_as(
-          DebugOptions).experiments = ['beam_fn_api'] + extra_experiments
-      portable_options = options.view_as(PortableOptions)
-      portable_options.environment_type = environment_type.upper()
-      if environment_config:
-        portable_options.environment_config = environment_config
-      if environment_cache_millis:
-        portable_options.environment_cache_millis = environment_cache_millis
-
-      return options
-
-    def test_metrics(self):
-      # Skip until Spark runner supports metrics.
-      raise unittest.SkipTest("BEAM-7219")
-
-    def test_sdf(self):
-      # Skip until Spark runner supports SDF.
-      raise unittest.SkipTest("BEAM-7222")
-
-    def test_sdf_with_watermark_tracking(self):
-      # Skip until Spark runner supports SDF.
-      raise unittest.SkipTest("BEAM-7222")
-
-    def test_sdf_with_sdf_initiated_checkpointing(self):
-      # Skip until Spark runner supports SDF.
-      raise unittest.SkipTest("BEAM-7222")
-
-    def test_sdf_synthetic_source(self):
-      # Skip until Spark runner supports SDF.
-      raise unittest.SkipTest("BEAM-7222")
-
-    def test_external_transforms(self):
-      # Skip until Spark runner supports external transforms.
-      raise unittest.SkipTest("BEAM-7232")
-
-    def test_callbacks_with_exception(self):
-      # Skip until Spark runner supports bundle finalization.
-      raise unittest.SkipTest("BEAM-7233")
-
-    def test_register_finalizations(self):
-      # Skip until Spark runner supports bundle finalization.
-      raise unittest.SkipTest("BEAM-7233")
-
-    def test_flattened_side_input(self):
-      # Blocked on support for transcoding
-      # https://jira.apache.org/jira/browse/BEAM-7236
-      super(SparkRunnerTest,
-            self).test_flattened_side_input(with_transcoding=False)
-
-    # Inherits all other tests from PortableRunnerTest.
-
   # Run the tests.
   logging.getLogger().setLevel(logging.INFO)
   unittest.main()

--- a/sdks/python/conftest.py
+++ b/sdks/python/conftest.py
@@ -24,6 +24,11 @@ from apache_beam.options import pipeline_options
 
 MAX_SUPPORTED_PYTHON_VERSION = (3, 8)
 
+def pytest_addoption(parser):
+  parser.addoption('--test-pipeline-options',
+                   help='Options to use in test pipelines. NOTE: Tests may '
+                        'ignore some or all of these options.')
+
 # See pytest.ini for main collection rules.
 collect_ignore_glob = []
 if sys.version_info < (3,):

--- a/sdks/python/scripts/pytest_validates_runner.sh
+++ b/sdks/python/scripts/pytest_validates_runner.sh
@@ -1,0 +1,38 @@
+#!/bin/bash
+#
+#    Licensed to the Apache Software Foundation (ASF) under one or more
+#    contributor license agreements.  See the NOTICE file distributed with
+#    this work for additional information regarding copyright ownership.
+#    The ASF licenses this file to You under the Apache License, Version 2.0
+#    (the "License"); you may not use this file except in compliance with
+#    the License.  You may obtain a copy of the License at
+#
+#       http://www.apache.org/licenses/LICENSE-2.0
+#
+#    Unless required by applicable law or agreed to in writing, software
+#    distributed under the License is distributed on an "AS IS" BASIS,
+#    WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+#    See the License for the specific language governing permissions and
+#    limitations under the License.
+#
+# Utility script for tox.ini for running validates runner tests via pytest.
+
+# Usage check.
+if [[ $# < 2 ]]; then
+  printf "Wrong number of arguments (found $#, expected 2+). Usage:\n"
+  printf "$> ./scripts/pytest_validates_runner.sh <envname> <testFile> <posarg>\n"
+  printf "\tenvname: suite base name.\n"
+  printf "\ttestFile: the file to test.\n"
+  printf "\tAdditional options will be passed as --test-pipeline-options.\n"
+  exit 1
+fi
+
+set -e
+
+envname=${1?First argument required: suite base name}
+shift;
+testFile=${1?Second argument required: test file path}
+shift;
+
+# Assume test pipeline options are double-escaped.
+pytest -o junit_suite_name=${envname} --junitxml=pytest_${envname}.xml ${testFile} "--test-pipeline-options=$@"

--- a/sdks/python/test-suites/portable/common.gradle
+++ b/sdks/python/test-suites/portable/common.gradle
@@ -20,66 +20,38 @@ import org.apache.tools.ant.taskdefs.condition.Os
 
 def pythonRootDir = "${rootDir}/sdks/python"
 def pythonVersionSuffix = project.ext.pythonVersion == '2.7' ? '2' : project.ext.pythonVersion.replace('.', '')
-def pythonContainerTask = ":sdks:python:container:py${pythonVersionSuffix}:docker"
 
-class CompatibilityMatrixConfig {
-  // Execute batch or streaming pipelines.
-  boolean streaming = false
-  // Execute on Docker or Process based environment.
-  SDK_WORKER_TYPE workerType = SDK_WORKER_TYPE.DOCKER
+ext {
+  pythonContainerTask = ":sdks:python:container:py${pythonVersionSuffix}:docker"
+}
 
-  enum SDK_WORKER_TYPE {
-    DOCKER, PROCESS, LOOPBACK
+def createFlinkRunnerTestTask(String workerType) {
+  def taskName = "flinkCompatibilityMatrix${workerType}"
+  // `project(':runners:flink:1.10:job-server').shadowJar.archivePath` is not resolvable until runtime, so hard-code it here.
+  def jobServerJar = "${rootDir}/runners/flink/1.10/job-server/build/libs/beam-runners-flink-1.10-job-server-${version}.jar"
+  def options = "--flink_job_server_jar=${jobServerJar} --environment_type=${workerType}"
+  if (workerType == 'PROCESS') {
+    options += " --environment_options=process_command=${buildDir.absolutePath}/sdk_worker.sh"
   }
-
-  // Whether to pre-optimize the pipeline with the Python optimizer.
-  boolean preOptimize = false
-}
-
-def flinkCompatibilityMatrix = {
-  def config = it ? it as CompatibilityMatrixConfig : new CompatibilityMatrixConfig()
-  def workerType = config.workerType.name()
-  def streaming = config.streaming
-  def environment_config = config.workerType == CompatibilityMatrixConfig.SDK_WORKER_TYPE.PROCESS ? "--environment_config='{\"command\": \"${buildDir.absolutePath}/sdk_worker.sh\"}'" : ""
-  def name = "flinkCompatibilityMatrix${streaming ? 'Streaming' : 'Batch'}${config.preOptimize ? 'PreOptimize' : ''}${workerType}"
-  def extra_experiments = []
-  if (config.preOptimize)
-    extra_experiments.add('pre_optimize=all')
-  tasks.create(name: name) {
-    dependsOn 'setupVirtualenv'
-    dependsOn ':runners:flink:1.10:job-server:shadowJar'
-    dependsOn ':sdks:java:container:docker' // required for test_external_transforms
-    if (workerType.toLowerCase() == 'docker')
-      dependsOn pythonContainerTask
-    else if (workerType.toLowerCase() == 'process')
-      dependsOn 'createProcessWorker'
-    doLast {
-      exec {
-        executable 'sh'
-        args '-c', ". ${envdir}/bin/activate && cd ${pythonRootDir} && pip install -e .[test] && python -m apache_beam.runners.portability.flink_runner_test --flink_job_server_jar=${project(":runners:flink:1.10:job-server:").shadowJar.archivePath} --environment_type=${workerType} ${environment_config} ${streaming ? '--streaming' : ''} ${extra_experiments ? '--extra_experiments=' + extra_experiments.join(',') : ''}"
-      }
-    }
+  def task = toxTask(taskName, 'flink-runner-test', options)
+  // Through the Flink job server, we transitively add dependencies on the expansion services needed in tests.
+  task.dependsOn ':runners:flink:1.10:job-server:shadowJar'
+  // The Java SDK worker is required to execute external transforms.
+  task.dependsOn ':sdks:java:container:docker'
+  if (workerType == 'DOCKER') {
+    task.dependsOn ext.pythonContainerTask
+  } else if (workerType == 'PROCESS') {
+    task.dependsOn 'createProcessWorker'
   }
+  return task
 }
 
-task flinkCompatibilityMatrixDocker() {
-  dependsOn flinkCompatibilityMatrix(streaming: false)
-  dependsOn flinkCompatibilityMatrix(streaming: true)
-}
-
-task flinkCompatibilityMatrixProcess() {
-  dependsOn flinkCompatibilityMatrix(streaming: false, workerType: CompatibilityMatrixConfig.SDK_WORKER_TYPE.PROCESS)
-  dependsOn flinkCompatibilityMatrix(streaming: true, workerType: CompatibilityMatrixConfig.SDK_WORKER_TYPE.PROCESS)
-}
-
-task flinkCompatibilityMatrixLoopback() {
-  dependsOn flinkCompatibilityMatrix(streaming: false, workerType: CompatibilityMatrixConfig.SDK_WORKER_TYPE.LOOPBACK)
-  dependsOn flinkCompatibilityMatrix(streaming: true, workerType: CompatibilityMatrixConfig.SDK_WORKER_TYPE.LOOPBACK)
-  dependsOn flinkCompatibilityMatrix(streaming: true, workerType: CompatibilityMatrixConfig.SDK_WORKER_TYPE.LOOPBACK, preOptimize: true)
-}
+createFlinkRunnerTestTask('DOCKER')
+createFlinkRunnerTestTask('PROCESS')
+createFlinkRunnerTestTask('LOOPBACK')
 
 task flinkValidatesRunner() {
-  dependsOn 'flinkCompatibilityMatrixLoopback'
+  dependsOn 'flinkCompatibilityMatrixLOOPBACK'
 }
 
 // TODO(BEAM-8598): Enable on pre-commit.
@@ -146,52 +118,30 @@ task createProcessWorker {
   }
 }
 
-def sparkCompatibilityMatrix = {
-  def config = it ? it as CompatibilityMatrixConfig : new CompatibilityMatrixConfig()
-  def workerType = config.workerType.name()
-  def streaming = config.streaming
-  def environment_config = config.workerType == CompatibilityMatrixConfig.SDK_WORKER_TYPE.PROCESS ? "--environment_config='{\"command\": \"${buildDir.absolutePath}/sdk_worker.sh\"}'" : ""
-  def name = "sparkCompatibilityMatrix${streaming ? 'Streaming' : 'Batch'}${config.preOptimize ? 'PreOptimize' : ''}${workerType}"
-  tasks.create(name: name) {
-    dependsOn 'createProcessWorker'
-    dependsOn 'setupVirtualenv'
-    dependsOn ':runners:spark:job-server:shadowJar'
-    doLast {
-      def argMap = [
-              "environment_type"    : workerType,
-              "spark_job_server_jar": project(":runners:spark:job-server:").shadowJar.archivePath,
-              "environment_cache_millis": 10000,
-      ]
-      def argString = mapToArgString(argMap)
-
-      // Optionally specify test function names separated by space e.g.:
-      // ./gradlew :sdks:python:test-suites:portable:py37:sparkValidatesRunner -Ptests="test_external_transforms test_read"
-      // Otherwise run all test functions under SparkRunnerTest
-      def tests = project.hasProperty('tests') ?
-              project.property('tests').split().collect{ "SparkRunnerTest.$it" }.join(' ') : ''
-
-      exec {
-        executable 'sh'
-        args '-c', ". ${envdir}/bin/activate && cd ${pythonRootDir} && pip install -e .[test] && python -m apache_beam.runners.portability.spark_runner_test $tests $argString ${environment_config}"
-      }
-    }
+def createSparkRunnerTestTask(String workerType) {
+  def taskName = "sparkCompatibilityMatrix${workerType}"
+  // `project(':runners:spark:job-server').shadowJar.archivePath` is not resolvable until runtime, so hard-code it here.
+  def jobServerJar = "${rootDir}/runners/spark/job-server/build/libs/beam-runners-spark-job-server-${version}.jar"
+  def options = "--spark_job_server_jar=${jobServerJar} --environment_type=${workerType}"
+  if (workerType == 'PROCESS') {
+    options += " --environment_options=process_command=${buildDir.absolutePath}/sdk_worker.sh"
   }
+  def task = toxTask(taskName, 'spark-runner-test', options)
+  task.dependsOn ':runners:spark:job-server:shadowJar'
+  if (workerType == 'DOCKER') {
+    task.dependsOn ext.pythonContainerTask
+  } else if (workerType == 'PROCESS') {
+    task.dependsOn 'createProcessWorker'
+  }
+  return task
 }
 
-task sparkCompatibilityMatrixDocker() {
-  dependsOn sparkCompatibilityMatrix(streaming: false)
-}
-
-task sparkCompatibilityMatrixProcess() {
-  dependsOn sparkCompatibilityMatrix(streaming: false, workerType: CompatibilityMatrixConfig.SDK_WORKER_TYPE.PROCESS)
-}
-
-task sparkCompatibilityMatrixLoopback() {
-  dependsOn sparkCompatibilityMatrix(streaming: false, workerType: CompatibilityMatrixConfig.SDK_WORKER_TYPE.LOOPBACK)
-}
+createSparkRunnerTestTask('DOCKER')
+createSparkRunnerTestTask('PROCESS')
+createSparkRunnerTestTask('LOOPBACK')
 
 task sparkValidatesRunner() {
-  dependsOn 'sparkCompatibilityMatrixLoopback'
+  dependsOn 'sparkCompatibilityMatrixLOOPBACK'
 }
 
 project.task("preCommitPy${pythonVersionSuffix}") {

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -275,3 +275,13 @@ deps =
 commands =
   time {toxinidir}/scripts/setup_nodejs.sh
   time {toxinidir}/scripts/run_eslint.sh
+
+[testenv:flink-runner-test]
+extras = test
+commands =
+  {toxinidir}/scripts/pytest_validates_runner.sh {envname} {toxinidir}/apache_beam/runners/portability/flink_runner_test.py {posargs}
+
+[testenv:spark-runner-test]
+extras = test
+commands =
+  {toxinidir}/scripts/pytest_validates_runner.sh {envname} {toxinidir}/apache_beam/runners/portability/spark_runner_test.py {posargs}


### PR DESCRIPTION
# Motivation

The main goals of migrating to pytest are:

1. Get Junit structured test output (BEAM-10527).
2. Replace PortableRunnerTest's bespoke timeout mechanism with pytest's (BEAM-9011). ~This also implicitly raises the timeout for all these tests from 60s to 600s, which should reduce the likelihood of timeout flakes (BEAM-8912).~

# Implementation

I originally wanted to do this in incremental changes, but I gradually realized a complete overhaul of these tests' configuration was needed. The main challenge was that `flink_runner_test.py` expected to be run as `__main__`, which is impossible with pytest. I basically reworked everything except the tests themselves; the tests themselves are unchanged.

## Test parametrization

- I left worker configuration in Gradle because it changes the test dependencies. I moved optimization and streaming into `flink_runner_test.py` because it removes the need to set up separate tox tasks, separate test result files, etc.
- Since `flink_job_server_driver`, `environment_type`, and `environment_config` are all pipeline options, I decided to pass them to `flink_runner_test.py` by introducing a global pytest option, `--test-pipeline-options`. `nose` uses `--test-pipeline-options` for integration tests, so I figured this would be generally useful beyond just these tests in the future.

# Bonus trivia

Prior to this change, we were running the exact same streaming test suite *four times* per Jenkins run.

Every `flinkCompatibilityMatrix` task ran the entirety of `flink_runner_test.py` which contained two classes: `FlinkRunnerTest` and `FlinkRunnerTestOptimized`. `FlinkRunnerTestOptimized` was basically the same thing as `FlinkRunnerTest`, but it added the `pre_optimize=all` experiment and skipped external transform tests, since the Python optimizer breaks external transforms (BEAM-7252). But we were *also* adding `pre_optimize=all` in Gradle, redundantly.

The old configuration looks like this:

```groovy
dependsOn flinkCompatibilityMatrix(streaming: false, workerType: CompatibilityMatrixConfig.SDK_WORKER_TYPE.LOOPBACK)
dependsOn flinkCompatibilityMatrix(streaming: true, workerType: CompatibilityMatrixConfig.SDK_WORKER_TYPE.LOOPBACK)
dependsOn flinkCompatibilityMatrix(streaming: true, workerType: CompatibilityMatrixConfig.SDK_WORKER_TYPE.LOOPBACK, preOptimize: true)
```

Notice that pre-optimized batch is missing. This is because `flinkCompatibilityMatrixBatchPreOptimize*` would run `FlinkRunnerTest` with `pre_optimize=all` but without skipping the external transform tests, causing failure.

What about streaming, then? Well, the optimizer *doesn't affect streaming pipelines at all*: https://github.com/apache/beam/blob/489cf2cbf335f372060469953ed7599f2838a591/sdks/python/apache_beam/runners/portability/portable_runner.py#L319

So in one invocation of `flinkValidatesRunner`, `flinkCompatibilityMatrixStreamingLoopback` would run `FlinkRunnerTest` (without `pre_optimize=all`) and `FlinkRunnerTestOptimized`, then `flinkCompatibilityMatrixStreamingPreOptimizeLoopback` would run `FlinkRunnerTest` (with `pre_optimize=all`) and `FlinkRunnerTestOptimized` (with `pre_optimize=all` twice). Besides the skips in `FlinkRunnerTestOptimized`, all four tests would be doing the exact same thing.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
