### PR TITLE
[BEAM-10720] Add implementation for elementwise str methods

### DIFF
--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -200,6 +200,15 @@ class DeferredSeries(frame_base.DeferredFrame):
 
   view = frame_base.wont_implement_method('memory sharing semantics')
 
+  @property
+  def str(self):
+    expr = expressions.ComputedExpression(
+        'str',
+        lambda df: df.str, [self._expr],
+        requires_partition_by=partitionings.Nothing(),
+        preserves_partition_by=partitionings.Nothing())
+    return _DeferredStringMethods(expr)
+
 
 for base in ['add',
              'sub',
@@ -869,3 +878,52 @@ class _DeferredLoc(object):
                 if len(args) > 1
                 else partitionings.Nothing()),
             preserves_partition_by=partitionings.Singleton()))
+
+class _DeferredStringMethods(frame_base.DeferredBase):
+  pass
+
+ELEMENTWISE_STRING_METHODS = [
+            'capitalize',
+            'casefold',
+            'contains',
+            'count',
+            'endswith',
+            'extract',
+            'extractall',
+            'findall',
+            'get',
+            'get_dummies',
+            'isalpha',
+            'isalnum',
+            'isdecimal',
+            'isdigit',
+            'islower',
+            'isnumeric',
+            'isspace',
+            'istitle',
+            'isupper',
+            'join',
+            'len',
+            'lower',
+            'lstrip',
+            'pad',
+            'partition',
+            'replace',
+            'rpartition',
+            'rsplit',
+            'rstrip',
+            'slice',
+            'slice_replace',
+            'split',
+            'startswith',
+            'strip',
+            'swapcase',
+            'title',
+            'upper',
+            'wrap',
+            'zfill',
+            '__getitem__',
+]
+
+for method in ELEMENTWISE_STRING_METHODS:
+  setattr(_DeferredStringMethods, method, frame_base._elementwise_method(method))

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -206,7 +206,7 @@ class DeferredSeries(frame_base.DeferredFrame):
         'str',
         lambda df: df.str, [self._expr],
         requires_partition_by=partitionings.Nothing(),
-        preserves_partition_by=partitionings.Nothing())
+        preserves_partition_by=partitionings.Singleton())
     return _DeferredStringMethods(expr)
 
 

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -926,4 +926,6 @@ ELEMENTWISE_STRING_METHODS = [
 ]
 
 for method in ELEMENTWISE_STRING_METHODS:
-  setattr(_DeferredStringMethods, method, frame_base._elementwise_method(method))
+  setattr(_DeferredStringMethods,
+          method,
+          frame_base._elementwise_method(method))

--- a/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
@@ -187,69 +187,38 @@ class DoctestTest(unittest.TestCase):
     self.assertEqual(result.failed, 0)
 
   def test_string_tests(self):
-    # TODO(BEAM-10720)
     result = doctests.testmod(
         pd.core.strings,
         use_beam=False,
         skip={
-            'pandas.core.strings.StringMethods': ['*'],
-            'pandas.core.strings.StringMethods.capitalize': ['*'],
-            'pandas.core.strings.StringMethods.casefold': ['*'],
             'pandas.core.strings.StringMethods.cat': ['*'],
-            'pandas.core.strings.StringMethods.contains': ['*'],
-            'pandas.core.strings.StringMethods.count': ['*'],
-            'pandas.core.strings.StringMethods.endswith': ['*'],
-            'pandas.core.strings.StringMethods.extract': ['*'],
-            'pandas.core.strings.StringMethods.extractall': ['*'],
-            'pandas.core.strings.StringMethods.findall': ['*'],
-            'pandas.core.strings.StringMethods.get': ['*'],
-            'pandas.core.strings.StringMethods.get_dummies': ['*'],
-            'pandas.core.strings.StringMethods.isalnum': ['*'],
-            'pandas.core.strings.StringMethods.isalpha': ['*'],
-            'pandas.core.strings.StringMethods.isdecimal': ['*'],
-            'pandas.core.strings.StringMethods.isdigit': ['*'],
-            'pandas.core.strings.StringMethods.islower': ['*'],
-            'pandas.core.strings.StringMethods.isnumeric': ['*'],
-            'pandas.core.strings.StringMethods.isspace': ['*'],
-            'pandas.core.strings.StringMethods.istitle': ['*'],
-            'pandas.core.strings.StringMethods.isupper': ['*'],
-            'pandas.core.strings.StringMethods.join': ['*'],
-            'pandas.core.strings.StringMethods.len': ['*'],
-            'pandas.core.strings.StringMethods.lower': ['*'],
-            'pandas.core.strings.StringMethods.lstrip': ['*'],
-            'pandas.core.strings.StringMethods.pad': ['*'],
-            'pandas.core.strings.StringMethods.partition': ['*'],
             'pandas.core.strings.StringMethods.repeat': ['*'],
-            'pandas.core.strings.StringMethods.replace': ['*'],
-            'pandas.core.strings.StringMethods.rpartition': ['*'],
-            'pandas.core.strings.StringMethods.rsplit': ['*'],
-            'pandas.core.strings.StringMethods.rstrip': ['*'],
-            'pandas.core.strings.StringMethods.slice': ['*'],
-            'pandas.core.strings.StringMethods.slice_replace': ['*'],
-            'pandas.core.strings.StringMethods.split': ['*'],
-            'pandas.core.strings.StringMethods.startswith': ['*'],
-            'pandas.core.strings.StringMethods.strip': ['*'],
-            'pandas.core.strings.StringMethods.swapcase': ['*'],
-            'pandas.core.strings.StringMethods.title': ['*'],
-            'pandas.core.strings.StringMethods.upper': ['*'],
-            'pandas.core.strings.StringMethods.wrap': ['*'],
-            'pandas.core.strings.StringMethods.zfill': ['*'],
-            'pandas.core.strings.str_contains': ['*'],
-            'pandas.core.strings.str_count': ['*'],
-            'pandas.core.strings.str_endswith': ['*'],
-            'pandas.core.strings.str_extract': ['*'],
-            'pandas.core.strings.str_extractall': ['*'],
-            'pandas.core.strings.str_findall': ['*'],
-            'pandas.core.strings.str_get': ['*'],
-            'pandas.core.strings.str_get_dummies': ['*'],
-            'pandas.core.strings.str_join': ['*'],
-            'pandas.core.strings.str_pad': ['*'],
             'pandas.core.strings.str_repeat': ['*'],
-            'pandas.core.strings.str_replace': ['*'],
-            'pandas.core.strings.str_slice': ['*'],
-            'pandas.core.strings.str_slice_replace': ['*'],
-            'pandas.core.strings.str_startswith': ['*'],
-            'pandas.core.strings.str_wrap': ['*'],
+
+            # The rest of the skipped tests represent bad test strings, fixed upstream
+            # in https://github.com/pandas-dev/pandas/commit/d095ac899da953d759992824592a72a1e6ff5e09
+            'pandas.core.strings.StringMethods': [
+                "s.str.split('_')", "s.str.replace('_', '')"
+            ],
+            'pandas.core.strings.str_split': ["s.str.split(expand=True)"],
+            'pandas.core.strings.str_replace': [
+                "pd.Series(['foo', 'fuz', np.nan]).str.replace('f', repr)"
+            ],
+            'pandas.core.strings.StringMethods.replace': [
+                "pd.Series(['foo', 'fuz', np.nan]).str.replace('f', repr)"
+            ],
+            'pandas.core.strings.StringMethods.partition': [
+                'idx.str.partition()'
+            ],
+            'pandas.core.strings.StringMethods.rpartition': [
+                'idx.str.partition()'
+            ],
+            # rsplit/split are particularly troublesome because the first test,
+            # defining a test series, is bad and must be skipped. But skipping it
+            # breaks every other test. To run the rest we would need to execute
+            # the first test but ignore the output.
+            'pandas.core.strings.StringMethods.rsplit': ["*"],
+            'pandas.core.strings.StringMethods.split': ["*"],
         })
     self.assertEqual(result.failed, 0)
 

--- a/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
@@ -195,8 +195,9 @@ class DoctestTest(unittest.TestCase):
             'pandas.core.strings.StringMethods.repeat': ['*'],
             'pandas.core.strings.str_repeat': ['*'],
 
-            # The rest of the skipped tests represent bad test strings, fixed upstream
-            # in https://github.com/pandas-dev/pandas/commit/d095ac899da953d759992824592a72a1e6ff5e09
+            # The rest of the skipped tests represent bad test strings,
+            # fixed upstream in
+            # https://github.com/pandas-dev/pandas/commit/d095ac899da953d759992824592a72a1e6ff5e09
             'pandas.core.strings.StringMethods': [
                 "s.str.split('_')", "s.str.replace('_', '')"
             ],
@@ -214,9 +215,9 @@ class DoctestTest(unittest.TestCase):
                 'idx.str.partition()'
             ],
             # rsplit/split are particularly troublesome because the first test,
-            # defining a test series, is bad and must be skipped. But skipping it
-            # breaks every other test. To run the rest we would need to execute
-            # the first test but ignore the output.
+            # defining a test series, is bad and must be skipped. But skipping
+            # it breaks every other test. To run the rest we would need to
+            # execute the first test but ignore the output.
             'pandas.core.strings.StringMethods.rsplit': ["*"],
             'pandas.core.strings.StringMethods.split': ["*"],
         })


### PR DESCRIPTION
This PR splits out the uncontroversial portions of #12705, the elementwise methods.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg)
![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg)
![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
