### PR TITLE
[BEAM-10650] OrderedListState API

### DIFF
--- a/model/pipeline/src/main/proto/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/beam_runner_api.proto
@@ -489,6 +489,7 @@ message StateSpec {
     CombiningStateSpec combining_spec = 3;
     MapStateSpec map_spec = 4;
     SetStateSpec set_spec = 5;
+    OrderedListStateSpec ordered_list_spec = 6;
   }
 }
 
@@ -497,6 +498,10 @@ message ReadModifyWriteStateSpec {
 }
 
 message BagStateSpec {
+  string element_coder_id = 1;
+}
+
+message OrderedListStateSpec {
   string element_coder_id = 1;
 }
 

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ParDoTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ParDoTranslation.java
@@ -555,6 +555,15 @@ public class ParDoTranslation {
           }
 
           @Override
+          public RunnerApi.StateSpec dispatchOrderedList(Coder<?> elementCoder) {
+            return builder
+                .setOrderedListSpec(
+                    RunnerApi.OrderedListStateSpec.newBuilder()
+                        .setElementCoderId(registerCoderOrThrow(components, elementCoder)))
+                .build();
+          }
+
+          @Override
           public RunnerApi.StateSpec dispatchCombining(
               Combine.CombineFn<?, ?, ?> combineFn, Coder<?> accumCoder) {
             return builder

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/InMemoryStateInternals.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/InMemoryStateInternals.java
@@ -24,14 +24,18 @@ import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
 import java.util.Map;
+import java.util.NavigableMap;
 import java.util.Objects;
 import java.util.Set;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
 import org.apache.beam.runners.core.StateTag.StateBinder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.state.BagState;
 import org.apache.beam.sdk.state.CombiningState;
 import org.apache.beam.sdk.state.MapState;
+import org.apache.beam.sdk.state.OrderedListState;
 import org.apache.beam.sdk.state.ReadableState;
 import org.apache.beam.sdk.state.ReadableStates;
 import org.apache.beam.sdk.state.SetState;
@@ -45,10 +49,12 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.TimestampCombiner;
 import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.beam.sdk.util.CombineFnUtil;
+import org.apache.beam.sdk.values.TimestampedValue;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
 import org.joda.time.Instant;
 
 /**
@@ -137,6 +143,12 @@ public class InMemoryStateInternals<K> implements StateInternals {
         Coder<KeyT> mapKeyCoder,
         Coder<ValueT> mapValueCoder) {
       return new InMemoryMap<>(mapKeyCoder, mapValueCoder);
+    }
+
+    @Override
+    public <T> OrderedListState<T> bindOrderedList(
+        StateTag<OrderedListState<T>> spec, Coder<T> elemCoder) {
+      return new InMemoryOrderedList<>(elemCoder);
     }
 
     @Override
@@ -439,6 +451,92 @@ public class InMemoryStateInternals<K> implements StateInternals {
       for (T elem : this.contents) {
         that.contents.add(uncheckedClone(elemCoder, elem));
       }
+      return that;
+    }
+  }
+
+  /** An {@link InMemoryState} implementation of {@link OrderedListState}. */
+  public static final class InMemoryOrderedList<T>
+      implements OrderedListState<T>, InMemoryState<InMemoryOrderedList<T>> {
+    private final Coder<T> elemCoder;
+    private NavigableMap<Instant, Collection<T>> contents = Maps.newTreeMap();
+
+    public InMemoryOrderedList(Coder<T> elemCoder) {
+      this.elemCoder = elemCoder;
+    }
+
+    @Override
+    public void clear() {
+      // Even though we're clearing we can't remove this from the in-memory state, since
+      // other users may already have a handle on this list.
+      // The result of get/read below must be stable for the lifetime of the bundle within which it
+      // was generated. In batch and direct runners the bundle lifetime can be
+      // greater than the window lifetime, in which case this method can be called while
+      // the result is still in use. We protect against this by hot-swapping instead of
+      // clearing the contents.
+      contents = Maps.newTreeMap();
+    }
+
+    @Override
+    public void clearRange(Instant minTimestamp, Instant limitTimestamp) {
+      contents.subMap(minTimestamp, true, limitTimestamp, false).clear();
+    }
+
+    @Override
+    public InMemoryOrderedList<T> readLater() {
+      return this;
+    }
+
+    @Override
+    public OrderedListState<T> readRangeLater(Instant minTimestamp, Instant limitTimestamp) {
+      return this;
+    }
+
+    @Override
+    public Iterable<TimestampedValue<T>> read() {
+      return readRange(Instant.ofEpochMilli(Long.MIN_VALUE), Instant.ofEpochMilli(Long.MAX_VALUE));
+    }
+
+    @Override
+    public Iterable<TimestampedValue<T>> readRange(Instant minTimestamp, Instant limitTimestamp) {
+      return contents.subMap(minTimestamp, true, limitTimestamp, false).entrySet().stream()
+          .flatMap(e -> e.getValue().stream().map(v -> TimestampedValue.of(v, e.getKey())))
+          .collect(Collectors.toList());
+    }
+
+    @Override
+    public void add(TimestampedValue<T> input) {
+      contents
+          .computeIfAbsent(input.getTimestamp(), x -> Lists.newArrayList())
+          .add(input.getValue());
+    }
+
+    @Override
+    public boolean isCleared() {
+      return contents.isEmpty();
+    }
+
+    @Override
+    public ReadableState<Boolean> isEmpty() {
+      return new ReadableState<Boolean>() {
+        @Override
+        public ReadableState<Boolean> readLater() {
+          return this;
+        }
+
+        @Override
+        public Boolean read() {
+          return contents.isEmpty();
+        }
+      };
+    }
+
+    @Override
+    public InMemoryOrderedList<T> copy() {
+      InMemoryOrderedList<T> that = new InMemoryOrderedList<>(elemCoder);
+      this.contents.entrySet().stream()
+          .flatMap(e -> e.getValue().stream().map(v -> TimestampedValue.of(v, e.getKey())))
+          .forEach(that::add);
       return that;
     }
   }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/StateTag.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/StateTag.java
@@ -23,6 +23,7 @@ import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.state.BagState;
 import org.apache.beam.sdk.state.CombiningState;
 import org.apache.beam.sdk.state.MapState;
+import org.apache.beam.sdk.state.OrderedListState;
 import org.apache.beam.sdk.state.SetState;
 import org.apache.beam.sdk.state.State;
 import org.apache.beam.sdk.state.StateSpec;
@@ -82,6 +83,8 @@ public interface StateTag<StateT extends State> extends Serializable {
         StateTag<MapState<KeyT, ValueT>> spec,
         Coder<KeyT> mapKeyCoder,
         Coder<ValueT> mapValueCoder);
+
+    <T> OrderedListState<T> bindOrderedList(StateTag<OrderedListState<T>> spec, Coder<T> elemCoder);
 
     <InputT, AccumT, OutputT> CombiningState<InputT, AccumT, OutputT> bindCombiningValue(
         StateTag<CombiningState<InputT, AccumT, OutputT>> spec,

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/StateTags.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/StateTags.java
@@ -25,6 +25,7 @@ import org.apache.beam.sdk.coders.CoderRegistry;
 import org.apache.beam.sdk.state.BagState;
 import org.apache.beam.sdk.state.CombiningState;
 import org.apache.beam.sdk.state.MapState;
+import org.apache.beam.sdk.state.OrderedListState;
 import org.apache.beam.sdk.state.SetState;
 import org.apache.beam.sdk.state.State;
 import org.apache.beam.sdk.state.StateBinder;
@@ -84,6 +85,12 @@ public class StateTags {
           Coder<KeyT> mapKeyCoder,
           Coder<ValueT> mapValueCoder) {
         return binder.bindMap(tagForSpec(id, spec), mapKeyCoder, mapValueCoder);
+      }
+
+      @Override
+      public <T> OrderedListState<T> bindOrderedList(
+          String id, StateSpec<OrderedListState<T>> spec, Coder<T> elemCoder) {
+        return binder.bindOrderedList(tagForSpec(id, spec), elemCoder);
       }
 
       @Override
@@ -194,6 +201,10 @@ public class StateTags {
   public static <K, V> StateTag<MapState<K, V>> map(
       String id, Coder<K> keyCoder, Coder<V> valueCoder) {
     return new SimpleStateTag<>(new StructuredId(id), StateSpecs.map(keyCoder, valueCoder));
+  }
+
+  public static <T> StateTag<OrderedListState<T>> orderedList(String id, Coder<T> elemCoder) {
+    return new SimpleStateTag<>(new StructuredId(id), StateSpecs.orderedList(elemCoder));
   }
 
   /** Create a state tag for holding the watermark. */

--- a/runners/flink/flink_runner.gradle
+++ b/runners/flink/flink_runner.gradle
@@ -210,6 +210,7 @@ def createValidatesRunnerTask(Map m) {
       excludeCategories 'org.apache.beam.sdk.testing.UsesBundleFinalizer'
       excludeCategories 'org.apache.beam.sdk.testing.UsesOnWindowExpiration'
       excludeCategories 'org.apache.beam.sdk.testing.UsesStrictTimerOrdering'
+      excludeCategories 'org.apache.beam.sdk.testing.UsesOrderedListState'
       if (config.streaming) {
         excludeCategories 'org.apache.beam.sdk.testing.UsesTimerMap'
         excludeCategories 'org.apache.beam.sdk.testing.UsesImpulse'

--- a/runners/flink/job-server/flink_job_server.gradle
+++ b/runners/flink/job-server/flink_job_server.gradle
@@ -150,10 +150,12 @@ def portableValidatesRunnerTask(String name, Boolean streaming) {
       excludeCategories 'org.apache.beam.sdk.testing.UsesParDoLifecycle'
       excludeCategories 'org.apache.beam.sdk.testing.UsesMapState'
       excludeCategories 'org.apache.beam.sdk.testing.UsesSetState'
+      excludeCategories 'org.apache.beam.sdk.testing.UsesOrderedListState'
       excludeCategories 'org.apache.beam.sdk.testing.UsesStrictTimerOrdering'
       excludeCategories 'org.apache.beam.sdk.testing.UsesTimerMap'
       excludeCategories 'org.apache.beam.sdk.testing.UsesOnWindowExpiration'
       excludeCategories 'org.apache.beam.sdk.testing.UsesBundleFinalizer'
+      excludeCategories 'org.apache.beam.sdk.testing.UsesOrderedListState'
       if (streaming) {
         excludeCategories 'org.apache.beam.sdk.testing.UsesTestStreamWithProcessingTime'
         excludeCategories 'org.apache.beam.sdk.testing.UsesTestStreamWithMultipleStages'

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkBroadcastStateInternals.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkBroadcastStateInternals.java
@@ -35,6 +35,7 @@ import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.state.BagState;
 import org.apache.beam.sdk.state.CombiningState;
 import org.apache.beam.sdk.state.MapState;
+import org.apache.beam.sdk.state.OrderedListState;
 import org.apache.beam.sdk.state.ReadableState;
 import org.apache.beam.sdk.state.SetState;
 import org.apache.beam.sdk.state.State;
@@ -111,6 +112,13 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
               Coder<ValueT> mapValueCoder) {
             throw new UnsupportedOperationException(
                 String.format("%s is not supported", MapState.class.getSimpleName()));
+          }
+
+          @Override
+          public <ElemT> OrderedListState<ElemT> bindOrderedList(
+              StateTag<OrderedListState<ElemT>> spec, Coder<ElemT> elemCoder) {
+            throw new UnsupportedOperationException(
+                String.format("%s is not supported", OrderedListState.class.getSimpleName()));
           }
 
           @Override

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
@@ -36,6 +36,7 @@ import org.apache.beam.sdk.coders.VoidCoder;
 import org.apache.beam.sdk.state.BagState;
 import org.apache.beam.sdk.state.CombiningState;
 import org.apache.beam.sdk.state.MapState;
+import org.apache.beam.sdk.state.OrderedListState;
 import org.apache.beam.sdk.state.ReadableState;
 import org.apache.beam.sdk.state.ReadableStates;
 import org.apache.beam.sdk.state.SetState;
@@ -147,6 +148,13 @@ public class FlinkStateInternals<K> implements StateInternals {
         Coder<KeyT> mapKeyCoder,
         Coder<ValueT> mapValueCoder) {
       return new FlinkMapState<>(flinkStateBackend, id, namespace, mapKeyCoder, mapValueCoder);
+    }
+
+    @Override
+    public <T> OrderedListState<T> bindOrderedList(
+        String id, StateSpec<OrderedListState<T>> spec, Coder<T> elemCoder) {
+      throw new UnsupportedOperationException(
+          String.format("%s is not supported", OrderedListState.class.getSimpleName()));
     }
 
     @Override
@@ -1284,6 +1292,13 @@ public class FlinkStateInternals<K> implements StateInternals {
         throw new RuntimeException(e);
       }
       return null;
+    }
+
+    @Override
+    public <T> OrderedListState<T> bindOrderedList(
+        String id, StateSpec<OrderedListState<T>> spec, Coder<T> elemCoder) {
+      throw new UnsupportedOperationException(
+          String.format("%s is not supported", OrderedListState.class.getSimpleName()));
     }
 
     @Override

--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -141,6 +141,7 @@ def commonExcludeCategories = [
   'org.apache.beam.sdk.testing.UsesGaugeMetrics',
   'org.apache.beam.sdk.testing.UsesSetState',
   'org.apache.beam.sdk.testing.UsesMapState',
+  'org.apache.beam.sdk.testing.UsesOrderedListState',
   'org.apache.beam.sdk.testing.UsesSplittableParDoWithWindowedSideInputs',
   'org.apache.beam.sdk.testing.UsesTestStream',
   'org.apache.beam.sdk.testing.UsesParDoLifecycle',

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -122,6 +122,7 @@ import org.apache.beam.sdk.runners.PTransformOverrideFactory;
 import org.apache.beam.sdk.runners.TransformHierarchy;
 import org.apache.beam.sdk.runners.TransformHierarchy.Node;
 import org.apache.beam.sdk.state.MapState;
+import org.apache.beam.sdk.state.OrderedListState;
 import org.apache.beam.sdk.state.SetState;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.Combine.CombineFn;
@@ -2056,6 +2057,12 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
           String.format(
               "%s does not currently support %s",
               DataflowRunner.class.getSimpleName(), MapState.class.getSimpleName()));
+    }
+    if (DoFnSignatures.usesOrderedListState(fn)) {
+      throw new UnsupportedOperationException(
+          String.format(
+              "%s does not currently support %s",
+              DataflowRunner.class.getSimpleName(), OrderedListState.class.getSimpleName()));
     }
     if (streaming && DoFnSignatures.requiresTimeSortedInput(fn)) {
       throw new UnsupportedOperationException(

--- a/runners/google-cloud-dataflow-java/worker/windmill/src/main/proto/windmill.proto
+++ b/runners/google-cloud-dataflow-java/worker/windmill/src/main/proto/windmill.proto
@@ -109,6 +109,62 @@ message TagBag {
   optional int64 fetch_max_bytes = 6 [default = 0x7fffffffffffffff];
 }
 
+// A single entry in a sorted list
+message SortedListEntry {
+  // The value payload.
+  optional bytes value = 1;
+  // The sort key.  must be strictly smaller than than 0x7fffffffffffffff.
+  optional int64 sort_key = 2;
+  // A unique id for this element.The combination of the sort key and the id
+  // identify an element. Entries written with the same sort_key and id will
+  // overwrite the previous entry.
+  optional uint64 id = 3;
+}
+
+message SortedListRange {
+  // start and limit describe the range of SortedList entries
+  // to be fetched.  The targeted range is [start, limit).
+  optional int64 start = 1 [default = -0x8000000000000000];
+  optional int64 limit = 2 [default = 0x7fffffffffffffff];
+}
+
+message TagSortedListFetchRequest {
+  optional bytes tag = 1;
+  optional string state_family = 2;
+  optional SortedListRange fetch_range = 3;
+
+  // Sets a limit on the maximum response value bytes
+  optional int64 fetch_max_bytes = 5 [default = 0x7fffffffffffffff];
+  // If a previous TagSortedListFetchRequest returned a continuation_position,
+  // then passing that token into requestPosition will cause the subsequent
+  // request to continue the previous request.
+  optional bytes request_position = 6;
+}
+
+message TagSortedListFetchResponse {
+  optional bytes tag = 1;
+  optional string state_family = 2;
+  repeated SortedListEntry entries = 3;
+  optional bytes continuation_position = 4;
+}
+
+message TagSortedListUpdateRequest {
+  optional bytes tag = 1;
+  optional string state_family = 2;
+
+  // The list of inserts and deletes to be applied. Deletes always happen before
+  // inserts. Inserts with the same sort_key+id overwrite each other.
+  repeated TagSortedListDeleteRequest deletes = 3;
+  repeated TagSortedListInsertRequest inserts = 4;
+}
+
+message TagSortedListInsertRequest {
+  repeated SortedListEntry entries = 1;
+}
+
+message TagSortedListDeleteRequest {
+  optional SortedListRange range = 1;
+}
 message GlobalDataId {
   required string tag = 1;
   required bytes version = 2;
@@ -197,6 +253,7 @@ message KeyedGetDataRequest {
   optional fixed64 sharding_key = 6;
   repeated TagValue values_to_fetch = 3;
   repeated TagBag bags_to_fetch = 8;
+  repeated TagSortedListFetchRequest sorted_lists_to_fetch = 9;
   repeated WatermarkHold watermark_holds_to_fetch = 5;
 
   optional int64 max_bytes = 7;
@@ -224,6 +281,7 @@ message KeyedGetDataResponse {
   optional bool failed = 2;
   repeated TagValue values = 3;
   repeated TagBag bags = 6;
+  repeated TagSortedListFetchResponse tag_sorted_lists = 8;
   repeated WatermarkHold watermark_holds = 5;
 
   reserved 4;
@@ -287,6 +345,7 @@ message WorkItemCommitRequest {
   repeated Timer output_timers = 4;
   repeated TagValue value_updates = 5;
   repeated TagBag bag_updates = 18;
+  repeated TagSortedListUpdateRequest sorted_list_updates = 24;
   repeated Counter counter_updates = 8;
   repeated GlobalDataRequest global_data_requests = 11;
   repeated GlobalData global_data_updates = 10;

--- a/runners/jet/build.gradle
+++ b/runners/jet/build.gradle
@@ -73,6 +73,7 @@ task validatesRunnerBatch(type: Test) {
         excludeCategories "org.apache.beam.sdk.testing.LargeKeys\$Above100MB"
         excludeCategories 'org.apache.beam.sdk.testing.UsesTimerMap'
         excludeCategories 'org.apache.beam.sdk.testing.UsesOnWindowExpiration'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesOrderedListState'
         excludeCategories 'org.apache.beam.sdk.testing.UsesImpulse' //impulse doesn't cooperate properly with Jet when multiple cluster members are used
         exclude '**/SplittableDoFnTest.class' //Splittable DoFn functionality not yet in the runner
         excludeCategories 'org.apache.beam.sdk.testing.UsesBundleFinalizer'

--- a/runners/portability/java/build.gradle
+++ b/runners/portability/java/build.gradle
@@ -132,6 +132,7 @@ task ulrValidatesRunnerTests(type: Test) {
     excludeCategories 'org.apache.beam.sdk.testing.UsesOnWindowExpiration'
     excludeCategories 'org.apache.beam.sdk.testing.UsesMapState'
     excludeCategories 'org.apache.beam.sdk.testing.UsesSetState'
+    excludeCategories 'org.apache.beam.sdk.testing.UsesOrderedListState'
     excludeCategories 'org.apache.beam.sdk.testing.UsesTestStreamWithMultipleStages'
     excludeCategories 'org.apache.beam.sdk.testing.UsesTimersInParDo'
   }

--- a/runners/samza/build.gradle
+++ b/runners/samza/build.gradle
@@ -93,6 +93,7 @@ task validatesRunner(type: Test) {
     excludeCategories 'org.apache.beam.sdk.testing.UsesStrictTimerOrdering'
     excludeCategories 'org.apache.beam.sdk.testing.UsesTimerMap'
     excludeCategories 'org.apache.beam.sdk.testing.UsesOnWindowExpiration'
+    excludeCategories 'org.apache.beam.sdk.testing.UsesOrderedListState'
     excludeCategories 'org.apache.beam.sdk.testing.UsesBundleFinalizer'
   }
   filter {

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaStoreStateInternals.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaStoreStateInternals.java
@@ -48,6 +48,7 @@ import org.apache.beam.sdk.coders.VoidCoder;
 import org.apache.beam.sdk.state.BagState;
 import org.apache.beam.sdk.state.CombiningState;
 import org.apache.beam.sdk.state.MapState;
+import org.apache.beam.sdk.state.OrderedListState;
 import org.apache.beam.sdk.state.ReadableState;
 import org.apache.beam.sdk.state.ReadableStates;
 import org.apache.beam.sdk.state.SetState;
@@ -169,6 +170,13 @@ public class SamzaStoreStateInternals<K> implements StateInternals {
               Coder<KeyT> mapKeyCoder,
               Coder<ValueT> mapValueCoder) {
             return new SamzaMapStateImpl<>(namespace, address, mapKeyCoder, mapValueCoder);
+          }
+
+          @Override
+          public <T> OrderedListState<T> bindOrderedList(
+              StateTag<OrderedListState<T>> spec, Coder<T> elemCoder) {
+            throw new UnsupportedOperationException(
+                String.format("%s is not supported", OrderedListState.class.getSimpleName()));
           }
 
           @Override

--- a/runners/spark/build.gradle
+++ b/runners/spark/build.gradle
@@ -144,6 +144,7 @@ task validatesRunnerBatch(type: Test) {
     excludeCategories 'org.apache.beam.sdk.testing.UsesKeyInParDo'
     excludeCategories 'org.apache.beam.sdk.testing.UsesOnWindowExpiration'
     excludeCategories 'org.apache.beam.sdk.testing.UsesStrictTimerOrdering'
+    excludeCategories 'org.apache.beam.sdk.testing.UsesOrderedListState'
     // Unbounded
     excludeCategories 'org.apache.beam.sdk.testing.UsesUnboundedPCollections'
     excludeCategories 'org.apache.beam.sdk.testing.UsesTestStream'
@@ -211,6 +212,7 @@ task validatesStructuredStreamingRunnerBatch(type: Test) {
     excludeCategories 'org.apache.beam.sdk.testing.UsesStatefulParDo'
     excludeCategories 'org.apache.beam.sdk.testing.UsesMapState'
     excludeCategories 'org.apache.beam.sdk.testing.UsesSetState'
+    excludeCategories 'org.apache.beam.sdk.testing.UsesOrderedListState'
     excludeCategories 'org.apache.beam.sdk.testing.UsesTimersInParDo'
     excludeCategories 'org.apache.beam.sdk.testing.UsesTimerMap'
     excludeCategories 'org.apache.beam.sdk.testing.UsesKeyInParDo'

--- a/runners/spark/job-server/build.gradle
+++ b/runners/spark/job-server/build.gradle
@@ -106,6 +106,7 @@ def portableValidatesRunnerTask(String name) {
       excludeCategories 'org.apache.beam.sdk.testing.UsesParDoLifecycle'
       excludeCategories 'org.apache.beam.sdk.testing.UsesMapState'
       excludeCategories 'org.apache.beam.sdk.testing.UsesSetState'
+      excludeCategories 'org.apache.beam.sdk.testing.UsesOrderedListState'
       excludeCategories 'org.apache.beam.sdk.testing.UsesTimerMap'
       excludeCategories 'org.apache.beam.sdk.testing.UsesKeyInParDo'
       excludeCategories 'org.apache.beam.sdk.testing.UsesOnWindowExpiration'

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/stateful/SparkStateInternals.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/stateful/SparkStateInternals.java
@@ -31,6 +31,7 @@ import org.apache.beam.sdk.coders.ListCoder;
 import org.apache.beam.sdk.state.BagState;
 import org.apache.beam.sdk.state.CombiningState;
 import org.apache.beam.sdk.state.MapState;
+import org.apache.beam.sdk.state.OrderedListState;
 import org.apache.beam.sdk.state.ReadableState;
 import org.apache.beam.sdk.state.SetState;
 import org.apache.beam.sdk.state.State;
@@ -119,6 +120,13 @@ class SparkStateInternals<K> implements StateInternals {
         Coder<ValueT> mapValueCoder) {
       throw new UnsupportedOperationException(
           String.format("%s is not supported", MapState.class.getSimpleName()));
+    }
+
+    @Override
+    public <T> OrderedListState<T> bindOrderedList(
+        StateTag<OrderedListState<T>> spec, Coder<T> elemCoder) {
+      throw new UnsupportedOperationException(
+          String.format("%s is not supported", OrderedListState.class.getSimpleName()));
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/state/OrderedListState.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/state/OrderedListState.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.state;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
+import org.apache.beam.sdk.values.TimestampedValue;
+import org.joda.time.Instant;
+
+/**
+ * A {@link ReadableState} cell containing a list of values sorted by timestamp. Timestamped values
+ * can be added to the list, and subranges can be read out in order. Subranges of the list can be
+ * deleted as well.
+ */
+@Experimental(Kind.STATE)
+public interface OrderedListState<T>
+    extends GroupingState<TimestampedValue<T>, Iterable<TimestampedValue<T>>> {
+  /**
+   * Read a timestamp-limited subrange of the list. The result is ordered by timestamp.
+   *
+   * <p>All values with timestamps >= minTimestamp and < limitTimestamp will be in the resuling
+   * iterable. This means that only timestamps strictly less than
+   * Instant.ofEpochMilli(Long.MAX_VALUE) can be used as timestamps.
+   */
+  Iterable<TimestampedValue<T>> readRange(Instant minTimestamp, Instant limitTimestamp);
+
+  /**
+   * Clear a timestamp-limited subrange of the list.
+   *
+   * <p>All values with timestamps >= minTimestamp and < limitTimestamp will be removed from the
+   * list.
+   */
+  void clearRange(Instant minTimestamp, Instant limitTimestamp);
+
+  /**
+   * Call to indicate that a specific range will be read from the list, allowing runners to batch
+   * multiple range reads.
+   */
+  OrderedListState<T> readRangeLater(Instant minTimestamp, Instant limitTimestamp);
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/state/StateBinder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/state/StateBinder.java
@@ -42,6 +42,9 @@ public interface StateBinder {
       Coder<KeyT> mapKeyCoder,
       Coder<ValueT> mapValueCoder);
 
+  <T> OrderedListState<T> bindOrderedList(
+      String id, StateSpec<OrderedListState<T>> spec, Coder<T> elemCoder);
+
   <InputT, AccumT, OutputT> CombiningState<InputT, AccumT, OutputT> bindCombining(
       String id,
       StateSpec<CombiningState<InputT, AccumT, OutputT>> spec,

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/state/StateKeySpec.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/state/StateKeySpec.java
@@ -1,0 +1,39 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.state;
+
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
+import org.apache.beam.sdk.schemas.FieldAccessDescriptor;
+
+@Experimental(Kind.SCHEMAS)
+public class StateKeySpec {
+  private final FieldAccessDescriptor keyDescriptor;
+
+  private StateKeySpec(FieldAccessDescriptor keyDescriptor) {
+    this.keyDescriptor = keyDescriptor;
+  }
+
+  public static StateKeySpec fields(String fieldNames) {
+    return new StateKeySpec(FieldAccessDescriptor.withFieldNames(fieldNames));
+  }
+
+  public static StateKeySpec fields(FieldAccessDescriptor fieldAccessDescriptor) {
+    return new StateKeySpec(fieldAccessDescriptor);
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/state/StateSpec.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/state/StateSpec.java
@@ -76,6 +76,8 @@ public interface StateSpec<StateT extends State> extends Serializable {
 
     ResultT dispatchBag(Coder<?> elementCoder);
 
+    ResultT dispatchOrderedList(Coder<?> elementCoder);
+
     ResultT dispatchCombining(Combine.CombineFn<?, ?, ?> combineFn, Coder<?> accumCoder);
 
     ResultT dispatchMap(Coder<?> keyCoder, Coder<?> valueCoder);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/UsesOrderedListState.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/UsesOrderedListState.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.testing;
+
+import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.sdk.state.OrderedListState;
+
+/** Category tag for validation tests which utilize {@link OrderedListState}. */
+@Internal
+public class UsesOrderedListState {}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
@@ -1031,6 +1031,11 @@ public class ParDo {
           }
 
           @Override
+          public String dispatchOrderedList(Coder<?> elementCoder) {
+            return "OrderedListState<" + elementCoder + ">";
+          }
+
+          @Override
           public String dispatchCombining(
               Combine.CombineFn<?, ?, ?> combineFn, Coder<?> accumCoder) {
             return "CombiningState<" + accumCoder + ">";

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
@@ -44,6 +44,7 @@ import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.schemas.FieldAccessDescriptor;
 import org.apache.beam.sdk.state.BagState;
 import org.apache.beam.sdk.state.MapState;
+import org.apache.beam.sdk.state.OrderedListState;
 import org.apache.beam.sdk.state.ReadableState;
 import org.apache.beam.sdk.state.SetState;
 import org.apache.beam.sdk.state.State;
@@ -2503,6 +2504,10 @@ public class DoFnSignatures {
 
   public static boolean usesSetState(DoFn<?, ?> doFn) {
     return usesGivenStateClass(doFn, SetState.class);
+  }
+
+  public static boolean usesOrderedListState(DoFn<?, ?> doFn) {
+    return usesGivenStateClass(doFn, OrderedListState.class);
   }
 
   public static boolean usesValueState(DoFn<?, ?> doFn) {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -76,6 +76,7 @@ import org.apache.beam.sdk.state.BagState;
 import org.apache.beam.sdk.state.CombiningState;
 import org.apache.beam.sdk.state.GroupingState;
 import org.apache.beam.sdk.state.MapState;
+import org.apache.beam.sdk.state.OrderedListState;
 import org.apache.beam.sdk.state.ReadableState;
 import org.apache.beam.sdk.state.SetState;
 import org.apache.beam.sdk.state.StateSpec;
@@ -94,6 +95,7 @@ import org.apache.beam.sdk.testing.TestStream;
 import org.apache.beam.sdk.testing.UsesKeyInParDo;
 import org.apache.beam.sdk.testing.UsesMapState;
 import org.apache.beam.sdk.testing.UsesOnWindowExpiration;
+import org.apache.beam.sdk.testing.UsesOrderedListState;
 import org.apache.beam.sdk.testing.UsesRequiresTimeSortedInput;
 import org.apache.beam.sdk.testing.UsesSetState;
 import org.apache.beam.sdk.testing.UsesSideInputs;
@@ -2239,6 +2241,170 @@ public class ParDoTest implements Serializable {
               .apply(ParDo.of(fn));
 
       PAssert.that(output).containsInAnyOrder(KV.of("a", 97), KV.of("b", 42), KV.of("c", 12));
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class, UsesOrderedListState.class})
+    public void testOrderedListState() {
+      final String stateId = "foo";
+
+      DoFn<KV<String, TimestampedValue<String>>, Iterable<TimestampedValue<String>>> fn =
+          new DoFn<KV<String, TimestampedValue<String>>, Iterable<TimestampedValue<String>>>() {
+
+            @StateId(stateId)
+            private final StateSpec<OrderedListState<String>> orderedListState =
+                StateSpecs.orderedList(StringUtf8Coder.of());
+
+            @ProcessElement
+            public void processElement(
+                @Element KV<String, TimestampedValue<String>> element,
+                @StateId(stateId) OrderedListState<String> state) {
+              state.add(element.getValue());
+            }
+
+            @OnWindowExpiration
+            public void onWindowExpiration(
+                @StateId(stateId) OrderedListState<String> state,
+                OutputReceiver<Iterable<TimestampedValue<String>>> o) {
+              Iterable<TimestampedValue<String>> strings = state.read();
+              o.output(strings);
+            }
+          };
+
+      PCollection<Iterable<TimestampedValue<String>>> output =
+          pipeline
+              .apply(
+                  Create.of(
+                      KV.of("hello", TimestampedValue.of("a", Instant.ofEpochMilli(97))),
+                      KV.of("hello", TimestampedValue.of("b", Instant.ofEpochMilli(42))),
+                      KV.of("hello", TimestampedValue.of("b", Instant.ofEpochMilli(52))),
+                      KV.of("hello", TimestampedValue.of("c", Instant.ofEpochMilli(12)))))
+              .apply(ParDo.of(fn));
+
+      List<TimestampedValue<String>> expected =
+          Lists.newArrayList(
+              TimestampedValue.of("c", Instant.ofEpochMilli(12)),
+              TimestampedValue.of("b", Instant.ofEpochMilli(42)),
+              TimestampedValue.of("b", Instant.ofEpochMilli(52)),
+              TimestampedValue.of("a", Instant.ofEpochMilli(97)));
+
+      PAssert.that(output).containsInAnyOrder(expected);
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class, UsesOrderedListState.class})
+    public void testOrderedListStateRangeFetch() {
+      final String stateId = "foo";
+
+      DoFn<KV<String, TimestampedValue<String>>, Iterable<TimestampedValue<String>>> fn =
+          new DoFn<KV<String, TimestampedValue<String>>, Iterable<TimestampedValue<String>>>() {
+
+            @StateId(stateId)
+            private final StateSpec<OrderedListState<String>> orderedListState =
+                StateSpecs.orderedList(StringUtf8Coder.of());
+
+            @ProcessElement
+            public void processElement(
+                @Element KV<String, TimestampedValue<String>> element,
+                @StateId(stateId) OrderedListState<String> state) {
+              state.add(element.getValue());
+            }
+
+            @OnWindowExpiration
+            public void onWindowExpiration(
+                @StateId(stateId) OrderedListState<String> state,
+                OutputReceiver<Iterable<TimestampedValue<String>>> o) {
+              o.output(state.readRange(Instant.ofEpochMilli(0), Instant.ofEpochMilli(12)));
+              o.output(state.readRange(Instant.ofEpochMilli(0), Instant.ofEpochMilli(13)));
+              o.output(state.readRange(Instant.ofEpochMilli(13), Instant.ofEpochMilli(53)));
+              o.output(state.readRange(Instant.ofEpochMilli(52), Instant.ofEpochMilli(98)));
+            }
+          };
+
+      PCollection<Iterable<TimestampedValue<String>>> output =
+          pipeline
+              .apply(
+                  Create.of(
+                      KV.of("hello", TimestampedValue.of("a", Instant.ofEpochMilli(97))),
+                      KV.of("hello", TimestampedValue.of("b", Instant.ofEpochMilli(42))),
+                      KV.of("hello", TimestampedValue.of("b", Instant.ofEpochMilli(52))),
+                      KV.of("hello", TimestampedValue.of("c", Instant.ofEpochMilli(12)))))
+              .apply(ParDo.of(fn));
+
+      List<TimestampedValue<String>> expected1 = Lists.newArrayList();
+
+      List<TimestampedValue<String>> expected2 =
+          Lists.newArrayList(TimestampedValue.of("c", Instant.ofEpochMilli(12)));
+
+      List<TimestampedValue<String>> expected3 =
+          Lists.newArrayList(
+              TimestampedValue.of("b", Instant.ofEpochMilli(42)),
+              TimestampedValue.of("b", Instant.ofEpochMilli(52)));
+
+      List<TimestampedValue<String>> expected4 =
+          Lists.newArrayList(
+              TimestampedValue.of("b", Instant.ofEpochMilli(52)),
+              TimestampedValue.of("a", Instant.ofEpochMilli(97)));
+
+      PAssert.that(output).containsInAnyOrder(expected1, expected2, expected3, expected4);
+      pipeline.run();
+    }
+
+    @Test
+    @Category({ValidatesRunner.class, UsesStatefulParDo.class, UsesOrderedListState.class})
+    public void testOrderedListStateRangeDelete() {
+      final String stateId = "foo";
+      DoFn<KV<String, TimestampedValue<String>>, Iterable<TimestampedValue<String>>> fn =
+          new DoFn<KV<String, TimestampedValue<String>>, Iterable<TimestampedValue<String>>>() {
+
+            @StateId(stateId)
+            private final StateSpec<OrderedListState<String>> orderedListState =
+                StateSpecs.orderedList(StringUtf8Coder.of());
+
+            @TimerId("timer")
+            private final TimerSpec timer = TimerSpecs.timer(TimeDomain.EVENT_TIME);
+
+            @ProcessElement
+            public void processElement(
+                @Element KV<String, TimestampedValue<String>> element,
+                @StateId(stateId) OrderedListState<String> state,
+                @TimerId("timer") Timer timer) {
+              state.add(element.getValue());
+              timer.set(Instant.ofEpochMilli(42));
+            }
+
+            @OnTimer("timer")
+            public void processTimer(
+                @StateId(stateId) OrderedListState<String> state, @Timestamp Instant ts) {
+              state.clearRange(Instant.EPOCH, ts.plus(1));
+            }
+
+            @OnWindowExpiration
+            public void onWindowExpiration(
+                @StateId(stateId) OrderedListState<String> state,
+                OutputReceiver<Iterable<TimestampedValue<String>>> o) {
+              o.output(state.read());
+            }
+          };
+
+      PCollection<Iterable<TimestampedValue<String>>> output =
+          pipeline
+              .apply(
+                  Create.of(
+                      KV.of("hello", TimestampedValue.of("a", Instant.ofEpochMilli(97))),
+                      KV.of("hello", TimestampedValue.of("b", Instant.ofEpochMilli(42))),
+                      KV.of("hello", TimestampedValue.of("b", Instant.ofEpochMilli(52))),
+                      KV.of("hello", TimestampedValue.of("c", Instant.ofEpochMilli(12)))))
+              .apply(ParDo.of(fn));
+
+      List<TimestampedValue<String>> expected =
+          Lists.newArrayList(
+              TimestampedValue.of("b", Instant.ofEpochMilli(52)),
+              TimestampedValue.of("a", Instant.ofEpochMilli(97)));
+
+      PAssert.that(output).containsInAnyOrder(expected);
       pipeline.run();
     }
 

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/FnApiStateAccessor.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/FnApiStateAccessor.java
@@ -36,6 +36,7 @@ import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.state.BagState;
 import org.apache.beam.sdk.state.CombiningState;
 import org.apache.beam.sdk.state.MapState;
+import org.apache.beam.sdk.state.OrderedListState;
 import org.apache.beam.sdk.state.ReadableState;
 import org.apache.beam.sdk.state.ReadableStates;
 import org.apache.beam.sdk.state.SetState;
@@ -331,6 +332,13 @@ public class FnApiStateAccessor<K> implements SideInputReader, StateBinder {
       Coder<KeyT> mapKeyCoder,
       Coder<ValueT> mapValueCoder) {
     throw new UnsupportedOperationException("TODO: Add support for a map state to the Fn API.");
+  }
+
+  @Override
+  public <T> OrderedListState<T> bindOrderedList(
+      String id, StateSpec<OrderedListState<T>> spec, Coder<T> elemCoder) {
+    throw new UnsupportedOperationException(
+        "TODO: Add support for a sorted-list state to the Fn API.");
   }
 
   @Override


### PR DESCRIPTION
This PR adds the API and and in-memory implementation for the timestamp-ordered list state. The API is currently marked experimental and is still subject to change.