### PR TITLE
[BEAM-11075] Go SDK's synthetic source supports hot keys generation

### DIFF
--- a/sdks/go/pkg/beam/io/synthetic/source.go
+++ b/sdks/go/pkg/beam/io/synthetic/source.go
@@ -128,14 +128,15 @@ func (fn *sourceFn) Setup() {
 // tracker received. Each element is a random byte slice key and value, in the
 // form of KV<[]byte, []byte>.
 func (fn *sourceFn) ProcessElement(rt *sdf.LockRTracker, config SourceConfig, emit func([]byte, []byte)) error {
+	generator := rand.New(rand.NewSource(0))
 	for i := rt.GetRestriction().(offsetrange.Restriction).Start; rt.TryClaim(i) == true; i++ {
 		key := make([]byte, config.KeySize)
 		val := make([]byte, config.ValueSize)
-		generator := rand.New(rand.NewSource(i))
+		generator.Seed(i)
 		randomSample := generator.Float64()
 		if randomSample < config.HotKeyFraction {
-			generatorHot := rand.New(rand.NewSource(i % int64(config.NumHotKeys)))
-			if _, err := generatorHot.Read(key); err != nil {
+			generator.Seed(i % int64(config.NumHotKeys))
+			if _, err := generator.Read(key); err != nil {
 				return err
 			}
 		} else {

--- a/sdks/go/pkg/beam/io/synthetic/source.go
+++ b/sdks/go/pkg/beam/io/synthetic/source.go
@@ -26,12 +26,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"github.com/apache/beam/sdks/go/pkg/beam"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/sdf"
-	"github.com/apache/beam/sdks/go/pkg/beam/io/rtrackers/offsetrange"
 	"math/rand"
 	"reflect"
 	"time"
+
+	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/sdf"
+	"github.com/apache/beam/sdks/go/pkg/beam/io/rtrackers/offsetrange"
 )
 
 func init() {
@@ -130,17 +131,15 @@ func (fn *sourceFn) ProcessElement(rt *sdf.LockRTracker, config SourceConfig, em
 	for i := rt.GetRestriction().(offsetrange.Restriction).Start; rt.TryClaim(i) == true; i++ {
 		key := make([]byte, config.KeySize)
 		val := make([]byte, config.ValueSize)
-		generator := sourceFn{}
-		generator.rng = rand.New(rand.NewSource(i))
-		randomSample := generator.rng.Float64()
+		generator := rand.New(rand.NewSource(i))
+		randomSample := generator.Float64()
 		if randomSample < config.HotKeyFraction {
-			generatorHot := sourceFn{}
-			generatorHot.rng = rand.New(rand.NewSource(i % int64(config.NumHotKeys)))
-			if _, err := generatorHot.rng.Read(key); err != nil {
+			generatorHot := rand.New(rand.NewSource(i % int64(config.NumHotKeys)))
+			if _, err := generatorHot.Read(key); err != nil {
 				return err
 			}
 		} else {
-			if _, err := generator.rng.Read(key); err != nil {
+			if _, err := fn.rng.Read(key); err != nil {
 				return err
 			}
 		}

--- a/sdks/go/pkg/beam/io/synthetic/source_test.go
+++ b/sdks/go/pkg/beam/io/synthetic/source_test.go
@@ -18,7 +18,6 @@ package synthetic
 import (
 	"encoding/hex"
 	"fmt"
-	"math"
 	"testing"
 )
 
@@ -168,15 +167,12 @@ func TestSourceConfig_BuildFromJSON(t *testing.T) {
 // for a synthetic source works correctly.
 func TestSourceConfigBuilder_NumHotKeys(t *testing.T) {
 	tests := []struct {
-		elms           int
-		hotKeys        int
-		hotKeyFraction float64
+		elms    int
+		hotKeys int
 	}{
-		{elms: 15, hotKeys: 2, hotKeyFraction: 1.0},
-		{elms: 30, hotKeys: 10, hotKeyFraction: 1.0},
-		{elms: 50, hotKeys: 25, hotKeyFraction: 1.0},
-		// {elms: 30, hotKeys: 10, hotKeyFraction: 0.5}, tests for hotKeyFraction < 1.0 could be Flaky
-		// {elms: 50, hotKeys: 25, hotKeyFraction: 0.75},
+		{elms: 15, hotKeys: 2},
+		{elms: 30, hotKeys: 10},
+		{elms: 50, hotKeys: 25},
 	}
 	for _, test := range tests {
 		test := test
@@ -184,7 +180,7 @@ func TestSourceConfigBuilder_NumHotKeys(t *testing.T) {
 			dfn := sourceFn{}
 			cfg := DefaultSourceConfig()
 			cfg.NumElements(test.elms)
-			cfg.HotKeyFraction(test.hotKeyFraction)
+			cfg.HotKeyFraction(1.0)
 			cfg.NumHotKeys(test.hotKeys)
 
 			keys, _, err := simulateSourceFn(t, &dfn, cfg.Build())
@@ -212,10 +208,9 @@ func TestSourceConfigBuilder_NumHotKeys(t *testing.T) {
 					numOfHotKeys, test.elms)
 			}
 
-			want := int(math.Floor(float64(test.hotKeys) * test.hotKeyFraction))
-			if numOfHotKeys != want {
+			if numOfHotKeys != test.hotKeys {
 				t.Errorf("SourceFn emitted wrong number of hot keys: got: %v, want: %v",
-					numOfHotKeys, want)
+					numOfHotKeys, test.hotKeys)
 			}
 		})
 	}

--- a/sdks/go/pkg/beam/io/synthetic/source_test.go
+++ b/sdks/go/pkg/beam/io/synthetic/source_test.go
@@ -195,17 +195,10 @@ func TestSourceConfigBuilder_NumHotKeys(t *testing.T) {
 			}
 
 			numOfHotKeys := 0
-			numOfAllKeys := 0
 			for _, element := range m {
-				numOfAllKeys += element
 				if element > 1 {
 					numOfHotKeys += 1
 				}
-			}
-
-			if numOfAllKeys != test.elms {
-				t.Errorf("SourceFn emitted wrong number of outputs: got: %v, want: %v",
-					numOfHotKeys, test.elms)
 			}
 
 			if numOfHotKeys != test.hotKeys {

--- a/sdks/go/pkg/beam/io/synthetic/source_test.go
+++ b/sdks/go/pkg/beam/io/synthetic/source_test.go
@@ -175,8 +175,8 @@ func TestSourceConfigBuilder_NumHotKeys(t *testing.T) {
 		{elms: 15, hotKeys: 2, hotKeyFraction: 1.0},
 		{elms: 30, hotKeys: 10, hotKeyFraction: 1.0},
 		{elms: 50, hotKeys: 25, hotKeyFraction: 1.0},
-		{elms: 30, hotKeys: 10, hotKeyFraction: 0.5},
-		{elms: 50, hotKeys: 25, hotKeyFraction: 0.75},
+		// {elms: 30, hotKeys: 10, hotKeyFraction: 0.5}, tests for hotKeyFraction < 1.0 could be Flaky
+		// {elms: 50, hotKeys: 25, hotKeyFraction: 0.75},
 	}
 	for _, test := range tests {
 		test := test

--- a/sdks/go/pkg/beam/io/synthetic/source_test.go
+++ b/sdks/go/pkg/beam/io/synthetic/source_test.go
@@ -16,7 +16,6 @@
 package synthetic
 
 import (
-	"bytes"
 	"encoding/hex"
 	"fmt"
 	"math"
@@ -194,16 +193,9 @@ func TestSourceConfigBuilder_NumHotKeys(t *testing.T) {
 			}
 
 			m := make(map[string]int)
-			for i := 0; i < len(keys); i++ {
-				tmp := keys[i]
-				keyHex := hex.EncodeToString(tmp)
-				m[keyHex] = 0
-				for j := 0; j < len(keys); j++ {
-					res := bytes.Compare(tmp, keys[j])
-					if res == 0 {
-						m[keyHex]++
-					}
-				}
+			for _, key := range keys {
+				encoded := hex.EncodeToString(key)
+				m[encoded]++
 			}
 
 			numOfHotKeys := 0


### PR DESCRIPTION
Add support for HotKeys and HotKeysFraction when generating Synthetic Source in Beam GO SDK
