### PR TITLE
Enable SDF testPairWithIndexWindowedTimestampedBounded in Spark Structured Streaming runner

### DIFF
--- a/runners/spark/build.gradle
+++ b/runners/spark/build.gradle
@@ -238,7 +238,6 @@ task validatesStructuredStreamingRunnerBatch(type: Test) {
     excludeTestsMatching 'org.apache.beam.sdk.transforms.FlattenTest.testFlattenMultipleCoders'
     // SDF
     excludeTestsMatching 'org.apache.beam.sdk.transforms.SplittableDoFnTest.testLifecycleMethodsBounded'
-    excludeTestsMatching 'org.apache.beam.sdk.transforms.SplittableDoFnTest.testPairWithIndexWindowedTimestampedBounded'
   }
 }
 


### PR DESCRIPTION
This passes now after some recent changes in core. A really minor improvement after reviewing the PR on SDF Bounded reads for Spark runner

R: @lukecwik 
