### PR TITLE
[BEAM-10761] Prefer TestPubsub#assertSubscriptionEventuallyExists when waiting to inject data

### DIFF
--- a/sdks/java/extensions/sql/jdbc/src/test/java/org/apache/beam/sdk/extensions/sql/jdbc/BeamSqlLineIT.java
+++ b/sdks/java/extensions/sql/jdbc/src/test/java/org/apache/beam/sdk/extensions/sql/jdbc/BeamSqlLineIT.java
@@ -111,7 +111,7 @@ public class BeamSqlLineIT implements Serializable {
                 + "taxi_rides.payload.longitude from taxi_rides LIMIT 3;");
 
     Future<List<List<String>>> expectedResult = runQueryInBackground(args);
-    eventsTopic.checkIfAnySubscriptionExists(project, Duration.standardMinutes(1));
+    eventsTopic.assertSubscriptionEventuallyCreated(project, Duration.standardMinutes(1));
 
     List<PubsubMessage> messages =
         ImmutableList.of(
@@ -150,7 +150,7 @@ public class BeamSqlLineIT implements Serializable {
                 + "         AND taxi_rides.payload.latitude < 40.720 LIMIT 2;");
 
     Future<List<List<String>>> expectedResult = runQueryInBackground(args);
-    eventsTopic.checkIfAnySubscriptionExists(project, Duration.standardMinutes(1));
+    eventsTopic.assertSubscriptionEventuallyCreated(project, Duration.standardMinutes(1));
 
     List<PubsubMessage> messages =
         ImmutableList.of(

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonIT.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonIT.java
@@ -68,7 +68,6 @@ import org.apache.beam.vendor.calcite.v1_20_0.com.google.common.collect.Immutabl
 import org.apache.beam.vendor.calcite.v1_20_0.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.calcite.v1_20_0.com.google.common.collect.ImmutableSet;
 import org.apache.beam.vendor.calcite.v1_20_0.org.apache.calcite.jdbc.CalciteConnection;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Supplier;
 import org.hamcrest.Matcher;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
@@ -154,21 +153,18 @@ public class PubsubJsonIT implements Serializable {
                         row(PAYLOAD_SCHEMA, 5, "bar"),
                         row(PAYLOAD_SCHEMA, 7, "baz")))));
 
-    // Send the start signal to make sure the signaling topic is initialized
-    Supplier<Void> start = resultSignal.waitForStart(Duration.standardMinutes(5));
-    pipeline.begin().apply(resultSignal.signalStart());
-
     // Start the pipeline
     pipeline.run();
 
-    // Wait until got the start response from the signalling topic
-    start.get();
+    // Block until a subscription for this topic exists
+    eventsTopic.assertSubscriptionEventuallyCreated(
+        pipeline.getOptions().as(GcpOptions.class).getProject(), Duration.standardMinutes(5));
 
     // Start publishing the messages when main pipeline is started and signaling topic is ready
     eventsTopic.publish(messages);
 
     // Poll the signaling topic for success message
-    resultSignal.waitForSuccess(Duration.standardSeconds(60));
+    resultSignal.waitForSuccess(Duration.standardMinutes(5));
   }
 
   @Ignore("Disable flake tracked at https://issues.apache.org/jira/browse/BEAM-5122")
@@ -225,15 +221,12 @@ public class PubsubJsonIT implements Serializable {
                         row(PAYLOAD_SCHEMA, 5, "bar"),
                         row(PAYLOAD_SCHEMA, 7, "baz")))));
 
-    // Send the start signal to make sure the signaling topic is initialized
-    Supplier<Void> start = resultSignal.waitForStart(Duration.standardMinutes(5));
-    pipeline.begin().apply("signal query results started", resultSignal.signalStart());
-
     // Start the pipeline
     pipeline.run();
 
-    // Wait until got the response from the signalling topics
-    start.get();
+    // Block until a subscription for this topic exists
+    eventsTopic.assertSubscriptionEventuallyCreated(
+        pipeline.getOptions().as(GcpOptions.class).getProject(), Duration.standardMinutes(5));
 
     // Start publishing the messages when main pipeline is started and signaling topics are ready
     eventsTopic.publish(messages);
@@ -305,7 +298,7 @@ public class PubsubJsonIT implements Serializable {
                 });
 
     eventsTopic.assertSubscriptionEventuallyCreated(
-        pipeline.getOptions().as(GcpOptions.class).getProject(), Duration.standardMinutes(1));
+        pipeline.getOptions().as(GcpOptions.class).getProject(), Duration.standardMinutes(5));
     eventsTopic.publish(messages);
     assertThat(queryResult.get(2, TimeUnit.MINUTES).size(), equalTo(3));
     pool.shutdown();
@@ -386,21 +379,18 @@ public class PubsubJsonIT implements Serializable {
                         row(PAYLOAD_SCHEMA, 5, "bar"),
                         row(PAYLOAD_SCHEMA, 7, "baz")))));
 
-    // Send the start signal to make sure the signaling topic is initialized
-    Supplier<Void> start = resultSignal.waitForStart(Duration.standardMinutes(5));
-    pipeline.begin().apply(resultSignal.signalStart());
-
     // Start the pipeline
     pipeline.run();
 
-    // Wait until got the start response from the signalling topic
-    start.get();
+    // Block until a subscription for this topic exists
+    eventsTopic.assertSubscriptionEventuallyCreated(
+        pipeline.getOptions().as(GcpOptions.class).getProject(), Duration.standardMinutes(5));
 
     // Start publishing the messages when main pipeline is started and signaling topic is ready
     eventsTopic.publish(messages);
 
     // Poll the signaling topic for success message
-    resultSignal.waitForSuccess(Duration.standardSeconds(60));
+    resultSignal.waitForSuccess(Duration.standardMinutes(5));
   }
 
   @Test
@@ -552,13 +542,12 @@ public class PubsubJsonIT implements Serializable {
     // Apply the PTransform to inject the input data
     query(sqlEnv, pipeline, injectQueryString);
 
-    // Send the start signal to make sure the signaling topic is initialized
-    Supplier<Void> start = resultSignal.waitForStart(Duration.standardMinutes(5));
-    filterPipeline.begin().apply("signal filter pipeline started", resultSignal.signalStart());
-
     // Start the filter pipeline and wait until it has started.
     filterPipeline.run();
-    start.get();
+
+    // Block until a subscription for this topic exists
+    eventsTopic.assertSubscriptionEventuallyCreated(
+        pipeline.getOptions().as(GcpOptions.class).getProject(), Duration.standardMinutes(5));
 
     // .. then run the injector pipeline
     pipeline.run().waitUntilFinish(Duration.standardMinutes(5));

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonIT.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/meta/provider/pubsub/PubsubJsonIT.java
@@ -304,7 +304,7 @@ public class PubsubJsonIT implements Serializable {
                   return result.build();
                 });
 
-    eventsTopic.checkIfAnySubscriptionExists(
+    eventsTopic.assertSubscriptionEventuallyCreated(
         pipeline.getOptions().as(GcpOptions.class).getProject(), Duration.standardMinutes(1));
     eventsTopic.publish(messages);
     assertThat(queryResult.get(2, TimeUnit.MINUTES).size(), equalTo(3));

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/TestPubsub.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/TestPubsub.java
@@ -188,7 +188,9 @@ public class TestPubsub implements TestRule {
 
   private List<SubscriptionPath> listSubscriptions(ProjectPath projectPath, TopicPath topicPath)
       throws IOException {
-    return pubsub.listSubscriptions(projectPath, topicPath);
+    return pubsub.listSubscriptions(projectPath, topicPath).stream()
+        .filter((path) -> !path.equals(subscriptionPath))
+        .collect(ImmutableList.toImmutableList());
   }
 
   /** Publish messages to {@link #topicPath()}. */

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/TestPubsub.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/TestPubsub.java
@@ -275,11 +275,30 @@ public class TestPubsub implements TestRule {
   /**
    * Check if topics exist.
    *
+   * <p>{@Deprecated prefer {@link #assertSubscriptionEventuallyCreated}}.
+   *
    * @param project GCP project identifier.
    * @param timeoutDuration Joda duration that sets a period of time before checking times out.
    */
+  @Deprecated
   public void checkIfAnySubscriptionExists(String project, Duration timeoutDuration)
       throws InterruptedException, IllegalArgumentException, IOException, TimeoutException {
+    try {
+      assertSubscriptionEventuallyCreated(project, timeoutDuration);
+    } catch (AssertionError e) {
+      throw new TimeoutException(e.getMessage());
+    }
+  }
+
+  /**
+   * Block until a subscription is created for this test topic in the specified project. Throws
+   * {@link AssertionError} if {@code timeoutDuration} is reached before a subscription is created.
+   *
+   * @param project GCP project identifier.
+   * @param timeoutDuration Joda duration before timeout occurs.
+   */
+  public void assertSubscriptionEventuallyCreated(String project, Duration timeoutDuration)
+      throws InterruptedException, IllegalArgumentException, IOException {
     if (timeoutDuration.getMillis() <= 0) {
       throw new IllegalArgumentException(String.format("timeoutDuration should be greater than 0"));
     }
@@ -299,7 +318,7 @@ public class TestPubsub implements TestRule {
     if (sizeOfSubscriptionList > 0) {
       return;
     } else {
-      throw new TimeoutException("Timed out when checking if topics exist for " + topicPath());
+      throw new AssertionError("Timed out before subscription created for " + topicPath());
     }
   }
 


### PR DESCRIPTION
- Renamed `TestPubsub#checkIfAnySubscriptionExists` to `TestPubsub#assertSubscriptionEventuallyCreated` (original is still there and marked deprecated), and updated the docstring.
- Use `TestPubsub#assertSubscriptionEventuallyCreated` everywhere that `TestPubsubSignal` was being used to block before injecting data into a pubsub topic.

R: @lukecwik 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg)
![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
