### PR TITLE
[BEAM-10869] Remove unused PubSubSink with_attributes property

### DIFF
--- a/model/pipeline/src/main/proto/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/beam_runner_api.proto
@@ -688,10 +688,6 @@ message PubSubWritePayload {
 
   // Attribute that uniquely identify messages.
   string id_attribute = 3;
-
-  // If true, writes Pub/Sub payload as well as attributes. If false, reads only the payload.
-  // TODO(BEAM-10869): consider removing/deprecating this field when fixed.
-  bool with_attributes = 4;
 }
 
 // A coder, the binary format for serialization and deserialization of data in

--- a/sdks/python/apache_beam/io/gcp/pubsub.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub.py
@@ -251,7 +251,7 @@ class _WriteStringsToPubSub(PTransform):
     self.timestamp_attribute = None
     self.project, self.topic_name = parse_topic(topic)
     self._sink = _PubSubSink(
-        topic, id_label=None, with_attributes=False, timestamp_attribute=None)
+        topic, id_label=None, timestamp_attribute=None)
 
   def expand(self, pcoll):
     pcoll = pcoll | 'EncodeString' >> Map(lambda s: s.encode('utf-8'))
@@ -293,7 +293,7 @@ class WriteToPubSub(PTransform):
     self.project, self.topic_name = parse_topic(topic)
     self.full_topic = topic
     self._sink = _PubSubSink(
-        topic, id_label, with_attributes, timestamp_attribute)
+        topic, id_label, timestamp_attribute)
 
   @staticmethod
   def message_to_proto_str(element):
@@ -437,14 +437,11 @@ class _PubSubSink(dataflow_io.NativeSink):
   def __init__(self,
                topic,  # type: str
                id_label,  # type: Optional[str]
-               with_attributes,  # type: bool
                timestamp_attribute  # type: Optional[str]
                ):
     self.coder = coders.BytesCoder()
     self.full_topic = topic
     self.id_label = id_label
-    #TODO(BEAM-10869): Remove with_attributes since we will never look at it.
-    self.with_attributes = with_attributes
     self.timestamp_attribute = timestamp_attribute
 
     self.project, self.topic_name = parse_topic(topic)

--- a/sdks/python/apache_beam/io/gcp/pubsub.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub.py
@@ -145,13 +145,14 @@ class ReadFromPubSub(PTransform):
 
   # Implementation note: This ``PTransform`` is overridden by Directrunner.
 
-  def __init__(self,
-               topic=None,  # type: Optional[str]
-               subscription=None,  # type: Optional[str]
-               id_label=None,  # type: Optional[str]
-               with_attributes=False,  # type: bool
-               timestamp_attribute=None  # type: Optional[str]
-              ):
+  def __init__(
+      self,
+      topic=None,  # type: Optional[str]
+      subscription=None,  # type: Optional[str]
+      id_label=None,  # type: Optional[str]
+      with_attributes=False,  # type: bool
+      timestamp_attribute=None  # type: Optional[str]
+  ):
     # type: (...) -> None
 
     """Initializes ``ReadFromPubSub``.
@@ -250,8 +251,7 @@ class _WriteStringsToPubSub(PTransform):
     self.id_label = None
     self.timestamp_attribute = None
     self.project, self.topic_name = parse_topic(topic)
-    self._sink = _PubSubSink(
-        topic, id_label=None, timestamp_attribute=None)
+    self._sink = _PubSubSink(topic, id_label=None, timestamp_attribute=None)
 
   def expand(self, pcoll):
     pcoll = pcoll | 'EncodeString' >> Map(lambda s: s.encode('utf-8'))
@@ -264,12 +264,13 @@ class WriteToPubSub(PTransform):
 
   # Implementation note: This ``PTransform`` is overridden by Directrunner.
 
-  def __init__(self,
-               topic,  # type: str
-               with_attributes=False,  # type: bool
-               id_label=None,  # type: Optional[str]
-               timestamp_attribute=None  # type: Optional[str]
-              ):
+  def __init__(
+      self,
+      topic,  # type: str
+      with_attributes=False,  # type: bool
+      id_label=None,  # type: Optional[str]
+      timestamp_attribute=None  # type: Optional[str]
+  ):
     # type: (...) -> None
 
     """Initializes ``WriteToPubSub``.
@@ -292,8 +293,7 @@ class WriteToPubSub(PTransform):
     self.timestamp_attribute = timestamp_attribute
     self.project, self.topic_name = parse_topic(topic)
     self.full_topic = topic
-    self._sink = _PubSubSink(
-        topic, id_label, timestamp_attribute)
+    self._sink = _PubSubSink(topic, id_label, timestamp_attribute)
 
   @staticmethod
   def message_to_proto_str(element):
@@ -373,14 +373,14 @@ class _PubSubSource(dataflow_io.NativeSource):
     with_attributes: If False, will fetch just message data. Otherwise,
       fetches ``PubsubMessage`` protobufs.
   """
-
-  def __init__(self,
-               topic=None,  # type: Optional[str]
-               subscription=None,  # type: Optional[str]
-               id_label=None,  # type: Optional[str]
-               with_attributes=False,  # type: bool
-               timestamp_attribute=None  # type: Optional[str]
-              ):
+  def __init__(
+      self,
+      topic=None,  # type: Optional[str]
+      subscription=None,  # type: Optional[str]
+      id_label=None,  # type: Optional[str]
+      with_attributes=False,  # type: bool
+      timestamp_attribute=None  # type: Optional[str]
+  ):
     self.coder = coders.BytesCoder()
     self.full_topic = topic
     self.full_subscription = subscription
@@ -433,12 +433,12 @@ class _PubSubSink(dataflow_io.NativeSink):
 
   This ``NativeSource`` is overridden by a native Pubsub implementation.
   """
-
-  def __init__(self,
-               topic,  # type: str
-               id_label,  # type: Optional[str]
-               timestamp_attribute  # type: Optional[str]
-               ):
+  def __init__(
+      self,
+      topic,  # type: str
+      id_label,  # type: Optional[str]
+      timestamp_attribute  # type: Optional[str]
+  ):
     self.coder = coders.BytesCoder()
     self.full_topic = topic
     self.id_label = id_label

--- a/sdks/python/apache_beam/io/gcp/pubsub_test.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub_test.py
@@ -781,7 +781,6 @@ class TestWriteToPubSub(unittest.TestCase):
     sink = _PubSubSink(
         topic='projects/fakeprj/topics/a_topic',
         id_label=None,
-        with_attributes=True,
         # We expect encoded PubSub write transform to always return attributes.
         timestamp_attribute=None)
     transform = Write(sink)
@@ -798,7 +797,6 @@ class TestWriteToPubSub(unittest.TestCase):
 
     self.assertEqual(
         'projects/fakeprj/topics/a_topic', pubsub_write_payload.topic)
-    self.assertTrue(pubsub_write_payload.with_attributes)
 
     proto_transform = beam_runner_api_pb2.PTransform(
         unique_name="dummy_label", spec=proto_transform_spec)
@@ -807,7 +805,6 @@ class TestWriteToPubSub(unittest.TestCase):
         proto_transform, pubsub_write_payload, None)
     self.assertTrue(isinstance(transform_from_proto, Write))
     self.assertTrue(isinstance(transform_from_proto.sink, _PubSubSink))
-    self.assertTrue(transform_from_proto.sink.with_attributes)
     self.assertEqual(
         'projects/fakeprj/topics/a_topic', transform_from_proto.sink.full_topic)
 
@@ -816,7 +813,6 @@ class TestWriteToPubSub(unittest.TestCase):
     sink = _PubSubSink(
         topic='projects/fakeprj/topics/a_topic',
         id_label=None,
-        with_attributes=True,
         # We expect encoded PubSub write transform to always return attributes.
         timestamp_attribute=None)
     transform = Write(sink)
@@ -837,7 +833,6 @@ class TestWriteToPubSub(unittest.TestCase):
 
     self.assertTrue(isinstance(transform_from_proto, Write))
     self.assertTrue(isinstance(transform_from_proto.sink, _PubSubSink))
-    self.assertTrue(transform_from_proto.sink.with_attributes)
     self.assertIsNone(transform_from_proto.sink.id_label)
     self.assertIsNone(transform_from_proto.sink.timestamp_attribute)
 

--- a/sdks/python/apache_beam/io/iobase.py
+++ b/sdks/python/apache_beam/io/iobase.py
@@ -1030,8 +1030,7 @@ class Write(ptransform.PTransform):
       payload = beam_runner_api_pb2.PubSubWritePayload(
           topic=self.sink.full_topic,
           id_attribute=self.sink.id_label,
-          timestamp_attribute=self.sink.timestamp_attribute,
-          with_attributes=self.sink.with_attributes)
+          timestamp_attribute=self.sink.timestamp_attribute)
       return (common_urns.composites.PUBSUB_WRITE.urn, payload)
     else:
       return super(Write, self).to_runner_api_parameter(context)
@@ -1052,7 +1051,6 @@ class Write(ptransform.PTransform):
     sink = _PubSubSink(
         topic=payload.topic or None,
         id_label=payload.id_attribute or None,
-        with_attributes=payload.with_attributes,
         timestamp_attribute=payload.timestamp_attribute or None)
     return Write(sink)
 


### PR DESCRIPTION
**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
