### PR TITLE
[BEAM-8719 BEAM-8768 BEAM-8769 BEAM-8770 BEAM-8771] Update minor hadoop dependencies

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -162,12 +162,24 @@ task javaPostCommit() {
   dependsOn ":sdks:java:io:google-cloud-platform:postCommit"
   dependsOn ":sdks:java:io:kinesis:integrationTest"
   dependsOn ":sdks:java:io:hadoop-format:hadoopFormatIOElasticTest"
+  dependsOn ":javaHadoop285Tests"
+}
+
+task javaHadoop285Tests() {
+  dependsOn ":sdks:java:io:hadoop-common:hadoopVersion285Test"
+  dependsOn ":sdks:java:io:hadoop-file-system:hadoopVersion285Test"
+  dependsOn ":sdks:java:io:hadoop-format:hadoopVersion285Test"
+  dependsOn ":sdks:java:io:hcatalog:hadoopVersion285Test"
+  dependsOn ":sdks:java:io:parquet:hadoopVersion285Test"
+  dependsOn ":sdks:java:extensions:sorter:hadoopVersion285Test"
+  dependsOn ":runners:spark:hadoopVersion285Test"
 }
 
 task sqlPostCommit() {
   dependsOn ":sdks:java:extensions:sql:postCommit"
   dependsOn ":sdks:java:extensions:sql:jdbc:postCommit"
   dependsOn ":sdks:java:extensions:sql:datacatalog:postCommit"
+  dependsOn ":sdks:java:extensions:sql:hadoopVersion285Test"
 }
 
 task goPreCommit() {

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -417,7 +417,7 @@ class BeamModulePlugin implements Plugin<Project> {
     // Try to keep grpc_version consistent with gRPC version in google_cloud_platform_libraries_bom
     def grpc_version = "1.32.2"
     def guava_version = "25.1-jre"
-    def hadoop_version = "2.8.5"
+    def hadoop_version = "2.10.1"
     def hamcrest_version = "2.1"
     def influxdb_version = "2.19"
     def jackson_version = "2.10.2"

--- a/runners/spark/build.gradle
+++ b/runners/spark/build.gradle
@@ -41,7 +41,10 @@ evaluationDependsOn(":runners:core-java")
 
 configurations {
   validatesRunner
+  hadoopVersion285
 }
+
+def hadoop_285_version = '2.8.5'
 
 test {
   systemProperty "beam.spark.test.reuseSparkContext", "true"
@@ -105,6 +108,7 @@ dependencies {
   validatesRunner project(path: project.path, configuration: "testRuntime")
   validatesRunner project(project.path)
   validatesRunner project(path: project.path, configuration: "provided")
+  hadoopVersion285 "org.apache.hadoop:hadoop-common:$hadoop_285_version"
 }
 
 configurations.testRuntimeClasspath {
@@ -115,6 +119,14 @@ configurations.testRuntimeClasspath {
 configurations.validatesRunner {
   // Testing the Spark runner causes a StackOverflowError if slf4j-jdk14 is on the classpath
   exclude group: "org.slf4j", module: "slf4j-jdk14"
+}
+
+configurations.hadoopVersion285 {
+  // Testing the Spark runner causes a StackOverflowError if slf4j-jdk14 is on the classpath
+  exclude group: "org.slf4j", module: "slf4j-jdk14"
+  resolutionStrategy {
+    force "org.apache.hadoop:hadoop-common:$hadoop_285_version"
+  }
 }
 
 task validatesRunnerBatch(type: Test) {
@@ -255,3 +267,24 @@ task validatesRunner {
 
 // Generates :runners:spark:runQuickstartJavaSpark
 createJavaExamplesArchetypeValidationTask(type: 'Quickstart', runner: 'Spark')
+
+task hadoopVersion285Test(type: Test) {
+  description = "Runs Spark tests with Hadoop version $hadoop_285_version"
+  systemProperty "beam.spark.test.reuseSparkContext", "true"
+  systemProperty "spark.sql.shuffle.partitions", "4"
+  systemProperty "spark.ui.enabled", "false"
+  systemProperty "spark.ui.showConsoleProgress", "false"
+  systemProperty "beamTestPipelineOptions", """[
+                    "--runner=TestSparkRunner",
+                    "--streaming=false",
+                    "--enableSparkMetricSinks=true"
+                  ]"""
+  // Only one SparkContext may be running in a JVM (SPARK-2243)
+  forkEvery 1
+  maxParallelForks 4
+  include "**/*Test.class"
+  useJUnit {
+    excludeCategories "org.apache.beam.runners.spark.StreamingTest"
+    excludeCategories "org.apache.beam.runners.spark.UsesCheckpointRecovery"
+  }
+}

--- a/sdks/java/extensions/sorter/build.gradle
+++ b/sdks/java/extensions/sorter/build.gradle
@@ -22,6 +22,12 @@ applyJavaNature(
 
 description = "Apache Beam :: SDKs :: Java :: Extensions :: Sorter"
 
+configurations {
+  hadoopVersion285
+}
+
+def hadoop_285_version = '2.8.5'
+
 dependencies {
   compile project(path: ":sdks:java:core", configuration: "shadow")
   compile library.java.vendored_guava_26_0_jre
@@ -32,4 +38,18 @@ dependencies {
   testCompile library.java.mockito_core
   testCompile library.java.junit
   testRuntimeOnly project(path: ":runners:direct-java", configuration: "shadow")
+  hadoopVersion285 "org.apache.hadoop:hadoop-common:$hadoop_285_version"
+  hadoopVersion285 "org.apache.hadoop:hadoop-mapreduce-client-core:$hadoop_285_version"
+}
+
+configurations.hadoopVersion285 {
+  resolutionStrategy {
+    force "org.apache.hadoop:hadoop-common:$hadoop_285_version"
+    force "org.apache.hadoop:hadoop-mapreduce-client-core:$hadoop_285_version"
+  }
+}
+
+task hadoopVersion285Test(type: Test) {
+  description = "Runs Sorter tests with Hadoop version $hadoop_285_version"
+  include '**/*Test.class'
 }

--- a/sdks/java/extensions/sql/build.gradle
+++ b/sdks/java/extensions/sql/build.gradle
@@ -43,7 +43,10 @@ configurations {
   // TODO: Migrate to a FMPP plugin once one exists
   fmppTask
   fmppTemplates
+  hadoopVersion285
 }
+
+def hadoop_285_version = '2.8.5'
 
 dependencies {
   javacc "net.java.dev.javacc:javacc:4.0"
@@ -79,6 +82,13 @@ dependencies {
   testCompile library.java.testcontainers_kafka
   testCompile project(path: ":sdks:java:io:mongodb", configuration: "testRuntime")
   testRuntimeClasspath library.java.slf4j_jdk14
+  hadoopVersion285 "org.apache.hadoop:hadoop-client:$hadoop_285_version"
+}
+
+configurations.hadoopVersion285 {
+  resolutionStrategy {
+    force "org.apache.hadoop:hadoop-client:$hadoop_285_version"
+  }
 }
 
 // Copy Calcite templates and our own template into the build directory
@@ -196,4 +206,9 @@ task postCommit {
   description = "Various integration tests"
   dependsOn runKafkaTableProviderIT
   dependsOn integrationTest
+}
+
+task hadoopVersion285Test(type: Test) {
+  description = "Runs SQL tests with Hadoop version $hadoop_285_version"
+  include '**/*Test.class'
 }

--- a/sdks/java/io/hadoop-common/build.gradle
+++ b/sdks/java/io/hadoop-common/build.gradle
@@ -22,6 +22,12 @@ applyJavaNature(automaticModuleName: 'org.apache.beam.sdk.io.hadoop.common')
 description = "Apache Beam :: SDKs :: Java :: IO :: Hadoop Common"
 ext.summary = "Library to add shared Hadoop classes among Beam IOs."
 
+configurations {
+  hadoopVersion285
+}
+
+def version285 = '2.8.5'
+
 dependencies {
   compile project(path: ":sdks:java:core", configuration: "shadow")
   provided library.java.hadoop_client
@@ -30,4 +36,20 @@ dependencies {
   testCompile library.java.hamcrest_core
   testCompile library.java.hamcrest_library
   testCompile library.java.junit
+  hadoopVersion285 "org.apache.hadoop:hadoop-client:$version285"
+  hadoopVersion285 "org.apache.hadoop:hadoop-common:$version285"
+  hadoopVersion285 "org.apache.hadoop:hadoop-mapreduce-client-core:$version285"
+}
+
+configurations.hadoopVersion285 {
+  resolutionStrategy {
+    force "org.apache.hadoop:hadoop-client:$version285"
+    force "org.apache.hadoop:hadoop-common:$version285"
+    force "org.apache.hadoop:hadoop-mapreduce-client-core:$version285"
+  }
+}
+
+task hadoopVersion285Test(type: Test) {
+  description = "Runs Hadoop common tests with Hadoop version $version285"
+  include '**/*Test.class'
 }

--- a/sdks/java/io/hadoop-file-system/build.gradle
+++ b/sdks/java/io/hadoop-file-system/build.gradle
@@ -24,6 +24,12 @@ applyJavaNature(
 description = "Apache Beam :: SDKs :: Java :: IO :: Hadoop File System"
 ext.summary = "Library to read and write Hadoop/HDFS file formats from Beam."
 
+configurations {
+  hadoopVersion285
+}
+
+def hadoop_285_version = '2.8.5'
+
 dependencies {
   compile library.java.vendored_guava_26_0_jre
   compile project(path: ":sdks:java:core", configuration: "shadow")
@@ -42,4 +48,20 @@ dependencies {
   testCompile library.java.hadoop_hdfs_tests
   testRuntimeOnly library.java.slf4j_jdk14
   testRuntimeOnly project(path: ":runners:direct-java", configuration: "shadow")
+  hadoopVersion285 "org.apache.hadoop:hadoop-client:$hadoop_285_version"
+  hadoopVersion285 "org.apache.hadoop:hadoop-common:$hadoop_285_version"
+  hadoopVersion285 "org.apache.hadoop:hadoop-mapreduce-client-core:$hadoop_285_version"
+}
+
+configurations.hadoopVersion285 {
+  resolutionStrategy {
+    force "org.apache.hadoop:hadoop-client:$hadoop_285_version"
+    force "org.apache.hadoop:hadoop-common:$hadoop_285_version"
+    force "org.apache.hadoop:hadoop-mapreduce-client-core:$hadoop_285_version"
+  }
+}
+
+task hadoopVersion285Test(type: Test) {
+  description = "Runs Hadoop file system tests with Hadoop version $hadoop_285_version"
+  include '**/*Test.class'
 }

--- a/sdks/java/io/hadoop-format/build.gradle
+++ b/sdks/java/io/hadoop-format/build.gradle
@@ -28,8 +28,13 @@ enableJavaPerformanceTesting()
 description = "Apache Beam :: SDKs :: Java :: IO :: Hadoop Format"
 ext.summary = "IO to read data from sources and to write data to sinks that implement Hadoop MapReduce Format."
 
+configurations {
+  hadoopVersion285
+}
+
 def log4j_version = "2.6.2"
 def elastic_search_version = "7.9.2"
+def hadoop_285_version = '2.8.5'
 
 configurations.create("sparkRunner")
 configurations.sparkRunner {
@@ -94,6 +99,18 @@ dependencies {
   sparkRunner project(":sdks:java:io:hadoop-file-system")
   sparkRunner library.java.spark_streaming
   sparkRunner library.java.spark_core
+
+  hadoopVersion285 "org.apache.hadoop:hadoop-common:$hadoop_285_version"
+  hadoopVersion285 "org.apache.hadoop:hadoop-mapreduce-client-core:$hadoop_285_version"
+  hadoopVersion285 "org.apache.hadoop:hadoop-hdfs:$hadoop_285_version"
+}
+
+configurations.hadoopVersion285 {
+  resolutionStrategy {
+    force "org.apache.hadoop:hadoop-common:$hadoop_285_version"
+    force "org.apache.hadoop:hadoop-mapreduce-client-core:$hadoop_285_version"
+    force "org.apache.hadoop:hadoop-hdfs:$hadoop_285_version"
+  }
 }
 
 // The cassandra.yaml file currently assumes "target/..." exists.
@@ -139,4 +156,11 @@ task hadoopFormatIOElasticTest(type: Test) {
   testClassesDirs = sourceSets.test.output.classesDirs
   include '**/HadoopFormatIOElasticIT.class'
   useJUnit { }
+}
+
+task hadoopVersion285Test(type: Test) {
+  dependsOn createTargetDirectoryForCassandra
+  description = "Runs Hadoop format tests with Hadoop version $hadoop_285_version"
+  outputs.upToDateWhen { false }
+  include '**/*Test.class'
 }

--- a/sdks/java/io/hcatalog/build.gradle
+++ b/sdks/java/io/hcatalog/build.gradle
@@ -22,6 +22,11 @@ applyJavaNature(automaticModuleName: 'org.apache.beam.sdk.io.hcatalog')
 description = "Apache Beam :: SDKs :: Java :: IO :: HCatalog"
 ext.summary = "IO to read and write for HCatalog source."
 
+configurations {
+  hadoopVersion285
+}
+
+def hadoop_285_version = '2.8.5'
 def hive_version = "2.1.0"
 
 test {
@@ -68,5 +73,16 @@ dependencies {
   testCompile "org.apache.hive:hive-common:$hive_version"
   testCompile "org.apache.hive:hive-cli:$hive_version"
   testRuntimeOnly project(path: ":runners:direct-java", configuration: "shadow")
+  hadoopVersion285 "org.apache.hadoop:hadoop-common:$hadoop_285_version"
 }
 
+configurations.hadoopVersion285 {
+  resolutionStrategy {
+    force "org.apache.hadoop:hadoop-common:$hadoop_285_version"
+  }
+}
+
+task hadoopVersion285Test(type: Test) {
+  description = "Runs HCatalog tests with Hadoop version $hadoop_285_version"
+  include '**/*Test.class'
+}

--- a/sdks/java/io/parquet/build.gradle
+++ b/sdks/java/io/parquet/build.gradle
@@ -24,6 +24,11 @@ applyJavaNature(
 description = "Apache Beam :: SDKs :: Java :: IO :: Parquet"
 ext.summary = "IO to read and write on Parquet storage format."
 
+configurations {
+  hadoopVersion285
+}
+
+def hadoop_285_version = '2.8.5'
 def parquet_version = "1.10.0"
 
 dependencies {
@@ -42,4 +47,16 @@ dependencies {
   testCompile library.java.hamcrest_library
   testRuntimeOnly library.java.slf4j_jdk14
   testRuntimeOnly project(path: ":runners:direct-java", configuration: "shadow")
+  hadoopVersion285 "org.apache.hadoop:hadoop-client:$hadoop_285_version"
+}
+
+configurations.hadoopVersion285 {
+  resolutionStrategy {
+    force "org.apache.hadoop:hadoop-client:$hadoop_285_version"
+  }
+}
+
+task hadoopVersion285Test(type: Test) {
+  description = "Runs Parquet tests with Hadoop version $hadoop_285_version"
+  include '**/*Test.class'
 }


### PR DESCRIPTION
This PR:
- updates Hadoop dependencies from 2.8.5 to 2.10.1
- adds tests for Hadoop 2.8.5 compatibility in modules that have hadoop dependencies as 'provided'

For the tests I've taken the approach that is already used in KafkaIO.

I tried to add tests for Hadoop 2.7.7 but without success. I haven't verified if the problem comes from tests configuration or the IO itself but since this PR is to assure the compatibility with the previous version used in Beam (2.8.5) I'd like not to touch it. It could be worth to file a Jira to add tests for 2.7.7 version.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
