### PR TITLE
More flexible dataframe conversions.

### DIFF
--- a/sdks/python/apache_beam/dataframe/convert.py
+++ b/sdks/python/apache_beam/dataframe/convert.py
@@ -31,13 +31,15 @@ from apache_beam.dataframe import transforms
 
 if TYPE_CHECKING:
   # pylint: disable=ungrouped-imports
+  from typing import Optional
   import pandas
 
 
 # TODO: Or should this be called as_dataframe?
 def to_dataframe(
     pcoll,  # type: pvalue.PCollection
-    proxy=None,  # type: pandas.core.generic.NDFrame
+    proxy=None,  # type: Optional[pandas.core.generic.NDFrame]
+    label=None,  # type: Optional[str]
 ):
   # type: (...) -> frame_base.DeferredFrame
 
@@ -61,8 +63,12 @@ def to_dataframe(
           "the input PCollection, or provide a proxy.")
     # If no proxy is given, assume this is an element-wise schema-aware
     # PCollection that needs to be batched.
+    if label is None:
+      # Attempt to come up with a reasonable, stable label by retrieving
+      # the name of these variables in the calling context.
+      label = 'BatchElements(%s)' % _var_name(pcoll, 2)
     proxy = schemas.generate_proxy(pcoll.element_type)
-    pcoll = pcoll | 'BatchElements' >> schemas.BatchRowsAsDataFrame()
+    pcoll = pcoll | label >> schemas.BatchRowsAsDataFrame(proxy=proxy)
   return frame_base.DeferredFrame.wrap(
       expressions.PlaceholderExpression(proxy, pcoll))
 
@@ -112,23 +118,7 @@ def to_pcollection(
   if label is None:
     # Attempt to come up with a reasonable, stable label by retrieving the name
     # of these variables in the calling context.
-    current_frame = inspect.currentframe()
-    if current_frame is None:
-      label = 'ToDataframe(...)'
-
-    else:
-      previous_frame = current_frame.f_back
-
-      def name(obj):
-        for key, value in previous_frame.f_locals.items():
-          if obj is value:
-            return key
-        for key, value in previous_frame.f_globals.items():
-          if obj is value:
-            return key
-        return '...'
-
-      label = 'ToDataframe(%s)' % ', '.join(name(e) for e in dataframes)
+    label = 'ToPCollection(%s)' % ', '.join(_var_name(e, 3) for e in dataframes)
 
   def extract_input(placeholder):
     if not isinstance(placeholder._reference, pvalue.PCollection):
@@ -156,3 +146,18 @@ def to_pcollection(
     return results[0]
   else:
     return tuple(value for key, value in sorted(results.items()))
+
+
+def _var_name(obj, level):
+  frame = inspect.currentframe()
+  for _ in range(level):
+    if frame is None:
+      return '...'
+    frame = frame.f_back
+  for key, value in frame.f_locals.items():
+    if obj is value:
+      return key
+  for key, value in frame.f_globals.items():
+    if obj is value:
+      return key
+  return '...'

--- a/sdks/python/apache_beam/dataframe/convert_test.py
+++ b/sdks/python/apache_beam/dataframe/convert_test.py
@@ -85,6 +85,13 @@ class ConverTest(unittest.TestCase):
       assert_that(pc_3a, equal_to(list(3 * a)), label='Check3a')
       assert_that(pc_ab, equal_to(list(a * b)), label='Checkab')
 
+  def test_convert_scalar(self):
+    with beam.Pipeline() as p:
+      pc = p | 'A' >> beam.Create([1, 2, 3])
+      s = convert.to_dataframe(pc)
+      pc_sum = convert.to_pcollection(s.sum())
+      assert_that(pc_sum, equal_to([6]))
+
 
 if __name__ == '__main__':
   unittest.main()

--- a/sdks/python/apache_beam/dataframe/convert_test.py
+++ b/sdks/python/apache_beam/dataframe/convert_test.py
@@ -66,11 +66,11 @@ class ConverTest(unittest.TestCase):
       a = pd.Series([1, 2, 3])
       b = pd.Series([100, 200, 300])
 
-      pc_a = p | 'A' >> beam.Create([a])
-      pc_b = p | 'B' >> beam.Create([b])
+      pc_a = p | 'A' >> beam.Create(a)
+      pc_b = p | 'B' >> beam.Create(b)
 
-      df_a = convert.to_dataframe(pc_a, proxy=a[:0])
-      df_b = convert.to_dataframe(pc_b, proxy=b[:0])
+      df_a = convert.to_dataframe(pc_a)
+      df_b = convert.to_dataframe(pc_b)
 
       df_2a = 2 * df_a
       df_3a = 3 * df_a

--- a/sdks/python/apache_beam/dataframe/schemas.py
+++ b/sdks/python/apache_beam/dataframe/schemas.py
@@ -146,15 +146,21 @@ class BatchRowsAsDataFrame(beam.PTransform):
   Batching parameters are inherited from
   :class:`~apache_beam.transforms.util.BatchElements`.
   """
-  def __init__(self, *args, **kwargs):
+  def __init__(self, *args, proxy, **kwargs):
     self._batch_elements_transform = BatchElements(*args, **kwargs)
+    self._proxy = proxy
 
   def expand(self, pcoll):
-    columns = [
-        name for name, _ in named_fields_from_element_type(pcoll.element_type)
-    ]
-    return pcoll | self._batch_elements_transform | beam.Map(
-        lambda batch: pd.DataFrame.from_records(batch, columns=columns))
+    if isinstance(self._proxy, pd.DataFrame):
+      columns = self._proxy.columns
+      construct = lambda batch: pd.DataFrame.from_records(
+          batch, columns=columns)
+    elif isinstance(self._proxy, pd.Series):
+      dtype = self._proxy.dtype
+      construct = lambda batch: pd.Series(batch, dtype=dtype)
+    else:
+      raise NotImplementedError("Unknown proxy type: %s" % self._proxy)
+    return pcoll | self._batch_elements_transform | beam.Map(construct)
 
 
 def generate_proxy(element_type):
@@ -163,18 +169,21 @@ def generate_proxy(element_type):
   """Generate a proxy pandas object for the given PCollection element_type.
 
   Currently only supports generating a DataFrame proxy from a schema-aware
-  PCollection.
+  PCollection or a Series proxy from a primitively typed PCollection.
   """
-  fields = named_fields_from_element_type(element_type)
-  proxy = pd.DataFrame(columns=[name for name, _ in fields])
+  if element_type != Any and element_type in BEAM_TO_PANDAS:
+    return pd.Series(dtype=BEAM_TO_PANDAS[element_type])
 
-  for name, typehint in fields:
-    # Default to np.object. This is lossy, we won't be able to recover the type
-    # at the output.
-    dtype = BEAM_TO_PANDAS.get(typehint, np.object)
-    proxy[name] = proxy[name].astype(dtype)
+  else:
+    fields = named_fields_from_element_type(element_type)
+    proxy = pd.DataFrame(columns=[name for name, _ in fields])
+    for name, typehint in fields:
+      # Default to np.object. This is lossy, we won't be able to recover
+      # the type at the output.
+      dtype = BEAM_TO_PANDAS.get(typehint, np.object)
+      proxy[name] = proxy[name].astype(dtype)
 
-  return proxy
+    return proxy
 
 
 def element_type_from_dataframe(proxy, include_indexes=False):

--- a/sdks/python/apache_beam/dataframe/schemas_test.py
+++ b/sdks/python/apache_beam/dataframe/schemas_test.py
@@ -124,10 +124,7 @@ class SchemasTest(unittest.TestCase):
           | beam.Create([
               Simple(name=unicode(i), id=i, height=float(i)) for i in range(5)
           ])
-          | schemas.BatchRowsAsDataFrame(
-              min_batch_size=10,
-              max_batch_size=10,
-              proxy=schemas.generate_proxy(Simple)))
+          | schemas.BatchRowsAsDataFrame(min_batch_size=10, max_batch_size=10))
       assert_that(res, matches_df(expected))
 
   def test_generate_proxy(self):
@@ -164,7 +161,7 @@ class SchemasTest(unittest.TestCase):
               Animal('Parrot', 24.0),
               Animal('Parrot', 26.0)
           ])
-          | schemas.BatchRowsAsDataFrame(proxy=schemas.generate_proxy(Animal))
+          | schemas.BatchRowsAsDataFrame()
           | transforms.DataframeTransform(
               lambda df: df.groupby('animal').mean(),
               # TODO: Generate proxy in this case as well
@@ -183,8 +180,7 @@ class SchemasTest(unittest.TestCase):
                 Animal('Parrot', 24.0),
                 Animal('Parrot', 26.0)
             ])
-            |
-            schemas.BatchRowsAsDataFrame(proxy=schemas.generate_proxy(Animal))
+            | schemas.BatchRowsAsDataFrame()
             | transforms.DataframeTransform(
                 lambda df: df.groupby('animal').mean().reset_index(),
                 # TODO: Generate proxy in this case as well

--- a/sdks/python/apache_beam/dataframe/schemas_test.py
+++ b/sdks/python/apache_beam/dataframe/schemas_test.py
@@ -124,7 +124,10 @@ class SchemasTest(unittest.TestCase):
           | beam.Create([
               Simple(name=unicode(i), id=i, height=float(i)) for i in range(5)
           ])
-          | schemas.BatchRowsAsDataFrame(min_batch_size=10, max_batch_size=10))
+          | schemas.BatchRowsAsDataFrame(
+              min_batch_size=10,
+              max_batch_size=10,
+              proxy=schemas.generate_proxy(Simple)))
       assert_that(res, matches_df(expected))
 
   def test_generate_proxy(self):
@@ -161,7 +164,7 @@ class SchemasTest(unittest.TestCase):
               Animal('Parrot', 24.0),
               Animal('Parrot', 26.0)
           ])
-          | schemas.BatchRowsAsDataFrame()
+          | schemas.BatchRowsAsDataFrame(proxy=schemas.generate_proxy(Animal))
           | transforms.DataframeTransform(
               lambda df: df.groupby('animal').mean(),
               # TODO: Generate proxy in this case as well
@@ -180,7 +183,8 @@ class SchemasTest(unittest.TestCase):
                 Animal('Parrot', 24.0),
                 Animal('Parrot', 26.0)
             ])
-            | schemas.BatchRowsAsDataFrame()
+            |
+            schemas.BatchRowsAsDataFrame(proxy=schemas.generate_proxy(Animal))
             | transforms.DataframeTransform(
                 lambda df: df.groupby('animal').mean().reset_index(),
                 # TODO: Generate proxy in this case as well


### PR DESCRIPTION
* Allow conversion of a PCollection of primitives (like ints) to a deferred Serries.
* Allow conversion of deferred scalars to singleton PCollections without specifying `yield_elements=pandas`.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
