### PR TITLE
Implementing Python Bounded Source Reader DoFn

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -588,10 +588,12 @@ class _BigQuerySource(dataflow_io.NativeSource):
         kms_key=self.kms_key)
 
 
+FieldSchema = collections.namedtuple('FieldSchema', 'fields mode name type')
+
+
 class _JsonToDictCoder(coders.Coder):
   """A coder for a JSON string to a Python dict."""
 
-  FieldSchema = collections.namedtuple('FieldSchema', 'fields mode name type')
 
   def __init__(self, table_schema):
     self.fields = self._convert_to_tuple(table_schema.fields)
@@ -624,7 +626,7 @@ class _JsonToDictCoder(coders.Coder):
       return []
 
     return [
-        cls.FieldSchema(
+        FieldSchema(
             cls._convert_to_tuple(x.fields), x.mode, x.name, x.type)
         for x in table_field_schemas
     ]

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -593,8 +593,6 @@ FieldSchema = collections.namedtuple('FieldSchema', 'fields mode name type')
 
 class _JsonToDictCoder(coders.Coder):
   """A coder for a JSON string to a Python dict."""
-
-
   def __init__(self, table_schema):
     self.fields = self._convert_to_tuple(table_schema.fields)
     self._converters = {
@@ -626,8 +624,7 @@ class _JsonToDictCoder(coders.Coder):
       return []
 
     return [
-        FieldSchema(
-            cls._convert_to_tuple(x.fields), x.mode, x.name, x.type)
+        FieldSchema(cls._convert_to_tuple(x.fields), x.mode, x.name, x.type)
         for x in table_field_schemas
     ]
 

--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -1530,15 +1530,14 @@ class _SDFBoundedSourceRestrictionProvider(core.RestrictionProvider):
   """
   A `RestrictionProvider` that is used by SDF for `BoundedSource`.
 
-  If source is provided, uses it for initializing restriction. Otherwise
-  initializes restriction based on input element that is expected to be of
-  BoundedSource type.
+  This restriction provider initializes restriction based on input
+  element that is expected to be of BoundedSource type.
   """
   def __init__(self, desired_chunk_size=None):
     self._desired_chunk_size = desired_chunk_size
 
   def _check_source(self, src):
-    if src is not None and not isinstance(src, BoundedSource):
+    if not isinstance(src, BoundedSource):
       raise RuntimeError(
           'SDFBoundedSourceRestrictionProvider can only utilize BoundedSource')
 

--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -54,6 +54,7 @@ from apache_beam.portability import python_urns
 from apache_beam.portability.api import beam_runner_api_pb2
 from apache_beam.pvalue import AsIter
 from apache_beam.pvalue import AsSingleton
+from apache_beam.transforms import PTransform
 from apache_beam.transforms import core
 from apache_beam.transforms import ptransform
 from apache_beam.transforms import window
@@ -1427,145 +1428,158 @@ class RestrictionProgress(object):
         fraction=self._fraction, remaining=self._remaining, completed=completed)
 
 
+class _SDFBoundedSourceRestriction(object):
+  """ A restriction wraps SourceBundle and RangeTracker. """
+  def __init__(self, source_bundle, range_tracker=None):
+    self._source_bundle = source_bundle
+    self._range_tracker = range_tracker
+
+  def __reduce__(self):
+    # The instance of RangeTracker shouldn't be serialized.
+    return (self.__class__, (self._source_bundle, ))
+
+  def range_tracker(self):
+    if not self._range_tracker:
+      self._range_tracker = self._source_bundle.source.get_range_tracker(
+          self._source_bundle.start_position, self._source_bundle.stop_position)
+    return self._range_tracker
+
+  def weight(self):
+    return self._source_bundle.weight
+
+  def source(self):
+    return self._source_bundle.source
+
+  def try_split(self, fraction_of_remainder):
+    consumed_fraction = self.range_tracker().fraction_consumed()
+    fraction = (
+        consumed_fraction + (1 - consumed_fraction) * fraction_of_remainder)
+    position = self.range_tracker().position_at_fraction(fraction)
+    # Need to stash current stop_pos before splitting since
+    # range_tracker.split will update its stop_pos if splits
+    # successfully.
+    stop_pos = self._source_bundle.stop_position
+    split_result = self.range_tracker().try_split(position)
+    if split_result:
+      split_pos, split_fraction = split_result
+      primary_weight = self._source_bundle.weight * split_fraction
+      residual_weight = self._source_bundle.weight - primary_weight
+      # Update self to primary weight and end position.
+      self._source_bundle = SourceBundle(
+          primary_weight,
+          self._source_bundle.source,
+          self._source_bundle.start_position,
+          split_pos)
+      return (
+          self,
+          _SDFBoundedSourceRestriction(
+              SourceBundle(
+                  residual_weight,
+                  self._source_bundle.source,
+                  split_pos,
+                  stop_pos)))
+
+
+class _SDFBoundedSourceRestrictionTracker(RestrictionTracker):
+  """An `iobase.RestrictionTracker` implementations for wrapping BoundedSource
+  with SDF. The tracked restriction is a _SDFBoundedSourceRestriction, which
+  wraps SourceBundle and RangeTracker.
+
+  Delegated RangeTracker guarantees synchronization safety.
+  """
+  def __init__(self, restriction):
+    if not isinstance(restriction, _SDFBoundedSourceRestriction):
+      raise ValueError(
+          'Initializing SDFBoundedSourceRestrictionTracker'
+          ' requires a _SDFBoundedSourceRestriction')
+    self.restriction = restriction
+
+  def current_progress(self):
+    # type: () -> RestrictionProgress
+    return RestrictionProgress(
+        fraction=self.restriction.range_tracker().fraction_consumed())
+
+  def current_restriction(self):
+    self.restriction.range_tracker()
+    return self.restriction
+
+  def start_pos(self):
+    return self.restriction.range_tracker().start_position()
+
+  def stop_pos(self):
+    return self.restriction.range_tracker().stop_position()
+
+  def try_claim(self, position):
+    return self.restriction.range_tracker().try_claim(position)
+
+  def try_split(self, fraction_of_remainder):
+    return self.restriction.try_split(fraction_of_remainder)
+
+  def check_done(self):
+    return self.restriction.range_tracker().fraction_consumed() >= 1.0
+
+  def is_bounded(self):
+    return True
+
+
+class _SDFBoundedSourceRestrictionProvider(core.RestrictionProvider):
+  """
+  A `RestrictionProvider` that is used by SDF for `BoundedSource`.
+
+  If source is provided, uses it for initializing restriction. Otherwise
+  initializes restriction based on input element that is expected to be of
+  BoundedSource type.
+  """
+  def __init__(self, source=None, desired_chunk_size=None):
+    self._check_source(source)
+    self._source = source
+    self._desired_chunk_size = desired_chunk_size
+
+  def _check_source(self, src):
+    _LOGGER.error("migryz>>>> _check_source: %s, type: %s", src, type(src))
+    if src is not None and not isinstance(src, BoundedSource):
+      raise RuntimeError(
+          'SDFBoundedSourceRestrictionProvider can only utilize BoundedSource')
+
+  def initial_restriction(self, element_source):
+    src = element_source if self._source is None else self._source
+    self._check_source(src)
+    range_tracker = src.get_range_tracker(None, None)
+    return _SDFBoundedSourceRestriction(
+        SourceBundle(
+            None,
+            src,
+            range_tracker.start_position(),
+            range_tracker.stop_position()))
+
+  def create_tracker(self, restriction):
+    return _SDFBoundedSourceRestrictionTracker(restriction)
+
+  def split(self, element, restriction):
+    if self._desired_chunk_size is None:
+      try:
+        estimated_size = restriction.source().estimate_size()
+      except NotImplementedError:
+        estimated_size = None
+      self._desired_chunk_size = Read.get_desired_chunk_size(estimated_size)
+
+    # Invoke source.split to get initial splitting results.
+    source_bundles = restriction.source().split(self._desired_chunk_size)
+    for source_bundle in source_bundles:
+      yield _SDFBoundedSourceRestriction(source_bundle)
+
+  def restriction_size(self, element, restriction):
+    return restriction.weight()
+
+  def restriction_coder(self):
+    return coders.DillCoder()
+
+
 class _SDFBoundedSourceWrapper(ptransform.PTransform):
   """A ``PTransform`` that uses SDF to read from a ``BoundedSource``.
 
   NOTE: This transform can only be used with beam_fn_api enabled.
   """
-  class _SDFBoundedSourceRestriction(object):
-    """ A restriction wraps SourceBundle and RangeTracker. """
-    def __init__(self, source_bundle, range_tracker=None):
-      self._source_bundle = source_bundle
-      self._range_tracker = range_tracker
-
-    def __reduce__(self):
-      # The instance of RangeTracker shouldn't be serialized.
-      return (self.__class__, (self._source_bundle, ))
-
-    def range_tracker(self):
-      if not self._range_tracker:
-        self._range_tracker = self._source_bundle.source.get_range_tracker(
-            self._source_bundle.start_position,
-            self._source_bundle.stop_position)
-      return self._range_tracker
-
-    def weight(self):
-      return self._source_bundle.weight
-
-    def source(self):
-      return self._source_bundle.source
-
-    def try_split(self, fraction_of_remainder):
-      consumed_fraction = self.range_tracker().fraction_consumed()
-      fraction = (
-          consumed_fraction + (1 - consumed_fraction) * fraction_of_remainder)
-      position = self.range_tracker().position_at_fraction(fraction)
-      # Need to stash current stop_pos before splitting since
-      # range_tracker.split will update its stop_pos if splits
-      # successfully.
-      stop_pos = self._source_bundle.stop_position
-      split_result = self.range_tracker().try_split(position)
-      if split_result:
-        split_pos, split_fraction = split_result
-        primary_weight = self._source_bundle.weight * split_fraction
-        residual_weight = self._source_bundle.weight - primary_weight
-        # Update self to primary weight and end position.
-        self._source_bundle = SourceBundle(
-            primary_weight,
-            self._source_bundle.source,
-            self._source_bundle.start_position,
-            split_pos)
-        return (
-            self,
-            _SDFBoundedSourceWrapper._SDFBoundedSourceRestriction(
-                SourceBundle(
-                    residual_weight,
-                    self._source_bundle.source,
-                    split_pos,
-                    stop_pos)))
-
-  class _SDFBoundedSourceRestrictionTracker(RestrictionTracker):
-    """An `iobase.RestrictionTracker` implementations for wrapping BoundedSource
-    with SDF. The tracked restriction is a _SDFBoundedSourceRestriction, which
-    wraps SourceBundle and RangeTracker.
-
-    Delegated RangeTracker guarantees synchronization safety.
-    """
-    def __init__(self, restriction):
-      if not isinstance(restriction,
-                        _SDFBoundedSourceWrapper._SDFBoundedSourceRestriction):
-        raise ValueError(
-            'Initializing SDFBoundedSourceRestrictionTracker'
-            ' requires a _SDFBoundedSourceRestriction')
-      self.restriction = restriction
-
-    def current_progress(self):
-      # type: () -> RestrictionProgress
-      return RestrictionProgress(
-          fraction=self.restriction.range_tracker().fraction_consumed())
-
-    def current_restriction(self):
-      self.restriction.range_tracker()
-      return self.restriction
-
-    def start_pos(self):
-      return self.restriction.range_tracker().start_position()
-
-    def stop_pos(self):
-      return self.restriction.range_tracker().stop_position()
-
-    def try_claim(self, position):
-      return self.restriction.range_tracker().try_claim(position)
-
-    def try_split(self, fraction_of_remainder):
-      return self.restriction.try_split(fraction_of_remainder)
-
-    def check_done(self):
-      return self.restriction.range_tracker().fraction_consumed() >= 1.0
-
-    def is_bounded(self):
-      return True
-
-  class _SDFBoundedSourceRestrictionProvider(core.RestrictionProvider):
-    """A `RestrictionProvider` that is used by SDF for `BoundedSource`."""
-    def __init__(self, source, desired_chunk_size=None):
-      self._source = source
-      self._desired_chunk_size = desired_chunk_size
-
-    def initial_restriction(self, element):
-      # Get initial range_tracker from source
-      range_tracker = self._source.get_range_tracker(None, None)
-      return _SDFBoundedSourceWrapper._SDFBoundedSourceRestriction(
-          SourceBundle(
-              None,
-              self._source,
-              range_tracker.start_position(),
-              range_tracker.stop_position()))
-
-    def create_tracker(self, restriction):
-      return _SDFBoundedSourceWrapper._SDFBoundedSourceRestrictionTracker(
-          restriction)
-
-    def split(self, element, restriction):
-      if self._desired_chunk_size is None:
-        try:
-          estimated_size = self._source.estimate_size()
-        except NotImplementedError:
-          estimated_size = None
-        self._desired_chunk_size = Read.get_desired_chunk_size(estimated_size)
-
-      # Invoke source.split to get initial splitting results.
-      source_bundles = self._source.split(self._desired_chunk_size)
-      for source_bundle in source_bundles:
-        yield _SDFBoundedSourceWrapper._SDFBoundedSourceRestriction(
-            source_bundle)
-
-    def restriction_size(self, element, restriction):
-      return restriction.weight()
-
-    def restriction_coder(self):
-      return coders.DillCoder()
-
   def __init__(self, source):
     if not isinstance(source, BoundedSource):
       raise RuntimeError('SDFBoundedSourceWrapper can only wrap BoundedSource')
@@ -1590,12 +1604,9 @@ class _SDFBoundedSourceWrapper(ptransform.PTransform):
           self,
           element,
           restriction_tracker=core.DoFn.RestrictionParam(
-              _SDFBoundedSourceWrapper._SDFBoundedSourceRestrictionProvider(
-                  source))):
+              _SDFBoundedSourceRestrictionProvider(source=source))):
         current_restriction = restriction_tracker.current_restriction()
-        assert isinstance(
-            current_restriction,
-            _SDFBoundedSourceWrapper._SDFBoundedSourceRestriction)
+        assert isinstance(current_restriction, _SDFBoundedSourceRestriction)
         return current_restriction.source().read(
             current_restriction.range_tracker())
 
@@ -1616,5 +1627,50 @@ class _SDFBoundedSourceWrapper(ptransform.PTransform):
   def display_data(self):
     return {
         'source': DisplayDataItem(self.source.__class__, label='Read Source'),
+        'source_dd': self.source
+    }
+
+
+class SDFBoundedSourceReader(PTransform):
+  """A ``PTransform`` that uses SDF to read from each ``BoundedSource`` in a
+  PCollection.
+
+  NOTE: This transform can only be used with beam_fn_api enabled.
+  """
+  def __init__(self):
+    super(SDFBoundedSourceReader, self).__init__()
+
+  def _create_sdf_bounded_source_dofn(self):
+    class SDFBoundedSourceDoFn(core.DoFn):
+      def __init__(self):
+        pass
+
+      def process(
+          self,
+          unused_element,
+          restriction_tracker=core.DoFn.RestrictionParam(
+              _SDFBoundedSourceRestrictionProvider())):
+        current_restriction = restriction_tracker.current_restriction()
+        assert isinstance(current_restriction, _SDFBoundedSourceRestriction)
+
+        result = current_restriction.source().read(
+            current_restriction.range_tracker())
+        return result
+
+    return SDFBoundedSourceDoFn()
+
+  def expand(self, pvalue):
+    return pvalue | core.ParDo(self._create_sdf_bounded_source_dofn())
+
+  def get_windowing(self, unused_inputs):
+    return core.Windowing(window.GlobalWindows())
+
+  def _infer_output_coder(self, input_type=None, input_coder=None):
+    return self.source.default_output_coder()
+
+  def display_data(self):
+    return {
+        'source': DisplayDataItem(
+            self.source.__class__, label='Read Bounded Sources'),
         'source_dd': self.source
     }

--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -54,7 +54,7 @@ from apache_beam.portability import python_urns
 from apache_beam.portability.api import beam_runner_api_pb2
 from apache_beam.pvalue import AsIter
 from apache_beam.pvalue import AsSingleton
-from apache_beam.transforms import Create
+from apache_beam.transforms import Impulse
 from apache_beam.transforms import PTransform
 from apache_beam.transforms import core
 from apache_beam.transforms import ptransform
@@ -893,7 +893,8 @@ class Read(ptransform.PTransform):
     if isinstance(self.source, BoundedSource):
       return (
           pbegin
-          | Create([self.source])
+          | Impulse()
+          | core.Map(lambda _: self.source)
           | SDFBoundedSourceReader(self.source.display_data()))
     elif isinstance(self.source, ptransform.PTransform):
       # The Read transform can also admit a full PTransform as an input

--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -1530,18 +1530,17 @@ class _SDFBoundedSourceRestrictionProvider(core.RestrictionProvider):
   initializes restriction based on input element that is expected to be of
   BoundedSource type.
   """
-  def __init__(self, source=None, desired_chunk_size=None):
+  def __init__(self, source: BoundedSource = None, desired_chunk_size=None):
     self._check_source(source)
     self._source = source
     self._desired_chunk_size = desired_chunk_size
 
   def _check_source(self, src):
-    _LOGGER.error("migryz>>>> _check_source: %s, type: %s", src, type(src))
     if src is not None and not isinstance(src, BoundedSource):
       raise RuntimeError(
           'SDFBoundedSourceRestrictionProvider can only utilize BoundedSource')
 
-  def initial_restriction(self, element_source):
+  def initial_restriction(self, element_source: BoundedSource):
     src = element_source if self._source is None else self._source
     self._check_source(src)
     range_tracker = src.get_range_tracker(None, None)

--- a/sdks/python/apache_beam/io/iobase_test.py
+++ b/sdks/python/apache_beam/io/iobase_test.py
@@ -42,7 +42,7 @@ class SDFBoundedSourceRestrictionProviderTest(unittest.TestCase):
     self.initial_range_source = RangeSource(
         self.initial_range_start, self.initial_range_stop)
     self.sdf_restriction_provider = (
-        iobase._SDFBoundedSourceWrapper._SDFBoundedSourceRestrictionProvider(
+        iobase._SDFBoundedSourceRestrictionProvider(
             self.initial_range_source, desired_chunk_size=2))
 
   def test_initial_restriction(self):
@@ -50,9 +50,7 @@ class SDFBoundedSourceRestrictionProviderTest(unittest.TestCase):
     restriction = (
         self.sdf_restriction_provider.initial_restriction(unused_element))
     self.assertTrue(
-        isinstance(
-            restriction,
-            iobase._SDFBoundedSourceWrapper._SDFBoundedSourceRestriction))
+        isinstance(restriction, iobase._SDFBoundedSourceRestriction))
     self.assertTrue(isinstance(restriction._source_bundle, SourceBundle))
     self.assertEqual(
         self.initial_range_start, restriction._source_bundle.start_position)
@@ -71,13 +69,10 @@ class SDFBoundedSourceRestrictionProviderTest(unittest.TestCase):
         expected_stop)
     restriction_tracker = (
         self.sdf_restriction_provider.create_tracker(
-            iobase._SDFBoundedSourceWrapper._SDFBoundedSourceRestriction(
-                source_bundle)))
+            iobase._SDFBoundedSourceRestriction(source_bundle)))
     self.assertTrue(
         isinstance(
-            restriction_tracker,
-            iobase._SDFBoundedSourceWrapper._SDFBoundedSourceRestrictionTracker)
-    )
+            restriction_tracker, iobase._SDFBoundedSourceRestrictionTracker))
     self.assertEqual(expected_start, restriction_tracker.start_pos())
     self.assertEqual(expected_stop, restriction_tracker.stop_pos())
 
@@ -103,7 +98,7 @@ class SDFBoundedSourceRestrictionProviderTest(unittest.TestCase):
     unused_element = None
     initial_concat_source = ConcatSource([self.initial_range_source])
     sdf_concat_restriction_provider = (
-        iobase._SDFBoundedSourceWrapper._SDFBoundedSourceRestrictionProvider(
+        iobase._SDFBoundedSourceRestrictionProvider(
             initial_concat_source, desired_chunk_size=2))
     restriction = (
         self.sdf_restriction_provider.initial_restriction(unused_element))
@@ -144,9 +139,8 @@ class SDFBoundedSourceRestrictionTrackerTest(unittest.TestCase):
         self.initial_start_pos,
         self.initial_stop_pos)
     self.sdf_restriction_tracker = (
-        iobase._SDFBoundedSourceWrapper._SDFBoundedSourceRestrictionTracker(
-            iobase._SDFBoundedSourceWrapper._SDFBoundedSourceRestriction(
-                source_bundle)))
+        iobase._SDFBoundedSourceRestrictionTracker(
+            iobase._SDFBoundedSourceRestriction(source_bundle)))
 
   def test_current_restriction_before_split(self):
     current_restriction = (self.sdf_restriction_tracker.current_restriction())

--- a/sdks/python/apache_beam/io/iobase_test.py
+++ b/sdks/python/apache_beam/io/iobase_test.py
@@ -42,13 +42,11 @@ class SDFBoundedSourceRestrictionProviderTest(unittest.TestCase):
     self.initial_range_source = RangeSource(
         self.initial_range_start, self.initial_range_stop)
     self.sdf_restriction_provider = (
-        iobase._SDFBoundedSourceRestrictionProvider(
-            desired_chunk_size=2))
+        iobase._SDFBoundedSourceRestrictionProvider(desired_chunk_size=2))
 
   def test_initial_restriction(self):
     element = self.initial_range_source
-    restriction = (
-        self.sdf_restriction_provider.initial_restriction(element))
+    restriction = (self.sdf_restriction_provider.initial_restriction(element))
     self.assertTrue(
         isinstance(restriction, iobase._SDFBoundedSourceRestriction))
     self.assertTrue(isinstance(restriction._source_bundle, SourceBundle))
@@ -78,8 +76,7 @@ class SDFBoundedSourceRestrictionProviderTest(unittest.TestCase):
 
   def test_simple_source_split(self):
     element = self.initial_range_source
-    restriction = (
-        self.sdf_restriction_provider.initial_restriction(element))
+    restriction = (self.sdf_restriction_provider.initial_restriction(element))
     expect_splits = [(0, 2), (2, 4)]
     split_bundles = list(
         self.sdf_restriction_provider.split(element, restriction))
@@ -98,14 +95,12 @@ class SDFBoundedSourceRestrictionProviderTest(unittest.TestCase):
     element = self.initial_range_source
     initial_concat_source = ConcatSource([self.initial_range_source])
     sdf_concat_restriction_provider = (
-        iobase._SDFBoundedSourceRestrictionProvider(
-            desired_chunk_size=2))
-    restriction = (
-        self.sdf_restriction_provider.initial_restriction(element))
+        iobase._SDFBoundedSourceRestrictionProvider(desired_chunk_size=2))
+    restriction = (self.sdf_restriction_provider.initial_restriction(element))
     expect_splits = [(0, 2), (2, 4)]
     split_bundles = list(
-        sdf_concat_restriction_provider.split(initial_concat_source,
-                                              restriction))
+        sdf_concat_restriction_provider.split(
+            initial_concat_source, restriction))
     self.assertTrue(
         all([
             isinstance(bundle._source_bundle, SourceBundle)
@@ -118,10 +113,8 @@ class SDFBoundedSourceRestrictionProviderTest(unittest.TestCase):
 
   def test_restriction_size(self):
     element = self.initial_range_source
-    restriction = (
-        self.sdf_restriction_provider.initial_restriction(element))
-    split_1, split_2 = self.sdf_restriction_provider.split(element,
-                                                           restriction)
+    restriction = (self.sdf_restriction_provider.initial_restriction(element))
+    split_1, split_2 = self.sdf_restriction_provider.split(element, restriction)
     split_1_size = self.sdf_restriction_provider.restriction_size(
         element, split_1)
     split_2_size = self.sdf_restriction_provider.restriction_size(

--- a/sdks/python/apache_beam/io/iobase_test.py
+++ b/sdks/python/apache_beam/io/iobase_test.py
@@ -205,7 +205,7 @@ class UseSdfBoundedSourcesTests(unittest.TestCase):
       actual = p | beam.io.Read(source)
       assert_that(actual, equal_to(expected_values))
 
-  @mock.patch('apache_beam.io.iobase._SDFBoundedSourceWrapper.expand')
+  @mock.patch('apache_beam.io.iobase.SDFBoundedSourceReader.expand')
   def test_sdf_wrapper_overrides_read(self, sdf_wrapper_mock_expand):
     def _fake_wrapper_expand(pbegin):
       return pbegin | beam.Create(['fake'])

--- a/sdks/python/apache_beam/io/iobase_test.py
+++ b/sdks/python/apache_beam/io/iobase_test.py
@@ -43,12 +43,12 @@ class SDFBoundedSourceRestrictionProviderTest(unittest.TestCase):
         self.initial_range_start, self.initial_range_stop)
     self.sdf_restriction_provider = (
         iobase._SDFBoundedSourceRestrictionProvider(
-            self.initial_range_source, desired_chunk_size=2))
+            desired_chunk_size=2))
 
   def test_initial_restriction(self):
-    unused_element = None
+    element = self.initial_range_source
     restriction = (
-        self.sdf_restriction_provider.initial_restriction(unused_element))
+        self.sdf_restriction_provider.initial_restriction(element))
     self.assertTrue(
         isinstance(restriction, iobase._SDFBoundedSourceRestriction))
     self.assertTrue(isinstance(restriction._source_bundle, SourceBundle))
@@ -77,12 +77,12 @@ class SDFBoundedSourceRestrictionProviderTest(unittest.TestCase):
     self.assertEqual(expected_stop, restriction_tracker.stop_pos())
 
   def test_simple_source_split(self):
-    unused_element = None
+    element = self.initial_range_source
     restriction = (
-        self.sdf_restriction_provider.initial_restriction(unused_element))
+        self.sdf_restriction_provider.initial_restriction(element))
     expect_splits = [(0, 2), (2, 4)]
     split_bundles = list(
-        self.sdf_restriction_provider.split(unused_element, restriction))
+        self.sdf_restriction_provider.split(element, restriction))
     self.assertTrue(
         all([
             isinstance(bundle._source_bundle, SourceBundle)
@@ -95,16 +95,17 @@ class SDFBoundedSourceRestrictionProviderTest(unittest.TestCase):
     self.assertEqual(expect_splits, list(splits))
 
   def test_concat_source_split(self):
-    unused_element = None
+    element = self.initial_range_source
     initial_concat_source = ConcatSource([self.initial_range_source])
     sdf_concat_restriction_provider = (
         iobase._SDFBoundedSourceRestrictionProvider(
-            initial_concat_source, desired_chunk_size=2))
+            desired_chunk_size=2))
     restriction = (
-        self.sdf_restriction_provider.initial_restriction(unused_element))
+        self.sdf_restriction_provider.initial_restriction(element))
     expect_splits = [(0, 2), (2, 4)]
     split_bundles = list(
-        sdf_concat_restriction_provider.split(unused_element, restriction))
+        sdf_concat_restriction_provider.split(initial_concat_source,
+                                              restriction))
     self.assertTrue(
         all([
             isinstance(bundle._source_bundle, SourceBundle)
@@ -116,15 +117,15 @@ class SDFBoundedSourceRestrictionProviderTest(unittest.TestCase):
     self.assertEqual(expect_splits, list(splits))
 
   def test_restriction_size(self):
-    unused_element = None
+    element = self.initial_range_source
     restriction = (
-        self.sdf_restriction_provider.initial_restriction(unused_element))
-    split_1, split_2 = self.sdf_restriction_provider.split(unused_element,
+        self.sdf_restriction_provider.initial_restriction(element))
+    split_1, split_2 = self.sdf_restriction_provider.split(element,
                                                            restriction)
     split_1_size = self.sdf_restriction_provider.restriction_size(
-        unused_element, split_1)
+        element, split_1)
     split_2_size = self.sdf_restriction_provider.restriction_size(
-        unused_element, split_2)
+        element, split_2)
     self.assertEqual(2, split_1_size)
     self.assertEqual(2, split_2_size)
 
@@ -208,7 +209,7 @@ class UseSdfBoundedSourcesTests(unittest.TestCase):
   @mock.patch('apache_beam.io.iobase.SDFBoundedSourceReader.expand')
   def test_sdf_wrapper_overrides_read(self, sdf_wrapper_mock_expand):
     def _fake_wrapper_expand(pbegin):
-      return pbegin | beam.Create(['fake'])
+      return pbegin | beam.Map(lambda x: 'fake')
 
     sdf_wrapper_mock_expand.side_effect = _fake_wrapper_expand
     self._run_sdf_wrapper_pipeline(RangeSource(0, 4), ['fake'])

--- a/sdks/python/apache_beam/io/textio_test.py
+++ b/sdks/python/apache_beam/io/textio_test.py
@@ -52,6 +52,14 @@ from apache_beam.testing.util import equal_to
 from apache_beam.transforms.core import Create
 
 
+class DummyCoder(coders.Coder):
+  def encode(self, x):
+    raise ValueError
+
+  def decode(self, x):
+    return (x * 2).decode('utf-8')
+
+
 class EOL(object):
   LF = 1
   CRLF = 2
@@ -537,12 +545,6 @@ class TextSourceTest(unittest.TestCase):
       assert_that(pcoll, equal_to(expected_data))
 
   def test_read_from_text_single_file_with_coder(self):
-    class DummyCoder(coders.Coder):
-      def encode(self, x):
-        raise ValueError
-
-      def decode(self, x):
-        return (x * 2).decode('utf-8')
 
     file_name, expected_data = write_data(5)
     assert len(expected_data) == 5


### PR DESCRIPTION
This is valuable for BigQuery repeatedly firing side input. This PR is intended to be used here: https://github.com/apache/beam/pull/13170

This makes the SDF Bounded Source reader available to use. A small change in functionality:
- If no `source` is provided to the initial restriction in the constructor, then the element is expected to be a source, and it's added to the initial restriction at creation.

r: @boyuanzz 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
