### PR TITLE
Support read/write ZetaSQL DATETIME/NUMERIC types from/to BigQuery

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -69,6 +69,7 @@
 ## Breaking Changes
 
 * X behavior was changed ([BEAM-X](https://issues.apache.org/jira/browse/BEAM-X)).
+* BigQuery's DATETIME type now maps to Beam logical type org.apache.beam.sdk.schemas.logicaltypes.SqlTypes.DATETIME
 
 ## Deprecations
 

--- a/sdks/java/extensions/sql/datacatalog/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/datacatalog/SchemaUtils.java
+++ b/sdks/java/extensions/sql/datacatalog/src/main/java/org/apache/beam/sdk/extensions/sql/meta/provider/datacatalog/SchemaUtils.java
@@ -48,6 +48,7 @@ class SchemaUtils {
           .put("STRING", FieldType.STRING)
           .put("TIME", FieldType.logicalType(SqlTypes.TIME))
           .put("TIMESTAMP", FieldType.DATETIME)
+          .put("NUMERIC", FieldType.DECIMAL)
           .put("MAP<STRING,STRING>", FieldType.map(FieldType.STRING, FieldType.STRING))
           .build();
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
@@ -619,8 +619,17 @@ public class BigQueryUtils {
   }
 
   private static Object toBeamValue(FieldType fieldType, Object jsonBQValue) {
-    if (jsonBQValue instanceof String && JSON_VALUE_PARSERS.containsKey(fieldType.getTypeName())) {
-      return JSON_VALUE_PARSERS.get(fieldType.getTypeName()).apply((String) jsonBQValue);
+    if (jsonBQValue instanceof String) {
+      String jsonBQString = (String) jsonBQValue;
+      if (JSON_VALUE_PARSERS.containsKey(fieldType.getTypeName())) {
+        return JSON_VALUE_PARSERS.get(fieldType.getTypeName()).apply(jsonBQString);
+      } else if (fieldType.isLogicalType(SqlTypes.DATETIME.getIdentifier())) {
+        return LocalDateTime.parse(jsonBQString, BIGQUERY_DATETIME_FORMATTER);
+      } else if (fieldType.isLogicalType(SqlTypes.DATE.getIdentifier())) {
+        return LocalDate.parse(jsonBQString);
+      } else if (fieldType.isLogicalType(SqlTypes.TIME.getIdentifier())) {
+        return LocalTime.parse(jsonBQString);
+      }
     }
 
     if (jsonBQValue instanceof List) {

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtilsTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtilsTest.java
@@ -75,6 +75,9 @@ public class BigQueryUtilsTest {
           .addNullableField("timestamp_variant2", Schema.FieldType.DATETIME)
           .addNullableField("timestamp_variant3", Schema.FieldType.DATETIME)
           .addNullableField("timestamp_variant4", Schema.FieldType.DATETIME)
+          .addNullableField("datetime", Schema.FieldType.logicalType(SqlTypes.DATETIME))
+          .addNullableField("date", Schema.FieldType.logicalType(SqlTypes.DATE))
+          .addNullableField("time", Schema.FieldType.logicalType(SqlTypes.TIME))
           .addNullableField("valid", Schema.FieldType.BOOLEAN)
           .addNullableField("binary", Schema.FieldType.BYTES)
           .addNullableField("numeric", Schema.FieldType.DECIMAL)
@@ -133,6 +136,15 @@ public class BigQueryUtilsTest {
           .setName("timestamp_variant4")
           .setType(StandardSQLTypeName.TIMESTAMP.toString());
 
+  private static final TableFieldSchema DATETIME =
+      new TableFieldSchema().setName("datetime").setType(StandardSQLTypeName.DATETIME.toString());
+
+  private static final TableFieldSchema DATE =
+      new TableFieldSchema().setName("date").setType(StandardSQLTypeName.DATE.toString());
+
+  private static final TableFieldSchema TIME =
+      new TableFieldSchema().setName("time").setType(StandardSQLTypeName.TIME.toString());
+
   private static final TableFieldSchema VALID =
       new TableFieldSchema().setName("valid").setType(StandardSQLTypeName.BOOL.toString());
 
@@ -177,6 +189,9 @@ public class BigQueryUtilsTest {
                   TIMESTAMP_VARIANT2,
                   TIMESTAMP_VARIANT3,
                   TIMESTAMP_VARIANT4,
+                  DATETIME,
+                  DATE,
+                  TIME,
                   VALID,
                   BINARY,
                   NUMERIC));
@@ -195,6 +210,9 @@ public class BigQueryUtilsTest {
                   TIMESTAMP_VARIANT2,
                   TIMESTAMP_VARIANT3,
                   TIMESTAMP_VARIANT4,
+                  DATETIME,
+                  DATE,
+                  TIME,
                   VALID,
                   BINARY,
                   NUMERIC));
@@ -223,6 +241,9 @@ public class BigQueryUtilsTest {
                   .withZoneUTC()
                   .parseDateTime("2019-08-18T15:52:07.123"),
               new DateTime(123456),
+              LocalDateTime.parse("2020-11-02T12:34:56.789876"),
+              LocalDate.parse("2020-11-02"),
+              LocalTime.parse("12:34:56.789876"),
               false,
               Base64.getDecoder().decode("ABCD1234"),
               new BigDecimal(123.456).setScale(3, RoundingMode.HALF_UP))
@@ -241,13 +262,16 @@ public class BigQueryUtilsTest {
               "timestamp_variant4",
               String.valueOf(
                   new DateTime(123456L, ISOChronology.getInstanceUTC()).getMillis() / 1000.0D))
+          .set("datetime", "2020-11-02 12:34:56.789876")
+          .set("date", "2020-11-02")
+          .set("time", "12:34:56.789876")
           .set("valid", "false")
           .set("binary", "ABCD1234")
           .set("numeric", "123.456");
 
   private static final Row NULL_FLAT_ROW =
       Row.withSchema(FLAT_TYPE)
-          .addValues(null, null, null, null, null, null, null, null, null, null)
+          .addValues(null, null, null, null, null, null, null, null, null, null, null, null, null)
           .build();
 
   private static final TableRow BQ_NULL_FLAT_ROW =
@@ -259,6 +283,9 @@ public class BigQueryUtilsTest {
           .set("timestamp_variant2", null)
           .set("timestamp_variant3", null)
           .set("timestamp_variant4", null)
+          .set("datetime", null)
+          .set("date", null)
+          .set("time", null)
           .set("valid", null)
           .set("binary", null)
           .set("numeric", null);
@@ -306,6 +333,9 @@ public class BigQueryUtilsTest {
                   TIMESTAMP_VARIANT2,
                   TIMESTAMP_VARIANT3,
                   TIMESTAMP_VARIANT4,
+                  DATETIME,
+                  DATE,
+                  TIME,
                   VALID,
                   BINARY,
                   NUMERIC));
@@ -349,6 +379,9 @@ public class BigQueryUtilsTest {
             TIMESTAMP_VARIANT2,
             TIMESTAMP_VARIANT3,
             TIMESTAMP_VARIANT4,
+            DATETIME,
+            DATE,
+            TIME,
             VALID,
             BINARY,
             NUMERIC));
@@ -387,6 +420,9 @@ public class BigQueryUtilsTest {
             TIMESTAMP_VARIANT2,
             TIMESTAMP_VARIANT3,
             TIMESTAMP_VARIANT4,
+            DATETIME,
+            DATE,
+            TIME,
             VALID,
             BINARY,
             NUMERIC));
@@ -411,6 +447,9 @@ public class BigQueryUtilsTest {
             TIMESTAMP_VARIANT2,
             TIMESTAMP_VARIANT3,
             TIMESTAMP_VARIANT4,
+            DATETIME,
+            DATE,
+            TIME,
             VALID,
             BINARY,
             NUMERIC));
@@ -433,12 +472,16 @@ public class BigQueryUtilsTest {
     TableRow row = toTableRow().apply(FLAT_ROW);
     System.out.println(row);
 
-    assertThat(row.size(), equalTo(10));
+    assertThat(row.size(), equalTo(13));
     assertThat(row, hasEntry("id", "123"));
     assertThat(row, hasEntry("value", "123.456"));
+    assertThat(row, hasEntry("datetime", "2020-11-02 12:34:56.789876"));
+    assertThat(row, hasEntry("date", "2020-11-02"));
+    assertThat(row, hasEntry("time", "12:34:56.789876"));
     assertThat(row, hasEntry("name", "test"));
     assertThat(row, hasEntry("valid", "false"));
     assertThat(row, hasEntry("binary", "ABCD1234"));
+    assertThat(row, hasEntry("numeric", "123.456"));
   }
 
   @Test
@@ -474,12 +517,12 @@ public class BigQueryUtilsTest {
 
     assertThat(row.size(), equalTo(1));
     row = (TableRow) row.get("row");
-    assertThat(row.size(), equalTo(10));
+    assertThat(row.size(), equalTo(13));
     assertThat(row, hasEntry("id", "123"));
     assertThat(row, hasEntry("value", "123.456"));
-    assertThat(row, hasEntry("value", "123.456"));
-    assertThat(row, hasEntry("value", "123.456"));
-    assertThat(row, hasEntry("value", "123.456"));
+    assertThat(row, hasEntry("datetime", "2020-11-02 12:34:56.789876"));
+    assertThat(row, hasEntry("date", "2020-11-02"));
+    assertThat(row, hasEntry("time", "12:34:56.789876"));
     assertThat(row, hasEntry("name", "test"));
     assertThat(row, hasEntry("valid", "false"));
     assertThat(row, hasEntry("binary", "ABCD1234"));
@@ -492,19 +535,23 @@ public class BigQueryUtilsTest {
 
     assertThat(row.size(), equalTo(1));
     row = ((List<TableRow>) row.get("rows")).get(0);
-    assertThat(row.size(), equalTo(10));
+    assertThat(row.size(), equalTo(13));
     assertThat(row, hasEntry("id", "123"));
     assertThat(row, hasEntry("value", "123.456"));
+    assertThat(row, hasEntry("datetime", "2020-11-02 12:34:56.789876"));
+    assertThat(row, hasEntry("date", "2020-11-02"));
+    assertThat(row, hasEntry("time", "12:34:56.789876"));
     assertThat(row, hasEntry("name", "test"));
     assertThat(row, hasEntry("valid", "false"));
     assertThat(row, hasEntry("binary", "ABCD1234"));
+    assertThat(row, hasEntry("numeric", "123.456"));
   }
 
   @Test
   public void testToTableRow_null_row() {
     TableRow row = toTableRow().apply(NULL_FLAT_ROW);
 
-    assertThat(row.size(), equalTo(10));
+    assertThat(row.size(), equalTo(13));
     assertThat(row, hasEntry("id", null));
     assertThat(row, hasEntry("value", null));
     assertThat(row, hasEntry("name", null));
@@ -512,6 +559,9 @@ public class BigQueryUtilsTest {
     assertThat(row, hasEntry("timestamp_variant2", null));
     assertThat(row, hasEntry("timestamp_variant3", null));
     assertThat(row, hasEntry("timestamp_variant4", null));
+    assertThat(row, hasEntry("datetime", null));
+    assertThat(row, hasEntry("date", null));
+    assertThat(row, hasEntry("time", null));
     assertThat(row, hasEntry("valid", null));
     assertThat(row, hasEntry("binary", null));
     assertThat(row, hasEntry("numeric", null));


### PR DESCRIPTION
Add support to 2 more new types: DATETIME and NUMERIC, similar to https://github.com/apache/beam/pull/12261

Also add the missing mapping for NUMERIC in SchemaUtils in Data Catalog.

r: @chamikaramj, @TheNeuralBit 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace
--- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg)
![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg)
![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
