### PR TITLE
[BEAM-11027] Avoid excessive logging of ZetaSQL on Nexmark run

### DIFF
--- a/sdks/java/testing/nexmark/src/main/resources/log4j.properties
+++ b/sdks/java/testing/nexmark/src/main/resources/log4j.properties
@@ -45,3 +45,6 @@ log4j.logger.org.apache.flink=WARN
 # SPARK-9183: Settings to avoid annoying messages when looking up nonexistent UDFs in SparkSQL with Hive support
 log4j.logger.org.apache.hadoop.hive.metastore.RetryingHMSHandler=FATAL
 log4j.logger.org.apache.hadoop.hive.ql.exec.FunctionRegistry=ERROR
+
+# Avoid excessive netty logging on ZetaSQL
+log4j.logger.com.google.zetasql.io.grpc.netty=WARN


### PR DESCRIPTION
Notice this while waiting for the Spark Nexmark run to finish on #13021

R: @lukecwik 
CC: @apilloud 