### PR TITLE
[BEAM-10861]Adds PubSub Runner API encoding to Read/Write transforms

### DIFF
--- a/model/pipeline/src/main/proto/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/beam_runner_api.proto
@@ -324,6 +324,12 @@ message StandardPTransforms {
 
     // Less well-known. Payload: WriteFilesPayload.
     WRITE_FILES = 3 [(beam_urn) = "beam:transform:write_files:v1"];
+
+    // Payload: PubSubReadPayload.
+    PUBSUB_READ = 4 [(beam_urn) = "beam:transform:pubsub_read:v1"];
+
+    // Payload: PubSubWritePayload.
+    PUBSUB_WRITE = 5 [(beam_urn) = "beam:transform:pubsub_write:v1"];
   }
   // Payload for all of these: CombinePayload
   enum CombineComponents {
@@ -648,6 +654,46 @@ message WriteFilesPayload {
   bool runner_determined_sharding = 4;
 
   map<string, SideInput> side_inputs = 5;
+}
+
+// Payload used by Google Cloud Pub/Sub read transform.
+// This can be used by runners that wish to override Beam Pub/Sub read transform
+// with a native implementation.
+message PubSubReadPayload {
+
+  // Topic to read from. Exactly one of topic or subscription should be set.
+  string topic = 1;
+
+  // Subscription to read from. Exactly one of topic or subscription should be set.
+  string subscription = 2;
+
+  // Attribute that provides element timestamps.
+  string timestamp_attribute = 3;
+
+  // Attribute to be used for uniquely identifying messages.
+  string id_attribute = 4;
+
+  // If true, reads Pub/Sub payload as well as attributes. If false, reads only the payload.
+  bool with_attributes = 5;
+}
+
+// Payload used by Google Cloud Pub/Sub write transform.
+// This can be used by runners that wish to override Beam Pub/Sub write transform
+// with a native implementation.
+message PubSubWritePayload {
+
+  // Topic to write to.
+  string topic = 1;
+
+  // Attribute that provides element timestamps.
+  string timestamp_attribute = 2;
+
+  // Attribute that uniquely identify messages.
+  string id_attribute = 3;
+
+  // If true, writes Pub/Sub payload as well as attributes. If false, reads only the payload.
+  // TODO(BEAM-10869): consider removing/deprecating this field when fixed.
+  bool with_attributes = 4;
 }
 
 // A coder, the binary format for serialization and deserialization of data in

--- a/sdks/python/apache_beam/io/gcp/pubsub_test.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub_test.py
@@ -600,9 +600,9 @@ class TestReadFromPubSub(unittest.TestCase):
         common_urns.composites.PUBSUB_READ.urn, proto_transform_spec.urn)
 
     pubsub_read_payload = (
-      proto_utils.parse_Bytes(
-          proto_transform_spec.payload,
-          beam_runner_api_pb2.PubSubReadPayload))
+        proto_utils.parse_Bytes(
+            proto_transform_spec.payload,
+            beam_runner_api_pb2.PubSubReadPayload))
     self.assertEqual(
         'projects/fakeprj/topics/a_topic', pubsub_read_payload.topic)
     self.assertEqual('a_label', pubsub_read_payload.id_attribute)
@@ -638,9 +638,9 @@ class TestReadFromPubSub(unittest.TestCase):
         common_urns.composites.PUBSUB_READ.urn, proto_transform_spec.urn)
 
     pubsub_read_payload = (
-      proto_utils.parse_Bytes(
-          proto_transform_spec.payload,
-          beam_runner_api_pb2.PubSubReadPayload))
+        proto_utils.parse_Bytes(
+            proto_transform_spec.payload,
+            beam_runner_api_pb2.PubSubReadPayload))
     self.assertEqual(
         'projects/fakeprj/subscriptions/a_subscription',
         pubsub_read_payload.subscription)
@@ -660,6 +660,7 @@ class TestReadFromPubSub(unittest.TestCase):
     self.assertEqual(
         'projects/fakeprj/subscriptions/a_subscription',
         transform_from_proto.source.full_subscription)
+
 
 @unittest.skipIf(pubsub is None, 'GCP dependencies are not installed')
 @mock.patch('google.cloud.pubsub.PublisherClient')

--- a/sdks/python/apache_beam/io/gcp/pubsub_test.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub_test.py
@@ -32,6 +32,8 @@ import hamcrest as hc
 import mock
 
 import apache_beam as beam
+from apache_beam.io import Read
+from apache_beam.io import Write
 from apache_beam.io.gcp.pubsub import PubsubMessage
 from apache_beam.io.gcp.pubsub import ReadFromPubSub
 from apache_beam.io.gcp.pubsub import ReadStringsFromPubSub
@@ -41,6 +43,9 @@ from apache_beam.io.gcp.pubsub import _PubSubSink
 from apache_beam.io.gcp.pubsub import _PubSubSource
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import StandardOptions
+from apache_beam.portability import common_urns
+from apache_beam.portability.api import beam_runner_api_pb2
+from apache_beam.runners import pipeline_context
 from apache_beam.runners.direct import transform_evaluator
 from apache_beam.runners.direct.direct_runner import _DirectReadFromPubSub
 from apache_beam.runners.direct.direct_runner import _get_transform_overrides
@@ -54,6 +59,7 @@ from apache_beam.transforms import window
 from apache_beam.transforms.core import Create
 from apache_beam.transforms.display import DisplayData
 from apache_beam.transforms.display_test import DisplayDataItemMatcher
+from apache_beam.utils import proto_utils
 from apache_beam.utils import timestamp
 
 # Protect against environments where the PubSub library is not available.
@@ -579,6 +585,81 @@ class TestReadFromPubSub(unittest.TestCase):
             p | ReadFromPubSub(
                 'projects/fakeprj/topics/a_topic', None, 'a_label'))
 
+  def test_runner_api_transformation_with_topic(self, unused_mock_pubsub):
+    source = _PubSubSource(
+        topic='projects/fakeprj/topics/a_topic',
+        subscription=None,
+        id_label='a_label',
+        timestamp_attribute='b_label',
+        with_attributes=True)
+    transform = Read(source)
+
+    context = pipeline_context.PipelineContext()
+    proto_transform_spec = transform.to_runner_api(context)
+    self.assertEqual(
+        common_urns.composites.PUBSUB_READ.urn, proto_transform_spec.urn)
+
+    pubsub_read_payload = (
+      proto_utils.parse_Bytes(
+          proto_transform_spec.payload,
+          beam_runner_api_pb2.PubSubReadPayload))
+    self.assertEqual(
+        'projects/fakeprj/topics/a_topic', pubsub_read_payload.topic)
+    self.assertEqual('a_label', pubsub_read_payload.id_attribute)
+    self.assertEqual('b_label', pubsub_read_payload.timestamp_attribute)
+    self.assertEqual('', pubsub_read_payload.subscription)
+    self.assertTrue(pubsub_read_payload.with_attributes)
+
+    proto_transform = beam_runner_api_pb2.PTransform(
+        unique_name="dummy_label", spec=proto_transform_spec)
+
+    transform_from_proto = Read.from_runner_api_parameter(
+        proto_transform, pubsub_read_payload, None)
+    self.assertTrue(isinstance(transform_from_proto, Read))
+    self.assertTrue(isinstance(transform_from_proto.source, _PubSubSource))
+    self.assertEqual(
+        'projects/fakeprj/topics/a_topic',
+        transform_from_proto.source.full_topic)
+    self.assertTrue(transform_from_proto.source.with_attributes)
+
+  def test_runner_api_transformation_with_subscription(
+      self, unused_mock_pubsub):
+    source = _PubSubSource(
+        topic=None,
+        subscription='projects/fakeprj/subscriptions/a_subscription',
+        id_label='a_label',
+        timestamp_attribute='b_label',
+        with_attributes=True)
+    transform = Read(source)
+
+    context = pipeline_context.PipelineContext()
+    proto_transform_spec = transform.to_runner_api(context)
+    self.assertEqual(
+        common_urns.composites.PUBSUB_READ.urn, proto_transform_spec.urn)
+
+    pubsub_read_payload = (
+      proto_utils.parse_Bytes(
+          proto_transform_spec.payload,
+          beam_runner_api_pb2.PubSubReadPayload))
+    self.assertEqual(
+        'projects/fakeprj/subscriptions/a_subscription',
+        pubsub_read_payload.subscription)
+    self.assertEqual('a_label', pubsub_read_payload.id_attribute)
+    self.assertEqual('b_label', pubsub_read_payload.timestamp_attribute)
+    self.assertEqual('', pubsub_read_payload.topic)
+    self.assertTrue(pubsub_read_payload.with_attributes)
+
+    proto_transform = beam_runner_api_pb2.PTransform(
+        unique_name="dummy_label", spec=proto_transform_spec)
+
+    transform_from_proto = Read.from_runner_api_parameter(
+        proto_transform, pubsub_read_payload, None)
+    self.assertTrue(isinstance(transform_from_proto, Read))
+    self.assertTrue(isinstance(transform_from_proto.source, _PubSubSource))
+    self.assertTrue(transform_from_proto.source.with_attributes)
+    self.assertEqual(
+        'projects/fakeprj/subscriptions/a_subscription',
+        transform_from_proto.source.full_subscription)
 
 @unittest.skipIf(pubsub is None, 'GCP dependencies are not installed')
 @mock.patch('google.cloud.pubsub.PublisherClient')
@@ -670,6 +751,40 @@ class TestWriteToPubSub(unittest.TestCase):
             | WriteToPubSub(
                 'projects/fakeprj/topics/a_topic',
                 timestamp_attribute='timestamp'))
+
+  def test_runner_api_transformation(self, unused_mock_pubsub):
+    sink = _PubSubSink(
+        topic='projects/fakeprj/topics/a_topic',
+        id_label=None,
+        with_attributes=True,
+        # We expect encoded PubSub write transform to always return attributes.
+        timestamp_attribute=None)
+    transform = Write(sink)
+
+    context = pipeline_context.PipelineContext()
+    proto_transform_spec = transform.to_runner_api(context)
+    self.assertEqual(
+        common_urns.composites.PUBSUB_WRITE.urn, proto_transform_spec.urn)
+
+    pubsub_write_payload = (
+        proto_utils.parse_Bytes(
+            proto_transform_spec.payload,
+            beam_runner_api_pb2.PubSubWritePayload))
+
+    self.assertEqual(
+        'projects/fakeprj/topics/a_topic', pubsub_write_payload.topic)
+    self.assertTrue(pubsub_write_payload.with_attributes)
+
+    proto_transform = beam_runner_api_pb2.PTransform(
+        unique_name="dummy_label", spec=proto_transform_spec)
+
+    transform_from_proto = Write.from_runner_api_parameter(
+        proto_transform, pubsub_write_payload, None)
+    self.assertTrue(isinstance(transform_from_proto, Write))
+    self.assertTrue(isinstance(transform_from_proto.sink, _PubSubSink))
+    self.assertTrue(transform_from_proto.sink.with_attributes)
+    self.assertEqual(
+        'projects/fakeprj/topics/a_topic', transform_from_proto.sink.full_topic)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -921,29 +921,50 @@ class Read(ptransform.PTransform):
     }
 
   def to_runner_api_parameter(self, context):
-    # type: (PipelineContext) -> Tuple[str, beam_runner_api_pb2.ReadPayload]
+    # type: (PipelineContext) -> Tuple[str, Any]
     from apache_beam.runners.dataflow.native_io import iobase as dataflow_io
     if isinstance(self.source, (BoundedSource, dataflow_io.NativeSource)):
+      from apache_beam.io.gcp.pubsub import _PubSubSource
+      if isinstance(self.source, _PubSubSource):
+        return (
+          common_urns.composites.PUBSUB_READ.urn,
+          beam_runner_api_pb2.PubSubReadPayload(
+              topic=self.source.full_topic,
+              subscription=self.source.full_subscription,
+              timestamp_attribute=self.source.timestamp_attribute,
+              with_attributes=self.source.with_attributes,
+              id_attribute=self.source.id_label))
       return (
-          common_urns.deprecated_primitives.READ.urn,
-          beam_runner_api_pb2.ReadPayload(
-              source=self.source.to_runner_api(context),
-              is_bounded=beam_runner_api_pb2.IsBounded.BOUNDED
-              if self.source.is_bounded() else
-              beam_runner_api_pb2.IsBounded.UNBOUNDED))
+        common_urns.deprecated_primitives.READ.urn,
+        beam_runner_api_pb2.ReadPayload(
+            source=self.source.to_runner_api(context),
+            is_bounded=beam_runner_api_pb2.IsBounded.BOUNDED
+            if self.source.is_bounded() else
+            beam_runner_api_pb2.IsBounded.UNBOUNDED))
     elif isinstance(self.source, ptransform.PTransform):
       return self.source.to_runner_api_parameter(context)
 
   @staticmethod
-  def from_runner_api_parameter(unused_ptransform, parameter, context):
-    # type: (beam_runner_api_pb2.ReadPayload, PipelineContext) -> Read
-    return Read(SourceBase.from_runner_api(parameter.source, context))
-
-
-ptransform.PTransform.register_urn(
-    common_urns.deprecated_primitives.READ.urn,
-    beam_runner_api_pb2.ReadPayload,
-    Read.from_runner_api_parameter)
+  @ptransform.PTransform.register_urn(
+      common_urns.deprecated_primitives.READ.urn,
+      beam_runner_api_pb2.ReadPayload)
+  @ptransform.PTransform.register_urn(
+      common_urns.composites.PUBSUB_READ.urn,
+      beam_runner_api_pb2.PubSubReadPayload)
+  def from_runner_api_parameter(transform, payload, context):
+    # type: (Any, Any, PipelineContext) -> Read
+    if transform.spec.urn == common_urns.composites.PUBSUB_READ.urn:
+      # Importing locally to prevent circular dependencies.
+      from apache_beam.io.gcp.pubsub import _PubSubSource
+      source = _PubSubSource(
+          topic=payload.topic,
+          subscription=payload.subscription,
+          id_label=payload.id_attribute,
+          with_attributes=payload.with_attributes,
+          timestamp_attribute=payload.timestamp_attribute)
+      return Read(source)
+    else:
+      return Read(SourceBase.from_runner_api(payload.source, context))
 
 
 class Write(ptransform.PTransform):
@@ -1000,6 +1021,40 @@ class Write(ptransform.PTransform):
       raise ValueError(
           'A sink must inherit iobase.Sink, iobase.NativeSink, '
           'or be a PTransform. Received : %r' % self.sink)
+
+  def to_runner_api_parameter(self, context):
+    # type: (PipelineContext) -> Tuple[str, Any]
+    # Importing locally to prevent circular dependencies.
+    from apache_beam.io.gcp.pubsub import _PubSubSink
+    if isinstance(self.sink, _PubSubSink):
+      payload = beam_runner_api_pb2.PubSubWritePayload(
+          topic=self.sink.full_topic,
+          id_attribute=self.sink.id_label,
+          timestamp_attribute=self.sink.timestamp_attribute,
+          with_attributes=self.sink.with_attributes)
+      return (common_urns.composites.PUBSUB_WRITE.urn, payload)
+    else:
+      return super(Write, self).to_runner_api_parameter(context)
+
+  @staticmethod
+  @ptransform.PTransform.register_urn(
+      common_urns.composites.PUBSUB_WRITE.urn,
+      beam_runner_api_pb2.PubSubWritePayload)
+  def from_runner_api_parameter(ptransform, payload, unused_context):
+    # type: (Any, Any, PipelineContext) -> Write
+    if ptransform.spec.urn != common_urns.composites.PUBSUB_WRITE.urn:
+      raise ValueError(
+          'Write transform cannot be constructed for the given proto %r',
+          ptransform)
+
+    # Importing locally to prevent circular dependencies.
+    from apache_beam.io.gcp.pubsub import _PubSubSink
+    sink = _PubSubSink(
+        topic=payload.topic,
+        id_label=payload.id_attribute,
+        with_attributes=payload.with_attributes,
+        timestamp_attribute=payload.timestamp_attribute)
+    return Write(sink)
 
 
 class WriteImpl(ptransform.PTransform):

--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -927,20 +927,20 @@ class Read(ptransform.PTransform):
       from apache_beam.io.gcp.pubsub import _PubSubSource
       if isinstance(self.source, _PubSubSource):
         return (
-          common_urns.composites.PUBSUB_READ.urn,
-          beam_runner_api_pb2.PubSubReadPayload(
-              topic=self.source.full_topic,
-              subscription=self.source.full_subscription,
-              timestamp_attribute=self.source.timestamp_attribute,
-              with_attributes=self.source.with_attributes,
-              id_attribute=self.source.id_label))
+            common_urns.composites.PUBSUB_READ.urn,
+            beam_runner_api_pb2.PubSubReadPayload(
+                topic=self.source.full_topic,
+                subscription=self.source.full_subscription,
+                timestamp_attribute=self.source.timestamp_attribute,
+                with_attributes=self.source.with_attributes,
+                id_attribute=self.source.id_label))
       return (
-        common_urns.deprecated_primitives.READ.urn,
-        beam_runner_api_pb2.ReadPayload(
-            source=self.source.to_runner_api(context),
-            is_bounded=beam_runner_api_pb2.IsBounded.BOUNDED
-            if self.source.is_bounded() else
-            beam_runner_api_pb2.IsBounded.UNBOUNDED))
+          common_urns.deprecated_primitives.READ.urn,
+          beam_runner_api_pb2.ReadPayload(
+              source=self.source.to_runner_api(context),
+              is_bounded=beam_runner_api_pb2.IsBounded.BOUNDED
+              if self.source.is_bounded() else
+              beam_runner_api_pb2.IsBounded.UNBOUNDED))
     elif isinstance(self.source, ptransform.PTransform):
       return self.source.to_runner_api_parameter(context)
 


### PR DESCRIPTION
This seems to be the correct place for this encoding since we would not want to override the full expansion of ReadFromPubSub/WriteToPubSub transforms.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python2_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python35_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
