### PR TITLE
[BEAM-10009] Add beam:logical_type:micros_instant:v1

### DIFF
--- a/model/fn-execution/src/main/resources/org/apache/beam/model/fnexecution/v1/standard_coders.yaml
+++ b/model/fn-execution/src/main/resources/org/apache/beam/model/fnexecution/v1/standard_coders.yaml
@@ -408,3 +408,12 @@ examples:
   "\x01\x00\x00\x00\x00\x00": {f_map: {}}
   "\x01\x00\x00\x00\x00\x02\x03foo\x01\xa9F\x03bar\x01\xff\xff\xff\xff\xff\xff\xff\xff\x7f": {f_map: {"foo": 9001, "bar": 9223372036854775807}}
   "\x01\x00\x00\x00\x00\x04\neverything\x00\x02is\x00\x05null!\x00\r\xc2\xaf\\_(\xe3\x83\x84)_/\xc2\xaf\x00": {f_map: {"everything":null, "is": null, "null!": null, "¯\\_(ツ)_/¯": null}}
+
+---
+
+coder:
+  urn: "beam:coder:row:v1"
+  # f_timestamp: logical(micros_instant), f_string: string, f_int: int64
+  payload: "\n\x7f\n\x0bf_timestamp\x1ap:n\n#beam:logical_type:micros_instant:v1\x1aG2E\nC\n\r\n\x07seconds\x1a\x02\x10\x04\n\x0c\n\x06micros\x1a\x02\x10\x04\x12$4d3f6e8f-7412-4ad7-bfd9-b424a1664aef\n\x0e\n\x08f_string\x1a\x02\x10\x07\n\x0b\n\x05f_int\x1a\x02\x10\x04\x12$33dafd37-397c-4083-a84e-42177d122221"
+examples:
+    "\x03\x00\x02\x00\xb6\x95\xd5\xf9\x05\xc0\xc4\x07\x1b2020-08-13T14:14:14.123456Z\xc0\xf7\x85\xda\xae\x98\xeb\x02": {f_timestamp: {seconds: 1597328054, micros: 123456}, f_string: "2020-08-13T14:14:14.123456Z", f_int: 1597328054123456}

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CommonCoderTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/CommonCoderTest.java
@@ -398,7 +398,13 @@ public class CommonCoderTest {
         }
 
         return row.build();
-      default: // DECIMAL, DATETIME, LOGICAL_TYPE
+      case LOGICAL_TYPE:
+        // Logical types are represented as their representation types in YAML. Parse as the
+        // representation type, then convert to the base type.
+        return fieldType
+            .getLogicalType()
+            .toInputType(parseField(value, fieldType.getLogicalType().getBaseType()));
+      default: // DECIMAL, DATETIME
         throw new IllegalArgumentException("Unsupported type name: " + fieldType.getTypeName());
     }
   }

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/SchemaTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/SchemaTranslationTest.java
@@ -30,15 +30,18 @@ import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.SchemaTranslation;
 import org.apache.beam.sdk.schemas.logicaltypes.FixedBytes;
+import org.apache.beam.sdk.schemas.logicaltypes.MicrosInstant;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.junit.Test;
+import org.junit.experimental.runners.Enclosed;
 import org.junit.runner.RunWith;
 import org.junit.runners.Parameterized;
 import org.junit.runners.Parameterized.Parameter;
 import org.junit.runners.Parameterized.Parameters;
 
 /** Tests for {@link SchemaTranslation}. */
+@RunWith(Enclosed.class)
 public class SchemaTranslationTest {
 
   /** Tests round-trip proto encodings for {@link Schema}. */
@@ -112,7 +115,8 @@ public class SchemaTranslationTest {
           .add(
               Schema.of(
                   Field.of("decimal", FieldType.DECIMAL), Field.of("datetime", FieldType.DATETIME)))
-          .add(Schema.of(Field.of("logical", FieldType.logicalType(FixedBytes.of(24)))))
+          .add(Schema.of(Field.of("fixed_bytes", FieldType.logicalType(FixedBytes.of(24)))))
+          .add(Schema.of(Field.of("micros_instant", FieldType.logicalType(new MicrosInstant()))))
           .add(
               Schema.of(
                       Field.of("field_with_option_atomic", FieldType.STRING)

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -539,12 +539,16 @@ public class Schema implements Serializable {
     /** The unique identifier for this type. */
     String getIdentifier();
 
-    /** A schema type representing how to interpret the argument. */
+    /**
+     * A schema type representing how to interpret the argument. {@code null} indicates this logical
+     * type is not parameterized by an argument.
+     */
+    @Nullable
     FieldType getArgumentType();
 
     /** An optional argument to configure the type. */
     @SuppressWarnings("TypeParameterUnusedInFormals")
-    default <T> T getArgument() {
+    default <T> @Nullable T getArgument() {
       return null;
     }
 
@@ -807,14 +811,24 @@ public class Schema implements Serializable {
             getLogicalType().getIdentifier(), other.getLogicalType().getIdentifier())) {
           return false;
         }
-        if (!getLogicalType().getArgumentType().equals(other.getLogicalType().getArgumentType())) {
-          return false;
-        }
-        if (!Row.Equals.deepEquals(
-            getLogicalType().getArgument(),
-            other.getLogicalType().getArgument(),
-            getLogicalType().getArgumentType())) {
-          return false;
+        if (getLogicalType().getArgument() == null) {
+          if (other.getLogicalType().getArgument() != null) {
+            return false;
+          }
+        } else {
+          if (!getLogicalType()
+              .getArgumentType()
+              .equals(other.getLogicalType().getArgumentType())) {
+            return false;
+          }
+          // Only check argument equality if argument type is non-null. null indicates argument is
+          // ignored.
+          if (!Row.Equals.deepEquals(
+              getLogicalType().getArgument(),
+              other.getLogicalType().getArgument(),
+              getLogicalType().getArgumentType())) {
+            return false;
+          }
         }
       }
       return Objects.equals(getTypeName(), other.getTypeName())

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/MicrosInstant.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/MicrosInstant.java
@@ -1,0 +1,72 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas.logicaltypes;
+
+import java.time.Instant;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.values.Row;
+
+/**
+ * A timestamp represented as microseconds since the epoch.
+ *
+ * <p>WARNING: This logical type exists solely for interoperability with other type systems such as
+ * SQL and other Beam SDKs. It should never be used in a native Java context where the {@code
+ * java.time.Instant} instances it describes may have higher than microsecond precision. Ignoring
+ * this will likely result in an {@code AssertionError} at pipeline execution time.
+ *
+ * <p>For a more faithful logical type to use with {@code java.time.Instant}, see {@link
+ * NanosInstant}.
+ */
+public class MicrosInstant implements Schema.LogicalType<Instant, Row> {
+  public static final String IDENTIFIER = "beam:logical_type:micros_instant:v1";
+  private final Schema schema;
+
+  public MicrosInstant() {
+    this.schema = Schema.builder().addInt64Field("seconds").addInt32Field("micros").build();
+  }
+
+  @Override
+  public Row toBaseType(Instant input) {
+    if (input.getNano() % 1000 != 0) {
+      throw new AssertionError(
+          "micros_instant logical type encountered a Java "
+              + "Instant with greater than microsecond precision.");
+    }
+    return Row.withSchema(schema).addValues(input.getEpochSecond(), input.getNano() / 1000).build();
+  }
+
+  @Override
+  public Instant toInputType(Row row) {
+    return Instant.ofEpochSecond(row.getInt64(0), row.getInt32(1) * 1000);
+  }
+
+  @Override
+  public String getIdentifier() {
+    return IDENTIFIER;
+  }
+
+  @Override
+  public Schema.FieldType getArgumentType() {
+    return null;
+  }
+
+  @Override
+  public Schema.FieldType getBaseType() {
+    return Schema.FieldType.row(schema);
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/MicrosInstant.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/MicrosInstant.java
@@ -34,6 +34,7 @@ import org.apache.beam.sdk.values.Row;
  */
 public class MicrosInstant implements Schema.LogicalType<Instant, Row> {
   public static final String IDENTIFIER = "beam:logical_type:micros_instant:v1";
+  // TODO(BEAM-10878): This should be a constant
   private final Schema schema;
 
   public MicrosInstant() {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/NanosType.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/NanosType.java
@@ -23,6 +23,7 @@ import org.apache.beam.sdk.values.Row;
 /** Base class for types representing timestamps or durations as nanoseconds. */
 abstract class NanosType<T> implements Schema.LogicalType<T, Row> {
   private final String identifier;
+  // TODO(BEAM-10878): This should be a constant
   protected final Schema schema;
 
   NanosType(String identifier) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/SqlTypes.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/SqlTypes.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.schemas.logicaltypes;
 
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
@@ -36,4 +37,7 @@ public class SqlTypes {
 
   /** Beam LogicalType corresponding to ZetaSQL DATETIME type. */
   public static final LogicalType<LocalDateTime, Row> DATETIME = new DateTime();
+
+  /** Beam LogicalType corresponding to ZetaSQL TIMESTAMP type. */
+  public static final LogicalType<Instant, Row> TIMESTAMP = new MicrosInstant();
 }

--- a/sdks/python/apache_beam/coders/row_coder_test.py
+++ b/sdks/python/apache_beam/coders/row_coder_test.py
@@ -35,6 +35,7 @@ from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
 from apache_beam.typehints.schemas import typing_to_runner_api
+from apache_beam.utils.timestamp import Timestamp
 
 Person = typing.NamedTuple(
     "Person",
@@ -46,24 +47,43 @@ Person = typing.NamedTuple(
         ("knows_javascript", bool),
         # TODO(BEAM-7372): Use bytes instead of ByteString
         ("payload", typing.Optional[typing.ByteString]),
-        ("custom_metadata", typing.Mapping[unicode, int])
+        ("custom_metadata", typing.Mapping[unicode, int]),
+        ("favorite_time", Timestamp),
     ])
 
 coders_registry.register_coder(Person, RowCoder)
 
 
 class RowCoderTest(unittest.TestCase):
-  JON_SNOW = Person("Jon Snow", 23, None, ["crow", "wildling"], False, None, {})
+  JON_SNOW = Person(
+      name="Jon Snow",
+      age=23,
+      address=None,
+      aliases=["crow", "wildling"],
+      knows_javascript=False,
+      payload=None,
+      custom_metadata={},
+      favorite_time=Timestamp.from_rfc3339('2016-03-18T23:22:59.123456Z'),
+  )
   PEOPLE = [
       JON_SNOW,
       Person(
           "Daenerys Targaryen",
           25,
-          "Westeros", ["Mother of Dragons"],
+          "Westeros",
+          ["Mother of Dragons"],
           False,
-          None, {"dragons": 3}),
+          None,
+          {"dragons": 3},
+          Timestamp.from_rfc3339('1970-04-26T17:46:40Z'),
+      ),
       Person(
-          "Michael Bluth", 30, None, [], True, b"I've made a huge mistake", {})
+          "Michael Bluth",
+          30,
+          None, [],
+          True,
+          b"I've made a huge mistake", {},
+          Timestamp.from_rfc3339('2020-08-12T15:51:00.032Z'))
   ]
 
   def test_create_row_coder_from_named_tuple(self):
@@ -113,6 +133,25 @@ class RowCoderTest(unittest.TestCase):
                         value_type=schema_pb2.FieldType(
                             atomic_type=schema_pb2.INT64),
                     ))),
+            schema_pb2.Field(
+                name="favorite_time",
+                type=schema_pb2.FieldType(
+                    logical_type=schema_pb2.LogicalType(
+                        urn="beam:logical_type:micros_instant:v1",
+                        representation=schema_pb2.FieldType(
+                            row_type=schema_pb2.RowType(
+                                schema=schema_pb2.Schema(
+                                    id="micros_instant",
+                                    fields=[
+                                        schema_pb2.Field(
+                                            name="seconds",
+                                            type=schema_pb2.FieldType(
+                                                atomic_type=schema_pb2.INT64)),
+                                        schema_pb2.Field(
+                                            name="micros",
+                                            type=schema_pb2.FieldType(
+                                                atomic_type=schema_pb2.INT64)),
+                                    ])))))),
         ])
     coder = RowCoder(schema)
 

--- a/sdks/python/apache_beam/coders/standard_coders_test.py
+++ b/sdks/python/apache_beam/coders/standard_coders_test.py
@@ -101,6 +101,15 @@ def value_parser_from_schema(schema):
       value_parser = attribute_parser_from_type(type_.map_type.value_type)
       return lambda x: dict(
           (key_parser(k), value_parser(v)) for k, v in x.items())
+    elif type_info == "row_type":
+      return value_parser_from_schema(type_.row_type.schema)
+    elif type_info == "logical_type":
+      # In YAML logical types are represented with their representation types.
+      to_language_type = schemas.LogicalType.from_runner_api(
+          type_.logical_type).to_language_type
+      parse_representation = attribute_parser_from_type(
+          type_.logical_type.representation)
+      return lambda x: to_language_type(parse_representation(x))
 
   parsers = [(field.name, attribute_parser_from_type(field.type))
              for field in schema.fields]

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -47,10 +47,12 @@ from __future__ import absolute_import
 
 import sys
 from typing import ByteString
+from typing import Generic
 from typing import Mapping
 from typing import NamedTuple
 from typing import Optional
 from typing import Sequence
+from typing import TypeVar
 from uuid import uuid4
 
 import numpy as np
@@ -65,6 +67,7 @@ from apache_beam.typehints.native_type_compatibility import _match_is_optional
 from apache_beam.typehints.native_type_compatibility import _safe_issubclass
 from apache_beam.typehints.native_type_compatibility import extract_optional_type
 from apache_beam.utils import proto_utils
+from apache_beam.utils.timestamp import Timestamp
 
 
 # Registry of typings for a schema by UUID
@@ -190,7 +193,17 @@ def typing_to_runner_api(type_):
     return schema_pb2.FieldType(
         map_type=schema_pb2.MapType(key_type=key_type, value_type=value_type))
 
-  raise ValueError("Unsupported type: %s" % type_)
+  try:
+    logical_type = LogicalType.from_typing(type_)
+  except ValueError:
+    raise ValueError("Unsupported type: %s" % type_)
+  else:
+    # TODO(bhulette): Add support for logical types that require arguments
+    return schema_pb2.FieldType(
+        logical_type=schema_pb2.LogicalType(
+            urn=logical_type.urn(),
+            representation=typing_to_runner_api(
+                logical_type.representation_type())))
 
 
 def typing_from_runner_api(fieldtype_proto):
@@ -243,7 +256,8 @@ def typing_from_runner_api(fieldtype_proto):
     return user_type
 
   elif type_info == "logical_type":
-    pass  # TODO
+    return LogicalType.from_runner_api(
+        fieldtype_proto.logical_type).language_type()
 
 
 def _hydrate_namedtuple_instance(encoded_schema, values):
@@ -279,3 +293,153 @@ def schema_from_element_type(element_type):  # (type) -> schema_pb2.Schema
 def named_fields_from_element_type(
     element_type):  # (type) -> typing.List[typing.Tuple[unicode, type]]
   return named_fields_from_schema(schema_from_element_type(element_type))
+
+
+# Registry of typings for a schema by UUID
+class LogicalTypeRegistry(object):
+  def __init__(self):
+    self.by_urn = {}
+    self.by_logical_type = {}
+    self.by_language_type = {}
+
+  def add(self, urn, logical_type):
+    self.by_urn[urn] = logical_type
+    self.by_logical_type[logical_type] = urn
+    self.by_language_type[logical_type.language_type()] = logical_type
+
+  def get_logical_type_by_urn(self, urn):
+    return self.by_urn.get(urn, None)
+
+  def get_urn_by_logial_type(self, logical_type):
+    return self.by_logical_type.get(logical_type, None)
+
+  def get_logical_type_by_language_type(self, representation_type):
+    return self.by_language_type.get(representation_type, None)
+
+
+LanguageT = TypeVar('LanguageT')
+RepresentationT = TypeVar('RepresentationT')
+ArgT = TypeVar('ArgT')
+
+
+class LogicalType(Generic[LanguageT, RepresentationT, ArgT]):
+  _known_logical_types = LogicalTypeRegistry()
+
+  @classmethod
+  def urn(cls):
+    # type: () -> unicode
+
+    """Return the URN used to identify this logical type"""
+    raise NotImplementedError()
+
+  @classmethod
+  def language_type(cls):
+    # type: () -> type
+
+    """Return the language type this LogicalType encodes.
+
+    The returned type should match LanguageT"""
+    raise NotImplementedError()
+
+  @classmethod
+  def representation_type(cls):
+    # type: () -> type
+
+    """Return the type of the representation this LogicalType uses to encode the
+    language type.
+
+    The returned type should match RepresentationT"""
+    raise NotImplementedError()
+
+  @classmethod
+  def argument_type(cls):
+    # type: () -> type
+
+    """Return the type of the argument used for variations of this LogicalType.
+
+    The returned type should match ArgT"""
+    raise NotImplementedError(cls)
+
+  def argument(self):
+    # type: () -> ArgT
+
+    """Return the argument for this instance of the LogicalType."""
+    raise NotImplementedError()
+
+  def to_representation_type(value):
+    # type: (LanguageT) -> RepresentationT
+
+    """Convert an instance of LanguageT to RepresentationT."""
+    raise NotImplementedError()
+
+  def to_language_type(value):
+    # type: (RepresentationT) -> LanguageT
+
+    """Convert an instance of RepresentationT to LanguageT."""
+    raise NotImplementedError()
+
+  @classmethod
+  def register_logical_type(cls, logical_type_cls):
+    """Register an implementation of LogicalType."""
+    cls._known_logical_types.add(logical_type_cls.urn(), logical_type_cls)
+
+  @classmethod
+  def from_typing(cls, typ):
+    # type: (type) -> LogicalType
+
+    """Construct an instance of a registered LogicalType implementation given a
+    typing.
+
+    Raises ValueError if no registered LogicalType implementation can encode the
+    given typing."""
+
+    logical_type = cls._known_logical_types.get_logical_type_by_language_type(
+        typ)
+    if logical_type is None:
+      raise ValueError("No logical type registered for typing '%s'" % typ)
+
+    return logical_type._from_typing(typ)
+
+  @classmethod
+  def _from_typing(cls, typ):
+    # type: (type) -> LogicalType
+
+    """Construct an instance of this LogicalType implementation given a typing.
+    """
+    raise NotImplementedError()
+
+  @classmethod
+  def from_runner_api(cls, logical_type_proto):
+    # type: (schema_pb2.LogicalType) -> LogicalType
+
+    """Construct an instance of a registered LogicalType implementation given a
+    proto LogicalType.
+
+    Raises ValueError if no LogicalType registered for the given URN.
+    """
+    logical_type = cls._known_logical_types.get_logical_type_by_urn(
+        logical_type_proto.urn)
+    if logical_type is None:
+      raise ValueError(
+          "No logical type registered for URN '%s'" % logical_type_proto.urn)
+    # TODO(bhulette): Use argument
+    return logical_type()
+
+
+class NoArgumentLogicalType(LogicalType[LanguageT, RepresentationT, None]):
+  @classmethod
+  def argument_type(cls):
+    # type: () -> type
+    return None
+
+  def argument(self):
+    # type: () -> ArgT
+    return None
+
+  @classmethod
+  def _from_typing(cls, typ):
+    # type: (type) -> LogicalType
+
+    # Sicne there's no argument, there can be no additional information encoded
+    # in the typing. Just construct an instance.
+    return cls()

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -448,7 +448,7 @@ class NoArgumentLogicalType(LogicalType[LanguageT, RepresentationT, None]):
   def _from_typing(cls, typ):
     # type: (type) -> LogicalType
 
-    # Sicne there's no argument, there can be no additional information encoded
+    # Since there's no argument, there can be no additional information encoded
     # in the typing. Just construct an instance.
     return cls()
 

--- a/sdks/python/apache_beam/typehints/schemas_test.py
+++ b/sdks/python/apache_beam/typehints/schemas_test.py
@@ -40,6 +40,7 @@ from apache_beam.typehints.schemas import named_tuple_from_schema
 from apache_beam.typehints.schemas import named_tuple_to_schema
 from apache_beam.typehints.schemas import typing_from_runner_api
 from apache_beam.typehints.schemas import typing_to_runner_api
+from apache_beam.utils.timestamp import Timestamp
 
 IS_PYTHON_3 = sys.version_info.major > 2
 
@@ -67,6 +68,7 @@ class SchemaTest(unittest.TestCase):
     # The bytes type cannot survive a roundtrip to/from proto in Python 2.
     # In order to use BYTES a user type has to use typing.ByteString (because
     # bytes == str, and we map str to STRING).
+    # TODO(BEAM-7372)
     if IS_PYTHON_3:
       all_nonoptional_primitives.extend([bytes])
 
@@ -97,6 +99,7 @@ class SchemaTest(unittest.TestCase):
                     Optional[Mapping[unicode, Optional[np.float64]]]),
                 ('optional_array', Optional[Sequence[np.float32]]),
                 ('array_optional', Sequence[Optional[bool]]),
+                ('timestamp', Timestamp),
             ])
     ]
 


### PR DESCRIPTION
This PR adds support for `beam:logical_type:micros_instant:v1` in Python and Java. It also adds logic for translating logical types which do not use the argument to portable Beam schemas.

In Python, `micros_instant:v1` is the default mapping for the microsecond-precision `beam.utils.timestamp.Timestamp` type when inferring a schema.

The change is tested via unit tests in Python and Java, as well as a new entry in `standard_coders_test.yaml`.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://builds.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg)
![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg)
![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
