### PR TITLE
[BEAM-11108] Add a version of TextIO implemented via SDF.

### DIFF
--- a/sdks/go/examples/stringsplit/stringsplit.go
+++ b/sdks/go/examples/stringsplit/stringsplit.go
@@ -39,11 +39,11 @@ package main
 import (
 	"context"
 	"flag"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/sdf"
 	"reflect"
 	"time"
 
 	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/sdf"
 	"github.com/apache/beam/sdks/go/pkg/beam/io/rtrackers/offsetrange"
 	"github.com/apache/beam/sdks/go/pkg/beam/log"
 	"github.com/apache/beam/sdks/go/pkg/beam/x/beamx"

--- a/sdks/go/examples/wordcount/wordcount.go
+++ b/sdks/go/examples/wordcount/wordcount.go
@@ -101,6 +101,14 @@ var (
 // output any number of elements. It operates on a PCollection of type string and
 // returns a PCollection of type string. Also, using named function transforms allows
 // for easy reuse, modular testing, and an improved monitoring experience.
+//
+// DoFns must be registered with Beam in order to be executed in ParDos. This is
+// done automatically by the starcgen code generator, or it can be done manually
+// by calling beam.RegisterFunction in an init() call.
+func init() {
+	beam.RegisterFunction(extractFn)
+	beam.RegisterFunction(formatFn)
+}
 
 var (
 	wordRE  = regexp.MustCompile(`[a-zA-Z]+('[a-z])?`)

--- a/sdks/go/pkg/beam/core/runtime/graphx/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate.go
@@ -123,7 +123,7 @@ func Marshal(edges []*graph.MultiEdge, opt *Options) (*pipepb.Pipeline, error) {
 	if len(edges) == 0 {
 		return nil, errors.New("empty graph")
 	}
-	
+
 	tree := NewScopeTree(edges)
 
 	m := newMarshaller(opt)

--- a/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange.go
+++ b/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange.go
@@ -89,6 +89,28 @@ func (r Restriction) EvenSplits(num int64) (splits []Restriction) {
 	return splits
 }
 
+// SizedSplits splits a restriction into multiple restrictions of the given
+// size. If the restriction cannot be evenly split, the final restriction will
+// be the remainder.
+//
+// Example: (0, 24) split into size 10s -> {(0, 10), (10, 20), (20, 24)}
+//
+// Size should be greater than 0. Otherwise there is no way to split the
+// restriction and this function will return the original restriction.
+func (r Restriction) SizedSplits(size int64) (splits []Restriction) {
+	if size < 1 {
+		// Don't split, just return original restriction.
+		return append(splits, r)
+	}
+
+	s := r.Start
+	for e := s + size; e < r.End; s, e = e, e+size {
+		splits = append(splits, Restriction{Start: s, End: e})
+	}
+	splits = append(splits, Restriction{Start: s, End: r.End})
+	return splits
+}
+
 // Size returns the restriction's size as the difference between Start and End.
 func (r Restriction) Size() float64 {
 	return float64(r.End - r.Start)

--- a/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange.go
+++ b/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange.go
@@ -61,9 +61,10 @@ type Restriction struct {
 	Start, End int64
 }
 
-// EvenSplits splits a restriction into a number of evenly sized restrictions.
-// Each split restriction is guaranteed to not be empty, and each unit from the
-// original restriction is guaranteed to be contained in one split restriction.
+// EvenSplits splits a restriction into a number of evenly sized restrictions
+// in ascending order. Each split restriction is guaranteed to not be empty, and
+// each unit from the original restriction is guaranteed to be contained in one
+// split restriction.
 //
 // Num should be greater than 0. Otherwise there is no way to split the
 // restriction and this function will return the original restriction.
@@ -90,8 +91,8 @@ func (r Restriction) EvenSplits(num int64) (splits []Restriction) {
 }
 
 // SizedSplits splits a restriction into multiple restrictions of the given
-// size. If the restriction cannot be evenly split, the final restriction will
-// be the remainder.
+// size, in ascending order. If the restriction cannot be evenly split, the
+// final restriction will be the remainder.
 //
 // Example: (0, 24) split into size 10s -> {(0, 10), (10, 20), (20, 24)}
 //

--- a/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange_test.go
+++ b/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange_test.go
@@ -63,10 +63,87 @@ func TestRestriction_EvenSplits(t *testing.T) {
 					t.Errorf("split restriction [%v, %v] has unexpected size. got: %v, want: %v or %v",
 						split.Start, split.End, size, min, min+1)
 				}
-				// Check: All elements are still in a split restrictions. This
-				// logic assumes that the splits are returned in order which
-				// isn't guaranteed by EvenSplits, but this check is way easier
-				// with the assumption.
+				// Check: All elements are still in a split restriction and
+				// the restrictions are in the appropriate ascending order.
+				if split.Start != prevEnd {
+					t.Errorf("restriction range [%v, %v] missing after splits.",
+						prevEnd, split.Start)
+				} else {
+					prevEnd = split.End
+				}
+			}
+			if prevEnd != r.End {
+				t.Errorf("restriction range [%v, %v] missing after splits.",
+					prevEnd, r.End)
+			}
+		})
+	}
+}
+
+// TestRestriction_SizedSplits tests various splits and checks that they all
+// follow the contract for SizedSplits. This means that all restrictions match
+// the given size unless it is a remainder, and that each element is present
+// in the split restrictions.
+func TestRestriction_SizedSplits(t *testing.T) {
+	tests := []struct {
+		rest Restriction
+		size int64
+		want []Restriction
+	}{
+		{
+			rest: Restriction{Start: 0, End: 11},
+			size: 5,
+			want: []Restriction{{0, 5}, {5, 10}, {10, 11}},
+		},
+		{
+			rest: Restriction{Start: 11, End: 22},
+			size: 5,
+			want: []Restriction{{11, 16}, {16, 21}, {21, 22}},
+		},
+		{
+			rest: Restriction{Start: 0, End: 1024 * 1024 * 1024},
+			size: 400 * 1024 * 1024,
+			want: []Restriction{
+				{0, 400 * 1024 * 1024},
+				{400 * 1024 * 1024, 800 * 1024 * 1024},
+				{800 * 1024 * 1024, 1024 * 1024 * 1024},
+			},
+		},
+		{
+			rest: Restriction{Start: 0, End: 5},
+			size: 10,
+			want: []Restriction{{0, 5}},
+		},
+		{
+			rest: Restriction{Start: 0, End: 21},
+			size: 0,
+			want: []Restriction{{0, 21}},
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(fmt.Sprintf("(rest[%v, %v], size = %v)",
+			test.rest.Start, test.rest.End, test.size), func(t *testing.T) {
+			r := test.rest
+
+			// Get the minimum size that a split restriction can be. Max size
+			// should be min + 1. This way we can check the size of each split.
+			splits := r.SizedSplits(test.size)
+			prevEnd := r.Start
+			for i, split := range splits {
+				size := split.End - split.Start
+				// Check: Each restriction has at least 1 element.
+				if size == 0 {
+					t.Errorf("split restriction [%v, %v] is empty, size must be greater than 0.",
+						split.Start, split.End)
+				}
+				// Check: Restrictions (except for the last one) must match the split size.
+				if i != len(splits)-1 && size != test.size {
+					t.Errorf("split restriction [%v, %v] has unexpected size. got: %v, want: %v",
+						split.Start, split.End, size, test.size)
+				}
+				// Check: All elements are still in a split restriction and
+				// the restrictions are in the appropriate ascending order.
 				if split.Start != prevEnd {
 					t.Errorf("restriction range [%v, %v] missing after splits.",
 						prevEnd, split.Start)

--- a/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange_test.go
+++ b/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange_test.go
@@ -86,21 +86,31 @@ func TestRestriction_EvenSplits(t *testing.T) {
 // in the split restrictions.
 func TestRestriction_SizedSplits(t *testing.T) {
 	tests := []struct {
+		name string
 		rest Restriction
 		size int64
 		want []Restriction
 	}{
 		{
+			name: "Remainder",
 			rest: Restriction{Start: 0, End: 11},
 			size: 5,
 			want: []Restriction{{0, 5}, {5, 10}, {10, 11}},
 		},
 		{
+			name: "OffsetRemainder",
 			rest: Restriction{Start: 11, End: 22},
 			size: 5,
 			want: []Restriction{{11, 16}, {16, 21}, {21, 22}},
 		},
 		{
+			name: "OffsetExact",
+			rest: Restriction{Start: 11, End: 21},
+			size: 5,
+			want: []Restriction{{11, 16}, {16, 21}},
+		},
+		{
+			name: "LargeValues",
 			rest: Restriction{Start: 0, End: 1024 * 1024 * 1024},
 			size: 400 * 1024 * 1024,
 			want: []Restriction{
@@ -110,11 +120,13 @@ func TestRestriction_SizedSplits(t *testing.T) {
 			},
 		},
 		{
+			name: "OverlyLargeSize",
 			rest: Restriction{Start: 0, End: 5},
 			size: 10,
 			want: []Restriction{{0, 5}},
 		},
 		{
+			name: "InvalidSize",
 			rest: Restriction{Start: 0, End: 21},
 			size: 0,
 			want: []Restriction{{0, 21}},
@@ -122,8 +134,8 @@ func TestRestriction_SizedSplits(t *testing.T) {
 	}
 	for _, test := range tests {
 		test := test
-		t.Run(fmt.Sprintf("(rest[%v, %v], size = %v)",
-			test.rest.Start, test.rest.End, test.size), func(t *testing.T) {
+		t.Run(fmt.Sprintf("%v (rest[%v, %v], size = %v)",
+			test.name, test.rest.Start, test.rest.End, test.size), func(t *testing.T) {
 			r := test.rest
 
 			// Get the minimum size that a split restriction can be. Max size

--- a/sdks/go/pkg/beam/io/textio/sdf.go
+++ b/sdks/go/pkg/beam/io/textio/sdf.go
@@ -1,0 +1,203 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package textio
+
+import (
+	"bufio"
+	"context"
+	"io"
+	"reflect"
+	"strings"
+
+	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/sdf"
+	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
+	"github.com/apache/beam/sdks/go/pkg/beam/io/filesystem"
+	"github.com/apache/beam/sdks/go/pkg/beam/io/rtrackers/offsetrange"
+	"github.com/apache/beam/sdks/go/pkg/beam/log"
+)
+
+func init() {
+	beam.RegisterType(reflect.TypeOf((*readSdfFn)(nil)).Elem())
+	beam.RegisterFunction(sizeFn)
+}
+
+// ReadSdf is a variation of Read implemented via SplittableDoFn. This should
+// result in increased performance with runners that support splitting.
+func ReadSdf(s beam.Scope, glob string) beam.PCollection {
+	s = s.Scope("textio.ReadSdf")
+
+	filesystem.ValidateScheme(glob)
+	return readSdf(s, beam.Create(s, glob))
+}
+
+// ReadAllSdf is a variation of ReadAll implemented via SplittableDoFn. This
+// should result in increased performance with runners that support splitting.
+func ReadAllSdf(s beam.Scope, col beam.PCollection) beam.PCollection {
+	s = s.Scope("textio.ReadAllSdf")
+
+	return readSdf(s, col)
+}
+
+// readSdf takes a PCollection of globs and returns a PCollection of lines from
+// all files in those globs. Unlike textio.read, this version uses an SDF for
+// reading files.
+func readSdf(s beam.Scope, col beam.PCollection) beam.PCollection {
+	files := beam.ParDo(s, expandFn, col)
+	sized := beam.ParDo(s, sizeFn, files)
+	return beam.ParDo(s, &readSdfFn{}, sized)
+}
+
+// sizeFn pairs a filename with the size of that file in bytes.
+// TODO(BEAM-11109): Once CreateInitialRestriction supports Context params and
+// error return values, this can be done in readSdfFn.CreateInitialRestriction.
+func sizeFn(ctx context.Context, filename string) (string, int64, error) {
+	fs, err := filesystem.New(ctx, filename)
+	if err != nil {
+		return "", -1, err
+	}
+	defer fs.Close()
+
+	size, err := fs.Size(ctx, filename)
+	if err != nil {
+		return "", -1, err
+	}
+	return filename, size, nil
+}
+
+// readSdfFn reads individual lines from a text file, given a filename and a
+// size in bytes for that file.
+type readSdfFn struct {
+}
+
+// CreateInitialRestriction creates an offset range restriction representing
+// the file, using the paired size rather than fetching the file's size.
+func (fn *readSdfFn) CreateInitialRestriction(_ string, size int64) offsetrange.Restriction {
+	return offsetrange.Restriction{
+		Start: 0,
+		End:   size,
+	}
+}
+
+const (
+	// blockSize is the desired size of each block for initial splits.
+	blockSize int64 = 64 * 1024 * 1024 // 64 MB
+	// tooSmall is the size limit for a block. If the last block is smaller than
+	// this, it gets merged with the previous block.
+	tooSmall = blockSize / 4
+)
+
+// SplitRestriction splits each file restriction into blocks of a predeterined
+// size, with some checks to avoid having small remainders.
+func (fn *readSdfFn) SplitRestriction(_ string, _ int64, rest offsetrange.Restriction) []offsetrange.Restriction {
+	splits := rest.SizedSplits(blockSize)
+	numSplits := len(splits)
+	if numSplits > 1 {
+		last := splits[numSplits-1]
+		if last.End-last.Start <= tooSmall {
+			// Last restriction is too small, so merge it with previous one.
+			splits[numSplits-2].End = last.End
+			splits = splits[:numSplits-1]
+		}
+	}
+	return splits
+}
+
+// Size returns the size of each restriction as its range.
+func (fn *readSdfFn) RestrictionSize(_ string, _ int64, rest offsetrange.Restriction) float64 {
+	return rest.Size()
+}
+
+// CreateTracker creates sdf.LockRTrackers wrapping offsetRange.Trackers for
+// each restriction.
+func (fn *readSdfFn) CreateTracker(rest offsetrange.Restriction) *sdf.LockRTracker {
+	return sdf.NewLockRTracker(offsetrange.NewTracker(rest))
+}
+
+// ProcessElement outputs all lines in the file that begin within the paired
+// restriction.
+//
+// Note that restrictions may not align perfectly with lines. So lines can begin
+// before the restriction and end within it (those are ignored), and lines can
+// begin within the restriction and past the restriction (those are entirely
+// output, including the portion outside the restriction). In some cases a
+// valid restriction might not output any lines.
+func (fn *readSdfFn) ProcessElement(ctx context.Context, rt *sdf.LockRTracker, filename string, _ int64, emit func(string)) error {
+	log.Infof(ctx, "Reading from %v", filename)
+
+	fs, err := filesystem.New(ctx, filename)
+	if err != nil {
+		return err
+	}
+	defer fs.Close()
+
+	fd, err := fs.OpenRead(ctx, filename)
+	if err != nil {
+		return err
+	}
+	defer fd.Close()
+
+	rd := bufio.NewReader(fd)
+
+	i := rt.GetRestriction().(offsetrange.Restriction).Start
+	if i > 0 {
+		// If restriction's starts after 0, we cannot assume a new line starts
+		// at the beginning of the restriction, so we must search for the first
+		// line beginning at or after restriction.Start. This is done by
+		// scanning to the byte just before the restriction and then reading
+		// until the next newline, leaving the reader at the start of a new
+		// line past restriction.Start.
+		i -= 1
+		n, err := rd.Discard(int(i)) // Scan to just before restriction.
+		if err == io.EOF {
+			return errors.Errorf("TextIO restriction lies outside the file being read. "+
+				"Restriction begins at %v bytes, but file is only %v bytes.", i+1, n)
+		}
+		if err != nil {
+			return err
+		}
+		line, err := rd.ReadString('\n') // Read until the first line within the restriction.
+		if err == io.EOF {
+			// No lines start in the restriction but it's still valid, so
+			// finish claiming before returning to avoid errors.
+			rt.TryClaim(rt.GetRestriction().(offsetrange.Restriction).End)
+			return nil
+		}
+		if err != nil {
+			return err
+		}
+		i += int64(len(line))
+	}
+
+	// Claim each line until we claim a line outside the restriction.
+	for rt.TryClaim(i) {
+		line, err := rd.ReadString('\n')
+		if err == io.EOF {
+			if len(line) != 0 {
+				emit(strings.TrimSuffix(line, "\n"))
+			}
+			// Finish claiming restriction before breaking to avoid errors.
+			rt.TryClaim(rt.GetRestriction().(offsetrange.Restriction).End)
+			break
+		}
+		if err != nil {
+			return err
+		}
+		emit(strings.TrimSuffix(line, "\n"))
+		i += int64(len(line))
+	}
+	return nil
+}

--- a/sdks/go/pkg/beam/io/textio/sdf_test.go
+++ b/sdks/go/pkg/beam/io/textio/sdf_test.go
@@ -1,0 +1,63 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package textio
+
+import (
+	"context"
+	"testing"
+)
+
+// TestReadSdf tests that readSdf successfully reads a test text file, and
+// outputs the correct number of lines for it, even for an exceedingly long
+// line.
+func TestReadSdf(t *testing.T) {
+	f := "../../../../data/textio_test.txt"
+	f, size, err := sizeFn(context.Background(), f)
+	if err != nil {
+		t.Fatalf("sizing failed: %v", err)
+	}
+
+	lines := fakeReadSdfFn(t, f, size)
+	want := 1
+	if len(lines) != 1 {
+		t.Fatalf("received %v lines, want %v", len(lines), want)
+	}
+}
+
+// fakeReadSdfFn calls the methods in readSdfFn on a single input to simulate
+// executing an SDF, and outputs all elements produced by that input.
+func fakeReadSdfFn(t *testing.T, f string, size int64) []string {
+	t.Helper()
+
+	// emit func output
+	var receivedLines []string
+	getLines := func(line string) {
+		receivedLines = append(receivedLines, line)
+	}
+
+	sdf := &readSdfFn{}
+	rest := sdf.CreateInitialRestriction(f, size)
+	splits := sdf.SplitRestriction(f, size, rest)
+	for _, split := range splits {
+		rt := sdf.CreateTracker(split)
+		err := sdf.ProcessElement(context.Background(), rt, f, size, getLines)
+		if err != nil {
+			t.Fatalf("error executing readSdf.ProcessElement: %v", err)
+		}
+	}
+
+	return receivedLines
+}

--- a/sdks/go/pkg/beam/io/textio/textio.go
+++ b/sdks/go/pkg/beam/io/textio/textio.go
@@ -104,7 +104,7 @@ func readFn(ctx context.Context, filename string, emit func(string)) error {
 			break
 		}
 		if err != nil {
-			return (err)
+			return err
 		}
 		emit(strings.TrimSuffix(line, "\n"))
 	}


### PR DESCRIPTION
Pretty straightforward. Read and ReadSdf should be functionally identical, and likewise for ReadAll and ReadAllSdf.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
