### PR TITLE
[BEAM-9547] Add not_implemented_ok

### DIFF
--- a/sdks/python/apache_beam/dataframe/doctests.py
+++ b/sdks/python/apache_beam/dataframe/doctests.py
@@ -169,6 +169,10 @@ class _InMemoryResultRecorder(object):
     return self._ALL_RESULTS[self._id][name]
 
 
+WONT_IMPLEMENT = 'apache_beam.dataframe.frame_base.WontImplementError'
+NOT_IMPLEMENTED = 'NotImplementedError'
+
+
 class _DeferrredDataframeOutputChecker(doctest.OutputChecker):
   """Validates output by replacing DeferredBase[...] with computed values.
   """
@@ -179,9 +183,11 @@ class _DeferrredDataframeOutputChecker(doctest.OutputChecker):
     else:
       self.compute = self.compute_using_session
     self._seen_wont_implement = False
+    self._seen_not_implemented = False
 
   def reset(self):
     self._seen_wont_implement = False
+    self._seen_not_implemented = False
 
   def compute_using_session(self, to_compute):
     session = expressions.PartitioningSession(self._env._inputs)
@@ -243,19 +249,28 @@ class _DeferrredDataframeOutputChecker(doctest.OutputChecker):
         got = traceback.format_exc()
     return want, got
 
+  @property
+  def _seen_error(self):
+    return self._seen_wont_implement or self._seen_not_implemented
+
   def check_output(self, want, got, optionflags):
-    if got.startswith('apache_beam.dataframe.frame_base.WontImplementError'):
+    # When an error occurs check_output is called with want=example.exc_msg,
+    # and got=exc_msg
+    if got.startswith(WONT_IMPLEMENT) and want.startswith(WONT_IMPLEMENT):
       self._seen_wont_implement = True
       return True
-    elif got.startswith('NameError') and self._seen_wont_implement:
-      # After raising WontImplementError, ignore NameErrors.
+    elif got.startswith(NOT_IMPLEMENTED) and want.startswith(NOT_IMPLEMENTED):
+      self._seen_not_implemented = True
+      return True
+    elif got.startswith('NameError') and self._seen_error:
+      # After raising WontImplementError or NotImplementError,
+      # ignore a NameError.
       # This allows us to gracefully skip tests like
       #    >>> res = df.unsupported_operation()
       #    >>> check(res)
       return True
     else:
-      # Reset.
-      self._seen_wont_implement = False
+      self.reset()
     want, got = self.fix(want, got)
     return super(_DeferrredDataframeOutputChecker,
                  self).check_output(want, got, optionflags)
@@ -279,7 +294,13 @@ class BeamDataframeDoctestRunner(doctest.DocTestRunner):
   by beam.
   """
   def __init__(
-      self, env, use_beam=True, wont_implement_ok=None, skip=None, **kwargs):
+      self,
+      env,
+      use_beam=True,
+      wont_implement_ok=None,
+      not_implemented_ok=None,
+      skip=None,
+      **kwargs):
     self._test_env = env
 
     def to_callable(cond):
@@ -293,6 +314,11 @@ class BeamDataframeDoctestRunner(doctest.DocTestRunner):
         for test,
         examples in (wont_implement_ok or {}).items()
     }
+    self._not_implemented_ok = {
+        test: [to_callable(cond) for cond in examples]
+        for test,
+        examples in (not_implemented_ok or {}).items()
+    }
     self._skip = {
         test: [to_callable(cond) for cond in examples]
         for test,
@@ -305,7 +331,19 @@ class BeamDataframeDoctestRunner(doctest.DocTestRunner):
     self.skipped = 0
     self.wont_implement = 0
     self._wont_implement_reasons = []
+    self.not_implemented = 0
+    self._not_implemented_reasons = []
     self._skipped_set = set()
+
+  def _is_wont_implement_ok(self, example, test):
+    return any(
+        wont_implement(example)
+        for wont_implement in self._wont_implement_ok.get(test.name, []))
+
+  def _is_not_implemented_ok(self, example, test):
+    return any(
+        not_implemented(example)
+        for not_implemented in self._not_implemented_ok.get(test.name, []))
 
   def run(self, test, **kwargs):
     self._checker.reset()
@@ -316,23 +354,25 @@ class BeamDataframeDoctestRunner(doctest.DocTestRunner):
         example.source = 'pass'
         example.want = ''
         self.skipped += 1
-      elif example.exc_msg is None and any(
-          wont_implement(example)
-          for wont_implement in self._wont_implement_ok.get(test.name, [])):
+      elif example.exc_msg is None and self._is_wont_implement_ok(example,
+                                                                  test):
         # Don't fail doctests that raise this error.
-        example.exc_msg = (
-            'apache_beam.dataframe.frame_base.WontImplementError: ...')
+        example.exc_msg = '%s: ...' % WONT_IMPLEMENT
+      elif example.exc_msg is None and self._is_not_implemented_ok(example,
+                                                                   test):
+        # Don't fail doctests that raise this error.
+        example.exc_msg = '%s: ...' % NOT_IMPLEMENTED
     with self._test_env.context():
       result = super(BeamDataframeDoctestRunner, self).run(test, **kwargs)
       return result
 
   def report_success(self, out, test, example, got):
-    def extract_concise_reason(got):
-      m = re.search(r"WontImplementError:\s+(.*)\n$", got)
+    def extract_concise_reason(got, expected_exc):
+      m = re.search(r"%s:\s+(.*)\n$" % expected_exc, got)
       if m:
         return m.group(1)
       elif "NameError" in got:
-        return "NameError following WontImplementError"
+        return "NameError following %s" % expected_exc
       elif re.match(r"DeferredBase\[\d+\]\n", got):
         return "DeferredBase[*]"
       else:
@@ -340,7 +380,13 @@ class BeamDataframeDoctestRunner(doctest.DocTestRunner):
 
     if self._checker._seen_wont_implement:
       self.wont_implement += 1
-      self._wont_implement_reasons.append(extract_concise_reason(got))
+      self._wont_implement_reasons.append(
+          extract_concise_reason(got, WONT_IMPLEMENT))
+
+    if self._checker._seen_not_implemented:
+      self.not_implemented += 1
+      self._not_implemented_reasons.append(
+          extract_concise_reason(got, NOT_IMPLEMENTED))
 
     return super(BeamDataframeDoctestRunner,
                  self).report_success(out, test, example, got)
@@ -365,9 +411,19 @@ class BeamDataframeDoctestRunner(doctest.DocTestRunner):
     for desc, count in reason_counts:
       print_partition(2, desc, count, self.wont_implement)
     print_partition(
+        1, "not implemented (yet)", self.not_implemented, self.tries)
+    reason_counts = sorted(
+        collections.Counter(self._not_implemented_reasons).items(),
+        key=lambda x: x[1],
+        reverse=True)
+    for desc, count in reason_counts:
+      print_partition(2, desc, count, self.not_implemented)
+    print_partition(1, "failed", self.failures, self.tries)
+    print_partition(
         1,
         "passed",
-        self.tries - self.skipped - self.wont_implement - self.failures,
+        self.tries - self.skipped - self.wont_implement - self.not_implemented -
+        self.failures,
         self.tries)
     print()
 
@@ -378,12 +434,14 @@ def teststring(text, report=True, **runner_kwargs):
       doctest.NORMALIZE_WHITESPACE | doctest.IGNORE_EXCEPTION_DETAIL)
 
   wont_implement_ok = runner_kwargs.pop('wont_implement_ok', False)
+  not_implemented_ok = runner_kwargs.pop('not_implemented_ok', False)
 
   parser = doctest.DocTestParser()
   runner = BeamDataframeDoctestRunner(
       TestEnvironment(),
       optionflags=optionflags,
       wont_implement_ok={'<string>': ['*']} if wont_implement_ok else None,
+      not_implemented_ok={'<string>': ['*']} if not_implemented_ok else None,
       **runner_kwargs)
   test = parser.get_doctest(
       text, {
@@ -424,6 +482,7 @@ def _run_patched(func, *args, **kwargs):
     use_beam = kwargs.pop('use_beam', True)
     skip = kwargs.pop('skip', {})
     wont_implement_ok = kwargs.pop('wont_implement_ok', {})
+    not_implemented_ok = kwargs.pop('not_implemented_ok', {})
     extraglobs = dict(kwargs.pop('extraglobs', {}))
     extraglobs['pd'] = env.fake_pandas_module()
     # Unfortunately the runner is not injectable.
@@ -432,6 +491,7 @@ def _run_patched(func, *args, **kwargs):
         env,
         use_beam=use_beam,
         wont_implement_ok=wont_implement_ok,
+        not_implemented_ok=not_implemented_ok,
         skip=skip,
         **kwargs)
     with expressions.allow_non_parallel_operations():

--- a/sdks/python/apache_beam/dataframe/doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/doctests_test.py
@@ -55,7 +55,7 @@ CHECK_USES_DEFERRED_DATAFRAMES = '''
 RangeIndex(start=0, stop=10, step=1)
 '''
 
-ERROR_RAISING_TESTS = '''
+WONT_IMPLEMENT_RAISING_TESTS = '''
 >>> import apache_beam
 >>> raise apache_beam.dataframe.frame_base.WontImplementError('anything')
 ignored exception
@@ -65,7 +65,7 @@ ignored result
 
 ERROR_RAISING_NAME_ERROR_TESTS = '''
 >>> import apache_beam
->>> raise apache_beam.dataframe.frame_base.WontImplementError('anything')
+>>> raise %s('anything')
 ignored exception
 >>> raise NameError
 ignored exception
@@ -76,6 +76,18 @@ ignored exception
 >>> raise NameError
 failed exception
 '''
+
+WONT_IMPLEMENT_RAISING_NAME_ERROR_TESTS = ERROR_RAISING_NAME_ERROR_TESTS % (
+    'apache_beam.dataframe.frame_base.WontImplementError', )
+
+NOT_IMPLEMENTED_RAISING_TESTS = '''
+>>> import apache_beam
+>>> raise NotImplementedError('anything')
+ignored exception
+'''
+
+NOT_IMPLEMENTED_RAISING_NAME_ERROR_TESTS = ERROR_RAISING_NAME_ERROR_TESTS % (
+    'NotImplementedError', )
 
 
 @unittest.skipIf(sys.version_info <= (3, ), 'Requires contextlib.ExitStack.')
@@ -115,20 +127,48 @@ class DoctestTest(unittest.TestCase):
     self.assertEqual(result.failed, 0)
 
   def test_wont_implement(self):
-    doctests.teststring(
-        ERROR_RAISING_TESTS,
+    result = doctests.teststring(
+        WONT_IMPLEMENT_RAISING_TESTS,
         optionflags=doctest.ELLIPSIS,
         wont_implement_ok=True)
-    doctests.teststring(
-        ERROR_RAISING_TESTS,
+    self.assertNotEqual(result.attempted, 0)
+    self.assertEqual(result.failed, 0)
+
+    result = doctests.teststring(
+        WONT_IMPLEMENT_RAISING_TESTS,
         optionflags=doctest.IGNORE_EXCEPTION_DETAIL,
         wont_implement_ok=True)
+    self.assertNotEqual(result.attempted, 0)
+    self.assertEqual(result.failed, 0)
 
   def test_wont_implement_followed_by_name_error(self):
     result = doctests.teststring(
-        ERROR_RAISING_NAME_ERROR_TESTS,
+        WONT_IMPLEMENT_RAISING_NAME_ERROR_TESTS,
         optionflags=doctest.ELLIPSIS,
         wont_implement_ok=True)
+    self.assertEqual(result.attempted, 6)
+    self.assertEqual(result.failed, 1)  # Only the very last one.
+
+  def test_not_implemented(self):
+    result = doctests.teststring(
+        NOT_IMPLEMENTED_RAISING_TESTS,
+        optionflags=doctest.ELLIPSIS,
+        not_implemented_ok=True)
+    self.assertNotEqual(result.attempted, 0)
+    self.assertEqual(result.failed, 0)
+
+    result = doctests.teststring(
+        NOT_IMPLEMENTED_RAISING_TESTS,
+        optionflags=doctest.IGNORE_EXCEPTION_DETAIL,
+        not_implemented_ok=True)
+    self.assertNotEqual(result.attempted, 0)
+    self.assertEqual(result.failed, 0)
+
+  def test_not_implemented_followed_by_name_error(self):
+    result = doctests.teststring(
+        NOT_IMPLEMENTED_RAISING_NAME_ERROR_TESTS,
+        optionflags=doctest.ELLIPSIS,
+        not_implemented_ok=True)
     self.assertEqual(result.attempted, 6)
     self.assertEqual(result.failed, 1)  # Only the very last one.
 


### PR DESCRIPTION
Adds an additional option to doctest, `not_implemented_ok`, which works identically to `wont_implement_ok`, but allows `NotImplementedError` to be raised.

My goal is to minimize the number of skipped tests, so anything unsupported raises `WontImplementError` or `NotImplementedError`. `NotImplementedError`s should link to a jira so users can indicate interest in a feature and track it's support.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
