### PR TITLE
[BEAM-10814][BEAM-10570] DataframeTransform outputs elements

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -199,7 +199,6 @@ task goIntegrationTests() {
 
 task pythonPreCommit() {
   dependsOn ":sdks:python:test-suites:tox:pycommon:preCommitPyCommon"
-  dependsOn ":sdks:python:test-suites:tox:py35:preCommitPy35"
   dependsOn ":sdks:python:test-suites:tox:py36:preCommitPy36"
   dependsOn ":sdks:python:test-suites:tox:py37:preCommitPy37"
   dependsOn ":sdks:python:test-suites:tox:py38:preCommitPy38"
@@ -212,7 +211,6 @@ task pythonDocsPreCommit() {
 }
 
 task pythonDockerBuildPreCommit() {
-  dependsOn ":sdks:python:container:py35:docker"
   dependsOn ":sdks:python:container:py36:docker"
   dependsOn ":sdks:python:container:py37:docker"
   dependsOn ":sdks:python:container:py38:docker"

--- a/sdks/python/apache_beam/coders/row_coder.py
+++ b/sdks/python/apache_beam/coders/row_coder.py
@@ -38,10 +38,10 @@ from apache_beam.coders.coders import VarIntCoder
 from apache_beam.portability import common_urns
 from apache_beam.portability.api import schema_pb2
 from apache_beam.typehints import row_type
+from apache_beam.typehints.schemas import PYTHON_ANY_URN
 from apache_beam.typehints.schemas import LogicalType
 from apache_beam.typehints.schemas import named_tuple_from_schema
 from apache_beam.typehints.schemas import schema_from_element_type
-from apache_beam.typehints.schemas import PYTHON_ANY_URN
 from apache_beam.utils import proto_utils
 
 __all__ = ["RowCoder"]

--- a/sdks/python/apache_beam/coders/row_coder.py
+++ b/sdks/python/apache_beam/coders/row_coder.py
@@ -41,6 +41,7 @@ from apache_beam.typehints import row_type
 from apache_beam.typehints.schemas import LogicalType
 from apache_beam.typehints.schemas import named_tuple_from_schema
 from apache_beam.typehints.schemas import schema_from_element_type
+from apache_beam.typehints.schemas import PYTHON_ANY_URN
 from apache_beam.utils import proto_utils
 
 __all__ = ["RowCoder"]
@@ -90,12 +91,7 @@ class RowCoder(FastCoder):
 
   @staticmethod
   def from_type_hint(type_hint, registry):
-    try:
-      schema = schema_from_element_type(type_hint)
-    except ValueError:
-      # TODO(BEAM-10570): Consider a pythonsdk logical type.
-      return typecoders.registry.get_coder(object)
-
+    schema = schema_from_element_type(type_hint)
     return RowCoder(schema)
 
   @staticmethod
@@ -140,6 +136,11 @@ def _nonnull_coder_from_type(field_type):
         _coder_from_type(field_type.map_type.key_type),
         _coder_from_type(field_type.map_type.value_type))
   elif type_info == "logical_type":
+    # Special case for the Any logical type. Just use the default coder for an
+    # unknown Python object.
+    if field_type.logical_type.urn == PYTHON_ANY_URN:
+      return typecoders.registry.get_coder(object)
+
     logical_type = LogicalType.from_runner_api(field_type.logical_type)
     return LogicalTypeCoder(
         logical_type, _coder_from_type(field_type.logical_type.representation))

--- a/sdks/python/apache_beam/dataframe/convert_test.py
+++ b/sdks/python/apache_beam/dataframe/convert_test.py
@@ -27,7 +27,7 @@ from apache_beam.testing.util import equal_to
 
 
 class ConverTest(unittest.TestCase):
-  def test_convert_yield_dataframes(self):
+  def test_convert_yield_pandas(self):
     def equal_to_unordered_series(expected):
       def check(actual):
         actual = pd.concat(actual)
@@ -52,9 +52,10 @@ class ConverTest(unittest.TestCase):
       df_ab = df_a * df_b
 
       # Converting multiple results at a time can be more efficient.
-      pc_2a, pc_ab = convert.to_pcollection(df_2a, df_ab, yield_dataframes=True)
+      pc_2a, pc_ab = convert.to_pcollection(df_2a, df_ab,
+                                            yield_elements='pandas')
       # But separate conversions can be done as well.
-      pc_3a = convert.to_pcollection(df_3a, yield_dataframes=True)
+      pc_3a = convert.to_pcollection(df_3a, yield_elements='pandas')
 
       assert_that(pc_2a, equal_to_unordered_series(2 * a), label='Check2a')
       assert_that(pc_3a, equal_to_unordered_series(3 * a), label='Check3a')

--- a/sdks/python/apache_beam/dataframe/convert_test.py
+++ b/sdks/python/apache_beam/dataframe/convert_test.py
@@ -23,10 +23,11 @@ import pandas as pd
 import apache_beam as beam
 from apache_beam.dataframe import convert
 from apache_beam.testing.util import assert_that
+from apache_beam.testing.util import equal_to
 
 
 class ConverTest(unittest.TestCase):
-  def test_convert(self):
+  def test_convert_yield_dataframes(self):
     def equal_to_unordered_series(expected):
       def check(actual):
         actual = pd.concat(actual)
@@ -51,13 +52,37 @@ class ConverTest(unittest.TestCase):
       df_ab = df_a * df_b
 
       # Converting multiple results at a time can be more efficient.
-      pc_2a, pc_ab = convert.to_pcollection(df_2a, df_ab)
+      pc_2a, pc_ab = convert.to_pcollection(df_2a, df_ab, yield_dataframes=True)
       # But separate conversions can be done as well.
-      pc_3a = convert.to_pcollection(df_3a)
+      pc_3a = convert.to_pcollection(df_3a, yield_dataframes=True)
 
       assert_that(pc_2a, equal_to_unordered_series(2 * a), label='Check2a')
       assert_that(pc_3a, equal_to_unordered_series(3 * a), label='Check3a')
       assert_that(pc_ab, equal_to_unordered_series(a * b), label='Checkab')
+
+  def test_convert(self):
+    with beam.Pipeline() as p:
+      a = pd.Series([1, 2, 3])
+      b = pd.Series([100, 200, 300])
+
+      pc_a = p | 'A' >> beam.Create([a])
+      pc_b = p | 'B' >> beam.Create([b])
+
+      df_a = convert.to_dataframe(pc_a, proxy=a[:0])
+      df_b = convert.to_dataframe(pc_b, proxy=b[:0])
+
+      df_2a = 2 * df_a
+      df_3a = 3 * df_a
+      df_ab = df_a * df_b
+
+      # Converting multiple results at a time can be more efficient.
+      pc_2a, pc_ab = convert.to_pcollection(df_2a, df_ab)
+      # But separate conversions can be done as well.
+      pc_3a = convert.to_pcollection(df_3a)
+
+      assert_that(pc_2a, equal_to(list(2 * a)), label='Check2a')
+      assert_that(pc_3a, equal_to(list(3 * a)), label='Check3a')
+      assert_that(pc_ab, equal_to(list(a * b)), label='Checkab')
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/dataframe/io.py
+++ b/sdks/python/apache_beam/dataframe/io.py
@@ -218,7 +218,7 @@ class _WriteToPandas(beam.PTransform):
     if isinstance(other, frame_base.DeferredBase):
       from apache_beam.dataframe import convert  # avoid circular import
       # TODO(roberwb): Amortize the computation for multiple writes?
-      other = convert.to_pcollection(other)
+      other = convert.to_pcollection(other, yield_elements='pandas')
     return super(_WriteToPandas, self).__ror__(other, label)
 
   def expand(self, pcoll):

--- a/sdks/python/apache_beam/dataframe/io_test.py
+++ b/sdks/python/apache_beam/dataframe/io_test.py
@@ -153,7 +153,8 @@ class IOTest(unittest.TestCase):
             # one pipeline.
 
             result = convert.to_pcollection(
-                p | getattr(io, 'read_%s' % format)(dest + '*', **read_kwargs))
+                p | getattr(io, 'read_%s' % format)(dest + '*', **read_kwargs),
+                yield_elements='pandas')
             assert_that(result, frame_equal_to(df, **check_options))
         except:
           os.system('head -n 100 ' + dest + '*')

--- a/sdks/python/apache_beam/dataframe/schemas.py
+++ b/sdks/python/apache_beam/dataframe/schemas.py
@@ -18,7 +18,7 @@
 r"""Utilities for relating schema-aware PCollections and dataframe transforms.
 
 Imposes a mapping between native Python typings (specifically those compatible
-with apache_beam.typehints.schemas), and common pandas dtypes.
+with :mod:`apache_beam.typehints.schemas`), and common pandas dtypes::
 
   pandas dtype                    Python typing
   np.int{8,16,32,64}      <-----> np.int{8,16,32,64}*
@@ -28,18 +28,18 @@ with apache_beam.typehints.schemas), and common pandas dtypes.
   Not supported           <------ Optional[bytes]
   np.bool                 <-----> np.bool
 
-* int, float, bool are treated the same as np.int64, np.float64, np.bool
+  * int, float, bool are treated the same as np.int64, np.float64, np.bool
 
-Any unknown or unsupported types are trested as Any and shunted to
-np.object:
+Any unknown or unsupported types are treated as :code:`Any` and shunted to
+:code:`np.object`::
 
   np.object               <-----> Any
 
 bytes, unicode strings and nullable Booleans are handled differently when using
 pandas 0.x vs. 1.x. pandas 0.x has no mapping for these types, so they are
-shunted to np.object.
+shunted to :code:`np.object`.
 
-pandas 1.x Only:
+pandas 1.x Only::
 
   np.dtype('S')     <-----> bytes
   pd.BooleanDType() <-----> Optional[bool]
@@ -47,15 +47,15 @@ pandas 1.x Only:
                        \--- str
 
 Pandas does not support hierarchical data natively. Currently, all structured
-types (Sequence, Mapping, nested NamedTuple types), will be shunted lossily to
-np.object/Any like all other unknown types. In the future these types may be
-given special consideration.
-
-TODO: Mapping for date/time types
-https://pandas.pydata.org/docs/user_guide/timeseries.html#overview
+types (:code:`Sequence`, :code:`Mapping`, nested :code:`NamedTuple` types), are
+shunted to :code:`np.object` like all other unknown types. In the future these
+types may be given special consideration.
 """
 
 # pytype: skip-file
+
+#TODO: Mapping for date/time types
+#https://pandas.pydata.org/docs/user_guide/timeseries.html#overview
 
 from __future__ import absolute_import
 

--- a/sdks/python/apache_beam/dataframe/schemas.py
+++ b/sdks/python/apache_beam/dataframe/schemas.py
@@ -16,24 +16,132 @@
 #
 
 """Utilities for relating schema-aware PCollections and dataframe transforms.
+
+pandas dtype               Python typing
+np.int{8,16,32,64}      <-----> np.int{8,16,32,64}*
+pd.Int{8,16,32,64}Dtype <-----> Optional[np.int{8,16,32,64}]*
+np.float{32,64}         <-----> Optional[np.float{32,64}]
+                           \--- np.float{32,64}
+np.dtype('S')           <-----> bytes
+Not supported           <------ Optional[bytes]
+np.bool                 <-----> np.bool
+
+* int, float, bool are treated the same as np.int64, np.float64, np.bool
+
+Any unknown or unsupported types are trested as Any and shunted to
+np.object:
+
+np.object               <-----> Any
+
+Strings and nullable Booleans are handled differently when using pandas 0.x vs.
+1.x. pandas 0.x has no mapping for these types, so they are shunted lossily to
+  np.object.
+
+pandas 0.x:
+np.object         <------ Optional[bool]
+                     \--- Optional[str]
+                      \-- str
+
+pandas 1.x:
+pd.BooleanDType() <-----> Optional[bool]
+pd.StringDType()  <-----> Optional[str]
+                     \--- str
+
+Pandas does not support hierarchical data natively. All structured types
+(Sequence, Mapping, nested NamedTuple types), will be shunted lossily to
+np.object/Any.
+
+TODO: Mapping for date/time types
+https://pandas.pydata.org/docs/user_guide/timeseries.html#overview
+
+timestamps and timedeltas in pandas always use nanosecond precision
 """
 
 # pytype: skip-file
 
 from __future__ import absolute_import
 
-import typing
+from typing import Any
+from typing import Union
+from typing import Optional
+from typing import TypeVar
+from typing import NamedTuple
 
+import numpy as np
 import pandas as pd
+from uuid import uuid4
 
 import apache_beam as beam
 from apache_beam import typehints
+from apache_beam.portability.api import schema_pb2
 from apache_beam.transforms.util import BatchElements
+from apache_beam.typehints.schemas import schema_from_element_type
 from apache_beam.typehints.schemas import named_fields_from_element_type
+from apache_beam.typehints.schemas import named_fields_to_schema
+from apache_beam.typehints.schemas import named_tuple_to_schema
+from apache_beam.typehints.schemas import named_tuple_from_schema
+from apache_beam.typehints.schemas import typing_from_runner_api
+from apache_beam.typehints.native_type_compatibility import _match_is_optional
+from apache_beam.typehints.native_type_compatibility import extract_optional_type
+from apache_beam.utils import proto_utils
 
-__all__ = ('BatchRowsAsDataFrame', 'generate_proxy')
+__all__ = (
+    'BatchRowsAsDataFrame',
+    'generate_proxy',
+    'UnbatchPandas',
+    'element_type_from_proxy')
 
-T = typing.TypeVar('T', bound=typing.NamedTuple)
+T = TypeVar('T', bound=NamedTuple)
+
+PD_MAJOR, _, _ = map(int, pd.__version__.split('.'))
+
+# Generate type map (presented visually in the docstring)
+_BIDIRECTIONAL = [
+    (np.bool, np.bool),
+    (np.int8, np.int8),
+    (np.int16, np.int16),
+    (np.int32, np.int32),
+    (np.int64, np.int64),
+    (pd.Int8Dtype(), Optional[np.int8]),
+    (pd.Int16Dtype(), Optional[np.int16]),
+    (pd.Int32Dtype(), Optional[np.int32]),
+    (pd.Int64Dtype(), Optional[np.int64]),
+    (np.float32, Optional[np.float32]),
+    (np.float64, Optional[np.float64]),
+    (np.object, Any),
+]
+
+if PD_MAJOR >= 1:
+  _BIDIRECTIONAL.extend([
+      (pd.StringDtype(), Optional[str]),
+      (pd.BooleanDtype(), Optional[np.bool]),
+  ])
+
+PANDAS_TO_BEAM = {
+    pd.Series([], dtype=dtype).dtype: fieldtype
+    for dtype,
+    fieldtype in _BIDIRECTIONAL
+}
+BEAM_TO_PANDAS = {fieldtype: dtype for dtype, fieldtype in _BIDIRECTIONAL}
+
+# Shunt non-nullable Beam types to the same pandas types as their non-nullable
+# equivalents for FLOATs, DOUBLEs, and STRINGs. pandas has no non-nullable dtype
+# for these.
+OPTIONAL_SHUNTS = [np.float32, np.float64]
+
+if PD_MAJOR >= 1:
+  OPTIONAL_SHUNTS.append(str)
+
+for typehint in OPTIONAL_SHUNTS:
+  BEAM_TO_PANDAS[typehint] = BEAM_TO_PANDAS[Optional[typehint]]
+
+# int, float -> int64, np.float64
+BEAM_TO_PANDAS[int] = BEAM_TO_PANDAS[np.int64]
+BEAM_TO_PANDAS[Optional[int]] = BEAM_TO_PANDAS[Optional[np.int64]]
+BEAM_TO_PANDAS[float] = BEAM_TO_PANDAS[np.float64]
+BEAM_TO_PANDAS[Optional[float]] = BEAM_TO_PANDAS[Optional[np.float64]]
+
+BEAM_TO_PANDAS[bytes] = 'bytes'
 
 
 @typehints.with_input_types(T)
@@ -55,17 +163,147 @@ class BatchRowsAsDataFrame(beam.PTransform):
         lambda batch: pd.DataFrame.from_records(batch, columns=columns))
 
 
-def _make_empty_series(name, typ):
-  try:
-    return pd.Series(name=name, dtype=typ)
-  except TypeError:
-    raise TypeError("Unable to convert type '%s' for field '%s'" % (name, typ))
+def _make_proxy_series(name, typehint):
+  # Default to np.object. This is lossy, we won't be able to recover the type
+  # at the output.
+  dtype = BEAM_TO_PANDAS.get(typehint, np.object)
+
+  return pd.Series(name=name, dtype=dtype)
 
 
 def generate_proxy(element_type):
+  """ Generate a proxy pandas object for the given PCollection element_type.
+
+  Currently only supports generating a DataFrame proxy from a schema-aware
+  PCollection."""
   # type: (type) -> pd.DataFrame
-  return pd.DataFrame({
-      name: _make_empty_series(name, typ)
-      for name,
-      typ in named_fields_from_element_type(element_type)
-  })
+  fields = named_fields_from_element_type(element_type)
+  return pd.DataFrame(
+      {name: _make_proxy_series(name, typehint)
+       for name, typehint in fields},
+      columns=[name for name, _ in fields])
+
+
+def element_type_from_proxy(proxy):
+  """ Generate an element_type for an element-wise PCollection from a proxy
+  pandas object. Currently only supports converting the element_type for
+  a schema-aware PCollection to a proxy DataFrame.
+
+  Currently only supports generating a DataFrame proxy from a schema-aware
+  PCollection."""
+  # type: (pd.DataFrame) -> type
+  indices = [] if proxy.index.names == (None, ) else [
+      (name, proxy.index.get_level_values(i).dtype) for i,
+      name in enumerate(proxy.index.names)
+  ]
+
+  return named_tuple_from_schema(
+      named_fields_to_schema([
+          (column, _dtype_to_fieldtype(dtype)) for column,
+          dtype in indices + list(zip(proxy.columns, proxy.dtypes))
+      ]))
+
+
+class _BaseDataframeUnbatchDoFn(beam.DoFn):
+  def __init__(self, namedtuple_ctor):
+    self._namedtuple_ctor = namedtuple_ctor
+
+  def _get_series(self, df):
+    raise NotImplementedError()
+
+  def process(self, df):
+    # TODO: Only do null checks for nullable types
+    def make_null_checking_generator(series):
+      nulls = pd.isnull(series)
+      return (None if isnull else value for isnull, value in zip(nulls, series))
+
+    all_series = self._get_series(df)
+    iterators = [
+        make_null_checking_generator(series) for series,
+        typehint in zip(all_series, self._namedtuple_ctor._field_types)
+    ]
+
+    # TODO: Avoid materializing the rows. Produce an object that references the
+    # underlying dataframe
+    for values in zip(*iterators):
+      yield self._namedtuple_ctor(*values)
+
+  def infer_output_type(self, input_type):
+    return self._namedtuple_ctor
+
+  @classmethod
+  def _from_serialized_schema(cls, schema_str):
+    return cls(
+        named_tuple_from_schema(
+            proto_utils.parse_Bytes(schema_str, schema_pb2.Schema)))
+
+  def __reduce__(self):
+    # when pickling, use bytes representation of the schema.
+    return (
+        self._from_serialized_schema,
+        (named_tuple_to_schema(self._namedtuple_ctor).SerializeToString(), ))
+
+
+class _UnbatchNoIndex(_BaseDataframeUnbatchDoFn):
+  def _get_series(self, df):
+    return [df[column] for column in df.columns]
+
+
+class _UnbatchWithIndex(_BaseDataframeUnbatchDoFn):
+  def _get_series(self, df):
+    return [df.index.get_level_values(i) for i in range(len(df.index.names))
+            ] + [df[column] for column in df.columns]
+
+
+def _unbatch_transform(proxy):
+  if isinstance(proxy, pd.DataFrame):
+    ctor = element_type_from_proxy(proxy)
+
+    if proxy.index.names == (None, ):  # Unnamed index, ignored
+      unbatcher = _UnbatchNoIndex(ctor)
+    else:  # MultiIndex
+      unbatcher = _UnbatchWithIndex(ctor)
+    return beam.ParDo(unbatcher)
+  elif isinstance(proxy, pd.Series):
+    # Raise a TypeError if proxy has an unknown type
+    output_type = _dtype_to_fieldtype(proxy.dtype)
+    # TODO: Should the index ever be included for a Series?
+    if _match_is_optional(output_type):
+
+      def unbatch(series):
+        for isnull, value in zip(pd.isnull(series), series):
+          yield None if isnull else value
+    else:
+
+      def unbatch(series):
+        yield from series
+
+    return beam.FlatMap(unbatch).with_output_types(output_type)
+  # TODO: What about scalar inputs?
+  else:
+    raise TypeError(
+        "Proxy '%s' has unsupported type '%s'" % (proxy, type(proxy)))
+
+
+def _dtype_to_fieldtype(dtype):
+  fieldtype = PANDAS_TO_BEAM.get(dtype)
+
+  if fieldtype is not None:
+    return fieldtype
+  elif dtype.kind is 'S':
+    return bytes
+  else:
+    raise TypeError("Unsupported dtype in proxy: '%s'" % dtype)
+
+
+@typehints.with_input_types(Union[pd.DataFrame, pd.Series])
+class UnbatchPandas(beam.PTransform):
+  """A transform that explodes a PCollection of DataFrame or Series. DataFrame
+  is converterd to a schema-aware PCollection, while Series is converted to its
+  underlying type.
+  """
+  def __init__(self, proxy):
+    self._proxy = proxy
+
+  def expand(self, pcoll):
+    return pcoll | _unbatch_transform(self._proxy)

--- a/sdks/python/apache_beam/dataframe/schemas.py
+++ b/sdks/python/apache_beam/dataframe/schemas.py
@@ -20,12 +20,11 @@ r"""Utilities for relating schema-aware PCollections and dataframe transforms.
 Imposes a mapping between native Python typings (specifically those compatible
 with apache_beam.typehints.schemas), and common pandas dtypes.
 
-  pandas dtype               Python typing
+  pandas dtype                    Python typing
   np.int{8,16,32,64}      <-----> np.int{8,16,32,64}*
   pd.Int{8,16,32,64}Dtype <-----> Optional[np.int{8,16,32,64}]*
   np.float{32,64}         <-----> Optional[np.float{32,64}]
                              \--- np.float{32,64}
-  np.dtype('S')           <-----> bytes
   Not supported           <------ Optional[bytes]
   np.bool                 <-----> np.bool
 
@@ -36,18 +35,13 @@ np.object:
 
   np.object               <-----> Any
 
-Strings and nullable Booleans are handled differently when using pandas 0.x vs.
-1.x. pandas 0.x has no mapping for these types, so they are shunted lossily to
-np.object.
+bytes, unicode strings and nullable Booleans are handled differently when using
+pandas 0.x vs. 1.x. pandas 0.x has no mapping for these types, so they are
+shunted to np.object.
 
-pandas 0.x:
+pandas 1.x Only:
 
-  np.object         <------ Optional[bool]
-                       \--- Optional[str]
-                        \-- str
-
-pandas 1.x:
-
+  np.dtype('S')     <-----> bytes
   pd.BooleanDType() <-----> Optional[bool]
   pd.StringDType()  <-----> Optional[str]
                        \--- str
@@ -184,7 +178,7 @@ def generate_proxy(element_type):
 
 
 def element_type_from_dataframe(proxy, include_indexes=False):
-  # type: (pd.DataFrame) -> type
+  # type: (pd.DataFrame, bool) -> type
 
   """Generate an element_type for an element-wise PCollection from a proxy
   pandas object. Currently only supports converting the element_type for

--- a/sdks/python/apache_beam/dataframe/schemas_test.py
+++ b/sdks/python/apache_beam/dataframe/schemas_test.py
@@ -21,13 +21,14 @@
 
 from __future__ import absolute_import
 
-import unittest
 import typing
+import unittest
 
 import future.tests.base  # pylint: disable=unused-import
+import numpy as np
 # patches unittest.testcase to be python3 compatible
 import pandas as pd
-import numpy as np
+from parameterized import parameterized
 from past.builtins import unicode
 
 import apache_beam as beam
@@ -38,7 +39,6 @@ from apache_beam.dataframe import transforms
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
-from parameterized import parameterized
 
 Simple = typing.NamedTuple(
     'Simple', [('name', unicode), ('id', int), ('height', float)])

--- a/sdks/python/apache_beam/dataframe/schemas_test.py
+++ b/sdks/python/apache_beam/dataframe/schemas_test.py
@@ -22,11 +22,12 @@
 from __future__ import absolute_import
 
 import unittest
-from typing import NamedTuple
+import typing
 
 import future.tests.base  # pylint: disable=unused-import
 # patches unittest.testcase to be python3 compatible
 import pandas as pd
+import numpy as np
 from past.builtins import unicode
 
 import apache_beam as beam
@@ -36,11 +37,14 @@ from apache_beam.dataframe import schemas
 from apache_beam.dataframe import transforms
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that
+from apache_beam.testing.util import equal_to
+from parameterized import parameterized
 
-Simple = NamedTuple(
+Simple = typing.NamedTuple(
     'Simple', [('name', unicode), ('id', int), ('height', float)])
 coders_registry.register_coder(Simple, RowCoder)
-Animal = NamedTuple('Animal', [('animal', unicode), ('max_speed', float)])
+Animal = typing.NamedTuple(
+    'Animal', [('animal', unicode), ('max_speed', typing.Optional[float])])
 coders_registry.register_coder(Animal, RowCoder)
 
 
@@ -57,6 +61,50 @@ def matches_df(expected):
           (sorted_actual, sorted_expected))
 
   return check_df_pcoll_equal
+
+
+# Test data for all supported types that can be easily tested.
+# Excludes bytes because it's difficult to create a series and dataframe bytes
+# dtype. For example:
+#   pd.Series([b'abc'], dtype=bytes).dtype != 'S'
+#   pd.Series([b'abc'], dtype=bytes).astype(bytes).dtype == 'S'
+COLUMNS = [
+    ([375, 24, 0, 10, 16], np.int32, 'i32'),
+    ([375, 24, 0, 10, 16], np.int64, 'i64'),
+    ([375, 24, None, 10, 16], pd.Int32Dtype(), 'i32_nullable'),
+    ([375, 24, None, 10, 16], pd.Int64Dtype(), 'i64_nullable'),
+    ([375., 24., None, 10., 16.], np.float64, 'f64'),
+    ([375., 24., None, 10., 16.], np.float32, 'f32'),
+    ([True, False, True, True, False], np.bool, 'bool'),
+    (['Falcon', 'Ostrich', None, 3.14, 0], np.object, 'any'),
+]
+
+if schemas.PD_MAJOR >= 1:
+  COLUMNS.extend([
+      ([True, False, True, None, False], pd.BooleanDtype(), 'bool_nullable'),
+      (['Falcon', 'Ostrich', None, 'Aardvark', 'Elephant'],
+       pd.StringDtype(),
+       'strdtype'),
+  ])
+
+NICE_TYPES_DF = pd.DataFrame({
+    name: pd.Series(arr, dtype=dtype, name=name)
+    for arr,
+    dtype,
+    name in COLUMNS
+})
+NICE_TYPES_PROXY = NICE_TYPES_DF[:0]
+
+SERIES_TESTS = [(pd.Series(arr, dtype=dtype, name=name), arr) for arr,
+                dtype,
+                name in COLUMNS]
+
+DF_RESULT = list(zip(*(arr for arr, _, _ in COLUMNS)))
+DF_TESTS = [(
+    NICE_TYPES_DF
+    if i == 0 else NICE_TYPES_DF.set_index([name
+                                            for _, _, name in COLUMNS[:i]]),
+    DF_RESULT) for i in range(len(COLUMNS) + 1)]
 
 
 class SchemasTest(unittest.TestCase):
@@ -79,10 +127,27 @@ class SchemasTest(unittest.TestCase):
 
   def test_generate_proxy(self):
     expected = pd.DataFrame({
-        'animal': pd.Series(dtype=unicode), 'max_speed': pd.Series(dtype=float)
+        'animal': pd.Series(
+            dtype=np.object if schemas.PD_MAJOR < 1 else pd.StringDtype()),
+        'max_speed': pd.Series(dtype=np.float64)
     })
 
     self.assertTrue(schemas.generate_proxy(Animal).equals(expected))
+
+  def test_nice_types_proxy_roundtrip(self):
+    roundtripped = schemas.generate_proxy(
+        schemas.element_type_from_proxy(NICE_TYPES_PROXY))
+    self.assertTrue(roundtripped.equals(NICE_TYPES_PROXY))
+
+  # TODO
+  @unittest.skip
+  def test_bytes_proxy_roundtrip(self):
+    proxy = pd.DataFrame({'bytes': []})
+    proxy.bytes = proxy.bytes.astype(bytes)
+
+    roundtripped = schemas.generate_proxy(
+        schemas.element_type_from_proxy(proxy))
+    self.assertTrue(roundtripped.equals(proxy))
 
   def test_batch_with_df_transform(self):
     with TestPipeline() as p:
@@ -99,12 +164,18 @@ class SchemasTest(unittest.TestCase):
               lambda df: df.groupby('animal').mean(),
               # TODO: Generate proxy in this case as well
               proxy=schemas.generate_proxy(Animal)))
-      assert_that(
-          res,
-          matches_df(
-              pd.DataFrame({'max_speed': [375.0, 25.0]},
-                           index=pd.Index(
-                               data=['Falcon', 'Parrot'], name='animal'))))
+      assert_that(res, equal_to([('Falcon', 375.), ('Parrot', 25.)]))
+
+  @parameterized.expand(SERIES_TESTS + DF_TESTS)
+  def test_unbatch(self, df_or_series, rows):
+    proxy = df_or_series[:0]
+
+    with TestPipeline() as p:
+      res = (
+          p | beam.Create([df_or_series[::2], df_or_series[1::2]])
+          | schemas.UnbatchPandas(proxy))
+
+      assert_that(res, equal_to(rows))
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/dataframe/transforms.py
+++ b/sdks/python/apache_beam/dataframe/transforms.py
@@ -60,9 +60,10 @@ class DataframeTransform(transforms.PTransform):
   passed to the callable as positional arguments, or a dictionary of
   PCollections, in which case they will be passed as keyword arguments.
   """
-  def __init__(self, func, proxy=None):
+  def __init__(self, func, proxy=None, yield_dataframes=False):
     self._func = func
     self._proxy = proxy
+    self._yield_dataframes = yield_dataframes
 
   def expand(self, input_pcolls):
     # Avoid circular import.
@@ -93,7 +94,10 @@ class DataframeTransform(transforms.PTransform):
     keys = list(result_frames_dict.keys())
     result_frames_tuple = tuple(result_frames_dict[key] for key in keys)
     result_pcolls_tuple = convert.to_pcollection(
-        *result_frames_tuple, label='Eval', always_return_tuple=True)
+        *result_frames_tuple,
+        label='Eval',
+        always_return_tuple=True,
+        yield_dataframes=self._yield_dataframes)
 
     # Convert back to the structure returned by self._func.
     result_pcolls_dict = dict(zip(keys, result_pcolls_tuple))

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -132,6 +132,7 @@ _BEAM_SCHEMA_ID = "_beam_schema_id"
 
 
 def named_fields_to_schema(names_and_types):
+  # type: Sequence[Tuple[str, typ]] -> schema_pb2.Schema
   return schema_pb2.Schema(
       fields=[
           schema_pb2.Field(name=name, type=typing_to_runner_api(type))

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -132,7 +132,7 @@ _BEAM_SCHEMA_ID = "_beam_schema_id"
 
 
 def named_fields_to_schema(names_and_types):
-  # type: Sequence[Tuple[str, typ]] -> schema_pb2.Schema
+  # type: (Sequence[Tuple[str, type]]) -> schema_pb2.Schema
   return schema_pb2.Schema(
       fields=[
           schema_pb2.Field(name=name, type=typing_to_runner_api(type))

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -53,6 +53,7 @@ wrapping the type in :code:`Optional`.
 
 from __future__ import absolute_import
 
+from typing import Any
 from typing import ByteString
 from typing import Generic
 from typing import Mapping
@@ -75,6 +76,8 @@ from apache_beam.typehints.native_type_compatibility import _safe_issubclass
 from apache_beam.typehints.native_type_compatibility import extract_optional_type
 from apache_beam.utils import proto_utils
 from apache_beam.utils.timestamp import Timestamp
+
+PYTHON_ANY_URN = "beam:logical:pythonsdk_any:v1"
 
 
 # Registry of typings for a schema by UUID
@@ -192,7 +195,9 @@ def typing_to_runner_api(type_):
   try:
     logical_type = LogicalType.from_typing(type_)
   except ValueError:
-    raise ValueError("Unsupported type: %s" % type_)
+    # Unknown type, just treat it like Any
+    return schema_pb2.FieldType(
+        logical_type=schema_pb2.LogicalType(urn=PYTHON_ANY_URN))
   else:
     # TODO(bhulette): Add support for logical types that require arguments
     return schema_pb2.FieldType(
@@ -252,8 +257,11 @@ def typing_from_runner_api(fieldtype_proto):
     return user_type
 
   elif type_info == "logical_type":
-    return LogicalType.from_runner_api(
-        fieldtype_proto.logical_type).language_type()
+    if fieldtype_proto.logical_type.urn == PYTHON_ANY_URN:
+      return Any
+    else:
+      return LogicalType.from_runner_api(
+          fieldtype_proto.logical_type).language_type()
 
 
 def _hydrate_namedtuple_instance(encoded_schema, values):

--- a/sdks/python/apache_beam/typehints/schemas_test.py
+++ b/sdks/python/apache_beam/typehints/schemas_test.py
@@ -188,8 +188,12 @@ class SchemaTest(unittest.TestCase):
       self.assertEqual(
           test_case, typing_to_runner_api(typing_from_runner_api(test_case)))
 
-  def test_unknown_primitive_raise_valueerror(self):
-    self.assertRaises(ValueError, lambda: typing_to_runner_api(np.uint32))
+  def test_unknown_primitive_maps_to_any(self):
+    self.assertEqual(
+        typing_to_runner_api(np.uint32),
+        schema_pb2.FieldType(
+            logical_type=schema_pb2.LogicalType(
+                urn="beam:logical:pythonsdk_any:v1")))
 
   def test_unknown_atomic_raise_valueerror(self):
     self.assertRaises(


### PR DESCRIPTION
This PR adds the ability for `DataframeTransform` to produce element-wise PCollections, via a new `UnbatchPandas` transform. The original behavior is still available, with a `yield_dataframes=True` option.

In order to support this, the PR also adds more robust support for converting between native Python types and pandas/numpy dtypes. Note that pandas' catch-all `np.object` type is mapped to `typing.Any`. This PR also closes BEAM-10570 - it adds support for RowCoder to encode fields with arbitrary Python types using FastPrimitivesCoder.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
