### PR TITLE
[BEAM-10781] Add PTransformOverride.get_replacement_transform_for_applied_ptransform()

### DIFF
--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -1333,8 +1333,8 @@ class PTransformOverride(with_metaclass(abc.ABCMeta,
     """
     raise NotImplementedError
 
-  def get_replacement_transform_for_applied_ptransform(self,
-                                                       applied_ptransform):
+  def get_replacement_transform_for_applied_ptransform(
+      self, applied_ptransform):
     # type: (AppliedPTransform) -> ptransform.PTransform
 
     """Provides a runner specific override for a given `AppliedPTransform`.

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -280,8 +280,9 @@ class Pipeline(object):
         # type: (AppliedPTransform) -> None
         if override.matches(original_transform_node):
           assert isinstance(original_transform_node, AppliedPTransform)
-          replacement_transform = override.get_replacement_transform_for_applied_ptransform(
-              original_transform_node)
+          replacement_transform = (
+              override.get_replacement_transform_for_applied_ptransform(
+                  original_transform_node))
           if replacement_transform is original_transform_node.transform:
             return
 

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -280,8 +280,8 @@ class Pipeline(object):
         # type: (AppliedPTransform) -> None
         if override.matches(original_transform_node):
           assert isinstance(original_transform_node, AppliedPTransform)
-          replacement_transform = override.get_replacement_transform(
-              original_transform_node.transform)
+          replacement_transform = override.get_replacement_transform_for_applied_ptransform(
+              original_transform_node)
           if replacement_transform is original_transform_node.transform:
             return
 
@@ -1333,7 +1333,25 @@ class PTransformOverride(with_metaclass(abc.ABCMeta,
     """
     raise NotImplementedError
 
-  @abc.abstractmethod
+  def get_replacement_transform_for_applied_ptransform(self,
+                                                       applied_ptransform):
+    # type: (AppliedPTransform) -> ptransform.PTransform
+
+    """Provides a runner specific override for a given `AppliedPTransform`.
+
+    Args:
+      applied_ptransform: `AppliedPTransform` containing the `PTransform` to be
+        replaced.
+
+    Returns:
+      A `PTransform` that will be the replacement for the `PTransform` inside
+      the `AppliedPTransform` given as an argument.
+    """
+    # Returns a PTransformReplacement
+    return self.get_replacement_transform(applied_ptransform.transform)
+
+  @deprecated(
+      since='2.24', current='get_replacement_transform_for_applied_ptransform')
   def get_replacement_transform(self, ptransform):
     # type: (Optional[ptransform.PTransform]) -> ptransform.PTransform
 

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -374,7 +374,9 @@ class PipelineTest(unittest.TestCase):
       def matches(self, applied_ptransform):
         return isinstance(applied_ptransform.transform, DoubleParDo)
 
-      def get_replacement_transform(self, ptransform):
+      def get_replacement_transform_for_applied_ptransform(self,
+                                                           applied_ptransform):
+        ptransform = applied_ptransform.transform
         if isinstance(ptransform, DoubleParDo):
           return TripleParDo()
         raise ValueError('Unsupported type of transform: %r' % ptransform)
@@ -391,14 +393,16 @@ class PipelineTest(unittest.TestCase):
       def matches(self, applied_ptransform):
         return isinstance(applied_ptransform.transform, DoubleParDo)
 
-      def get_replacement_transform(self, ptransform):
+      def get_replacement_transform_for_applied_ptransform(self,
+                                                           applied_ptransform):
         return ToStringParDo()
 
     class WithTypeHintOverride(PTransformOverride):
       def matches(self, applied_ptransform):
         return isinstance(applied_ptransform.transform, DoubleParDo)
 
-      def get_replacement_transform(self, ptransform):
+      def get_replacement_transform_for_applied_ptransform(self,
+                                                           applied_ptransform):
         return ToStringParDo().with_input_types(int).with_output_types(str)
 
     for override, expected_type in [(NoTypeHintOverride(), typehints.Any),
@@ -441,7 +445,8 @@ class PipelineTest(unittest.TestCase):
       def matches(self, applied_ptransform):
         return applied_ptransform.full_label == 'MyMultiOutput'
 
-      def get_replacement_transform(self, ptransform):
+      def get_replacement_transform_for_applied_ptransform(self,
+                                                           applied_ptransform):
         return MultiOutputComposite()
 
     def mux_input(x):

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -374,8 +374,8 @@ class PipelineTest(unittest.TestCase):
       def matches(self, applied_ptransform):
         return isinstance(applied_ptransform.transform, DoubleParDo)
 
-      def get_replacement_transform_for_applied_ptransform(self,
-                                                           applied_ptransform):
+      def get_replacement_transform_for_applied_ptransform(
+          self, applied_ptransform):
         ptransform = applied_ptransform.transform
         if isinstance(ptransform, DoubleParDo):
           return TripleParDo()
@@ -393,16 +393,16 @@ class PipelineTest(unittest.TestCase):
       def matches(self, applied_ptransform):
         return isinstance(applied_ptransform.transform, DoubleParDo)
 
-      def get_replacement_transform_for_applied_ptransform(self,
-                                                           applied_ptransform):
+      def get_replacement_transform_for_applied_ptransform(
+          self, applied_ptransform):
         return ToStringParDo()
 
     class WithTypeHintOverride(PTransformOverride):
       def matches(self, applied_ptransform):
         return isinstance(applied_ptransform.transform, DoubleParDo)
 
-      def get_replacement_transform_for_applied_ptransform(self,
-                                                           applied_ptransform):
+      def get_replacement_transform_for_applied_ptransform(
+          self, applied_ptransform):
         return ToStringParDo().with_input_types(int).with_output_types(str)
 
     for override, expected_type in [(NoTypeHintOverride(), typehints.Any),
@@ -445,8 +445,8 @@ class PipelineTest(unittest.TestCase):
       def matches(self, applied_ptransform):
         return applied_ptransform.full_label == 'MyMultiOutput'
 
-      def get_replacement_transform_for_applied_ptransform(self,
-                                                           applied_ptransform):
+      def get_replacement_transform_for_applied_ptransform(
+          self, applied_ptransform):
         return MultiOutputComposite()
 
     def mux_input(x):

--- a/sdks/python/apache_beam/runners/dataflow/ptransform_overrides.py
+++ b/sdks/python/apache_beam/runners/dataflow/ptransform_overrides.py
@@ -97,7 +97,8 @@ class JrhReadPTransformOverride(PTransformOverride):
         isinstance(applied_ptransform.transform, Read) and
         isinstance(applied_ptransform.transform.source, BoundedSource))
 
-  def get_replacement_transform_for_applied_ptransform(self, applied_ptransform):
+  def get_replacement_transform_for_applied_ptransform(
+      self, applied_ptransform):
     from apache_beam.io import Read
     from apache_beam.transforms import core
     from apache_beam.transforms import util

--- a/sdks/python/apache_beam/runners/dataflow/ptransform_overrides.py
+++ b/sdks/python/apache_beam/runners/dataflow/ptransform_overrides.py
@@ -40,8 +40,8 @@ class CreatePTransformOverride(PTransformOverride):
     else:
       return False
 
-  def get_replacement_transform_for_applied_ptransform(self,
-                                                       applied_ptransform):
+  def get_replacement_transform_for_applied_ptransform(
+      self, applied_ptransform):
     # Imported here to avoid circular dependencies.
     # pylint: disable=wrong-import-order, wrong-import-position
     from apache_beam import PTransform
@@ -54,8 +54,7 @@ class CreatePTransformOverride(PTransformOverride):
       def expand(self, pbegin):
         return pbegin | ptransform.as_read()
 
-    return LegacyCreate().with_output_types(
-        ptransform.get_output_type())
+    return LegacyCreate().with_output_types(ptransform.get_output_type())
 
 
 class ReadPTransformOverride(PTransformOverride):
@@ -70,8 +69,8 @@ class ReadPTransformOverride(PTransformOverride):
         return True
     return False
 
-  def get_replacement_transform_for_applied_ptransform(self,
-                                                       applied_ptransform):
+  def get_replacement_transform_for_applied_ptransform(
+      self, applied_ptransform):
 
     from apache_beam import pvalue
     from apache_beam.io import iobase
@@ -98,8 +97,7 @@ class JrhReadPTransformOverride(PTransformOverride):
         isinstance(applied_ptransform.transform, Read) and
         isinstance(applied_ptransform.transform.source, BoundedSource))
 
-  def get_replacement_transformfor_applied_ptransform(self,
-                                                      applied_ptransform):
+  def get_replacement_transformfor_applied_ptransform(self, applied_ptransform):
     from apache_beam.io import Read
     from apache_beam.transforms import core
     from apache_beam.transforms import util
@@ -121,7 +119,8 @@ class JrhReadPTransformOverride(PTransformOverride):
                         split.start_position, split.stop_position))))
 
     return JrhRead().with_output_types(
-        applied_ptransform.transform.get_type_hints().simple_output_type('Read'))
+        applied_ptransform.transform.get_type_hints().simple_output_type(
+            'Read'))
 
 
 class CombineValuesPTransformOverride(PTransformOverride):

--- a/sdks/python/apache_beam/runners/dataflow/ptransform_overrides.py
+++ b/sdks/python/apache_beam/runners/dataflow/ptransform_overrides.py
@@ -97,7 +97,7 @@ class JrhReadPTransformOverride(PTransformOverride):
         isinstance(applied_ptransform.transform, Read) and
         isinstance(applied_ptransform.transform.source, BoundedSource))
 
-  def get_replacement_transformfor_applied_ptransform(self, applied_ptransform):
+  def get_replacement_transform_for_applied_ptransform(self, applied_ptransform):
     from apache_beam.io import Read
     from apache_beam.transforms import core
     from apache_beam.transforms import util

--- a/sdks/python/apache_beam/runners/dataflow/ptransform_overrides.py
+++ b/sdks/python/apache_beam/runners/dataflow/ptransform_overrides.py
@@ -40,10 +40,13 @@ class CreatePTransformOverride(PTransformOverride):
     else:
       return False
 
-  def get_replacement_transform(self, ptransform):
+  def get_replacement_transform_for_applied_ptransform(self,
+                                                       applied_ptransform):
     # Imported here to avoid circular dependencies.
     # pylint: disable=wrong-import-order, wrong-import-position
     from apache_beam import PTransform
+
+    ptransform = applied_ptransform.transform
 
     # Return a wrapper rather than ptransform.as_read() directly to
     # ensure backwards compatibility of the pipeline structure.
@@ -51,7 +54,8 @@ class CreatePTransformOverride(PTransformOverride):
       def expand(self, pbegin):
         return pbegin | ptransform.as_read()
 
-    return LegacyCreate().with_output_types(ptransform.get_output_type())
+    return LegacyCreate().with_output_types(
+        ptransform.get_output_type())
 
 
 class ReadPTransformOverride(PTransformOverride):
@@ -66,9 +70,13 @@ class ReadPTransformOverride(PTransformOverride):
         return True
     return False
 
-  def get_replacement_transform(self, ptransform):
+  def get_replacement_transform_for_applied_ptransform(self,
+                                                       applied_ptransform):
+
     from apache_beam import pvalue
     from apache_beam.io import iobase
+
+    transform = applied_ptransform.transform
 
     class Read(iobase.Read):
       override = True
@@ -77,8 +85,8 @@ class ReadPTransformOverride(PTransformOverride):
         return pvalue.PCollection(
             self.pipeline, is_bounded=self.source.is_bounded())
 
-    return Read(ptransform.source).with_output_types(
-        ptransform.get_type_hints().simple_output_type('Read'))
+    return Read(transform.source).with_output_types(
+        transform.get_type_hints().simple_output_type('Read'))
 
 
 class JrhReadPTransformOverride(PTransformOverride):
@@ -90,12 +98,13 @@ class JrhReadPTransformOverride(PTransformOverride):
         isinstance(applied_ptransform.transform, Read) and
         isinstance(applied_ptransform.transform.source, BoundedSource))
 
-  def get_replacement_transform(self, ptransform):
+  def get_replacement_transformfor_applied_ptransform(self,
+                                                      applied_ptransform):
     from apache_beam.io import Read
     from apache_beam.transforms import core
     from apache_beam.transforms import util
     # Make this a local to narrow what's captured in the closure.
-    source = ptransform.source
+    source = applied_ptransform.transform.source
 
     class JrhRead(core.PTransform):
       def expand(self, pbegin):
@@ -112,7 +121,7 @@ class JrhReadPTransformOverride(PTransformOverride):
                         split.start_position, split.stop_position))))
 
     return JrhRead().with_output_types(
-        ptransform.get_type_hints().simple_output_type('Read'))
+        applied_ptransform.transform.get_type_hints().simple_output_type('Read'))
 
 
 class CombineValuesPTransformOverride(PTransformOverride):

--- a/sdks/python/apache_beam/runners/direct/direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner.py
@@ -282,8 +282,8 @@ def _get_transform_overrides(pipeline_options):
       if isinstance(applied_ptransform.transform, CombinePerKey):
         return applied_ptransform.inputs[0].windowing.is_default()
 
-    def get_replacement_transform_for_applied_ptransform(self,
-                                                         applied_ptransform):
+    def get_replacement_transform_for_applied_ptransform(
+        self, applied_ptransform):
       # TODO: Move imports to top. Pipeline <-> Runner dependency cause problems
       # with resolving imports when they are at top.
       # pylint: disable=wrong-import-position
@@ -299,8 +299,8 @@ def _get_transform_overrides(pipeline_options):
       # Note: we match the exact class, since we replace it with a subclass.
       return applied_ptransform.transform.__class__ == _GroupByKeyOnly
 
-    def get_replacement_transform_for_applied_ptransform(self,
-                                                         applied_ptransform):
+    def get_replacement_transform_for_applied_ptransform(
+        self, applied_ptransform):
       # Use specialized streaming implementation.
       transform = _StreamingGroupByKeyOnly()
       return transform
@@ -314,7 +314,8 @@ def _get_transform_overrides(pipeline_options):
           isinstance(transform.dofn, _GroupAlsoByWindowDoFn) and
           transform.__class__ != _StreamingGroupAlsoByWindow)
 
-    def get_replacement_transform_for_applied_ptransform(self, applied_ptransform):
+    def get_replacement_transform_for_applied_ptransform(
+        self, applied_ptransform):
       # Use specialized streaming implementation.
       transform = _StreamingGroupAlsoByWindow(
           applied_ptransform.transform.dofn.windowing)
@@ -326,8 +327,8 @@ def _get_transform_overrides(pipeline_options):
       self.applied_ptransform = applied_ptransform
       return isinstance(applied_ptransform.transform, TestStream)
 
-    def get_replacement_transform_for_applied_ptransform(self,
-                                                         applied_ptransform):
+    def get_replacement_transform_for_applied_ptransform(
+        self, applied_ptransform):
       from apache_beam.runners.direct.test_stream_impl import _ExpandableTestStream
       return _ExpandableTestStream(applied_ptransform.transform)
 
@@ -342,8 +343,8 @@ def _get_transform_overrides(pipeline_options):
       from apache_beam.transforms.core import GroupByKey
       return isinstance(applied_ptransform.transform, GroupByKey)
 
-    def get_replacement_transform_for_applied_ptransform(self,
-                                                         applied_ptransform):
+    def get_replacement_transform_for_applied_ptransform(
+        self, applied_ptransform):
       return _GroupByKey()
 
   overrides = [
@@ -454,8 +455,8 @@ def _get_pubsub_transform_overrides(pipeline_options):
       return isinstance(
           applied_ptransform.transform, beam_pubsub.ReadFromPubSub)
 
-    def get_replacement_transform_for_applied_ptransform(self,
-                                                         applied_ptransform):
+    def get_replacement_transform_for_applied_ptransform(
+        self, applied_ptransform):
       if not pipeline_options.view_as(StandardOptions).streaming:
         raise Exception(
             'PubSub I/O is only available in streaming mode '
@@ -468,14 +469,14 @@ def _get_pubsub_transform_overrides(pipeline_options):
           applied_ptransform.transform,
           (beam_pubsub.WriteToPubSub, beam_pubsub._WriteStringsToPubSub))
 
-    def get_replacement_transform_for_applied_ptransform(self,
-                                                         applied_ptransform):
+    def get_replacement_transform_for_applied_ptransform(
+        self, applied_ptransform):
       if not pipeline_options.view_as(StandardOptions).streaming:
         raise Exception(
             'PubSub I/O is only available in streaming mode '
             '(use the --streaming flag).')
-      return beam.ParDo(_DirectWriteToPubSubFn(
-          applied_ptransform.transform._sink))
+      return beam.ParDo(
+          _DirectWriteToPubSubFn(applied_ptransform.transform._sink))
 
   return [ReadFromPubSubOverride(), WriteToPubSubOverride()]
 

--- a/sdks/python/apache_beam/runners/direct/sdf_direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/sdf_direct_runner.py
@@ -67,7 +67,9 @@ class SplittableParDoOverride(PTransformOverride):
       signature = DoFnSignature(transform.fn)
       return signature.is_splittable_dofn()
 
-  def get_replacement_transform(self, ptransform):
+  def get_replacement_transform_for_applied_ptransform(self,
+                                                       applied_ptransform):
+    ptransform = applied_ptransform.transform
     assert isinstance(ptransform, ParDo)
     do_fn = ptransform.fn
     signature = DoFnSignature(do_fn)
@@ -204,8 +206,9 @@ class ProcessKeyedElementsViaKeyedWorkItemsOverride(PTransformOverride):
   def matches(self, applied_ptransform):
     return isinstance(applied_ptransform.transform, ProcessKeyedElements)
 
-  def get_replacement_transform(self, ptransform):
-    return ProcessKeyedElementsViaKeyedWorkItems(ptransform)
+  def get_replacement_transform_for_applied_ptransform(self,
+                                                       applied_ptransform):
+    return ProcessKeyedElementsViaKeyedWorkItems(applied_ptransform.transform)
 
 
 class ProcessKeyedElementsViaKeyedWorkItems(PTransform):

--- a/sdks/python/apache_beam/runners/direct/sdf_direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/sdf_direct_runner.py
@@ -67,8 +67,8 @@ class SplittableParDoOverride(PTransformOverride):
       signature = DoFnSignature(transform.fn)
       return signature.is_splittable_dofn()
 
-  def get_replacement_transform_for_applied_ptransform(self,
-                                                       applied_ptransform):
+  def get_replacement_transform_for_applied_ptransform(
+      self, applied_ptransform):
     ptransform = applied_ptransform.transform
     assert isinstance(ptransform, ParDo)
     do_fn = ptransform.fn
@@ -206,8 +206,8 @@ class ProcessKeyedElementsViaKeyedWorkItemsOverride(PTransformOverride):
   def matches(self, applied_ptransform):
     return isinstance(applied_ptransform.transform, ProcessKeyedElements)
 
-  def get_replacement_transform_for_applied_ptransform(self,
-                                                       applied_ptransform):
+  def get_replacement_transform_for_applied_ptransform(
+      self, applied_ptransform):
     return ProcessKeyedElementsViaKeyedWorkItems(applied_ptransform.transform)
 
 


### PR DESCRIPTION
`PTransformOverride.get_replacement_transform_for_applied_ptransform()` is a new method that replaces `PTransformOverride.get_replacement_transform()`. This new method provides access to the `AppliedPTransform` when constructing the replacement transform, whereas the old method only provides access to the `PTransform`.

- Introduces `PTransformOverride.get_replacement_transform_for_applied_ptransform(self, applied_ptransform)`. The user can override this to provide a replacement `PTransform` using the input `AppliedPTransform`.
- Provides a default implementation of this method that calls `PTransformOverride.get_replacement_transform()` for backwards compatibility.
- Deprecates `PTransformOverride.get_replacement_transform()`.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website
--- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg)
![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
