### PR TITLE
[BEAM-10824] [BEAM-7654] Change hash function in ApproximateUniqueCombineFn

### DIFF
--- a/sdks/python/apache_beam/transforms/stats.py
+++ b/sdks/python/apache_beam/transforms/stats.py
@@ -15,7 +15,16 @@
 # limitations under the License.
 #
 
-"""This module has all statistic related transforms."""
+"""This module has all statistic related transforms.
+
+This ApproximateUnique class will be deprecated [1]. PLease look into using the
+approximate algorithms in the Beam Java SDK instead [2].
+
+[1] https://lists.apache.org/thread.html/501605df5027567099b81f18c080469661fb426
+4a002615fa1510502%40%3Cdev.beam.apache.org%3E
+[2] https://github.com/apache/beam/blob/master/sdks/java/core/src/main/java/org/
+apache/beam/sdk/transforms/ApproximateUnique.java
+"""
 
 # pytype: skip-file
 
@@ -138,11 +147,12 @@ class _LargestUnique(object):
   An object to keep samples and calculate sample hash space. It is an
   accumulator of a combine function.
   """
+  # We use unsigned 64-bit hashes.
   _HASH_SPACE_SIZE = 2.0**64
 
   def __init__(self, sample_size):
     self._sample_size = sample_size
-    self._min_hash = sys.maxsize
+    self._min_hash = 2.0**64
     self._sample_heap = []
     self._sample_set = set()
 
@@ -167,7 +177,6 @@ class _LargestUnique(object):
         self._min_hash = self._sample_heap[0]
       elif element < self._min_hash:
         self._min_hash = element
-
     return True
 
   def get_estimate(self):
@@ -189,7 +198,6 @@ class _LargestUnique(object):
     est = log1p(-sample_size/sample_space) / log1p(-1/sample_space)
       * hash_space / sample_space
     """
-
     if len(self._sample_heap) < self._sample_size:
       return len(self._sample_heap)
     else:
@@ -198,7 +206,6 @@ class _LargestUnique(object):
           math.log1p(-self._sample_size / sample_space_size) /
           math.log1p(-1 / sample_space_size) * self._HASH_SPACE_SIZE /
           sample_space_size)
-
       return round(est)
 
 

--- a/sdks/python/apache_beam/transforms/stats.py
+++ b/sdks/python/apache_beam/transforms/stats.py
@@ -226,7 +226,7 @@ class ApproximateUniqueCombineFn(CombineFn):
       accumulator.add(hashed_value)
       return accumulator
     except Exception as e:
-      raise RuntimeError("Runtime exception: %s", e)
+      raise RuntimeError("Runtime exception: %s" % e)
 
   # created an issue https://issues.apache.org/jira/browse/BEAM-7285 to speed up
   # merge process.

--- a/sdks/python/apache_beam/transforms/stats_test.py
+++ b/sdks/python/apache_beam/transforms/stats_test.py
@@ -496,8 +496,7 @@ class ApproximateUniqueTest(unittest.TestCase):
         'The key coder "Base64PickleCoder" '
         'for ApproximateUniqueCombineFn is not deterministic.')
 
-  def test_approximate_unique_combine_fn_add_values(self):
-    # test if the combiner adds values correctly.
+  def test_approximate_unique_combine_fn_adds_values_correctly(self):
     test_input = [['a', 'b', 'c'], ['b', 'd']]
     sample_size = 30
     coder = coders.StrUtf8Coder()
@@ -510,8 +509,7 @@ class ApproximateUniqueTest(unittest.TestCase):
     result = 4
     self.assertEqual(combine_fn.extract_output(accumulator), result)
 
-  def test_approximate_unique_combine_fn_merge_values(self):
-    # test if the combiner merges values correctly.
+  def test_approximate_unique_combine_fn_merges_values_correctly(self):
     test_input = [['a', 'b', 'c'], ['b', 'd']]
     sample_size = 30
     coder = coders.StrUtf8Coder()

--- a/sdks/python/apache_beam/transforms/stats_test.py
+++ b/sdks/python/apache_beam/transforms/stats_test.py
@@ -164,49 +164,8 @@ class ApproximateUniqueTest(unittest.TestCase):
     # expected max error.
     sample_size = 16
     max_err = 2 / math.sqrt(sample_size)
-    test_input = [
-        4,
-        34,
-        29,
-        46,
-        80,
-        66,
-        51,
-        81,
-        31,
-        9,
-        26,
-        36,
-        10,
-        41,
-        90,
-        35,
-        33,
-        19,
-        88,
-        86,
-        28,
-        93,
-        38,
-        76,
-        15,
-        87,
-        12,
-        39,
-        84,
-        13,
-        32,
-        49,
-        65,
-        100,
-        16,
-        27,
-        23,
-        30,
-        96,
-        54
-    ]
-
+    test_input = list(range(100))
+    random.shuffle(test_input)
     actual_count = len(set(test_input))
 
     with TestPipeline() as pipeline:
@@ -483,8 +442,7 @@ class ApproximateUniqueTest(unittest.TestCase):
           equal_to([True]),
           label='assert:globally_by_error_with_skewed_data')
 
-  def test_approximate_unique_combine_fn_by_nondeterministic_coder(self):
-    # test if the combiner throws an error with a nondeterministic coder.
+  def test_approximate_unique_combine_fn_requires_nondeterministic_coder(self):
     sample_size = 30
     coder = coders.Base64PickleCoder()
 
@@ -496,8 +454,7 @@ class ApproximateUniqueTest(unittest.TestCase):
         'The key coder "Base64PickleCoder" '
         'for ApproximateUniqueCombineFn is not deterministic.')
 
-  def test_approximate_unique_combine_fn_by_wrong_coder(self):
-    # test if the combiner throws an error with a wrong coder.
+  def test_approximate_unique_combine_fn_requires_compatible_coder(self):
     test_input = 'a'
     sample_size = 30
     coder = coders.FloatCoder()

--- a/sdks/python/apache_beam/transforms/stats_test.py
+++ b/sdks/python/apache_beam/transforms/stats_test.py
@@ -496,6 +496,19 @@ class ApproximateUniqueTest(unittest.TestCase):
         'The key coder "Base64PickleCoder" '
         'for ApproximateUniqueCombineFn is not deterministic.')
 
+  def test_approximate_unique_combine_fn_by_wrong_coder(self):
+    # test if the combiner throws an error with a wrong coder.
+    test_input = 'a'
+    sample_size = 30
+    coder = coders.FloatCoder()
+    combine_fn = ApproximateUniqueCombineFn(sample_size, coder)
+    accumulator = combine_fn.create_accumulator()
+    with self.assertRaises(RuntimeError) as e:
+      accumulator = combine_fn.add_input(accumulator, test_input)
+
+    expected_msg = 'Runtime exception: required argument is not a float'
+    assert e.exception.args[0] == expected_msg
+
   def test_approximate_unique_combine_fn_adds_values_correctly(self):
     test_input = [['a', 'b', 'c'], ['b', 'd']]
     sample_size = 30

--- a/sdks/python/apache_beam/transforms/stats_test.py
+++ b/sdks/python/apache_beam/transforms/stats_test.py
@@ -465,8 +465,7 @@ class ApproximateUniqueTest(unittest.TestCase):
     with self.assertRaises(RuntimeError) as e:
       accumulator = combine_fn.add_input(accumulator, test_input)
 
-    expected_msg = 'Runtime exception: required argument is not a float'
-    assert e.exception.args[0] == expected_msg
+    self.assertRegex(e.exception.args[0], 'Runtime exception')
 
   def test_approximate_unique_combine_fn_adds_values_correctly(self):
     test_input = [['a', 'b', 'c'], ['b', 'd']]

--- a/sdks/python/apache_beam/transforms/stats_test.py
+++ b/sdks/python/apache_beam/transforms/stats_test.py
@@ -27,6 +27,7 @@ import sys
 import unittest
 from builtins import range
 from collections import defaultdict
+
 import hamcrest as hc
 from parameterized import parameterized
 from parameterized import parameterized_class
@@ -50,13 +51,13 @@ except ImportError:
   mmh3_options = [(None, )]
 
 
-@parameterized_class(('sys.modules[\'mmh3\']', ), mmh3_options)
+@parameterized_class(('mmh3_option', ), mmh3_options)
 class ApproximateUniqueTest(unittest.TestCase):
-  """Unit tests for ApproximateUnique.Globally, ApproximateUnique.PerKey,
-  and ApproximateUniqueCombineFn.
-  """
+  """Unit tests for ApproximateUnique.Globally and ApproximateUnique.PerKey."""
   random.seed(0)
-  sys.modules['mmh3'] = None
+
+  def setUp(self):
+    sys.modules['mmh3'] = self.mmh3_option
 
   @parameterized.expand([
       (
@@ -92,7 +93,7 @@ class ApproximateUniqueTest(unittest.TestCase):
   def test_approximate_unique_global(
       self, name, test_input, sample_size, est_error, label):
     # check that only either sample_size or est_error is not None
-    assert (bool(sample_size) != bool(est_error))
+    assert bool(sample_size) != bool(est_error)
     if sample_size:
       error = 2 / math.sqrt(sample_size)
     else:
@@ -117,7 +118,7 @@ class ApproximateUniqueTest(unittest.TestCase):
   ])
   def test_approximate_unique_perkey(self, name, sample_size, est_error, label):
     # check that only either sample_size or est_error is set
-    assert (bool(sample_size) != bool(est_error))
+    assert bool(sample_size) != bool(est_error)
     if sample_size:
       error = 2 / math.sqrt(sample_size)
     else:

--- a/sdks/python/apache_beam/transforms/stats_test.py
+++ b/sdks/python/apache_beam/transforms/stats_test.py
@@ -47,6 +47,8 @@ class ApproximateUniqueTest(unittest.TestCase):
   """Unit tests for ApproximateUnique.Globally, ApproximateUnique.PerKey,
   and ApproximateUniqueCombineFn.
   """
+  random.seed(0)
+
   def test_approximate_unique_global_by_invalid_size(self):
     # test if the transformation throws an error as expected with an invalid
     # small input size (< 16).

--- a/sdks/python/container/base_image_requirements.txt
+++ b/sdks/python/container/base_image_requirements.txt
@@ -57,7 +57,7 @@ google-cloud-datastore==1.7.4
 cython==0.29.13
 guppy==0.1.11;python_version<="2.7"
 guppy3==3.0.9;python_version>="3.5"
-mmh3>=2.5.1,<3.0
+mmh3==2.5.1
 
 # These are additional packages likely to be used by customers.
 numpy==1.16.5;python_version<="2.7"

--- a/sdks/python/container/base_image_requirements.txt
+++ b/sdks/python/container/base_image_requirements.txt
@@ -57,6 +57,7 @@ google-cloud-datastore==1.7.4
 cython==0.29.13
 guppy==0.1.11;python_version<="2.7"
 guppy3==3.0.9;python_version>="3.5"
+mmh3>=2.5.1,<3.0
 
 # These are additional packages likely to be used by customers.
 numpy==1.16.5;python_version<="2.7"

--- a/sdks/python/container/license_scripts/dep_urls_py.yaml
+++ b/sdks/python/container/license_scripts/dep_urls_py.yaml
@@ -77,6 +77,8 @@ pip_dependencies:
     license: "https://raw.githubusercontent.com/mtth/hdfs/master/LICENSE"
   httplib2:
     license: "https://raw.githubusercontent.com/httplib2/httplib2/master/LICENSE"
+  mmh3:
+    license: "https://raw.githubusercontent.com/hajimes/mmh3/master/LICENSE"
   mock:
     license: "https://raw.githubusercontent.com/testing-cabal/mock/master/LICENSE.txt"
   monotonic:

--- a/sdks/python/container/license_scripts/dep_urls_py.yaml
+++ b/sdks/python/container/license_scripts/dep_urls_py.yaml
@@ -77,8 +77,6 @@ pip_dependencies:
     license: "https://raw.githubusercontent.com/mtth/hdfs/master/LICENSE"
   httplib2:
     license: "https://raw.githubusercontent.com/httplib2/httplib2/master/LICENSE"
-  mmh3:
-    license: "https://raw.githubusercontent.com/hajimes/mmh3/master/LICENSE"
   mock:
     license: "https://raw.githubusercontent.com/testing-cabal/mock/master/LICENSE.txt"
   monotonic:

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -165,6 +165,7 @@ REQUIRED_PACKAGES = [
     'requests>=2.24.0,<3.0.0',
     'typing>=3.7.0,<3.8.0; python_full_version < "3.5.3"',
     'typing-extensions>=3.7.0,<3.8.0',
+    'mmh3>=2.5.1,<2.5.2',
     ]
 
 # [BEAM-8181] pyarrow cannot be installed on 32-bit Windows platforms.

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -165,7 +165,6 @@ REQUIRED_PACKAGES = [
     'requests>=2.24.0,<3.0.0',
     'typing>=3.7.0,<3.8.0; python_full_version < "3.5.3"',
     'typing-extensions>=3.7.0,<3.8.0',
-    'mmh3>=2.5.1,<2.5.2',
     ]
 
 # [BEAM-8181] pyarrow cannot be installed on 32-bit Windows platforms.


### PR DESCRIPTION
Replace python built-in hash() function with hashlib.md5 (with an option for murmurhash), which is deterministic. Refactor test cases. 
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg)
![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg)
![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
