### PR TITLE
[BEAM-10603] Implement the new Large Source Recording API.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,8 @@
     More details will be in an upcoming [blog post](https://beam.apache.org/blog/python-performance-runtime-type-checking/index.html).
 * Added support for Python 3 type annotations on PTransforms using typed PCollections ([BEAM-10258](https://issues.apache.org/jira/browse/BEAM-10258)).
     More details will be in an upcoming [blog post](https://beam.apache.org/blog/python-improved-annotations/index.html).
+* Improved the Interactive Beam API where recording streaming jobs now start a long running background recording job. Running ib.show() or ib.collect() samples from the recording ([BEAM-10603](https://issues.apache.org/jira/browse/BEAM-10603)).
+* In Interactive Beam, ib.show() and ib.collect() now have "n" and "duration" as parameters. These mean read only up to "n" elements and up to "duration" seconds of data read from the recording ([BEAM-10603](https://issues.apache.org/jira/browse/BEAM-10603)).
 * X feature added (Java/Python) ([BEAM-X](https://issues.apache.org/jira/browse/BEAM-X)).
 
 ## Breaking Changes

--- a/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization.py
+++ b/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization.py
@@ -32,12 +32,8 @@ from datetime import timedelta
 
 from dateutil import tz
 
-from apache_beam import pvalue
 from apache_beam.runners.interactive import interactive_environment as ie
-from apache_beam.runners.interactive import pipeline_instrument as instr
 from apache_beam.runners.interactive.utils import elements_to_df
-from apache_beam.runners.interactive.utils import obfuscate
-from apache_beam.runners.interactive.utils import to_element_list
 from apache_beam.transforms.window import GlobalWindow
 from apache_beam.transforms.window import IntervalWindow
 
@@ -140,7 +136,7 @@ _NO_DATA_REMOVAL_SCRIPT = """
 
 
 def visualize(
-    pcoll,
+    stream,
     dynamic_plotting_interval=None,
     include_window_info=False,
     display_facets=False):
@@ -177,7 +173,7 @@ def visualize(
   if not _pcoll_visualization_ready:
     return None
   pv = PCollectionVisualization(
-      pcoll,
+      stream,
       include_window_info=include_window_info,
       display_facets=display_facets)
   if ie.current_env().is_in_notebook:
@@ -192,7 +188,7 @@ def visualize(
     logging.getLogger('timeloop').disabled = True
     tl = Timeloop()
 
-    def dynamic_plotting(pcoll, pv, tl, include_window_info, display_facets):
+    def dynamic_plotting(stream, pv, tl, include_window_info, display_facets):
       @tl.job(interval=timedelta(seconds=dynamic_plotting_interval))
       def continuous_update_display():  # pylint: disable=unused-variable
         # Always creates a new PCollVisualization instance when the
@@ -202,11 +198,14 @@ def visualize(
         # plotting interval information when instantiated because it's already
         # in dynamic plotting logic.
         updated_pv = PCollectionVisualization(
-            pcoll,
+            stream,
             include_window_info=include_window_info,
             display_facets=display_facets)
         updated_pv.display(updating_pv=pv)
-        if ie.current_env().is_terminated(pcoll.pipeline):
+
+        # Stop updating the visualizations as soon as the stream will not yield
+        # new elements.
+        if stream.is_done():
           try:
             tl.stop()
           except RuntimeError:
@@ -216,7 +215,7 @@ def visualize(
       tl.start()
       return tl
 
-    return dynamic_plotting(pcoll, pv, tl, include_window_info, display_facets)
+    return dynamic_plotting(stream, pv, tl, include_window_info, display_facets)
   return None
 
 
@@ -227,32 +226,18 @@ class PCollectionVisualization(object):
   access current interactive environment for materialized PCollection data at
   the moment of self instantiation through cache.
   """
-  def __init__(self, pcoll, include_window_info=False, display_facets=False):
+  def __init__(self, stream, include_window_info=False, display_facets=False):
     assert _pcoll_visualization_ready, (
         'Dependencies for PCollection visualization are not available. Please '
         'use `pip install apache-beam[interactive]` to install necessary '
         'dependencies and make sure that you are executing code in an '
         'interactive environment such as a Jupyter notebook.')
-    assert isinstance(
-        pcoll,
-        pvalue.PCollection), ('pcoll should be apache_beam.pvalue.PCollection')
-    self._pcoll = pcoll
-    # This allows us to access cache key and other meta data about the pipeline
-    # whether it's the pipeline defined in user code or a copy of that pipeline.
-    # Thus, this module doesn't need any other user input but the PCollection
-    # variable to be visualized. It then automatically figures out the pipeline
-    # definition, materialized data and the pipeline result for the execution
-    # even if the user never assigned or waited the result explicitly.
-    # With only the constructor of PipelineInstrument, any interactivity related
-    # pre-process or instrument is not triggered for performance concerns.
-    self._pin = instr.PipelineInstrument(pcoll.pipeline)
+    self._stream = stream
     # Variable name as the title for element value in the rendered data table.
-    self._pcoll_var = self._pin.cacheable_var_by_pcoll_id(
-        self._pin.pcolls_to_pcoll_id.get(str(pcoll), None))
+    self._pcoll_var = stream.var
     if not self._pcoll_var:
       self._pcoll_var = 'Value'
-    self._cache_key = self._pin.cache_key(self._pcoll)
-    obfuscated_id = obfuscate(self._cache_key, id(self))
+    obfuscated_id = stream.display_id(id(self))
     self._dive_display_id = 'facets_dive_{}'.format(obfuscated_id)
     self._overview_display_id = 'facets_overview_{}'.format(obfuscated_id)
     self._df_display_id = 'df_{}'.format(obfuscated_id)
@@ -407,13 +392,7 @@ class PCollectionVisualization(object):
           self._is_datatable_empty = False
 
   def _to_dataframe(self):
-    results = []
-    cache_manager = ie.current_env().get_cache_manager(self._pcoll.pipeline)
-    if cache_manager.exists('full', self._cache_key):
-      coder = cache_manager.load_pcoder('full', self._cache_key)
-      reader, _ = cache_manager.read('full', self._cache_key)
-      results = list(to_element_list(reader, coder, include_window_info=True))
-
+    results = list(self._stream.read(tail=False))
     return elements_to_df(results, self._include_window_info)
 
 

--- a/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization_test.py
+++ b/sdks/python/apache_beam/runners/interactive/display/pcoll_visualization_test.py
@@ -31,6 +31,7 @@ from apache_beam.runners.interactive import interactive_beam as ib
 from apache_beam.runners.interactive import interactive_environment as ie
 from apache_beam.runners.interactive import interactive_runner as ir
 from apache_beam.runners.interactive.display import pcoll_visualization as pv
+from apache_beam.runners.interactive.recording_manager import RecordingManager
 from apache_beam.transforms.window import GlobalWindow
 from apache_beam.transforms.window import IntervalWindow
 from apache_beam.utils.windowed_value import PaneInfo
@@ -68,31 +69,27 @@ class PCollectionVisualizationTest(unittest.TestCase):
     self._p = beam.Pipeline(ir.InteractiveRunner())
     # pylint: disable=range-builtin-not-iterating
     self._pcoll = self._p | 'Create' >> beam.Create(range(5))
+
     ib.watch(self)
-    self._p.run()
+    ie.current_env().track_user_pipelines()
 
-  def test_raise_error_for_non_pcoll_input(self):
-    class Foo(object):
-      pass
-
-    with self.assertRaises(AssertionError) as ctx:
-      pv.PCollectionVisualization(Foo())
-      self.assertTrue(
-          'pcoll should be apache_beam.pvalue.PCollection' in ctx.exception)
+    recording_manager = RecordingManager(self._p)
+    recording = recording_manager.record([self._pcoll], 5, 5)
+    self._stream = recording.stream(self._pcoll)
 
   def test_pcoll_visualization_generate_unique_display_id(self):
-    pv_1 = pv.PCollectionVisualization(self._pcoll)
-    pv_2 = pv.PCollectionVisualization(self._pcoll)
+    pv_1 = pv.PCollectionVisualization(self._stream)
+    pv_2 = pv.PCollectionVisualization(self._stream)
     self.assertNotEqual(pv_1._dive_display_id, pv_2._dive_display_id)
     self.assertNotEqual(pv_1._overview_display_id, pv_2._overview_display_id)
     self.assertNotEqual(pv_1._df_display_id, pv_2._df_display_id)
 
   def test_one_shot_visualization_not_return_handle(self):
-    self.assertIsNone(pv.visualize(self._pcoll, display_facets=True))
+    self.assertIsNone(pv.visualize(self._stream, display_facets=True))
 
   def test_dynamic_plotting_return_handle(self):
     h = pv.visualize(
-        self._pcoll, dynamic_plotting_interval=1, display_facets=True)
+        self._stream, dynamic_plotting_interval=1, display_facets=True)
     self.assertIsInstance(h, timeloop.Timeloop)
     h.stop()
 
@@ -111,10 +108,10 @@ class PCollectionVisualizationTest(unittest.TestCase):
       mocked_display_overview,
       mocked_display_dive):
     original_pcollection_visualization = pv.PCollectionVisualization(
-        self._pcoll, display_facets=True)
+        self._stream, display_facets=True)
     # Dynamic plotting always creates a new PCollectionVisualization.
     new_pcollection_visualization = pv.PCollectionVisualization(
-        self._pcoll, display_facets=True)
+        self._stream, display_facets=True)
     # The display uses ANY data the moment display is invoked, and updates
     # web elements with ids fetched from the given updating_pv.
     new_pcollection_visualization.display(
@@ -142,7 +139,7 @@ class PCollectionVisualizationTest(unittest.TestCase):
   def test_display_plain_text_when_kernel_has_no_frontend(self, _mocked_head):
     # Resets the notebook check to False.
     ie.current_env()._is_in_notebook = False
-    self.assertIsNone(pv.visualize(self._pcoll, display_facets=True))
+    self.assertIsNone(pv.visualize(self._stream, display_facets=True))
     _mocked_head.assert_called_once()
 
   def test_event_time_formatter(self):

--- a/sdks/python/apache_beam/runners/interactive/interactive_beam.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_beam.py
@@ -351,6 +351,20 @@ def show(*pcolls, **configs):
   n = configs.pop('n', 'inf')
   duration = configs.pop('duration', 'inf')
 
+  if isinstance(n, str):
+    assert n == 'inf', (
+        'Currently only the string \'inf\' is supported. This denotes reading '
+        'elements until the recording is stopped via a kernel interrupt.')
+  elif isinstance(n, int):
+    assert n > 0, 'n needs to be positive or the string \'inf\''
+
+  if isinstance(duration, str):
+    assert duration == 'inf', (
+        'Currently only the string \'inf\' is supported. This denotes reading '
+        'elements until the recording is stopped via a kernel interrupt.')
+  elif isinstance(duration, int):
+    assert duration > 0, 'duration needs to be positive or the string \'inf\''
+
   if n == 'inf':
     n = float('inf')
 
@@ -360,8 +374,8 @@ def show(*pcolls, **configs):
   # This assertion is to protect the backward compatibility for function
   # signature change after Python 2 deprecation.
   assert not configs, (
-      'The only configs supported are include_window_info and '
-      'visualize_data.')
+      'The only supported arguments are include_window_info, visualize_data, '
+      'n, and duration')
 
   recording_manager = RecordingManager(user_pipeline)
   recording = recording_manager.record(
@@ -427,6 +441,20 @@ def collect(pcoll, n='inf', duration='inf', include_window_info=False):
   """
   assert isinstance(pcoll, beam.pvalue.PCollection), (
       '{} is not an apache_beam.pvalue.PCollection.'.format(pcoll))
+
+  if isinstance(n, str):
+    assert n == 'inf', (
+        'Currently only the string \'inf\' is supported. This denotes reading '
+        'elements until the recording is stopped via a kernel interrupt.')
+  elif isinstance(n, int):
+    assert n > 0, 'n needs to be positive or the string \'inf\''
+
+  if isinstance(duration, str):
+    assert duration == 'inf', (
+        'Currently only the string \'inf\' is supported. This denotes reading '
+        'elements until the recording is stopped via a kernel interrupt.')
+  elif isinstance(duration, int):
+    assert duration > 0, 'duration needs to be positive or the string \'inf\''
 
   if n == 'inf':
     n = float('inf')

--- a/sdks/python/apache_beam/runners/interactive/interactive_beam.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_beam.py
@@ -267,22 +267,23 @@ def show(*pcolls, **configs):
   a notebook, or prints a heading sampled data if used within an ipython shell.
   Noop if used in a non-interactive environment.
 
+  Args:
+    include_window_info: (optional) if True, windowing information of the
+        data will be visualized too. Default is false.
+    visualize_data: (optional) by default, the visualization contains data
+        tables rendering data from given pcolls separately as if they are
+        converted into dataframes. If visualize_data is True, there will be a
+        more dive-in widget and statistically overview widget of the data.
+        Otherwise, those 2 data visualization widgets will not be displayed.
+    n: (optional) max number of elements to visualize. Default 'inf'.
+    duration: (optional) max duration of elements to read. Default 'inf'.
+
   The given pcolls can be dictionary of PCollections (as values), or iterable
   of PCollections or plain PCollection values.
 
   The user can specify either the max number of elements with `n` to read
   or the maximum duration of elements to read with `duration`. When a limiter is
   not supplied, it is assumed to be infinite.
-
-  There are 2 boolean configurations:
-
-    #. include_window_info=<True/False>. If True, windowing information of the
-       data will be visualized too. Default is false.
-    #. visualize_data=<True/False>. By default, the visualization contains data
-       tables rendering data from given pcolls separately as if they are
-       converted into dataframes. If visualize_data is True, there will be a
-       more dive-in widget and statistically overview widget of the data.
-       Otherwise, those 2 data visualization widgets will not be displayed.
 
   By default, the visualization contains data tables rendering data from given
   pcolls separately as if they are converted into dataframes. If visualize_data
@@ -429,6 +430,10 @@ def collect(pcoll, n='inf', duration='inf', include_window_info=False):
   into memory. The user can specify either the max number of elements to read
   or the maximum duration of elements to read. When a limiter is not supplied,
   it is assumed to be infinite.
+
+  Args:
+    n: (optional) max number of elements to visualize. Default 'inf'.
+    duration: (optional) max duration of elements to read. Default 'inf'.
 
   For example::
 

--- a/sdks/python/apache_beam/runners/interactive/interactive_beam_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_beam_test.py
@@ -94,6 +94,8 @@ class InteractiveBeamTest(unittest.TestCase):
     # The pcoll is not watched since watch(locals()) is not explicitly called.
     self.assertFalse(pcoll in _get_watched_pcollections_with_variable_names())
     # The call of show watches pcoll.
+    ib.watch({'p': p})
+    ie.current_env().track_user_pipelines()
     ib.show(pcoll)
     self.assertTrue(pcoll in _get_watched_pcollections_with_variable_names())
 
@@ -104,6 +106,8 @@ class InteractiveBeamTest(unittest.TestCase):
     pcoll = p | 'Create' >> beam.Create(range(10))
     self.assertFalse(pcoll in ie.current_env().computed_pcollections)
     # The call of show marks pcoll computed.
+    ib.watch(locals())
+    ie.current_env().track_user_pipelines()
     ib.show(pcoll)
     self.assertTrue(pcoll in ie.current_env().computed_pcollections)
 
@@ -115,6 +119,8 @@ class InteractiveBeamTest(unittest.TestCase):
     p = beam.Pipeline(ir.InteractiveRunner())
     # pylint: disable=range-builtin-not-iterating
     pcoll = p | 'Create' >> beam.Create(range(10))
+    ib.watch(locals())
+    ie.current_env().track_user_pipelines()
     ie.current_env().mark_pcollection_computed([pcoll])
     ie.current_env()._is_in_ipython = True
     ie.current_env()._is_in_notebook = True
@@ -129,6 +135,8 @@ class InteractiveBeamTest(unittest.TestCase):
     p = beam.Pipeline(ir.InteractiveRunner())
     # pylint: disable=range-builtin-not-iterating
     pcoll = p | 'Create' >> beam.Create(range(10))
+    ib.watch(locals())
+    ie.current_env().track_user_pipelines()
     ie.current_env().mark_pcollection_computed([pcoll])
     ie.current_env()._is_in_ipython = True
     ie.current_env()._is_in_notebook = True

--- a/sdks/python/apache_beam/runners/interactive/messaging/interactive_environment_inspector.py
+++ b/sdks/python/apache_beam/runners/interactive/messaging/interactive_environment_inspector.py
@@ -133,7 +133,7 @@ class InteractiveEnvironmentInspector(object):
     value = self.get_val(identifier)
     if isinstance(value, beam.pvalue.PCollection):
       from apache_beam.runners.interactive import interactive_beam as ib
-      dataframe = ib.collect(value, include_window_info)
+      dataframe = ib.collect(value, include_window_info=include_window_info)
       return dataframe.to_json(orient='table')
     return {}
 

--- a/sdks/python/apache_beam/runners/interactive/messaging/interactive_environment_inspector_test.py
+++ b/sdks/python/apache_beam/runners/interactive/messaging/interactive_environment_inspector_test.py
@@ -176,21 +176,23 @@ class InteractiveEnvironmentInspectorTest(unittest.TestCase):
   def test_get_pcoll_data(self):
     pipeline = beam.Pipeline(ir.InteractiveRunner())
     # pylint: disable=range-builtin-not-iterating
-    pcoll = pipeline | 'Create' >> beam.Create(range(10))
+    pcoll = pipeline | 'Create' >> beam.Create(list(range(10)))
     counts = pcoll | beam.combiners.Count.PerElement()
 
     ib.watch(locals())
+    ie.current_env().track_user_pipelines()
     counts_identifier = obfuscate(inspector.meta('counts', counts))
     ins = inspector.InteractiveEnvironmentInspector()
     _ = ins.list_inspectables()
 
     actual_counts_pcoll_data = ins.get_pcoll_data(counts_identifier)
-    expected_counts_pcoll_data = ib.collect(counts).to_json(orient='table')
+    expected_counts_pcoll_data = ib.collect(
+        counts, n=10).to_json(orient='table')
     self.assertEqual(actual_counts_pcoll_data, expected_counts_pcoll_data)
 
     actual_counts_with_window_info = ins.get_pcoll_data(counts_identifier, True)
-    expected_counts_with_window_info = ib.collect(counts,
-                                                  True).to_json(orient='table')
+    expected_counts_with_window_info = ib.collect(
+        counts, include_window_info=True).to_json(orient='table')
     self.assertEqual(
         actual_counts_with_window_info, expected_counts_with_window_info)
 


### PR DESCRIPTION
Change-Id: I660b98ac7cd562eb03aab6d15d829eae8726ebad

The following API changes the way that the Interactive Runner caches
data from unbounded sources. Previously, a user-configurable duration
would run a "Background Caching Job" that would cache all elements from
unbounded source. Then, the user pipeline would run by reading from
that cache after completion. Now, there is a long lived "Background
Recording Job". This replaces the caching job with a background pipeline
that records elements from the unbounded sources and most importantly
does not block user pipeline execution.

The following APIs have changed:
show(*pcolls, include_window_info=False, visualize_data=False) -->
show(*pcolls, n='inf', duration='inf', include_window_info=False, visualize_data=False)

The show() command was modified to include a max number of elements and
a max duration of elements to read. The show() command will end when
either of the limiters gets triggered, whichever comes first. If a
limiter is not supplied it is assumed to be infinite. For example,
show(pcoll, n=5000) will read and block until 5000 elements are read.
collect(pcoll, include_window_info=False) -->
collect(pcoll, n='inf', duration='inf', include_window_info=False)

The collect() command was modified to include a max number of elements and
a max duration of elements to read. The collect() command will end when
either of the limiters gets triggered, whichever comes first. If a
limiter is not supplied it is assumed to be infinite. For example,
show(pcoll, n=5000) will read and block until 5000 elements are read.

head() was removed.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace
--- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg)
![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg)
![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
