### PR TITLE
[BEAM-10668] Replace toLowerCase().equals() with equalsIgnoreCase

### DIFF
--- a/sdks/java/extensions/sql/datacatalog/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/datacatalog/BigQueryTableFactory.java
+++ b/sdks/java/extensions/sql/datacatalog/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/datacatalog/BigQueryTableFactory.java
@@ -43,7 +43,7 @@ class BigQueryTableFactory implements TableFactory {
 
   @Override
   public Optional<Builder> tableBuilder(Entry entry) {
-    if (!URI.create(entry.getLinkedResource()).getAuthority().toLowerCase().equals(BIGQUERY_API)) {
+    if (!URI.create(entry.getLinkedResource()).getAuthority().equalsIgnoreCase(BIGQUERY_API)) {
       return Optional.empty();
     }
 

--- a/sdks/java/extensions/sql/datacatalog/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/datacatalog/PubsubTableFactory.java
+++ b/sdks/java/extensions/sql/datacatalog/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/datacatalog/PubsubTableFactory.java
@@ -36,7 +36,7 @@ class PubsubTableFactory implements TableFactory {
 
   @Override
   public Optional<Builder> tableBuilder(Entry entry) {
-    if (!URI.create(entry.getLinkedResource()).getAuthority().toLowerCase().equals(PUBSUB_API)) {
+    if (!URI.create(entry.getLinkedResource()).getAuthority().equalsIgnoreCase(PUBSUB_API)) {
       return Optional.empty();
     }
 


### PR DESCRIPTION
There are a couple of instances in the code where toLowerCase().equals() is used, when equalsIgnoreCase() would suffice. The latter is more concise + also doesn't involve the default Locale that's used with toLowerCase(), which might be problematic depending on the String being compared.