### PR TITLE
[BEAM-10848] Initialize gauge to 0

### DIFF
--- a/sdks/python/apache_beam/metrics/cells.py
+++ b/sdks/python/apache_beam/metrics/cells.py
@@ -484,7 +484,7 @@ class GaugeAggregator(MetricAggregator):
   @staticmethod
   def identity_element():
     # type: () -> GaugeData
-    return GaugeData(None, timestamp=0)
+    return GaugeData(0, timestamp=0)
 
   def combine(self, x, y):
     # type: (GaugeData, GaugeData) -> GaugeData

--- a/sdks/python/apache_beam/metrics/monitoring_infos_test.py
+++ b/sdks/python/apache_beam/metrics/monitoring_infos_test.py
@@ -67,8 +67,9 @@ class MonitoringInfosTest(unittest.TestCase):
 
   def test_int64_user_gauge(self):
     metric = GaugeCell().get_cumulative()
-    result = monitoring_infos.int64_user_gauge('gaugenamespace', 'gaugename', metric)
-    ts, gauge_value = monitoring_infos.extract_gauge_value(result)
+    result = monitoring_infos.int64_user_gauge(
+          'gaugenamespace', 'gaugename', metric)
+    _, gauge_value = monitoring_infos.extract_gauge_value(result)
     self.assertEqual(0, gauge_value)
 
 

--- a/sdks/python/apache_beam/metrics/monitoring_infos_test.py
+++ b/sdks/python/apache_beam/metrics/monitoring_infos_test.py
@@ -68,7 +68,7 @@ class MonitoringInfosTest(unittest.TestCase):
   def test_int64_user_gauge(self):
     metric = GaugeCell().get_cumulative()
     result = monitoring_infos.int64_user_gauge(
-          'gaugenamespace', 'gaugename', metric)
+        'gaugenamespace', 'gaugename', metric)
     _, gauge_value = monitoring_infos.extract_gauge_value(result)
     self.assertEqual(0, gauge_value)
 

--- a/sdks/python/apache_beam/metrics/monitoring_infos_test.py
+++ b/sdks/python/apache_beam/metrics/monitoring_infos_test.py
@@ -21,6 +21,7 @@ from __future__ import absolute_import
 import unittest
 
 from apache_beam.metrics import monitoring_infos
+from apache_beam.metrics.cells import GaugeCell
 
 
 class MonitoringInfosTest(unittest.TestCase):
@@ -63,6 +64,12 @@ class MonitoringInfosTest(unittest.TestCase):
     namespace, name = monitoring_infos.parse_namespace_and_name(input)
     self.assertEqual(namespace, "counternamespace")
     self.assertEqual(name, "countername")
+
+  def test_int64_user_gauge(self):
+    metric = GaugeCell().get_cumulative()
+    result = monitoring_infos.int64_user_gauge('gaugenamespace', 'gaugename', metric)
+    ts, gauge_value = monitoring_infos.extract_gauge_value(result)
+    self.assertEqual(0, gauge_value)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The PR addresses the encoding issue of Gauges by initializing them with 0. 