### PR TITLE
[BEAM-3376] Adds possibility to customize of default_value evaluation in CombineFn.

### DIFF
--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -63,8 +63,15 @@ V = TypeVar('V')
 TimestampType = Union[int, float, Timestamp, Duration]
 
 
-class CombinerWithoutDefaults(ptransform.PTransform):
-  """Super class to inherit without_defaults to built-in Combiners."""
+class _SupportsCombiningGlobally(ptransform.PTransform):
+  """Helper for defining per-window combine scenarios in built-in combiners.
+
+  In combine-per-window scenarios users may need to indicate whether a result
+  of reducing an empty input collection during combining should be
+  an empty collection or CombineFn.default_value().
+
+  Note that combine-per-key scenarios always have an non-empty input.
+  """
   def __init__(self, has_defaults=True):
     self.has_defaults = has_defaults
 
@@ -79,7 +86,7 @@ class CombinerWithoutDefaults(ptransform.PTransform):
 
 class Mean(object):
   """Combiners for computing arithmetic means of elements."""
-  class Globally(CombinerWithoutDefaults):
+  class Globally(_SupportsCombiningGlobally):
     """combiners.Mean.Globally computes the arithmetic mean of the elements."""
     def expand(self, pcoll):
       if self.has_defaults:
@@ -126,7 +133,7 @@ class MeanCombineFn(core.CombineFn):
 
 class Count(object):
   """Combiners for counting elements."""
-  class Globally(CombinerWithoutDefaults):
+  class Globally(_SupportsCombiningGlobally):
     """combiners.Count.Globally counts the total number of elements."""
     def expand(self, pcoll):
       if self.has_defaults:
@@ -177,7 +184,7 @@ class Top(object):
 
   # pylint: disable=no-self-argument
 
-  class Of(CombinerWithoutDefaults):
+  class Of(_SupportsCombiningGlobally):
     """Obtain a list of the compare-most N elements in a PCollection.
 
     This transform will retrieve the n greatest elements in the PCollection
@@ -654,7 +661,7 @@ class Sample(object):
 
   # pylint: disable=no-self-argument
 
-  class FixedSizeGlobally(CombinerWithoutDefaults):
+  class FixedSizeGlobally(_SupportsCombiningGlobally):
     """Sample n elements from the input PCollection without replacement."""
     def __init__(self, n):
       super(Sample.FixedSizeGlobally, self).__init__()
@@ -780,7 +787,7 @@ class SingleInputTupleCombineFn(_TupleCombineFnBase):
     ]
 
 
-class ToList(CombinerWithoutDefaults):
+class ToList(_SupportsCombiningGlobally):
   """A global CombineFn that condenses a PCollection into a single list."""
   def __init__(self, label='ToList'):  # pylint: disable=useless-super-delegation
     super(ToList, self).__init__(label)
@@ -811,7 +818,7 @@ class ToListCombineFn(core.CombineFn):
     return accumulator
 
 
-class ToDict(CombinerWithoutDefaults):
+class ToDict(_SupportsCombiningGlobally):
   """A global CombineFn that condenses a PCollection into a single dict.
 
   PCollections should consist of 2-tuples, notionally (key, value) pairs.
@@ -851,7 +858,7 @@ class ToDictCombineFn(core.CombineFn):
     return accumulator
 
 
-class ToSet(CombinerWithoutDefaults):
+class ToSet(_SupportsCombiningGlobally):
   """A global CombineFn that condenses a PCollection into a set."""
   def __init__(self, label='ToSet'):  # pylint: disable=useless-super-delegation
     super(ToSet, self).__init__(label)
@@ -956,7 +963,7 @@ class Latest(object):
   """Combiners for computing the latest element"""
   @with_input_types(T)
   @with_output_types(T)
-  class Globally(CombinerWithoutDefaults):
+  class Globally(_SupportsCombiningGlobally):
     """Compute the element with the latest timestamp from a
     PCollection."""
     @staticmethod

--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -66,9 +66,10 @@ TimestampType = Union[int, float, Timestamp, Duration]
 class _SupportsCombiningGlobally(ptransform.PTransform):
   """Helper for defining per-window combine scenarios in built-in combiners.
 
-  In combine-per-window scenarios users may need to indicate whether a result
-  of reducing an empty input collection during combining should be
-  an empty collection or CombineFn.default_value().
+  In combine-per-window scenarios users may need to indicate how to reduce an
+  empty input collection when a window has no elements. The result can
+  either be a default value (obtained by calling a combiner on an empty input)
+  or an empty collection if without_defaults() is used.
 
   Note that combine-per-key scenarios always have an non-empty input.
   """

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -889,31 +889,12 @@ class CombineFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
   5. The extract_output operation is invoked on the final accumulator to get
      the output value.
 
+  Note: If this **CombineFn** is used with a transform that has defaults,
+  **apply** will be called with an empty list at expansion time to get the
+  default value.
   """
   def default_label(self):
     return self.__class__.__name__
-
-  def default_value(self, *args, **kwargs):
-    """Returns a default reduction of an empty input.
-
-    Some combiners require a default value when reducing an empty collection,
-    which may be necessary when combining elements in an empty window.
-
-    If **CombineFn** is used with a transform that requires defaults,
-    default_value may be called during transform expansion.
-
-    Args:
-      *args: Additional arguments and side inputs.
-      **kwargs: Additional arguments and side inputs.
-    """
-    # Defalut values may be evaluated at pipeline construction time.
-    # Make a copy to avoid passing any side-effects to the serialized pipeline
-    # representaiton.
-    combine_copy = copy.copy(self)
-    # TODO(BEAM-3736): add setup.
-    default = combine_copy.apply([], *args, **kwargs)
-    # TODO(BEAM-3736): add teardown.
-    return default
 
   def create_accumulator(self, *args, **kwargs):
     """Return a fresh, empty accumulator for the combine operation.
@@ -2003,7 +1984,7 @@ class CombineGlobally(PTransform):
       combine_fn = (
           self.fn if isinstance(self.fn, CombineFn) else
           CombineFn.from_callable(self.fn))
-      default_value = combine_fn.default_value(*self.args, **self.kwargs)
+      default_value = combine_fn.apply([], *self.args, **self.kwargs)
     else:
       default_value = pvalue.AsSingleton._NO_DEFAULT  # pylint: disable=protected-access
     view = pvalue.AsSingleton(combined, default_value=default_value)

--- a/sdks/python/scripts/generate_pydoc.sh
+++ b/sdks/python/scripts/generate_pydoc.sh
@@ -166,7 +166,7 @@ ignore_identifiers = [
   'apache_beam.pvalue.PValue',
   'apache_beam.runners.direct.executor.CallableTask',
   'apache_beam.testing.synthetic_pipeline._Random',
-  'apache_beam.transforms.combiners.CombinerWithoutDefaults',
+  'apache_beam.transforms.combiners._SupportsCombiningGlobally',
   'apache_beam.transforms.core.CallableWrapperCombineFn',
   'apache_beam.transforms.ptransform.PTransformWithSideInputs',
   'apache_beam.transforms.trigger._ParallelTriggerFn',


### PR DESCRIPTION
This change makes it possible to customize default value evaluation in CombineFn to match Java SDK, see: 
https://github.com/apache/beam/blob/f639a7e760dcbe82f2d0236f715e964dd746931d/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Combine.java#L461

If necessary users could to skip CombineFn.setup and CombineFn.teardown during calculation of the default value during initial pipeline expansion, see discussion in upcoming https://github.com/apache/beam/pull/13048#discussion_r503585072. 

Also adds some rewording/explanation for default_value usage following previous PRs (#12074, #3984).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
