### PR TITLE
[BEAM-11020] Adding multi-window splitting to Go SDF.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/datasource_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasource_test.go
@@ -597,11 +597,11 @@ type TestSplittableUnit struct {
 
 // Split checks the input fraction for correctness, but otherwise always returns
 // a successful split. The split elements are just copies of the original.
-func (n *TestSplittableUnit) Split(f float64) (*FullValue, *FullValue, error) {
+func (n *TestSplittableUnit) Split(f float64) ([]*FullValue, []*FullValue, error) {
 	if f > 1.0 || f < 0.0 {
 		return nil, nil, errors.Errorf("Error")
 	}
-	return &FullValue{Elm: n.elm}, &FullValue{Elm: n.elm}, nil
+	return []*FullValue{{Elm: n.elm}}, []*FullValue{{Elm: n.elm}}, nil
 }
 
 // GetProgress always returns 0, to keep tests consistent.

--- a/sdks/go/pkg/beam/core/runtime/exec/dynsplit_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/dynsplit_test.go
@@ -103,11 +103,11 @@ func TestDynamicSplit(t *testing.T) {
 			// with the input coder to the path.
 			// TODO(BEAM-10579) Switch to using splittable unit's input coder
 			// once that is implemented.
-			p, err := decodeDynSplitElm(splitRes.split.PS, cdr)
+			p, err := decodeDynSplitElm(splitRes.split.PS[0], cdr)
 			if err != nil {
 				t.Errorf("Failed decoding primary element split: %v", err)
 			}
-			_, err = decodeDynSplitElm(splitRes.split.RS, cdr)
+			_, err = decodeDynSplitElm(splitRes.split.RS[0], cdr)
 			if err != nil {
 				t.Errorf("Failed decoding residual element split: %v", err)
 			}

--- a/sdks/go/pkg/beam/core/runtime/exec/dynsplit_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/dynsplit_test.go
@@ -99,6 +99,15 @@ func TestDynamicSplit(t *testing.T) {
 				t.Errorf("Incorrect split result (ignoring split elements): %v", diff)
 			}
 
+			// Validate that we get one primary and restriction, as expected for
+			// a DoFn that doesn't observe windows.
+			if got, want := len(splitRes.split.PS), 1; got != want {
+				t.Errorf("Incorrect number of primaries returned: got %v, want %v", got, want)
+			}
+			if got, want := len(splitRes.split.RS), 1; got != want {
+				t.Errorf("Incorrect number of residuals returned: got %v, want %v", got, want)
+			}
+
 			// Validate split elements are encoded correctly by decoding them
 			// with the input coder to the path.
 			// TODO(BEAM-10579) Switch to using splittable unit's input coder

--- a/sdks/go/pkg/beam/core/runtime/exec/plan.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/plan.go
@@ -215,10 +215,10 @@ type SplitResult struct {
 
 	// Extra information included for sub-element splits. If PS and RS are
 	// present then a sub-element split occurred.
-	PS   []byte // Primary split. If an element is split, this is the encoded primary.
-	RS   []byte // Residual split. If an element is split, this is the encoded residual.
-	TId  string // Transform ID of the transform receiving the split elements.
-	InId string // Input ID of the input the split elements are received from.
+	PS   [][]byte // Primary splits. If an element is split, these are the encoded primaries.
+	RS   [][]byte // Residual splits. If an element is split, these are the encoded residuals.
+	TId  string   // Transform ID of the transform receiving the split elements.
+	InId string   // Input ID of the input the split elements are received from.
 }
 
 // Split takes a set of potential split indexes, and if successful returns

--- a/sdks/go/pkg/beam/core/runtime/exec/sdf.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf.go
@@ -350,7 +350,6 @@ func (n *ProcessSizedElementsAndRestrictions) ProcessElement(_ context.Context, 
 		// currW updated between processing.
 		n.numW = len(elm.Windows)
 
-		//for _, w := range elm.Windows {
 		for i := 0; i < n.numW; i++ {
 			rest := elm.Elm.(*FullValue).Elm2
 			rt := n.ctInv.Invoke(rest)

--- a/sdks/go/pkg/beam/core/runtime/exec/sdf_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf_test.go
@@ -21,15 +21,25 @@ import (
 
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/window"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/sdf"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
+	"github.com/apache/beam/sdks/go/pkg/beam/io/rtrackers/offsetrange"
 	"github.com/google/go-cmp/cmp"
 )
 
 // testTimestamp is a constant used to check that timestamps are retained.
 const testTimestamp = 15
 
-// testWindow is a constant used to check that windows are retained
+// testWindows is a constant used to check that windows are retained.
 var testWindows = []typex.Window{window.IntervalWindow{Start: 10, End: 20}}
+
+// testMultiWindows is used for tests that care about multiple windows.
+var testMultiWindows = []typex.Window{
+	window.IntervalWindow{Start: 10, End: 20},
+	window.IntervalWindow{Start: 11, End: 21},
+	window.IntervalWindow{Start: 12, End: 22},
+	window.IntervalWindow{Start: 13, End: 23},
+}
 
 // TestSdfNodes verifies that the various SDF nodes fulfill each of their
 // described contracts, that they each successfully invoke any SDF methods
@@ -457,9 +467,11 @@ func TestAsSplittableUnit(t *testing.T) {
 					VetRTracker: VetRTracker{Rest: elm.Elm.(*FullValue).Elm2.(*VetRestriction)},
 					Done:        test.doneWork,
 					Remaining:   test.remainingWork,
+					ThisIsDone:  false,
 				}
 				node.elm = &elm
 				node.currW = test.currWindow
+				node.numW = len(test.windows)
 
 				// Call from SplittableUnit and check results.
 				su := SplittableUnit(node)
@@ -478,15 +490,18 @@ func TestAsSplittableUnit(t *testing.T) {
 	// the restriction tracker.
 	t.Run("Split", func(t *testing.T) {
 		tests := []struct {
-			name         string
-			fn           *graph.DoFn
-			in           FullValue
-			wantPrimary  FullValue
-			wantResidual FullValue
+			name          string
+			fn            *graph.DoFn
+			frac          float64
+			doneRt        bool // Result that RTracker will return for IsDone.
+			in            FullValue
+			wantPrimaries []*FullValue
+			wantResiduals []*FullValue
 		}{
 			{
 				name: "SingleElem",
 				fn:   dfn,
+				frac: 0.5,
 				in: FullValue{
 					Elm: &FullValue{
 						Elm:  1,
@@ -496,7 +511,7 @@ func TestAsSplittableUnit(t *testing.T) {
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
 				},
-				wantPrimary: FullValue{
+				wantPrimaries: []*FullValue{{
 					Elm: &FullValue{
 						Elm:  1,
 						Elm2: &VetRestriction{ID: "Sdf.1", RestSize: true, Val: 1},
@@ -504,8 +519,8 @@ func TestAsSplittableUnit(t *testing.T) {
 					Elm2:      1.0,
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
-				},
-				wantResidual: FullValue{
+				}},
+				wantResiduals: []*FullValue{{
 					Elm: &FullValue{
 						Elm:  1,
 						Elm2: &VetRestriction{ID: "Sdf.2", RestSize: true, Val: 1},
@@ -513,11 +528,12 @@ func TestAsSplittableUnit(t *testing.T) {
 					Elm2:      1.0,
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
-				},
+				}},
 			},
 			{
 				name: "KvElem",
 				fn:   kvdfn,
+				frac: 0.5,
 				in: FullValue{
 					Elm: &FullValue{
 						Elm: &FullValue{
@@ -530,7 +546,7 @@ func TestAsSplittableUnit(t *testing.T) {
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
 				},
-				wantPrimary: FullValue{
+				wantPrimaries: []*FullValue{{
 					Elm: &FullValue{
 						Elm: &FullValue{
 							Elm:  1,
@@ -541,8 +557,8 @@ func TestAsSplittableUnit(t *testing.T) {
 					Elm2:      3.0,
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
-				},
-				wantResidual: FullValue{
+				}},
+				wantResiduals: []*FullValue{{
 					Elm: &FullValue{
 						Elm: &FullValue{
 							Elm:  1,
@@ -553,7 +569,153 @@ func TestAsSplittableUnit(t *testing.T) {
 					Elm2:      3.0,
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
+				}},
+			},
+			{
+				name:   "DoneRTracker",
+				fn:     dfn,
+				doneRt: true,
+				frac:   0.5,
+				in: FullValue{
+					Elm: &FullValue{
+						Elm:  1,
+						Elm2: &VetRestriction{ID: "Sdf"},
+					},
+					Elm2:      1.0,
+					Timestamp: testTimestamp,
+					Windows:   testWindows,
 				},
+				wantPrimaries: []*FullValue{},
+				wantResiduals: []*FullValue{},
+			},
+			{
+				// MultiWindow split where split point lands inside currently
+				// processing restriction tracker.
+				name: "MultiWindow/RestrictionSplit",
+				fn:   dfn,
+				frac: 0.125, // Should be in the middle of the first (current) window.
+				in: FullValue{
+					Elm: &FullValue{
+						Elm:  1,
+						Elm2: &VetRestriction{ID: "Sdf"},
+					},
+					Elm2:      1.0,
+					Timestamp: testTimestamp,
+					Windows:   testMultiWindows,
+				},
+				wantPrimaries: []*FullValue{{
+					Elm: &FullValue{
+						Elm:  1,
+						Elm2: &VetRestriction{ID: "Sdf.1", RestSize: true, Val: 1},
+					},
+					Elm2:      1.0,
+					Timestamp: testTimestamp,
+					Windows:   testMultiWindows[0:1],
+				}},
+				wantResiduals: []*FullValue{{
+					Elm: &FullValue{
+						Elm:  1,
+						Elm2: &VetRestriction{ID: "Sdf.2", RestSize: true, Val: 1},
+					},
+					Elm2:      1.0,
+					Timestamp: testTimestamp,
+					Windows:   testMultiWindows[0:1],
+				}, {
+					Elm: &FullValue{
+						Elm:  1,
+						Elm2: &VetRestriction{ID: "Sdf", RestSize: true, Val: 1},
+					},
+					Elm2:      1.0,
+					Timestamp: testTimestamp,
+					Windows:   testMultiWindows[1:4],
+				}},
+			},
+			{
+				// MultiWindow split where the split lands outside the current
+				// window, and performs a window boundary split instead.
+				name: "MultiWindow/WindowBoundarySplit",
+				fn:   dfn,
+				frac: 0.55,
+				in: FullValue{
+					Elm: &FullValue{
+						Elm:  1,
+						Elm2: &VetRestriction{ID: "Sdf"},
+					},
+					Elm2:      1.0,
+					Timestamp: testTimestamp,
+					Windows:   testMultiWindows,
+				},
+				wantPrimaries: []*FullValue{{
+					Elm: &FullValue{
+						Elm:  1,
+						Elm2: &VetRestriction{ID: "Sdf", RestSize: true, Val: 1},
+					},
+					Elm2:      1.0,
+					Timestamp: testTimestamp,
+					Windows:   testMultiWindows[0:2],
+				}},
+				wantResiduals: []*FullValue{{
+					Elm: &FullValue{
+						Elm:  1,
+						Elm2: &VetRestriction{ID: "Sdf", RestSize: true, Val: 1},
+					},
+					Elm2:      1.0,
+					Timestamp: testTimestamp,
+					Windows:   testMultiWindows[2:4],
+				}},
+			},
+			{
+				// Tests that a MultiWindow split with a Done RTracker will
+				// fallback to a window boundary split.
+				name:   "MultiWindow/DoneRTrackerSplit",
+				fn:     dfn,
+				frac:   0.125,
+				doneRt: true,
+				in: FullValue{
+					Elm: &FullValue{
+						Elm:  1,
+						Elm2: &VetRestriction{ID: "Sdf"},
+					},
+					Elm2:      1.0,
+					Timestamp: testTimestamp,
+					Windows:   testMultiWindows,
+				},
+				wantPrimaries: []*FullValue{{
+					Elm: &FullValue{
+						Elm:  1,
+						Elm2: &VetRestriction{ID: "Sdf", RestSize: true, Val: 1},
+					},
+					Elm2:      1.0,
+					Timestamp: testTimestamp,
+					Windows:   testMultiWindows[0:1],
+				}},
+				wantResiduals: []*FullValue{{
+					Elm: &FullValue{
+						Elm:  1,
+						Elm2: &VetRestriction{ID: "Sdf", RestSize: true, Val: 1},
+					},
+					Elm2:      1.0,
+					Timestamp: testTimestamp,
+					Windows:   testMultiWindows[1:4],
+				}},
+			},
+			{
+				// Test that if a window boundary split lands at the end of an
+				// element, it results in a no-op.
+				name: "MultiWindow/NoResidual",
+				fn:   dfn,
+				frac: 0.95, // Should round to end of element and cause a no-op.
+				in: FullValue{
+					Elm: &FullValue{
+						Elm:  1,
+						Elm2: &VetRestriction{ID: "Sdf"},
+					},
+					Elm2:      1.0,
+					Timestamp: testTimestamp,
+					Windows:   testMultiWindows,
+				},
+				wantPrimaries: []*FullValue{},
+				wantResiduals: []*FullValue{},
 			},
 		}
 		for _, test := range tests {
@@ -564,28 +726,180 @@ func TestAsSplittableUnit(t *testing.T) {
 				node := &ProcessSizedElementsAndRestrictions{PDo: n}
 				node.rt = &SplittableUnitRTracker{
 					VetRTracker: VetRTracker{Rest: test.in.Elm.(*FullValue).Elm2.(*VetRestriction)},
+					Done:        0,
+					Remaining:   1.0,
+					ThisIsDone:  test.doneRt,
 				}
 				node.elm = &test.in
+				node.numW = len(test.in.Windows)
+				node.currW = 0
 
 				// Call from SplittableUnit and check results.
 				su := SplittableUnit(node)
-				frac := 0.5
 				if err := node.Up(context.Background()); err != nil {
 					t.Fatalf("ProcessSizedElementsAndRestrictions.Up() failed: %v", err)
 				}
-				gotPrimary, gotResidual, err := su.Split(frac)
+				gotPrimaries, gotResiduals, err := su.Split(test.frac)
 				if err != nil {
-					t.Fatalf("SplittableUnit.Split(%v) failed: %v", frac, err)
+					t.Fatalf("SplittableUnit.Split(%v) failed: %v", test.frac, err)
 				}
-				if diff := cmp.Diff(gotPrimary, &test.wantPrimary); diff != "" {
-					t.Errorf("SplittableUnit.Split(%v) has incorrect primary: %v", frac, diff)
+				if diff := cmp.Diff(gotPrimaries, test.wantPrimaries); diff != "" {
+					t.Errorf("SplittableUnit.Split(%v) has incorrect primary (-got, +want)\n%v", test.frac, diff)
 				}
-				if diff := cmp.Diff(gotResidual, &test.wantResidual); diff != "" {
-					t.Errorf("SplittableUnit.Split(%v) has incorrect residual: %v", frac, diff)
+				if diff := cmp.Diff(gotResiduals, test.wantResiduals); diff != "" {
+					t.Errorf("SplittableUnit.Split(%v) has incorrect residual (-got, +want)\n%v", test.frac, diff)
 				}
 			})
 		}
 	})
+}
+
+// TestMultiWindowProcessing tests that ProcessSizedElementsAndRestrictions
+// handles processing multiple windows correctly, even when progress is
+// reported and splits are performed during processing.
+func TestMultiWindowProcessing(t *testing.T) {
+	// Set up our SDF to block on the second window of four, at the second
+	// position of the restriction. (i.e. window at 0.5 progress, full element
+	// at 0.375 progress)
+	blockW := 1
+	wsdf := WindowBlockingSdf{
+		block: make(chan struct{}),
+		claim: 1,
+		w:     testMultiWindows[blockW],
+	}
+	dfn, err := graph.NewDoFn(&wsdf, graph.NumMainInputs(graph.MainSingle))
+	if err != nil {
+		t.Fatalf("invalid function: %v", err)
+	}
+
+	// Create a plan with a single valid element as input to ProcessElement.
+	in := FullValue{
+		Elm: &FullValue{
+			Elm:  1,
+			Elm2: offsetrange.Restriction{Start: 0, End: 4},
+		},
+		Elm2:      4.0,
+		Timestamp: testTimestamp,
+		Windows:   testMultiWindows,
+	}
+	capt := &CaptureNode{UID: 2}
+	n := &ParDo{UID: 1, Fn: dfn, Out: []Node{capt}}
+	node := &ProcessSizedElementsAndRestrictions{PDo: n}
+	root := &FixedRoot{UID: 0, Elements: []MainInput{{Key: in}}, Out: node}
+	units := []Unit{root, node, capt}
+	p, err := NewPlan("a", units)
+	if err != nil {
+		t.Fatalf("failed to construct plan: %v", err)
+	}
+
+	// Start a goroutine for processing, expecting to synchronize with it once
+	// while processing is blocked (to validate processing) and a second time
+	// it's done (to validate final outputs).
+	done := make(chan struct{})
+	go func() {
+		if err := p.Execute(context.Background(), "1", DataContext{}); err != nil {
+			t.Fatalf("execute failed: %v", err)
+		}
+		done <- struct{}{}
+	}()
+
+	// Once SDF is blocked, check that it is tracking windows properly, and that
+	// getting progress and splitting works as expected.
+	<-wsdf.block
+
+	if got, want := node.currW, blockW; got != want {
+		t.Errorf("Incorrect current window during processing, got %v, want %v", got, want)
+	}
+	if got, want := node.numW, len(testMultiWindows); got != want {
+		t.Errorf("Incorrect total number of windows during processing, got %v, want %v", got, want)
+	}
+
+	su := <-node.SU
+	if got, want := su.GetProgress(), 1.5/4.0; !floatEquals(got, want, 0.00001) {
+		t.Errorf("Incorrect result from GetProgress() during processing, got %v, want %v", got, want)
+	}
+	// Split should hit window boundary between 2 and 3. We don't need to check
+	// the split result here, just the effects it has on currW and numW.
+	frac := 0.5
+	if _, _, err := su.Split(frac); err != nil {
+		t.Errorf("Split(%v) failed with error: %v", frac, err)
+	}
+	if got, want := node.currW, blockW; got != want {
+		t.Errorf("Incorrect current window after splitting, got %v, want %v", got, want)
+	}
+	if got, want := node.numW, 3; got != want {
+		t.Errorf("Incorrect total number of windows after splitting, got %v, want %v", got, want)
+	}
+
+	// Now we can unblock SDF and finish processing, then check that the results
+	// respected the windowed split.
+	node.SU <- su
+	wsdf.block <- struct{}{}
+	<-done
+
+	gotOut := capt.Elements
+	wantOut := []FullValue{{ // Only 3 windows, 4th should be gone after split.
+		Elm:       1,
+		Timestamp: testTimestamp,
+		Windows:   testMultiWindows[0:1],
+	}, {
+		Elm:       1,
+		Timestamp: testTimestamp,
+		Windows:   testMultiWindows[1:2],
+	}, {
+		Elm:       1,
+		Timestamp: testTimestamp,
+		Windows:   testMultiWindows[2:3],
+	}}
+	if diff := cmp.Diff(gotOut, wantOut); diff != "" {
+		t.Errorf("ProcessSizedElementsAndRestrictions produced incorrect outputs (-got, +want):\n%v", diff)
+	}
+}
+
+// WindowBlockingSdf is a very basic SDF that blocks execution once, in one
+// window and at one position within the restriction.
+type WindowBlockingSdf struct {
+	block chan struct{}
+	claim int64 // The SDF will block after claiming this position.
+	w     typex.Window
+}
+
+// CreateInitialRestriction creates a four-element offset range.
+func (fn *WindowBlockingSdf) CreateInitialRestriction(_ int) offsetrange.Restriction {
+	return offsetrange.Restriction{Start: 0, End: 4}
+}
+
+// SplitRestriction is a no-op, and does not split.
+func (fn *WindowBlockingSdf) SplitRestriction(_ int, rest offsetrange.Restriction) []offsetrange.Restriction {
+	return []offsetrange.Restriction{rest}
+}
+
+// RestrictionSize defers to the default offset range restriction size.
+func (fn *WindowBlockingSdf) RestrictionSize(_ int, rest offsetrange.Restriction) float64 {
+	return rest.Size()
+}
+
+// CreateTracker creates a LockRTracker wrapping an offset range RTracker.
+func (fn *WindowBlockingSdf) CreateTracker(rest offsetrange.Restriction) *sdf.LockRTracker {
+	return sdf.NewLockRTracker(offsetrange.NewTracker(rest))
+}
+
+// ProcessElement observes windows, and, while claiming positions in the
+// restriction, checks each position+window pair to see if it matches the
+// block position and window. If it does, then this sends a token through the
+// block channel and receives it back, to give another thread a chance to
+// perform work before unblocking. Finally, once all work has been claimed, it
+// outputs the original input element.
+func (fn *WindowBlockingSdf) ProcessElement(w typex.Window, rt *sdf.LockRTracker, elm int, emit func(int)) {
+	i := rt.GetRestriction().(offsetrange.Restriction).Start
+	for rt.TryClaim(i) {
+		if w == fn.w && i == fn.claim {
+			fn.block <- struct{}{}
+			<-fn.block
+		}
+		i++
+	}
+	emit(elm)
 }
 
 // SplittableUnitRTracker is a VetRTracker with some added behavior needed for
@@ -593,9 +907,12 @@ func TestAsSplittableUnit(t *testing.T) {
 type SplittableUnitRTracker struct {
 	VetRTracker
 	Done, Remaining float64 // Allows manually setting progress.
+	ThisIsDone      bool
 }
 
-func (rt *SplittableUnitRTracker) IsDone() bool { return false }
+func (rt *SplittableUnitRTracker) IsDone() bool {
+	return rt.ThisIsDone
+}
 
 func (rt *SplittableUnitRTracker) TrySplit(_ float64) (interface{}, interface{}, error) {
 	rest1 := rt.Rest.copy()

--- a/sdks/go/pkg/beam/core/runtime/harness/harness.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/harness.go
@@ -363,19 +363,25 @@ func (c *control) handleInstruction(ctx context.Context, req *fnpb.InstructionRe
 
 		var pRoots []*fnpb.BundleApplication
 		var rRoots []*fnpb.DelayedBundleApplication
-		if sr.PS != nil && sr.RS != nil {
-			pRoots = []*fnpb.BundleApplication{{
-				TransformId: sr.TId,
-				InputId:     sr.InId,
-				Element:     sr.PS,
-			}}
-			rRoots = []*fnpb.DelayedBundleApplication{{
-				Application: &fnpb.BundleApplication{
+		if sr.PS != nil && len(sr.PS) > 0 && sr.RS != nil && len(sr.RS) > 0 {
+			pRoots = make([]*fnpb.BundleApplication, len(sr.PS))
+			for i, p := range sr.PS {
+				pRoots[i] = &fnpb.BundleApplication{
 					TransformId: sr.TId,
 					InputId:     sr.InId,
-					Element:     sr.RS,
-				},
-			}}
+					Element:     p,
+				}
+			}
+			rRoots = make([]*fnpb.DelayedBundleApplication, len(sr.RS))
+			for i, r := range sr.RS {
+				rRoots[i] = &fnpb.DelayedBundleApplication{
+					Application: &fnpb.BundleApplication{
+						TransformId: sr.TId,
+						InputId:     sr.InId,
+						Element:     r,
+					},
+				}
+			}
 		}
 
 		return &fnpb.InstructionResponse{

--- a/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange.go
+++ b/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange.go
@@ -180,8 +180,8 @@ func (tracker *Tracker) TrySplit(fraction float64) (primary, residual interface{
 
 // GetProgress reports progress based on the claimed size and unclaimed sizes of the restriction.
 func (tracker *Tracker) GetProgress() (done, remaining float64) {
-	done = float64(tracker.claimed - tracker.rest.Start)
-	remaining = float64(tracker.rest.End - tracker.claimed)
+	done = float64((tracker.claimed + 1) - tracker.rest.Start)
+	remaining = float64(tracker.rest.End - (tracker.claimed + 1))
 	return
 }
 


### PR DESCRIPTION
Adjust Go SDF splitting and execution code so that splits take exploded windows into consideration and perform splits at window boundaries. Also required adjusting various split logic to accept multiple residuals and primaries from splits.

The changes to the splitting logic itself are in exec/sdf.go, and the tests are in the corresponding test file. The rest of the changes are mostly related to adjusting other code to handle the change from single primaries and restrictions to multiple primaries and restrictions, or just small bugfixes (like offsetrange.RTracker.GetProgress).

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
