### PR TITLE
[BEAM-10009] Add support for logical types and beam:logical_type:millis_instant:v1 in Python schemas

### DIFF
--- a/model/fn-execution/src/main/resources/org/apache/beam/model/fnexecution/v1/standard_coders.yaml
+++ b/model/fn-execution/src/main/resources/org/apache/beam/model/fnexecution/v1/standard_coders.yaml
@@ -408,3 +408,12 @@ examples:
   "\x01\x00\x00\x00\x00\x00": {f_map: {}}
   "\x01\x00\x00\x00\x00\x02\x03foo\x01\xa9F\x03bar\x01\xff\xff\xff\xff\xff\xff\xff\xff\x7f": {f_map: {"foo": 9001, "bar": 9223372036854775807}}
   "\x01\x00\x00\x00\x00\x04\neverything\x00\x02is\x00\x05null!\x00\r\xc2\xaf\\_(\xe3\x83\x84)_/\xc2\xaf\x00": {f_map: {"everything":null, "is": null, "null!": null, "¯\\_(ツ)_/¯": null}}
+
+---
+
+coder:
+  urn: "beam:coder:row:v1"
+  # f_timestamp: logical(millis_instant), f_string: string, f_int: int64
+  payload: "\n:\n\x0bf_timestamp\x1a+:)\n#beam:logical_type:millis_instant:v1\x1a\x02\x10\x04\n\x0e\n\x08f_string\x1a\x02\x10\x07\n\x0b\n\x05f_int\x1a\x02\x10\x04\x12$a5af4d2a-6371-4f77-a03c-1818dd4cb317"
+examples:
+  "\x03\x00\xf0\xad\xaf\xc1\xbe.\x142020-08-13T14:14:14Z\xf0\xad\xaf\xc1\xbe.": {f_timestamp: 1597328054000, f_string: "2020-08-13T14:14:14Z", f_int: 1597328054000}

--- a/model/pipeline/src/main/proto/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/beam_runner_api.proto
@@ -875,6 +875,10 @@ message StandardCoders {
     //   - For present values the null indicator is followed by the value
     //     encoded with it's corresponding coder.
     //
+    // Standard logical types:
+    //   - beam:logical_type:millis_instant:v1: An instant in time represented
+    //     by INT64 milliseconds since the epoch. Timezone-naive.
+    //
     // The payload for RowCoder is an instance of Schema.
     // Components: None
     // Experimental.

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CommonCoderTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CommonCoderTest.java
@@ -398,7 +398,11 @@ public class CommonCoderTest {
         }
 
         return row.build();
-      default: // DECIMAL, DATETIME, LOGICAL_TYPE
+      case DATETIME:
+        // Logical types are represented as their representation types in YAML. DATETIME is an alias
+        // for beam:logical_type:millis_instant:v1, represented as INT64 millis since epoch.
+        return Instant.ofEpochMilli((Long) value);
+      default: // DECIMAL, LOGICAL_TYPE
         throw new IllegalArgumentException("Unsupported type name: " + fieldType.getTypeName());
     }
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaCoderHelpers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaCoderHelpers.java
@@ -30,9 +30,9 @@ import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.coders.ByteCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.coders.DelegateCoder;
 import org.apache.beam.sdk.coders.DoubleCoder;
 import org.apache.beam.sdk.coders.FloatCoder;
-import org.apache.beam.sdk.coders.InstantCoder;
 import org.apache.beam.sdk.coders.IterableCoder;
 import org.apache.beam.sdk.coders.ListCoder;
 import org.apache.beam.sdk.coders.MapCoder;
@@ -46,6 +46,7 @@ import org.apache.beam.sdk.schemas.Schema.TypeName;
 import org.apache.beam.sdk.util.common.ElementByteSizeObserver;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
+import org.joda.time.Instant;
 import org.joda.time.ReadableInstant;
 
 class SchemaCoderHelpers {
@@ -61,7 +62,12 @@ class SchemaCoderHelpers {
           .put(TypeName.FLOAT, FloatCoder.of())
           .put(TypeName.DOUBLE, DoubleCoder.of())
           .put(TypeName.STRING, StringUtf8Coder.of())
-          .put(TypeName.DATETIME, InstantCoder.of())
+          // DATETIME is an alias for logical millis_instant, encoded as an INT64 millis since
+          // epoch.
+          .put(
+              TypeName.DATETIME,
+              DelegateCoder.<Instant, Long>of(
+                  VarLongCoder.of(), Instant::getMillis, Instant::ofEpochMilli))
           .put(TypeName.BOOLEAN, BooleanCoder.of())
           .build();
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java
@@ -46,7 +46,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
 @Experimental(Kind.SCHEMAS)
 public class SchemaTranslation {
 
-  private static final String URN_BEAM_LOGICAL_DATETIME = "beam:logical_type:datetime:v1";
+  private static final String URN_BEAM_LOGICAL_DATETIME = "beam:logical_type:millis_instant:v1";
   private static final String URN_BEAM_LOGICAL_DECIMAL = "beam:logical_type:decimal:v1";
   private static final String URN_BEAM_LOGICAL_JAVASDK = "beam:logical_type:javasdk:v1";
 

--- a/sdks/python/apache_beam/coders/row_coder.py
+++ b/sdks/python/apache_beam/coders/row_coder.py
@@ -38,6 +38,7 @@ from apache_beam.coders.coders import VarIntCoder
 from apache_beam.portability import common_urns
 from apache_beam.portability.api import schema_pb2
 from apache_beam.typehints import row_type
+from apache_beam.typehints.schemas import LogicalType
 from apache_beam.typehints.schemas import named_fields_to_schema
 from apache_beam.typehints.schemas import named_tuple_from_schema
 from apache_beam.typehints.schemas import named_tuple_to_schema
@@ -141,6 +142,10 @@ def _nonnull_coder_from_type(field_type):
     return MapCoder(
         _coder_from_type(field_type.map_type.key_type),
         _coder_from_type(field_type.map_type.value_type))
+  elif type_info == "logical_type":
+    logical_type = LogicalType.from_runner_api(field_type.logical_type)
+    return LogicalTypeCoder(
+        logical_type, _coder_from_type(field_type.logical_type.representation))
   elif type_info == "row_type":
     return RowCoder(field_type.row_type.schema)
 
@@ -217,3 +222,34 @@ class RowCoderImpl(StreamCoderImpl):
         is_null in zip(self.components, nulls) if not is_null
     ] if self.has_nullable_fields else self.components
     return TupleCoder(components).get_impl()
+
+
+class LogicalTypeCoder(FastCoder):
+  def __init__(self, logical_type, representation_coder):
+    self.logical_type = logical_type
+    self.representation_coder = representation_coder
+
+  def _create_impl(self):
+    return LogicalTypeCoderImpl(self.logical_type, self.representation_coder)
+
+  def is_deterministic(self):
+    return self.representation_coder.is_deterministic()
+
+  def to_type_hint(self):
+    return self.logical_type.language_type()
+
+
+class LogicalTypeCoderImpl(StreamCoderImpl):
+  def __init__(self, logical_type, representation_coder):
+    self.logical_type = logical_type
+    self.representation_coder = representation_coder.get_impl()
+
+  def encode_to_stream(self, value, out, nested):
+    return self.representation_coder.encode_to_stream(
+        self.logical_type.to_representation_type(value), out, nested)
+
+  def decode_from_stream(self, in_stream, nested):
+    #import ipdb
+    #ipdb.set_trace()
+    return self.logical_type.to_language_type(
+        self.representation_coder.decode_from_stream(in_stream, nested))

--- a/sdks/python/apache_beam/coders/row_coder_test.py
+++ b/sdks/python/apache_beam/coders/row_coder_test.py
@@ -63,7 +63,7 @@ class RowCoderTest(unittest.TestCase):
       knows_javascript=False,
       payload=None,
       custom_metadata={},
-      favorite_time=Timestamp.from_rfc3339('2016-03-18T23:22:59.123'),
+      favorite_time=Timestamp.from_rfc3339('2016-03-18T23:22:59.123Z'),
   )
   PEOPLE = [
       JON_SNOW,

--- a/sdks/python/apache_beam/coders/standard_coders_test.py
+++ b/sdks/python/apache_beam/coders/standard_coders_test.py
@@ -101,6 +101,13 @@ def value_parser_from_schema(schema):
       value_parser = attribute_parser_from_type(type_.map_type.value_type)
       return lambda x: dict(
           (key_parser(k), value_parser(v)) for k, v in x.items())
+    elif type_info == "logical_type":
+      # In YAML logical types are represented with their representation types.
+      to_language_type = schemas.LogicalType.from_runner_api(
+          type_.logical_type).to_language_type
+      parse_representation = attribute_parser_from_type(
+          type_.logical_type.representation)
+      return lambda x: to_language_type(parse_representation(x))
 
   parsers = [(field.name, attribute_parser_from_type(field.type))
              for field in schema.fields]

--- a/sdks/python/apache_beam/transforms/sql_test.py
+++ b/sdks/python/apache_beam/transforms/sql_test.py
@@ -30,6 +30,7 @@ from past.builtins import unicode
 
 import apache_beam as beam
 from apache_beam import coders
+from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to

--- a/sdks/python/apache_beam/transforms/sql_test.py
+++ b/sdks/python/apache_beam/transforms/sql_test.py
@@ -218,7 +218,7 @@ class SqlTransformTest(unittest.TestCase):
           | beam.Map(lambda x: TimestampWrapper(timestamp=x)).with_output_types(
               TimestampWrapper)
           | SqlTransform(
-              """"
+              """
             SELECT
               YEAR(`timestamp`) AS `year`,
               MONTH(`timestamp`) AS `month`

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -17,7 +17,7 @@
 
 """ Support for mapping python types to proto Schemas and back again.
 
-Python              Schema
+Python typing       Schema FieldType
 np.int8     <-----> BYTE
 np.int16    <-----> INT16
 np.int32    <-----> INT32
@@ -27,6 +27,14 @@ np.float32  <-----> FLOAT
 np.float64  <-----> DOUBLE
 float       ---/
 bool        <-----> BOOLEAN
+Timestamp   <-----> LogicalType(urn="beam:logical_type:millis_instant:v1")
+Mapping     <-----> MapType
+Sequence    <-----> ArrayType
+NamedTuple  <-----> RowType
+beam.Row    ---/
+
+nullable=True on a Beam FieldType is represented in Python by wrapping the
+typing in Optional.
 
 The mappings for STRING and BYTES are different between python 2 and python 3,
 because of the changes to str:
@@ -47,10 +55,12 @@ from __future__ import absolute_import
 
 import sys
 from typing import ByteString
+from typing import Generic
 from typing import Mapping
 from typing import NamedTuple
 from typing import Optional
 from typing import Sequence
+from typing import TypeVar
 from uuid import uuid4
 
 import numpy as np
@@ -64,6 +74,7 @@ from apache_beam.typehints.native_type_compatibility import _match_is_optional
 from apache_beam.typehints.native_type_compatibility import _safe_issubclass
 from apache_beam.typehints.native_type_compatibility import extract_optional_type
 from apache_beam.utils import proto_utils
+from apache_beam.utils.timestamp import Timestamp
 
 
 # Registry of typings for a schema by UUID
@@ -183,7 +194,17 @@ def typing_to_runner_api(type_):
     return schema_pb2.FieldType(
         map_type=schema_pb2.MapType(key_type=key_type, value_type=value_type))
 
-  raise ValueError("Unsupported type: %s" % type_)
+  try:
+    logical_type = LogicalType.from_typing(type_)
+  except ValueError:
+    raise ValueError("Unsupported type: %s" % type_)
+  else:
+    # TODO(bhulette): Add support for logical types that require arguments
+    return schema_pb2.FieldType(
+        logical_type=schema_pb2.LogicalType(
+            urn=logical_type.urn(),
+            representation=typing_to_runner_api(
+                logical_type.representation_type())))
 
 
 def typing_from_runner_api(fieldtype_proto):
@@ -236,7 +257,8 @@ def typing_from_runner_api(fieldtype_proto):
     return user_type
 
   elif type_info == "logical_type":
-    pass  # TODO
+    return LogicalType.from_runner_api(
+        fieldtype_proto.logical_type).language_type()
 
 
 def _hydrate_namedtuple_instance(encoded_schema, values):
@@ -251,3 +273,178 @@ def named_tuple_from_schema(schema):
 
 def named_tuple_to_schema(named_tuple):
   return typing_to_runner_api(named_tuple).row_type.schema
+
+
+# Registry of typings for a schema by UUID
+class LogicalTypeRegistry(object):
+  def __init__(self):
+    self.by_urn = {}
+    self.by_logical_type = {}
+    self.by_language_type = {}
+
+  def add(self, urn, logical_type):
+    self.by_urn[urn] = logical_type
+    self.by_logical_type[logical_type] = urn
+    self.by_language_type[logical_type.language_type()] = logical_type
+
+  def get_logical_type_by_urn(self, urn):
+    return self.by_urn.get(urn, None)
+
+  def get_urn_by_logial_type(self, logical_type):
+    return self.by_logical_type.get(logical_type, None)
+
+  def get_logical_type_by_language_type(self, representation_type):
+    return self.by_language_type.get(representation_type, None)
+
+
+LanguageT = TypeVar('LanguageT')
+RepresentationT = TypeVar('RepresentationT')
+ArgT = TypeVar('ArgT')
+
+
+class LogicalType(Generic[LanguageT, RepresentationT, ArgT]):
+  _known_logical_types = LogicalTypeRegistry()
+
+  @classmethod
+  def urn(cls):
+    # type: () -> unicode
+
+    """Return the URN used to identify this logical type"""
+    raise NotImplementedError()
+
+  @classmethod
+  def language_type(cls):
+    # type: () -> type
+
+    """Return the language type this LogicalType encodes.
+
+    The returned type should match LanguageT"""
+    raise NotImplementedError()
+
+  @classmethod
+  def representation_type(cls):
+    # type: () -> type
+
+    """Return the type of the representation this LogicalType uses to encode the
+    language type.
+
+    The returned type should match RepresentationT"""
+    raise NotImplementedError()
+
+  @classmethod
+  def argument_type(cls):
+    # type: () -> type
+
+    """Return the type of the argument used for variations of this LogicalType.
+
+    The returned type should match ArgT"""
+    raise NotImplementedError(cls)
+
+  def argument(self):
+    # type: () -> ArgT
+
+    """Return the argument for this instance of the LogicalType."""
+    raise NotImplementedError()
+
+  def to_representation_type(value):
+    # type: (LanguageT) -> RepresentationT
+
+    """Convert an instance of LanguageT to RepresentationT."""
+    raise NotImplementedError()
+
+  def to_language_type(value):
+    # type: (RepresentationT) -> LanguageT
+
+    """Convert an instance of RepresentationT to LanguageT."""
+    raise NotImplementedError()
+
+  @classmethod
+  def register_logical_type(cls, logical_type_cls):
+    """Register an implementation of LogicalType."""
+    cls._known_logical_types.add(logical_type_cls.urn(), logical_type_cls)
+
+  @classmethod
+  def from_typing(cls, typ):
+    # type: (type) -> LogicalType
+
+    """Construct an instance of a registered LogicalType implementation given a
+    typing.
+
+    Raises ValueError if no registered LogicalType implementation can encode the
+    given typing."""
+
+    logical_type = cls._known_logical_types.get_logical_type_by_language_type(
+        typ)
+    if logical_type is None:
+      raise ValueError("No logical type registered for typing '%s'" % typ)
+
+    return logical_type._from_typing(typ)
+
+  @classmethod
+  def _from_typing(cls, typ):
+    # type: (type) -> LogicalType
+
+    """Construct an instance of this LogicalType implementation given a typing.
+    """
+    raise NotImplementedError()
+
+  @classmethod
+  def from_runner_api(cls, logical_type_proto):
+    # type: (schema_pb2.LogicalType) -> LogicalType
+
+    """Construct an instance of a registered LogicalType implementation given a
+    proto LogicalType.
+
+    Raises ValueError if no LogicalType registered for the given URN.
+    """
+    logical_type = cls._known_logical_types.get_logical_type_by_urn(
+        logical_type_proto.urn)
+    if logical_type is None:
+      raise ValueError(
+          "No logical type registered for URN '%s'" % logical_type_proto.urn)
+    # TODO(bhulette): Use argument
+    return logical_type()
+
+
+class NoArgumentLogicalType(LogicalType[LanguageT, RepresentationT, None]):
+  @classmethod
+  def argument_type(cls):
+    # type: () -> type
+    return None
+
+  def argument(self):
+    # type: () -> ArgT
+    return None
+
+  @classmethod
+  def _from_typing(cls, typ):
+    # type: (type) -> LogicalType
+
+    # Sicne there's no argument, there can be no additional information encoded
+    # in the typing. Just construct an instance.
+    return cls()
+
+
+@LogicalType.register_logical_type
+class MillisInstant(NoArgumentLogicalType[Timestamp, np.int64]):
+  @classmethod
+  def urn(cls):
+    return "beam:logical_type:millis_instant:v1"
+
+  @classmethod
+  def representation_type(cls):
+    # type: () -> type
+    return np.int64
+
+  @classmethod
+  def language_type(cls):
+    return Timestamp
+
+  def to_representation_type(self, value):
+    # type: (Timestamp) -> np.int64
+    # TODO: Raise error if loss of precision?
+    return np.int64(value.micros // 1000)
+
+  def to_language_type(self, value):
+    # type: (np.int64) -> Timestamp
+    return Timestamp(micros=int(value * 1000))

--- a/sdks/python/apache_beam/typehints/schemas_test.py
+++ b/sdks/python/apache_beam/typehints/schemas_test.py
@@ -40,6 +40,7 @@ from apache_beam.typehints.schemas import named_tuple_from_schema
 from apache_beam.typehints.schemas import named_tuple_to_schema
 from apache_beam.typehints.schemas import typing_from_runner_api
 from apache_beam.typehints.schemas import typing_to_runner_api
+from apache_beam.utils.timestamp import Timestamp
 
 IS_PYTHON_3 = sys.version_info.major > 2
 
@@ -67,6 +68,7 @@ class SchemaTest(unittest.TestCase):
     # The bytes type cannot survive a roundtrip to/from proto in Python 2.
     # In order to use BYTES a user type has to use typing.ByteString (because
     # bytes == str, and we map str to STRING).
+    # TODO(BEAM-7372)
     if IS_PYTHON_3:
       all_nonoptional_primitives.extend([bytes])
 
@@ -97,6 +99,7 @@ class SchemaTest(unittest.TestCase):
                     Optional[Mapping[unicode, Optional[np.float64]]]),
                 ('optional_array', Optional[Sequence[np.float32]]),
                 ('array_optional', Sequence[Optional[bool]]),
+                ('timestamp', Timestamp),
             ])
     ]
 


### PR DESCRIPTION
This PR adds support for logical types in Python schemas, and adds the first logical type implementation there for `beam:logical_type:millis_instant:v1`. 

I chose `apache_beam.utils.timestamp.Timestamp` as the Python type mapping for millis_instant . Note that `Timestamp` is represented as microseconds since the epoch, so this is a lossy mapping, but there is precedent for this in Python's `WindowedValueCoder`: https://github.com/apache/beam/blob/699f872ea1ef3bdb1588a029fc6b1e3185e986a6/sdks/python/apache_beam/coders/coder_impl.py#L1236-L1240

Also in this PR:
- some changes to the Java SDK implementation of Beam schemas to make its `FieldType.DATETIME` type behave exactly like `beam:logical_type:millis_instant:v1` when used in portabillity (afa939e). `DATETIME` will be deprecated and removed in favor of a Java implementation of millis_instant in the future (BEAM-7554).
- Unit testing in schemas_test and row_coder_test.
- Tests using Timestamp in the Python SqlTransform.
- Test cases in standard_coders_test.yaml (the first logical type tested there).

Note the Python implementation of LogicalTypes in this PR is limited to those that do not use an argument.

R: @robertwb 
CC: @lostluck 


Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
