### PR TITLE
[BEAM-9932] Adding documentation to describe cross-language test pipelines

### DIFF
--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/ValidateRunnerXlangTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/ValidateRunnerXlangTest.java
@@ -54,7 +54,30 @@ import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/** Test External transforms. */
+/**
+ * Runner Validation Test Suite for Cross-language Transforms.
+ *
+ * <p>As per Beams's Portability Framework design, Cross-language transforms should work out of the
+ * box. In spite of this, there always exists a possibility of rough edges existing. It could be
+ * caused due to unpolished implementation of any part of the execution code path, for example: –>
+ * Transform expansion [SDK] –> Pipeline construction [SDK] –> Cross-language artifact staging
+ * [Runner] –> Language specific serialization/deserialization of PCollection (and other data types)
+ * [Runner/SDK]
+ *
+ * <p>In an effort to improve developer visibility into potential problems, this test suite
+ * validates correct execution of 5 Core Beam transforms when used as cross-language transforms
+ * within the Java SDK from any foreign SDK: –> ParDo
+ * (https://beam.apache.org/documentation/programming-guide/#pardo) –> GroupByKey
+ * (https://beam.apache.org/documentation/programming-guide/#groupbykey) –> CoGroupByKey
+ * (https://beam.apache.org/documentation/programming-guide/#cogroupbykey) –> Combine
+ * (https://beam.apache.org/documentation/programming-guide/#combine) –> Flatten
+ * (https://beam.apache.org/documentation/programming-guide/#flatten) –> Partition
+ * (https://beam.apache.org/documentation/programming-guide/#partition)
+ *
+ * <p>See Runner Validation Test Plan for Cross-language transforms
+ * (https://docs.google.com/document/d/1xQp0ElIV84b8OCVz8CD2hvbiWdR8w4BvWxPTZJZA6NA") for further
+ * details.
+ */
 @RunWith(JUnit4.class)
 public class ValidateRunnerXlangTest implements Serializable {
   @Rule public transient TestPipeline testPipeline = TestPipeline.create();
@@ -110,6 +133,14 @@ public class ValidateRunnerXlangTest implements Serializable {
     }
   }
 
+  /**
+   * Motivation behind singleInputOutputTest.
+   *
+   * <p>Target transform – ParDo (https://beam.apache.org/documentation/programming-guide/#pardo)
+   * Test scenario – Mapping elements from a single input collection to a single output collection
+   * Boundary conditions checked – –> PCollection<?> to external transforms –> PCollection<?> from
+   * external transforms
+   */
   @Test
   @Category({ValidatesRunner.class, UsesCrossLanguageTransforms.class})
   public void singleInputOutputTest() throws IOException {
@@ -120,6 +151,14 @@ public class ValidateRunnerXlangTest implements Serializable {
     PAssert.that(col).containsInAnyOrder("01", "02", "03");
   }
 
+  /**
+   * Motivation behind multiInputOutputWithSideInputTest.
+   *
+   * <p>Target transform – ParDo (https://beam.apache.org/documentation/programming-guide/#pardo)
+   * Test scenario – Mapping elements from multiple input collections (main and side) to multiple
+   * output collections (main and side) Boundary conditions checked – –> PCollectionTuple to
+   * external transforms –> PCollectionTuple from external transforms
+   */
   @Test
   @Category({ValidatesRunner.class, UsesCrossLanguageTransforms.class})
   public void multiInputOutputWithSideInputTest() {
@@ -135,6 +174,15 @@ public class ValidateRunnerXlangTest implements Serializable {
     PAssert.that(pTuple.get("side")).containsInAnyOrder("ss");
   }
 
+  /**
+   * Motivation behind groupByKeyTest.
+   *
+   * <p>Target transform – GroupByKey
+   * (https://beam.apache.org/documentation/programming-guide/#groupbykey) Test scenario – Grouping
+   * a collection of KV<K,V> to a collection of KV<K, Iterable<V>> by key Boundary conditions
+   * checked – –> PCollection<KV<?, ?>> to external transforms –> PCollection<KV<?, Iterable<?>>>
+   * from external transforms
+   */
   @Test
   @Category({ValidatesRunner.class, UsesCrossLanguageTransforms.class})
   public void groupByKeyTest() {
@@ -154,6 +202,15 @@ public class ValidateRunnerXlangTest implements Serializable {
     PAssert.that(col).containsInAnyOrder("0:1,2", "1:3");
   }
 
+  /**
+   * Motivation behind coGroupByKeyTest.
+   *
+   * <p>Target transform – CoGroupByKey
+   * (https://beam.apache.org/documentation/programming-guide/#cogroupbykey) Test scenario –
+   * Grouping multiple input collections with keys to a collection of KV<K, CoGbkResult> by key
+   * Boundary conditions checked – –> KeyedPCollectionTuple<?> to external transforms –>
+   * PCollection<KV<?, Iterable<?>>> from external transforms
+   */
   @Test
   @Category({ValidatesRunner.class, UsesCrossLanguageTransforms.class})
   public void coGroupByKeyTest() {
@@ -177,6 +234,14 @@ public class ValidateRunnerXlangTest implements Serializable {
     PAssert.that(col).containsInAnyOrder("0:1,2,4", "1:3,5,6");
   }
 
+  /**
+   * Motivation behind combineGloballyTest.
+   *
+   * <p>Target transform – Combine
+   * (https://beam.apache.org/documentation/programming-guide/#combine) Test scenario – Combining
+   * elements globally with a predefined simple CombineFn Boundary conditions checked – –>
+   * PCollection<?> to external transforms –> PCollection<?> from external transforms
+   */
   @Test
   @Category({ValidatesRunner.class, UsesCrossLanguageTransforms.class})
   public void combineGloballyTest() {
@@ -187,6 +252,14 @@ public class ValidateRunnerXlangTest implements Serializable {
     PAssert.that(col).containsInAnyOrder(6L);
   }
 
+  /**
+   * Motivation behind combinePerKeyTest.
+   *
+   * <p>Target transform – Combine
+   * (https://beam.apache.org/documentation/programming-guide/#combine) Test scenario – Combining
+   * elements per key with a predefined simple merging function Boundary conditions checked – –>
+   * PCollection<?> to external transforms –> PCollection<?> from external transforms
+   */
   @Test
   @Category({ValidatesRunner.class, UsesCrossLanguageTransforms.class})
   public void combinePerKeyTest() {
@@ -197,6 +270,14 @@ public class ValidateRunnerXlangTest implements Serializable {
     PAssert.that(col).containsInAnyOrder(KV.of("a", 3L), KV.of("b", 3L));
   }
 
+  /**
+   * Motivation behind flattenTest.
+   *
+   * <p>Target transform – Flatten
+   * (https://beam.apache.org/documentation/programming-guide/#flatten) Test scenario – Merging
+   * multiple collections into a single collection Boundary conditions checked – –>
+   * PCollectionList<?> to external transforms –> PCollection<?> from external transforms
+   */
   @Test
   @Category({ValidatesRunner.class, UsesCrossLanguageTransforms.class})
   public void flattenTest() {
@@ -209,6 +290,15 @@ public class ValidateRunnerXlangTest implements Serializable {
     PAssert.that(col).containsInAnyOrder(1L, 2L, 3L, 4L, 5L, 6L);
   }
 
+  /**
+   * Motivation behind partitionTest.
+   *
+   * <p>Target transform – Partition
+   * (https://beam.apache.org/documentation/programming-guide/#partition) Test scenario – Splitting
+   * a single collection into multiple collections with a predefined simple PartitionFn Boundary
+   * conditions checked – –> PCollection<?> to external transforms –> PCollectionList<?> from
+   * external transforms
+   */
   @Test
   @Category({ValidatesRunner.class, UsesCrossLanguageTransforms.class})
   public void partitionTest() {

--- a/sdks/python/apache_beam/transforms/validate_runner_xlang_test.py
+++ b/sdks/python/apache_beam/transforms/validate_runner_xlang_test.py
@@ -23,26 +23,26 @@ Runner Validation Test Suite for Cross-language Transforms
  should work out of the box. In spite of this, there always exists a
  possibility of rough edges existing. It could be caused due to unpolished
  implementation of any part of the execution code path, for example:
- –> Transform expansion [SDK]
- –> Pipeline construction [SDK]
- –> Cross-language artifact staging [Runner]
- –> Language specific serialization/deserialization of PCollection (and
+ - Transform expansion [SDK]
+ - Pipeline construction [SDK]
+ - Cross-language artifact staging [Runner]
+ - Language specific serialization/deserialization of PCollection (and
  other data types) [Runner/SDK]
 
  In an effort to improve developer visibility into potential problems,
  this test suite validates correct execution of 5 Core Beam transforms when
  used as cross-language transforms within the Python SDK from any foreign SDK:
-  –> ParDo
+  - ParDo
   (https://beam.apache.org/documentation/programming-guide/#pardo)
-  –> GroupByKey
+  - GroupByKey
   (https://beam.apache.org/documentation/programming-guide/#groupbykey)
-  –> CoGroupByKey
+  - CoGroupByKey
   (https://beam.apache.org/documentation/programming-guide/#cogroupbykey)
-  –> Combine
+  - Combine
   (https://beam.apache.org/documentation/programming-guide/#combine)
-  –> Flatten
+  - Flatten
   (https://beam.apache.org/documentation/programming-guide/#flatten)
-  –> Partition
+  - Partition
   (https://beam.apache.org/documentation/programming-guide/#partition)
 
   See Runner Validation Test Plan for Cross-language transforms at
@@ -83,13 +83,13 @@ class CrossLanguageTestPipelines(object):
 
   def run_prefix(self, pipeline):
     """
-    Target transform – ParDo
+    Target transform - ParDo
     (https://beam.apache.org/documentation/programming-guide/#pardo)
-    Test scenario – Mapping elements from a single input collection to a
+    Test scenario - Mapping elements from a single input collection to a
     single output collection
-    Boundary conditions checked –
-     –> PCollection<?> to external transforms
-     –> PCollection<?> from external transforms
+    Boundary conditions checked -
+     - PCollection<?> to external transforms
+     - PCollection<?> from external transforms
     """
     with pipeline as p:
       res = (
@@ -103,13 +103,13 @@ class CrossLanguageTestPipelines(object):
 
   def run_multi_input_output_with_sideinput(self, pipeline):
     """
-    Target transform – ParDo
+    Target transform - ParDo
     (https://beam.apache.org/documentation/programming-guide/#pardo)
-    Test scenario – Mapping elements from multiple input collections (main
+    Test scenario - Mapping elements from multiple input collections (main
     and side) to multiple output collections (main and side)
-    Boundary conditions checked –
-     –> PCollectionTuple to external transforms
-     –> PCollectionTuple from external transforms
+    Boundary conditions checked -
+     - PCollectionTuple to external transforms
+     - PCollectionTuple from external transforms
     """
     with pipeline as p:
       main1 = p | 'Main1' >> beam.Create(
@@ -125,13 +125,13 @@ class CrossLanguageTestPipelines(object):
 
   def run_group_by_key(self, pipeline):
     """
-    Target transform – GroupByKey
+    Target transform - GroupByKey
     (https://beam.apache.org/documentation/programming-guide/#groupbykey)
-    Test scenario – Grouping a collection of KV<K,V> to a collection of
+    Test scenario - Grouping a collection of KV<K,V> to a collection of
     KV<K, Iterable<V>> by key
-    Boundary conditions checked –
-     –> PCollection<KV<?, ?>> to external transforms
-     –> PCollection<KV<?, Iterable<?>>> from external transforms
+    Boundary conditions checked -
+     - PCollection<KV<?, ?>> to external transforms
+     - PCollection<KV<?, Iterable<?>>> from external transforms
     """
     with pipeline as p:
       res = (
@@ -145,13 +145,13 @@ class CrossLanguageTestPipelines(object):
 
   def run_cogroup_by_key(self, pipeline):
     """
-    Target transform – CoGroupByKey
+    Target transform - CoGroupByKey
     (https://beam.apache.org/documentation/programming-guide/#cogroupbykey)
-    Test scenario – Grouping multiple input collections with keys to a
+    Test scenario - Grouping multiple input collections with keys to a
     collection of KV<K, CoGbkResult> by key
-    Boundary conditions checked –
-     –> KeyedPCollectionTuple<?> to external transforms
-     –> PCollection<KV<?, Iterable<?>>> from external transforms
+    Boundary conditions checked -
+     - KeyedPCollectionTuple<?> to external transforms
+     - PCollection<KV<?, Iterable<?>>> from external transforms
     """
     with pipeline as p:
       col1 = p | 'create_col1' >> beam.Create(
@@ -168,13 +168,13 @@ class CrossLanguageTestPipelines(object):
 
   def run_combine_globally(self, pipeline):
     """
-    Target transform – Combine
+    Target transform - Combine
     (https://beam.apache.org/documentation/programming-guide/#combine)
-    Test scenario – Combining elements globally with a predefined simple
+    Test scenario - Combining elements globally with a predefined simple
     CombineFn
-    Boundary conditions checked –
-     –> PCollection<?> to external transforms
-     –> PCollection<?> from external transforms
+    Boundary conditions checked -
+     - PCollection<?> to external transforms
+     - PCollection<?> from external transforms
     """
     with pipeline as p:
       res = (
@@ -186,13 +186,13 @@ class CrossLanguageTestPipelines(object):
 
   def run_combine_per_key(self, pipeline):
     """
-    Target transform – Combine
+    Target transform - Combine
     (https://beam.apache.org/documentation/programming-guide/#combine)
-    Test scenario – Combining elements per key with a predefined simple
+    Test scenario - Combining elements per key with a predefined simple
     merging function
-    Boundary conditions checked –
-     –> PCollection<?> to external transforms
-     –> PCollection<?> from external transforms
+    Boundary conditions checked -
+     - PCollection<?> to external transforms
+     - PCollection<?> from external transforms
     """
     with pipeline as p:
       res = (
@@ -205,12 +205,12 @@ class CrossLanguageTestPipelines(object):
 
   def run_flatten(self, pipeline):
     """
-    Target transform – Flatten
+    Target transform - Flatten
     (https://beam.apache.org/documentation/programming-guide/#flatten)
-    Test scenario – Merging multiple collections into a single collection
-    Boundary conditions checked –
-     –> PCollectionList<?> to external transforms
-     –> PCollection<?> from external transforms
+    Test scenario - Merging multiple collections into a single collection
+    Boundary conditions checked -
+     - PCollectionList<?> to external transforms
+     - PCollection<?> from external transforms
     """
     with pipeline as p:
       col1 = p | 'col1' >> beam.Create([1, 2, 3]).with_output_types(int)
@@ -222,13 +222,13 @@ class CrossLanguageTestPipelines(object):
 
   def run_partition(self, pipeline):
     """
-    Target transform – Partition
+    Target transform - Partition
     (https://beam.apache.org/documentation/programming-guide/#partition)
-    Test scenario – Splitting a single collection into multiple collections
+    Test scenario - Splitting a single collection into multiple collections
     with a predefined simple PartitionFn
-    Boundary conditions checked –
-     –> PCollection<?> to external transforms
-     –> PCollectionList<?> from external transforms
+    Boundary conditions checked -
+     - PCollection<?> to external transforms
+     - PCollectionList<?> from external transforms
     """
     with pipeline as p:
       res = (

--- a/sdks/python/apache_beam/transforms/validate_runner_xlang_test.py
+++ b/sdks/python/apache_beam/transforms/validate_runner_xlang_test.py
@@ -14,6 +14,42 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 #
+
+"""
+###########################################################
+Runner Validation Test Suite for Cross-language Transforms
+###########################################################
+ As per Beams's Portability Framework design, Cross-language transforms
+ should work out of the box. In spite of this, there always exists a
+ possibility of rough edges existing. It could be caused due to unpolished
+ implementation of any part of the execution code path, for example:
+ –> Transform expansion [SDK]
+ –> Pipeline construction [SDK]
+ –> Cross-language artifact staging [Runner]
+ –> Language specific serialization/deserialization of PCollection (and
+ other data types) [Runner/SDK]
+
+ In an effort to improve developer visibility into potential problems,
+ this test suite validates correct execution of 5 Core Beam transforms when
+ used as cross-language transforms within the Python SDK from any foreign SDK:
+  –> ParDo
+  (https://beam.apache.org/documentation/programming-guide/#pardo)
+  –> GroupByKey
+  (https://beam.apache.org/documentation/programming-guide/#groupbykey)
+  –> CoGroupByKey
+  (https://beam.apache.org/documentation/programming-guide/#cogroupbykey)
+  –> Combine
+  (https://beam.apache.org/documentation/programming-guide/#combine)
+  –> Flatten
+  (https://beam.apache.org/documentation/programming-guide/#flatten)
+  –> Partition
+  (https://beam.apache.org/documentation/programming-guide/#partition)
+
+  See Runner Validation Test Plan for Cross-language transforms at
+https://docs.google.com/document/d/1xQp0ElIV84b8OCVz8CD2hvbiWdR8w4BvWxPTZJZA6NA
+  for further details.
+"""
+
 from __future__ import absolute_import
 
 import logging
@@ -46,6 +82,15 @@ class CrossLanguageTestPipelines(object):
         'localhost:%s' % os.environ.get('EXPANSION_PORT'))
 
   def run_prefix(self, pipeline):
+    """
+    Target transform – ParDo
+    (https://beam.apache.org/documentation/programming-guide/#pardo)
+    Test scenario – Mapping elements from a single input collection to a
+    single output collection
+    Boundary conditions checked –
+     –> PCollection<?> to external transforms
+     –> PCollection<?> from external transforms
+    """
     with pipeline as p:
       res = (
           p
@@ -57,6 +102,15 @@ class CrossLanguageTestPipelines(object):
       assert_that(res, equal_to(['0a', '0b']))
 
   def run_multi_input_output_with_sideinput(self, pipeline):
+    """
+    Target transform – ParDo
+    (https://beam.apache.org/documentation/programming-guide/#pardo)
+    Test scenario – Mapping elements from multiple input collections (main
+    and side) to multiple output collections (main and side)
+    Boundary conditions checked –
+     –> PCollectionTuple to external transforms
+     –> PCollectionTuple from external transforms
+    """
     with pipeline as p:
       main1 = p | 'Main1' >> beam.Create(
           ['a', 'bb'], reshuffle=False).with_output_types(unicode)
@@ -70,6 +124,15 @@ class CrossLanguageTestPipelines(object):
       assert_that(res['side'], equal_to(['ss']), label='CheckSide')
 
   def run_group_by_key(self, pipeline):
+    """
+    Target transform – GroupByKey
+    (https://beam.apache.org/documentation/programming-guide/#groupbykey)
+    Test scenario – Grouping a collection of KV<K,V> to a collection of
+    KV<K, Iterable<V>> by key
+    Boundary conditions checked –
+     –> PCollection<KV<?, ?>> to external transforms
+     –> PCollection<KV<?, Iterable<?>>> from external transforms
+    """
     with pipeline as p:
       res = (
           p
@@ -81,6 +144,15 @@ class CrossLanguageTestPipelines(object):
       assert_that(res, equal_to(['0:1,2', '1:3']))
 
   def run_cogroup_by_key(self, pipeline):
+    """
+    Target transform – CoGroupByKey
+    (https://beam.apache.org/documentation/programming-guide/#cogroupbykey)
+    Test scenario – Grouping multiple input collections with keys to a
+    collection of KV<K, CoGbkResult> by key
+    Boundary conditions checked –
+     –> KeyedPCollectionTuple<?> to external transforms
+     –> PCollection<KV<?, Iterable<?>>> from external transforms
+    """
     with pipeline as p:
       col1 = p | 'create_col1' >> beam.Create(
           [(0, "1"), (0, "2"), (1, "3")], reshuffle=False).with_output_types(
@@ -95,6 +167,15 @@ class CrossLanguageTestPipelines(object):
       assert_that(res, equal_to(['0:1,2,4', '1:3,5,6']))
 
   def run_combine_globally(self, pipeline):
+    """
+    Target transform – Combine
+    (https://beam.apache.org/documentation/programming-guide/#combine)
+    Test scenario – Combining elements globally with a predefined simple
+    CombineFn
+    Boundary conditions checked –
+     –> PCollection<?> to external transforms
+     –> PCollection<?> from external transforms
+    """
     with pipeline as p:
       res = (
           p
@@ -104,6 +185,15 @@ class CrossLanguageTestPipelines(object):
       assert_that(res, equal_to([6]))
 
   def run_combine_per_key(self, pipeline):
+    """
+    Target transform – Combine
+    (https://beam.apache.org/documentation/programming-guide/#combine)
+    Test scenario – Combining elements per key with a predefined simple
+    merging function
+    Boundary conditions checked –
+     –> PCollection<?> to external transforms
+     –> PCollection<?> from external transforms
+    """
     with pipeline as p:
       res = (
           p
@@ -114,6 +204,14 @@ class CrossLanguageTestPipelines(object):
       assert_that(res, equal_to([('a', 3), ('b', 3)]))
 
   def run_flatten(self, pipeline):
+    """
+    Target transform – Flatten
+    (https://beam.apache.org/documentation/programming-guide/#flatten)
+    Test scenario – Merging multiple collections into a single collection
+    Boundary conditions checked –
+     –> PCollectionList<?> to external transforms
+     –> PCollection<?> from external transforms
+    """
     with pipeline as p:
       col1 = p | 'col1' >> beam.Create([1, 2, 3]).with_output_types(int)
       col2 = p | 'col2' >> beam.Create([4, 5, 6]).with_output_types(int)
@@ -123,6 +221,15 @@ class CrossLanguageTestPipelines(object):
       assert_that(res, equal_to([1, 2, 3, 4, 5, 6]))
 
   def run_partition(self, pipeline):
+    """
+    Target transform – Partition
+    (https://beam.apache.org/documentation/programming-guide/#partition)
+    Test scenario – Splitting a single collection into multiple collections
+    with a predefined simple PartitionFn
+    Boundary conditions checked –
+     –> PCollection<?> to external transforms
+     –> PCollectionList<?> from external transforms
+    """
     with pipeline as p:
       res = (
           p


### PR DESCRIPTION
Added documentation, to both the [java](https://github.com/apache/beam/blob/master/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/ValidateRunnerXlangTest.java) and [python](https://github.com/apache/beam/blob/master/sdks/python/apache_beam/transforms/validate_runner_xlang_test.py) equivalents, explaining the design of the test suite tasked with validating a cross-language runner. It is directly inspired from [Runner Validation Test Plan for Cross-language transforms](https://docs.google.com/document/d/1xQp0ElIV84b8OCVz8CD2hvbiWdR8w4BvWxPTZJZA6NA/edit?usp=sharing).

This pull request serves as a replacement for the [original](https://github.com/apache/beam/pull/12071) to correct for botched git workflows. It contains only the cherry picked latest and relevant commits. Refer to the [original](https://github.com/apache/beam/pull/12071) pull request to view incremental development.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
