### PR TITLE
[BEAM-11144] Fix trigger prefetching so that the correct trigger index

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterAllStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterAllStateMachine.java
@@ -46,11 +46,25 @@ public class AfterAllStateMachine extends TriggerStateMachine {
   }
 
   @Override
+  public void prefetchOnElement(PrefetchContext c) {
+    for (ExecutableTriggerStateMachine subTrigger : c.trigger().subTriggers()) {
+      subTrigger.invokePrefetchOnElement(c.forTrigger(subTrigger));
+    }
+  }
+
+  @Override
   public void onElement(OnElementContext c) throws Exception {
     for (ExecutableTriggerStateMachine subTrigger : c.trigger().unfinishedSubTriggers()) {
       // Since subTriggers are all OnceTriggers, they must either CONTINUE or FIRE_AND_FINISH.
       // invokeElement will automatically mark the finish bit if they return FIRE_AND_FINISH.
       subTrigger.invokeOnElement(c);
+    }
+  }
+
+  @Override
+  public void prefetchOnMerge(MergingPrefetchContext c) {
+    for (ExecutableTriggerStateMachine subTrigger : c.trigger().subTriggers()) {
+      subTrigger.invokePrefetchOnMerge(c.forTrigger(subTrigger));
     }
   }
 
@@ -64,6 +78,13 @@ public class AfterAllStateMachine extends TriggerStateMachine {
       allFinished &= c.forTrigger(subTrigger1).trigger().isFinished();
     }
     c.trigger().setFinished(allFinished);
+  }
+
+  @Override
+  public void prefetchShouldFire(PrefetchContext c) {
+    for (ExecutableTriggerStateMachine subTrigger : c.trigger().subTriggers()) {
+      subTrigger.invokePrefetchShouldFire(c.forTrigger(subTrigger));
+    }
   }
 
   /**

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterDelayFromFirstElementStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterDelayFromFirstElementStateMachine.java
@@ -20,8 +20,6 @@ package org.apache.beam.runners.core.triggers;
 import java.util.List;
 import java.util.Locale;
 import java.util.Objects;
-import org.apache.beam.runners.core.MergingStateAccessor;
-import org.apache.beam.runners.core.StateAccessor;
 import org.apache.beam.runners.core.StateMerging;
 import org.apache.beam.runners.core.StateTag;
 import org.apache.beam.runners.core.StateTags;
@@ -153,8 +151,8 @@ public abstract class AfterDelayFromFirstElementStateMachine extends TriggerStat
   }
 
   @Override
-  public void prefetchOnElement(StateAccessor<?> state) {
-    state.access(DELAYED_UNTIL_TAG).readLater();
+  public void prefetchOnElement(PrefetchContext c) {
+    c.state().access(DELAYED_UNTIL_TAG).readLater();
   }
 
   @Override
@@ -174,9 +172,8 @@ public abstract class AfterDelayFromFirstElementStateMachine extends TriggerStat
   }
 
   @Override
-  public void prefetchOnMerge(MergingStateAccessor<?, ?> state) {
-    super.prefetchOnMerge(state);
-    StateMerging.prefetchCombiningValues(state, DELAYED_UNTIL_TAG);
+  public void prefetchOnMerge(MergingPrefetchContext c) {
+    StateMerging.prefetchCombiningValues(c.state(), DELAYED_UNTIL_TAG);
   }
 
   @Override
@@ -209,8 +206,8 @@ public abstract class AfterDelayFromFirstElementStateMachine extends TriggerStat
   }
 
   @Override
-  public void prefetchShouldFire(StateAccessor<?> state) {
-    state.access(DELAYED_UNTIL_TAG).readLater();
+  public void prefetchShouldFire(PrefetchContext c) {
+    c.state().access(DELAYED_UNTIL_TAG).readLater();
   }
 
   @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterEachStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterEachStateMachine.java
@@ -48,6 +48,13 @@ public class AfterEachStateMachine extends TriggerStateMachine {
     checkArgument(subTriggers.size() > 1);
   }
 
+  @Override
+  public void prefetchOnElement(PrefetchContext c) {
+    for (ExecutableTriggerStateMachine subTrigger : c.trigger().subTriggers()) {
+      subTrigger.invokePrefetchOnElement(c.forTrigger(subTrigger));
+    }
+  }
+
   /** Returns an {@code AfterEach} {@code Trigger} with the given subtriggers. */
   @SafeVarargs
   public static TriggerStateMachine inOrder(TriggerStateMachine... triggers) {
@@ -74,6 +81,13 @@ public class AfterEachStateMachine extends TriggerStateMachine {
   }
 
   @Override
+  public void prefetchOnMerge(MergingPrefetchContext c) {
+    for (ExecutableTriggerStateMachine subTrigger : c.trigger().subTriggers()) {
+      subTrigger.invokePrefetchOnMerge(c.forTrigger(subTrigger));
+    }
+  }
+
+  @Override
   public void onMerge(OnMergeContext context) throws Exception {
     // If merging makes a subtrigger no-longer-finished, it will automatically
     // begin participating in shouldFire and onFire appropriately.
@@ -91,6 +105,13 @@ public class AfterEachStateMachine extends TriggerStateMachine {
       }
     }
     updateFinishedState(context);
+  }
+
+  @Override
+  public void prefetchShouldFire(PrefetchContext c) {
+    for (ExecutableTriggerStateMachine subTrigger : c.trigger().subTriggers()) {
+      subTrigger.invokePrefetchShouldFire(c.forTrigger(subTrigger));
+    }
   }
 
   @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterFirstStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterFirstStateMachine.java
@@ -46,9 +46,23 @@ public class AfterFirstStateMachine extends TriggerStateMachine {
   }
 
   @Override
+  public void prefetchOnElement(PrefetchContext c) {
+    for (ExecutableTriggerStateMachine subTrigger : c.trigger().subTriggers()) {
+      subTrigger.invokePrefetchOnElement(c.forTrigger(subTrigger));
+    }
+  }
+
+  @Override
   public void onElement(OnElementContext c) throws Exception {
     for (ExecutableTriggerStateMachine subTrigger : c.trigger().subTriggers()) {
       subTrigger.invokeOnElement(c);
+    }
+  }
+
+  @Override
+  public void prefetchOnMerge(MergingPrefetchContext c) {
+    for (ExecutableTriggerStateMachine subTrigger : c.trigger().subTriggers()) {
+      subTrigger.invokePrefetchOnMerge(c.forTrigger(subTrigger));
     }
   }
 
@@ -58,6 +72,13 @@ public class AfterFirstStateMachine extends TriggerStateMachine {
       subTrigger.invokeOnMerge(c);
     }
     updateFinishedStatus(c);
+  }
+
+  @Override
+  public void prefetchShouldFire(PrefetchContext c) {
+    for (ExecutableTriggerStateMachine subTrigger : c.trigger().subTriggers()) {
+      subTrigger.invokePrefetchShouldFire(c.forTrigger(subTrigger));
+    }
   }
 
   @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterWatermarkStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/AfterWatermarkStateMachine.java
@@ -92,6 +92,13 @@ public class AfterWatermarkStateMachine {
     }
 
     @Override
+    public void prefetchOnElement(PrefetchContext c) {
+      for (ExecutableTriggerStateMachine subTrigger : c.trigger().subTriggers()) {
+        subTrigger.invokePrefetchOnElement(c);
+      }
+    }
+
+    @Override
     public void onElement(OnElementContext c) throws Exception {
       if (!endOfWindowReached(c)) {
         c.setTimer(c.window().maxTimestamp(), TimeDomain.EVENT_TIME);
@@ -106,6 +113,13 @@ public class AfterWatermarkStateMachine {
         for (ExecutableTriggerStateMachine subTrigger : c.trigger().subTriggers()) {
           subTrigger.invokeOnElement(c);
         }
+      }
+    }
+
+    @Override
+    public void prefetchOnMerge(MergingPrefetchContext c) {
+      for (ExecutableTriggerStateMachine subTrigger : c.trigger().subTriggers()) {
+        subTrigger.invokePrefetchOnMerge(c);
       }
     }
 
@@ -143,6 +157,13 @@ public class AfterWatermarkStateMachine {
     private boolean endOfWindowReached(TriggerStateMachine.TriggerContext context) {
       return context.currentEventTime() != null
           && context.currentEventTime().isAfter(context.window().maxTimestamp());
+    }
+
+    @Override
+    public void prefetchShouldFire(PrefetchContext c) {
+      for (ExecutableTriggerStateMachine subTrigger : c.trigger().subTriggers()) {
+        subTrigger.invokePrefetchShouldFire(c);
+      }
     }
 
     @Override
@@ -254,6 +275,9 @@ public class AfterWatermarkStateMachine {
     }
 
     @Override
+    public void prefetchOnElement(PrefetchContext c) {}
+
+    @Override
     public void onElement(OnElementContext c) throws Exception {
       // We're interested in knowing when the input watermark passes the end of the window.
       // (It is possible this has already happened, in which case the timer will be fired
@@ -262,6 +286,9 @@ public class AfterWatermarkStateMachine {
         c.setTimer(c.window().maxTimestamp(), TimeDomain.EVENT_TIME);
       }
     }
+
+    @Override
+    public void prefetchOnMerge(MergingPrefetchContext c) {}
 
     @Override
     public void onMerge(OnMergeContext c) throws Exception {
@@ -296,6 +323,9 @@ public class AfterWatermarkStateMachine {
     public int hashCode() {
       return Objects.hash(getClass());
     }
+
+    @Override
+    public void prefetchShouldFire(PrefetchContext c) {}
 
     @Override
     public boolean shouldFire(TriggerStateMachine.TriggerContext context) throws Exception {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/DefaultTriggerStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/DefaultTriggerStateMachine.java
@@ -36,6 +36,9 @@ public class DefaultTriggerStateMachine extends TriggerStateMachine {
   }
 
   @Override
+  public void prefetchOnElement(PrefetchContext c) {}
+
+  @Override
   public void onElement(OnElementContext c) throws Exception {
     // If the end of the window has already been reached, then we are already ready to fire
     // and do not need to set a wake-up timer.
@@ -45,6 +48,9 @@ public class DefaultTriggerStateMachine extends TriggerStateMachine {
   }
 
   @Override
+  public void prefetchOnMerge(MergingPrefetchContext c) {}
+
+  @Override
   public void onMerge(OnMergeContext c) throws Exception {
     // If the end of the window has already been reached, then we are already ready to fire
     // and do not need to set a wake-up timer.
@@ -52,6 +58,9 @@ public class DefaultTriggerStateMachine extends TriggerStateMachine {
       c.setTimer(c.window().maxTimestamp(), TimeDomain.EVENT_TIME);
     }
   }
+
+  @Override
+  public void prefetchShouldFire(PrefetchContext c) {}
 
   @Override
   public void clear(TriggerContext c) throws Exception {}

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/ExecutableTriggerStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/ExecutableTriggerStateMachine.java
@@ -112,12 +112,20 @@ public class ExecutableTriggerStateMachine implements Serializable {
     return previous;
   }
 
+  public void invokePrefetchOnElement(TriggerStateMachine.PrefetchContext c) {
+    trigger.prefetchOnElement(c.forTrigger(this));
+  }
+
   /**
    * Invoke the {@link TriggerStateMachine#onElement} method for this trigger, ensuring that the
    * bits are properly updated if the trigger finishes.
    */
   public void invokeOnElement(TriggerStateMachine.OnElementContext c) throws Exception {
     trigger.onElement(c.forTrigger(this));
+  }
+
+  public void invokePrefetchOnMerge(TriggerStateMachine.MergingPrefetchContext c) {
+    trigger.prefetchOnMerge(c.forTrigger(this));
   }
 
   /**
@@ -127,6 +135,10 @@ public class ExecutableTriggerStateMachine implements Serializable {
   public void invokeOnMerge(TriggerStateMachine.OnMergeContext c) throws Exception {
     TriggerStateMachine.OnMergeContext subContext = c.forTrigger(this);
     trigger.onMerge(subContext);
+  }
+
+  public void invokePrefetchShouldFire(TriggerStateMachine.PrefetchContext c) {
+    trigger.prefetchShouldFire(c.forTrigger(this));
   }
 
   public boolean invokeShouldFire(TriggerStateMachine.TriggerContext c) throws Exception {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/NeverStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/NeverStateMachine.java
@@ -41,10 +41,19 @@ public final class NeverStateMachine extends TriggerStateMachine {
   }
 
   @Override
+  public void prefetchOnElement(PrefetchContext c) {}
+
+  @Override
   public void onElement(OnElementContext c) {}
 
   @Override
+  public void prefetchOnMerge(MergingPrefetchContext c) {}
+
+  @Override
   public void onMerge(OnMergeContext c) {}
+
+  @Override
+  public void prefetchShouldFire(PrefetchContext c) {}
 
   @Override
   public boolean shouldFire(TriggerStateMachine.TriggerContext context) {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/OrFinallyStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/OrFinallyStateMachine.java
@@ -34,9 +34,23 @@ class OrFinallyStateMachine extends TriggerStateMachine {
   }
 
   @Override
+  public void prefetchOnElement(PrefetchContext c) {
+    for (ExecutableTriggerStateMachine subTrigger : c.trigger().subTriggers()) {
+      subTrigger.invokePrefetchOnElement(c.forTrigger(subTrigger));
+    }
+  }
+
+  @Override
   public void onElement(OnElementContext c) throws Exception {
     c.trigger().subTrigger(ACTUAL).invokeOnElement(c);
     c.trigger().subTrigger(UNTIL).invokeOnElement(c);
+  }
+
+  @Override
+  public void prefetchOnMerge(MergingPrefetchContext c) {
+    for (ExecutableTriggerStateMachine subTrigger : c.trigger().subTriggers()) {
+      subTrigger.invokePrefetchOnMerge(c.forTrigger(subTrigger));
+    }
   }
 
   @Override
@@ -45,6 +59,13 @@ class OrFinallyStateMachine extends TriggerStateMachine {
       subTrigger.invokeOnMerge(c);
     }
     updateFinishedState(c);
+  }
+
+  @Override
+  public void prefetchShouldFire(PrefetchContext c) {
+    for (ExecutableTriggerStateMachine subTrigger : c.trigger().subTriggers()) {
+      subTrigger.invokePrefetchShouldFire(c.forTrigger(subTrigger));
+    }
   }
 
   @Override

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/RepeatedlyStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/RepeatedlyStateMachine.java
@@ -53,13 +53,28 @@ public class RepeatedlyStateMachine extends TriggerStateMachine {
   }
 
   @Override
+  public void prefetchOnElement(PrefetchContext c) {
+    getRepeated(c).invokePrefetchOnElement(c);
+  }
+
+  @Override
   public void onElement(OnElementContext c) throws Exception {
     getRepeated(c).invokeOnElement(c);
   }
 
   @Override
+  public void prefetchOnMerge(MergingPrefetchContext c) {
+    getRepeated(c).invokePrefetchOnMerge(c);
+  }
+
+  @Override
   public void onMerge(OnMergeContext c) throws Exception {
     getRepeated(c).invokeOnMerge(c);
+  }
+
+  @Override
+  public void prefetchShouldFire(PrefetchContext c) {
+    getRepeated(c).invokePrefetchShouldFire(c);
   }
 
   @Override
@@ -84,5 +99,9 @@ public class RepeatedlyStateMachine extends TriggerStateMachine {
 
   private ExecutableTriggerStateMachine getRepeated(TriggerContext context) {
     return context.trigger().subTrigger(REPEATED);
+  }
+
+  private ExecutableTriggerStateMachine getRepeated(PrefetchContext context) {
+    return context.trigger().subTriggers().get(REPEATED);
   }
 }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/ReshuffleTriggerStateMachine.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/ReshuffleTriggerStateMachine.java
@@ -33,10 +33,19 @@ public class ReshuffleTriggerStateMachine extends TriggerStateMachine {
   }
 
   @Override
+  public void prefetchOnElement(PrefetchContext c) {}
+
+  @Override
   public void onElement(TriggerStateMachine.OnElementContext c) {}
 
   @Override
+  public void prefetchOnMerge(MergingPrefetchContext c) {}
+
+  @Override
   public void onMerge(TriggerStateMachine.OnMergeContext c) {}
+
+  @Override
+  public void prefetchShouldFire(PrefetchContext c) {}
 
   @Override
   public boolean shouldFire(TriggerStateMachine.TriggerContext context) throws Exception {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/TriggerStateMachineRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/triggers/TriggerStateMachineRunner.java
@@ -107,21 +107,12 @@ public class TriggerStateMachineRunner<W extends BoundedWindow> {
 
   public void prefetchForValue(W window, StateAccessor<?> state) {
     prefetchIsClosed(state);
-    rootTrigger
-        .getSpec()
-        .prefetchOnElement(contextFactory.createStateAccessor(window, rootTrigger));
-  }
-
-  public void prefetchOnFire(W window, StateAccessor<?> state) {
-    prefetchIsClosed(state);
-    rootTrigger.getSpec().prefetchOnFire(contextFactory.createStateAccessor(window, rootTrigger));
+    rootTrigger.invokePrefetchOnElement(contextFactory.createPrefetchContext(window, rootTrigger));
   }
 
   public void prefetchShouldFire(W window, StateAccessor<?> state) {
     prefetchIsClosed(state);
-    rootTrigger
-        .getSpec()
-        .prefetchShouldFire(contextFactory.createStateAccessor(window, rootTrigger));
+    rootTrigger.invokePrefetchShouldFire(contextFactory.createPrefetchContext(window, rootTrigger));
   }
 
   /** Run the trigger logic to deal with a new value. */
@@ -142,10 +133,8 @@ public class TriggerStateMachineRunner<W extends BoundedWindow> {
         value.readLater();
       }
     }
-    rootTrigger
-        .getSpec()
-        .prefetchOnMerge(
-            contextFactory.createMergingStateAccessor(window, mergingWindows, rootTrigger));
+    rootTrigger.invokePrefetchOnMerge(
+        contextFactory.createMergingPrefetchContext(window, mergingWindows, rootTrigger));
   }
 
   /** Run the trigger merging logic as part of executing the specified merge. */

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/ExecutableTriggerStateMachineTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/ExecutableTriggerStateMachineTest.java
@@ -86,10 +86,19 @@ public class ExecutableTriggerStateMachineTest {
     }
 
     @Override
+    public void prefetchOnElement(PrefetchContext c) {}
+
+    @Override
     public void onElement(OnElementContext c) throws Exception {}
 
     @Override
+    public void prefetchOnMerge(MergingPrefetchContext c) {}
+
+    @Override
     public void onMerge(OnMergeContext c) throws Exception {}
+
+    @Override
+    public void prefetchShouldFire(PrefetchContext c) {}
 
     @Override
     public void clear(TriggerContext c) throws Exception {}

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/RepeatedlyStateMachineTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/RepeatedlyStateMachineTest.java
@@ -182,14 +182,7 @@ public class RepeatedlyStateMachineTest {
   @Test
   public void testToString() {
     TriggerStateMachine trigger =
-        RepeatedlyStateMachine.forever(
-            new StubTriggerStateMachine() {
-              @Override
-              public String toString() {
-                return "innerTrigger";
-              }
-            });
-
+        RepeatedlyStateMachine.forever(StubTriggerStateMachine.named("innerTrigger"));
     assertEquals("Repeatedly.forever(innerTrigger)", trigger.toString());
   }
 }

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/StubTriggerStateMachine.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/StubTriggerStateMachine.java
@@ -42,10 +42,19 @@ abstract class StubTriggerStateMachine extends TriggerStateMachine {
   public void onFire(TriggerContext context) throws Exception {}
 
   @Override
+  public void prefetchOnElement(PrefetchContext c) {}
+
+  @Override
   public void onElement(OnElementContext c) throws Exception {}
 
   @Override
+  public void prefetchOnMerge(MergingPrefetchContext c) {}
+
+  @Override
   public void onMerge(OnMergeContext c) throws Exception {}
+
+  @Override
+  public void prefetchShouldFire(PrefetchContext c) {}
 
   @Override
   public boolean shouldFire(TriggerContext context) throws Exception {

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/TriggerStateMachineTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/TriggerStateMachineTest.java
@@ -61,10 +61,19 @@ public class TriggerStateMachineTest {
     }
 
     @Override
+    public void prefetchOnElement(PrefetchContext c) {}
+
+    @Override
     public void onElement(TriggerStateMachine.OnElementContext c) {}
 
     @Override
+    public void prefetchOnMerge(MergingPrefetchContext c) {}
+
+    @Override
     public void onMerge(TriggerStateMachine.OnMergeContext c) {}
+
+    @Override
+    public void prefetchShouldFire(PrefetchContext c) {}
 
     @Override
     public boolean shouldFire(TriggerStateMachine.TriggerContext context) throws Exception {
@@ -82,10 +91,19 @@ public class TriggerStateMachineTest {
     }
 
     @Override
+    public void prefetchOnElement(PrefetchContext c) {}
+
+    @Override
     public void onElement(TriggerStateMachine.OnElementContext c) {}
 
     @Override
+    public void prefetchOnMerge(MergingPrefetchContext c) {}
+
+    @Override
     public void onMerge(TriggerStateMachine.OnMergeContext c) {}
+
+    @Override
+    public void prefetchShouldFire(PrefetchContext c) {}
 
     @Override
     public boolean shouldFire(TriggerStateMachine.TriggerContext context) throws Exception {

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/TriggerStateMachineTester.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/triggers/TriggerStateMachineTester.java
@@ -299,7 +299,9 @@ public class TriggerStateMachineTester<InputT, W extends BoundedWindow> {
             new TestTimers(windowNamespace(window)),
             executableTrigger,
             getFinishedSet(window));
-    executableTrigger.getSpec().prefetchShouldFire(context.state());
+    executableTrigger
+        .getSpec()
+        .prefetchShouldFire(contextFactory.createPrefetchContext(window, executableTrigger));
     return executableTrigger.invokeShouldFire(context);
   }
 
@@ -311,9 +313,10 @@ public class TriggerStateMachineTester<InputT, W extends BoundedWindow> {
             executableTrigger,
             getFinishedSet(window));
 
-    executableTrigger.getSpec().prefetchShouldFire(context.state());
+    executableTrigger
+        .getSpec()
+        .prefetchShouldFire(contextFactory.createPrefetchContext(window, executableTrigger));
     if (executableTrigger.invokeShouldFire(context)) {
-      executableTrigger.getSpec().prefetchOnFire(context.state());
       executableTrigger.invokeOnFire(context);
       if (context.trigger().isFinished()) {
         activeWindows.remove(window);


### PR DESCRIPTION
is used for the state namespace.

Previously prefetching was fetching non-existent state, possibly adding
unnecessary fetches as well as neglecting to prefetch actual state used.

Another way to accomplish this would be to change the TriggerStateMachine
prefetch methods to take a TriggerContext instead of a raw state accessor.
This would allow for TriggerStateMachine to get the correct state for
subtriggers.  That seems more inline with how the nonprefetch methods work
however that is a public interface change.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
