### PR TITLE
[BEAM-10779] Support multiple main inputs and side inputs for PTransformOverride

### DIFF
--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -284,6 +284,8 @@ class Pipeline(object):
               original_transform_node.transform)
           if replacement_transform is original_transform_node.transform:
             return
+          replacement_transform.side_inputs = tuple(
+              original_transform_node.transform.side_inputs)
 
           replacement_transform_node = AppliedPTransform(
               original_transform_node.parent,
@@ -307,19 +309,13 @@ class Pipeline(object):
             roots[roots.index(original_transform_node)] = (
                 replacement_transform_node)
 
-          inputs = replacement_transform_node.inputs
-          # TODO:  Support replacing PTransforms with multiple inputs.
+          inputs = override.get_replacement_inputs(original_transform_node)
           if len(inputs) > 1:
-            raise NotImplementedError(
-                'PTransform overriding is only supported for PTransforms that '
-                'have a single input. Tried to replace input of '
-                'AppliedPTransform %r that has %d inputs' %
-                (original_transform_node, len(inputs)))
+            transform_input = inputs
           elif len(inputs) == 1:
-            input_node = inputs[0]
+            transform_input = inputs[0]
           elif len(inputs) == 0:
-            input_node = pvalue.PBegin(self.pipeline)
-
+            transform_input = pvalue.PBegin(self.pipeline)
           try:
             # We have to add the new AppliedTransform to the stack before
             # expand() and pop it out later to make sure that parts get added
@@ -333,7 +329,7 @@ class Pipeline(object):
             # conflicts with labels of the children of the original.
             self.pipeline._remove_labels_recursively(original_transform_node)
 
-            new_output = replacement_transform.expand(input_node)
+            new_output = replacement_transform.expand(transform_input)
             assert isinstance(
                 new_output, (dict, pvalue.PValue, pvalue.DoOutputsTuple))
 
@@ -1348,6 +1344,22 @@ class PTransformOverride(with_metaclass(abc.ABCMeta,
     """
     # Returns a PTransformReplacement
     raise NotImplementedError
+
+  def get_replacement_inputs(self, applied_ptransform):
+    # type: (AppliedPTransform) -> Iterable[pvalue.PValue]
+    """Provides inputs that will be passed to the replacement PTransform.
+
+    Args:
+      applied_ptransform: Original AppliedPTransform containing the PTransform
+        to be replaced.
+
+    Returns:
+      An iterable of PValues that will be passed to the expand() method of the
+      replacement PTransform.
+    """
+    return tuple(applied_ptransform.inputs) + tuple(
+        side_input.pvalue
+        for side_input in applied_ptransform.side_inputs)
 
 
 class ComponentIdMap(object):

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -1347,6 +1347,7 @@ class PTransformOverride(with_metaclass(abc.ABCMeta,
 
   def get_replacement_inputs(self, applied_ptransform):
     # type: (AppliedPTransform) -> Iterable[pvalue.PValue]
+
     """Provides inputs that will be passed to the replacement PTransform.
 
     Args:
@@ -1358,8 +1359,7 @@ class PTransformOverride(with_metaclass(abc.ABCMeta,
       replacement PTransform.
     """
     return tuple(applied_ptransform.inputs) + tuple(
-        side_input.pvalue
-        for side_input in applied_ptransform.side_inputs)
+        side_input.pvalue for side_input in applied_ptransform.side_inputs)
 
 
 class ComponentIdMap(object):

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -119,6 +119,32 @@ class ToStringParDo(beam.PTransform):
     return input | 'Inner' >> beam.Map(lambda a: copy.copy(str(a)))
 
 
+class FlattenAndDouble(beam.PTransform):
+  def expand(self, pcolls):
+    return pcolls | beam.Flatten() | 'Double' >> DoubleParDo()
+
+
+class FlattenAndTriple(beam.PTransform):
+  def expand(self, pcolls):
+    return pcolls | beam.Flatten() | 'Triple' >> TripleParDo()
+
+
+class AddWithProductDoFn(beam.DoFn):
+  def process(self, input, a, b):
+    yield input + a * b
+
+
+class AddThenMultiplyDoFn(beam.DoFn):
+  def process(self, input, a, b):
+    yield (input + a) * b
+
+
+class AddThenMultiply(beam.PTransform):
+  def expand(self, pvalues):
+    return pvalues[0] | beam.ParDo(
+        AddThenMultiplyDoFn(), AsSingleton(pvalues[1]), AsSingleton(pvalues[2]))
+
+
 class PipelineTest(unittest.TestCase):
   @staticmethod
   def custom_callable(pcoll):
@@ -412,6 +438,74 @@ class PipelineTest(unittest.TestCase):
 
       p.replace_all([override])
       self.assertEqual(pcoll.producer.inputs[0].element_type, expected_type)
+
+  def test_ptransform_override_multiple_inputs(self):
+    class MyParDoOverride(PTransformOverride):
+      def matches(self, applied_ptransform):
+        return isinstance(applied_ptransform.transform, FlattenAndDouble)
+
+      def get_replacement_transform(self, applied_ptransform):
+        return FlattenAndTriple()
+
+    p = Pipeline()
+    pcoll1 = p | 'pc1' >> beam.Create([1, 2, 3])
+    pcoll2 = p | 'pc2' >> beam.Create([4, 5, 6])
+    pcoll3 = (pcoll1, pcoll2) | 'FlattenAndMultiply' >> FlattenAndDouble()
+    assert_that(pcoll3, equal_to([3, 6, 9, 12, 15, 18]))
+
+    p.replace_all([MyParDoOverride()])
+    p.run()
+
+  def test_ptransform_override_side_inputs(self):
+    class MyParDoOverride(PTransformOverride):
+      def matches(self, applied_ptransform):
+        return (
+            isinstance(applied_ptransform.transform, ParDo) and
+            isinstance(applied_ptransform.transform.fn, AddWithProductDoFn))
+
+      def get_replacement_transform(self, transform):
+        return AddThenMultiply()
+
+    p = Pipeline()
+    pcoll1 = p | 'pc1' >> beam.Create([2])
+    pcoll2 = p | 'pc2' >> beam.Create([3])
+    pcoll3 = p | 'pc3' >> beam.Create([4, 5, 6])
+    result = pcoll3 | 'Operate' >> beam.ParDo(
+        AddWithProductDoFn(), AsSingleton(pcoll1), AsSingleton(pcoll2))
+    assert_that(result, equal_to([18, 21, 24]))
+
+    p.replace_all([MyParDoOverride()])
+    p.run()
+
+  def test_ptransform_override_replacement_inputs(self):
+    class MyParDoOverride(PTransformOverride):
+      def matches(self, applied_ptransform):
+        return (
+            isinstance(applied_ptransform.transform, ParDo) and
+            isinstance(applied_ptransform.transform.fn, AddWithProductDoFn))
+
+      def get_replacement_transform(self, transform):
+        return AddThenMultiply()
+
+      def get_replacement_inputs(self, applied_ptransform):
+        assert len(applied_ptransform.inputs) == 1
+        assert len(applied_ptransform.side_inputs) == 2
+        # Swap the order of the two side inputs
+        return (
+            applied_ptransform.inputs[0],
+            applied_ptransform.side_inputs[1].pvalue,
+            applied_ptransform.side_inputs[0].pvalue)
+
+    p = Pipeline()
+    pcoll1 = p | 'pc1' >> beam.Create([2])
+    pcoll2 = p | 'pc2' >> beam.Create([3])
+    pcoll3 = p | 'pc3' >> beam.Create([4, 5, 6])
+    result = pcoll3 | 'Operate' >> beam.ParDo(
+        AddWithProductDoFn(), AsSingleton(pcoll1), AsSingleton(pcoll2))
+    assert_that(result, equal_to([14, 16, 18]))
+
+    p.replace_all([MyParDoOverride()])
+    p.run()
 
   def test_ptransform_override_multiple_outputs(self):
     class MultiOutputComposite(PTransform):


### PR DESCRIPTION
Currently, `PTransformOverride` only supports overriding `PTransform` s that have a single input. This change adds support for multiple main inputs and side inputs.

The change introduces a new method `PTransformOverride.get_replacement_inputs(self, applied_ptransform)` that can be overridden by end users. This method will be called to get the inputs for the replacement `PTransform.` The default implementation will return a tuple of all the main inputs in order, concatenated with the all the side inputs `PValue` s in order.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg)
![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
