### PR TITLE
[BEAM-10861] Adds URNs and payloads to PubSub transforms to allow runner-native overrides

### DIFF
--- a/model/pipeline/src/main/proto/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/beam_runner_api.proto
@@ -676,7 +676,7 @@ message PubSubReadPayload {
   // If true, reads Pub/Sub payload as well as attributes. If false, reads only the payload.
   bool with_attributes = 5;
 
-  // Parse function for attibutes.
+  // JSON serialized parse function for attibutes.
   string serialized_attribute_fn = 6;
 }
 
@@ -697,7 +697,7 @@ message PubSubWritePayload {
   // If true, writes Pub/Sub payload as well as attributes. If false, reads only the payload.
   bool with_attributes = 4;
 
-  // Parse function for attributes.
+  // JSON serialized parse function for attributes.
   string serialized_attribute_fn = 5;
 
   // Coder ID for the Pub/Sub sink (if the runner requires it).

--- a/model/pipeline/src/main/proto/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/beam_runner_api.proto
@@ -324,6 +324,12 @@ message StandardPTransforms {
 
     // Less well-known. Payload: WriteFilesPayload.
     WRITE_FILES = 3 [(beam_urn) = "beam:transform:write_files:v1"];
+
+    // Payload: PubSubReadPayload.
+    PUBSUB_READ = 4 [(beam_urn) = "beam:transform:pubsub_read:v1"];
+
+    // Payload: PubSubWritePayload.
+    PUBSUB_WRITE = 5 [(beam_urn) = "beam:transform:pubsub_write:v1"];
   }
   // Payload for all of these: CombinePayload
   enum CombineComponents {
@@ -648,6 +654,54 @@ message WriteFilesPayload {
   bool runner_determined_sharding = 4;
 
   map<string, SideInput> side_inputs = 5;
+}
+
+// Payload used by Google Cloud Pub/Sub read transform.
+// This can be used by runners that wish to override Beam Pub/Sub read transform
+// with a native implementation.
+message PubSubReadPayload {
+
+  // Topic to read from. Exactly one of topic or subscription should be set.
+  string topic = 1;
+
+  // Subscription to read from. Exactly one of topic or subscription should be set.
+  string subscription = 2;
+
+  // Attribute that provides element timestamps.
+  string timestamp_attribute = 3;
+
+  // Attribute to be used for uniquely identifying messages.
+  string id_attribute = 4;
+
+  // If true, reads Pub/Sub payload as well as attributes. If false, reads only the payload.
+  bool with_attributes = 5;
+
+  // Parse function for attibutes.
+  string serialized_attribute_fn = 6;
+}
+
+// Payload used by Google Cloud Pub/Sub write transform.
+// This can be used by runners that wish to override Beam Pub/Sub write transform
+// with a native implementation.
+message PubSubWritePayload {
+
+  // Topic to write to.
+  string topic = 1;
+
+  // Attribute that provides element timestamps.
+  string timestamp_attribute = 2;
+
+  // Attribute that uniquely identify messages.
+  string id_attribute = 3;
+
+  // If true, writes Pub/Sub payload as well as attributes. If false, reads only the payload.
+  bool with_attributes = 4;
+
+  // Parse function for attributes.
+  string serialized_attribute_fn = 5;
+
+  // Coder ID for the Pub/Sub sink (if the runner requires it).
+  string coder_id = 6;
 }
 
 // A coder, the binary format for serialization and deserialization of data in

--- a/sdks/python/apache_beam/io/gcp/pubsub.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub.py
@@ -38,6 +38,8 @@ from past.builtins import unicode
 from apache_beam import coders
 from apache_beam.io.iobase import Read
 from apache_beam.io.iobase import Write
+from apache_beam.portability import common_urns
+from apache_beam.portability.api import beam_runner_api_pb2
 from apache_beam.runners.dataflow.native_io import iobase as dataflow_io
 from apache_beam.transforms import Map
 from apache_beam.transforms import PTransform
@@ -145,13 +147,14 @@ class ReadFromPubSub(PTransform):
 
   # Implementation note: This ``PTransform`` is overridden by Directrunner.
 
-  def __init__(self,
-               topic=None,  # type: Optional[str]
-               subscription=None,  # type: Optional[str]
-               id_label=None,  # type: Optional[str]
-               with_attributes=False,  # type: bool
-               timestamp_attribute=None  # type: Optional[str]
-              ):
+  def __init__(
+      self,
+      topic=None,  # type: Optional[str]
+      subscription=None,  # type: Optional[str]
+      id_label=None,  # type: Optional[str]
+      with_attributes=False,  # type: bool
+      timestamp_attribute=None  # type: Optional[str]
+  ):
     # type: (...) -> None
 
     """Initializes ``ReadFromPubSub``.
@@ -203,10 +206,31 @@ class ReadFromPubSub(PTransform):
       pcoll.element_type = PubsubMessage
     return pcoll
 
+  def _pubsub_read_payload(self):
+    return beam_runner_api_pb2.PubSubReadPayload(
+        topic=self._source.full_topic,
+        subscription=self._source.full_subscription,
+        timestamp_attribute=self._source.timestamp_attribute,
+        id_attribute=self._source.id_label,
+        with_attributes=self.with_attributes,
+        serialized_attribute_fn='')
+
   def to_runner_api_parameter(self, context):
-    # Required as this is identified by type in PTransformOverrides.
-    # TODO(BEAM-3812): Use an actual URN here.
-    return self.to_runner_api_pickled(context)
+    payload = self._pubsub_read_payload()
+    return (common_urns.composites.PUBSUB_READ.urn, payload)
+
+  @staticmethod
+  @PTransform.register_urn(
+      common_urns.composites.PUBSUB_READ.urn,
+      beam_runner_api_pb2.PubSubReadPayload)
+  def from_runner_api_parameter(
+      unused_ptransform, pubsub_read_payload, unused_context):
+    return ReadFromPubSub(
+        topic=pubsub_read_payload.topic,
+        subscription=pubsub_read_payload.subscription,
+        id_label=pubsub_read_payload.id_attribute,
+        with_attributes=pubsub_read_payload.with_attributes,
+        timestamp_attribute=pubsub_read_payload.timestamp_attribute)
 
 
 @deprecated(since='2.7.0', extra_message='Use ReadFromPubSub instead.')
@@ -260,12 +284,13 @@ class WriteToPubSub(PTransform):
 
   # Implementation note: This ``PTransform`` is overridden by Directrunner.
 
-  def __init__(self,
-               topic,  # type: str
-               with_attributes=False,  # type: bool
-               id_label=None,  # type: Optional[str]
-               timestamp_attribute=None  # type: Optional[str]
-              ):
+  def __init__(
+      self,
+      topic,  # type: str
+      with_attributes=False,  # type: bool
+      id_label=None,  # type: Optional[str]
+      timestamp_attribute=None  # type: Optional[str]
+  ):
     # type: (...) -> None
 
     """Initializes ``WriteToPubSub``.
@@ -308,10 +333,32 @@ class WriteToPubSub(PTransform):
     pcoll.element_type = bytes
     return pcoll | Write(self._sink)
 
+  def _pubsub_write_payload(self):
+    return beam_runner_api_pb2.PubSubWritePayload(
+        topic=self._sink.full_topic,
+        timestamp_attribute=self._sink.timestamp_attribute,
+        id_attribute=self._sink.id_label,
+        with_attributes=self.with_attributes,
+        serialized_attribute_fn='')
+
   def to_runner_api_parameter(self, context):
-    # Required as this is identified by type in PTransformOverrides.
-    # TODO(BEAM-3812): Use an actual URN here.
-    return self.to_runner_api_pickled(context)
+    payload = self._pubsub_write_payload()
+    sink_coder = coders.WindowedValueCoder(
+        self._sink.coder, coders.coders.GlobalWindowCoder())
+    payload.coder_id = context.coders.get_id(sink_coder)
+    return (common_urns.composites.PUBSUB_WRITE.urn, payload)
+
+  @staticmethod
+  @PTransform.register_urn(
+      common_urns.composites.PUBSUB_WRITE.urn,
+      beam_runner_api_pb2.PubSubWritePayload)
+  def from_runner_api_parameter(
+      unused_ptransform, pubsub_write_payload, unused_context):
+    return WriteToPubSub(
+        topic=pubsub_write_payload.topic,
+        with_attributes=pubsub_write_payload.with_attributes,
+        id_label=pubsub_write_payload.id_attribute,
+        timestamp_attribute=pubsub_write_payload.timestamp_attribute)
 
 
 PROJECT_ID_REGEXP = '[a-z][-a-z0-9:.]{4,61}[a-z0-9]'
@@ -352,14 +399,14 @@ class _PubSubSource(dataflow_io.NativeSource):
     with_attributes: If False, will fetch just message data. Otherwise,
       fetches ``PubsubMessage`` protobufs.
   """
-
-  def __init__(self,
-               topic=None,  # type: Optional[str]
-               subscription=None,  # type: Optional[str]
-               id_label=None,  # type: Optional[str]
-               with_attributes=False,  # type: bool
-               timestamp_attribute=None  # type: Optional[str]
-              ):
+  def __init__(
+      self,
+      topic=None,  # type: Optional[str]
+      subscription=None,  # type: Optional[str]
+      id_label=None,  # type: Optional[str]
+      with_attributes=False,  # type: bool
+      timestamp_attribute=None  # type: Optional[str]
+  ):
     self.coder = coders.BytesCoder()
     self.full_topic = topic
     self.full_subscription = subscription
@@ -412,13 +459,13 @@ class _PubSubSink(dataflow_io.NativeSink):
 
   This ``NativeSource`` is overridden by a native Pubsub implementation.
   """
-
-  def __init__(self,
-               topic,  # type: str
-               id_label,  # type: Optional[str]
-               with_attributes,  # type: bool
-               timestamp_attribute  # type: Optional[str]
-              ):
+  def __init__(
+      self,
+      topic,  # type: str
+      id_label,  # type: Optional[str]
+      with_attributes,  # type: bool
+      timestamp_attribute  # type: Optional[str]
+  ):
     self.coder = coders.BytesCoder()
     self.full_topic = topic
     self.id_label = id_label

--- a/sdks/python/apache_beam/io/gcp/pubsub_test.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub_test.py
@@ -41,6 +41,9 @@ from apache_beam.io.gcp.pubsub import _PubSubSink
 from apache_beam.io.gcp.pubsub import _PubSubSource
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import StandardOptions
+from apache_beam.portability import common_urns
+from apache_beam.portability.api import beam_runner_api_pb2
+from apache_beam.runners import pipeline_context
 from apache_beam.runners.direct import transform_evaluator
 from apache_beam.runners.direct.direct_runner import _DirectReadFromPubSub
 from apache_beam.runners.direct.direct_runner import _get_transform_overrides
@@ -54,6 +57,7 @@ from apache_beam.transforms import window
 from apache_beam.transforms.core import Create
 from apache_beam.transforms.display import DisplayData
 from apache_beam.transforms.display_test import DisplayDataItemMatcher
+from apache_beam.utils import proto_utils
 from apache_beam.utils import timestamp
 
 # Protect against environments where the PubSub library is not available.
@@ -579,6 +583,59 @@ class TestReadFromPubSub(unittest.TestCase):
             p | ReadFromPubSub(
                 'projects/fakeprj/topics/a_topic', None, 'a_label'))
 
+  def test_runner_api_transformation_with_topic(self, unused_mock_pubsub):
+    context = pipeline_context.PipelineContext()
+    transform = ReadFromPubSub(
+        topic='projects/fakeprj/topics/a_topic',
+        subscription=None,
+        id_label='a_label',
+        timestamp_attribute='b_label',
+        with_attributes=True)
+    proto_transform = transform.to_runner_api(context)
+    self.assertEqual(
+        common_urns.composites.PUBSUB_READ.urn, proto_transform.urn)
+
+    pubsub_read_payload = (
+        proto_utils.parse_Bytes(
+            proto_transform.payload, beam_runner_api_pb2.PubSubReadPayload))
+    self.assertEqual(
+        'projects/fakeprj/topics/a_topic', pubsub_read_payload.topic)
+    self.assertEqual('a_label', pubsub_read_payload.id_attribute)
+    self.assertEqual('b_label', pubsub_read_payload.timestamp_attribute)
+    self.assertTrue(pubsub_read_payload.with_attributes)
+    self.assertEqual('', pubsub_read_payload.subscription)
+
+    transform_from_proto = ReadFromPubSub.from_runner_api_parameter(
+        None, pubsub_read_payload, None)
+    self.assertTrue(isinstance(transform_from_proto, ReadFromPubSub))
+
+  def test_runner_api_tranformation_with_subscription(self, unused_mock_pubsub):
+    context = pipeline_context.PipelineContext()
+    transform = ReadFromPubSub(
+        topic=None,
+        subscription='projects/fakeprj/subscriptions/a_subscription',
+        id_label='a_label',
+        timestamp_attribute='b_label',
+        with_attributes=True)
+    proto_transform = transform.to_runner_api(context)
+    self.assertEqual(
+        common_urns.composites.PUBSUB_READ.urn, proto_transform.urn)
+
+    pubsub_read_payload = (
+        proto_utils.parse_Bytes(
+            proto_transform.payload, beam_runner_api_pb2.PubSubReadPayload))
+    self.assertEqual(
+        'projects/fakeprj/subscriptions/a_subscription',
+        pubsub_read_payload.subscription)
+    self.assertEqual('a_label', pubsub_read_payload.id_attribute)
+    self.assertEqual('b_label', pubsub_read_payload.timestamp_attribute)
+    self.assertTrue(pubsub_read_payload.with_attributes)
+    self.assertEqual('', pubsub_read_payload.topic)
+
+    transform_from_proto = ReadFromPubSub.from_runner_api_parameter(
+        None, pubsub_read_payload, None)
+    self.assertTrue(isinstance(transform_from_proto, ReadFromPubSub))
+
 
 @unittest.skipIf(pubsub is None, 'GCP dependencies are not installed')
 @mock.patch('google.cloud.pubsub.PublisherClient')
@@ -670,6 +727,30 @@ class TestWriteToPubSub(unittest.TestCase):
             | WriteToPubSub(
                 'projects/fakeprj/topics/a_topic',
                 timestamp_attribute='timestamp'))
+
+  def test_runner_api_transformation(self, unused_mock_pubsub):
+    context = pipeline_context.PipelineContext()
+    transform = WriteToPubSub(
+        topic='projects/fakeprj/topics/a_topic',
+        id_label='a_label',
+        timestamp_attribute='b_label',
+        with_attributes=True)
+    proto_transform = transform.to_runner_api(context)
+    self.assertEqual(
+        common_urns.composites.PUBSUB_WRITE.urn, proto_transform.urn)
+
+    pubsub_write_payload = (
+        proto_utils.parse_Bytes(
+            proto_transform.payload, beam_runner_api_pb2.PubSubWritePayload))
+    self.assertEqual(
+        'projects/fakeprj/topics/a_topic', pubsub_write_payload.topic)
+    self.assertEqual('a_label', pubsub_write_payload.id_attribute)
+    self.assertEqual('b_label', pubsub_write_payload.timestamp_attribute)
+    self.assertTrue(pubsub_write_payload.with_attributes)
+
+    transform_from_proto = WriteToPubSub.from_runner_api_parameter(
+        None, pubsub_write_payload, None)
+    self.assertTrue(isinstance(transform_from_proto, WriteToPubSub))
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This is needed to allow runners to override portable definition of transforms.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg)
![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg)
![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
