### PR TITLE
[BEAM-10989] Add @SchemaCaseFormat annotation

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FieldValueTypeInformation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FieldValueTypeInformation.java
@@ -20,14 +20,19 @@ package org.apache.beam.sdk.schemas;
 import com.google.auto.value.AutoValue;
 import java.io.Serializable;
 import java.lang.annotation.Annotation;
+import java.lang.reflect.AnnotatedElement;
 import java.lang.reflect.Field;
+import java.lang.reflect.Member;
 import java.lang.reflect.Method;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
+import org.apache.beam.sdk.schemas.annotations.SchemaCaseFormat;
+import org.apache.beam.sdk.schemas.annotations.SchemaFieldName;
 import org.apache.beam.sdk.schemas.logicaltypes.OneOfType;
 import org.apache.beam.sdk.schemas.utils.ReflectUtils;
 import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.CaseFormat;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** Represents type information for a Java type that will be used to infer a Schema type. */
@@ -106,7 +111,7 @@ public abstract class FieldValueTypeInformation implements Serializable {
   public static FieldValueTypeInformation forField(Field field) {
     TypeDescriptor type = TypeDescriptor.of(field.getGenericType());
     return new AutoValue_FieldValueTypeInformation.Builder()
-        .setName(field.getName())
+        .setName(getNameOverride(field.getName(), field))
         .setNullable(hasNullableAnnotation(field))
         .setType(type)
         .setRawType(type.getRawType())
@@ -116,6 +121,29 @@ public abstract class FieldValueTypeInformation implements Serializable {
         .setMapValueType(getMapValueType(field))
         .setOneOfTypes(Collections.emptyMap())
         .build();
+  }
+
+  public static <T extends AnnotatedElement & Member> String getNameOverride(
+      String original, T member) {
+    SchemaFieldName fieldName = member.getAnnotation(SchemaFieldName.class);
+    SchemaCaseFormat caseFormatAnnotation = member.getAnnotation(SchemaCaseFormat.class);
+    SchemaCaseFormat classCaseFormatAnnotation =
+        member.getDeclaringClass().getAnnotation(SchemaCaseFormat.class);
+    if (fieldName != null) {
+      if (caseFormatAnnotation != null) {
+        throw new RuntimeException(
+            String.format(
+                "Cannot define both @SchemaFieldName and @SchemaCaseFormat. From member '%s'.",
+                member.getName()));
+      }
+      return fieldName.value();
+    } else if (caseFormatAnnotation != null) {
+      return CaseFormat.LOWER_CAMEL.to(caseFormatAnnotation.value(), original);
+    } else if (classCaseFormatAnnotation != null) {
+      return CaseFormat.LOWER_CAMEL.to(classCaseFormatAnnotation.value(), original);
+    } else {
+      return original;
+    }
   }
 
   public static FieldValueTypeInformation forGetter(Method method) {
@@ -131,7 +159,7 @@ public abstract class FieldValueTypeInformation implements Serializable {
     TypeDescriptor type = TypeDescriptor.of(method.getGenericReturnType());
     boolean nullable = hasNullableReturnType(method);
     return new AutoValue_FieldValueTypeInformation.Builder()
-        .setName(name)
+        .setName(getNameOverride(name, method))
         .setNullable(nullable)
         .setType(type)
         .setRawType(type.getRawType())

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaBeanSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaBeanSchema.java
@@ -110,12 +110,13 @@ public class JavaBeanSchema extends GetterBasedSchemaProvider {
             typeDescriptor.getRawType(), GetterTypeSupplier.INSTANCE);
 
     // If there are no creator methods, then validate that we have setters for every field.
-    // Otherwise, we will have not way of creating the class.
+    // Otherwise, we will have no way of creating instances of the class.
     if (ReflectUtils.getAnnotatedCreateMethod(typeDescriptor.getRawType()) == null
         && ReflectUtils.getAnnotatedConstructor(typeDescriptor.getRawType()) == null) {
       JavaBeanUtils.validateJavaBean(
           GetterTypeSupplier.INSTANCE.get(typeDescriptor.getRawType(), schema),
-          SetterTypeSupplier.INSTANCE.get(typeDescriptor.getRawType(), schema));
+          SetterTypeSupplier.INSTANCE.get(typeDescriptor.getRawType(), schema),
+          schema);
     }
     return schema;
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/annotations/SchemaCaseFormat.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/annotations/SchemaCaseFormat.java
@@ -1,0 +1,73 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas.annotations;
+
+import java.lang.annotation.Documented;
+import java.lang.annotation.ElementType;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+import java.lang.annotation.Target;
+import javax.annotation.Nonnull;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.CaseFormat;
+
+/**
+ * When used on a {@link org.apache.beam.sdk.schemas.JavaFieldSchema POJO}, {@link
+ * org.apache.beam.sdk.schemas.JavaBeanSchema Java Bean}, or {@link
+ * org.apache.beam.sdk.schemas.AutoValueSchema AutoValue} class the specified case format will be
+ * used for all the generated Schema fields.
+ *
+ * <p>The annotation can also be used on individual POJO fields, and Java Bean and AutoValue getters
+ * to change the case format just for those fields.
+ *
+ * <p>For example, say we have a POJO with fields that we want in our schema but under names with a
+ * different case format:
+ *
+ * <pre><code>
+ * {@literal @}DefaultSchema(JavaFieldSchema.class)
+ * {@literal @}SchemaCaseFormat(CaseFormat.LOWER_UNDERSCORE)
+ *   class MyClass {
+ *     public String user;
+ *     public int ageInYears;
+ *    {@literal @}SchemaCaseFormat(CaseFormat.UPPER_CAMEL)
+ *     public boolean knowsJavascript;
+ *   }
+ * </code></pre>
+ *
+ * <p>The resulting schema will have fields named "user", "age_in_years", "KnowsJavascript".
+ *
+ * <p>A common application of this annotation is to make schema fields use the {@code
+ * lower_underscore} case format, which is recommended for schemas that will be used across language
+ * boundaries.
+ *
+ * <p><b>NOTE:</b> This annotation assumes that field and method names follow the convention of
+ * using the {@code lowerCamel} case format. If that is not the case, we make a best effort to
+ * convert the field name but the result is not well defined.
+ */
+@Documented
+@Retention(RetentionPolicy.RUNTIME)
+@Target({ElementType.FIELD, ElementType.METHOD, ElementType.TYPE})
+@SuppressWarnings("rawtypes")
+@Experimental(Kind.SCHEMAS)
+public @interface SchemaCaseFormat {
+
+  /** The name to use for the generated schema field. */
+  @Nonnull
+  CaseFormat value();
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/annotations/SchemaFieldName.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/annotations/SchemaFieldName.java
@@ -27,13 +27,16 @@ import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 
 /**
- * When used on a POJO field or a JavaBean getter, the specified name is used for the generated
- * schema field.
+ * When used on a {@link org.apache.beam.sdk.schemas.JavaFieldSchema POJO} field, a {@link
+ * org.apache.beam.sdk.schemas.JavaBeanSchema Java Bean} getter, or an {@link
+ * org.apache.beam.sdk.schemas.AutoValueSchema AutoValue} getter, the specified name is used for the
+ * generated schema field.
  *
- * <p>For example, a Java POJO with a field that we want in our schema but under a different name.
+ * <p>For example, say we have a Java POJO with a field that we want in our schema but under a
+ * different name:
  *
  * <pre><code>
- *  {@literal @}DefaultSchema(JavaBeanSchema.class)
+ *  {@literal @}DefaultSchema(JavaFieldSchema.class)
  *   class MyClass {
  *     public String user;
  *

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtils.java
@@ -65,6 +65,9 @@ public class JavaBeanUtils {
     return StaticSchemaInference.schemaFromClass(clazz, fieldValueTypeSupplier);
   }
 
+  private static final String CONSTRUCTOR_HELP_STRING =
+      "In order to infer a Schema from a Java Bean, it must have a constructor annotated with @SchemaCreate, or it must have a compatible setter for every getter used as a Schema field.";
+
   // Make sure that there are matching setters and getters.
   public static void validateJavaBean(
       List<FieldValueTypeInformation> getters,
@@ -80,28 +83,25 @@ public class JavaBeanUtils {
       }
     }
 
-    final String HELP_STRING =
-        "In order to infer a Schema from a Java Bean, it must have a constructor annotated with @SchemaCreate, or it must have a compatible setter for every getter used as a Schema field.";
-
     for (FieldValueTypeInformation type : getters) {
       FieldValueTypeInformation setterType = setterMap.get(type.getName());
       if (setterType == null) {
         throw new RuntimeException(
             String.format(
                 "Java Bean '%s' contains a getter for field '%s', but does not contain a matching setter. %s",
-                type.getMethod().getDeclaringClass(), type.getName(), HELP_STRING));
+                type.getMethod().getDeclaringClass(), type.getName(), CONSTRUCTOR_HELP_STRING));
       }
       if (!type.getType().equals(setterType.getType())) {
         throw new RuntimeException(
             String.format(
                 "Java Bean '%s' contains a setter for field '%s' that has a mismatching type. %s",
-                type.getMethod().getDeclaringClass(), type.getName(), HELP_STRING));
+                type.getMethod().getDeclaringClass(), type.getName(), CONSTRUCTOR_HELP_STRING));
       }
       if (!type.isNullable() == setterType.isNullable()) {
         throw new RuntimeException(
             String.format(
                 "Java Bean '%s' contains a setter for field '%s' that has a mismatching nullable attribute. %s",
-                type.getMethod().getDeclaringClass(), type.getName(), HELP_STRING));
+                type.getMethod().getDeclaringClass(), type.getName(), CONSTRUCTOR_HELP_STRING));
       }
     }
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/POJOUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/POJOUtils.java
@@ -158,10 +158,13 @@ public class POJOUtils {
           .newInstance();
     } catch (InstantiationException
         | IllegalAccessException
+        | IllegalStateException
         | NoSuchMethodException
         | InvocationTargetException e) {
       throw new RuntimeException(
-          "Unable to generate a creator for " + clazz + " with schema " + schema);
+          String.format(
+              "Unable to generate a creator for POJO '%s' with inferred schema: %s\nNote POJOs must have a zero-argument constructor, or a constructor annotated with @SchemaCreate.",
+              clazz, schema));
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/POJOUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/POJOUtils.java
@@ -163,7 +163,7 @@ public class POJOUtils {
         | InvocationTargetException e) {
       throw new RuntimeException(
           String.format(
-              "Unable to generate a creator for POJO '%s' with inferred schema: %s\nNote POJOs must have a zero-argument constructor, or a constructor annotated with @SchemaCreate.",
+              "Unable to generate a creator for POJO '%s' with inferred schema: %s%nNote POJOs must have a zero-argument constructor, or a constructor annotated with @SchemaCreate.",
               clazz, schema));
     }
   }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JavaBeanSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JavaBeanSchemaTest.java
@@ -26,10 +26,12 @@ import static org.apache.beam.sdk.schemas.utils.TestJavaBeans.NESTED_BEAN_SCHEMA
 import static org.apache.beam.sdk.schemas.utils.TestJavaBeans.NESTED_MAP_BEAN_SCHEMA;
 import static org.apache.beam.sdk.schemas.utils.TestJavaBeans.PRIMITIVE_ARRAY_BEAN_SCHEMA;
 import static org.apache.beam.sdk.schemas.utils.TestJavaBeans.SIMPLE_BEAN_SCHEMA;
+import static org.hamcrest.Matchers.containsString;
 import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertSame;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import java.math.BigDecimal;
@@ -41,6 +43,7 @@ import java.util.Map;
 import org.apache.beam.sdk.schemas.utils.SchemaTestUtils;
 import org.apache.beam.sdk.schemas.utils.TestJavaBeans.AllNullableBean;
 import org.apache.beam.sdk.schemas.utils.TestJavaBeans.ArrayOfByteArray;
+import org.apache.beam.sdk.schemas.utils.TestJavaBeans.BeanWithNoCreateOption;
 import org.apache.beam.sdk.schemas.utils.TestJavaBeans.IterableBean;
 import org.apache.beam.sdk.schemas.utils.TestJavaBeans.MismatchingNullableBean;
 import org.apache.beam.sdk.schemas.utils.TestJavaBeans.NestedArrayBean;
@@ -503,5 +506,25 @@ public class JavaBeanSchemaTest {
             .build();
     ArrayOfByteArray converted = registry.getFromRowFunction(ArrayOfByteArray.class).apply(row);
     assertEquals(expectedArrayOfByteArray, converted);
+  }
+
+  @Test
+  public void testNoCreateOptionThrows() {
+    SchemaRegistry registry = SchemaRegistry.createDefault();
+
+    RuntimeException thrown =
+        assertThrows(
+            RuntimeException.class, () -> registry.getSchema(BeanWithNoCreateOption.class));
+
+    assertThat(
+        "Message should mention there's an issue with setters.",
+        thrown.getMessage(),
+        containsString("setter"));
+    assertThat(
+        "Message should mention the problem field.", thrown.getMessage(), containsString("str"));
+    assertThat(
+        "Message should suggest alternative of using @SchemaCreate to avoid need for setters.",
+        thrown.getMessage(),
+        containsString("@SchemaCreate"));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/SchemaTestUtils.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/SchemaTestUtils.java
@@ -36,6 +36,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterable
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 import org.hamcrest.BaseMatcher;
 import org.hamcrest.Description;
+import org.hamcrest.Matcher;
 
 /** Utilities for testing schemas. */
 public class SchemaTestUtils {
@@ -43,6 +44,27 @@ public class SchemaTestUtils {
   // (recursively) contain the same fields with the same names, but possibly different orders.
   public static void assertSchemaEquivalent(Schema expected, Schema actual) {
     assertTrue("Expected: " + expected + "  Got: " + actual, actual.equivalent(expected));
+  }
+
+  public static Matcher<Schema> equivalentTo(Schema expected) {
+    return new BaseMatcher<Schema>() {
+      @Override
+      public boolean matches(Object actual) {
+        if (!(actual instanceof Schema)) {
+          return false;
+        }
+        return expected.equivalent((Schema) actual);
+      }
+
+      @Override
+      public void describeTo(Description description) {
+        description.appendText(expected.toString());
+      }
+    };
+  }
+
+  public static Matcher<Row> equivalentTo(Row expected) {
+    return new RowEquivalent(expected);
   }
 
   public static class RowEquivalent extends BaseMatcher<Row> {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestJavaBeans.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestJavaBeans.java
@@ -27,9 +27,11 @@ import org.apache.beam.sdk.schemas.JavaBeanSchema;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
+import org.apache.beam.sdk.schemas.annotations.SchemaCaseFormat;
 import org.apache.beam.sdk.schemas.annotations.SchemaCreate;
 import org.apache.beam.sdk.schemas.annotations.SchemaFieldName;
 import org.apache.beam.sdk.schemas.annotations.SchemaIgnore;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.CaseFormat;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.DateTime;
 import org.joda.time.Instant;
@@ -1199,6 +1201,60 @@ public class TestJavaBeans {
   public static final Schema ARRAY_OF_BYTE_ARRAY_BEAM_SCHEMA =
       Schema.builder().addArrayField("byteBuffers", FieldType.BYTES).build();
 
+  @DefaultSchema(JavaBeanSchema.class)
+  @SchemaCaseFormat(CaseFormat.LOWER_UNDERSCORE)
+  public static class BeanWithCaseFormat {
+    private String user;
+    private int ageInYears;
+    private boolean knowsJavascript;
+
+    @SchemaCreate
+    public BeanWithCaseFormat(String user, int ageInYears, boolean knowsJavascript) {
+      this.user = user;
+      this.ageInYears = ageInYears;
+      this.knowsJavascript = knowsJavascript;
+    }
+
+    public String getUser() {
+      return user;
+    }
+
+    public int getAgeInYears() {
+      return ageInYears;
+    }
+
+    @SchemaCaseFormat(CaseFormat.UPPER_CAMEL)
+    public boolean getKnowsJavascript() {
+      return knowsJavascript;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      BeanWithCaseFormat that = (BeanWithCaseFormat) o;
+      return ageInYears == that.ageInYears
+          && knowsJavascript == that.knowsJavascript
+          && Objects.equals(user, that.user);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(user, ageInYears, knowsJavascript);
+    }
+  }
+
+  public static final Schema CASE_FORMAT_BEAM_SCHEMA =
+      Schema.builder()
+          .addStringField("user")
+          .addInt32Field("age_in_years")
+          .addBooleanField("KnowsJavascript")
+          .build();
+
   // A Bean that has no way for us to create an instance. Should throw an error during schema
   // generation.
   @DefaultSchema(JavaBeanSchema.class)
@@ -1209,4 +1265,66 @@ public class TestJavaBeans {
       return str;
     }
   }
+
+  // A Bean that has no @SchemaCreate, so it must be created with Setters.
+  // It also renames fields, which has the potential to make us misidentify setters.
+  @DefaultSchema(JavaBeanSchema.class)
+  @SchemaCaseFormat(CaseFormat.LOWER_UNDERSCORE)
+  public static class BeanWithRenamedFieldsAndSetters {
+    private String user;
+    private int ageInYears;
+    private boolean knowsJavascript;
+
+    @SchemaFieldName("username")
+    public String getUser() {
+      return user;
+    }
+
+    public int getAgeInYears() {
+      return ageInYears;
+    }
+
+    @SchemaCaseFormat(CaseFormat.UPPER_CAMEL)
+    public boolean getKnowsJavascript() {
+      return knowsJavascript;
+    }
+
+    public void setUser(String user) {
+      this.user = user;
+    }
+
+    public void setAgeInYears(int ageInYears) {
+      this.ageInYears = ageInYears;
+    }
+
+    public void setKnowsJavascript(boolean knowsJavascript) {
+      this.knowsJavascript = knowsJavascript;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      BeanWithCaseFormat that = (BeanWithCaseFormat) o;
+      return ageInYears == that.ageInYears
+          && knowsJavascript == that.knowsJavascript
+          && Objects.equals(user, that.user);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(user, ageInYears, knowsJavascript);
+    }
+  }
+
+  public static final Schema RENAMED_FIELDS_AND_SETTERS_BEAM_SCHEMA =
+      Schema.builder()
+          .addStringField("username")
+          .addInt32Field("age_in_years")
+          .addBooleanField("KnowsJavascript")
+          .build();
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestJavaBeans.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestJavaBeans.java
@@ -1198,4 +1198,15 @@ public class TestJavaBeans {
   /** The schema for {@link NestedArrayBean}. * */
   public static final Schema ARRAY_OF_BYTE_ARRAY_BEAM_SCHEMA =
       Schema.builder().addArrayField("byteBuffers", FieldType.BYTES).build();
+
+  // A Bean that has no way for us to create an instance. Should throw an error during schema
+  // generation.
+  @DefaultSchema(JavaBeanSchema.class)
+  public static class BeanWithNoCreateOption {
+    private String str;
+
+    public String getStr() {
+      return str;
+    }
+  }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestPOJOs.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestPOJOs.java
@@ -1011,4 +1011,14 @@ public class TestPOJOs {
           .addNullableField("bigDecimal", FieldType.DECIMAL)
           .addNullableField("stringBuilder", FieldType.STRING)
           .build();
+
+  @DefaultSchema(JavaFieldSchema.class)
+  public static class PojoNoCreateOption {
+    public String user;
+
+    // JavaFieldSchema will not try to use this constructor unless annotated with @SchemaCreate
+    public PojoNoCreateOption(String user) {
+      this.user = user;
+    }
+  }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestPOJOs.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestPOJOs.java
@@ -27,10 +27,12 @@ import org.apache.beam.sdk.schemas.JavaFieldSchema;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
+import org.apache.beam.sdk.schemas.annotations.SchemaCaseFormat;
 import org.apache.beam.sdk.schemas.annotations.SchemaCreate;
 import org.apache.beam.sdk.schemas.annotations.SchemaFieldName;
 import org.apache.beam.sdk.schemas.annotations.SchemaIgnore;
 import org.apache.beam.sdk.schemas.logicaltypes.EnumerationType;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.CaseFormat;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.DateTime;
 import org.joda.time.Instant;
@@ -1010,6 +1012,50 @@ public class TestPOJOs {
           .addNullableField("byteBuffer", FieldType.BYTES)
           .addNullableField("bigDecimal", FieldType.DECIMAL)
           .addNullableField("stringBuilder", FieldType.STRING)
+          .build();
+
+  @DefaultSchema(JavaFieldSchema.class)
+  @SchemaCaseFormat(CaseFormat.LOWER_UNDERSCORE)
+  public static class PojoWithCaseFormat {
+    public String user;
+    public int ageInYears;
+
+    @SchemaCaseFormat(CaseFormat.UPPER_CAMEL)
+    public boolean knowsJavascript;
+
+    @SchemaCreate
+    public PojoWithCaseFormat(String user, int ageInYears, boolean knowsJavascript) {
+      this.user = user;
+      this.ageInYears = ageInYears;
+      this.knowsJavascript = knowsJavascript;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (o == null || getClass() != o.getClass()) {
+        return false;
+      }
+      PojoWithCaseFormat that = (PojoWithCaseFormat) o;
+      return ageInYears == that.ageInYears
+          && knowsJavascript == that.knowsJavascript
+          && user.equals(that.user);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(user, ageInYears, knowsJavascript);
+    }
+  }
+
+  /** The schema for {@link PojoWithCaseFormat}. * */
+  public static final Schema CASE_FORMAT_POJO_SCHEMA =
+      Schema.builder()
+          .addField("user", FieldType.STRING)
+          .addField("age_in_years", FieldType.INT32)
+          .addField("KnowsJavascript", FieldType.BOOLEAN)
           .build();
 
   @DefaultSchema(JavaFieldSchema.class)


### PR DESCRIPTION
Adds an `@SchemaCaseFormat` annotation that can be used to control the case format used in schema field names. For example:

```java
@DefaultSchema(JavaFieldSchema.class)
@SchemaCaseFormat(CaseFormat.LOWER_UNDERSCORE)
class MyClass {
   public String user;
   public int ageInYears;
   @SchemaCaseFormat(CaseFormat.UPPER_CAMEL)
   public boolean knowsJavascript;
}
```

Will produce a schema with fields "user", "age_in_years", and "KnowsJavascript".

I think the primary application of this will be using `lower_underscore` for schemas that will be used across languages (e.g. in LogicalType base types, and cross-language transform configuration objects), but I figured a general purpose solution based on [`CaseFormat`](https://guava.dev/releases/23.0/api/docs/com/google/common/base/CaseFormat.html) would be more valuable.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
