### PR TITLE
[BEAM-8258] basic metric feature for nexmark

### DIFF
--- a/sdks/python/apache_beam/testing/benchmarks/nexmark/monitor.py
+++ b/sdks/python/apache_beam/testing/benchmarks/nexmark/monitor.py
@@ -1,0 +1,48 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+from __future__ import absolute_import
+
+from time import time
+
+import apache_beam as beam
+from apache_beam.metrics import Metrics
+from apache_beam.testing.benchmarks.nexmark.nexmark_util import MonitorSuffix
+
+
+class Monitor(object):
+  """
+  A monitor of elements with support for later retrieving their metrics
+  """
+  def __init__(self, namespace, name_prefix):
+    # type: (str, str) -> None
+    self.namespace = namespace
+    self.name_prefix = name_prefix
+    self.doFn = MonitorDoFn(namespace, name_prefix)
+
+
+class MonitorDoFn(beam.DoFn):
+  def __init__(self, namespace, prefix):
+    self.element_count = Metrics.counter(
+        namespace, prefix + MonitorSuffix.ELEMENT_COUNTER)
+    self.event_time = Metrics.distribution(
+        namespace, prefix + MonitorSuffix.EVENT_TIME)
+
+  def process(self, element):
+    self.element_count.inc()
+    self.event_time.update(int(time() * 1000))
+    yield element

--- a/sdks/python/apache_beam/testing/benchmarks/nexmark/monitor.py
+++ b/sdks/python/apache_beam/testing/benchmarks/nexmark/monitor.py
@@ -21,12 +21,18 @@ from time import time
 
 import apache_beam as beam
 from apache_beam.metrics import Metrics
-from apache_beam.testing.benchmarks.nexmark.nexmark_util import MonitorSuffix
 
 
 class Monitor(object):
   """
   A monitor of elements with support for later retrieving their metrics
+
+  monitor objects contains a doFn to record metrics
+
+  Args:
+    namespace: the namespace all metrics within this Monitor uses
+    name_prefix: a prefix for this Monitor's metrics' names, intended to
+      be unique in per-monitor basis in pipeline
   """
   def __init__(self, namespace, name_prefix):
     # type: (str, str) -> None
@@ -46,3 +52,8 @@ class MonitorDoFn(beam.DoFn):
     self.element_count.inc()
     self.event_time.update(int(time() * 1000))
     yield element
+
+
+class MonitorSuffix:
+  ELEMENT_COUNTER = '.elements'
+  EVENT_TIME = '.event_time'

--- a/sdks/python/apache_beam/testing/benchmarks/nexmark/monitor.py
+++ b/sdks/python/apache_beam/testing/benchmarks/nexmark/monitor.py
@@ -47,13 +47,22 @@ class MonitorDoFn(beam.DoFn):
         namespace, prefix + MonitorSuffix.ELEMENT_COUNTER)
     self.event_time = Metrics.distribution(
         namespace, prefix + MonitorSuffix.EVENT_TIME)
+    self.event_timestamp = Metrics.distribution(
+        namespace, prefix + MonitorSuffix.EVENT_TIMESTAMP)
 
-  def process(self, element):
-    self.element_count.inc()
+  def start_bundle(self):
     self.event_time.update(int(time() * 1000))
+
+  def process(self, element, timestamp=beam.DoFn.TimestampParam):
+    self.element_count.inc()
+    self.event_timestamp.update(timestamp)
     yield element
+
+  def finish_bundle(self):
+    self.event_time.update(int(time() * 1000))
 
 
 class MonitorSuffix:
   ELEMENT_COUNTER = '.elements'
+  EVENT_TIMESTAMP = '.event_timestamp'
   EVENT_TIME = '.event_time'

--- a/sdks/python/apache_beam/testing/benchmarks/nexmark/nexmark_launcher.py
+++ b/sdks/python/apache_beam/testing/benchmarks/nexmark/nexmark_launcher.py
@@ -60,6 +60,7 @@ Usage
 # pytype: skip-file
 
 from __future__ import absolute_import
+from __future__ import division
 from __future__ import print_function
 
 import argparse
@@ -67,7 +68,6 @@ import logging
 import sys
 import uuid
 
-from apache_beam.testing.benchmarks.nexmark.monitor import Monitor
 from google.cloud import pubsub
 
 import apache_beam as beam
@@ -77,6 +77,7 @@ from apache_beam.options.pipeline_options import SetupOptions
 from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.options.pipeline_options import TestOptions
 from apache_beam.testing.benchmarks.nexmark import nexmark_util
+from apache_beam.testing.benchmarks.nexmark.monitor import Monitor
 from apache_beam.testing.benchmarks.nexmark.nexmark_util import Command
 from apache_beam.testing.benchmarks.nexmark.nexmark_util import MonitorSuffix
 from apache_beam.testing.benchmarks.nexmark.queries import query0
@@ -224,7 +225,7 @@ class NexmarkLauncher(object):
       events = self.generate_events()
       events = events | 'event_monitor' >> beam.ParDo(event_monitor.doFn)
       output = query.load(events, query_args)
-      output | 'result_monitor' >> beam.ParDo(result_monitor.doFn)
+      output | 'result_monitor' >> beam.ParDo(result_monitor.doFn)  # pylint: disable=expression-not-assigned
 
       result = self.pipeline.run()
       job_duration = (

--- a/sdks/python/apache_beam/testing/benchmarks/nexmark/nexmark_launcher.py
+++ b/sdks/python/apache_beam/testing/benchmarks/nexmark/nexmark_launcher.py
@@ -78,8 +78,8 @@ from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.options.pipeline_options import TestOptions
 from apache_beam.testing.benchmarks.nexmark import nexmark_util
 from apache_beam.testing.benchmarks.nexmark.monitor import Monitor
+from apache_beam.testing.benchmarks.nexmark.monitor import MonitorSuffix
 from apache_beam.testing.benchmarks.nexmark.nexmark_util import Command
-from apache_beam.testing.benchmarks.nexmark.nexmark_util import MonitorSuffix
 from apache_beam.testing.benchmarks.nexmark.queries import query0
 from apache_beam.testing.benchmarks.nexmark.queries import query1
 from apache_beam.testing.benchmarks.nexmark.queries import query2

--- a/sdks/python/apache_beam/testing/benchmarks/nexmark/nexmark_util.py
+++ b/sdks/python/apache_beam/testing/benchmarks/nexmark/nexmark_util.py
@@ -194,11 +194,6 @@ class CountAndLog(beam.PTransform):
         | "Log" >> beam.Map(log_count_info))
 
 
-class MonitorSuffix:
-  ELEMENT_COUNTER = '.elements'
-  EVENT_TIME = '.event_time'
-
-
 def log_count_info(count):
   logging.info('Query resulted in %d results', count)
   return count
@@ -239,7 +234,7 @@ def get_counter_metric(result, namespace, name):
       MetricsFilter().with_namespace(namespace).with_name(name))
   counters = metrics['counters']
   if len(counters) > 1:
-    raise ValueError(
+    raise RuntimeError(
         '%d instead of one metric result matches name: %s in namespace %s' %
         (len(counters), name, namespace))
   return counters[0].result if len(counters) > 0 else -1

--- a/sdks/python/apache_beam/testing/benchmarks/nexmark/nexmark_util.py
+++ b/sdks/python/apache_beam/testing/benchmarks/nexmark/nexmark_util.py
@@ -42,6 +42,8 @@ import logging
 import threading
 
 import apache_beam as beam
+from apache_beam.metrics import MetricsFilter
+from apache_beam.runners.runner import PipelineResult  # pylint: disable=unused-import
 from apache_beam.testing.benchmarks.nexmark.models import auction_bid
 from apache_beam.testing.benchmarks.nexmark.models import nexmark_model
 from apache_beam.testing.benchmarks.nexmark.models.field_name import FieldNames
@@ -192,6 +194,11 @@ class CountAndLog(beam.PTransform):
         | "Log" >> beam.Map(log_count_info))
 
 
+class MonitorSuffix:
+  ELEMENT_COUNTER = '.elements'
+  EVENT_TIME = '.event_time'
+
+
 def log_count_info(count):
   logging.info('Query resulted in %d results', count)
   return count
@@ -221,5 +228,34 @@ def unnest_to_json(cand):
 
 
 def millis_to_timestamp(millis):
+  # type: (int) -> Timestamp
   micro_second = millis * 1000
   return Timestamp(micros=micro_second)
+
+
+def get_counter_metric(result, namespace, name):
+  # type: (PipelineResult, str, str) -> int
+  metrics = result.metrics().query(
+      MetricsFilter().with_namespace(namespace).with_name(name))
+  counters = metrics['counters']
+  if len(counters) > 1:
+    raise ValueError(
+        '%d instead of one metric result matches name: %s in namespace %s' %
+        (len(counters), name, namespace))
+  return counters[0].result if len(counters) > 0 else -1
+
+
+def get_start_time_metric(result, namespace, name):
+  # type: (PipelineResult, str, str) -> int
+  distributions = result.metrics().query(
+      MetricsFilter().with_namespace(namespace).with_name(
+          name))['distributions']
+  return min(map(lambda m: m.result.min, distributions))
+
+
+def get_end_time_metric(result, namespace, name):
+  # type: (PipelineResult, str, str) -> int
+  distributions = result.metrics().query(
+      MetricsFilter().with_namespace(namespace).with_name(
+          name))['distributions']
+  return max(map(lambda m: m.result.max, distributions))


### PR DESCRIPTION
added beam-metric based performance monitoring
performance are logged to console after the query is done or canceled by nexmark suite

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace
--- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg)
![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg)
![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
