### PR TITLE
[BEAM-9547] Raise NotImplementedError and WontImplementError throughout DeferredDataframe

### DIFF
--- a/sdks/python/apache_beam/dataframe/frame_base.py
+++ b/sdks/python/apache_beam/dataframe/frame_base.py
@@ -251,6 +251,13 @@ def wont_implement_method(msg):
   return wrapper
 
 
+def not_implemented_method(op, jira):
+  def wrapper(self, *args, **kwargs):
+    raise NotImplementedError("'%s' is not yet supported (%s)" % (op, jira))
+
+  return wrapper
+
+
 def copy_and_mutate(func):
   def wrapper(self, *args, **kwargs):
     copy = self.copy()

--- a/sdks/python/apache_beam/dataframe/frame_base.py
+++ b/sdks/python/apache_beam/dataframe/frame_base.py
@@ -251,7 +251,7 @@ def wont_implement_method(msg):
   return wrapper
 
 
-def not_implemented_method(op, jira):
+def not_implemented_method(op, jira='BEAM-9547'):
   def wrapper(self, *args, **kwargs):
     raise NotImplementedError("'%s' is not yet supported (%s)" % (op, jira))
 

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -70,7 +70,7 @@ class DeferredSeries(frame_base.DeferredFrame):
             preserves_partition_by=partitionings.Singleton(),
             requires_partition_by=partitionings.Nothing()))
 
-  reindex = frame_base.not_implemented_method('reindex', 'BEAM-XXXX')
+  reindex = frame_base.not_implemented_method('reindex')
 
   to_numpy = to_string = frame_base.wont_implement_method('non-deferred value')
 
@@ -312,36 +312,34 @@ class DeferredDataFrame(frame_base.DeferredFrame):
           requires_partition_by=partitionings.Nothing(),
           preserves_partition_by=partitionings.Nothing()))
 
-  at = frame_base.not_implemented_method('at', 'BEAM-XXXX')
+  at = frame_base.not_implemented_method('at')
 
   @property
   def loc(self):
     return _DeferredLoc(self)
 
-  _get_index = _set_index = frame_base.not_implemented_method('index',
-                                                              'BEAM-XXXX')
+  _get_index = _set_index = frame_base.not_implemented_method('index')
   index = property(_get_index, _set_index)
 
   @property
   def axes(self):
     return (self.index, self.columns)
 
-  apply = frame_base.not_implemented_method('apply', 'BEAM-XXXX')
-  explode = frame_base.not_implemented_method('explode', 'BEAM-XXXX')
-  isin = frame_base.not_implemented_method('isin', 'BEAM-XXXX')
-  assign = frame_base.not_implemented_method('assign', 'BEAM-XXXX')
-  append = frame_base.not_implemented_method('append', 'BEAM-XXXX')
-  combine = frame_base.not_implemented_method('combine', 'BEAM-XXXX')
-  combine_first = frame_base.not_implemented_method('combine_first',
-                                                    'BEAM-XXXX')
-  cov = frame_base.not_implemented_method('cov', 'BEAM-XXXX')
-  corr = frame_base.not_implemented_method('corr', 'BEAM-XXXX')
-  count = frame_base.not_implemented_method('count', 'BEAM-XXXX')
-  dot = frame_base.not_implemented_method('dot', 'BEAM-XXXX')
-  drop = frame_base.not_implemented_method('drop', 'BEAM-XXXX')
-  eval = frame_base.not_implemented_method('eval', 'BEAM-XXXX')
-  reindex = frame_base.not_implemented_method('reindex', 'BEAM-XXXX')
-  melt = frame_base.not_implemented_method('melt', 'BEAM-XXXX')
+  apply = frame_base.not_implemented_method('apply')
+  explode = frame_base.not_implemented_method('explode')
+  isin = frame_base.not_implemented_method('isin')
+  assign = frame_base.not_implemented_method('assign')
+  append = frame_base.not_implemented_method('append')
+  combine = frame_base.not_implemented_method('combine')
+  combine_first = frame_base.not_implemented_method('combine_first')
+  cov = frame_base.not_implemented_method('cov')
+  corr = frame_base.not_implemented_method('corr')
+  count = frame_base.not_implemented_method('count')
+  dot = frame_base.not_implemented_method('dot')
+  drop = frame_base.not_implemented_method('drop')
+  eval = frame_base.not_implemented_method('eval')
+  reindex = frame_base.not_implemented_method('reindex')
+  melt = frame_base.not_implemented_method('melt')
 
   def aggregate(self, func, axis=0, *args, **kwargs):
     if axis is None:
@@ -827,7 +825,7 @@ class DeferredGroupBy(frame_base.DeferredFrame):
       # TODO: Add support for strings in (UN)LIFTABLE_AGGREGATIONS. Test by
       # running doctests for pandas.core.groupby.generic
       raise NotImplementedError('GroupBy.agg currently only supports callable '
-                                'arguments (BEAM-XXXX)')
+                                'arguments')
     return DeferredDataFrame(
         expressions.ComputedExpression(
             'agg',

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -275,8 +275,9 @@ class DeferredDataFrame(frame_base.DeferredFrame):
           "Indexing with a deferred frame is not yet supported. Consider "
           "using df.loc[...]")
 
-    if (isinstance(key, list) and key_column in self._expr.proxy().columns
-        for key_column in key) or key in self._expr.proxy().columns:
+    if (isinstance(key, list) and
+        all(key_column in self._expr.proxy().columns
+            for key_column in key)) or key in self._expr.proxy().columns:
       return self._elementwise(lambda df: df[key], 'get_column')
     else:
       raise NotImplementedError(key)

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -70,6 +70,8 @@ class DeferredSeries(frame_base.DeferredFrame):
             preserves_partition_by=partitionings.Singleton(),
             requires_partition_by=partitionings.Nothing()))
 
+  reindex = frame_base.not_implemented_method('reindex', 'BEAM-XXXX')
+
   to_numpy = to_string = frame_base.wont_implement_method('non-deferred value')
 
   transform = frame_base._elementwise_method(
@@ -116,6 +118,11 @@ class DeferredSeries(frame_base.DeferredFrame):
   diff = frame_base.wont_implement_method('order-sensitive')
 
   head = tail = frame_base.wont_implement_method('order-sensitive')
+
+  memory_usage = frame_base.wont_implement_method('non-deferred value')
+
+  # In Series __contains__ checks the index
+  __contains__ = frame_base.wont_implement_method('non-deferred value')
 
   @frame_base.args_to_kwargs(pd.Series)
   @frame_base.populate_defaults(pd.Series)
@@ -226,29 +233,6 @@ class DeferredSeries(frame_base.DeferredFrame):
     return _DeferredStringMethods(expr)
 
 
-for base in ['add',
-             'sub',
-             'mul',
-             'div',
-             'truediv',
-             'floordiv',
-             'mod',
-             'pow',
-             'and',
-             'or']:
-  for p in ['%s', 'r%s', '__%s__', '__r%s__']:
-    # TODO: non-trivial level?
-    name = p % base
-    setattr(
-        DeferredSeries,
-        name,
-        frame_base._elementwise_method(name, restrictions={'level': None}))
-  setattr(
-      DeferredSeries,
-      '__i%s__' % base,
-      frame_base._elementwise_method('__i%s__' % base, inplace=True))
-for name in ['__lt__', '__le__', '__gt__', '__ge__', '__eq__', '__ne__']:
-  setattr(DeferredSeries, name, frame_base._elementwise_method(name))
 for name in ['apply', 'map', 'transform']:
   setattr(DeferredSeries, name, frame_base._elementwise_method(name))
 
@@ -258,6 +242,10 @@ class DeferredDataFrame(frame_base.DeferredFrame):
   @property
   def T(self):
     return self.transpose()
+
+  @property
+  def columns(self):
+    return self._expr.proxy().columns
 
   def groupby(self, by):
     # TODO: what happens to the existing index?
@@ -280,12 +268,22 @@ class DeferredDataFrame(frame_base.DeferredFrame):
 
   def __getitem__(self, key):
     # TODO: Replicate pd.DataFrame.__getitem__ logic
-    if (isinstance(key, list) and
-        all(key_column in self._expr.proxy().columns
-            for key_column in key)) or key in self._expr.proxy().columns:
+    if isinstance(key, frame_base.DeferredBase):
+      # Fail early if key is a DeferredBase as it interacts surprisingly with
+      # key in self._expr.proxy().columns
+      raise NotImplementedError(
+          "Indexing with a deferred frame is not yet supported. Consider "
+          "using df.loc[...]")
+
+    if (isinstance(key, list) and key_column in self._expr.proxy().columns
+        for key_column in key) or key in self._expr.proxy().columns:
       return self._elementwise(lambda df: df[key], 'get_column')
     else:
       raise NotImplementedError(key)
+
+  def __contains__(self, key):
+    # Checks if proxy has the given column
+    return self._expr.proxy().__contains__(key)
 
   def __setitem__(self, key, value):
     if isinstance(key, str):
@@ -314,12 +312,36 @@ class DeferredDataFrame(frame_base.DeferredFrame):
           requires_partition_by=partitionings.Nothing(),
           preserves_partition_by=partitionings.Nothing()))
 
-  def at(self, *args, **kwargs):
-    raise NotImplementedError()
+  at = frame_base.not_implemented_method('at', 'BEAM-XXXX')
 
   @property
   def loc(self):
     return _DeferredLoc(self)
+
+  _get_index = _set_index = frame_base.not_implemented_method('index',
+                                                              'BEAM-XXXX')
+  index = property(_get_index, _set_index)
+
+  @property
+  def axes(self):
+    return (self.index, self.columns)
+
+  apply = frame_base.not_implemented_method('apply', 'BEAM-XXXX')
+  explode = frame_base.not_implemented_method('explode', 'BEAM-XXXX')
+  isin = frame_base.not_implemented_method('isin', 'BEAM-XXXX')
+  assign = frame_base.not_implemented_method('assign', 'BEAM-XXXX')
+  append = frame_base.not_implemented_method('append', 'BEAM-XXXX')
+  combine = frame_base.not_implemented_method('combine', 'BEAM-XXXX')
+  combine_first = frame_base.not_implemented_method('combine_first',
+                                                    'BEAM-XXXX')
+  cov = frame_base.not_implemented_method('cov', 'BEAM-XXXX')
+  corr = frame_base.not_implemented_method('corr', 'BEAM-XXXX')
+  count = frame_base.not_implemented_method('count', 'BEAM-XXXX')
+  dot = frame_base.not_implemented_method('dot', 'BEAM-XXXX')
+  drop = frame_base.not_implemented_method('drop', 'BEAM-XXXX')
+  eval = frame_base.not_implemented_method('eval', 'BEAM-XXXX')
+  reindex = frame_base.not_implemented_method('reindex', 'BEAM-XXXX')
+  melt = frame_base.not_implemented_method('melt', 'BEAM-XXXX')
 
   def aggregate(self, func, axis=0, *args, **kwargs):
     if axis is None:
@@ -383,6 +405,7 @@ class DeferredDataFrame(frame_base.DeferredFrame):
   applymap = frame_base._elementwise_method('applymap')
 
   memory_usage = frame_base.wont_implement_method('non-deferred value')
+  info = frame_base.wont_implement_method('non-deferred value')
 
   all = frame_base._agg_method('all')
   any = frame_base._agg_method('any')
@@ -398,6 +421,8 @@ class DeferredDataFrame(frame_base.DeferredFrame):
 
   def mode(self, axis=0, *args, **kwargs):
     if axis == 1 or axis == 'columns':
+      # Number of columns is max(number mode values for each row), so we can't
+      # determine how many there will be before looking at the data.
       raise frame_base.WontImplementError('non-deferred column values')
     return frame_base.DeferredFrame.wrap(
         expressions.ComputedExpression(
@@ -766,8 +791,9 @@ class DeferredDataFrame(frame_base.DeferredFrame):
   transform = frame_base._elementwise_method(
       'transform', restrictions={'axis': 0})
 
-  def transpose(self, *args, **kwargs):
-    raise frame_base.WontImplementError('non-deferred column values')
+  transpose = frame_base.wont_implement_method('non-deferred column values')
+  pivot = frame_base.wont_implement_method('non-deferred column values')
+  pivot_table = frame_base.wont_implement_method('non-deferred column values')
 
   def unstack(self, *args, **kwargs):
     if self._expr.proxy().index.nlevels == 1:
@@ -798,7 +824,10 @@ for meth in ('filter', ):
 class DeferredGroupBy(frame_base.DeferredFrame):
   def agg(self, fn):
     if not callable(fn):
-      raise NotImplementedError(fn)
+      # TODO: Add support for strings in (UN)LIFTABLE_AGGREGATIONS. Test by
+      # running doctests for pandas.core.groupby.generic
+      raise NotImplementedError('GroupBy.agg currently only supports callable '
+                                'arguments (BEAM-XXXX)')
     return DeferredDataFrame(
         expressions.ComputedExpression(
             'agg',
@@ -962,3 +991,37 @@ for method in ELEMENTWISE_STRING_METHODS:
   setattr(_DeferredStringMethods,
           method,
           frame_base._elementwise_method(method))
+
+for base in ['add',
+             'sub',
+             'mul',
+             'div',
+             'truediv',
+             'floordiv',
+             'mod',
+             'pow',
+             'and',
+             'or']:
+  for p in ['%s', 'r%s', '__%s__', '__r%s__']:
+    # TODO: non-trivial level?
+    name = p % base
+    setattr(
+        DeferredSeries,
+        name,
+        frame_base._elementwise_method(name, restrictions={'level': None}))
+    setattr(
+        DeferredDataFrame,
+        name,
+        frame_base._elementwise_method(name, restrictions={'level': None}))
+  setattr(
+      DeferredSeries,
+      '__i%s__' % base,
+      frame_base._elementwise_method('__i%s__' % base, inplace=True))
+  setattr(
+      DeferredDataFrame,
+      '__i%s__' % base,
+      frame_base._elementwise_method('__i%s__' % base, inplace=True))
+
+for name in ['__lt__', '__le__', '__gt__', '__ge__', '__eq__', '__ne__']:
+  setattr(DeferredSeries, name, frame_base._elementwise_method(name))
+  setattr(DeferredDataFrame, name, frame_base._elementwise_method(name))

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -340,6 +340,8 @@ class DeferredDataFrame(frame_base.DeferredFrame):
   eval = frame_base.not_implemented_method('eval')
   reindex = frame_base.not_implemented_method('reindex')
   melt = frame_base.not_implemented_method('melt')
+  pivot = frame_base.not_implemented_method('pivot')
+  pivot_table = frame_base.not_implemented_method('pivot_table')
 
   def aggregate(self, func, axis=0, *args, **kwargs):
     if axis is None:
@@ -790,8 +792,6 @@ class DeferredDataFrame(frame_base.DeferredFrame):
       'transform', restrictions={'axis': 0})
 
   transpose = frame_base.wont_implement_method('non-deferred column values')
-  pivot = frame_base.wont_implement_method('non-deferred column values')
-  pivot_table = frame_base.wont_implement_method('non-deferred column values')
 
   def unstack(self, *args, **kwargs):
     if self._expr.proxy().index.nlevels == 1:

--- a/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
@@ -75,7 +75,6 @@ class DoctestTest(unittest.TestCase):
             'pandas.core.frame.DataFrame.mode': [
                 "df.mode(axis='columns', numeric_only=True)"
             ],
-            'pandas.core.frame.DataFrame.pivot': ['*'],
         },
         not_implemented_ok={
             'pandas.core.frame.DataFrame.isin': ['*'],
@@ -84,6 +83,10 @@ class DoctestTest(unittest.TestCase):
             'pandas.core.frame.DataFrame.count': ['*'],
             'pandas.core.frame.DataFrame.reindex': ['*'],
             'pandas.core.frame.DataFrame.reindex_axis': ['*'],
+
+            # We should be able to support pivot and pivot_table for categorical
+            # columns
+            'pandas.core.frame.DataFrame.pivot': ['*'],
 
             # DataFrame.__getitem__ cannot be used as loc
             'pandas.core.frame.DataFrame.query': [
@@ -145,9 +148,9 @@ class DoctestTest(unittest.TestCase):
                 'df.to_records(index_dtypes=index_dtypes)',
             ],
             # These tests use the static method pd.pivot_table, which doesn't
-            # actually raise WontImplementError
+            # actually raise NotImplementedError
             'pandas.core.frame.DataFrame.pivot_table': ['*'],
-            # Expected to raise a ValueError, but we raise WontImplement
+            # Expected to raise a ValueError, but we raise NotImplementedError
             'pandas.core.frame.DataFrame.pivot': [
                 "df.pivot(index='foo', columns='bar', values='baz')"
             ],

--- a/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
@@ -68,32 +68,62 @@ class DoctestTest(unittest.TestCase):
             ],
             'pandas.core.frame.DataFrame.unstack': ['*'],
             'pandas.core.frame.DataFrame.memory_usage': ['*'],
-        },
-        skip={
-            'pandas.core.frame.DataFrame.T': [
-                'df1_transposed.dtypes', 'df2_transposed.dtypes'
+            'pandas.core.frame.DataFrame.info': ['*'],
+            # Not equal to df.agg('mode', axis='columns', numeric_only=True)
+            # because there can be multiple columns if a row has more than one
+            # mode
+            'pandas.core.frame.DataFrame.mode': [
+                "df.mode(axis='columns', numeric_only=True)"
             ],
-            'pandas.core.frame.DataFrame.agg': ['*'],
-            'pandas.core.frame.DataFrame.aggregate': ['*'],
-            'pandas.core.frame.DataFrame.append': ['*'],
-            'pandas.core.frame.DataFrame.apply': ['*'],
-            'pandas.core.frame.DataFrame.applymap': ['df ** 2'],
-            'pandas.core.frame.DataFrame.assign': ['*'],
+            'pandas.core.frame.DataFrame.pivot': ['*'],
+        },
+        not_implemented_ok={
+            'pandas.core.frame.DataFrame.isin': ['*'],
+            'pandas.core.frame.DataFrame.melt': ['*'],
             'pandas.core.frame.DataFrame.axes': ['*'],
-            'pandas.core.frame.DataFrame.combine': ['*'],
-            'pandas.core.frame.DataFrame.combine_first': ['*'],
-            'pandas.core.frame.DataFrame.compare': ['*'],
-            'pandas.core.frame.DataFrame.corr': ['*'],
             'pandas.core.frame.DataFrame.count': ['*'],
+            'pandas.core.frame.DataFrame.reindex': ['*'],
+            'pandas.core.frame.DataFrame.reindex_axis': ['*'],
+
+            # DataFrame.__getitem__ cannot be used as loc
+            'pandas.core.frame.DataFrame.query': [
+                'df[df.A > df.B]', "df[df.B == df['C C']]"
+            ],
+
+            # We can implement this as a zipping operator, but it won't have the
+            # same capability. The doctest includes an example that branches on
+            # a deferred result.
+            'pandas.core.frame.DataFrame.combine': ['*'],
+
+            # Can be implemented as a zipping operator
+            'pandas.core.frame.DataFrame.combine_first': ['*'],
+
+            # Difficult to parallelize but should be possible?
+            'pandas.core.frame.DataFrame.corr': ['*'],
             'pandas.core.frame.DataFrame.cov': ['*'],
             'pandas.core.frame.DataFrame.dot': ['*'],
-            'pandas.core.frame.DataFrame.drop': ['*'],
-            'pandas.core.frame.DataFrame.drop_duplicates': ['*'],
-            'pandas.core.frame.DataFrame.duplicated': ['*'],
+
+            # element-wise
             'pandas.core.frame.DataFrame.eval': ['*'],
             'pandas.core.frame.DataFrame.explode': ['*'],
+
+            # Trivially elementwise for axis=columns. Relies on global indexing
+            # for axis=rows.
+            'pandas.core.frame.DataFrame.drop': ['*'],
+            'pandas.core.frame.DataFrame.rename': ['*'],
+            'pandas.core.frame.DataFrame.apply': ['*'],
+
+            # Zipping operation if input is a DeferredSeries
+            'pandas.core.frame.DataFrame.assign': ['*'],
+
+            # In theory this is possible for bounded inputs?
+            'pandas.core.frame.DataFrame.append': ['*'],
+        },
+        skip={
+            'pandas.core.frame.DataFrame.compare': ['*'],
+            'pandas.core.frame.DataFrame.drop_duplicates': ['*'],
+            'pandas.core.frame.DataFrame.duplicated': ['*'],
             'pandas.core.frame.DataFrame.groupby': [
-                # More keyword arguments.
                 'df.groupby(level=0).mean()',
                 'df.groupby(level="Type").mean()',
                 'df.groupby(by=["b"], dropna=False).sum()',
@@ -101,47 +131,67 @@ class DoctestTest(unittest.TestCase):
             ],
             'pandas.core.frame.DataFrame.idxmax': ['*'],
             'pandas.core.frame.DataFrame.idxmin': ['*'],
-            'pandas.core.frame.DataFrame.info': ['*'],
-            'pandas.core.frame.DataFrame.isin': ['*'],
-            'pandas.core.frame.DataFrame.iterrows': ["print(df['int'].dtype)"],
-            'pandas.core.frame.DataFrame.melt': ['*'],
-            'pandas.core.frame.DataFrame.memory_usage': ['*'],
+            'pandas.core.frame.DataFrame.pop': ['*'],
+            'pandas.core.frame.DataFrame.set_axis': ['*'],
+            'pandas.core.frame.DataFrame.sort_index': ['*'],
+            'pandas.core.frame.DataFrame.to_markdown': ['*'],
+            'pandas.core.frame.DataFrame.to_parquet': ['*'],
+            'pandas.core.frame.DataFrame.value_counts': ['*'],
+
+            'pandas.core.frame.DataFrame.to_records': [
+                'df.index = df.index.rename("I")',
+                'index_dtypes = f"<S{df.index.str.len().max()}"', # 1.x
+                'index_dtypes = "<S{}".format(df.index.str.len().max())', #0.x
+                'df.to_records(index_dtypes=index_dtypes)',
+            ],
+            # These tests use the static method pd.pivot_table, which doesn't
+            # actually raise WontImplementError
+            'pandas.core.frame.DataFrame.pivot_table': ['*'],
+            # Expected to raise a ValueError, but we raise WontImplement
+            'pandas.core.frame.DataFrame.pivot': [
+                "df.pivot(index='foo', columns='bar', values='baz')"
+            ],
+            'pandas.core.frame.DataFrame.append': [
+                'df',
+                # pylint: disable=line-too-long
+                "pd.concat([pd.DataFrame([i], columns=['A']) for i in range(5)],\n"
+                "          ignore_index=True)"
+            ],
+            'pandas.core.frame.DataFrame.eval': ['df'],
+            # No override for __matmul__ and friends
+            'pandas.core.frame.DataFrame.dot': ['df @ other'],
+            'pandas.core.frame.DataFrame.melt': [
+                "df.columns = [list('ABC'), list('DEF')]", "df"
+            ],
             'pandas.core.frame.DataFrame.merge': [
                 # Order-sensitive index, checked in frames_test.py.
                 "df1.merge(df2, left_on='lkey', right_on='rkey')",
                 "df1.merge(df2, left_on='lkey', right_on='rkey',\n"
                 "          suffixes=('_left', '_right'))",
             ],
-            # Not equal to df.agg('mode', axis='columns', numeric_only=True)
-            'pandas.core.frame.DataFrame.mode': [
-                "df.mode(axis='columns', numeric_only=True)"
-            ],
-            'pandas.core.frame.DataFrame.pivot': ['*'],
-            'pandas.core.frame.DataFrame.pivot_table': ['*'],
-            'pandas.core.frame.DataFrame.pop': ['*'],
-            'pandas.core.frame.DataFrame.query': ['*'],
-            'pandas.core.frame.DataFrame.reindex': ['*'],
-            # Sets df.index
-            'pandas.core.frame.DataFrame.reindex_axis': ['*'],
-            'pandas.core.frame.DataFrame.rename': ['*'],
             # Raises right exception, but testing framework has matching issues.
             'pandas.core.frame.DataFrame.replace': [
                 "df.replace({'a string': 'new value', True: False})  # raises"
             ],
-            # Uses unseeded np.random.
-            'pandas.core.frame.DataFrame.round': ['*'],
-            'pandas.core.frame.DataFrame.set_axis': ['*'],
-            'pandas.core.frame.DataFrame.set_index': ['*'],
-            'pandas.core.frame.DataFrame.sort_index': ['*'],
+            # Should raise WontImplement order-sensitive
+            'pandas.core.frame.DataFrame.set_index': [
+                "df.set_index([pd.Index([1, 2, 3, 4]), 'year'])",
+                "df.set_index([s, s**2])",
+            ],
+            'pandas.core.frame.DataFrame.to_sparse': ['type(df)'],
+
+            # DeferredSeries has no attribute dtype. Should we allow this and
+            # defer to proxy?
+            'pandas.core.frame.DataFrame.iterrows': ["print(df['int'].dtype)"],
+
+            # Skipped because "seen_wont_implement" is reset before getting to
+            # these calls, so the NameError they raise is not ignored.
+            'pandas.core.frame.DataFrame.T': [
+                'df1_transposed.dtypes', 'df2_transposed.dtypes'
+            ],
             'pandas.core.frame.DataFrame.transpose': [
                 'df1_transposed.dtypes', 'df2_transposed.dtypes'
             ],
-            'pandas.core.frame.DataFrame.to_markdown': ['*'],
-            'pandas.core.frame.DataFrame.to_parquet': ['*'],
-            # Uses df.index
-            'pandas.core.frame.DataFrame.to_records': ['*'],
-            'pandas.core.frame.DataFrame.to_sparse': ['type(df)'],
-            'pandas.core.frame.DataFrame.value_counts': ['*'],
         })
     self.assertEqual(result.failed, 0)
 
@@ -165,6 +215,7 @@ class DoctestTest(unittest.TestCase):
                 "s.nlargest(3)",
                 "s.nlargest(3, keep='last')",
             ],
+            'pandas.core.series.Series.memory_usage': ['*'],
             'pandas.core.series.Series.nsmallest': [
                 "s.nsmallest()",
                 "s.nsmallest(3)",
@@ -178,6 +229,9 @@ class DoctestTest(unittest.TestCase):
             'pandas.core.series.Series.unstack': ['*'],
             'pandas.core.series.Series.values': ['*'],
             'pandas.core.series.Series.view': ['*'],
+        },
+        not_implemented_ok={
+            'pandas.core.series.Series.reindex': ['*'],
         },
         skip={
             'pandas.core.series.Series.array': ['*'],
@@ -199,12 +253,10 @@ class DoctestTest(unittest.TestCase):
             'pandas.core.series.Series.groupby': ['*'],
             'pandas.core.series.Series.idxmax': ['*'],
             'pandas.core.series.Series.idxmin': ['*'],
-            'pandas.core.series.Series.memory_usage': ['*'],
             'pandas.core.series.Series.name': ['*'],
             'pandas.core.series.Series.nonzero': ['*'],
             'pandas.core.series.Series.pop': ['*'],
             'pandas.core.series.Series.quantile': ['*'],
-            'pandas.core.series.Series.reindex': ['*'],
             'pandas.core.series.Series.rename': ['*'],
             'pandas.core.series.Series.repeat': ['*'],
             'pandas.core.series.Series.replace': ['*'],


### PR DESCRIPTION
This PR reduces the number of skipped test cases in `pandas.core.frame` down to 36 (6.3%), and they are all due to issues with the test framework, not unimplemented functionality. The rest of the test cases raise wont implement (13.5%), raise not implemented (11.5%), or pass (68.7%).


### Now raises WontImplementError
- Series.memory_usage
- `Series.__contains__` - checks for a value in the entire index. Maybe this could be implemented as a deferred scalar?
- [`DataFrame.info`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.info.html)


### Now raises NotImplementedError
I'm pretty confident the following could be implemented at least partially:
- `DataFrame.__getitem__(DeferredBase)`
- [`DataFrame.apply`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.apply.html)
- [`DataFrame.explode`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.explode.html)
- [`DataFrame.isin`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.isin.html)
- [`DataFrame.assign`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.assign.html)
- [`DataFrame.combine`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.combine.html)
- [`DataFrame.combine_first`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.combine_first.html)
- [`DataFrame.drop`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.drop.html)
- [`DataFrame.eval`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.eval.html)
- [`DataFrame.melt`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.melt.html)
- [`DataFrame.at`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.at.html)
- [`DataFrame.count`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.count.html)
- [`DataFrame.cov`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.cov.html)
- [`DataFrame.corr`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.corr.html)
- [`DataFrame.dot`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.dot.html)
- [`DataFrame.pivot`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.pivot.html)
- [`DataFrame.pivot_table`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.pivot_table.html)

I _think_ the following could be implemented:
- [`Series.reindex`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.Series.reindex.html)
- [`DataFrame.index`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.index) (deferred access and assignment)
- [`DataFrame.reindex`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.reindex.html)
- [`DataFrame.append`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.append.html)


### New functionality
- Arithmetic operators for DataFrame

I provided implementations for the following functions dealing with columns, but they're not deferred which seems wrong:
- [`DataFrame.columns`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.columns.html)
- `DataFrame.__contains__`
- [`DataFrame.axes`](https://pandas.pydata.org/pandas-docs/stable/reference/api/pandas.DataFrame.axes.html) (returns `(self.index, self.columns)`, so it will fail until `index` is supported)


Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
