### PR TITLE
[BEAM-10759] Uses reader Avro schema to deserialize in KafkaIO

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/ConfluentSchemaRegistryDeserializerProvider.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/ConfluentSchemaRegistryDeserializerProvider.java
@@ -92,17 +92,18 @@ public class ConfluentSchemaRegistryDeserializerProvider<T> implements Deseriali
             .build();
     Deserializer<T> deserializer =
         (Deserializer<T>)
-            new ConfluentSchemaRegistryDeserializer(
-                getSchemaRegistryClient(),
-                new Schema.Parser().parse(getSchemaMetadata().getSchema()));
+            new ConfluentSchemaRegistryDeserializer(getSchemaRegistryClient(), getAvroSchema());
     deserializer.configure(csrConfig, isKey);
     return deserializer;
   }
 
   @Override
   public Coder<T> getCoder(CoderRegistry coderRegistry) {
-    final Schema avroSchema = new Schema.Parser().parse(getSchemaMetadata().getSchema());
-    return (Coder<T>) AvroCoder.of(avroSchema);
+    return (Coder<T>) AvroCoder.of(getAvroSchema());
+  }
+
+  private Schema getAvroSchema() {
+    return new Schema.Parser().parse(getSchemaMetadata().getSchema());
   }
 
   private SchemaMetadata getSchemaMetadata() {

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/ConfluentSchemaRegistryDeserializerProvider.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/ConfluentSchemaRegistryDeserializerProvider.java
@@ -124,7 +124,7 @@ class ConfluentSchemaRegistryDeserializer extends KafkaAvroDeserializer {
   Schema readerSchema;
 
   ConfluentSchemaRegistryDeserializer(SchemaRegistryClient client, Schema readerSchema) {
-    this.schemaRegistry = client;
+    super(client);
     this.readerSchema = readerSchema;
   }
 

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/ConfluentSchemaRegistryDeserializerProviderTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/ConfluentSchemaRegistryDeserializerProviderTest.java
@@ -45,7 +45,8 @@ public class ConfluentSchemaRegistryDeserializerProviderTest {
     assertEquals(AVRO_SCHEMA, coderV0.getSchema());
 
     try {
-      Integer version = mockRegistryClient.register(subject, AVRO_SCHEMA_V1);
+      mockRegistryClient.register(subject, AVRO_SCHEMA_V1);
+      Integer version = mockRegistryClient.getVersion(subject, AVRO_SCHEMA_V1);
       AvroCoder coderV1 =
           (AvroCoder)
               mockDeserializerProvider(schemaRegistryUrl, subject, version).getCoder(coderRegistry);

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/ConfluentSchemaRegistryDeserializerProviderTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/ConfluentSchemaRegistryDeserializerProviderTest.java
@@ -45,7 +45,6 @@ public class ConfluentSchemaRegistryDeserializerProviderTest {
     assertEquals(AVRO_SCHEMA, coderV0.getSchema());
 
     try {
-      mockRegistryClient.register(subject, AVRO_SCHEMA_V1);
       Integer version = mockRegistryClient.getVersion(subject, AVRO_SCHEMA_V1);
       AvroCoder coderV1 =
           (AvroCoder)
@@ -71,6 +70,7 @@ public class ConfluentSchemaRegistryDeserializerProviderTest {
     SchemaRegistryClient mockRegistryClient =
         MockSchemaRegistry.getClientForScope(schemaRegistryUrl);
     try {
+      mockRegistryClient.register(subject, AVRO_SCHEMA_V1);
       mockRegistryClient.register(subject, AVRO_SCHEMA);
     } catch (IOException | RestClientException e) {
       throw new RuntimeException("Unable to register schema for subject: " + subject, e);
@@ -103,6 +103,6 @@ public class ConfluentSchemaRegistryDeserializerProviderTest {
           + "     {\"name\": \"favorite_color\", \"type\": [\"string\", \"null\"]}\n"
           + " ]\n"
           + "}";
-  private static final org.apache.avro.Schema AVRO_SCHEMA_V1 =
+  static final org.apache.avro.Schema AVRO_SCHEMA_V1 =
       new org.apache.avro.Schema.Parser().parse(AVRO_SCHEMA_V1_STRING);
 }

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.sdk.io.kafka;
 
-import static org.apache.beam.sdk.io.kafka.ConfluentSchemaRegistryDeserializerProviderTest.AVRO_SCHEMA_V1;
 import static org.apache.beam.sdk.io.kafka.ConfluentSchemaRegistryDeserializerProviderTest.mockDeserializerProvider;
 import static org.apache.beam.sdk.metrics.MetricResultsMatchers.attemptedMetricsResult;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
@@ -59,7 +58,6 @@ import java.util.concurrent.atomic.AtomicBoolean;
 import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.avro.generic.GenericRecord;
-import org.apache.avro.generic.GenericRecordBuilder;
 import org.apache.beam.sdk.Pipeline.PipelineExecutionException;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.coders.BigEndianIntegerCoder;
@@ -1809,13 +1807,9 @@ public class KafkaIOTest {
     }
   }
 
-  /**
-   * Mock records with a different schema to test deserializing evolved schema using
-   * ConfluentSchemaRegistryDeserializerProvider
-   */
   private abstract static class BaseAvroSerializableFunction
       implements SerializableFunction<Integer, byte[]> {
-    static transient Serializer<GenericRecord> serializer = null;
+    static transient Serializer<AvroGeneratedUser> serializer = null;
     final String topic;
     final String schemaRegistryUrl;
     final boolean isKey;
@@ -1826,7 +1820,7 @@ public class KafkaIOTest {
       this.isKey = isKey;
     }
 
-    static Serializer<GenericRecord> getSerializer(boolean isKey, String schemaRegistryUrl) {
+    static Serializer<AvroGeneratedUser> getSerializer(boolean isKey, String schemaRegistryUrl) {
       if (serializer == null) {
         SchemaRegistryClient mockRegistryClient =
             MockSchemaRegistry.getClientForScope(schemaRegistryUrl);
@@ -1848,14 +1842,7 @@ public class KafkaIOTest {
     @Override
     public byte[] apply(Integer i) {
       return getSerializer(isKey, schemaRegistryUrl)
-          .serialize(
-              topic,
-              new GenericRecordBuilder(AVRO_SCHEMA_V1)
-                  .set("name", "KeyName" + i)
-                  .set("age", i)
-                  .set("favorite_number", i)
-                  .set("favorite_color", "color" + i)
-                  .build());
+          .serialize(topic, new AvroGeneratedUser("KeyName" + i, i, "color" + i));
     }
   }
 
@@ -1867,14 +1854,7 @@ public class KafkaIOTest {
     @Override
     public byte[] apply(Integer i) {
       return getSerializer(isKey, schemaRegistryUrl)
-          .serialize(
-              topic,
-              new GenericRecordBuilder(AVRO_SCHEMA_V1)
-                  .set("name", "ValueName" + i)
-                  .set("age", i)
-                  .set("favorite_number", i)
-                  .set("favorite_color", "color" + i)
-                  .build());
+          .serialize(topic, new AvroGeneratedUser("ValueName" + i, i, "color" + i));
     }
   }
 }


### PR DESCRIPTION
The existing ConfluentSchemaRegistryDeserializerProvider uses the writer schema to deserialize Avro records from Kafka, but passes a fixed schema to the AvroCoder. If the Kafka topic contains evolved schema, the AvroCoder will fail to encode the records. 

This commit uses the deserialize(bytes, readerSchema) method from KafkaAvroDeserializer, in order to deserialize Kafak Avro records with a schema consistent with AvroCoder. 

The change causes ConfluentSchemaRegistryDeserializerProviderTest to fail, due to an existing error. mockRegistryClient.register returns the schema id but not the schema version. With the changes in this commit, the mockRegistryClient will be called one more time, which in turns call mockRegistryClient.register(). This causes schema id and schema version to deviate. Therefore, the unit test is modified to correctly acquire the schema version. 

I have ran local test on the java sdk, and spotless test. The modified logic has been tested on an actual pipeline with Dataflow Runner, which successfully read from a topic with evolved schema.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg)
![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
