### PR TITLE
[BEAM-11146] Add fasterCopy option to Flink runner

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,7 @@
 * Added support for avro payload format in Beam SQL Kafka Table ([BEAM-10885](https://issues.apache.org/jira/browse/BEAM-10885))
 * Added support for json payload format in Beam SQL Kafka Table ([BEAM-10893](https://issues.apache.org/jira/browse/BEAM-10893))
 * Added support for avro payload format in Beam SQL Pubsub Table ([BEAM-10857](https://issues.apache.org/jira/browse/BEAM-10857))
+* Added option to disable unnecessary copying between operators in Flink Runner (Java) ([BEAM-11146](https://issues.apache.org/jira/browse/BEAM-11146))
 * X feature added (Java/Python) ([BEAM-X](https://issues.apache.org/jira/browse/BEAM-X)).
 
 ## Breaking Changes

--- a/runners/flink/1.8/src/test/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializerTest.java
+++ b/runners/flink/1.8/src/test/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializerTest.java
@@ -24,9 +24,11 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.Serializable;
+import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
 import org.apache.beam.sdk.coders.AtomicCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.flink.api.common.typeutils.ComparatorTestBase;
 import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.junit.Test;
@@ -59,7 +61,9 @@ public class CoderTypeSerializerTest implements Serializable {
   }
 
   private void testWriteAndReadConfigSnapshot(Coder<String> coder) throws IOException {
-    CoderTypeSerializer<String> serializer = new CoderTypeSerializer<>(coder);
+    CoderTypeSerializer<String> serializer =
+        new CoderTypeSerializer<>(
+            coder, new SerializablePipelineOptions(PipelineOptionsFactory.create()));
 
     TypeSerializerSnapshot writtenSnapshot = serializer.snapshotConfiguration();
     ComparatorTestBase.TestOutputView outView = new ComparatorTestBase.TestOutputView();

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchPortablePipelineTranslator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchPortablePipelineTranslator.java
@@ -312,7 +312,8 @@ public class FlinkBatchPortablePipelineTranslator
       unionCoders.add(coder);
     }
     UnionCoder unionCoder = UnionCoder.of(unionCoders);
-    TypeInformation<RawUnionValue> typeInformation = new CoderTypeInformation<>(unionCoder);
+    TypeInformation<RawUnionValue> typeInformation =
+        new CoderTypeInformation<>(unionCoder, context.getPipelineOptions());
 
     RunnerApi.ExecutableStagePayload stagePayload;
     try {
@@ -423,7 +424,8 @@ public class FlinkBatchPortablePipelineTranslator
               .returns(
                   new CoderTypeInformation<>(
                       WindowedValue.getFullCoder(
-                          (Coder<T>) VoidCoder.of(), GlobalWindow.Coder.INSTANCE)));
+                          (Coder<T>) VoidCoder.of(), GlobalWindow.Coder.INSTANCE),
+                      context.getPipelineOptions()));
     } else {
       for (String pCollectionId : allInputs.values()) {
         DataSet<WindowedValue<T>> current = context.getDataSetOrThrow(pCollectionId);
@@ -497,7 +499,7 @@ public class FlinkBatchPortablePipelineTranslator
             windowingStrategy.getWindowFn().windowCoder());
 
     TypeInformation<WindowedValue<KV<K, List<V>>>> partialReduceTypeInfo =
-        new CoderTypeInformation<>(outputCoder);
+        new CoderTypeInformation<>(outputCoder, context.getPipelineOptions());
 
     Grouping<WindowedValue<KV<K, V>>> inputGrouping =
         inputDataSet.groupBy(new KvKeySelector<>(inputElementCoder.getKeyCoder()));
@@ -538,7 +540,8 @@ public class FlinkBatchPortablePipelineTranslator
       PTransformNode transform, RunnerApi.Pipeline pipeline, BatchTranslationContext context) {
     TypeInformation<WindowedValue<byte[]>> typeInformation =
         new CoderTypeInformation<>(
-            WindowedValue.getFullCoder(ByteArrayCoder.of(), GlobalWindow.Coder.INSTANCE));
+            WindowedValue.getFullCoder(ByteArrayCoder.of(), GlobalWindow.Coder.INSTANCE),
+            context.getPipelineOptions());
     DataSource<WindowedValue<byte[]>> dataSource =
         new DataSource<>(
                 context.getExecutionEnvironment(),
@@ -613,7 +616,8 @@ public class FlinkBatchPortablePipelineTranslator
       Coder<WindowedValue<?>> outputCoder,
       String transformName,
       String collectionId) {
-    TypeInformation<WindowedValue<?>> outputType = new CoderTypeInformation<>(outputCoder);
+    TypeInformation<WindowedValue<?>> outputType =
+        new CoderTypeInformation<>(outputCoder, context.getPipelineOptions());
     FlinkExecutableStagePruningFunction pruningFunction =
         new FlinkExecutableStagePruningFunction(unionTag, context.getPipelineOptions());
     FlatMapOperator<RawUnionValue, WindowedValue<?>> pruningOperator =

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchTransformTranslators.java
@@ -300,7 +300,8 @@ class FlinkBatchTransformTranslators {
               WindowedValue.getFullCoder(
                   KvCoder.of(
                       inputCoder.getKeyCoder(), IterableCoder.of(inputCoder.getValueCoder())),
-                  windowingStrategy.getWindowFn().windowCoder()));
+                  windowingStrategy.getWindowFn().windowCoder()),
+              context.getPipelineOptions());
       final DataSet<WindowedValue<KV<K, Iterable<InputT>>>> outputDataSet =
           new GroupReduceOperator<>(
                   inputGrouping,
@@ -349,7 +350,8 @@ class FlinkBatchTransformTranslators {
           new CoderTypeInformation<>(
               WindowedValue.getFullCoder(
                   KvCoder.of(inputCoder.getKeyCoder(), accumulatorCoder),
-                  windowingStrategy.getWindowFn().windowCoder()));
+                  windowingStrategy.getWindowFn().windowCoder()),
+              context.getPipelineOptions());
 
       Grouping<WindowedValue<KV<K, InputT>>> inputGrouping =
           inputDataSet.groupBy(new KvKeySelector<>(inputCoder.getKeyCoder()));
@@ -693,8 +695,8 @@ class FlinkBatchTransformTranslators {
 
       TypeInformation<WindowedValue<RawUnionValue>> typeInformation =
           new CoderTypeInformation<>(
-              WindowedValue.getFullCoder(
-                  unionCoder, windowingStrategy.getWindowFn().windowCoder()));
+              WindowedValue.getFullCoder(unionCoder, windowingStrategy.getWindowFn().windowCoder()),
+              context.getPipelineOptions());
 
       List<PCollectionView<?>> sideInputs;
       try {
@@ -842,7 +844,8 @@ class FlinkBatchTransformTranslators {
                 .returns(
                     new CoderTypeInformation<>(
                         WindowedValue.getFullCoder(
-                            (Coder<T>) VoidCoder.of(), GlobalWindow.Coder.INSTANCE)));
+                            (Coder<T>) VoidCoder.of(), GlobalWindow.Coder.INSTANCE),
+                        context.getPipelineOptions()));
       } else {
         for (PValue taggedPc : allInputs.values()) {
           checkArgument(

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchTranslationContext.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkBatchTranslationContext.java
@@ -143,7 +143,7 @@ class FlinkBatchTranslationContext {
     WindowedValue.FullWindowedValueCoder<T> windowedValueCoder =
         WindowedValue.getFullCoder(coder, windowingStrategy.getWindowFn().windowCoder());
 
-    return new CoderTypeInformation<>(windowedValueCoder);
+    return new CoderTypeInformation<>(windowedValueCoder, options);
   }
 
   Map<TupleTag<?>, PCollection<?>> getInputs(PTransform<?, ?> transform) {

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
@@ -22,6 +22,7 @@ import org.apache.beam.sdk.options.ApplicationNameOptions;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.StreamingOptions;
 
 /**
@@ -281,4 +282,8 @@ public interface FlinkPipelineOptions
   Boolean getFasterCopy();
 
   void setFasterCopy(Boolean fasterCopy);
+
+  static FlinkPipelineOptions defaults() {
+    return PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+  }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
@@ -274,4 +274,11 @@ public interface FlinkPipelineOptions
   Boolean getReIterableGroupByKeyResult();
 
   void setReIterableGroupByKeyResult(Boolean reIterableGroupByKeyResult);
+
+  @Description(
+      "Remove unneeded deep copy between operators. See https://issues.apache.org/jira/browse/BEAM-11146")
+  @Default.Boolean(false)
+  Boolean getFasterCopy();
+
+  void setFasterCopy(Boolean fasterCopy);
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkRunner.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkRunner.java
@@ -79,6 +79,11 @@ public class FlinkRunner extends PipelineRunner<PipelineResult> {
 
     LOG.info("Executing pipeline using FlinkRunner.");
 
+    if (!options.getFasterCopy()) {
+      LOG.warn(
+          "For maximum performance you should set the 'fasterCopy' option. See more at https://issues.apache.org/jira/browse/BEAM-11146");
+    }
+
     FlinkPipelineExecutionEnvironment env = new FlinkPipelineExecutionEnvironment(options);
 
     LOG.info("Translating pipeline to Flink program.");

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTranslationContext.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTranslationContext.java
@@ -115,7 +115,7 @@ class FlinkStreamingTranslationContext {
         WindowedValue.getFullCoder(
             valueCoder, collection.getWindowingStrategy().getWindowFn().windowCoder());
 
-    return new CoderTypeInformation<>(windowedValueCoder);
+    return new CoderTypeInformation<>(windowedValueCoder, options);
   }
 
   public AppliedPTransform<?, ?, ?> getCurrentTransform() {

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/TestFlinkRunner.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/TestFlinkRunner.java
@@ -22,7 +22,6 @@ import org.apache.beam.sdk.Pipeline.PipelineExecutionException;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.PipelineRunner;
 import org.apache.beam.sdk.options.PipelineOptions;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.util.UserCodeException;
 
 /** Test Flink runner. */
@@ -46,7 +45,7 @@ public class TestFlinkRunner extends PipelineRunner<PipelineResult> {
   }
 
   public static TestFlinkRunner create(boolean streaming) {
-    FlinkPipelineOptions flinkOptions = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions flinkOptions = FlinkPipelineOptions.defaults();
     flinkOptions.setStreaming(streaming);
     return TestFlinkRunner.fromOptions(flinkOptions);
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/types/CoderTypeInformation.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/types/CoderTypeInformation.java
@@ -36,16 +36,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class CoderTypeInformation<T> extends TypeInformation<T> implements AtomicType<T> {
 
   private final Coder<T> coder;
-  private final @Nullable SerializablePipelineOptions pipelineOptions;
+  private final SerializablePipelineOptions pipelineOptions;
 
-  public CoderTypeInformation(Coder<T> coder) {
+  public CoderTypeInformation(Coder<T> coder, PipelineOptions pipelineOptions) {
     checkNotNull(coder);
-    this.coder = coder;
-    this.pipelineOptions = null;
-  }
-
-  private CoderTypeInformation(Coder<T> coder, PipelineOptions pipelineOptions) {
-    checkNotNull(coder);
+    checkNotNull(pipelineOptions);
     this.coder = coder;
     this.pipelineOptions = new SerializablePipelineOptions(pipelineOptions);
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -1200,7 +1200,7 @@ public class DoFnOperator<InputT, OutputT>
     private Map<TupleTag<?>, Integer> tagsToIds;
     private Map<TupleTag<?>, OutputTag<WindowedValue<?>>> tagsToOutputTags;
     private Map<TupleTag<?>, Coder<WindowedValue<?>>> tagsToCoders;
-    private SerializablePipelineOptions pipelineOptions;
+    private final SerializablePipelineOptions pipelineOptions;
 
     // There is no side output.
     @SuppressWarnings("unchecked")

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KvToByteBufferKeySelector.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/KvToByteBufferKeySelector.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.flink.translation.wrappers.streaming;
 
 import java.nio.ByteBuffer;
+import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
 import org.apache.beam.runners.flink.translation.types.CoderTypeInformation;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.util.WindowedValue;
@@ -35,9 +36,11 @@ public class KvToByteBufferKeySelector<K, V>
     implements KeySelector<WindowedValue<KV<K, V>>, ByteBuffer>, ResultTypeQueryable<ByteBuffer> {
 
   private final Coder<K> keyCoder;
+  private final SerializablePipelineOptions pipelineOptions;
 
-  public KvToByteBufferKeySelector(Coder<K> keyCoder) {
+  public KvToByteBufferKeySelector(Coder<K> keyCoder, SerializablePipelineOptions pipelineOptions) {
     this.keyCoder = keyCoder;
+    this.pipelineOptions = pipelineOptions;
   }
 
   @Override
@@ -48,6 +51,6 @@ public class KvToByteBufferKeySelector<K, V>
 
   @Override
   public TypeInformation<ByteBuffer> getProducedType() {
-    return new CoderTypeInformation<>(FlinkKeyUtils.ByteBufferCoder.of());
+    return new CoderTypeInformation<>(FlinkKeyUtils.ByteBufferCoder.of(), pipelineOptions.get());
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
@@ -430,7 +430,9 @@ public class UnboundedSourceWrapper<OutputT, CheckpointMarkT extends UnboundedSo
     OperatorStateStore stateStore = context.getOperatorStateStore();
     @SuppressWarnings("unchecked")
     CoderTypeInformation<KV<? extends UnboundedSource<OutputT, CheckpointMarkT>, CheckpointMarkT>>
-        typeInformation = (CoderTypeInformation) new CoderTypeInformation<>(checkpointCoder);
+        typeInformation =
+            (CoderTypeInformation)
+                new CoderTypeInformation<>(checkpointCoder, serializedOptions.get());
     stateForCheckpoint =
         stateStore.getListState(
             new ListStateDescriptor<>(

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/BufferingDoFnRunner.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/BufferingDoFnRunner.java
@@ -23,6 +23,7 @@ import java.util.Comparator;
 import java.util.Iterator;
 import java.util.List;
 import org.apache.beam.runners.core.DoFnRunner;
+import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
 import org.apache.beam.runners.flink.translation.types.CoderTypeSerializer;
 import org.apache.beam.sdk.state.TimeDomain;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -55,7 +56,8 @@ public class BufferingDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, 
       org.apache.beam.sdk.coders.Coder windowCoder,
       OperatorStateBackend operatorStateBackend,
       @Nullable KeyedStateBackend<Object> keyedStateBackend,
-      int maxConcurrentCheckpoints)
+      int maxConcurrentCheckpoints,
+      SerializablePipelineOptions pipelineOptions)
       throws Exception {
     return new BufferingDoFnRunner<>(
         doFnRunner,
@@ -64,7 +66,8 @@ public class BufferingDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, 
         windowCoder,
         operatorStateBackend,
         keyedStateBackend,
-        maxConcurrentCheckpoints);
+        maxConcurrentCheckpoints,
+        pipelineOptions);
   }
 
   /** The underlying DoFnRunner that any buffered data will be handed over to eventually. */
@@ -87,7 +90,8 @@ public class BufferingDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, 
       org.apache.beam.sdk.coders.Coder windowCoder,
       OperatorStateBackend operatorStateBackend,
       @Nullable KeyedStateBackend keyedStateBackend,
-      int maxConcurrentCheckpoints)
+      int maxConcurrentCheckpoints,
+      SerializablePipelineOptions pipelineOptions)
       throws Exception {
     Preconditions.checkArgument(
         maxConcurrentCheckpoints > 0 && maxConcurrentCheckpoints < Short.MAX_VALUE,
@@ -104,7 +108,7 @@ public class BufferingDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, 
               new ListStateDescriptor<>(
                   stateName + stateId,
                   new CoderTypeSerializer<>(
-                      new BufferedElements.Coder(inputCoder, windowCoder, null)));
+                      new BufferedElements.Coder(inputCoder, windowCoder, null), pipelineOptions));
           if (keyedStateBackend != null) {
             return KeyedBufferingElementsHandler.create(keyedStateBackend, stateDescriptor);
           } else {

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkBroadcastStateInternals.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkBroadcastStateInternals.java
@@ -27,11 +27,13 @@ import java.util.Map;
 import org.apache.beam.runners.core.StateInternals;
 import org.apache.beam.runners.core.StateNamespace;
 import org.apache.beam.runners.core.StateTag;
+import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
 import org.apache.beam.runners.flink.translation.types.CoderTypeInformation;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.ListCoder;
 import org.apache.beam.sdk.coders.MapCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.state.BagState;
 import org.apache.beam.sdk.state.CombiningState;
 import org.apache.beam.sdk.state.MapState;
@@ -68,9 +70,15 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
   // stateName -> <namespace, state>
   private Map<String, Map<String, ?>> stateForNonZeroOperator;
 
-  public FlinkBroadcastStateInternals(int indexInSubtaskGroup, OperatorStateBackend stateBackend) {
+  private final SerializablePipelineOptions pipelineOptions;
+
+  public FlinkBroadcastStateInternals(
+      int indexInSubtaskGroup,
+      OperatorStateBackend stateBackend,
+      SerializablePipelineOptions pipelineOptions) {
     this.stateBackend = stateBackend;
     this.indexInSubtaskGroup = indexInSubtaskGroup;
+    this.pipelineOptions = pipelineOptions;
     if (indexInSubtaskGroup != 0) {
       stateForNonZeroOperator = new HashMap<>();
     }
@@ -91,13 +99,15 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
           @Override
           public <T2> ValueState<T2> bindValue(StateTag<ValueState<T2>> address, Coder<T2> coder) {
 
-            return new FlinkBroadcastValueState<>(stateBackend, address, namespace, coder);
+            return new FlinkBroadcastValueState<>(
+                stateBackend, address, namespace, coder, pipelineOptions.get());
           }
 
           @Override
           public <T2> BagState<T2> bindBag(StateTag<BagState<T2>> address, Coder<T2> elemCoder) {
 
-            return new FlinkBroadcastBagState<>(stateBackend, address, namespace, elemCoder);
+            return new FlinkBroadcastBagState<>(
+                stateBackend, address, namespace, elemCoder, pipelineOptions.get());
           }
 
           @Override
@@ -130,7 +140,7 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
                   Combine.CombineFn<InputT, AccumT, OutputT> combineFn) {
 
             return new FlinkCombiningState<>(
-                stateBackend, address, combineFn, namespace, accumCoder);
+                stateBackend, address, combineFn, namespace, accumCoder, pipelineOptions.get());
           }
 
           @Override
@@ -175,14 +185,15 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
         OperatorStateBackend flinkStateBackend,
         String name,
         StateNamespace namespace,
-        Coder<T> coder) {
+        Coder<T> coder,
+        PipelineOptions pipelineOptions) {
       this.name = name;
 
       this.namespace = namespace;
       this.flinkStateBackend = flinkStateBackend;
 
       CoderTypeInformation<Map<String, T>> typeInfo =
-          new CoderTypeInformation<>(MapCoder.of(StringUtf8Coder.of(), coder));
+          new CoderTypeInformation<>(MapCoder.of(StringUtf8Coder.of(), coder), pipelineOptions);
 
       flinkStateDescriptor =
           new ListStateDescriptor<>(name, typeInfo.createSerializer(new ExecutionConfig()));
@@ -290,8 +301,9 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
         OperatorStateBackend flinkStateBackend,
         StateTag<ValueState<T>> address,
         StateNamespace namespace,
-        Coder<T> coder) {
-      super(flinkStateBackend, address.getId(), namespace, coder);
+        Coder<T> coder,
+        PipelineOptions pipelineOptions) {
+      super(flinkStateBackend, address.getId(), namespace, coder, pipelineOptions);
 
       this.namespace = namespace;
       this.address = address;
@@ -349,8 +361,9 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
         OperatorStateBackend flinkStateBackend,
         StateTag<BagState<T>> address,
         StateNamespace namespace,
-        Coder<T> coder) {
-      super(flinkStateBackend, address.getId(), namespace, ListCoder.of(coder));
+        Coder<T> coder,
+        PipelineOptions pipelineOptions) {
+      super(flinkStateBackend, address.getId(), namespace, ListCoder.of(coder), pipelineOptions);
 
       this.namespace = namespace;
       this.address = address;
@@ -436,8 +449,9 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
         StateTag<CombiningState<InputT, AccumT, OutputT>> address,
         Combine.CombineFn<InputT, AccumT, OutputT> combineFn,
         StateNamespace namespace,
-        Coder<AccumT> accumCoder) {
-      super(flinkStateBackend, address.getId(), namespace, accumCoder);
+        Coder<AccumT> accumCoder,
+        PipelineOptions pipelineOptions) {
+      super(flinkStateBackend, address.getId(), namespace, accumCoder, pipelineOptions);
 
       this.namespace = namespace;
       this.address = address;
@@ -552,8 +566,9 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
         Combine.CombineFn<InputT, AccumT, OutputT> combineFn,
         StateNamespace namespace,
         Coder<AccumT> accumCoder,
-        FlinkBroadcastStateInternals<K2> flinkStateInternals) {
-      super(flinkStateBackend, address.getId(), namespace, accumCoder);
+        FlinkBroadcastStateInternals<K2> flinkStateInternals,
+        PipelineOptions pipelineOptions) {
+      super(flinkStateBackend, address.getId(), namespace, accumCoder, pipelineOptions);
 
       this.namespace = namespace;
       this.address = address;
@@ -687,7 +702,7 @@ public class FlinkBroadcastStateInternals<K> implements StateInternals {
         Coder<AccumT> accumCoder,
         FlinkBroadcastStateInternals<K2> flinkStateInternals,
         CombineWithContext.Context context) {
-      super(flinkStateBackend, address.getId(), namespace, accumCoder);
+      super(flinkStateBackend, address.getId(), namespace, accumCoder, pipelineOptions.get());
 
       this.namespace = namespace;
       this.address = address;

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
@@ -29,6 +29,7 @@ import org.apache.beam.runners.core.StateInternals;
 import org.apache.beam.runners.core.StateNamespace;
 import org.apache.beam.runners.core.StateNamespaces;
 import org.apache.beam.runners.core.StateTag;
+import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
 import org.apache.beam.runners.flink.translation.types.CoderTypeSerializer;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.FlinkKeyUtils;
 import org.apache.beam.sdk.coders.Coder;
@@ -96,16 +97,24 @@ public class FlinkStateInternals<K> implements StateInternals {
   // Watermark holds for all keys/windows of this partition, allows efficient lookup of the minimum
   private final TreeMultiset<Long> watermarkHolds = TreeMultiset.create();
   // State to persist combined watermark holds for all keys of this partition
-  private final MapStateDescriptor<String, Instant> watermarkHoldStateDescriptor =
-      new MapStateDescriptor<>(
-          "watermark-holds",
-          StringSerializer.INSTANCE,
-          new CoderTypeSerializer<>(InstantCoder.of()));
+  private final MapStateDescriptor<String, Instant> watermarkHoldStateDescriptor;
 
-  public FlinkStateInternals(KeyedStateBackend<ByteBuffer> flinkStateBackend, Coder<K> keyCoder)
+  private final SerializablePipelineOptions pipelineOptions;
+
+  public FlinkStateInternals(
+      KeyedStateBackend<ByteBuffer> flinkStateBackend,
+      Coder<K> keyCoder,
+      SerializablePipelineOptions pipelineOptions)
       throws Exception {
     this.flinkStateBackend = flinkStateBackend;
     this.keyCoder = keyCoder;
+    watermarkHoldStateDescriptor =
+        new MapStateDescriptor<>(
+            "watermark-holds",
+            StringSerializer.INSTANCE,
+            new CoderTypeSerializer<>(InstantCoder.of(), pipelineOptions));
+    this.pipelineOptions = pipelineOptions;
+
     restoreWatermarkHoldsView();
   }
 
@@ -166,7 +175,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     public <T2> ValueState<T2> bindValue(
         String id, StateSpec<ValueState<T2>> spec, Coder<T2> coder) {
       FlinkValueState<T2> valueState =
-          new FlinkValueState<>(flinkStateBackend, id, namespace, coder);
+          new FlinkValueState<>(flinkStateBackend, id, namespace, coder, pipelineOptions);
       collectGlobalWindowStateDescriptor(valueState.flinkStateDescriptor);
       return valueState;
     }
@@ -174,14 +183,15 @@ public class FlinkStateInternals<K> implements StateInternals {
     @Override
     public <T2> BagState<T2> bindBag(String id, StateSpec<BagState<T2>> spec, Coder<T2> elemCoder) {
       FlinkBagState<Object, T2> bagState =
-          new FlinkBagState<>(flinkStateBackend, id, namespace, elemCoder);
+          new FlinkBagState<>(flinkStateBackend, id, namespace, elemCoder, pipelineOptions);
       collectGlobalWindowStateDescriptor(bagState.flinkStateDescriptor);
       return bagState;
     }
 
     @Override
     public <T2> SetState<T2> bindSet(String id, StateSpec<SetState<T2>> spec, Coder<T2> elemCoder) {
-      FlinkSetState<T2> setState = new FlinkSetState<>(flinkStateBackend, id, namespace, elemCoder);
+      FlinkSetState<T2> setState =
+          new FlinkSetState<>(flinkStateBackend, id, namespace, elemCoder, pipelineOptions);
       collectGlobalWindowStateDescriptor(setState.flinkStateDescriptor);
       return setState;
     }
@@ -193,7 +203,8 @@ public class FlinkStateInternals<K> implements StateInternals {
         Coder<KeyT> mapKeyCoder,
         Coder<ValueT> mapValueCoder) {
       FlinkMapState<KeyT, ValueT> mapState =
-          new FlinkMapState<>(flinkStateBackend, id, namespace, mapKeyCoder, mapValueCoder);
+          new FlinkMapState<>(
+              flinkStateBackend, id, namespace, mapKeyCoder, mapValueCoder, pipelineOptions);
       collectGlobalWindowStateDescriptor(mapState.flinkStateDescriptor);
       return mapState;
     }
@@ -212,7 +223,8 @@ public class FlinkStateInternals<K> implements StateInternals {
         Coder<AccumT> accumCoder,
         Combine.CombineFn<InputT, AccumT, OutputT> combineFn) {
       FlinkCombiningState<Object, InputT, AccumT, OutputT> combiningState =
-          new FlinkCombiningState<>(flinkStateBackend, id, combineFn, namespace, accumCoder);
+          new FlinkCombiningState<>(
+              flinkStateBackend, id, combineFn, namespace, accumCoder, pipelineOptions);
       collectGlobalWindowStateDescriptor(combiningState.flinkStateDescriptor);
       return combiningState;
     }
@@ -231,7 +243,8 @@ public class FlinkStateInternals<K> implements StateInternals {
               combineFn,
               namespace,
               accumCoder,
-              CombineContextFactory.createFromStateContext(stateContext));
+              CombineContextFactory.createFromStateContext(stateContext),
+              pipelineOptions);
       collectGlobalWindowStateDescriptor(combiningStateWithContext.flinkStateDescriptor);
       return combiningStateWithContext;
     }
@@ -263,13 +276,15 @@ public class FlinkStateInternals<K> implements StateInternals {
         KeyedStateBackend<ByteBuffer> flinkStateBackend,
         String stateId,
         StateNamespace namespace,
-        Coder<T> coder) {
+        Coder<T> coder,
+        SerializablePipelineOptions pipelineOptions) {
 
       this.namespace = namespace;
       this.stateId = stateId;
       this.flinkStateBackend = flinkStateBackend;
 
-      flinkStateDescriptor = new ValueStateDescriptor<>(stateId, new CoderTypeSerializer<>(coder));
+      flinkStateDescriptor =
+          new ValueStateDescriptor<>(stateId, new CoderTypeSerializer<>(coder, pipelineOptions));
     }
 
     @Override
@@ -347,14 +362,15 @@ public class FlinkStateInternals<K> implements StateInternals {
         KeyedStateBackend<ByteBuffer> flinkStateBackend,
         String stateId,
         StateNamespace namespace,
-        Coder<T> coder) {
+        Coder<T> coder,
+        SerializablePipelineOptions pipelineOptions) {
 
       this.namespace = namespace;
       this.stateId = stateId;
       this.flinkStateBackend = flinkStateBackend;
       this.storesVoidValues = coder instanceof VoidCoder;
       this.flinkStateDescriptor =
-          new ListStateDescriptor<>(stateId, new CoderTypeSerializer<>(coder));
+          new ListStateDescriptor<>(stateId, new CoderTypeSerializer<>(coder, pipelineOptions));
     }
 
     @Override
@@ -486,7 +502,8 @@ public class FlinkStateInternals<K> implements StateInternals {
         String stateId,
         Combine.CombineFn<InputT, AccumT, OutputT> combineFn,
         StateNamespace namespace,
-        Coder<AccumT> accumCoder) {
+        Coder<AccumT> accumCoder,
+        SerializablePipelineOptions pipelineOptions) {
 
       this.namespace = namespace;
       this.stateId = stateId;
@@ -494,7 +511,8 @@ public class FlinkStateInternals<K> implements StateInternals {
       this.flinkStateBackend = flinkStateBackend;
 
       flinkStateDescriptor =
-          new ValueStateDescriptor<>(stateId, new CoderTypeSerializer<>(accumCoder));
+          new ValueStateDescriptor<>(
+              stateId, new CoderTypeSerializer<>(accumCoder, pipelineOptions));
     }
 
     @Override
@@ -649,7 +667,8 @@ public class FlinkStateInternals<K> implements StateInternals {
         CombineWithContext.CombineFnWithContext<InputT, AccumT, OutputT> combineFn,
         StateNamespace namespace,
         Coder<AccumT> accumCoder,
-        CombineWithContext.Context context) {
+        CombineWithContext.Context context,
+        SerializablePipelineOptions pipelineOptions) {
 
       this.namespace = namespace;
       this.stateId = stateId;
@@ -658,7 +677,8 @@ public class FlinkStateInternals<K> implements StateInternals {
       this.context = context;
 
       flinkStateDescriptor =
-          new ValueStateDescriptor<>(stateId, new CoderTypeSerializer<>(accumCoder));
+          new ValueStateDescriptor<>(
+              stateId, new CoderTypeSerializer<>(accumCoder, pipelineOptions));
     }
 
     @Override
@@ -934,15 +954,16 @@ public class FlinkStateInternals<K> implements StateInternals {
         String stateId,
         StateNamespace namespace,
         Coder<KeyT> mapKeyCoder,
-        Coder<ValueT> mapValueCoder) {
+        Coder<ValueT> mapValueCoder,
+        SerializablePipelineOptions pipelineOptions) {
       this.namespace = namespace;
       this.stateId = stateId;
       this.flinkStateBackend = flinkStateBackend;
       this.flinkStateDescriptor =
           new MapStateDescriptor<>(
               stateId,
-              new CoderTypeSerializer<>(mapKeyCoder),
-              new CoderTypeSerializer<>(mapValueCoder));
+              new CoderTypeSerializer<>(mapKeyCoder, pipelineOptions),
+              new CoderTypeSerializer<>(mapValueCoder, pipelineOptions));
     }
 
     @Override
@@ -1120,13 +1141,14 @@ public class FlinkStateInternals<K> implements StateInternals {
         KeyedStateBackend<ByteBuffer> flinkStateBackend,
         String stateId,
         StateNamespace namespace,
-        Coder<T> coder) {
+        Coder<T> coder,
+        SerializablePipelineOptions pipelineOptions) {
       this.namespace = namespace;
       this.stateId = stateId;
       this.flinkStateBackend = flinkStateBackend;
       this.flinkStateDescriptor =
           new MapStateDescriptor<>(
-              stateId, new CoderTypeSerializer<>(coder), new BooleanSerializer());
+              stateId, new CoderTypeSerializer<>(coder, pipelineOptions), new BooleanSerializer());
     }
 
     @Override
@@ -1287,9 +1309,12 @@ public class FlinkStateInternals<K> implements StateInternals {
   public static class EarlyBinder implements StateBinder {
 
     private final KeyedStateBackend keyedStateBackend;
+    private final SerializablePipelineOptions pipelineOptions;
 
-    public EarlyBinder(KeyedStateBackend keyedStateBackend) {
+    public EarlyBinder(
+        KeyedStateBackend keyedStateBackend, SerializablePipelineOptions pipelineOptions) {
       this.keyedStateBackend = keyedStateBackend;
+      this.pipelineOptions = pipelineOptions;
     }
 
     @Override
@@ -1297,7 +1322,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         keyedStateBackend.getOrCreateKeyedState(
             StringSerializer.INSTANCE,
-            new ValueStateDescriptor<>(id, new CoderTypeSerializer<>(coder)));
+            new ValueStateDescriptor<>(id, new CoderTypeSerializer<>(coder, pipelineOptions)));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
@@ -1310,7 +1335,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         keyedStateBackend.getOrCreateKeyedState(
             StringSerializer.INSTANCE,
-            new ListStateDescriptor<>(id, new CoderTypeSerializer<>(elemCoder)));
+            new ListStateDescriptor<>(id, new CoderTypeSerializer<>(elemCoder, pipelineOptions)));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
@@ -1324,7 +1349,9 @@ public class FlinkStateInternals<K> implements StateInternals {
         keyedStateBackend.getOrCreateKeyedState(
             StringSerializer.INSTANCE,
             new MapStateDescriptor<>(
-                id, new CoderTypeSerializer<>(elemCoder), VoidSerializer.INSTANCE));
+                id,
+                new CoderTypeSerializer<>(elemCoder, pipelineOptions),
+                VoidSerializer.INSTANCE));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
@@ -1342,8 +1369,8 @@ public class FlinkStateInternals<K> implements StateInternals {
             StringSerializer.INSTANCE,
             new MapStateDescriptor<>(
                 id,
-                new CoderTypeSerializer<>(mapKeyCoder),
-                new CoderTypeSerializer<>(mapValueCoder)));
+                new CoderTypeSerializer<>(mapKeyCoder, pipelineOptions),
+                new CoderTypeSerializer<>(mapValueCoder, pipelineOptions)));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
@@ -1366,7 +1393,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         keyedStateBackend.getOrCreateKeyedState(
             StringSerializer.INSTANCE,
-            new ValueStateDescriptor<>(id, new CoderTypeSerializer<>(accumCoder)));
+            new ValueStateDescriptor<>(id, new CoderTypeSerializer<>(accumCoder, pipelineOptions)));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
@@ -1383,7 +1410,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         keyedStateBackend.getOrCreateKeyedState(
             StringSerializer.INSTANCE,
-            new ValueStateDescriptor<>(id, new CoderTypeSerializer<>(accumCoder)));
+            new ValueStateDescriptor<>(id, new CoderTypeSerializer<>(accumCoder, pipelineOptions)));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
@@ -1399,7 +1426,7 @@ public class FlinkStateInternals<K> implements StateInternals {
             new MapStateDescriptor<>(
                 "watermark-holds",
                 StringSerializer.INSTANCE,
-                new CoderTypeSerializer<>(InstantCoder.of())));
+                new CoderTypeSerializer<>(InstantCoder.of(), pipelineOptions)));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkExecutionEnvironmentsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkExecutionEnvironmentsTest.java
@@ -28,7 +28,6 @@ import java.io.InputStream;
 import java.net.InetSocketAddress;
 import java.nio.file.Files;
 import java.util.Collections;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.LocalEnvironment;
 import org.apache.flink.api.java.RemoteEnvironment;
@@ -54,7 +53,7 @@ public class FlinkExecutionEnvironmentsTest {
 
   @Test
   public void shouldSetParallelismBatch() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(TestFlinkRunner.class);
     options.setParallelism(42);
 
@@ -68,7 +67,7 @@ public class FlinkExecutionEnvironmentsTest {
 
   @Test
   public void shouldSetParallelismStreaming() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(TestFlinkRunner.class);
     options.setParallelism(42);
 
@@ -82,7 +81,7 @@ public class FlinkExecutionEnvironmentsTest {
 
   @Test
   public void shouldSetMaxParallelismStreaming() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(TestFlinkRunner.class);
     options.setMaxParallelism(42);
 
@@ -98,7 +97,7 @@ public class FlinkExecutionEnvironmentsTest {
   public void shouldInferParallelismFromEnvironmentBatch() throws IOException {
     String flinkConfDir = extractFlinkConfig();
 
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(TestFlinkRunner.class);
     options.setFlinkMaster("host:80");
 
@@ -114,7 +113,7 @@ public class FlinkExecutionEnvironmentsTest {
   public void shouldInferParallelismFromEnvironmentStreaming() throws IOException {
     String confDir = extractFlinkConfig();
 
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(TestFlinkRunner.class);
     options.setFlinkMaster("host:80");
 
@@ -128,7 +127,7 @@ public class FlinkExecutionEnvironmentsTest {
 
   @Test
   public void shouldFallbackToDefaultParallelismBatch() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(TestFlinkRunner.class);
     options.setFlinkMaster("host:80");
 
@@ -142,7 +141,7 @@ public class FlinkExecutionEnvironmentsTest {
 
   @Test
   public void shouldFallbackToDefaultParallelismStreaming() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(TestFlinkRunner.class);
     options.setFlinkMaster("host:80");
 
@@ -156,7 +155,7 @@ public class FlinkExecutionEnvironmentsTest {
 
   @Test
   public void useDefaultParallelismFromContextBatch() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(TestFlinkRunner.class);
 
     ExecutionEnvironment bev =
@@ -170,7 +169,7 @@ public class FlinkExecutionEnvironmentsTest {
 
   @Test
   public void useDefaultParallelismFromContextStreaming() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(TestFlinkRunner.class);
 
     StreamExecutionEnvironment sev =
@@ -184,7 +183,7 @@ public class FlinkExecutionEnvironmentsTest {
 
   @Test
   public void shouldParsePortForRemoteEnvironmentBatch() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(FlinkRunner.class);
     options.setFlinkMaster("host:1234");
 
@@ -198,7 +197,7 @@ public class FlinkExecutionEnvironmentsTest {
 
   @Test
   public void shouldParsePortForRemoteEnvironmentStreaming() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(FlinkRunner.class);
     options.setFlinkMaster("host:1234");
 
@@ -212,7 +211,7 @@ public class FlinkExecutionEnvironmentsTest {
 
   @Test
   public void shouldAllowPortOmissionForRemoteEnvironmentBatch() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(FlinkRunner.class);
     options.setFlinkMaster("host");
 
@@ -226,7 +225,7 @@ public class FlinkExecutionEnvironmentsTest {
 
   @Test
   public void shouldAllowPortOmissionForRemoteEnvironmentStreaming() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(FlinkRunner.class);
     options.setFlinkMaster("host");
 
@@ -240,7 +239,7 @@ public class FlinkExecutionEnvironmentsTest {
 
   @Test
   public void shouldTreatAutoAndEmptyHostTheSameBatch() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(FlinkRunner.class);
 
     ExecutionEnvironment sev =
@@ -258,7 +257,7 @@ public class FlinkExecutionEnvironmentsTest {
 
   @Test
   public void shouldTreatAutoAndEmptyHostTheSameStreaming() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(FlinkRunner.class);
 
     StreamExecutionEnvironment sev =
@@ -276,7 +275,7 @@ public class FlinkExecutionEnvironmentsTest {
 
   @Test
   public void shouldDetectMalformedPortBatch() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(FlinkRunner.class);
     options.setFlinkMaster("host:p0rt");
 
@@ -288,7 +287,7 @@ public class FlinkExecutionEnvironmentsTest {
 
   @Test
   public void shouldDetectMalformedPortStreaming() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(FlinkRunner.class);
     options.setFlinkMaster("host:p0rt");
 
@@ -300,7 +299,7 @@ public class FlinkExecutionEnvironmentsTest {
 
   @Test
   public void shouldSupportIPv4Batch() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(FlinkRunner.class);
 
     options.setFlinkMaster("192.168.1.1:1234");
@@ -318,7 +317,7 @@ public class FlinkExecutionEnvironmentsTest {
 
   @Test
   public void shouldSupportIPv4Streaming() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(FlinkRunner.class);
 
     options.setFlinkMaster("192.168.1.1:1234");
@@ -336,7 +335,7 @@ public class FlinkExecutionEnvironmentsTest {
 
   @Test
   public void shouldSupportIPv6Batch() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(FlinkRunner.class);
 
     options.setFlinkMaster("[FE80:CD00:0000:0CDE:1257:0000:211E:729C]:1234");
@@ -355,7 +354,7 @@ public class FlinkExecutionEnvironmentsTest {
 
   @Test
   public void shouldSupportIPv6Streaming() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(FlinkRunner.class);
 
     options.setFlinkMaster("[FE80:CD00:0000:0CDE:1257:0000:211E:729C]:1234");
@@ -374,7 +373,7 @@ public class FlinkExecutionEnvironmentsTest {
 
   @Test
   public void shouldRemoveHttpProtocolFromHostBatch() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(FlinkRunner.class);
 
     for (String flinkMaster :
@@ -391,7 +390,7 @@ public class FlinkExecutionEnvironmentsTest {
 
   @Test
   public void shouldRemoveHttpProtocolFromHostStreaming() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(FlinkRunner.class);
 
     for (String flinkMaster :
@@ -416,7 +415,7 @@ public class FlinkExecutionEnvironmentsTest {
   @Test
   public void shouldAutoSetIdleSourcesFlagWithoutCheckpointing() {
     // Checkpointing disabled, shut down sources immediately
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     FlinkExecutionEnvironments.createStreamExecutionEnvironment(options, Collections.emptyList());
     assertThat(options.getShutdownSourcesAfterIdleMs(), is(0L));
   }
@@ -424,7 +423,7 @@ public class FlinkExecutionEnvironmentsTest {
   @Test
   public void shouldAutoSetIdleSourcesFlagWithCheckpointing() {
     // Checkpointing is enabled, never shut down sources
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setCheckpointingInterval(1000L);
     FlinkExecutionEnvironments.createStreamExecutionEnvironment(options, Collections.emptyList());
     assertThat(options.getShutdownSourcesAfterIdleMs(), is(Long.MAX_VALUE));
@@ -433,7 +432,7 @@ public class FlinkExecutionEnvironmentsTest {
   @Test
   public void shouldAcceptExplicitlySetIdleSourcesFlagWithoutCheckpointing() {
     // Checkpointing disabled, accept flag
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setShutdownSourcesAfterIdleMs(42L);
     FlinkExecutionEnvironments.createStreamExecutionEnvironment(options, Collections.emptyList());
     assertThat(options.getShutdownSourcesAfterIdleMs(), is(42L));
@@ -442,7 +441,7 @@ public class FlinkExecutionEnvironmentsTest {
   @Test
   public void shouldAcceptExplicitlySetIdleSourcesFlagWithCheckpointing() {
     // Checkpointing enable, still accept flag
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setCheckpointingInterval(1000L);
     options.setShutdownSourcesAfterIdleMs(42L);
     FlinkExecutionEnvironments.createStreamExecutionEnvironment(options, Collections.emptyList());
@@ -452,7 +451,7 @@ public class FlinkExecutionEnvironmentsTest {
   @Test
   public void shouldSetSavepointRestoreForRemoteStreaming() {
     String path = "fakePath";
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(TestFlinkRunner.class);
     options.setFlinkMaster("host:80");
     options.setSavepointPath(path);

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironmentTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironmentTest.java
@@ -46,7 +46,6 @@ import org.apache.beam.runners.core.construction.resources.PipelineResources;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.GenerateSequence;
 import org.apache.beam.sdk.io.TextIO;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.runners.PTransformOverride;
 import org.apache.beam.sdk.runners.PTransformOverrideFactory;
 import org.apache.beam.sdk.transforms.Create;
@@ -84,7 +83,7 @@ public class FlinkPipelineExecutionEnvironmentTest implements Serializable {
 
   @Test
   public void shouldRecognizeAndTranslateStreamingPipeline() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(TestFlinkRunner.class);
     options.setFlinkMaster("[auto]");
 
@@ -152,7 +151,7 @@ public class FlinkPipelineExecutionEnvironmentTest implements Serializable {
 
   @Test
   public void shouldUseDefaultTempLocationIfNoneSet() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(TestFlinkRunner.class);
     options.setFlinkMaster("clusterAddress");
 
@@ -168,7 +167,7 @@ public class FlinkPipelineExecutionEnvironmentTest implements Serializable {
 
   @Test
   public void shouldUsePreparedFilesOnRemoteEnvironment() throws Exception {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(TestFlinkRunner.class);
     options.setFlinkMaster("clusterAddress");
 
@@ -189,7 +188,7 @@ public class FlinkPipelineExecutionEnvironmentTest implements Serializable {
 
   @Test
   public void shouldUsePreparedFilesOnRemoteStreamEnvironment() throws Exception {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(TestFlinkRunner.class);
     options.setFlinkMaster("clusterAddress");
     options.setStreaming(true);
@@ -214,7 +213,7 @@ public class FlinkPipelineExecutionEnvironmentTest implements Serializable {
   public void shouldUseTransformOverrides() {
     boolean[] testParameters = {true, false};
     for (boolean streaming : testParameters) {
-      FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+      FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
       options.setStreaming(streaming);
       options.setRunner(FlinkRunner.class);
       FlinkPipelineExecutionEnvironment flinkEnv = new FlinkPipelineExecutionEnvironment(options);
@@ -234,7 +233,7 @@ public class FlinkPipelineExecutionEnvironmentTest implements Serializable {
 
   @Test
   public void shouldProvideParallelismToTransformOverrides() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setStreaming(true);
     options.setRunner(FlinkRunner.class);
     FlinkPipelineExecutionEnvironment flinkEnv = new FlinkPipelineExecutionEnvironment(options);
@@ -278,7 +277,7 @@ public class FlinkPipelineExecutionEnvironmentTest implements Serializable {
 
   @Test
   public void shouldUseStreamingTransformOverridesWithUnboundedSources() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     // no explicit streaming mode set
     options.setRunner(FlinkRunner.class);
     FlinkPipelineExecutionEnvironment flinkEnv = new FlinkPipelineExecutionEnvironment(options);
@@ -303,7 +302,7 @@ public class FlinkPipelineExecutionEnvironmentTest implements Serializable {
 
   @Test
   public void testTranslationModeOverrideWithUnboundedSources() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(FlinkRunner.class);
     options.setStreaming(false);
 
@@ -319,7 +318,7 @@ public class FlinkPipelineExecutionEnvironmentTest implements Serializable {
   public void testTranslationModeNoOverrideWithoutUnboundedSources() {
     boolean[] testArgs = new boolean[] {true, false};
     for (boolean streaming : testArgs) {
-      FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+      FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
       options.setRunner(FlinkRunner.class);
       options.setStreaming(streaming);
 
@@ -408,7 +407,7 @@ public class FlinkPipelineExecutionEnvironmentTest implements Serializable {
 
   private FlinkPipelineOptions setPipelineOptions(
       String flinkMaster, String tempLocation, List<String> filesToStage) {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(TestFlinkRunner.class);
     options.setFlinkMaster(flinkMaster);
     options.setTempLocation(tempLocation);

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineOptionsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineOptionsTest.java
@@ -71,7 +71,7 @@ public class FlinkPipelineOptionsTest {
   /** These defaults should only be changed with a very good reason. */
   @Test
   public void testDefaults() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     assertThat(options.getParallelism(), is(-1));
     assertThat(options.getMaxParallelism(), is(-1));
     assertThat(options.getFlinkMaster(), is("[auto]"));
@@ -111,9 +111,7 @@ public class FlinkPipelineOptionsTest {
         mainTag,
         Collections.emptyList(),
         new DoFnOperator.MultiOutputOutputManagerFactory<>(
-            mainTag,
-            coder,
-            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
+            mainTag, coder, new SerializablePipelineOptions(FlinkPipelineOptions.defaults())),
         WindowingStrategy.globalDefault(),
         new HashMap<>(),
         Collections.emptyList(),
@@ -140,10 +138,7 @@ public class FlinkPipelineOptionsTest {
             mainTag,
             Collections.emptyList(),
             new DoFnOperator.MultiOutputOutputManagerFactory<>(
-                mainTag,
-                coder,
-                new SerializablePipelineOptions(
-                    PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
+                mainTag, coder, new SerializablePipelineOptions(FlinkPipelineOptions.defaults())),
             WindowingStrategy.globalDefault(),
             new HashMap<>(),
             Collections.emptyList(),

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineOptionsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineOptionsTest.java
@@ -24,6 +24,7 @@ import static org.hamcrest.core.IsNull.nullValue;
 import java.util.Collections;
 import java.util.HashMap;
 import org.apache.beam.repackaged.core.org.apache.commons.lang3.SerializationUtils;
+import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.DoFnOperator;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
@@ -95,6 +96,7 @@ public class FlinkPipelineOptionsTest {
     assertThat(options.getSavepointPath(), is(nullValue()));
     assertThat(options.getAllowNonRestoredState(), is(false));
     assertThat(options.getDisableMetrics(), is(false));
+    assertThat(options.getFasterCopy(), is(false));
   }
 
   @Test(expected = Exception.class)
@@ -108,7 +110,10 @@ public class FlinkPipelineOptionsTest {
         Collections.emptyMap(),
         mainTag,
         Collections.emptyList(),
-        new DoFnOperator.MultiOutputOutputManagerFactory<>(mainTag, coder),
+        new DoFnOperator.MultiOutputOutputManagerFactory<>(
+            mainTag,
+            coder,
+            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
         WindowingStrategy.globalDefault(),
         new HashMap<>(),
         Collections.emptyList(),
@@ -134,7 +139,11 @@ public class FlinkPipelineOptionsTest {
             Collections.emptyMap(),
             mainTag,
             Collections.emptyList(),
-            new DoFnOperator.MultiOutputOutputManagerFactory<>(mainTag, coder),
+            new DoFnOperator.MultiOutputOutputManagerFactory<>(
+                mainTag,
+                coder,
+                new SerializablePipelineOptions(
+                    PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
             WindowingStrategy.globalDefault(),
             new HashMap<>(),
             Collections.emptyList(),

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkRequiresStableInputTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkRequiresStableInputTest.java
@@ -30,7 +30,6 @@ import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.ResolveOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.options.PipelineOptions;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.MapElements;
@@ -123,7 +122,7 @@ public class FlinkRequiresStableInputTest {
    */
   @Test(timeout = 30_000)
   public void testParDoRequiresStableInput() throws Exception {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setParallelism(1);
     // We only want to trigger external savepoints but we require
     // checkpointing to be enabled for @RequiresStableInput

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkRunnerTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkRunnerTest.java
@@ -23,7 +23,6 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.GenerateSequence;
 import org.apache.beam.sdk.options.PipelineOptions;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.flink.client.program.OptimizerPlanEnvironment;
 import org.apache.flink.client.program.PackagedProgram;
 import org.apache.flink.client.program.ProgramInvocationException;
@@ -57,7 +56,7 @@ public class FlinkRunnerTest extends FlinkRunnerTestCompat {
 
   /** Main method for {@code testEnsureStdoutStdErrIsRestored()}. */
   public static void main(String[] args) {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(NotExecutingFlinkRunner.class);
     Pipeline p = Pipeline.create(options);
     p.apply(GenerateSequence.from(0));

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkSavepointTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkSavepointTest.java
@@ -33,7 +33,6 @@ import org.apache.beam.runners.core.construction.PipelineTranslation;
 import org.apache.beam.runners.jobsubmission.JobInvocation;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.GenerateSequence;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.PortablePipelineOptions;
 import org.apache.beam.sdk.state.BagState;
 import org.apache.beam.sdk.state.StateSpec;
@@ -151,7 +150,7 @@ public class FlinkSavepointTest implements Serializable {
   }
 
   private void runSavepointAndRestore(boolean isPortablePipeline) throws Exception {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setStreaming(true);
     // Initial parallelism
     options.setParallelism(2);

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkSubmissionTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkSubmissionTest.java
@@ -161,7 +161,7 @@ public class FlinkSubmissionTest {
 
   /** The Flink program which is executed by the CliFrontend. */
   public static void main(String[] args) {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(FlinkRunner.class);
     options.setStreaming(streaming);
     options.setParallelism(1);

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkTransformOverridesTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkTransformOverridesTest.java
@@ -32,7 +32,6 @@ import org.apache.beam.sdk.io.WriteFiles;
 import org.apache.beam.sdk.io.WriteFilesResult;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.options.PipelineOptions;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.runners.AppliedPTransform;
 import org.apache.beam.sdk.testing.TestPipeline;
@@ -55,7 +54,7 @@ public class FlinkTransformOverridesTest {
 
   @Test
   public void testRunnerDeterminedSharding() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setRunner(TestFlinkRunner.class);
     options.setFlinkMaster("[auto]");
     options.setParallelism(5);

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/FlinkBroadcastStateInternalsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/FlinkBroadcastStateInternalsTest.java
@@ -20,7 +20,10 @@ package org.apache.beam.runners.flink.streaming;
 import java.util.Collections;
 import org.apache.beam.runners.core.StateInternals;
 import org.apache.beam.runners.core.StateInternalsTest;
+import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
+import org.apache.beam.runners.flink.FlinkPipelineOptions;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.state.FlinkBroadcastStateInternals;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
@@ -45,7 +48,10 @@ public class FlinkBroadcastStateInternalsTest extends StateInternalsTest {
       OperatorStateBackend operatorStateBackend =
           backend.createOperatorStateBackend(
               new DummyEnvironment("test", 1, 0), "", Collections.emptyList(), null);
-      return new FlinkBroadcastStateInternals<>(1, operatorStateBackend);
+      return new FlinkBroadcastStateInternals<>(
+          1,
+          operatorStateBackend,
+          new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/FlinkBroadcastStateInternalsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/FlinkBroadcastStateInternalsTest.java
@@ -23,7 +23,6 @@ import org.apache.beam.runners.core.StateInternalsTest;
 import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
 import org.apache.beam.runners.flink.FlinkPipelineOptions;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.state.FlinkBroadcastStateInternals;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.flink.runtime.operators.testutils.DummyEnvironment;
 import org.apache.flink.runtime.state.OperatorStateBackend;
 import org.apache.flink.runtime.state.memory.MemoryStateBackend;
@@ -51,7 +50,7 @@ public class FlinkBroadcastStateInternalsTest extends StateInternalsTest {
       return new FlinkBroadcastStateInternals<>(
           1,
           operatorStateBackend,
-          new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+          new SerializablePipelineOptions(FlinkPipelineOptions.defaults()));
     } catch (Exception e) {
       throw new RuntimeException(e);
     }

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/FlinkStateInternalsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/FlinkStateInternalsTest.java
@@ -33,7 +33,6 @@ import org.apache.beam.runners.flink.FlinkPipelineOptions;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.state.FlinkStateInternals;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.state.WatermarkHoldState;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.transforms.windowing.TimestampCombiner;
@@ -68,7 +67,7 @@ public class FlinkStateInternalsTest extends StateInternalsTest {
       return new FlinkStateInternals<>(
           keyedStateBackend,
           StringUtf8Coder.of(),
-          new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+          new SerializablePipelineOptions(FlinkPipelineOptions.defaults()));
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -81,7 +80,7 @@ public class FlinkStateInternalsTest extends StateInternalsTest {
         new FlinkStateInternals<>(
             keyedStateBackend,
             StringUtf8Coder.of(),
-            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+            new SerializablePipelineOptions(FlinkPipelineOptions.defaults()));
 
     StateTag<WatermarkHoldState> stateTag =
         StateTags.watermarkStateInternal("hold", TimestampCombiner.EARLIEST);
@@ -136,7 +135,7 @@ public class FlinkStateInternalsTest extends StateInternalsTest {
         new FlinkStateInternals<>(
             keyedStateBackend,
             StringUtf8Coder.of(),
-            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+            new SerializablePipelineOptions(FlinkPipelineOptions.defaults()));
     globalWindow = stateInternals.state(StateNamespaces.global(), stateTag);
     fixedWindow =
         stateInternals.state(

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/FlinkStateInternalsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/FlinkStateInternalsTest.java
@@ -28,9 +28,12 @@ import org.apache.beam.runners.core.StateInternalsTest;
 import org.apache.beam.runners.core.StateNamespaces;
 import org.apache.beam.runners.core.StateTag;
 import org.apache.beam.runners.core.StateTags;
+import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
+import org.apache.beam.runners.flink.FlinkPipelineOptions;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.state.FlinkStateInternals;
 import org.apache.beam.sdk.coders.CoderException;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.state.WatermarkHoldState;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.transforms.windowing.TimestampCombiner;
@@ -62,7 +65,10 @@ public class FlinkStateInternalsTest extends StateInternalsTest {
   protected StateInternals createStateInternals() {
     try {
       KeyedStateBackend<ByteBuffer> keyedStateBackend = createStateBackend();
-      return new FlinkStateInternals<>(keyedStateBackend, StringUtf8Coder.of());
+      return new FlinkStateInternals<>(
+          keyedStateBackend,
+          StringUtf8Coder.of(),
+          new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
     } catch (Exception e) {
       throw new RuntimeException(e);
     }
@@ -72,7 +78,10 @@ public class FlinkStateInternalsTest extends StateInternalsTest {
   public void testWatermarkHoldsPersistence() throws Exception {
     KeyedStateBackend<ByteBuffer> keyedStateBackend = createStateBackend();
     FlinkStateInternals stateInternals =
-        new FlinkStateInternals<>(keyedStateBackend, StringUtf8Coder.of());
+        new FlinkStateInternals<>(
+            keyedStateBackend,
+            StringUtf8Coder.of(),
+            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
 
     StateTag<WatermarkHoldState> stateTag =
         StateTags.watermarkStateInternal("hold", TimestampCombiner.EARLIEST);
@@ -123,7 +132,11 @@ public class FlinkStateInternalsTest extends StateInternalsTest {
     assertThat(fixedWindow.read(), is(middle));
 
     // Discard watermark view and recover it
-    stateInternals = new FlinkStateInternals<>(keyedStateBackend, StringUtf8Coder.of());
+    stateInternals =
+        new FlinkStateInternals<>(
+            keyedStateBackend,
+            StringUtf8Coder.of(),
+            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
     globalWindow = stateInternals.state(StateNamespaces.global(), stateTag);
     fixedWindow =
         stateInternals.state(

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/GroupByWithNullValuesTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/GroupByWithNullValuesTest.java
@@ -24,7 +24,6 @@ import org.apache.beam.runners.flink.FlinkPipelineOptions;
 import org.apache.beam.runners.flink.TestFlinkRunner;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.GenerateSequence;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.GroupByKey;
@@ -44,7 +43,7 @@ public class GroupByWithNullValuesTest implements Serializable {
 
   @Test
   public void testGroupByWithNullValues() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
 
     options.setRunner(TestFlinkRunner.class);
     options.setStreaming(true);

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperatorTest.java
@@ -49,7 +49,6 @@ import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.coders.VarLongCoder;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.state.StateSpec;
 import org.apache.beam.sdk.state.StateSpecs;
 import org.apache.beam.sdk.state.TimeDomain;
@@ -141,14 +140,11 @@ public class DoFnOperatorTest {
             outputTag,
             Collections.emptyList(),
             new DoFnOperator.MultiOutputOutputManagerFactory<>(
-                outputTag,
-                coder,
-                new SerializablePipelineOptions(
-                    PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
+                outputTag, coder, new SerializablePipelineOptions(FlinkPipelineOptions.defaults())),
             WindowingStrategy.globalDefault(),
             new HashMap<>(), /* side-input mapping */
             Collections.emptyList(), /* side inputs */
-            PipelineOptionsFactory.as(FlinkPipelineOptions.class),
+            FlinkPipelineOptions.defaults(),
             null,
             null,
             DoFnSchemaInformation.create(),
@@ -213,12 +209,11 @@ public class DoFnOperatorTest {
                 tagsToOutputTags,
                 tagsToCoders,
                 tagsToIds,
-                new SerializablePipelineOptions(
-                    PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
+                new SerializablePipelineOptions(FlinkPipelineOptions.defaults())),
             WindowingStrategy.globalDefault(),
             new HashMap<>(), /* side-input mapping */
             Collections.emptyList(), /* side inputs */
-            PipelineOptionsFactory.as(FlinkPipelineOptions.class),
+            FlinkPipelineOptions.defaults(),
             null,
             null,
             DoFnSchemaInformation.create(),
@@ -353,12 +348,11 @@ public class DoFnOperatorTest {
             new DoFnOperator.MultiOutputOutputManagerFactory<>(
                 outputTag,
                 outputCoder,
-                new SerializablePipelineOptions(
-                    PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
+                new SerializablePipelineOptions(FlinkPipelineOptions.defaults())),
             windowingStrategy,
             new HashMap<>(), /* side-input mapping */
             Collections.emptyList(), /* side inputs */
-            PipelineOptionsFactory.as(FlinkPipelineOptions.class),
+            FlinkPipelineOptions.defaults(),
             keyCoder, /* key coder */
             keySelector,
             DoFnSchemaInformation.create(),
@@ -369,14 +363,11 @@ public class DoFnOperatorTest {
             doFnOperator,
             keySelector,
             new CoderTypeInformation<>(
-                FlinkKeyUtils.ByteBufferCoder.of(),
-                PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+                FlinkKeyUtils.ByteBufferCoder.of(), FlinkPipelineOptions.defaults()));
 
     testHarness.setup(
         new CoderTypeSerializer<>(
-            outputCoder,
-            new SerializablePipelineOptions(
-                PipelineOptionsFactory.as(FlinkPipelineOptions.class))));
+            outputCoder, new SerializablePipelineOptions(FlinkPipelineOptions.defaults())));
 
     testHarness.open();
 
@@ -472,12 +463,11 @@ public class DoFnOperatorTest {
             new DoFnOperator.MultiOutputOutputManagerFactory<>(
                 outputTag,
                 outputCoder,
-                new SerializablePipelineOptions(
-                    PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
+                new SerializablePipelineOptions(FlinkPipelineOptions.defaults())),
             windowingStrategy,
             new HashMap<>(), /* side-input mapping */
             Collections.emptyList(), /* side inputs */
-            PipelineOptionsFactory.as(FlinkPipelineOptions.class),
+            FlinkPipelineOptions.defaults(),
             keyCoder, /* key coder */
             keySelector,
             DoFnSchemaInformation.create(),
@@ -488,8 +478,7 @@ public class DoFnOperatorTest {
             doFnOperator,
             keySelector,
             new CoderTypeInformation<>(
-                FlinkKeyUtils.ByteBufferCoder.of(),
-                PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+                FlinkKeyUtils.ByteBufferCoder.of(), FlinkPipelineOptions.defaults()));
 
     testHarness.open();
 
@@ -714,14 +703,11 @@ public class DoFnOperatorTest {
             outputTag,
             Collections.emptyList(),
             new DoFnOperator.MultiOutputOutputManagerFactory<>(
-                outputTag,
-                coder,
-                new SerializablePipelineOptions(
-                    PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
+                outputTag, coder, new SerializablePipelineOptions(FlinkPipelineOptions.defaults())),
             windowingStrategy,
             new HashMap<>(), /* side-input mapping */
             Collections.emptyList(), /* side inputs */
-            PipelineOptionsFactory.as(FlinkPipelineOptions.class),
+            FlinkPipelineOptions.defaults(),
             StringUtf8Coder.of(), /* key coder */
             keySelector,
             DoFnSchemaInformation.create(),
@@ -734,8 +720,7 @@ public class DoFnOperatorTest {
                 doFnOperator,
                 keySelector,
                 new CoderTypeInformation<>(
-                    FlinkKeyUtils.ByteBufferCoder.of(),
-                    PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+                    FlinkKeyUtils.ByteBufferCoder.of(), FlinkPipelineOptions.defaults()));
     return testHarness;
   }
 
@@ -774,14 +759,11 @@ public class DoFnOperatorTest {
             outputTag,
             Collections.emptyList(),
             new DoFnOperator.MultiOutputOutputManagerFactory<>(
-                outputTag,
-                coder,
-                new SerializablePipelineOptions(
-                    PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
+                outputTag, coder, new SerializablePipelineOptions(FlinkPipelineOptions.defaults())),
             WindowingStrategy.of(FixedWindows.of(Duration.millis(100))),
             sideInputMapping, /* side-input mapping */
             ImmutableList.of(view1, view2), /* side inputs */
-            PipelineOptionsFactory.as(FlinkPipelineOptions.class),
+            FlinkPipelineOptions.defaults(),
             keyed ? keyCoder : null,
             keyed ? keySelector : null,
             DoFnSchemaInformation.create(),
@@ -798,8 +780,7 @@ public class DoFnOperatorTest {
               keySelector,
               null,
               new CoderTypeInformation<>(
-                  FlinkKeyUtils.ByteBufferCoder.of(),
-                  PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+                  FlinkKeyUtils.ByteBufferCoder.of(), FlinkPipelineOptions.defaults()));
     }
 
     testHarness.open();
@@ -896,8 +877,7 @@ public class DoFnOperatorTest {
 
     CoderTypeInformation<ByteBuffer> keyCoderInfo =
         new CoderTypeInformation<>(
-            FlinkKeyUtils.ByteBufferCoder.of(),
-            PipelineOptionsFactory.as(FlinkPipelineOptions.class));
+            FlinkKeyUtils.ByteBufferCoder.of(), FlinkPipelineOptions.defaults());
 
     OneInputStreamOperatorTestHarness<
             WindowedValue<KV<String, Long>>, WindowedValue<KV<String, Long>>>
@@ -978,12 +958,11 @@ public class DoFnOperatorTest {
                   new DoFnOperator.MultiOutputOutputManagerFactory<>(
                       outputTag,
                       coder,
-                      new SerializablePipelineOptions(
-                          PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
+                      new SerializablePipelineOptions(FlinkPipelineOptions.defaults())),
                   WindowingStrategy.globalDefault(),
                   sideInputMapping, /* side-input mapping */
                   ImmutableList.of(view1, view2), /* side inputs */
-                  PipelineOptionsFactory.as(FlinkPipelineOptions.class),
+                  FlinkPipelineOptions.defaults(),
                   null,
                   null,
                   DoFnSchemaInformation.create(),
@@ -1022,12 +1001,11 @@ public class DoFnOperatorTest {
                   new DoFnOperator.MultiOutputOutputManagerFactory<>(
                       outputTag,
                       coder,
-                      new SerializablePipelineOptions(
-                          PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
+                      new SerializablePipelineOptions(FlinkPipelineOptions.defaults())),
                   WindowingStrategy.of(FixedWindows.of(Duration.millis(100))),
                   sideInputMapping, /* side-input mapping */
                   ImmutableList.of(view1, view2), /* side inputs */
-                  PipelineOptionsFactory.as(FlinkPipelineOptions.class),
+                  FlinkPipelineOptions.defaults(),
                   keyCoder,
                   keySelector,
                   DoFnSchemaInformation.create(),
@@ -1039,8 +1017,7 @@ public class DoFnOperatorTest {
               // we use a dummy key for the second input since it is considered to be broadcast
               null,
               new CoderTypeInformation<>(
-                  FlinkKeyUtils.ByteBufferCoder.of(),
-                  PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+                  FlinkKeyUtils.ByteBufferCoder.of(), FlinkPipelineOptions.defaults()));
         });
   }
 
@@ -1127,12 +1104,11 @@ public class DoFnOperatorTest {
                   new DoFnOperator.MultiOutputOutputManagerFactory<>(
                       outputTag,
                       coder,
-                      new SerializablePipelineOptions(
-                          PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
+                      new SerializablePipelineOptions(FlinkPipelineOptions.defaults())),
                   WindowingStrategy.of(FixedWindows.of(Duration.millis(100))),
                   sideInputMapping, /* side-input mapping */
                   ImmutableList.of(view1, view2), /* side inputs */
-                  PipelineOptionsFactory.as(FlinkPipelineOptions.class),
+                  FlinkPipelineOptions.defaults(),
                   null,
                   null,
                   DoFnSchemaInformation.create(),
@@ -1172,12 +1148,11 @@ public class DoFnOperatorTest {
                   new DoFnOperator.MultiOutputOutputManagerFactory<>(
                       outputTag,
                       coder,
-                      new SerializablePipelineOptions(
-                          PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
+                      new SerializablePipelineOptions(FlinkPipelineOptions.defaults())),
                   WindowingStrategy.of(FixedWindows.of(Duration.millis(100))),
                   sideInputMapping, /* side-input mapping */
                   ImmutableList.of(view1, view2), /* side inputs */
-                  PipelineOptionsFactory.as(FlinkPipelineOptions.class),
+                  FlinkPipelineOptions.defaults(),
                   keyCoder,
                   keySelector,
                   DoFnSchemaInformation.create(),
@@ -1189,8 +1164,7 @@ public class DoFnOperatorTest {
               // we use a dummy key for the second input since it is considered to be broadcast
               null,
               new CoderTypeInformation<>(
-                  FlinkKeyUtils.ByteBufferCoder.of(),
-                  PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+                  FlinkKeyUtils.ByteBufferCoder.of(), FlinkPipelineOptions.defaults()));
         });
   }
 
@@ -1291,12 +1265,10 @@ public class DoFnOperatorTest {
 
     final CoderTypeSerializer<WindowedValue<String>> outputSerializer =
         new CoderTypeSerializer<>(
-            outputCoder,
-            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+            outputCoder, new SerializablePipelineOptions(FlinkPipelineOptions.defaults()));
     CoderTypeInformation<ByteBuffer> keyCoderInfo =
         new CoderTypeInformation<>(
-            FlinkKeyUtils.ByteBufferCoder.of(),
-            PipelineOptionsFactory.as(FlinkPipelineOptions.class));
+            FlinkKeyUtils.ByteBufferCoder.of(), FlinkPipelineOptions.defaults());
     KeySelector<WindowedValue<Integer>, ByteBuffer> keySelector =
         e -> FlinkKeyUtils.encodeKey(e.getValue(), keyCoder);
 
@@ -1377,12 +1349,11 @@ public class DoFnOperatorTest {
             new DoFnOperator.MultiOutputOutputManagerFactory<>(
                 outputTag,
                 outputCoder,
-                new SerializablePipelineOptions(
-                    PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
+                new SerializablePipelineOptions(FlinkPipelineOptions.defaults())),
             windowingStrategy,
             new HashMap<>(), /* side-input mapping */
             Collections.emptyList(), /* side inputs */
-            PipelineOptionsFactory.as(FlinkPipelineOptions.class),
+            FlinkPipelineOptions.defaults(),
             keyCoder /* key coder */,
             keySelector,
             DoFnSchemaInformation.create(),
@@ -1399,7 +1370,7 @@ public class DoFnOperatorTest {
         WindowedValue.getValueOnlyCoder(StringUtf8Coder.of());
 
     TupleTag<String> outputTag = new TupleTag<>("main-output");
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setMaxBundleSize(2L);
     options.setMaxBundleTimeMills(10L);
 
@@ -1536,14 +1507,13 @@ public class DoFnOperatorTest {
     StringUtf8Coder keyCoder = StringUtf8Coder.of();
     KvToByteBufferKeySelector keySelector =
         new KvToByteBufferKeySelector<>(
-            keyCoder,
-            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+            keyCoder, new SerializablePipelineOptions(FlinkPipelineOptions.defaults()));
     KvCoder<String, String> kvCoder = KvCoder.of(keyCoder, StringUtf8Coder.of());
     WindowedValue.ValueOnlyWindowedValueCoder<KV<String, String>> windowedValueCoder =
         WindowedValue.getValueOnlyCoder(kvCoder);
 
     TupleTag<String> outputTag = new TupleTag<>("main-output");
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setMaxBundleSize(2L);
     options.setMaxBundleTimeMills(10L);
 
@@ -1669,7 +1639,7 @@ public class DoFnOperatorTest {
 
   @Test
   public void testCheckpointBufferingWithMultipleBundles() throws Exception {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setMaxBundleSize(10L);
     options.setCheckpointingInterval(1L);
 
@@ -1774,7 +1744,7 @@ public class DoFnOperatorTest {
 
   @Test
   public void testExactlyOnceBuffering() throws Exception {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setMaxBundleSize(2L);
     options.setCheckpointingInterval(1L);
 
@@ -1885,7 +1855,7 @@ public class DoFnOperatorTest {
   @Test
   @SuppressWarnings("unchecked")
   public void testExactlyOnceBufferingKeyed() throws Exception {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setMaxBundleSize(2L);
     options.setCheckpointingInterval(1L);
 
@@ -2038,9 +2008,9 @@ public class DoFnOperatorTest {
         new DoFnOperator.MultiOutputOutputManagerFactory(
             outputTag,
             WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE),
-            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+            new SerializablePipelineOptions(FlinkPipelineOptions.defaults()));
 
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     // should make the DoFnOperator creation fail
     options.setCheckpointingInterval(-1L);
     new DoFnOperator(
@@ -2063,7 +2033,7 @@ public class DoFnOperatorTest {
 
   @Test
   public void testBundleProcessingExceptionIsFatalDuringCheckpointing() throws Exception {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setMaxBundleSize(10L);
     options.setCheckpointingInterval(1L);
 
@@ -2158,7 +2128,7 @@ public class DoFnOperatorTest {
   }
 
   private static DoFnOperator getOperatorForCleanupInspection() {
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setParallelism(4);
 
     TupleTag<String> outputTag = new TupleTag<>("main-output");

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperatorTest.java
@@ -38,6 +38,7 @@ import java.util.Optional;
 import java.util.function.Supplier;
 import java.util.stream.Collectors;
 import org.apache.beam.runners.core.StatefulDoFnRunner;
+import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
 import org.apache.beam.runners.flink.FlinkPipelineOptions;
 import org.apache.beam.runners.flink.metrics.FlinkMetricContainer;
 import org.apache.beam.runners.flink.translation.types.CoderTypeInformation;
@@ -139,7 +140,11 @@ public class DoFnOperatorTest {
             Collections.emptyMap(),
             outputTag,
             Collections.emptyList(),
-            new DoFnOperator.MultiOutputOutputManagerFactory<>(outputTag, coder),
+            new DoFnOperator.MultiOutputOutputManagerFactory<>(
+                outputTag,
+                coder,
+                new SerializablePipelineOptions(
+                    PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
             WindowingStrategy.globalDefault(),
             new HashMap<>(), /* side-input mapping */
             Collections.emptyList(), /* side inputs */
@@ -204,7 +209,12 @@ public class DoFnOperatorTest {
             mainOutput,
             ImmutableList.of(additionalOutput1, additionalOutput2),
             new DoFnOperator.MultiOutputOutputManagerFactory(
-                mainOutput, tagsToOutputTags, tagsToCoders, tagsToIds),
+                mainOutput,
+                tagsToOutputTags,
+                tagsToCoders,
+                tagsToIds,
+                new SerializablePipelineOptions(
+                    PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
             WindowingStrategy.globalDefault(),
             new HashMap<>(), /* side-input mapping */
             Collections.emptyList(), /* side inputs */
@@ -340,7 +350,11 @@ public class DoFnOperatorTest {
             Collections.emptyMap(),
             outputTag,
             Collections.emptyList(),
-            new DoFnOperator.MultiOutputOutputManagerFactory<>(outputTag, outputCoder),
+            new DoFnOperator.MultiOutputOutputManagerFactory<>(
+                outputTag,
+                outputCoder,
+                new SerializablePipelineOptions(
+                    PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
             windowingStrategy,
             new HashMap<>(), /* side-input mapping */
             Collections.emptyList(), /* side inputs */
@@ -354,9 +368,15 @@ public class DoFnOperatorTest {
         new KeyedOneInputStreamOperatorTestHarness<>(
             doFnOperator,
             keySelector,
-            new CoderTypeInformation<>(FlinkKeyUtils.ByteBufferCoder.of()));
+            new CoderTypeInformation<>(
+                FlinkKeyUtils.ByteBufferCoder.of(),
+                PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
 
-    testHarness.setup(new CoderTypeSerializer<>(outputCoder));
+    testHarness.setup(
+        new CoderTypeSerializer<>(
+            outputCoder,
+            new SerializablePipelineOptions(
+                PipelineOptionsFactory.as(FlinkPipelineOptions.class))));
 
     testHarness.open();
 
@@ -449,7 +469,11 @@ public class DoFnOperatorTest {
             Collections.emptyMap(),
             outputTag,
             Collections.emptyList(),
-            new DoFnOperator.MultiOutputOutputManagerFactory<>(outputTag, outputCoder),
+            new DoFnOperator.MultiOutputOutputManagerFactory<>(
+                outputTag,
+                outputCoder,
+                new SerializablePipelineOptions(
+                    PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
             windowingStrategy,
             new HashMap<>(), /* side-input mapping */
             Collections.emptyList(), /* side inputs */
@@ -463,7 +487,9 @@ public class DoFnOperatorTest {
         new KeyedOneInputStreamOperatorTestHarness<>(
             doFnOperator,
             keySelector,
-            new CoderTypeInformation<>(FlinkKeyUtils.ByteBufferCoder.of()));
+            new CoderTypeInformation<>(
+                FlinkKeyUtils.ByteBufferCoder.of(),
+                PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
 
     testHarness.open();
 
@@ -687,7 +713,11 @@ public class DoFnOperatorTest {
             Collections.emptyMap(),
             outputTag,
             Collections.emptyList(),
-            new DoFnOperator.MultiOutputOutputManagerFactory<>(outputTag, coder),
+            new DoFnOperator.MultiOutputOutputManagerFactory<>(
+                outputTag,
+                coder,
+                new SerializablePipelineOptions(
+                    PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
             windowingStrategy,
             new HashMap<>(), /* side-input mapping */
             Collections.emptyList(), /* side inputs */
@@ -703,7 +733,9 @@ public class DoFnOperatorTest {
             new KeyedOneInputStreamOperatorTestHarness<>(
                 doFnOperator,
                 keySelector,
-                new CoderTypeInformation<>(FlinkKeyUtils.ByteBufferCoder.of()));
+                new CoderTypeInformation<>(
+                    FlinkKeyUtils.ByteBufferCoder.of(),
+                    PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
     return testHarness;
   }
 
@@ -741,7 +773,11 @@ public class DoFnOperatorTest {
             Collections.emptyMap(),
             outputTag,
             Collections.emptyList(),
-            new DoFnOperator.MultiOutputOutputManagerFactory<>(outputTag, coder),
+            new DoFnOperator.MultiOutputOutputManagerFactory<>(
+                outputTag,
+                coder,
+                new SerializablePipelineOptions(
+                    PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
             WindowingStrategy.of(FixedWindows.of(Duration.millis(100))),
             sideInputMapping, /* side-input mapping */
             ImmutableList.of(view1, view2), /* side inputs */
@@ -761,7 +797,9 @@ public class DoFnOperatorTest {
               doFnOperator,
               keySelector,
               null,
-              new CoderTypeInformation<>(FlinkKeyUtils.ByteBufferCoder.of()));
+              new CoderTypeInformation<>(
+                  FlinkKeyUtils.ByteBufferCoder.of(),
+                  PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
     }
 
     testHarness.open();
@@ -850,14 +888,16 @@ public class DoFnOperatorTest {
     TupleTag<KV<String, Long>> outputTag = new TupleTag<>("main-output");
 
     StringUtf8Coder keyCoder = StringUtf8Coder.of();
-    KvToByteBufferKeySelector keySelector = new KvToByteBufferKeySelector<>(keyCoder);
+    KvToByteBufferKeySelector keySelector = new KvToByteBufferKeySelector<>(keyCoder, null);
     KvCoder<String, Long> coder = KvCoder.of(keyCoder, VarLongCoder.of());
 
     FullWindowedValueCoder<KV<String, Long>> kvCoder =
         WindowedValue.getFullCoder(coder, windowingStrategy.getWindowFn().windowCoder());
 
     CoderTypeInformation<ByteBuffer> keyCoderInfo =
-        new CoderTypeInformation<>(FlinkKeyUtils.ByteBufferCoder.of());
+        new CoderTypeInformation<>(
+            FlinkKeyUtils.ByteBufferCoder.of(),
+            PipelineOptionsFactory.as(FlinkPipelineOptions.class));
 
     OneInputStreamOperatorTestHarness<
             WindowedValue<KV<String, Long>>, WindowedValue<KV<String, Long>>>
@@ -935,7 +975,11 @@ public class DoFnOperatorTest {
                   Collections.emptyMap(),
                   outputTag,
                   Collections.emptyList(),
-                  new DoFnOperator.MultiOutputOutputManagerFactory<>(outputTag, coder),
+                  new DoFnOperator.MultiOutputOutputManagerFactory<>(
+                      outputTag,
+                      coder,
+                      new SerializablePipelineOptions(
+                          PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
                   WindowingStrategy.globalDefault(),
                   sideInputMapping, /* side-input mapping */
                   ImmutableList.of(view1, view2), /* side inputs */
@@ -975,7 +1019,11 @@ public class DoFnOperatorTest {
                   Collections.emptyMap(),
                   outputTag,
                   Collections.emptyList(),
-                  new DoFnOperator.MultiOutputOutputManagerFactory<>(outputTag, coder),
+                  new DoFnOperator.MultiOutputOutputManagerFactory<>(
+                      outputTag,
+                      coder,
+                      new SerializablePipelineOptions(
+                          PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
                   WindowingStrategy.of(FixedWindows.of(Duration.millis(100))),
                   sideInputMapping, /* side-input mapping */
                   ImmutableList.of(view1, view2), /* side inputs */
@@ -990,7 +1038,9 @@ public class DoFnOperatorTest {
               keySelector,
               // we use a dummy key for the second input since it is considered to be broadcast
               null,
-              new CoderTypeInformation<>(FlinkKeyUtils.ByteBufferCoder.of()));
+              new CoderTypeInformation<>(
+                  FlinkKeyUtils.ByteBufferCoder.of(),
+                  PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
         });
   }
 
@@ -1074,7 +1124,11 @@ public class DoFnOperatorTest {
                   Collections.emptyMap(),
                   outputTag,
                   Collections.emptyList(),
-                  new DoFnOperator.MultiOutputOutputManagerFactory<>(outputTag, coder),
+                  new DoFnOperator.MultiOutputOutputManagerFactory<>(
+                      outputTag,
+                      coder,
+                      new SerializablePipelineOptions(
+                          PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
                   WindowingStrategy.of(FixedWindows.of(Duration.millis(100))),
                   sideInputMapping, /* side-input mapping */
                   ImmutableList.of(view1, view2), /* side inputs */
@@ -1115,7 +1169,11 @@ public class DoFnOperatorTest {
                   Collections.emptyMap(),
                   outputTag,
                   Collections.emptyList(),
-                  new DoFnOperator.MultiOutputOutputManagerFactory<>(outputTag, coder),
+                  new DoFnOperator.MultiOutputOutputManagerFactory<>(
+                      outputTag,
+                      coder,
+                      new SerializablePipelineOptions(
+                          PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
                   WindowingStrategy.of(FixedWindows.of(Duration.millis(100))),
                   sideInputMapping, /* side-input mapping */
                   ImmutableList.of(view1, view2), /* side inputs */
@@ -1130,7 +1188,9 @@ public class DoFnOperatorTest {
               keySelector,
               // we use a dummy key for the second input since it is considered to be broadcast
               null,
-              new CoderTypeInformation<>(FlinkKeyUtils.ByteBufferCoder.of()));
+              new CoderTypeInformation<>(
+                  FlinkKeyUtils.ByteBufferCoder.of(),
+                  PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
         });
   }
 
@@ -1230,9 +1290,13 @@ public class DoFnOperatorTest {
     TupleTag<String> outputTag = new TupleTag<>("main-output");
 
     final CoderTypeSerializer<WindowedValue<String>> outputSerializer =
-        new CoderTypeSerializer<>(outputCoder);
+        new CoderTypeSerializer<>(
+            outputCoder,
+            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
     CoderTypeInformation<ByteBuffer> keyCoderInfo =
-        new CoderTypeInformation<>(FlinkKeyUtils.ByteBufferCoder.of());
+        new CoderTypeInformation<>(
+            FlinkKeyUtils.ByteBufferCoder.of(),
+            PipelineOptionsFactory.as(FlinkPipelineOptions.class));
     KeySelector<WindowedValue<Integer>, ByteBuffer> keySelector =
         e -> FlinkKeyUtils.encodeKey(e.getValue(), keyCoder);
 
@@ -1310,7 +1374,11 @@ public class DoFnOperatorTest {
             Collections.emptyMap(),
             outputTag,
             Collections.emptyList(),
-            new DoFnOperator.MultiOutputOutputManagerFactory<>(outputTag, outputCoder),
+            new DoFnOperator.MultiOutputOutputManagerFactory<>(
+                outputTag,
+                outputCoder,
+                new SerializablePipelineOptions(
+                    PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
             windowingStrategy,
             new HashMap<>(), /* side-input mapping */
             Collections.emptyList(), /* side inputs */
@@ -1347,7 +1415,8 @@ public class DoFnOperatorTest {
     DoFnOperator.MultiOutputOutputManagerFactory<String> outputManagerFactory =
         new DoFnOperator.MultiOutputOutputManagerFactory(
             outputTag,
-            WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE));
+            WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE),
+            new SerializablePipelineOptions(options));
 
     DoFnOperator<String, String> doFnOperator =
         new DoFnOperator<>(
@@ -1465,7 +1534,10 @@ public class DoFnOperatorTest {
   public void testBundleKeyed() throws Exception {
 
     StringUtf8Coder keyCoder = StringUtf8Coder.of();
-    KvToByteBufferKeySelector keySelector = new KvToByteBufferKeySelector<>(keyCoder);
+    KvToByteBufferKeySelector keySelector =
+        new KvToByteBufferKeySelector<>(
+            keyCoder,
+            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
     KvCoder<String, String> kvCoder = KvCoder.of(keyCoder, StringUtf8Coder.of());
     WindowedValue.ValueOnlyWindowedValueCoder<KV<String, String>> windowedValueCoder =
         WindowedValue.getValueOnlyCoder(kvCoder);
@@ -1493,7 +1565,8 @@ public class DoFnOperatorTest {
     DoFnOperator.MultiOutputOutputManagerFactory<String> outputManagerFactory =
         new DoFnOperator.MultiOutputOutputManagerFactory(
             outputTag,
-            WindowedValue.getFullCoder(kvCoder.getValueCoder(), GlobalWindow.Coder.INSTANCE));
+            WindowedValue.getFullCoder(kvCoder.getValueCoder(), GlobalWindow.Coder.INSTANCE),
+            new SerializablePipelineOptions(options));
 
     DoFnOperator<KV<String, String>, KV<String, String>> doFnOperator =
         new DoFnOperator(
@@ -1609,7 +1682,8 @@ public class DoFnOperatorTest {
     DoFnOperator.MultiOutputOutputManagerFactory<String> outputManagerFactory =
         new DoFnOperator.MultiOutputOutputManagerFactory<>(
             outputTag,
-            WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE));
+            WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE),
+            new SerializablePipelineOptions(options));
 
     @SuppressWarnings("unchecked")
     Supplier<DoFnOperator<String, String>> doFnOperatorSupplier =
@@ -1733,7 +1807,8 @@ public class DoFnOperatorTest {
     DoFnOperator.MultiOutputOutputManagerFactory<String> outputManagerFactory =
         new DoFnOperator.MultiOutputOutputManagerFactory(
             outputTag,
-            WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE));
+            WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE),
+            new SerializablePipelineOptions(options));
 
     Supplier<DoFnOperator<String, String>> doFnOperatorSupplier =
         () ->
@@ -1817,7 +1892,8 @@ public class DoFnOperatorTest {
     TupleTag<String> outputTag = new TupleTag<>("main-output");
 
     StringUtf8Coder keyCoder = StringUtf8Coder.of();
-    KvToByteBufferKeySelector keySelector = new KvToByteBufferKeySelector<>(keyCoder);
+    KvToByteBufferKeySelector keySelector =
+        new KvToByteBufferKeySelector<>(keyCoder, new SerializablePipelineOptions(options));
     KvCoder<String, String> kvCoder = KvCoder.of(keyCoder, StringUtf8Coder.of());
     WindowedValue.ValueOnlyWindowedValueCoder<KV<String, String>> windowedValueCoder =
         WindowedValue.getValueOnlyCoder(kvCoder);
@@ -1848,7 +1924,8 @@ public class DoFnOperatorTest {
     DoFnOperator.MultiOutputOutputManagerFactory<String> outputManagerFactory =
         new DoFnOperator.MultiOutputOutputManagerFactory(
             outputTag,
-            WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE));
+            WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE),
+            new SerializablePipelineOptions(options));
 
     Supplier<DoFnOperator<KV<String, String>, KV<String, String>>> doFnOperatorSupplier =
         () ->
@@ -1942,7 +2019,7 @@ public class DoFnOperatorTest {
     TupleTag<String> outputTag = new TupleTag<>("main-output");
 
     StringUtf8Coder keyCoder = StringUtf8Coder.of();
-    KvToByteBufferKeySelector keySelector = new KvToByteBufferKeySelector<>(keyCoder);
+    KvToByteBufferKeySelector keySelector = new KvToByteBufferKeySelector<>(keyCoder, null);
     KvCoder<String, String> kvCoder = KvCoder.of(keyCoder, StringUtf8Coder.of());
     WindowedValue.ValueOnlyWindowedValueCoder<KV<String, String>> windowedValueCoder =
         WindowedValue.getValueOnlyCoder(kvCoder);
@@ -1960,7 +2037,8 @@ public class DoFnOperatorTest {
     DoFnOperator.MultiOutputOutputManagerFactory<String> outputManagerFactory =
         new DoFnOperator.MultiOutputOutputManagerFactory(
             outputTag,
-            WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE));
+            WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE),
+            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
 
     FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
     // should make the DoFnOperator creation fail
@@ -1998,7 +2076,8 @@ public class DoFnOperatorTest {
     DoFnOperator.MultiOutputOutputManagerFactory<String> outputManagerFactory =
         new DoFnOperator.MultiOutputOutputManagerFactory(
             outputTag,
-            WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE));
+            WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE),
+            new SerializablePipelineOptions(options));
 
     @SuppressWarnings("unchecked")
     DoFnOperator doFnOperator =
@@ -2097,7 +2176,8 @@ public class DoFnOperatorTest {
     DoFnOperator.MultiOutputOutputManagerFactory<String> outputManagerFactory =
         new DoFnOperator.MultiOutputOutputManagerFactory(
             outputTag,
-            WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE));
+            WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE),
+            new SerializablePipelineOptions(options));
 
     return new DoFnOperator<>(
         doFn,

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperatorTest.java
@@ -85,7 +85,6 @@ import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.coders.VoidCoder;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.state.BagState;
 import org.apache.beam.sdk.state.TimeDomain;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
@@ -200,7 +199,7 @@ public class ExecutableStageDoFnOperatorTest {
         new DoFnOperator.MultiOutputOutputManagerFactory(
             mainOutput,
             VoidCoder.of(),
-            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+            new SerializablePipelineOptions(FlinkPipelineOptions.defaults()));
     ExecutableStageDoFnOperator<Integer, Integer> operator =
         getOperator(mainOutput, Collections.emptyList(), outputManagerFactory);
 
@@ -232,7 +231,7 @@ public class ExecutableStageDoFnOperatorTest {
         new DoFnOperator.MultiOutputOutputManagerFactory(
             mainOutput,
             VoidCoder.of(),
-            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+            new SerializablePipelineOptions(FlinkPipelineOptions.defaults()));
     ExecutableStageDoFnOperator<Integer, Integer> operator =
         getOperator(mainOutput, Collections.emptyList(), outputManagerFactory);
 
@@ -302,7 +301,7 @@ public class ExecutableStageDoFnOperatorTest {
             tagsToOutputTags,
             tagsToCoders,
             tagsToIds,
-            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+            new SerializablePipelineOptions(FlinkPipelineOptions.defaults()));
 
     WindowedValue<Integer> zero = WindowedValue.valueInGlobalWindow(0);
     WindowedValue<Integer> three = WindowedValue.valueInGlobalWindow(3);
@@ -425,7 +424,7 @@ public class ExecutableStageDoFnOperatorTest {
         new DoFnOperator.MultiOutputOutputManagerFactory(
             mainOutput,
             VoidCoder.of(),
-            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+            new SerializablePipelineOptions(FlinkPipelineOptions.defaults()));
     ExecutableStageDoFnOperator<KV<String, Integer>, Integer> operator =
         getOperator(
             mainOutput,
@@ -442,8 +441,7 @@ public class ExecutableStageDoFnOperatorTest {
             new KeyedOneInputStreamOperatorTestHarness<>(
                 operator,
                 val -> val.getValue().getKey(),
-                new CoderTypeInformation<>(
-                    StringUtf8Coder.of(), PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+                new CoderTypeInformation<>(StringUtf8Coder.of(), FlinkPipelineOptions.defaults()));
     RemoteBundle bundle = Mockito.mock(RemoteBundle.class);
     when(bundle.getInputReceivers())
         .thenReturn(
@@ -562,7 +560,7 @@ public class ExecutableStageDoFnOperatorTest {
         new DoFnOperator.MultiOutputOutputManagerFactory(
             mainOutput,
             VoidCoder.of(),
-            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+            new SerializablePipelineOptions(FlinkPipelineOptions.defaults()));
     ExecutableStageDoFnOperator<Integer, Integer> operator =
         getOperator(mainOutput, Collections.emptyList(), outputManagerFactory);
 
@@ -599,7 +597,7 @@ public class ExecutableStageDoFnOperatorTest {
         new DoFnOperator.MultiOutputOutputManagerFactory(
             mainOutput,
             VarIntCoder.of(),
-            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+            new SerializablePipelineOptions(FlinkPipelineOptions.defaults()));
     VarIntCoder keyCoder = VarIntCoder.of();
     ExecutableStageDoFnOperator<Integer, Integer> operator =
         getOperator(
@@ -615,8 +613,7 @@ public class ExecutableStageDoFnOperatorTest {
             new KeyedOneInputStreamOperatorTestHarness(
                 operator,
                 val -> val,
-                new CoderTypeInformation<>(
-                    keyCoder, PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+                new CoderTypeInformation<>(keyCoder, FlinkPipelineOptions.defaults()));
 
     RemoteBundle bundle = Mockito.mock(RemoteBundle.class);
     when(bundle.getInputReceivers())
@@ -718,7 +715,7 @@ public class ExecutableStageDoFnOperatorTest {
         new DoFnOperator.MultiOutputOutputManagerFactory(
             mainOutput,
             VoidCoder.of(),
-            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+            new SerializablePipelineOptions(FlinkPipelineOptions.defaults()));
     StringUtf8Coder keyCoder = StringUtf8Coder.of();
 
     WindowingStrategy windowingStrategy =
@@ -766,8 +763,7 @@ public class ExecutableStageDoFnOperatorTest {
                 operator,
                 operator.keySelector,
                 new CoderTypeInformation<>(
-                    FlinkKeyUtils.ByteBufferCoder.of(),
-                    PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+                    FlinkKeyUtils.ByteBufferCoder.of(), FlinkPipelineOptions.defaults()));
 
     testHarness.open();
 
@@ -890,7 +886,7 @@ public class ExecutableStageDoFnOperatorTest {
         new DoFnOperator.MultiOutputOutputManagerFactory(
             mainOutput,
             VoidCoder.of(),
-            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+            new SerializablePipelineOptions(FlinkPipelineOptions.defaults()));
 
     StringUtf8Coder keyCoder = StringUtf8Coder.of();
 
@@ -914,8 +910,7 @@ public class ExecutableStageDoFnOperatorTest {
                 operator,
                 operator.keySelector,
                 new CoderTypeInformation<>(
-                    FlinkKeyUtils.ByteBufferCoder.of(),
-                    PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+                    FlinkKeyUtils.ByteBufferCoder.of(), FlinkPipelineOptions.defaults()));
 
     RemoteBundle bundle = Mockito.mock(RemoteBundle.class);
     when(bundle.getInputReceivers())
@@ -1098,9 +1093,9 @@ public class ExecutableStageDoFnOperatorTest {
             tagsToOutputTags,
             tagsToCoders,
             tagsToIds,
-            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+            new SerializablePipelineOptions(FlinkPipelineOptions.defaults()));
 
-    FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+    FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
 
     ExecutableStageDoFnOperator<Integer, Integer> operator =
         new ExecutableStageDoFnOperator<>(
@@ -1177,7 +1172,7 @@ public class ExecutableStageDoFnOperatorTest {
             Collections.emptyMap() /* sideInputTagMapping */,
             Collections.emptyList() /* sideInputs */,
             Collections.emptyMap() /* sideInputId mapping */,
-            PipelineOptionsFactory.as(FlinkPipelineOptions.class),
+            FlinkPipelineOptions.defaults(),
             stagePayload,
             jobInfo,
             contextFactory,

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperatorTest.java
@@ -60,6 +60,7 @@ import org.apache.beam.runners.core.StateNamespaces;
 import org.apache.beam.runners.core.StateTags;
 import org.apache.beam.runners.core.StatefulDoFnRunner;
 import org.apache.beam.runners.core.TimerInternals;
+import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
 import org.apache.beam.runners.core.construction.Timer;
 import org.apache.beam.runners.flink.FlinkPipelineOptions;
 import org.apache.beam.runners.flink.metrics.DoFnRunnerWithMetricsUpdate;
@@ -196,7 +197,10 @@ public class ExecutableStageDoFnOperatorTest {
   public void sdkErrorsSurfaceOnClose() throws Exception {
     TupleTag<Integer> mainOutput = new TupleTag<>("main-output");
     DoFnOperator.MultiOutputOutputManagerFactory<Integer> outputManagerFactory =
-        new DoFnOperator.MultiOutputOutputManagerFactory(mainOutput, VoidCoder.of());
+        new DoFnOperator.MultiOutputOutputManagerFactory(
+            mainOutput,
+            VoidCoder.of(),
+            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
     ExecutableStageDoFnOperator<Integer, Integer> operator =
         getOperator(mainOutput, Collections.emptyList(), outputManagerFactory);
 
@@ -225,7 +229,10 @@ public class ExecutableStageDoFnOperatorTest {
   public void expectedInputsAreSent() throws Exception {
     TupleTag<Integer> mainOutput = new TupleTag<>("main-output");
     DoFnOperator.MultiOutputOutputManagerFactory<Integer> outputManagerFactory =
-        new DoFnOperator.MultiOutputOutputManagerFactory(mainOutput, VoidCoder.of());
+        new DoFnOperator.MultiOutputOutputManagerFactory(
+            mainOutput,
+            VoidCoder.of(),
+            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
     ExecutableStageDoFnOperator<Integer, Integer> operator =
         getOperator(mainOutput, Collections.emptyList(), outputManagerFactory);
 
@@ -291,7 +298,11 @@ public class ExecutableStageDoFnOperatorTest {
 
     DoFnOperator.MultiOutputOutputManagerFactory<Integer> outputManagerFactory =
         new DoFnOperator.MultiOutputOutputManagerFactory(
-            mainOutput, tagsToOutputTags, tagsToCoders, tagsToIds);
+            mainOutput,
+            tagsToOutputTags,
+            tagsToCoders,
+            tagsToIds,
+            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
 
     WindowedValue<Integer> zero = WindowedValue.valueInGlobalWindow(0);
     WindowedValue<Integer> three = WindowedValue.valueInGlobalWindow(3);
@@ -411,7 +422,10 @@ public class ExecutableStageDoFnOperatorTest {
   public void testWatermarkHandling() throws Exception {
     TupleTag<Integer> mainOutput = new TupleTag<>("main-output");
     DoFnOperator.MultiOutputOutputManagerFactory<Integer> outputManagerFactory =
-        new DoFnOperator.MultiOutputOutputManagerFactory(mainOutput, VoidCoder.of());
+        new DoFnOperator.MultiOutputOutputManagerFactory(
+            mainOutput,
+            VoidCoder.of(),
+            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
     ExecutableStageDoFnOperator<KV<String, Integer>, Integer> operator =
         getOperator(
             mainOutput,
@@ -428,7 +442,8 @@ public class ExecutableStageDoFnOperatorTest {
             new KeyedOneInputStreamOperatorTestHarness<>(
                 operator,
                 val -> val.getValue().getKey(),
-                new CoderTypeInformation<>(StringUtf8Coder.of()));
+                new CoderTypeInformation<>(
+                    StringUtf8Coder.of(), PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
     RemoteBundle bundle = Mockito.mock(RemoteBundle.class);
     when(bundle.getInputReceivers())
         .thenReturn(
@@ -544,7 +559,10 @@ public class ExecutableStageDoFnOperatorTest {
   public void testStageBundleClosed() throws Exception {
     TupleTag<Integer> mainOutput = new TupleTag<>("main-output");
     DoFnOperator.MultiOutputOutputManagerFactory<Integer> outputManagerFactory =
-        new DoFnOperator.MultiOutputOutputManagerFactory(mainOutput, VoidCoder.of());
+        new DoFnOperator.MultiOutputOutputManagerFactory(
+            mainOutput,
+            VoidCoder.of(),
+            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
     ExecutableStageDoFnOperator<Integer, Integer> operator =
         getOperator(mainOutput, Collections.emptyList(), outputManagerFactory);
 
@@ -578,7 +596,10 @@ public class ExecutableStageDoFnOperatorTest {
   public void testEnsureStateCleanupWithKeyedInput() throws Exception {
     TupleTag<Integer> mainOutput = new TupleTag<>("main-output");
     DoFnOperator.MultiOutputOutputManagerFactory<Integer> outputManagerFactory =
-        new DoFnOperator.MultiOutputOutputManagerFactory(mainOutput, VarIntCoder.of());
+        new DoFnOperator.MultiOutputOutputManagerFactory(
+            mainOutput,
+            VarIntCoder.of(),
+            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
     VarIntCoder keyCoder = VarIntCoder.of();
     ExecutableStageDoFnOperator<Integer, Integer> operator =
         getOperator(
@@ -592,7 +613,10 @@ public class ExecutableStageDoFnOperatorTest {
     KeyedOneInputStreamOperatorTestHarness<Integer, WindowedValue<Integer>, WindowedValue<Integer>>
         testHarness =
             new KeyedOneInputStreamOperatorTestHarness(
-                operator, val -> val, new CoderTypeInformation<>(keyCoder));
+                operator,
+                val -> val,
+                new CoderTypeInformation<>(
+                    keyCoder, PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
 
     RemoteBundle bundle = Mockito.mock(RemoteBundle.class);
     when(bundle.getInputReceivers())
@@ -691,7 +715,10 @@ public class ExecutableStageDoFnOperatorTest {
       throws Exception {
     TupleTag<Integer> mainOutput = new TupleTag<>("main-output");
     DoFnOperator.MultiOutputOutputManagerFactory<Integer> outputManagerFactory =
-        new DoFnOperator.MultiOutputOutputManagerFactory(mainOutput, VoidCoder.of());
+        new DoFnOperator.MultiOutputOutputManagerFactory(
+            mainOutput,
+            VoidCoder.of(),
+            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
     StringUtf8Coder keyCoder = StringUtf8Coder.of();
 
     WindowingStrategy windowingStrategy =
@@ -738,7 +765,9 @@ public class ExecutableStageDoFnOperatorTest {
             new KeyedOneInputStreamOperatorTestHarness(
                 operator,
                 operator.keySelector,
-                new CoderTypeInformation<>(FlinkKeyUtils.ByteBufferCoder.of()));
+                new CoderTypeInformation<>(
+                    FlinkKeyUtils.ByteBufferCoder.of(),
+                    PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
 
     testHarness.open();
 
@@ -858,7 +887,10 @@ public class ExecutableStageDoFnOperatorTest {
   public void testEnsureStateCleanupOnFinalWatermark() throws Exception {
     TupleTag<Integer> mainOutput = new TupleTag<>("main-output");
     DoFnOperator.MultiOutputOutputManagerFactory<Integer> outputManagerFactory =
-        new DoFnOperator.MultiOutputOutputManagerFactory(mainOutput, VoidCoder.of());
+        new DoFnOperator.MultiOutputOutputManagerFactory(
+            mainOutput,
+            VoidCoder.of(),
+            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
 
     StringUtf8Coder keyCoder = StringUtf8Coder.of();
 
@@ -881,7 +913,9 @@ public class ExecutableStageDoFnOperatorTest {
             new KeyedOneInputStreamOperatorTestHarness(
                 operator,
                 operator.keySelector,
-                new CoderTypeInformation<>(FlinkKeyUtils.ByteBufferCoder.of()));
+                new CoderTypeInformation<>(
+                    FlinkKeyUtils.ByteBufferCoder.of(),
+                    PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
 
     RemoteBundle bundle = Mockito.mock(RemoteBundle.class);
     when(bundle.getInputReceivers())
@@ -1060,7 +1094,11 @@ public class ExecutableStageDoFnOperatorTest {
 
     DoFnOperator.MultiOutputOutputManagerFactory<Integer> outputManagerFactory =
         new DoFnOperator.MultiOutputOutputManagerFactory(
-            mainOutput, tagsToOutputTags, tagsToCoders, tagsToIds);
+            mainOutput,
+            tagsToOutputTags,
+            tagsToCoders,
+            tagsToIds,
+            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
 
     FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
 
@@ -1146,7 +1184,7 @@ public class ExecutableStageDoFnOperatorTest {
             createOutputMap(mainOutput, additionalOutputs),
             windowingStrategy,
             keyCoder,
-            keyCoder != null ? new KvToByteBufferKeySelector<>(keyCoder) : null);
+            keyCoder != null ? new KvToByteBufferKeySelector<>(keyCoder, null) : null);
 
     Whitebox.setInternalState(operator, "stateRequestHandler", stateRequestHandler);
     return operator;

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperatorTest.java
@@ -39,7 +39,6 @@ import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderRegistry;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.VarLongCoder;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.Sum;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
@@ -216,11 +215,11 @@ public class WindowDoFnOperatorTest {
         new MultiOutputOutputManagerFactory<>(
             outputTag,
             outputCoder,
-            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
+            new SerializablePipelineOptions(FlinkPipelineOptions.defaults())),
         windowingStrategy,
         emptyMap(),
         emptyList(),
-        PipelineOptionsFactory.as(FlinkPipelineOptions.class),
+        FlinkPipelineOptions.defaults(),
         VarLongCoder.of(),
         new WorkItemKeySelector(VarLongCoder.of()));
   }

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperatorTest.java
@@ -32,6 +32,7 @@ import java.io.ByteArrayOutputStream;
 import java.nio.ByteBuffer;
 import org.apache.beam.runners.core.KeyedWorkItem;
 import org.apache.beam.runners.core.SystemReduceFn;
+import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
 import org.apache.beam.runners.flink.FlinkPipelineOptions;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.DoFnOperator.MultiOutputOutputManagerFactory;
 import org.apache.beam.sdk.coders.Coder;
@@ -212,7 +213,10 @@ public class WindowDoFnOperatorTest {
         (Coder) inputCoder,
         outputTag,
         emptyList(),
-        new MultiOutputOutputManagerFactory<>(outputTag, outputCoder),
+        new MultiOutputOutputManagerFactory<>(
+            outputTag,
+            outputCoder,
+            new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class))),
         windowingStrategy,
         emptyMap(),
         emptyList(),

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapperTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapperTest.java
@@ -125,7 +125,7 @@ public class UnboundedSourceWrapperTest {
     @Test(timeout = 30_000)
     public void testValueEmission() throws Exception {
       final int numElementsPerShard = 20;
-      FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+      FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
 
       final long[] numElementsReceived = {0L};
       final int[] numWatermarksReceived = {0};
@@ -608,7 +608,7 @@ public class UnboundedSourceWrapperTest {
 
     private static void testSourceDoesNotShutdown(boolean shouldHaveReaders) throws Exception {
       final int parallelism = 2;
-      FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+      FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
       // Make sure we do not shut down
       options.setShutdownSourcesAfterIdleMs(Long.MAX_VALUE);
 
@@ -696,7 +696,7 @@ public class UnboundedSourceWrapperTest {
           new UnboundedReadFromBoundedSource.BoundedToUnboundedSourceAdapter<>(
               CountingSource.upTo(1000));
 
-      FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+      FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
 
       UnboundedSourceWrapper<
               Long, UnboundedReadFromBoundedSource.BoundedToUnboundedSourceAdapter.Checkpoint<Long>>
@@ -763,7 +763,7 @@ public class UnboundedSourceWrapperTest {
 
     @Test
     public void testAccumulatorRegistrationOnOperatorClose() throws Exception {
-      FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+      FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
 
       TestCountingSource source = new TestCountingSource(20).withoutSplitting();
 
@@ -800,7 +800,7 @@ public class UnboundedSourceWrapperTest {
           new IdlingUnboundedSource<>(
               Arrays.asList("first", "second", "third"), StringUtf8Coder.of());
 
-      FlinkPipelineOptions options = PipelineOptionsFactory.as(FlinkPipelineOptions.class);
+      FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
       options.setShutdownSourcesAfterIdleMs(0L);
       options.setParallelism(4);
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/BufferingDoFnRunnerTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/BufferingDoFnRunnerTest.java
@@ -23,8 +23,11 @@ import static org.hamcrest.Matchers.is;
 import java.util.Collections;
 import java.util.List;
 import org.apache.beam.runners.core.DoFnRunner;
+import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
+import org.apache.beam.runners.flink.FlinkPipelineOptions;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
@@ -166,6 +169,7 @@ public class BufferingDoFnRunnerTest {
         WindowedValue.getFullCoder(VarIntCoder.of(), GlobalWindow.Coder.INSTANCE),
         operatorStateBackend,
         null,
-        concurrentCheckpoints);
+        concurrentCheckpoints,
+        new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
   }
 }

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/BufferingDoFnRunnerTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/stableinput/BufferingDoFnRunnerTest.java
@@ -27,7 +27,6 @@ import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
 import org.apache.beam.runners.flink.FlinkPipelineOptions;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VarIntCoder;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
@@ -170,6 +169,6 @@ public class BufferingDoFnRunnerTest {
         operatorStateBackend,
         null,
         concurrentCheckpoints,
-        new SerializablePipelineOptions(PipelineOptionsFactory.as(FlinkPipelineOptions.class)));
+        new SerializablePipelineOptions(FlinkPipelineOptions.defaults()));
   }
 }

--- a/website/www/site/layouts/shortcodes/flink_java_pipeline_options.html
+++ b/website/www/site/layouts/shortcodes/flink_java_pipeline_options.html
@@ -73,6 +73,11 @@ Should be called before running the tests.
   <td>Default: <code>true</code></td>
 </tr>
 <tr>
+  <td><code>fasterCopy</code></td>
+  <td>Remove unneeded deep copy between operators. See https://issues.apache.org/jira/browse/BEAM-11146</td>
+  <td>Default: <code>false</code></td>
+</tr>
+<tr>
   <td><code>filesToStage</code></td>
   <td>Jar-Files to send to all workers and put on the classpath. The default value is all files from the classpath.</td>
   <td></td>

--- a/website/www/site/layouts/shortcodes/flink_python_pipeline_options.html
+++ b/website/www/site/layouts/shortcodes/flink_python_pipeline_options.html
@@ -73,6 +73,11 @@ Should be called before running the tests.
   <td>Default: <code>true</code></td>
 </tr>
 <tr>
+  <td><code>faster_copy</code></td>
+  <td>Remove unneeded deep copy between operators. See https://issues.apache.org/jira/browse/BEAM-11146</td>
+  <td>Default: <code>false</code></td>
+</tr>
+<tr>
   <td><code>files_to_stage</code></td>
   <td>Jar-Files to send to all workers and put on the classpath. The default value is all files from the classpath.</td>
   <td></td>


### PR DESCRIPTION
The `fasterCopy` option, removes an unnecessary deep copy in the Flink runner between each operator. This should lead to improved performance in all cases. The Jira issue has more info.

This is my first contribution to Beam and I just did what I thought was right. The biggest issue here was to get pipeline options into the `CoderTypeSerializer`. I tried my best, but welcome any feedback!

One thing I am not quite sure how to do is test this. Should all flink tests be ran twice with this option toggled? All tests pass with the change in `CoderTypeSerializer` applied, but I've not tried all of them with the flag enabled. How would one go about this?

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
