### PR TITLE
[BEAM-10720] Finish implementing StringMethods (cat, repeat)

### DIFF
--- a/sdks/python/apache_beam/dataframe/frame_base.py
+++ b/sdks/python/apache_beam/dataframe/frame_base.py
@@ -19,10 +19,8 @@ from __future__ import absolute_import
 import functools
 import inspect
 import sys
-from typing import Any
 from typing import Callable
 from typing import Dict
-from typing import List
 from typing import Optional
 from typing import Union
 
@@ -157,7 +155,7 @@ def _elementwise_function(func, name=None, restrictions=None, inplace=False):
 def _proxy_function(
       func,  # type: Union[Callable, str]
       name=None,  # type: Optional[str]
-      restrictions=None,  # type: Optional[Dict[str, Union[Any, List[Any]]]]
+      restrictions=None,  # type: Optional[Dict[str, Union[Any, List[Any], Callable[[Any], Bool]]
       inplace=False,  # type: bool
       requires_partition_by=partitionings.Singleton(),  # type: partitionings.Partitioning
       preserves_partition_by=partitionings.Nothing(),  # type: partitionings.Partitioning
@@ -172,7 +170,7 @@ def _proxy_function(
     restrictions = {}
 
   def wrapper(*args, **kwargs):
-    for key, values in ():  #restrictions.items():
+    for key, values in restrictions.items():
       if key in kwargs:
         value = kwargs[key]
       else:
@@ -184,9 +182,14 @@ def _proxy_function(
         if len(args) <= ix:
           continue
         value = args[ix]
-      if not isinstance(values, list):
-        values = [values]
-      if value not in values:
+      if callable(values):
+        check = values
+      elif isinstance(values, list):
+        check = lambda x, values=values: x in values
+      else:
+        check = lambda x, value=value: x == value
+
+      if not check(value):
         raise NotImplementedError(
             '%s=%s not supported for %s' % (key, value, name))
     deferred_arg_indices = []

--- a/sdks/python/apache_beam/dataframe/frame_base.py
+++ b/sdks/python/apache_beam/dataframe/frame_base.py
@@ -19,8 +19,10 @@ from __future__ import absolute_import
 import functools
 import inspect
 import sys
+from typing import Any
 from typing import Callable
 from typing import Dict
+from typing import List
 from typing import Optional
 from typing import Union
 
@@ -155,7 +157,7 @@ def _elementwise_function(func, name=None, restrictions=None, inplace=False):
 def _proxy_function(
       func,  # type: Union[Callable, str]
       name=None,  # type: Optional[str]
-      restrictions=None,  # type: Optional[Dict[str, Union[Any, List[Any], Callable[[Any], Bool]]
+      restrictions=None,  # type: Optional[Dict[str, Union[Any, List[Any], Callable[[Any], bool]]]]
       inplace=False,  # type: bool
       requires_partition_by=partitionings.Singleton(),  # type: partitionings.Partitioning
       preserves_partition_by=partitionings.Nothing(),  # type: partitionings.Partitioning

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -264,12 +264,7 @@ class DeferredSeries(frame_base.DeferredFrame):
 
   @property
   def str(self):
-    expr = expressions.ComputedExpression(
-        'str',
-        lambda df: df.str, [self._expr],
-        requires_partition_by=partitionings.Nothing(),
-        preserves_partition_by=partitionings.Singleton())
-    return _DeferredStringMethods(expr)
+    return _DeferredStringMethods(self._expr)
 
 
 for name in ['apply', 'map', 'transform']:
@@ -1011,18 +1006,33 @@ class _DeferredLoc(object):
             preserves_partition_by=partitionings.Singleton()))
 
 class _DeferredStringMethods(frame_base.DeferredBase):
+  def __init__(self, expr):
+    str_expr = expressions.ComputedExpression(
+        'str',
+        lambda df: df.str, [expr],
+        requires_partition_by=partitionings.Nothing(),
+        preserves_partition_by=partitionings.Singleton())
+    # Use str_expr (i.e. Series.str) as self._expr. This allows us
+    # to use frame_base.elementwise_method for most methods.
+    super(_DeferredStringMethods, self).__init__(str_expr)
+
+    # But also keep an expr for the underlying series, for when we need to
+    # partition it.
+    self._series_expr = expr
+    self._str_expr = str_expr
+
   @frame_base.args_to_kwargs(pd.core.strings.StringMethods)
   @frame_base.populate_defaults(pd.core.strings.StringMethods)
   def cat(self, others, join, **kwargs):
     if others is None:
       # Concatenate series into a single String
       requires = partitionings.Singleton()
-      func = lambda df: df.cat(join=join, **kwargs)
-      args = [self._expr]
+      func = lambda df: df.str.cat(join=join, **kwargs)
+      args = [self._series_expr]
 
-    elif isinstance(others, frame_base.DeferredBase) or \
-         (isinstance(others, list) and \
-          all(isinstance(other, frame_base.DeferredBase) for other in others)):
+    elif (isinstance(others, frame_base.DeferredBase) or
+         (isinstance(others, list) and
+          all(isinstance(other, frame_base.DeferredBase) for other in others))):
       if join is None:
         raise frame_base.WontImplementError("cat with others=Series or "
                                             "others=List[Series] requires "
@@ -1033,8 +1043,8 @@ class _DeferredStringMethods(frame_base.DeferredBase):
 
       requires = partitionings.Index()
       def func(*args):
-        return args[0].cat(others=args[1:], join=join, **kwargs)
-      args = [self._expr] + [other._expr for other in others]
+        return args[0].str.cat(others=args[1:], join=join, **kwargs)
+      args = [self._series_expr] + [other._expr for other in others]
 
     else:
       raise frame_base.WontImplementError("others must be None, Series, or "
@@ -1049,10 +1059,27 @@ class _DeferredStringMethods(frame_base.DeferredBase):
             requires_partition_by=requires,
             preserves_partition_by=partitionings.Singleton()))
 
-  repeat = frame_base._elementwise_method('repeat',
-                                          restrictions={
-                                              'repeats':
-                                              lambda r: isinstance(r, int)})
+  @frame_base.args_to_kwargs(pd.core.strings.StringMethods)
+  def repeat(self, repeats):
+    if isinstance(repeats, int):
+      return frame_base.DeferredFrame.wrap(
+          expressions.ComputedExpression(
+              'repeat',
+              lambda series: series.str.repeat(repeats),
+              [self._series_expr],
+              requires_partition_by=partitionings.Nothing(),
+              preserves_partition_by=partitionings.Singleton()))
+    elif isinstance(repeats, frame_base.DeferredBase):
+      return frame_base.DeferredFrame.wrap(
+          expressions.ComputedExpression(
+              'repeat',
+              lambda series, repeats_series: series.str.repeat(repeats_series),
+              [self._series_expr, repeats._expr],
+              requires_partition_by=partitionings.Index(),
+              preserves_partition_by=partitionings.Singleton()))
+    elif isinstance(repeats, list):
+      raise frame_base.WontImplementError("repeats must be an integer or a Series.")
+
 
 ELEMENTWISE_STRING_METHODS = [
             'capitalize',

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -1063,7 +1063,8 @@ class _DeferredStringMethods(frame_base.DeferredBase):
               requires_partition_by=partitionings.Index(),
               preserves_partition_by=partitionings.Singleton()))
     elif isinstance(repeats, list):
-      raise frame_base.WontImplementError("repeats must be an integer or a Series.")
+      raise frame_base.WontImplementError("repeats must be an integer or a "
+                                          "Series.")
 
 
 ELEMENTWISE_STRING_METHODS = [

--- a/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
@@ -290,46 +290,18 @@ class DoctestTest(unittest.TestCase):
         pd.core.strings,
         use_beam=False,
         wont_implement_ok={
+            # These methods can accept deferred series objects, but not lists
             'pandas.core.strings.StringMethods.cat': [
                 "s.str.cat(['A', 'B', 'C', 'D'], sep=',')",
                 "s.str.cat(['A', 'B', 'C', 'D'], sep=',', na_rep='-')",
                 "s.str.cat(['A', 'B', 'C', 'D'], na_rep='-')"
             ],
-        },
-        skip={
-            # TODO: These should probably raise WontImplement
             'pandas.core.strings.StringMethods.repeat': [
                 's.str.repeat(repeats=[1, 2, 3])'
             ],
             'pandas.core.strings.str_repeat': [
                 's.str.repeat(repeats=[1, 2, 3])'
             ],
-
-            # The rest of the skipped tests represent bad test strings,
-            # fixed upstream in
-            # https://github.com/pandas-dev/pandas/commit/d095ac899da953d759992824592a72a1e6ff5e09
-            'pandas.core.strings.StringMethods': [
-                "s.str.split('_')", "s.str.replace('_', '')"
-            ],
-            'pandas.core.strings.str_split': ["s.str.split(expand=True)"],
-            'pandas.core.strings.str_replace': [
-                "pd.Series(['foo', 'fuz', np.nan]).str.replace('f', repr)"
-            ],
-            'pandas.core.strings.StringMethods.replace': [
-                "pd.Series(['foo', 'fuz', np.nan]).str.replace('f', repr)"
-            ],
-            'pandas.core.strings.StringMethods.partition': [
-                'idx.str.partition()'
-            ],
-            'pandas.core.strings.StringMethods.rpartition': [
-                'idx.str.partition()'
-            ],
-            # rsplit/split are particularly troublesome because the first test,
-            # defining a test series, is bad and must be skipped. But skipping
-            # it breaks every other test. To run the rest we would need to
-            # execute the first test but ignore the output.
-            'pandas.core.strings.StringMethods.rsplit': ["*"],
-            'pandas.core.strings.StringMethods.split': ["*"],
         })
     self.assertEqual(result.failed, 0)
 

--- a/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
@@ -289,10 +289,21 @@ class DoctestTest(unittest.TestCase):
     result = doctests.testmod(
         pd.core.strings,
         use_beam=False,
+        wont_implement_ok={
+            'pandas.core.strings.StringMethods.cat': [
+                "s.str.cat(['A', 'B', 'C', 'D'], sep=',')",
+                "s.str.cat(['A', 'B', 'C', 'D'], sep=',', na_rep='-')",
+                "s.str.cat(['A', 'B', 'C', 'D'], na_rep='-')"
+            ],
+        },
         skip={
-            'pandas.core.strings.StringMethods.cat': ['*'],
-            'pandas.core.strings.StringMethods.repeat': ['*'],
-            'pandas.core.strings.str_repeat': ['*'],
+            # TODO: These should probably raise WontImplement
+            'pandas.core.strings.StringMethods.repeat': [
+                's.str.repeat(repeats=[1, 2, 3])'
+            ],
+            'pandas.core.strings.str_repeat': [
+                's.str.repeat(repeats=[1, 2, 3])'
+            ],
 
             # The rest of the skipped tests represent bad test strings,
             # fixed upstream in

--- a/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
@@ -302,7 +302,17 @@ class DoctestTest(unittest.TestCase):
             'pandas.core.strings.str_repeat': [
                 's.str.repeat(repeats=[1, 2, 3])'
             ],
-        })
+        },
+        skip={
+            # Bad test strings
+            'pandas.core.strings.str_replace': [
+                "pd.Series(['foo', 'fuz', np.nan]).str.replace('f', repr)"
+            ],
+            'pandas.core.strings.StringMethods.replace': [
+                "pd.Series(['foo', 'fuz', np.nan]).str.replace('f', repr)"
+            ],
+        }
+    )
     self.assertEqual(result.failed, 0)
 
   def test_datetime_tests(self):

--- a/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
@@ -311,8 +311,7 @@ class DoctestTest(unittest.TestCase):
             'pandas.core.strings.StringMethods.replace': [
                 "pd.Series(['foo', 'fuz', np.nan]).str.replace('f', repr)"
             ],
-        }
-    )
+        })
     self.assertEqual(result.failed, 0)
 
   def test_datetime_tests(self):

--- a/sdks/python/apache_beam/dataframe/transforms_test.py
+++ b/sdks/python/apache_beam/dataframe/transforms_test.py
@@ -273,7 +273,7 @@ class TransformTest(unittest.TestCase):
       assert_that(res['res'], equal_to_series(three_series), 'CheckDictOut')
 
   def test_cat(self):
-    # verify that cat works with a List[Series] sicne this is
+    # verify that cat works with a List[Series] since this is
     # missing from doctests
     df = pd.DataFrame({
         'one': ['A', 'B', 'C'],
@@ -283,6 +283,15 @@ class TransformTest(unittest.TestCase):
     self.run_scenario(df, lambda df: df.two.str.cat([df.three], join='outer'))
     self.run_scenario(
         df, lambda df: df.one.str.cat([df.two, df.three], join='outer'))
+
+  def test_repeat(self):
+    # verify that repeat works with a Series since this is
+    # missing from doctests
+    df = pd.DataFrame({
+        'strings': ['A', 'B', 'C', 'D', 'E'],
+        'repeats': [3, 1, 4, 5, 2],
+    })
+    self.run_scenario(df, lambda df: df.strings.str.repeat(df.repeats))
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/dataframe/transforms_test.py
+++ b/sdks/python/apache_beam/dataframe/transforms_test.py
@@ -272,6 +272,18 @@ class TransformTest(unittest.TestCase):
           lambda x: {'res': 3 * x}, proxy, yield_elements='pandas')
       assert_that(res['res'], equal_to_series(three_series), 'CheckDictOut')
 
+  def test_cat(self):
+    # verify that cat works with a List[Series] sicne this is
+    # missing from doctests
+    df = pd.DataFrame({
+        'one': ['A', 'B', 'C'],
+        'two': ['BB', 'CC', 'A'],
+        'three': ['CCC', 'AA', 'B'],
+    })
+    self.run_scenario(df, lambda df: df.two.str.cat([df.three], join='outer'))
+    self.run_scenario(
+        df, lambda df: df.one.str.cat([df.two, df.three], join='outer'))
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
This PR adds implementations for the non-trivial operations in `pd.Series.str`:
- [`cat`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.str.cat.html) can accept another Series or DataFrame making it a zipping operation, or it may produce a scalar.
- [`repeat`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.str.repeat.html) can accept another Series making it a zipping operation.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace
--- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg)
![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg)
![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
