### PR TITLE
Minor programming guide improvements

### DIFF
--- a/sdks/python/apache_beam/examples/snippets/snippets_test.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets_test.py
@@ -1011,12 +1011,10 @@ class SnippetsTest(unittest.TestCase):
           | 'pair_with_one' >> beam.Map(lambda x: (x, 1)))
 
       counts = (
-          # [START model_setting_trigger]
           pcollection | WindowInto(
               FixedWindows(1 * 60),
               trigger=AfterProcessingTime(10 * 60),
               accumulation_mode=AccumulationMode.DISCARDING)
-          # [END model_setting_trigger]
           | 'group' >> beam.GroupByKey()
           | 'count' >>
           beam.Map(lambda word_ones: (word_ones[0], sum(word_ones[1]))))

--- a/website/www/site/content/en/documentation/programming-guide.md
+++ b/website/www/site/content/en/documentation/programming-guide.md
@@ -4000,7 +4000,10 @@ sets the window's **accumulation mode**.
 {{< /highlight >}}
 
 {{< highlight py >}}
-{{< code_sample "sdks/python/apache_beam/examples/snippets/snippets_test.py" model_setting_trigger >}}
+  pcollection | WindowInto(
+    FixedWindows(1 * 60),
+    trigger=AfterProcessingTime(1 * 60),
+    accumulation_mode=AccumulationMode.DISCARDING)
 {{< /highlight >}}
 
 #### 9.4.1. Window accumulation modes {#window-accumulation-modes}

--- a/website/www/site/content/en/documentation/programming-guide.md
+++ b/website/www/site/content/en/documentation/programming-guide.md
@@ -3554,8 +3554,8 @@ Now, consider the same pipeline, but using a windowing function:
 
 **Figure 5:** `GroupByKey` and `ParDo` with windowing, on a bounded collection.
 
-As before, the pipeline creates a bounded `PCollection` of file lines. We
-then set a [windowing function](#setting-your-pcollections-windowing-function)
+As before, the pipeline creates a bounded `PCollection` by reading lines from a
+file. We then set a [windowing function](#setting-your-pcollections-windowing-function)
 for that `PCollection`.  The `GroupByKey` transform groups the elements of the
 `PCollection` by both key and window, based on the windowing function. The
 subsequent `ParDo` transform gets applied multiple times per key, once for each

--- a/website/www/site/content/en/documentation/programming-guide.md
+++ b/website/www/site/content/en/documentation/programming-guide.md
@@ -3539,8 +3539,8 @@ pipeline processes data, consider the following pipeline:
 
 **Figure 4:** `GroupByKey` and `ParDo` without windowing, on a bounded collection.
 
-In the above pipeline, we create a bounded `PCollection` by reading a set of
-key/value pairs using `TextIO`. We then group the collection using `GroupByKey`,
+In the above pipeline, we create a bounded `PCollection` by reading lines from a
+file using `TextIO`. We then group the collection using `GroupByKey`,
 and apply a `ParDo` transform to the grouped `PCollection`. In this example, the
 `GroupByKey` creates a collection of unique keys, and then `ParDo` gets applied
 exactly once per key.
@@ -3554,7 +3554,7 @@ Now, consider the same pipeline, but using a windowing function:
 
 **Figure 5:** `GroupByKey` and `ParDo` with windowing, on a bounded collection.
 
-As before, the pipeline creates a bounded `PCollection` of key/value pairs. We
+As before, the pipeline creates a bounded `PCollection` of file lines. We
 then set a [windowing function](#setting-your-pcollections-windowing-function)
 for that `PCollection`.  The `GroupByKey` transform groups the elements of the
 `PCollection` by both key and window, based on the windowing function. The

--- a/website/www/site/static/images/unwindowed-pipeline-bounded.svg
+++ b/website/www/site/static/images/unwindowed-pipeline-bounded.svg
@@ -37,8 +37,8 @@
         <path d="M1072.5,80 L1072.5,100" id="Directed-edge" stroke="#3062A8" stroke-width="2" stroke-linecap="square" transform="translate(1072.500000, 90.000000) rotate(-90.000000) translate(-1072.500000, -90.000000) "></path>
         <g id="PCollection" transform="translate(1084.500000, 55.000000)">
             <circle id="PCollection-symbol" stroke="#757575" stroke-width="2" fill="#FFFFFF" cx="35" cy="35" r="35"></circle>
-            <text id="Rows-after-ParDo" font-family="Roboto-Regular, Roboto" font-size="15" font-weight="normal" fill="#000000">
-                <tspan x="17.1015625" y="21">Rows </tspan>
+            <text id="Lines-after-ParDo" font-family="Roboto-Regular, Roboto" font-size="15" font-weight="normal" fill="#000000">
+                <tspan x="17.1015625" y="21">Lines </tspan>
                 <tspan x="19.8554688" y="39">after </tspan>
                 <tspan x="14.9555664" y="57">ParDo</tspan>
             </text>
@@ -55,8 +55,8 @@
         </g>
         <g id="PCollection" transform="translate(763.000000, 61.000000)">
             <circle id="PCollection-symbol" stroke="#757575" stroke-width="2" fill="#FFFFFF" cx="30.9530303" cy="31.2207576" r="30.530303"></circle>
-            <text id="Rows-by-key" font-family="Roboto-Regular, Roboto" font-size="15" font-weight="normal" fill="#000000">
-                <tspan x="12.616714" y="27">Rows </tspan>
+            <text id="Lines-by-key" font-family="Roboto-Regular, Roboto" font-size="15" font-weight="normal" fill="#000000">
+                <tspan x="12.616714" y="27">Lines</tspan>
                 <tspan x="10.0788722" y="45">by key</tspan>
             </text>
         </g>
@@ -72,28 +72,23 @@
         </g>
         <g id="PCollection" transform="translate(374.000000, 61.000000)">
             <circle id="PCollection-symbol" stroke="#757575" stroke-width="2" fill="#FFFFFF" cx="31" cy="31" r="31"></circle>
-            <text id="Table-rows" font-family="Roboto-Regular, Roboto" font-size="16" font-weight="normal" fill="#000000">
-                <tspan x="11.2070312" y="28">Table </tspan>
-                <tspan x="13.59375" y="47">rows</tspan>
+            <text id="File-lines" font-family="Roboto-Regular, Roboto" font-size="16" font-weight="normal" fill="#000000">
+                <tspan x="16" y="28">File</tspan>
+                <tspan x="16" y="47">lines</tspan>
             </text>
         </g>
         <g id="PTransform" transform="translate(160.000000, 30.000000)">
             <rect id="PTransform-symbol" fill="#3062A8" x="0" y="0" width="194" height="124"></rect>
-            <text id="Read-from-Kafka-IO" font-family="Roboto-Regular, Roboto" font-size="24" font-weight="normal" fill="#FFFFFF">
+            <text id="Read-from-Text-IO" font-family="Roboto-Regular, Roboto" font-size="24" font-weight="normal" fill="#FFFFFF">
                 <tspan x="44" y="55">Read from </tspan>
-                <tspan x="44" y="83">Kafka IO</tspan>
+                <tspan x="44" y="83">Text IO</tspan>
             </text>
         </g>
         <path id="Directed-edge" d="M146,92 L113,92 L113,90 L146,90 L146,84 L160,91 L146,98 L146,92 Z" fill="#E0E0E0" fill-rule="nonzero"></path>
-        <g id="Database" transform="translate(0.000000, 40.000000)">
-            <g id="Database-symbol" transform="translate(0.000000, 0.000000)">
-                <ellipse id="Oval" fill="#E0E0E0" cx="56.5" cy="83.2631579" rx="56.5" ry="17.8421053"></ellipse>
-                <rect id="Rectangle" fill="#E0E0E0" x="0" y="17.8421053" width="113" height="65.4210526"></rect>
-                <ellipse id="Oval" fill="#EFEFEF" cx="56.5" cy="17.8421053" rx="56.5" ry="17.8421053"></ellipse>
-            </g>
-            <text id="Database-table" font-family="Roboto-Regular, Roboto" font-size="18" font-weight="normal" fill="#414141">
-                <tspan x="18" y="61">Database </tspan>
-                <tspan x="18" y="82">table</tspan>
+        <g id="Document" transform="translate(0.000000, 50.000000)">
+            <path d="M0,0 L0,81.1880544 C5.73926173,85.0626848 15.1689615,87 28.2890992,87 C56.5,87 57.2032971,71.8576229 84.878475,71.8576229 C90.6940962,71.8576229 100.067938,74.9677667 113,81.1880544 L113,0 L0,0 Z" id="Document-symbol" fill="#E0E0E0"></path>
+            <text id="Text-file" font-family="Roboto-Regular, Roboto" font-size="18" font-weight="normal" fill="#414141">
+                <tspan x="25" y="43">Text file</tspan>
             </text>
         </g>
     </g>

--- a/website/www/site/static/images/windowing-pipeline-bounded.svg
+++ b/website/www/site/static/images/windowing-pipeline-bounded.svg
@@ -23,8 +23,8 @@
 	    <path d="M204.5,296 L204.5,316" id="Directed-edge" stroke="#3062A8" stroke-width="2" stroke-linecap="square" transform="translate(204.500000, 306.000000) rotate(-90.000000) translate(-204.500000, -306.000000) "></path>
 	    <g id="PCollection" transform="translate(214.000000, 271.000000)">
 	        <circle id="PCollection-symbol" stroke="#757575" stroke-width="2" fill="#FFFFFF" cx="35" cy="35" r="35"></circle>
-	        <text id="Rows-after-ParDo" font-family="Roboto-Regular, Roboto" font-size="15" font-weight="normal" fill="#000000">
-	            <tspan x="17.1015625" y="21">Rows </tspan>
+	        <text id="Lines-after-ParDo" font-family="Roboto-Regular, Roboto" font-size="15" font-weight="normal" fill="#000000">
+	            <tspan x="17.1015625" y="21">Lines </tspan>
 	            <tspan x="19.8554688" y="39">after </tspan>
 	            <tspan x="14.9555664" y="57">ParDo</tspan>
 	        </text>
@@ -60,9 +60,9 @@
 	    </g>
 	    <g id="PCollection" transform="translate(696.500000, 61.000000)">
 	        <circle id="PCollection-symbol" stroke="#757575" stroke-width="2" fill="#FFFFFF" cx="31" cy="31" r="31"></circle>
-	        <text id="Table-rows" font-family="Roboto-Regular, Roboto" font-size="16" font-weight="normal" fill="#000000">
-	            <tspan x="11.7070312" y="28">Table </tspan>
-	            <tspan x="14.09375" y="47">rows</tspan>
+	        <text id="File-lines" font-family="Roboto-Regular, Roboto" font-size="16" font-weight="normal" fill="#000000">
+	            <tspan x="16" y="28">File</tspan>
+	            <tspan x="16" y="47">lines</tspan>
 	        </text>
 	    </g>
 	    <g id="PTransform" transform="translate(482.000000, 30.000000)">
@@ -78,30 +78,25 @@
 	    </g>
 	    <g id="PCollection" transform="translate(374.000000, 61.000000)">
 	        <circle id="PCollection-symbol" stroke="#757575" stroke-width="2" fill="#FFFFFF" cx="31" cy="31" r="31"></circle>
-	        <text id="Table-rows" font-family="Roboto-Regular, Roboto" font-size="16" font-weight="normal" fill="#000000">
-	            <tspan x="11.2070312" y="28">Table </tspan>
-	            <tspan x="13.59375" y="47">rows</tspan>
+	        <text id="File-lines" font-family="Roboto-Regular, Roboto" font-size="16" font-weight="normal" fill="#000000">
+	            <tspan x="16" y="28">File</tspan>
+	            <tspan x="16" y="47">lines</tspan>
 	        </text>
 	    </g>
 	    <g id="PTransform" transform="translate(160.000000, 30.000000)">
 	        <rect id="PTransform-symbol" fill="#3062A8" x="0" y="0" width="194" height="124"></rect>
-	        <text id="Read-from-Kafka-IO" font-family="Roboto-Regular, Roboto" font-size="24" font-weight="normal" fill="#FFFFFF">
+	        <text id="Read-from-Text-IO" font-family="Roboto-Regular, Roboto" font-size="24" font-weight="normal" fill="#FFFFFF">
 	            <tspan x="44" y="55">Read from </tspan>
-	            <tspan x="44" y="83">Kafka IO</tspan>
+	            <tspan x="44" y="83">Text IO</tspan>
 	        </text>
 	    </g>
 	    <path id="Directed-edge" d="M146,92 L113,92 L113,90 L146,90 L146,84 L160,91 L146,98 L146,92 Z" fill="#E0E0E0" fill-rule="nonzero"></path>
-	    <g id="Database" transform="translate(0.000000, 40.000000)">
-	        <g id="Database-symbol" transform="translate(0.000000, 0.000000)">
-	            <ellipse id="Oval" fill="#E0E0E0" cx="56.5" cy="83.2631579" rx="56.5" ry="17.8421053"></ellipse>
-	            <rect id="Rectangle" fill="#E0E0E0" x="0" y="17.8421053" width="113" height="65.4210526"></rect>
-	            <ellipse id="Oval" fill="#EFEFEF" cx="56.5" cy="17.8421053" rx="56.5" ry="17.8421053"></ellipse>
-	        </g>
-	        <text id="Database-table" font-family="Roboto-Regular, Roboto" font-size="18" font-weight="normal" fill="#414141">
-	            <tspan x="18" y="61">Database </tspan>
-	            <tspan x="18" y="82">table</tspan>
-	        </text>
-	    </g>
+        <g id="Document" transform="translate(0.000000, 50.000000)">
+            <path d="M0,0 L0,81.1880544 C5.73926173,85.0626848 15.1689615,87 28.2890992,87 C56.5,87 57.2032971,71.8576229 84.878475,71.8576229 C90.6940962,71.8576229 100.067938,74.9677667 113,81.1880544 L113,0 L0,0 Z" id="Document-symbol" fill="#E0E0E0"></path>
+            <text id="Text-file" font-family="Roboto-Regular, Roboto" font-size="18" font-weight="normal" fill="#414141">
+                <tspan x="25" y="43">Text file</tspan>
+            </text>
+        </g>
 	    <g id="Legend" transform="translate(0.000000, 388.000000)">
 	        <rect id="PTransform-symbol" fill="#3062A8" x="0" y="4" width="15" height="15"></rect>
 	        <text id="PTransform" font-family="Roboto-Regular, Roboto" font-size="18" font-weight="normal" fill="#000000">

--- a/website/www/site/static/images/windowing-pipeline-unbounded.svg
+++ b/website/www/site/static/images/windowing-pipeline-unbounded.svg
@@ -19,21 +19,21 @@
 -->
 <svg width="1158px" height="468px" viewBox="0 0 1158 468" version="1.1" xmlns="http://www.w3.org/2000/svg" xmlns:xlink="http://www.w3.org/1999/xlink">
     <title>Pipeline applying windowing.</title>
-	<g id="windowing-pipeline-unbounded" transform="translate(1.000000, 0.000000)">
-	    <g id="Legend" transform="translate(0.000000, 413.000000)">
-	        <rect id="PTransform-symbol" fill="#3062A8" x="0" y="4" width="15" height="15"></rect>
-	        <text id="PTransform" font-family="Roboto-Regular, Roboto" font-size="18" font-weight="normal" fill="#000000">
-	            <tspan x="22" y="17">PTransform</tspan>
-	        </text>
-	        <text id="Aggregation" font-family="Roboto-Regular, Roboto" font-size="18" font-weight="normal" fill="#000000">
-	            <tspan x="162" y="17">Aggregating PTransform</tspan>
-	        </text>
-	        <text id="PCollection" font-family="Roboto-Regular, Roboto" font-size="18" font-weight="normal" fill="#000000">
-	            <tspan x="22" y="52">PCollection</tspan>
-	        </text>
-	        <circle id="PCollection-symbol" fill="#FFFFFF" stroke="#757575" stroke-width="2" cx="7.5" cy="46.5" r="7.5"></circle>
-	        <path d="M143.364341,5 L154,12.4782609 L143.364341,20 L133,12.5217391 L143.364341,5 Z" id="Rectangle" fill="#3062A8"></path>
-	    </g>
+    <g id="windowing-pipeline-unbounded" transform="translate(1.000000, 0.000000)">
+        <g id="Legend" transform="translate(0.000000, 413.000000)">
+            <rect id="PTransform-symbol" fill="#3062A8" x="0" y="4" width="15" height="15"></rect>
+            <text id="PTransform" font-family="Roboto-Regular, Roboto" font-size="18" font-weight="normal" fill="#000000">
+                <tspan x="22" y="17">PTransform</tspan>
+            </text>
+            <text id="Aggregation" font-family="Roboto-Regular, Roboto" font-size="18" font-weight="normal" fill="#000000">
+                <tspan x="162" y="17">Aggregating PTransform</tspan>
+            </text>
+            <text id="PCollection" font-family="Roboto-Regular, Roboto" font-size="18" font-weight="normal" fill="#000000">
+                <tspan x="22" y="52">PCollection</tspan>
+            </text>
+            <circle id="PCollection-symbol" fill="#FFFFFF" stroke="#757575" stroke-width="2" cx="7.5" cy="46.5" r="7.5"></circle>
+            <path d="M143.364341,5 L154,12.4782609 L143.364341,20 L133,12.5217391 L143.364341,5 Z" id="Rectangle" fill="#3062A8"></path>
+        </g>
         <path d="M270.05,290.765 L270.05,310.765" id="Directed-edge" stroke="#3062A8" stroke-width="2" stroke-linecap="square" transform="translate(270.050000, 300.765000) rotate(-90.000000) translate(-270.050000, -300.765000) "></path>
         <g id="PCollection" transform="translate(281.550000, 257.265000)">
             <circle id="PCollection-symbol" stroke="#757575" stroke-width="2" fill="#FFFFFF" cx="42.5" cy="42.5" r="42.5"></circle>
@@ -57,9 +57,9 @@
         <g id="PCollection" transform="translate(1021.000000, 27.000000)">
             <circle id="PCollection-symbol" stroke="#757575" stroke-width="2" fill="#FFFFFF" cx="35" cy="35" r="35"></circle>
             <text id="Rows-after-ParDo" font-family="Roboto-Regular, Roboto" font-size="15" font-weight="normal" fill="#000000">
-                <tspan x="17.1015625" y="21">Rows </tspan>
-                <tspan x="19.8554688" y="39">after </tspan>
-                <tspan x="14.9555664" y="57">ParDo</tspan>
+                <tspan x="20" y="21">Coll </tspan>
+                <tspan x="20" y="39">after </tspan>
+                <tspan x="17" y="57">ParDo</tspan>
             </text>
         </g>
         <g id="PTransform" transform="translate(804.500000, 0.000000)">
@@ -74,9 +74,9 @@
         </g>
         <g id="PCollection" transform="translate(696.500000, 31.000000)">
             <circle id="PCollection-symbol" stroke="#757575" stroke-width="2" fill="#FFFFFF" cx="31" cy="31" r="31"></circle>
-            <text id="Table-rows" font-family="Roboto-Regular, Roboto" font-size="16" font-weight="normal" fill="#000000">
-                <tspan x="11.7070312" y="28">Table </tspan>
-                <tspan x="14.09375" y="47">rows</tspan>
+            <text id="KV-pairs" font-family="Roboto-Regular, Roboto" font-size="16" font-weight="normal" fill="#000000">
+                <tspan x="17" y="28">K/V</tspan>
+                <tspan x="16" y="47">pairs</tspan>
             </text>
         </g>
         <g id="PTransform" transform="translate(482.000000, 0.000000)">
@@ -92,9 +92,9 @@
         </g>
         <g id="PCollection" transform="translate(374.000000, 31.000000)">
             <circle id="PCollection-symbol" stroke="#757575" stroke-width="2" fill="#FFFFFF" cx="31" cy="31" r="31"></circle>
-            <text id="Table-rows" font-family="Roboto-Regular, Roboto" font-size="16" font-weight="normal" fill="#000000">
-                <tspan x="11.2070312" y="28">Table </tspan>
-                <tspan x="13.59375" y="47">rows</tspan>
+            <text id="KV-pairs" font-family="Roboto-Regular, Roboto" font-size="16" font-weight="normal" fill="#000000">
+                <tspan x="17" y="28">K/V</tspan>
+                <tspan x="16" y="47">pairs</tspan>
             </text>
         </g>
         <g id="PTransform" transform="translate(160.000000, 0.000000)">
@@ -105,16 +105,16 @@
             </text>
         </g>
         <path id="Directed-edge" d="M146,62 L113,62 L113,60 L146,60 L146,54 L160,61 L146,68 L146,62 Z" fill="#E0E0E0" fill-rule="nonzero"></path>
-        <g id="Database" transform="translate(0.000000, 10.000000)">
-            <g id="Database-symbol" transform="translate(0.000000, 0.000000)">
+        <g id="Kafka" transform="translate(0.000000, 10.000000)">
+            <g id="Kafka-topic-symbol" transform="translate(0.000000, 0.000000)">
                 <ellipse id="Oval" fill="#E0E0E0" cx="56.5" cy="83.2631579" rx="56.5" ry="17.8421053"></ellipse>
                 <rect id="Rectangle" fill="#E0E0E0" x="0" y="17.8421053" width="113" height="65.4210526"></rect>
                 <ellipse id="Oval" fill="#EFEFEF" cx="56.5" cy="17.8421053" rx="56.5" ry="17.8421053"></ellipse>
             </g>
-            <text id="Database-table" font-family="Roboto-Regular, Roboto" font-size="18" font-weight="normal" fill="#414141">
-                <tspan x="18" y="61">Database </tspan>
-                <tspan x="18" y="82">table</tspan>
+            <text id="Kafka-topic" font-family="Roboto-Regular, Roboto" font-size="18" font-weight="normal" fill="#414141">
+                <tspan x="34" y="61">Kafka </tspan>
+                <tspan x="34" y="82">topic</tspan>
             </text>
-	    </g>
-	</g>
+        </g>
+    </g>
 </svg>


### PR DESCRIPTION
While going through the programming guide, I found two small things that can be improved.

First is in the [Windowing with bounded PCollections](https://beam.apache.org/documentation/programming-guide/#windowing-bounded-collections) section. The description mentions reading using `TextIO` but the images display reading from a database table via Kafka IO.

I've updated both diagrams (there's also a slight change in the text) to better reflect the content in the section.

Here's the "unwindowed" before & after:
<img width="1170" alt="unwindowed-before" src="https://user-images.githubusercontent.com/184055/94370803-9f964880-00e1-11eb-893c-1517f07cfe5e.png">
<img width="1176" alt="unwindowed-after" src="https://user-images.githubusercontent.com/184055/94370806-a329cf80-00e1-11eb-8b5f-0f3c2ba9d193.png">

Here's the "windowing" before & after:
<img width="1185" alt="windowing-before" src="https://user-images.githubusercontent.com/184055/94370822-be94da80-00e1-11eb-8e93-95f44ca93afb.png">
<img width="1193" alt="windowing-after" src="https://user-images.githubusercontent.com/184055/94370828-c05e9e00-00e1-11eb-99b8-ffbe1febf70b.png">

The second change is a minor one in the [Setting a trigger](https://beam.apache.org/documentation/programming-guide/#setting-a-trigger) section. The python example uses a code snippet from a test suite, but it is wrong with regards to the text - the text (and the Java snippet) use a one minute `afterProcessing` trigger whereas the incorrect snippet uses a 10 minute trigget (`10 * 60`). I've copy-pasted the whole code snippet and removed the now obsolete commands from the test suite.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
