### PR TITLE
[BEAM-10619] Report ratio of implemented pandas tests

### DIFF
--- a/sdks/python/apache_beam/dataframe/doctests.py
+++ b/sdks/python/apache_beam/dataframe/doctests.py
@@ -377,13 +377,13 @@ def teststring(text, report=True, **runner_kwargs):
   optionflags |= (
       doctest.NORMALIZE_WHITESPACE | doctest.IGNORE_EXCEPTION_DETAIL)
 
-  wont_implement = runner_kwargs.pop('wont_implement', False)
+  wont_implement_ok = runner_kwargs.pop('wont_implement_ok', False)
 
   parser = doctest.DocTestParser()
   runner = BeamDataframeDoctestRunner(
       TestEnvironment(),
       optionflags=optionflags,
-      wont_implement={'<string>': ['*']} if wont_implement else None,
+      wont_implement_ok ={'<string>': ['*']} if wont_implement_ok else None,
       **runner_kwargs)
   test = parser.get_doctest(
       text, {

--- a/sdks/python/apache_beam/dataframe/doctests.py
+++ b/sdks/python/apache_beam/dataframe/doctests.py
@@ -38,6 +38,8 @@ The (novel) sequence of events when running a doctest is as follows.
 """
 
 from __future__ import absolute_import
+from __future__ import division
+from __future__ import print_function
 
 import collections
 import contextlib
@@ -273,7 +275,8 @@ class BeamDataframeDoctestRunner(doctest.DocTestRunner):
   """A Doctest runner suitable for replacing the `pd` module with one backed
   by beam.
   """
-  def __init__(self, env, use_beam=True, skip=None, **kwargs):
+  def __init__(
+      self, env, use_beam=True, wont_implement=None, skip=None, **kwargs):
     self._test_env = env
 
     def to_callable(cond):
@@ -282,6 +285,11 @@ class BeamDataframeDoctestRunner(doctest.DocTestRunner):
       else:
         return lambda example: example.source.strip() == cond
 
+    self._wont_implement = {
+        test: [to_callable(cond) for cond in examples]
+        for test,
+        examples in (wont_implement or {}).items()
+    }
     self._skip = {
         test: [to_callable(cond) for cond in examples]
         for test,
@@ -290,24 +298,78 @@ class BeamDataframeDoctestRunner(doctest.DocTestRunner):
     super(BeamDataframeDoctestRunner, self).__init__(
         checker=_DeferrredDataframeOutputChecker(self._test_env, use_beam),
         **kwargs)
+    self.success = 0
+    self.skipped = 0
+    self.wont_implement = 0
+    self._wont_implement_reasons = []
+    self._skipped_set = set()
 
   def run(self, test, **kwargs):
     self._checker.reset()
-    if test.name in self._skip:
-      for example in test.examples:
-        if any(should_skip(example) for should_skip in self._skip[test.name]):
-          example.source = 'pass'
-          example.want = ''
     for example in test.examples:
-      if example.exc_msg is None:
+      if any(should_skip(example)
+             for should_skip in self._skip.get(test.name, [])):
+        self._skipped_set.add(example)
+        example.source = 'pass'
+        example.want = ''
+        self.skipped += 1
+      elif example.exc_msg is None and any(
+          wont_implement(example)
+          for wont_implement in self._wont_implement.get(test.name, [])):
         # Don't fail doctests that raise this error.
         example.exc_msg = (
             'apache_beam.dataframe.frame_base.WontImplementError: ...')
+        self.wont_implement += 1
     with self._test_env.context():
-      return super(BeamDataframeDoctestRunner, self).run(test, **kwargs)
+      result = super(BeamDataframeDoctestRunner, self).run(test, **kwargs)
+      return result
+
+  def report_success(self, out, test, example, got):
+    def extract_concise_reason(got):
+      m = re.search(r"(WontImplementError:.*)\n$", got)
+      if m:
+        return m.group(1)
+      elif "NameError" in got:
+        return "NameError"
+      elif re.match(r"DeferredBase\[\d+\]\n", got):
+        return "DeferredBase[*]"
+      else:
+        return got.replace("\n", "\\n")
+
+    if example.exc_msg == (
+        'apache_beam.dataframe.frame_base.WontImplementError: ...'):
+      self._wont_implement_reasons.append(extract_concise_reason(got))
+
+    return super(BeamDataframeDoctestRunner,
+                 self).report_success(out, test, example, got)
 
   def fake_pandas_module(self):
     return self._test_env.fake_pandas_module()
+
+  def summarize(self):
+    super(BeamDataframeDoctestRunner, self).summarize()
+    if self.failures:
+      return
+
+    def print_partition(indent, desc, n, total):
+      print("%s%d %s (%.1f%%)" % ("  " * indent, n, desc, n / total * 100))
+
+    print()
+    print("%d total test cases:" % self.tries)
+    print_partition(1, "skipped", self.skipped, self.tries)
+    print_partition(1, "won't implement", self.wont_implement, self.tries)
+    reason_counts = sorted(
+        collections.Counter(self._wont_implement_reasons).items(),
+        key=lambda x: x[1],
+        reverse=True)
+    for desc, count in reason_counts:
+      print_partition(2, desc, count, self.wont_implement)
+    print_partition(
+        1,
+        "passed",
+        self.tries - self.skipped - self.wont_implement - self.failures,
+        self.tries)
+    print()
 
 
 def teststring(text, report=True, **runner_kwargs):
@@ -315,9 +377,14 @@ def teststring(text, report=True, **runner_kwargs):
   optionflags |= (
       doctest.NORMALIZE_WHITESPACE | doctest.IGNORE_EXCEPTION_DETAIL)
 
+  wont_implement = runner_kwargs.pop('wont_implement', False)
+
   parser = doctest.DocTestParser()
   runner = BeamDataframeDoctestRunner(
-      TestEnvironment(), optionflags=optionflags, **runner_kwargs)
+      TestEnvironment(),
+      optionflags=optionflags,
+      wont_implement={'<string>': ['*']} if wont_implement else None,
+      **runner_kwargs)
   test = parser.get_doctest(
       text, {
           'pd': runner.fake_pandas_module(), 'np': np
@@ -355,12 +422,17 @@ def _run_patched(func, *args, **kwargs):
     env = TestEnvironment()
     use_beam = kwargs.pop('use_beam', True)
     skip = kwargs.pop('skip', {})
+    wont_implement = kwargs.pop('wont_implement', {})
     extraglobs = dict(kwargs.pop('extraglobs', {}))
     extraglobs['pd'] = env.fake_pandas_module()
     # Unfortunately the runner is not injectable.
     original_doc_test_runner = doctest.DocTestRunner
     doctest.DocTestRunner = lambda **kwargs: BeamDataframeDoctestRunner(
-        env, use_beam=use_beam, skip=skip, **kwargs)
+        env,
+        use_beam=use_beam,
+        wont_implement=wont_implement,
+        skip=skip,
+        **kwargs)
     with expressions.allow_non_parallel_operations():
       return func(
           *args, extraglobs=extraglobs, optionflags=optionflags, **kwargs)

--- a/sdks/python/apache_beam/dataframe/doctests.py
+++ b/sdks/python/apache_beam/dataframe/doctests.py
@@ -383,7 +383,7 @@ def teststring(text, report=True, **runner_kwargs):
   runner = BeamDataframeDoctestRunner(
       TestEnvironment(),
       optionflags=optionflags,
-      wont_implement_ok ={'<string>': ['*']} if wont_implement_ok else None,
+      wont_implement_ok={'<string>': ['*']} if wont_implement_ok else None,
       **runner_kwargs)
   test = parser.get_doctest(
       text, {

--- a/sdks/python/apache_beam/dataframe/doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/doctests_test.py
@@ -116,7 +116,9 @@ class DoctestTest(unittest.TestCase):
 
   def test_wont_implement(self):
     doctests.teststring(
-        ERROR_RAISING_TESTS, optionflags=doctest.ELLIPSIS, wont_implement_ok=True)
+        ERROR_RAISING_TESTS,
+        optionflags=doctest.ELLIPSIS,
+        wont_implement_ok=True)
     doctests.teststring(
         ERROR_RAISING_TESTS,
         optionflags=doctest.IGNORE_EXCEPTION_DETAIL,

--- a/sdks/python/apache_beam/dataframe/doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/doctests_test.py
@@ -116,17 +116,17 @@ class DoctestTest(unittest.TestCase):
 
   def test_wont_implement(self):
     doctests.teststring(
-        ERROR_RAISING_TESTS, optionflags=doctest.ELLIPSIS, wont_implement=True)
+        ERROR_RAISING_TESTS, optionflags=doctest.ELLIPSIS, wont_implement_ok=True)
     doctests.teststring(
         ERROR_RAISING_TESTS,
         optionflags=doctest.IGNORE_EXCEPTION_DETAIL,
-        wont_implement=True)
+        wont_implement_ok=True)
 
   def test_wont_implement_followed_by_name_error(self):
     result = doctests.teststring(
         ERROR_RAISING_NAME_ERROR_TESTS,
         optionflags=doctest.ELLIPSIS,
-        wont_implement=True)
+        wont_implement_ok=True)
     self.assertEqual(result.attempted, 6)
     self.assertEqual(result.failed, 1)  # Only the very last one.
 

--- a/sdks/python/apache_beam/dataframe/doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/doctests_test.py
@@ -115,13 +115,18 @@ class DoctestTest(unittest.TestCase):
     self.assertEqual(result.failed, 0)
 
   def test_wont_implement(self):
-    doctests.teststring(ERROR_RAISING_TESTS, optionflags=doctest.ELLIPSIS)
     doctests.teststring(
-        ERROR_RAISING_TESTS, optionflags=doctest.IGNORE_EXCEPTION_DETAIL)
+        ERROR_RAISING_TESTS, optionflags=doctest.ELLIPSIS, wont_implement=True)
+    doctests.teststring(
+        ERROR_RAISING_TESTS,
+        optionflags=doctest.IGNORE_EXCEPTION_DETAIL,
+        wont_implement=True)
 
   def test_wont_implement_followed_by_name_error(self):
     result = doctests.teststring(
-        ERROR_RAISING_NAME_ERROR_TESTS, optionflags=doctest.ELLIPSIS)
+        ERROR_RAISING_NAME_ERROR_TESTS,
+        optionflags=doctest.ELLIPSIS,
+        wont_implement=True)
     self.assertEqual(result.attempted, 6)
     self.assertEqual(result.failed, 1)  # Only the very last one.
 

--- a/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
@@ -32,7 +32,7 @@ class DoctestTest(unittest.TestCase):
         pd.core.frame,
         use_beam=False,
         report=True,
-        wont_implement={
+        wont_implement_ok={
             'pandas.core.frame.DataFrame.T': ['*'],
             'pandas.core.frame.DataFrame.cummax': ['*'],
             'pandas.core.frame.DataFrame.cummin': ['*'],
@@ -114,7 +114,7 @@ class DoctestTest(unittest.TestCase):
         pd.core.series,
         use_beam=False,
         report=True,
-        wont_implement={
+        wont_implement_ok={
             'pandas.core.series.Series.__array__': ['*'],
             'pandas.core.series.Series.cummax': ['*'],
             'pandas.core.series.Series.cummin': ['*'],

--- a/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
@@ -31,8 +31,31 @@ class DoctestTest(unittest.TestCase):
     result = doctests.testmod(
         pd.core.frame,
         use_beam=False,
-        skip={
+        report=True,
+        wont_implement={
             'pandas.core.frame.DataFrame.T': ['*'],
+            'pandas.core.frame.DataFrame.cummax': ['*'],
+            'pandas.core.frame.DataFrame.cummin': ['*'],
+            'pandas.core.frame.DataFrame.cumsum': ['*'],
+            'pandas.core.frame.DataFrame.cumprod': ['*'],
+            'pandas.core.frame.DataFrame.diff': ['*'],
+            'pandas.core.frame.DataFrame.items': ['*'],
+            'pandas.core.frame.DataFrame.itertuples': ['*'],
+            'pandas.core.frame.DataFrame.iterrows': ['*'],
+            'pandas.core.frame.DataFrame.iteritems': ['*'],
+            'pandas.core.frame.DataFrame.to_records': ['*'],
+            'pandas.core.frame.DataFrame.to_dict': ['*'],
+            'pandas.core.frame.DataFrame.to_numpy': ['*'],
+            'pandas.core.frame.DataFrame.to_string': ['*'],
+            'pandas.core.frame.DataFrame.transpose': ['*'],
+            'pandas.core.frame.DataFrame.shape': ['*'],
+            'pandas.core.frame.DataFrame.unstack': ['*'],
+            'pandas.core.frame.DataFrame.memory_usage': ['*'],
+        },
+        skip={
+            'pandas.core.frame.DataFrame.T': [
+                'df1_transposed.dtypes', 'df2_transposed.dtypes'
+            ],
             'pandas.core.frame.DataFrame.agg': ['*'],
             'pandas.core.frame.DataFrame.aggregate': ['*'],
             'pandas.core.frame.DataFrame.append': ['*'],
@@ -90,6 +113,16 @@ class DoctestTest(unittest.TestCase):
     result = doctests.testmod(
         pd.core.series,
         use_beam=False,
+        report=True,
+        wont_implement={
+            'pandas.core.series.Series.__array__': ['*'],
+            'pandas.core.series.Series.cummax': ['*'],
+            'pandas.core.series.Series.cummin': ['*'],
+            'pandas.core.series.Series.cumsum': ['*'],
+            'pandas.core.series.Series.cumprod': ['*'],
+            'pandas.core.series.Series.diff': ['*'],
+            'pandas.core.series.Series.unstack': ['*'],
+        },
         skip={
             'pandas.core.series.Series.append': ['*'],
             'pandas.core.series.Series.argmax': ['*'],


### PR DESCRIPTION
The report looks like this when run with `pytest -s`:
```
apache_beam/dataframe/pandas_doctests_test.py 829 total test cases.
722 will implement, 107 won't implement.
257 skipped.
69.0% (572/829) of all test cases pass or raise WontImplementError
.676 total test cases.
631 will implement, 45 won't implement.
265 skipped.
60.8% (411/676) of all test cases pass or raise WontImplementError
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.
