### PR TITLE
[BEAM-11196] Set parent of fused stages to the lowest common ancestor

### DIFF
--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
@@ -484,6 +484,13 @@ class TransformContext(object):
         self.maybe_length_prefixed_coder(
             self.components.pcollections[pcoll_id].coder_id))
 
+  @memoize_on_instance
+  def parents_map(self):
+    return {
+        child: parent
+        for (parent, transform) in self.components.transforms.items()
+        for child in transform.subtransforms
+    }
 
 def leaf_transform_stages(
     root_ids,  # type: Iterable[str]
@@ -1183,12 +1190,7 @@ def _lowest_common_ancestor(a, b, context):
   '''
   assert a != b
 
-  parents = {
-      child: parent
-      for parent,
-      transform in context.components.transforms.items()
-      for child in transform.subtransforms
-  }
+  parents = context.parents_map()
 
   def get_ancestors(name):
     ancestor = name

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
@@ -780,7 +780,8 @@ def eliminate_common_key_with_none(stages, context):
         for stage in sibling_stages
     ]
     parent = functools.reduce(
-        lambda a, b: _lowest_common_ancestor(a, b, context),
+        lambda a,
+        b: _lowest_common_ancestor(a, b, context),
         [s.name for s in sibling_stages])
     for to_delete_pcoll_id in output_pcoll_ids[1:]:
       pcoll_id_remap[to_delete_pcoll_id] = output_pcoll_ids[0]

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
@@ -24,6 +24,7 @@ import unittest
 import apache_beam as beam
 from apache_beam import runners
 from apache_beam.options import pipeline_options
+from apache_beam.portability.api import beam_runner_api_pb2
 from apache_beam.portability import common_urns
 from apache_beam.runners.portability.fn_api_runner import translations
 from apache_beam.transforms import combiners
@@ -32,29 +33,43 @@ from apache_beam.transforms import environments
 from apache_beam.transforms.core import Create
 
 
+def _parent_name(stage):
+  if isinstance(stage.parent, translations.Stage):
+    return stage.parent.name
+  return stage.parent
+
+
 class TranslationsTest(unittest.TestCase):
   def test_eliminate_common_key_with_void(self):
-    pipeline = beam.Pipeline()
-    pcoll = pipeline | 'Start' >> beam.Create([1, 2, 3])
-    _ = pcoll | 'TestKeyWithNoneA' >> beam.ParDo(core._KeyWithNone())
-    _ = pcoll | 'TestKeyWithNoneB' >> beam.ParDo(core._KeyWithNone())
+    class MultipleKeyWithNone(beam.PTransform):
+      def expand(self, pcoll):
+        _ = pcoll | 'key-with-none-a' >> beam.ParDo(core._KeyWithNone())
+        _ = pcoll | 'key-with-none-b' >> beam.ParDo(core._KeyWithNone())
 
+    pipeline = beam.Pipeline()
+    _ = pipeline | beam.Create(
+        [1, 2, 3]) | 'multiple-key-with-none' >> MultipleKeyWithNone()
     pipeline_proto = pipeline.to_runner_api()
     _, stages = translations.create_and_optimize_stages(
         pipeline_proto, [translations.eliminate_common_key_with_none],
         known_runner_urns=frozenset())
     key_with_none_stages = [
-        stage for stage in stages if 'TestKeyWithNone' in stage.name
+        stage for stage in stages if 'key-with-none' in stage.name
     ]
     self.assertEqual(len(key_with_none_stages), 1)
+    self.assertIn(
+        'multiple-key-with-none', _parent_name(key_with_none_stages[0]))
 
   def test_pack_combiners(self):
+    class MultipleCombines(beam.PTransform):
+      def expand(self, pcoll):
+        _ = pcoll | 'mean-perkey' >> combiners.Mean.PerKey()
+        _ = pcoll | 'count-perkey' >> combiners.Count.PerKey()
+
     pipeline = beam.Pipeline()
     vals = [6, 3, 1, 1, 9, 1, 5, 2, 0, 6]
-    pcoll = pipeline | 'start-perkey' >> Create([('a', x) for x in vals])
-    _ = pcoll | 'mean-perkey' >> combiners.Mean.PerKey()
-    _ = pcoll | 'count-perkey' >> combiners.Count.PerKey()
-
+    _ = pipeline | Create([('a', x) for x in vals
+                           ]) | 'multiple-combines' >> MultipleCombines()
     environment = environments.DockerEnvironment.from_options(
         pipeline_options.PortableOptions(sdk_location='container'))
     pipeline_proto = pipeline.to_runner_api(default_environment=environment)
@@ -68,14 +83,18 @@ class TranslationsTest(unittest.TestCase):
           combine_per_key_stages.append(stage)
     self.assertEqual(len(combine_per_key_stages), 1)
     self.assertIn('/Pack', combine_per_key_stages[0].name)
+    self.assertIn('multiple-combines', _parent_name(combine_per_key_stages[0]))
+    self.assertNotIn('-perkey', _parent_name(combine_per_key_stages[0]))
 
   def test_pack_combiners_with_missing_environment_capability(self):
+    class MultipleCombines(beam.PTransform):
+      def expand(self, pcoll):
+        _ = pcoll | 'mean-perkey' >> combiners.Mean.PerKey()
+        _ = pcoll | 'count-perkey' >> combiners.Count.PerKey()
+
     pipeline = beam.Pipeline()
     vals = [6, 3, 1, 1, 9, 1, 5, 2, 0, 6]
-    pcoll = pipeline | 'start-perkey' >> Create([('a', x) for x in vals])
-    _ = pcoll | 'mean-perkey' >> combiners.Mean.PerKey()
-    _ = pcoll | 'count-perkey' >> combiners.Count.PerKey()
-
+    _ = pipeline | Create([('a', x) for x in vals]) | MultipleCombines()
     environment = environments.DockerEnvironment(capabilities=())
     pipeline_proto = pipeline.to_runner_api(default_environment=environment)
     _, stages = translations.create_and_optimize_stages(
@@ -89,15 +108,18 @@ class TranslationsTest(unittest.TestCase):
     # Combiner packing should be skipped because the environment is missing
     # the beam:combinefn:packed_python:v1 capability.
     self.assertEqual(len(combine_per_key_stages), 2)
-    self.assertNotIn('/Pack', combine_per_key_stages[0].name)
+    for combine_per_key_stage in combine_per_key_stages:
+      self.assertNotIn('/Pack', combine_per_key_stage.name)
 
   def test_pack_global_combiners(self):
+    class MultipleCombines(beam.PTransform):
+      def expand(self, pcoll):
+        _ = pcoll | 'mean-globally' >> combiners.Mean.Globally()
+        _ = pcoll | 'count-globally' >> combiners.Count.Globally()
+
     pipeline = beam.Pipeline()
     vals = [6, 3, 1, 1, 9, 1, 5, 2, 0, 6]
-    pcoll = pipeline | 'start' >> Create(vals)
-    _ = pcoll | 'mean' >> combiners.Mean.Globally()
-    _ = pcoll | 'count' >> combiners.Count.Globally()
-
+    _ = pipeline | Create(vals) | 'multiple-combines' >> MultipleCombines()
     environment = environments.DockerEnvironment.from_options(
         pipeline_options.PortableOptions(sdk_location='container'))
     pipeline_proto = pipeline.to_runner_api(default_environment=environment)
@@ -111,6 +133,7 @@ class TranslationsTest(unittest.TestCase):
         stage for stage in stages if 'KeyWithVoid' in stage.name
     ]
     self.assertEqual(len(key_with_void_stages), 1)
+    self.assertIn('-globally', _parent_name(key_with_void_stages[0]))
 
     combine_per_key_stages = []
     for stage in stages:
@@ -119,6 +142,8 @@ class TranslationsTest(unittest.TestCase):
           combine_per_key_stages.append(stage)
     self.assertEqual(len(combine_per_key_stages), 1)
     self.assertIn('/Pack', combine_per_key_stages[0].name)
+    self.assertIn('multiple-combines', _parent_name(combine_per_key_stages[0]))
+    self.assertNotIn('-globally', _parent_name(combine_per_key_stages[0]))
 
   def test_optimize_empty_pipeline(self):
     pipeline = beam.Pipeline()

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
@@ -24,19 +24,12 @@ import unittest
 import apache_beam as beam
 from apache_beam import runners
 from apache_beam.options import pipeline_options
-from apache_beam.portability.api import beam_runner_api_pb2
 from apache_beam.portability import common_urns
 from apache_beam.runners.portability.fn_api_runner import translations
 from apache_beam.transforms import combiners
 from apache_beam.transforms import core
 from apache_beam.transforms import environments
 from apache_beam.transforms.core import Create
-
-
-def _parent_name(stage):
-  if isinstance(stage.parent, translations.Stage):
-    return stage.parent.name
-  return stage.parent
 
 
 class TranslationsTest(unittest.TestCase):
@@ -58,7 +51,7 @@ class TranslationsTest(unittest.TestCase):
     ]
     self.assertEqual(len(key_with_none_stages), 1)
     self.assertIn(
-        'multiple-key-with-none', _parent_name(key_with_none_stages[0]))
+        'multiple-key-with-none', key_with_none_stages[0].parent)
 
   def test_pack_combiners(self):
     class MultipleCombines(beam.PTransform):
@@ -83,8 +76,8 @@ class TranslationsTest(unittest.TestCase):
           combine_per_key_stages.append(stage)
     self.assertEqual(len(combine_per_key_stages), 1)
     self.assertIn('/Pack', combine_per_key_stages[0].name)
-    self.assertIn('multiple-combines', _parent_name(combine_per_key_stages[0]))
-    self.assertNotIn('-perkey', _parent_name(combine_per_key_stages[0]))
+    self.assertIn('multiple-combines', combine_per_key_stages[0].parent)
+    self.assertNotIn('-perkey', combine_per_key_stages[0].parent)
 
   def test_pack_combiners_with_missing_environment_capability(self):
     class MultipleCombines(beam.PTransform):
@@ -133,7 +126,7 @@ class TranslationsTest(unittest.TestCase):
         stage for stage in stages if 'KeyWithVoid' in stage.name
     ]
     self.assertEqual(len(key_with_void_stages), 1)
-    self.assertIn('-globally', _parent_name(key_with_void_stages[0]))
+    self.assertIn('-globally', key_with_void_stages[0].parent)
 
     combine_per_key_stages = []
     for stage in stages:
@@ -142,8 +135,8 @@ class TranslationsTest(unittest.TestCase):
           combine_per_key_stages.append(stage)
     self.assertEqual(len(combine_per_key_stages), 1)
     self.assertIn('/Pack', combine_per_key_stages[0].name)
-    self.assertIn('multiple-combines', _parent_name(combine_per_key_stages[0]))
-    self.assertNotIn('-globally', _parent_name(combine_per_key_stages[0]))
+    self.assertIn('multiple-combines', combine_per_key_stages[0].parent)
+    self.assertNotIn('-globally', combine_per_key_stages[0].parent)
 
   def test_optimize_empty_pipeline(self):
     pipeline = beam.Pipeline()

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
@@ -50,8 +50,7 @@ class TranslationsTest(unittest.TestCase):
         stage for stage in stages if 'key-with-none' in stage.name
     ]
     self.assertEqual(len(key_with_none_stages), 1)
-    self.assertIn(
-        'multiple-key-with-none', key_with_none_stages[0].parent)
+    self.assertIn('multiple-key-with-none', key_with_none_stages[0].parent)
 
   def test_pack_combiners(self):
     class MultipleCombines(beam.PTransform):

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
@@ -125,7 +125,8 @@ class TranslationsTest(unittest.TestCase):
         stage for stage in stages if 'KeyWithVoid' in stage.name
     ]
     self.assertEqual(len(key_with_void_stages), 1)
-    self.assertIn('-globally', key_with_void_stages[0].parent)
+    self.assertIn('multiple-combines', key_with_void_stages[0].parent)
+    self.assertNotIn('-globally', key_with_void_stages[0].parent)
 
     combine_per_key_stages = []
     for stage in stages:


### PR DESCRIPTION
Currently the parent of the fused stage is set to `None` if the two stages do not share a common parent. This sets it to the lowest common ancestor, if one exists.

------------------------

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
