### PR TITLE
[BEAM-10571] Use schemas in ExternalConfigurationPayload

### DIFF
--- a/model/pipeline/src/main/proto/external_transforms.proto
+++ b/model/pipeline/src/main/proto/external_transforms.proto
@@ -29,17 +29,15 @@ option java_package = "org.apache.beam.model.pipeline.v1";
 option java_outer_classname = "ExternalTransforms";
 
 import "beam_runner_api.proto";
-
-message ConfigValue {
-  // Coder and its components (in case of a compound Coder)
-  repeated string coder_urn = 1;
-  // The Payload which is decoded using the coder_urn
-  bytes payload = 2;
-}
+import "schema.proto";
 
 // A configuration payload for an external transform.
 // Used as the payload of ExternalTransform as part of an ExpansionRequest.
 message ExternalConfigurationPayload {
-  // Configuration key => value
-  map<string, ConfigValue> configuration = 1;
+  // A schema for use in beam:coder:row:v1
+  Schema schema = 1;
+
+  // A payload which can be decoded using beam:coder:row:v1 and the given
+  // schema.
+  bytes payload = 2;
 }

--- a/sdks/java/expansion-service/build.gradle
+++ b/sdks/java/expansion-service/build.gradle
@@ -44,6 +44,10 @@ dependencies {
   compile library.java.slf4j_api
   runtimeOnly library.java.slf4j_jdk14
   testCompile library.java.junit
+  // TODO(BEAM-10632): Remove this. Currently Schema inference (used in
+  // ExpansionServiceTest) hits an NPE when checker is enabled and
+  // checkerframework is not in the classpath.
+  testCompile "org.checkerframework:checker:3.5.0"
 }
 
 task runExpansionService (type: JavaExec) {

--- a/sdks/java/expansion-service/src/main/java/org/apache/beam/sdk/expansion/service/ExpansionService.java
+++ b/sdks/java/expansion-service/src/main/java/org/apache/beam/sdk/expansion/service/ExpansionService.java
@@ -22,23 +22,19 @@ import static org.apache.beam.sdk.util.Preconditions.checkArgumentNotNull;
 
 import com.google.auto.service.AutoService;
 import java.io.IOException;
+import java.lang.reflect.Constructor;
+import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
-import java.util.ArrayDeque;
 import java.util.Collections;
-import java.util.Deque;
 import java.util.List;
 import java.util.Map;
 import java.util.ServiceLoader;
 import java.util.Set;
-import java.util.UUID;
 import java.util.stream.Collectors;
 import org.apache.beam.model.expansion.v1.ExpansionApi;
 import org.apache.beam.model.expansion.v1.ExpansionServiceGrpc;
-import org.apache.beam.model.pipeline.v1.ExternalTransforms;
+import org.apache.beam.model.pipeline.v1.ExternalTransforms.ExternalConfigurationPayload;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
-import org.apache.beam.runners.core.construction.BeamUrns;
-import org.apache.beam.runners.core.construction.CoderTranslation;
-import org.apache.beam.runners.core.construction.CoderTranslation.TranslationContext;
 import org.apache.beam.runners.core.construction.Environments;
 import org.apache.beam.runners.core.construction.PipelineTranslation;
 import org.apache.beam.runners.core.construction.RehydratedComponents;
@@ -46,17 +42,26 @@ import org.apache.beam.runners.core.construction.SdkComponents;
 import org.apache.beam.runners.fnexecution.artifact.ArtifactRetrievalService;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.RowCoder;
 import org.apache.beam.sdk.expansion.ExternalTransformRegistrar;
 import org.apache.beam.sdk.options.ExperimentalOptions;
 import org.apache.beam.sdk.options.PortablePipelineOptions;
+import org.apache.beam.sdk.schemas.NoSuchSchemaException;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.Field;
+import org.apache.beam.sdk.schemas.SchemaCoder;
+import org.apache.beam.sdk.schemas.SchemaRegistry;
+import org.apache.beam.sdk.schemas.SchemaTranslation;
 import org.apache.beam.sdk.transforms.ExternalTransformBuilder;
 import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionList;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.PDone;
 import org.apache.beam.sdk.values.PInput;
 import org.apache.beam.sdk.values.POutput;
+import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.vendor.grpc.v1p26p0.io.grpc.Server;
 import org.apache.beam.vendor.grpc.v1p26p0.io.grpc.ServerBuilder;
@@ -100,6 +105,8 @@ public class ExpansionService extends ExpansionServiceGrpc.ExpansionServiceImplB
   public static class ExternalTransformRegistrarLoader
       implements ExpansionService.ExpansionServiceRegistrar {
 
+    private static final SchemaRegistry SCHEMA_REGISTRY = SchemaRegistry.createDefault();
+
     @Override
     public Map<String, ExpansionService.TransformProvider> knownTransforms() {
       ImmutableMap.Builder<String, ExpansionService.TransformProvider> builder =
@@ -114,13 +121,10 @@ public class ExpansionService extends ExpansionServiceGrpc.ExpansionServiceImplB
               urn,
               spec -> {
                 try {
-                  ExternalTransforms.ExternalConfigurationPayload payload =
-                      ExternalTransforms.ExternalConfigurationPayload.parseFrom(spec.getPayload());
+                  Class configClass = getConfigClass(builderInstance);
                   return builderInstance.buildExternal(
                       payloadToConfig(
-                          payload,
-                          (Class<? extends ExternalTransformBuilder<?, ?, ?>>)
-                              builderInstance.getClass()));
+                          ExternalConfigurationPayload.parseFrom(spec.getPayload()), configClass));
                 } catch (Exception e) {
                   throw new RuntimeException(
                       String.format("Failed to build transform %s from spec %s", urn, spec), e);
@@ -132,51 +136,135 @@ public class ExpansionService extends ExpansionServiceGrpc.ExpansionServiceImplB
       return builder.build();
     }
 
-    Object payloadToConfig(
-        ExternalTransforms.ExternalConfigurationPayload payload,
-        Class<? extends ExternalTransformBuilder<?, ?, ?>> builderClass)
-        throws Exception {
-      Object configObject = initConfiguration(builderClass);
-      populateConfiguration(configObject, payload);
-      return configObject;
-    }
-
-    private static Object initConfiguration(
-        Class<? extends ExternalTransformBuilder<?, ?, ?>> builderClass) throws Exception {
-      for (Method method : builderClass.getMethods()) {
+    private static <ConfigT> Class<ConfigT> getConfigClass(
+        ExternalTransformBuilder<ConfigT, ?, ?> transformBuilder) {
+      Class<ConfigT> configurationClass = null;
+      for (Method method : transformBuilder.getClass().getMethods()) {
         if (method.getName().equals("buildExternal")) {
           Preconditions.checkState(
               method.getParameterCount() == 1,
               "Build method for ExternalTransformBuilder %s must have exactly one parameter, but"
                   + " had %s parameters.",
-              builderClass.getSimpleName(),
+              transformBuilder.getClass().getSimpleName(),
               method.getParameterCount());
-          Class<?> configurationClass = method.getParameterTypes()[0];
+          configurationClass = (Class<ConfigT>) method.getParameterTypes()[0];
           if (Object.class.equals(configurationClass)) {
             continue;
           }
-          return configurationClass.getDeclaredConstructor().newInstance();
+          break;
         }
       }
-      throw new RuntimeException("Couldn't find build method on ExternalTransformBuilder.");
+
+      if (configurationClass == null) {
+        throw new AssertionError("Failed to find buildExternal method.");
+      }
+
+      return configurationClass;
     }
 
-    @VisibleForTesting
-    static void populateConfiguration(
-        Object config, ExternalTransforms.ExternalConfigurationPayload payload) throws Exception {
+    private static <ConfigT> Row decodeRow(ExternalConfigurationPayload payload) {
+      Schema payloadSchema = SchemaTranslation.schemaFromProto(payload.getSchema());
+
+      if (payloadSchema.getFieldCount() == 0) {
+        return Row.withSchema(Schema.of()).build();
+      }
+
+      // Coerce field names to camel-case
       Converter<String, String> camelCaseConverter =
           CaseFormat.LOWER_UNDERSCORE.converterTo(CaseFormat.LOWER_CAMEL);
-      for (Map.Entry<String, ExternalTransforms.ConfigValue> entry :
-          payload.getConfigurationMap().entrySet()) {
-        String key = entry.getKey();
-        ExternalTransforms.ConfigValue value = entry.getValue();
+      payloadSchema =
+          payloadSchema.getFields().stream()
+              .map(
+                  (field) -> {
+                    Preconditions.checkNotNull(field.getName());
+                    if (field.getName().contains("_")) {
+                      @Nullable String newName = camelCaseConverter.convert(field.getName());
+                      assert newName != null
+                          : "@AssumeAssertion(nullness): converter type is imprecise; it is nullness-preserving";
+                      return field.withName(newName);
+                    } else {
+                      return field;
+                    }
+                  })
+              .collect(Schema.toSchema());
 
-        String fieldName = camelCaseConverter.convert(key);
-        assert fieldName != null
-            : "@AssumeAssertion(nullness): converter type is imprecise; it is nullness-preserving";
-        List<String> coderUrns = value.getCoderUrnList();
-        Preconditions.checkArgument(coderUrns.size() > 0, "No Coder URN provided.");
-        Coder coder = resolveCoder(coderUrns);
+      Row configRow;
+      try {
+        configRow = RowCoder.of(payloadSchema).decode(payload.getPayload().newInput());
+      } catch (IOException e) {
+        throw new RuntimeException("Error decoding payload", e);
+      }
+      return configRow;
+    }
+
+    /**
+     * Attempt to create an instance of {@link ConfigT} from an {@link
+     * ExternalConfigurationPayload}. If a schema is registered for {@link ConfigT} this method will
+     * attempt to ise it. Throws an {@link IllegalArgumentException} if the schema in {@code
+     * payload} is not {@link Schema#assignableTo(Schema) assignable to} the registered schema.
+     *
+     * <p>If no Schema is registered, {@link ConfigT} must have a zero-argument constructor and
+     * setters corresponding to each field in the row encoded by {@code payload}. Note {@link
+     * ConfigT} may have additional setters not represented in the {@ocde payload} schema.
+     *
+     * <p>Exposed for testing only. No backwards compatibility guarantees.
+     */
+    @VisibleForTesting
+    public static <ConfigT> ConfigT payloadToConfig(
+        ExternalConfigurationPayload payload, Class<ConfigT> configurationClass) {
+      try {
+        return payloadToConfigSchema(payload, configurationClass);
+      } catch (NoSuchSchemaException schemaException) {
+        LOG.warn(
+            "Configuration class '{}' has no schema registered. Attempting to construct with setter approach.",
+            configurationClass.getName());
+        try {
+          return payloadToConfigSetters(payload, configurationClass);
+        } catch (ReflectiveOperationException e) {
+          throw new IllegalArgumentException(
+              String.format(
+                  "Failed to construct instance of configuration class '%s'",
+                  configurationClass.getName()),
+              e);
+        }
+      }
+    }
+
+    private static <ConfigT> ConfigT payloadToConfigSchema(
+        ExternalConfigurationPayload payload, Class<ConfigT> configurationClass)
+        throws NoSuchSchemaException {
+      Schema configSchema = SCHEMA_REGISTRY.getSchema(configurationClass);
+      SerializableFunction<Row, ConfigT> fromRowFunc =
+          SCHEMA_REGISTRY.getFromRowFunction(configurationClass);
+
+      Row payloadRow = decodeRow(payload);
+
+      if (!payloadRow.getSchema().assignableTo(configSchema)) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Schema in expansion request payload is not assignable to the schema for the configuration object.\n\nPayload Schema: %s\n\nConfiguration Schema: %s",
+                payloadRow.getSchema(), configSchema));
+      }
+
+      return fromRowFunc.apply(payloadRow);
+    }
+
+    private static <ConfigT> ConfigT payloadToConfigSetters(
+        ExternalConfigurationPayload payload, Class<ConfigT> configurationClass)
+        throws ReflectiveOperationException {
+      Row configRow = decodeRow(payload);
+
+      Constructor<ConfigT> constructor = configurationClass.getDeclaredConstructor();
+      constructor.setAccessible(true);
+
+      ConfigT config = constructor.newInstance();
+      for (Field field : configRow.getSchema().getFields()) {
+        String key = field.getName();
+        @Nullable Object value = configRow.getValue(field.getName());
+
+        String fieldName = key;
+
+        Coder coder = SchemaCoder.coderForFieldType(field.getType());
         Class type = coder.getEncodedTypeDescriptor().getRawType();
 
         String setterName =
@@ -186,7 +274,7 @@ public class ExpansionService extends ExpansionServiceGrpc.ExpansionServiceImplB
           // retrieve the setter for this field
           method = config.getClass().getMethod(setterName, type);
         } catch (NoSuchMethodException e) {
-          throw new RuntimeException(
+          throw new IllegalArgumentException(
               String.format(
                   "The configuration class %s is missing a setter %s for %s with type %s",
                   config.getClass(),
@@ -195,48 +283,18 @@ public class ExpansionService extends ExpansionServiceGrpc.ExpansionServiceImplB
                   coder.getEncodedTypeDescriptor().getType().getTypeName()),
               e);
         }
-        method.invoke(
-            config, coder.decode(entry.getValue().getPayload().newInput(), Coder.Context.NESTED));
+        invokeSetter(config, value, method);
       }
+      return config;
     }
 
-    private static Coder resolveCoder(List<String> coderUrns) throws Exception {
-      Preconditions.checkArgument(coderUrns.size() > 0, "No Coder URN provided.");
-      RunnerApi.Components.Builder componentsBuilder = RunnerApi.Components.newBuilder();
-      Deque<String> coderQueue = new ArrayDeque<>(coderUrns);
-      RunnerApi.Coder coder = buildProto(coderQueue, componentsBuilder);
-
-      RehydratedComponents rehydratedComponents =
-          RehydratedComponents.forComponents(componentsBuilder.build());
-      return CoderTranslation.fromProto(coder, rehydratedComponents, TranslationContext.DEFAULT);
-    }
-
-    private static RunnerApi.Coder buildProto(
-        Deque<String> coderUrns, RunnerApi.Components.Builder componentsBuilder) {
-      Preconditions.checkArgument(coderUrns.size() > 0, "No URNs left to construct coder from");
-
-      final String coderUrn = coderUrns.pop();
-      RunnerApi.Coder.Builder coderBuilder =
-          RunnerApi.Coder.newBuilder()
-              .setSpec(RunnerApi.FunctionSpec.newBuilder().setUrn(coderUrn).build());
-
-      if (coderUrn.equals(BeamUrns.getUrn(RunnerApi.StandardCoders.Enum.ITERABLE))) {
-        RunnerApi.Coder elementCoder = buildProto(coderUrns, componentsBuilder);
-        String coderId = UUID.randomUUID().toString();
-        componentsBuilder.putCoders(coderId, elementCoder);
-        coderBuilder.addComponentCoderIds(coderId);
-      } else if (coderUrn.equals(BeamUrns.getUrn(RunnerApi.StandardCoders.Enum.KV))) {
-        RunnerApi.Coder element1Coder = buildProto(coderUrns, componentsBuilder);
-        RunnerApi.Coder element2Coder = buildProto(coderUrns, componentsBuilder);
-        String coderId1 = UUID.randomUUID().toString();
-        String coderId2 = UUID.randomUUID().toString();
-        componentsBuilder.putCoders(coderId1, element1Coder);
-        componentsBuilder.putCoders(coderId2, element2Coder);
-        coderBuilder.addComponentCoderIds(coderId1);
-        coderBuilder.addComponentCoderIds(coderId2);
-      }
-
-      return coderBuilder.build();
+    // Checker framework is conservative for Method#invoke, args are NonNull
+    // See https://checkerframework.org/manual/#reflection-resolution
+    @SuppressWarnings("nullness")
+    private static <ConfigT> void invokeSetter(
+        ConfigT config, @Nullable Object value, Method method)
+        throws IllegalAccessException, InvocationTargetException {
+      method.invoke(config, value);
     }
   }
 

--- a/sdks/java/expansion-service/src/main/java/org/apache/beam/sdk/expansion/service/ExpansionService.java
+++ b/sdks/java/expansion-service/src/main/java/org/apache/beam/sdk/expansion/service/ExpansionService.java
@@ -242,7 +242,8 @@ public class ExpansionService extends ExpansionServiceGrpc.ExpansionServiceImplB
       if (!payloadRow.getSchema().assignableTo(configSchema)) {
         throw new IllegalArgumentException(
             String.format(
-                "Schema in expansion request payload is not assignable to the schema for the configuration object.\n\nPayload Schema: %s\n\nConfiguration Schema: %s",
+                "Schema in expansion request payload is not assignable to the schema for the "
+                    + "configuration object.%n%nPayload Schema: %s%n%nConfiguration Schema: %s",
                 payloadRow.getSchema(), configSchema));
       }
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOExternalTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOExternalTest.java
@@ -32,9 +32,15 @@ import org.apache.beam.sdk.coders.BooleanCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.expansion.service.ExpansionService;
 import org.apache.beam.sdk.options.ValueProvider;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.Field;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.schemas.SchemaCoder;
+import org.apache.beam.sdk.schemas.SchemaTranslation;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.grpc.v1p26p0.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.grpc.v1p26p0.io.grpc.stub.StreamObserver;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
@@ -55,26 +61,16 @@ public class PubsubIOExternalTest {
     Boolean needsAttributes = true;
 
     ExternalTransforms.ExternalConfigurationPayload payload =
-        ExternalTransforms.ExternalConfigurationPayload.newBuilder()
-            .putConfiguration(
-                "topic",
-                ExternalTransforms.ConfigValue.newBuilder()
-                    .addCoderUrn("beam:coder:string_utf8:v1")
-                    .setPayload(ByteString.copyFrom(encodeString(topic)))
-                    .build())
-            .putConfiguration(
-                "id_label",
-                ExternalTransforms.ConfigValue.newBuilder()
-                    .addCoderUrn("beam:coder:string_utf8:v1")
-                    .setPayload(ByteString.copyFrom(encodeString(idAttribute)))
-                    .build())
-            .putConfiguration(
-                "with_attributes",
-                ExternalTransforms.ConfigValue.newBuilder()
-                    .addCoderUrn("beam:coder:bool:v1")
-                    .setPayload(ByteString.copyFrom(encodeBoolean(needsAttributes)))
-                    .build())
-            .build();
+        encodeRow(
+            Row.withSchema(
+                    Schema.of(
+                        Field.of("topic", FieldType.STRING),
+                        Field.of("id_label", FieldType.STRING),
+                        Field.of("with_attributes", FieldType.BOOLEAN)))
+                .withFieldValue("topic", topic)
+                .withFieldValue("id_label", idAttribute)
+                .withFieldValue("with_attributes", needsAttributes)
+                .build());
 
     RunnerApi.Components defaultInstance = RunnerApi.Components.getDefaultInstance();
     ExpansionApi.ExpansionRequest request =
@@ -126,20 +122,14 @@ public class PubsubIOExternalTest {
     String idAttribute = "id_foo";
 
     ExternalTransforms.ExternalConfigurationPayload payload =
-        ExternalTransforms.ExternalConfigurationPayload.newBuilder()
-            .putConfiguration(
-                "topic",
-                ExternalTransforms.ConfigValue.newBuilder()
-                    .addCoderUrn("beam:coder:string_utf8:v1")
-                    .setPayload(ByteString.copyFrom(encodeString(topic)))
-                    .build())
-            .putConfiguration(
-                "id_label",
-                ExternalTransforms.ConfigValue.newBuilder()
-                    .addCoderUrn("beam:coder:string_utf8:v1")
-                    .setPayload(ByteString.copyFrom(encodeString(idAttribute)))
-                    .build())
-            .build();
+        encodeRow(
+            Row.withSchema(
+                    Schema.of(
+                        Field.of("topic", FieldType.STRING),
+                        Field.of("id_label", FieldType.STRING)))
+                .withFieldValue("topic", topic)
+                .withFieldValue("id_label", idAttribute)
+                .build());
 
     Pipeline p = Pipeline.create();
     p.apply("unbounded", Create.of(1, 2, 3)).setIsBoundedInternal(PCollection.IsBounded.UNBOUNDED);
@@ -239,5 +229,19 @@ public class PubsubIOExternalTest {
 
     @Override
     public void onCompleted() {}
+  }
+
+  private static ExternalTransforms.ExternalConfigurationPayload encodeRow(Row row) {
+    ByteString.Output outputStream = ByteString.newOutput();
+    try {
+      SchemaCoder.of(row.getSchema()).encode(row, outputStream);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    return ExternalTransforms.ExternalConfigurationPayload.newBuilder()
+        .setSchema(SchemaTranslation.schemaToProto(row.getSchema(), true))
+        .setPayload(outputStream.toByteString())
+        .build();
   }
 }

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -630,7 +630,6 @@ public class KafkaIO {
       /** Parameters class to expose the Read transform to an external SDK. */
       public static class Configuration {
 
-        // All byte arrays are UTF-8 encoded strings
         private Map<String, String> consumerConfig;
         private List<String> topics;
         private String keyDeserializer;
@@ -2041,7 +2040,6 @@ public class KafkaIO {
       /** Parameters class to expose the Write transform to an external SDK. */
       public static class Configuration {
 
-        // All byte arrays are UTF-8 encoded strings
         private Map<String, String> producerConfig;
         private String topic;
         private String keySerializer;

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -562,10 +562,7 @@ public class KafkaIO {
         setValueDeserializerProvider(LocalDeserializerProvider.of(valueDeserializer));
         setValueCoder(resolveCoder(valueDeserializer));
 
-        Map<String, Object> consumerConfig = new HashMap<>();
-        for (KV<String, String> kv : config.consumerConfig) {
-          consumerConfig.put(kv.getKey(), kv.getValue());
-        }
+        Map<String, Object> consumerConfig = new HashMap<>(config.consumerConfig);
         // Key and Value Deserializers always have to be in the config.
         consumerConfig.put(ConsumerConfig.KEY_DESERIALIZER_CLASS_CONFIG, keyDeserializer.getName());
         consumerConfig.put(
@@ -634,19 +631,19 @@ public class KafkaIO {
       public static class Configuration {
 
         // All byte arrays are UTF-8 encoded strings
-        private Iterable<KV<String, String>> consumerConfig;
-        private Iterable<String> topics;
+        private Map<String, String> consumerConfig;
+        private List<String> topics;
         private String keyDeserializer;
         private String valueDeserializer;
         private Long startReadTime;
         private Long maxNumRecords;
         private Long maxReadTime;
 
-        public void setConsumerConfig(Iterable<KV<String, String>> consumerConfig) {
+        public void setConsumerConfig(Map<String, String> consumerConfig) {
           this.consumerConfig = consumerConfig;
         }
 
-        public void setTopics(Iterable<String> topics) {
+        public void setTopics(List<String> topics) {
           this.topics = topics;
         }
 
@@ -2011,10 +2008,7 @@ public class KafkaIO {
           External.Configuration configuration) {
         setTopic(configuration.topic);
 
-        Map<String, Object> producerConfig = new HashMap<>();
-        for (KV<String, String> kv : configuration.producerConfig) {
-          producerConfig.put(kv.getKey(), kv.getValue());
-        }
+        Map<String, Object> producerConfig = new HashMap<>(configuration.producerConfig);
         Class keySerializer = resolveClass(configuration.keySerializer);
         Class valSerializer = resolveClass(configuration.valueSerializer);
 
@@ -2048,12 +2042,12 @@ public class KafkaIO {
       public static class Configuration {
 
         // All byte arrays are UTF-8 encoded strings
-        private Iterable<KV<String, String>> producerConfig;
+        private Map<String, String> producerConfig;
         private String topic;
         private String keySerializer;
         private String valueSerializer;
 
-        public void setProducerConfig(Iterable<KV<String, String>> producerConfig) {
+        public void setProducerConfig(Map<String, String> producerConfig) {
           this.producerConfig = producerConfig;
         }
 

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOExternalTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOExternalTest.java
@@ -34,7 +34,6 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.IterableCoder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
-import org.apache.beam.sdk.coders.VarLongCoder;
 import org.apache.beam.sdk.expansion.service.ExpansionService;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.Field;

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOExternalTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOExternalTest.java
@@ -26,6 +26,7 @@ import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.beam.model.expansion.v1.ExpansionApi;
 import org.apache.beam.model.pipeline.v1.ExternalTransforms;
+import org.apache.beam.model.pipeline.v1.ExternalTransforms.ExternalConfigurationPayload;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.runners.core.construction.ParDoTranslation;
 import org.apache.beam.runners.core.construction.PipelineTranslation;
@@ -35,10 +36,16 @@ import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VarLongCoder;
 import org.apache.beam.sdk.expansion.service.ExpansionService;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.Field;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.schemas.SchemaCoder;
+import org.apache.beam.sdk.schemas.SchemaTranslation;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.Impulse;
 import org.apache.beam.sdk.transforms.WithKeys;
 import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.grpc.v1p26p0.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.grpc.v1p26p0.io.grpc.stub.StreamObserver;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
@@ -70,42 +77,21 @@ public class KafkaIOExternalTest {
     Long startReadTime = 100L;
 
     ExternalTransforms.ExternalConfigurationPayload payload =
-        ExternalTransforms.ExternalConfigurationPayload.newBuilder()
-            .putConfiguration(
-                "topics",
-                ExternalTransforms.ConfigValue.newBuilder()
-                    .addCoderUrn("beam:coder:iterable:v1")
-                    .addCoderUrn("beam:coder:string_utf8:v1")
-                    .setPayload(ByteString.copyFrom(listAsBytes(topics)))
-                    .build())
-            .putConfiguration(
-                "consumer_config",
-                ExternalTransforms.ConfigValue.newBuilder()
-                    .addCoderUrn("beam:coder:iterable:v1")
-                    .addCoderUrn("beam:coder:kv:v1")
-                    .addCoderUrn("beam:coder:string_utf8:v1")
-                    .addCoderUrn("beam:coder:string_utf8:v1")
-                    .setPayload(ByteString.copyFrom(mapAsBytes(consumerConfig)))
-                    .build())
-            .putConfiguration(
-                "key_deserializer",
-                ExternalTransforms.ConfigValue.newBuilder()
-                    .addCoderUrn("beam:coder:string_utf8:v1")
-                    .setPayload(ByteString.copyFrom(encodeString(keyDeserializer)))
-                    .build())
-            .putConfiguration(
-                "value_deserializer",
-                ExternalTransforms.ConfigValue.newBuilder()
-                    .addCoderUrn("beam:coder:string_utf8:v1")
-                    .setPayload(ByteString.copyFrom(encodeString(valueDeserializer)))
-                    .build())
-            .putConfiguration(
-                "start_read_time",
-                ExternalTransforms.ConfigValue.newBuilder()
-                    .addCoderUrn("beam:coder:varint:v1")
-                    .setPayload(ByteString.copyFrom(encodeLong(startReadTime)))
-                    .build())
-            .build();
+        encodeRow(
+            Row.withSchema(
+                    Schema.of(
+                        Field.of("topics", FieldType.array(FieldType.STRING)),
+                        Field.of(
+                            "consumer_config", FieldType.map(FieldType.STRING, FieldType.STRING)),
+                        Field.of("key_deserializer", FieldType.STRING),
+                        Field.of("value_deserializer", FieldType.STRING),
+                        Field.of("start_read_time", FieldType.INT64)))
+                .withFieldValue("topics", topics)
+                .withFieldValue("consumer_config", consumerConfig)
+                .withFieldValue("key_deserializer", keyDeserializer)
+                .withFieldValue("value_deserializer", valueDeserializer)
+                .withFieldValue("start_read_time", startReadTime)
+                .build());
 
     RunnerApi.Components defaultInstance = RunnerApi.Components.getDefaultInstance();
     ExpansionApi.ExpansionRequest request =
@@ -207,35 +193,19 @@ public class KafkaIOExternalTest {
             .build();
 
     ExternalTransforms.ExternalConfigurationPayload payload =
-        ExternalTransforms.ExternalConfigurationPayload.newBuilder()
-            .putConfiguration(
-                "topic",
-                ExternalTransforms.ConfigValue.newBuilder()
-                    .addCoderUrn("beam:coder:string_utf8:v1")
-                    .setPayload(ByteString.copyFrom(encodeString(topic)))
-                    .build())
-            .putConfiguration(
-                "producer_config",
-                ExternalTransforms.ConfigValue.newBuilder()
-                    .addCoderUrn("beam:coder:iterable:v1")
-                    .addCoderUrn("beam:coder:kv:v1")
-                    .addCoderUrn("beam:coder:string_utf8:v1")
-                    .addCoderUrn("beam:coder:string_utf8:v1")
-                    .setPayload(ByteString.copyFrom(mapAsBytes(producerConfig)))
-                    .build())
-            .putConfiguration(
-                "key_serializer",
-                ExternalTransforms.ConfigValue.newBuilder()
-                    .addCoderUrn("beam:coder:string_utf8:v1")
-                    .setPayload(ByteString.copyFrom(encodeString(keySerializer)))
-                    .build())
-            .putConfiguration(
-                "value_serializer",
-                ExternalTransforms.ConfigValue.newBuilder()
-                    .addCoderUrn("beam:coder:string_utf8:v1")
-                    .setPayload(ByteString.copyFrom(encodeString(valueSerializer)))
-                    .build())
-            .build();
+        encodeRow(
+            Row.withSchema(
+                    Schema.of(
+                        Field.of("topic", FieldType.STRING),
+                        Field.of(
+                            "producer_config", FieldType.map(FieldType.STRING, FieldType.STRING)),
+                        Field.of("key_serializer", FieldType.STRING),
+                        Field.of("value_serializer", FieldType.STRING)))
+                .withFieldValue("topic", topic)
+                .withFieldValue("producer_config", producerConfig)
+                .withFieldValue("key_serializer", keySerializer)
+                .withFieldValue("value_serializer", valueSerializer)
+                .build());
 
     Pipeline p = Pipeline.create();
     p.apply(Impulse.create()).apply(WithKeys.of("key"));
@@ -322,10 +292,18 @@ public class KafkaIOExternalTest {
     return baos.toByteArray();
   }
 
-  private static byte[] encodeLong(Long str) throws IOException {
-    ByteArrayOutputStream baos = new ByteArrayOutputStream();
-    VarLongCoder.of().encode(str, baos);
-    return baos.toByteArray();
+  private static ExternalConfigurationPayload encodeRow(Row row) {
+    ByteString.Output outputStream = ByteString.newOutput();
+    try {
+      SchemaCoder.of(row.getSchema()).encode(row, outputStream);
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+
+    return ExternalConfigurationPayload.newBuilder()
+        .setSchema(SchemaTranslation.schemaToProto(row.getSchema(), true))
+        .setPayload(outputStream.toByteString())
+        .build();
   }
 
   private static class TestStreamObserver<T> implements StreamObserver<T> {

--- a/sdks/python/apache_beam/io/kafka.py
+++ b/sdks/python/apache_beam/io/kafka.py
@@ -93,7 +93,7 @@ from apache_beam.transforms.external import NamedTupleBasedPayloadBuilder
 ReadFromKafkaSchema = typing.NamedTuple(
     'ReadFromKafkaSchema',
     [
-        ('consumer_config', typing.List[typing.Tuple[unicode, unicode]]),
+        ('consumer_config', typing.Mapping[unicode, unicode]),
         ('topics', typing.List[unicode]),
         ('key_deserializer', unicode),
         ('value_deserializer', unicode),
@@ -158,7 +158,7 @@ class ReadFromKafka(ExternalTransform):
         self.URN,
         NamedTupleBasedPayloadBuilder(
             ReadFromKafkaSchema(
-                consumer_config=list(consumer_config.items()),
+                consumer_config=consumer_config,
                 topics=topics,
                 key_deserializer=key_deserializer,
                 value_deserializer=value_deserializer,
@@ -172,7 +172,7 @@ class ReadFromKafka(ExternalTransform):
 WriteToKafkaSchema = typing.NamedTuple(
     'WriteToKafkaSchema',
     [
-        ('producer_config', typing.List[typing.Tuple[unicode, unicode]]),
+        ('producer_config', typing.Mapping[unicode, unicode]),
         ('topic', unicode),
         ('key_serializer', unicode),
         ('value_serializer', unicode),
@@ -220,7 +220,7 @@ class WriteToKafka(ExternalTransform):
         self.URN,
         NamedTupleBasedPayloadBuilder(
             WriteToKafkaSchema(
-                producer_config=list(producer_config.items()),
+                producer_config=producer_config,
                 topic=topic,
                 key_serializer=key_serializer,
                 value_serializer=value_serializer,

--- a/sdks/python/apache_beam/runners/portability/expansion_service_test.py
+++ b/sdks/python/apache_beam/runners/portability/expansion_service_test.py
@@ -29,7 +29,7 @@ from past.builtins import unicode
 
 import apache_beam as beam
 import apache_beam.transforms.combiners as combine
-from apache_beam.coders import StrUtf8Coder
+from apache_beam.coders import RowCoder
 from apache_beam.pipeline import PipelineOptions
 from apache_beam.portability.api import beam_expansion_api_pb2_grpc
 from apache_beam.portability.api.external_transforms_pb2 import ExternalConfigurationPayload
@@ -274,12 +274,8 @@ class FibTransform(ptransform.PTransform):
 def parse_string_payload(input_byte):
   payload = ExternalConfigurationPayload()
   payload.ParseFromString(input_byte)
-  coder = StrUtf8Coder()
-  return {
-      k: coder.decode_nested(v.payload)
-      for k,
-      v in payload.configuration.items()
-  }
+
+  return RowCoder(payload.schema).decode(payload.payload)._asdict()
 
 
 server = None

--- a/sdks/python/apache_beam/transforms/external_test.py
+++ b/sdks/python/apache_beam/transforms/external_test.py
@@ -30,13 +30,7 @@ from past.builtins import unicode
 
 import apache_beam as beam
 from apache_beam import Pipeline
-from apache_beam.coders import BooleanCoder
-from apache_beam.coders import FloatCoder
-from apache_beam.coders import IterableCoder
-from apache_beam.coders import StrUtf8Coder
-from apache_beam.coders import TupleCoder
-from apache_beam.coders import VarIntCoder
-from apache_beam.portability.api.external_transforms_pb2 import ConfigValue
+from apache_beam.coders import RowCoder
 from apache_beam.portability.api.external_transforms_pb2 import ExternalConfigurationPayload
 from apache_beam.runners.portability import expansion_service
 from apache_beam.runners.portability.expansion_service_test import FibTransform
@@ -56,7 +50,9 @@ class PayloadBase(object):
       'boolean': True,
       'string_example': u'thing',
       'list_of_strings': [u'foo', u'bar'],
-      'optional_kv': (u'key', 1.1),
+      'mapping': {
+          u'key': 1.1
+      },
       'optional_integer': None,
   }
 
@@ -65,35 +61,10 @@ class PayloadBase(object):
       'boolean': True,
       'string_example': 'thing',
       'list_of_strings': ['foo', 'bar'],
-      'optional_kv': ('key', 1.1),
+      'mapping': {
+          'key': 1.1
+      },
       'optional_integer': None,
-  }
-
-  args = {
-      'integer_example': ConfigValue(
-          coder_urn=['beam:coder:varint:v1'],
-          payload=VarIntCoder().get_impl().encode_nested(
-              values['integer_example'])),
-      'boolean': ConfigValue(
-          coder_urn=['beam:coder:bool:v1'],
-          payload=BooleanCoder().get_impl().encode_nested(values['boolean'])),
-      'string_example': ConfigValue(
-          coder_urn=['beam:coder:string_utf8:v1'],
-          payload=StrUtf8Coder().get_impl().encode_nested(
-              values['string_example'])),
-      'list_of_strings': ConfigValue(
-          coder_urn=['beam:coder:iterable:v1', 'beam:coder:string_utf8:v1'],
-          payload=IterableCoder(StrUtf8Coder()).get_impl().encode_nested(
-              values['list_of_strings'])),
-      'optional_kv': ConfigValue(
-          coder_urn=[
-              'beam:coder:kv:v1',
-              'beam:coder:string_utf8:v1',
-              'beam:coder:double:v1'
-          ],
-          payload=TupleCoder([StrUtf8Coder(),
-                              FloatCoder()]).get_impl().encode_nested(
-                                  values['optional_kv'])),
   }
 
   def get_payload_from_typing_hints(self, values):
@@ -106,35 +77,41 @@ class PayloadBase(object):
 
   def test_typing_payload_builder(self):
     result = self.get_payload_from_typing_hints(self.values)
-    expected = get_payload(self.args)
-    self.assertEqual(result, expected)
+    decoded = RowCoder(result.schema).decode(result.payload)
+    for key, value in self.values.items():
+      self.assertEqual(getattr(decoded, key), value)
 
+  # TODO(BEAM-7372): Drop py2 specific "bytes" tests
   def test_typing_payload_builder_with_bytes(self):
     """
     string_utf8 coder will be used even if values are not unicode in python 2.x
     """
     result = self.get_payload_from_typing_hints(self.bytes_values)
-    expected = get_payload(self.args)
-    self.assertEqual(result, expected)
+    decoded = RowCoder(result.schema).decode(result.payload)
+    for key, value in self.values.items():
+      self.assertEqual(getattr(decoded, key), value)
 
   def test_typehints_payload_builder(self):
-    result = self.get_payload_from_beam_typehints(self.values)
-    expected = get_payload(self.args)
-    self.assertEqual(result, expected)
+    result = self.get_payload_from_typing_hints(self.values)
+    decoded = RowCoder(result.schema).decode(result.payload)
+    for key, value in self.values.items():
+      self.assertEqual(getattr(decoded, key), value)
 
+  # TODO(BEAM-7372): Drop py2 specific "bytes" tests
   def test_typehints_payload_builder_with_bytes(self):
     """
     string_utf8 coder will be used even if values are not unicode in python 2.x
     """
-    result = self.get_payload_from_beam_typehints(self.bytes_values)
-    expected = get_payload(self.args)
-    self.assertEqual(result, expected)
+    result = self.get_payload_from_typing_hints(self.bytes_values)
+    decoded = RowCoder(result.schema).decode(result.payload)
+    for key, value in self.values.items():
+      self.assertEqual(getattr(decoded, key), value)
 
   def test_optional_error(self):
     """
     value can only be None if typehint is Optional
     """
-    with self.assertRaises(RuntimeError):
+    with self.assertRaises(ValueError):
       self.get_payload_from_typing_hints({k: None for k in self.values})
 
 
@@ -147,7 +124,7 @@ class ExternalTuplePayloadTest(PayloadBase, unittest.TestCase):
             ('boolean', bool),
             ('string_example', unicode),
             ('list_of_strings', typing.List[unicode]),
-            ('optional_kv', typing.Optional[typing.Tuple[unicode, float]]),
+            ('mapping', typing.Mapping[unicode, float]),
             ('optional_integer', typing.Optional[int]),
         ])
 
@@ -168,47 +145,32 @@ class ExternalImplicitPayloadTest(unittest.TestCase):
   def test_implicit_payload_builder(self):
     builder = ImplicitSchemaPayloadBuilder(PayloadBase.values)
     result = builder.build()
-    expected = get_payload(PayloadBase.args)
-    self.assertEqual(result, expected)
+
+    decoded = RowCoder(result.schema).decode(result.payload)
+    for key, value in PayloadBase.values.items():
+      # Note the default value in the getattr call.
+      # ImplicitSchemaPayloadBuilder omits fields with valu=None since their
+      # type cannot be inferred.
+      self.assertEqual(getattr(decoded, key, None), value)
 
   def test_implicit_payload_builder_with_bytes(self):
     values = PayloadBase.bytes_values
     builder = ImplicitSchemaPayloadBuilder(values)
     result = builder.build()
+
+    decoded = RowCoder(result.schema).decode(result.payload)
     if sys.version_info[0] < 3:
-      # in python 2.x bytes coder will be inferred
-      args = {
-          'integer_example': ConfigValue(
-              coder_urn=['beam:coder:varint:v1'],
-              payload=VarIntCoder().get_impl().encode_nested(
-                  values['integer_example'])),
-          'boolean': ConfigValue(
-              coder_urn=['beam:coder:bool:v1'],
-              payload=BooleanCoder().get_impl().encode_nested(
-                  values['boolean'])),
-          'string_example': ConfigValue(
-              coder_urn=['beam:coder:bytes:v1'],
-              payload=StrUtf8Coder().get_impl().encode_nested(
-                  values['string_example'])),
-          'list_of_strings': ConfigValue(
-              coder_urn=['beam:coder:iterable:v1', 'beam:coder:bytes:v1'],
-              payload=IterableCoder(StrUtf8Coder()).get_impl().encode_nested(
-                  values['list_of_strings'])),
-          'optional_kv': ConfigValue(
-              coder_urn=[
-                  'beam:coder:kv:v1',
-                  'beam:coder:bytes:v1',
-                  'beam:coder:double:v1'
-              ],
-              payload=TupleCoder([StrUtf8Coder(),
-                                  FloatCoder()]).get_impl().encode_nested(
-                                      values['optional_kv'])),
-      }
-      expected = get_payload(args)
-      self.assertEqual(result, expected)
+      for key, value in PayloadBase.bytes_values.items():
+        # Note the default value in the getattr call.
+        # ImplicitSchemaPayloadBuilder omits fields with valu=None since their
+        # type cannot be inferred.
+        self.assertEqual(getattr(decoded, key, None), value)
     else:
-      expected = get_payload(PayloadBase.args)
-      self.assertEqual(result, expected)
+      for key, value in PayloadBase.values.items():
+        # Note the default value in the getattr call.
+        # ImplicitSchemaPayloadBuilder omits fields with valu=None since their
+        # type cannot be inferred.
+        self.assertEqual(getattr(decoded, key, None), value)
 
 
 class ExternalTransformTest(unittest.TestCase):

--- a/sdks/python/apache_beam/transforms/external_test_py3.py
+++ b/sdks/python/apache_beam/transforms/external_test_py3.py
@@ -48,7 +48,7 @@ class ExternalAnnotationPayloadTest(PayloadBase, unittest.TestCase):
           boolean: bool,
           string_example: str,
           list_of_strings: typing.List[str],
-          optional_kv: typing.Optional[typing.Tuple[str, float]] = None,
+          mapping: typing.Mapping[str, float],
           optional_integer: typing.Optional[int] = None,
           expansion_service=None):
         super(AnnotatedTransform, self).__init__(
@@ -59,7 +59,7 @@ class ExternalAnnotationPayloadTest(PayloadBase, unittest.TestCase):
                 boolean=boolean,
                 string_example=string_example,
                 list_of_strings=list_of_strings,
-                optional_kv=optional_kv,
+                mapping=mapping,
                 optional_integer=optional_integer,
             ),
             expansion_service)
@@ -76,7 +76,7 @@ class ExternalAnnotationPayloadTest(PayloadBase, unittest.TestCase):
           boolean: bool,
           string_example: str,
           list_of_strings: typehints.List[str],
-          optional_kv: typehints.Optional[typehints.KV[str, float]] = None,
+          mapping: typehints.Dict[str, float],
           optional_integer: typehints.Optional[int] = None,
           expansion_service=None):
         super(AnnotatedTransform, self).__init__(
@@ -87,7 +87,7 @@ class ExternalAnnotationPayloadTest(PayloadBase, unittest.TestCase):
                 boolean=boolean,
                 string_example=string_example,
                 list_of_strings=list_of_strings,
-                optional_kv=optional_kv,
+                mapping=mapping,
                 optional_integer=optional_integer,
             ),
             expansion_service)

--- a/sdks/python/apache_beam/transforms/external_test_py37.py
+++ b/sdks/python/apache_beam/transforms/external_test_py37.py
@@ -47,7 +47,7 @@ class ExternalDataclassesPayloadTest(PayloadBase, unittest.TestCase):
       boolean: bool
       string_example: str
       list_of_strings: typing.List[str]
-      optional_kv: typing.Optional[typing.Tuple[str, float]] = None
+      mapping: typing.Mapping[str, float] = dataclasses.field(default=dict)
       optional_integer: typing.Optional[int] = None
       expansion_service: dataclasses.InitVar[typing.Optional[str]] = None
 
@@ -62,7 +62,7 @@ class ExternalDataclassesPayloadTest(PayloadBase, unittest.TestCase):
       boolean: bool
       string_example: str
       list_of_strings: typehints.List[str]
-      optional_kv: typehints.Optional[typehints.KV[str, float]] = None
+      mapping: typehints.Dict[str, float] = {}
       optional_integer: typehints.Optional[int] = None
       expansion_service: dataclasses.InitVar[typehints.Optional[str]] = None
 


### PR DESCRIPTION
- 16bc9bb: The bulk of the change. Changes external_transform.proto to encode a Schema and a Row, and modifies Java's ExpansionService, and Python's SchemaBasedPayloadBuilders, to use the new representation.
- 5ff29d8: Changes related to KafkaIO. Since KV is not supported in schemas, KafkaIO configuration types are changed to use `Map<String, String>` instead of `List<KV<String, String>>`. Also updates references to external_transform.proto in KafkaIOExternalTest.
- 0ef3701: Updates references to external_transform.proto in PubsubIOExternalTest.
- b8936db: Updates references to external_transform.proto in XVR test fixtures (Java and Python).

Some notes about the implementation:
- Since KV is not supported by Rows, I've updated the tests that used them in this context to use a Map instead. In many unit tests this is not a true replacement, but I think it's valid since the only application that currently requires KV is encoding a Map as a List<KV>.
- For users of Python's SchemaBasedPayloadBuilder and implementors of Java's ExternalTransformBuilder the change should be transparent (with the exception that they can no longer use KV).
- For ExternalTransformBuilder implementations it is now possible to register a Schema for ConfigT and we will use that to populate an instance rather than the existing setter approach.
- Due to BEAM-10632 I've temporarily added a testCompile dependency on checker framework to :sdks:java:expansion-service so that I can still test the schema inference capability.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
