### PR TITLE
[BEAM-9547] Add support for `DataFrame.assign`

### DIFF
--- a/sdks/python/apache_beam/dataframe/frame_base.py
+++ b/sdks/python/apache_beam/dataframe/frame_base.py
@@ -238,7 +238,7 @@ def _proxy_function(
       actual_func = func
 
     def apply(*actual_args):
-      actual_args, actual_kwargs = actual_args[:len(constant_args)], actual_args[len(constant_args):]
+      actual_args, actual_kwargs = actual_args[:len(deferred_arg_exprs)], actual_args[len(deferred_arg_exprs):]
 
       full_args = list(constant_args)
       for ix, arg in zip(deferred_arg_indices, actual_args):

--- a/sdks/python/apache_beam/dataframe/frame_base.py
+++ b/sdks/python/apache_beam/dataframe/frame_base.py
@@ -216,20 +216,42 @@ def _proxy_function(
       else:
         constant_args[ix] = arg
 
+    deferred_kwarg_keys = []
+    deferred_kwarg_exprs = []
+    constant_kwargs = {key: None for key in kwargs.keys()}
+    for key, arg in kwargs.items():
+      if isinstance(arg, DeferredBase):
+        deferred_kwarg_keys.append(key)
+        deferred_kwarg_exprs.append(arg._expr)
+      elif isinstance(arg, pd.core.generic.NDFrame):
+        deferred_kwarg_keys.append(key)
+        deferred_kwarg_exprs.append(
+            expressions.ConstantExpression(arg, arg[0:0]))
+      else:
+        constant_kwargs[key] = arg
+
+    deferred_exprs = deferred_arg_exprs + deferred_kwarg_exprs
+
     if inplace:
       actual_func = copy_and_mutate(func)
     else:
       actual_func = func
 
     def apply(*actual_args):
+      actual_args, actual_kwargs = actual_args[:len(constant_args)], actual_args[len(constant_args):]
+
       full_args = list(constant_args)
       for ix, arg in zip(deferred_arg_indices, actual_args):
         full_args[ix] = arg
-      return actual_func(*full_args, **kwargs)
 
-    if any(isinstance(arg.proxy(), pd.core.generic.NDFrame)
-           for arg in deferred_arg_exprs
-           ) and not requires_partition_by.is_subpartitioning_of(
+      full_kwargs = dict(constant_kwargs)
+      for key, arg in zip(deferred_kwarg_keys, actual_kwargs):
+        full_kwargs[key] = arg
+
+      return actual_func(*full_args, **full_kwargs)
+
+    if any(isinstance(arg.proxy(), pd.core.generic.NDFrame) for arg in
+           deferred_exprs) and not requires_partition_by.is_subpartitioning_of(
                partitionings.Index()):
       # Implicit join on index.
       actual_requires_partition_by = partitionings.Index()
@@ -239,7 +261,7 @@ def _proxy_function(
     result_expr = expressions.ComputedExpression(
         name,
         apply,
-        deferred_arg_exprs,
+        deferred_exprs,
         requires_partition_by=actual_requires_partition_by,
         preserves_partition_by=preserves_partition_by)
     if inplace:

--- a/sdks/python/apache_beam/dataframe/frame_base.py
+++ b/sdks/python/apache_beam/dataframe/frame_base.py
@@ -218,7 +218,7 @@ def _proxy_function(
 
     deferred_kwarg_keys = []
     deferred_kwarg_exprs = []
-    constant_kwargs = {key: None for key in kwargs.keys()}
+    constant_kwargs = {key: None for key in kwargs}
     for key, arg in kwargs.items():
       if isinstance(arg, DeferredBase):
         deferred_kwarg_keys.append(key)
@@ -238,7 +238,8 @@ def _proxy_function(
       actual_func = func
 
     def apply(*actual_args):
-      actual_args, actual_kwargs = actual_args[:len(deferred_arg_exprs)], actual_args[len(deferred_arg_exprs):]
+      actual_args, actual_kwargs = (actual_args[:len(deferred_arg_exprs)],
+                                    actual_args[len(deferred_arg_exprs):])
 
       full_args = list(constant_args)
       for ix, arg in zip(deferred_arg_indices, actual_args):

--- a/sdks/python/apache_beam/dataframe/frame_base_test.py
+++ b/sdks/python/apache_beam/dataframe/frame_base_test.py
@@ -41,6 +41,22 @@ class FrameBaseTest(unittest.TestCase):
     self.assertTrue(sub(x, b)._expr.evaluate_at(session).equals(a - b))
     self.assertTrue(sub(a, y)._expr.evaluate_at(session).equals(a - b))
 
+  def test_elementwise_func_kwarg(self):
+    a = pd.Series([1, 2, 3])
+    b = pd.Series([100, 200, 300])
+    empty_proxy = a[:0]
+    x = frames.DeferredSeries(expressions.PlaceholderExpression(empty_proxy))
+    y = frames.DeferredSeries(expressions.PlaceholderExpression(empty_proxy))
+    sub = frame_base._elementwise_function(lambda x, y=1: x - y)
+
+    session = expressions.Session({x._expr: a, y._expr: b})
+    self.assertTrue(sub(x, y=y)._expr.evaluate_at(session).equals(a - b))
+    self.assertTrue(sub(x)._expr.evaluate_at(session).equals(a - 1))
+    self.assertTrue(sub(1, y=x)._expr.evaluate_at(session).equals(1 - a))
+    self.assertTrue(sub(x, y=b)._expr.evaluate_at(session).equals(a - b))
+    self.assertTrue(sub(a, y=y)._expr.evaluate_at(session).equals(a - b))
+    self.assertTrue(sub(x, y)._expr.evaluate_at(session).equals(a - b))
+
   def test_maybe_inplace(self):
     @frame_base.maybe_inplace
     def add_one(frame):

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -510,10 +510,19 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
   def axes(self):
     return (self.index, self.columns)
 
+  def assign(self, **kwargs):
+    for name, value in kwargs.items():
+      if not callable(value) and not isinstance(value, DeferredSeries):
+        raise frame_base.WontImplementError("Unsupported value for new "
+                                            f"column '{name}': '{value}'. "
+                                            "Only callables and Series "
+                                            "instances are supported.")
+    return frame_base._elementwise_method('assign')(self, **kwargs)
+
+
   apply = frame_base.not_implemented_method('apply')
   explode = frame_base.not_implemented_method('explode')
   isin = frame_base.not_implemented_method('isin')
-  assign = frame_base.not_implemented_method('assign')
   append = frame_base.not_implemented_method('append')
   combine = frame_base.not_implemented_method('combine')
   combine_first = frame_base.not_implemented_method('combine_first')

--- a/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
@@ -118,9 +118,6 @@ class DoctestTest(unittest.TestCase):
             'pandas.core.frame.DataFrame.rename': ['*'],
             'pandas.core.frame.DataFrame.apply': ['*'],
 
-            # Zipping operation if input is a DeferredSeries
-            'pandas.core.frame.DataFrame.assign': ['*'],
-
             # In theory this is possible for bounded inputs?
             'pandas.core.frame.DataFrame.append': ['*'],
         },


### PR DESCRIPTION
R: @robertwb 

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
