### PR TITLE
[BEAM-10959] Store a fixed amount of known process bundle instructions to prevent failures due to concurrency within a runner.

### DIFF
--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -367,7 +367,7 @@ class BundleProcessorCache(object):
     self.fns[bundle_descriptor.id] = bundle_descriptor
 
   def activate(self, instruction_id):
-    # type: str -> None
+    # type: (str) -> None
 
     """Makes the ``instruction_id`` known to the bundle processor.
 

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -449,7 +449,7 @@ class BundleProcessorCache(object):
     with self._lock:
       self.failed_instruction_ids[instruction_id] = True
       while len(self.failed_instruction_ids) > MAX_FAILED_INSTRUCTIONS:
-        self.failed_instruction_ids.popitem()
+        self.failed_instruction_ids.popitem(last=False)
       processor = self.active_bundle_processors[instruction_id][1]
       del self.active_bundle_processors[instruction_id]
 
@@ -469,7 +469,7 @@ class BundleProcessorCache(object):
       self.known_not_running_instruction_ids[instruction_id] = True
       while len(self.known_not_running_instruction_ids
                 ) > MAX_KNOWN_NOT_RUNNING_INSTRUCTIONS:
-        self.known_not_running_instruction_ids.popitem()
+        self.known_not_running_instruction_ids.popitem(last=False)
       descriptor_id, processor = (
           self.active_bundle_processors.pop(instruction_id))
 

--- a/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker_test.py
@@ -32,6 +32,7 @@ from builtins import range
 from collections import namedtuple
 
 import grpc
+import hamcrest as hc
 import mock
 
 from apache_beam.coders import VarIntCoder
@@ -42,6 +43,7 @@ from apache_beam.portability.api import metrics_pb2
 from apache_beam.runners.worker import sdk_worker
 from apache_beam.runners.worker import statecache
 from apache_beam.runners.worker import statesampler
+from apache_beam.runners.worker.sdk_worker import BundleProcessorCache
 from apache_beam.runners.worker.sdk_worker import CachingStateHandler
 from apache_beam.runners.worker.sdk_worker import SdkWorker
 from apache_beam.utils import thread_pool_executor
@@ -133,6 +135,96 @@ class SdkWorkerTest(unittest.TestCase):
         1,
         lull_duration_s * 1e9,
         threading.current_thread())
+
+  def test_inactive_bundle_processor_returns_empty_progress_response(self):
+    bundle_processor = mock.MagicMock()
+    bundle_processor_cache = BundleProcessorCache(None, None, {})
+    bundle_processor_cache.activate('instruction_id')
+    worker = SdkWorker(bundle_processor_cache)
+    split_request = beam_fn_api_pb2.InstructionRequest(
+        instruction_id='progress_instruction_id',
+        process_bundle_progress=beam_fn_api_pb2.ProcessBundleProgressRequest(
+            instruction_id='instruction_id'))
+    self.assertEqual(
+        worker.do_instruction(split_request),
+        beam_fn_api_pb2.InstructionResponse(
+            instruction_id='progress_instruction_id',
+            process_bundle_progress=beam_fn_api_pb2.
+            ProcessBundleProgressResponse()))
+
+    # Add a mock bundle processor as if it was running before it's released
+    bundle_processor_cache.active_bundle_processors['instruction_id'] = (
+        'descriptor_id', bundle_processor)
+    bundle_processor_cache.release('instruction_id')
+    self.assertEqual(
+        worker.do_instruction(split_request),
+        beam_fn_api_pb2.InstructionResponse(
+            instruction_id='progress_instruction_id',
+            process_bundle_progress=beam_fn_api_pb2.
+            ProcessBundleProgressResponse()))
+
+  def test_failed_bundle_processor_returns_failed_progress_response(self):
+    bundle_processor = mock.MagicMock()
+    bundle_processor_cache = BundleProcessorCache(None, None, {})
+    bundle_processor_cache.activate('instruction_id')
+    worker = SdkWorker(bundle_processor_cache)
+
+    # Add a mock bundle processor as if it was running before it's discarded
+    bundle_processor_cache.active_bundle_processors['instruction_id'] = (
+        'descriptor_id', bundle_processor)
+    bundle_processor_cache.discard('instruction_id')
+    split_request = beam_fn_api_pb2.InstructionRequest(
+        instruction_id='progress_instruction_id',
+        process_bundle_progress=beam_fn_api_pb2.ProcessBundleProgressRequest(
+            instruction_id='instruction_id'))
+    hc.assert_that(
+        worker.do_instruction(split_request).error,
+        hc.contains_string(
+            'Bundle processing associated with instruction_id has failed'))
+
+  def test_inactive_bundle_processor_returns_empty_split_response(self):
+    bundle_processor = mock.MagicMock()
+    bundle_processor_cache = BundleProcessorCache(None, None, {})
+    bundle_processor_cache.activate('instruction_id')
+    worker = SdkWorker(bundle_processor_cache)
+    split_request = beam_fn_api_pb2.InstructionRequest(
+        instruction_id='split_instruction_id',
+        process_bundle_split=beam_fn_api_pb2.ProcessBundleSplitRequest(
+            instruction_id='instruction_id'))
+    self.assertEqual(
+        worker.do_instruction(split_request),
+        beam_fn_api_pb2.InstructionResponse(
+            instruction_id='split_instruction_id',
+            process_bundle_split=beam_fn_api_pb2.ProcessBundleSplitResponse()))
+
+    # Add a mock bundle processor as if it was running before it's released
+    bundle_processor_cache.active_bundle_processors['instruction_id'] = (
+        'descriptor_id', bundle_processor)
+    bundle_processor_cache.release('instruction_id')
+    self.assertEqual(
+        worker.do_instruction(split_request),
+        beam_fn_api_pb2.InstructionResponse(
+            instruction_id='split_instruction_id',
+            process_bundle_split=beam_fn_api_pb2.ProcessBundleSplitResponse()))
+
+  def test_failed_bundle_processor_returns_failed_split_response(self):
+    bundle_processor = mock.MagicMock()
+    bundle_processor_cache = BundleProcessorCache(None, None, {})
+    bundle_processor_cache.activate('instruction_id')
+    worker = SdkWorker(bundle_processor_cache)
+
+    # Add a mock bundle processor as if it was running before it's discarded
+    bundle_processor_cache.active_bundle_processors['instruction_id'] = (
+        'descriptor_id', bundle_processor)
+    bundle_processor_cache.discard('instruction_id')
+    split_request = beam_fn_api_pb2.InstructionRequest(
+        instruction_id='split_instruction_id',
+        process_bundle_split=beam_fn_api_pb2.ProcessBundleSplitRequest(
+            instruction_id='instruction_id'))
+    hc.assert_that(
+        worker.do_instruction(split_request).error,
+        hc.contains_string(
+            'Bundle processing associated with instruction_id has failed'))
 
   def test_log_lull_in_bundle_processor(self):
     bundle_processor_cache = mock.MagicMock()


### PR DESCRIPTION

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
