### PR TITLE
[BEAM-10720,BEAM-10721] Add skipped tests for Series.dt and Series.str methods

### DIFF
--- a/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
@@ -172,6 +172,107 @@ class DoctestTest(unittest.TestCase):
         })
     self.assertEqual(result.failed, 0)
 
+  def test_string_tests(self):
+    # TODO(BEAM-10720)
+    result = doctests.testmod(
+        pd.core.strings,
+        use_beam=False,
+        skip={
+            'pandas.core.strings.StringMethods': ['*'],
+            'pandas.core.strings.StringMethods.capitalize': ['*'],
+            'pandas.core.strings.StringMethods.casefold': ['*'],
+            'pandas.core.strings.StringMethods.cat': ['*'],
+            'pandas.core.strings.StringMethods.contains': ['*'],
+            'pandas.core.strings.StringMethods.count': ['*'],
+            'pandas.core.strings.StringMethods.endswith': ['*'],
+            'pandas.core.strings.StringMethods.extract': ['*'],
+            'pandas.core.strings.StringMethods.extractall': ['*'],
+            'pandas.core.strings.StringMethods.findall': ['*'],
+            'pandas.core.strings.StringMethods.get': ['*'],
+            'pandas.core.strings.StringMethods.get_dummies': ['*'],
+            'pandas.core.strings.StringMethods.isalnum': ['*'],
+            'pandas.core.strings.StringMethods.isalpha': ['*'],
+            'pandas.core.strings.StringMethods.isdecimal': ['*'],
+            'pandas.core.strings.StringMethods.isdigit': ['*'],
+            'pandas.core.strings.StringMethods.islower': ['*'],
+            'pandas.core.strings.StringMethods.isnumeric': ['*'],
+            'pandas.core.strings.StringMethods.isspace': ['*'],
+            'pandas.core.strings.StringMethods.istitle': ['*'],
+            'pandas.core.strings.StringMethods.isupper': ['*'],
+            'pandas.core.strings.StringMethods.join': ['*'],
+            'pandas.core.strings.StringMethods.len': ['*'],
+            'pandas.core.strings.StringMethods.lower': ['*'],
+            'pandas.core.strings.StringMethods.lstrip': ['*'],
+            'pandas.core.strings.StringMethods.pad': ['*'],
+            'pandas.core.strings.StringMethods.partition': ['*'],
+            'pandas.core.strings.StringMethods.repeat': ['*'],
+            'pandas.core.strings.StringMethods.replace': ['*'],
+            'pandas.core.strings.StringMethods.rpartition': ['*'],
+            'pandas.core.strings.StringMethods.rsplit': ['*'],
+            'pandas.core.strings.StringMethods.rstrip': ['*'],
+            'pandas.core.strings.StringMethods.slice': ['*'],
+            'pandas.core.strings.StringMethods.slice_replace': ['*'],
+            'pandas.core.strings.StringMethods.split': ['*'],
+            'pandas.core.strings.StringMethods.startswith': ['*'],
+            'pandas.core.strings.StringMethods.strip': ['*'],
+            'pandas.core.strings.StringMethods.swapcase': ['*'],
+            'pandas.core.strings.StringMethods.title': ['*'],
+            'pandas.core.strings.StringMethods.upper': ['*'],
+            'pandas.core.strings.StringMethods.wrap': ['*'],
+            'pandas.core.strings.StringMethods.zfill': ['*'],
+            'pandas.core.strings.str_contains': ['*'],
+            'pandas.core.strings.str_count': ['*'],
+            'pandas.core.strings.str_endswith': ['*'],
+            'pandas.core.strings.str_extract': ['*'],
+            'pandas.core.strings.str_extractall': ['*'],
+            'pandas.core.strings.str_findall': ['*'],
+            'pandas.core.strings.str_get': ['*'],
+            'pandas.core.strings.str_get_dummies': ['*'],
+            'pandas.core.strings.str_join': ['*'],
+            'pandas.core.strings.str_pad': ['*'],
+            'pandas.core.strings.str_repeat': ['*'],
+            'pandas.core.strings.str_replace': ['*'],
+            'pandas.core.strings.str_slice': ['*'],
+            'pandas.core.strings.str_slice_replace': ['*'],
+            'pandas.core.strings.str_startswith': ['*'],
+            'pandas.core.strings.str_wrap': ['*'],
+        })
+    self.assertEqual(result.failed, 0)
+
+  def test_datetime_tests(self):
+    # TODO(BEAM-10721)
+    datetimelike_result = doctests.testmod(
+        pd.core.arrays.datetimelike,
+        use_beam=False,
+        skip={
+            'pandas.core.arrays.datetimelike.AttributesMixin._unbox_scalar': [
+                '*'
+            ],
+            'pandas.core.arrays.datetimelike.TimelikeOps.ceil': ['*'],
+            'pandas.core.arrays.datetimelike.TimelikeOps.floor': ['*'],
+            'pandas.core.arrays.datetimelike.TimelikeOps.round': ['*'],
+        })
+
+    datetime_result = doctests.testmod(
+        pd.core.arrays.datetimes,
+        use_beam=False,
+        skip={
+            'pandas.core.arrays.datetimes.DatetimeArray.is_leap_year': ['*'],
+            'pandas.core.arrays.datetimes.DatetimeArray.is_month_end': ['*'],
+            'pandas.core.arrays.datetimes.DatetimeArray.is_month_start': ['*'],
+            'pandas.core.arrays.datetimes.DatetimeArray.is_quarter_end': ['*'],
+            'pandas.core.arrays.datetimes.DatetimeArray.is_quarter_start': [
+                '*'
+            ],
+            'pandas.core.arrays.datetimes.DatetimeArray.is_year_end': ['*'],
+            'pandas.core.arrays.datetimes.DatetimeArray.is_year_start': ['*'],
+            'pandas.core.arrays.datetimes.DatetimeArray.to_period': ['*'],
+            'pandas.core.arrays.datetimes.DatetimeArray.tz_localize': ['*'],
+        })
+
+    self.assertEqual(datetimelike_result.failed, 0)
+    self.assertEqual(datetime_result.failed, 0)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
I noticed that a lot of useful pandas methods are hidden behind Series.dt and Series.str, and tested from separate modules. This PR adds some skipped tests for those modules.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
