### PR TITLE
[BEAM-11188] Add wrappers to Go Xlang examples, and adjust front-end.

### DIFF
--- a/sdks/go/examples/xlang/cogroup_by/cogroup_by.go
+++ b/sdks/go/examples/xlang/cogroup_by/cogroup_by.go
@@ -30,9 +30,8 @@ import (
 	"reflect"
 	"sort"
 
+	"github.com/apache/beam/sdks/go/examples/xlang"
 	"github.com/apache/beam/sdks/go/pkg/beam"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
 	"github.com/apache/beam/sdks/go/pkg/beam/testing/passert"
 	"github.com/apache/beam/sdks/go/pkg/beam/x/beamx"
 
@@ -93,10 +92,7 @@ func main() {
 	// Using the cross-language transform
 	col1 := beam.ParDo(s, getKV, beam.Create(s, KV{X: 0, Y: "1"}, KV{X: 0, Y: "2"}, KV{X: 1, Y: "3"}))
 	col2 := beam.ParDo(s, getKV, beam.Create(s, KV{X: 0, Y: "4"}, KV{X: 1, Y: "5"}, KV{X: 1, Y: "6"}))
-	namedInputs := map[string]beam.PCollection{"col1": col1, "col2": col2}
-	outputType := typex.NewCoGBK(typex.New(reflectx.Int64), typex.New(reflectx.String))
-	c := beam.CrossLanguageWithSink(s, "beam:transforms:xlang:test:cgbk", nil, *expansionAddr, namedInputs, outputType)
-
+	c := xlang.CoGroupByKey(s, *expansionAddr, col1, col2)
 	sums := beam.ParDo(s, sumCounts, c)
 	formatted := beam.ParDo(s, formatFn, sums)
 	passert.Equals(s, formatted, "0:[1 2 4]", "1:[3 5 6]")

--- a/sdks/go/examples/xlang/combine/combine.go
+++ b/sdks/go/examples/xlang/combine/combine.go
@@ -29,9 +29,8 @@ import (
 	"log"
 	"reflect"
 
+	"github.com/apache/beam/sdks/go/examples/xlang"
 	"github.com/apache/beam/sdks/go/pkg/beam"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
 	"github.com/apache/beam/sdks/go/pkg/beam/testing/passert"
 	"github.com/apache/beam/sdks/go/pkg/beam/x/beamx"
 
@@ -89,8 +88,7 @@ func main() {
 	// Using the cross-language transform
 	kvs := beam.Create(s, KV{X: "a", Y: 1}, KV{X: "a", Y: 2}, KV{X: "b", Y: 3})
 	ins := beam.ParDo(s, getKV, kvs)
-	outputType := typex.NewKV(typex.New(reflectx.String), typex.New(reflectx.Int64))
-	c := beam.CrossLanguageWithSingleInputOutput(s, "beam:transforms:xlang:test:compk", nil, *expansionAddr, ins, outputType)
+	c := xlang.CombinePerKey(s, *expansionAddr, ins)
 
 	formatted := beam.ParDo(s, formatFn, c)
 	passert.Equals(s, formatted, "a:3", "b:3")

--- a/sdks/go/examples/xlang/combine_globally/combine_globally.go
+++ b/sdks/go/examples/xlang/combine_globally/combine_globally.go
@@ -28,9 +28,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/apache/beam/sdks/go/examples/xlang"
 	"github.com/apache/beam/sdks/go/pkg/beam"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
 	"github.com/apache/beam/sdks/go/pkg/beam/testing/passert"
 	"github.com/apache/beam/sdks/go/pkg/beam/x/beamx"
 
@@ -67,8 +66,7 @@ func main() {
 	in := beam.CreateList(s, []int64{1, 2, 3})
 
 	// Using the cross-language transform
-	outputType := typex.New(reflectx.Int64)
-	c := beam.CrossLanguageWithSingleInputOutput(s, "beam:transforms:xlang:test:comgl", nil, *expansionAddr, in, outputType)
+	c := xlang.CombineGlobally(s, *expansionAddr, in)
 
 	formatted := beam.ParDo(s, formatFn, c)
 	passert.Equals(s, formatted, "6")

--- a/sdks/go/examples/xlang/flatten/flatten.go
+++ b/sdks/go/examples/xlang/flatten/flatten.go
@@ -28,9 +28,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/apache/beam/sdks/go/examples/xlang"
 	"github.com/apache/beam/sdks/go/pkg/beam"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
 	"github.com/apache/beam/sdks/go/pkg/beam/testing/passert"
 	"github.com/apache/beam/sdks/go/pkg/beam/x/beamx"
 
@@ -68,9 +67,7 @@ func main() {
 	col2 := beam.CreateList(s, []int64{4, 5, 6})
 
 	// Using the cross-language transform
-	namedInputs := map[string]beam.PCollection{"col1": col1, "col2": col2}
-	outputType := typex.New(reflectx.Int64)
-	c := beam.CrossLanguageWithSink(s, "beam:transforms:xlang:test:flatten", nil, *expansionAddr, namedInputs, outputType)
+	c := xlang.Flatten(s, *expansionAddr, col1, col2)
 
 	formatted := beam.ParDo(s, formatFn, c)
 	passert.Equals(s, formatted, "1", "2", "3", "4", "5", "6")

--- a/sdks/go/examples/xlang/group_by/group_by.go
+++ b/sdks/go/examples/xlang/group_by/group_by.go
@@ -30,9 +30,8 @@ import (
 	"reflect"
 	"sort"
 
+	"github.com/apache/beam/sdks/go/examples/xlang"
 	"github.com/apache/beam/sdks/go/pkg/beam"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
 	"github.com/apache/beam/sdks/go/pkg/beam/testing/passert"
 	"github.com/apache/beam/sdks/go/pkg/beam/x/beamx"
 
@@ -91,11 +90,10 @@ func main() {
 
 	// Using the cross-language transform
 	kvs := beam.Create(s, KV{X: "0", Y: 1}, KV{X: "0", Y: 2}, KV{X: "1", Y: 3})
-	ins := beam.ParDo(s, getKV, kvs)
-	outputType := typex.NewCoGBK(typex.New(reflectx.String), typex.New(reflectx.Int64))
-	outs := beam.CrossLanguageWithSingleInputOutput(s, "beam:transforms:xlang:test:gbk", nil, *expansionAddr, ins, outputType)
+	in := beam.ParDo(s, getKV, kvs)
+	out := xlang.GroupByKey(s, *expansionAddr, in)
 
-	vals := beam.ParDo(s, collectValues, outs)
+	vals := beam.ParDo(s, collectValues, out)
 	formatted := beam.ParDo(s, formatFn, vals)
 	passert.Equals(s, formatted, "0:[1 2]", "1:[3]")
 

--- a/sdks/go/examples/xlang/multi_input_output/multi.go
+++ b/sdks/go/examples/xlang/multi_input_output/multi.go
@@ -28,9 +28,8 @@ import (
 	"flag"
 	"log"
 
+	"github.com/apache/beam/sdks/go/examples/xlang"
 	"github.com/apache/beam/sdks/go/pkg/beam"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
 	"github.com/apache/beam/sdks/go/pkg/beam/testing/passert"
 	"github.com/apache/beam/sdks/go/pkg/beam/x/beamx"
 
@@ -58,15 +57,12 @@ func main() {
 	main1 := beam.CreateList(s, []string{"a", "bb"})
 	main2 := beam.CreateList(s, []string{"x", "yy", "zzz"})
 	side := beam.CreateList(s, []string{"s"})
-	namedInputs := map[string]beam.PCollection{"main1": main1, "main2": main2, "side": side}
 
 	// Using the cross-language transform
-	outputType := typex.New(reflectx.String)
-	namedOutputs := map[string]typex.FullType{"main": outputType, "side": outputType}
-	multi := beam.CrossLanguage(s, "beam:transforms:xlang:test:multi", nil, *expansionAddr, namedInputs, namedOutputs)
+	mainOut, sideOut := xlang.Multi(s, *expansionAddr, main1, main2, side)
 
-	passert.Equals(s, multi["main"], "as", "bbs", "xs", "yys", "zzzs")
-	passert.Equals(s, multi["side"], "ss")
+	passert.Equals(s, mainOut, "as", "bbs", "xs", "yys", "zzzs")
+	passert.Equals(s, sideOut, "ss")
 
 	if err := beamx.Run(context.Background(), p); err != nil {
 		log.Fatalf("Failed to execute job: %v", err)

--- a/sdks/go/examples/xlang/partition/partition.go
+++ b/sdks/go/examples/xlang/partition/partition.go
@@ -28,9 +28,8 @@ import (
 	"fmt"
 	"log"
 
+	"github.com/apache/beam/sdks/go/examples/xlang"
 	"github.com/apache/beam/sdks/go/pkg/beam"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
 	"github.com/apache/beam/sdks/go/pkg/beam/testing/passert"
 	"github.com/apache/beam/sdks/go/pkg/beam/x/beamx"
 
@@ -67,12 +66,9 @@ func main() {
 	col := beam.CreateList(s, []int64{1, 2, 3, 4, 5, 6})
 
 	// Using the cross-language transform
-	outputType := typex.New(reflectx.Int64)
-	namedOutputs := map[string]typex.FullType{"0": outputType, "1": outputType}
-	c := beam.CrossLanguageWithSource(s, "beam:transforms:xlang:test:partition", nil, *expansionAddr, col, namedOutputs)
-
-	formatted0 := beam.ParDo(s, formatFn, c["0"])
-	formatted1 := beam.ParDo(s, formatFn, c["1"])
+	out0, out1 := xlang.Partition(s, *expansionAddr, col)
+	formatted0 := beam.ParDo(s, formatFn, out0)
+	formatted1 := beam.ParDo(s, formatFn, out1)
 
 	passert.Equals(s, formatted0, "2", "4", "6")
 	passert.Equals(s, formatted1, "1", "3", "5")

--- a/sdks/go/examples/xlang/transforms.go
+++ b/sdks/go/examples/xlang/transforms.go
@@ -1,0 +1,85 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package xlang contains functionality for testing cross-language transforms.
+package xlang
+
+import (
+	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/graph"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
+)
+
+func CoGroupByKey(s beam.Scope, addr string, col1, col2 beam.PCollection) beam.PCollection {
+	s = s.Scope("XLangTest.CoGroupByKey")
+	namedInputs := map[string]beam.PCollection{"col1": col1, "col2": col2}
+	outT := beam.UnnamedOutput(typex.NewCoGBK(typex.New(reflectx.Int64), typex.New(reflectx.String)))
+	outs := beam.CrossLanguage(s, "beam:transforms:xlang:test:cgbk", nil, addr, namedInputs, outT)
+	return outs[graph.UnnamedOutputTag]
+}
+
+func CombinePerKey(s beam.Scope, addr string, col beam.PCollection) beam.PCollection {
+	s = s.Scope("XLangTest.CombinePerKey")
+	outT := beam.UnnamedOutput(typex.NewKV(typex.New(reflectx.String), typex.New(reflectx.Int64)))
+	outs := beam.CrossLanguage(s, "beam:transforms:xlang:test:compk", nil, addr, beam.UnnamedInput(col), outT)
+	return outs[graph.UnnamedOutputTag]
+}
+
+func CombineGlobally(s beam.Scope, addr string, col beam.PCollection) beam.PCollection {
+	s = s.Scope("XLangTest.CombineGlobally")
+	outT := beam.UnnamedOutput(typex.New(reflectx.Int64))
+	outs := beam.CrossLanguage(s, "beam:transforms:xlang:test:comgl", nil, addr, beam.UnnamedInput(col), outT)
+	return outs[graph.UnnamedOutputTag]
+}
+
+func Flatten(s beam.Scope, addr string, col1, col2 beam.PCollection) beam.PCollection {
+	s = s.Scope("XLangTest.Flatten")
+	namedInputs := map[string]beam.PCollection{"col1": col1, "col2": col2}
+	outT := beam.UnnamedOutput(typex.New(reflectx.Int64))
+	outs := beam.CrossLanguage(s, "beam:transforms:xlang:test:flatten", nil, addr, namedInputs, outT)
+	return outs[graph.UnnamedOutputTag]
+}
+
+func GroupByKey(s beam.Scope, addr string, col beam.PCollection) beam.PCollection {
+	s = s.Scope("XLangTest.GroupByKey")
+	outT := beam.UnnamedOutput(typex.NewCoGBK(typex.New(reflectx.String), typex.New(reflectx.Int64)))
+	outs := beam.CrossLanguage(s, "beam:transforms:xlang:test:gbk", nil, addr, beam.UnnamedInput(col), outT)
+	return outs[graph.UnnamedOutputTag]
+}
+
+func Multi(s beam.Scope, addr string, main1, main2, side beam.PCollection) (mainOut, sideOut beam.PCollection) {
+	s = s.Scope("XLangTest.Multi")
+	namedInputs := map[string]beam.PCollection{"main1": main1, "main2": main2, "side": side}
+	outT := typex.New(reflectx.String)
+	namedOutputs := map[string]typex.FullType{"main": outT, "side": outT}
+	multi := beam.CrossLanguage(s, "beam:transforms:xlang:test:multi", nil, addr, namedInputs, namedOutputs)
+	return multi["main"], multi["side"]
+}
+
+func Partition(s beam.Scope, addr string, col beam.PCollection) (out0, out1 beam.PCollection) {
+	s = s.Scope("XLangTest.Partition")
+	outT := typex.New(reflectx.Int64)
+	namedOutputs := map[string]typex.FullType{"0": outT, "1": outT}
+	c := beam.CrossLanguage(s, "beam:transforms:xlang:test:partition", nil, addr, beam.UnnamedInput(col), namedOutputs)
+	return c["0"], c["1"]
+}
+
+func Count(s beam.Scope, addr string, col beam.PCollection) beam.PCollection {
+	s = s.Scope("XLang.Count")
+	outT := beam.UnnamedOutput(typex.NewKV(typex.New(reflectx.String), typex.New(reflectx.Int64)))
+	c := beam.CrossLanguage(s, "beam:transforms:xlang:count", nil, addr, beam.UnnamedInput(col), outT)
+	return c[graph.UnnamedOutputTag]
+}

--- a/sdks/go/examples/xlang/wordcount/wordcount.go
+++ b/sdks/go/examples/xlang/wordcount/wordcount.go
@@ -31,9 +31,8 @@ import (
 	"regexp"
 	"strings"
 
+	"github.com/apache/beam/sdks/go/examples/xlang"
 	"github.com/apache/beam/sdks/go/pkg/beam"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
-	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
 	"github.com/apache/beam/sdks/go/pkg/beam/testing/passert"
 	"github.com/apache/beam/sdks/go/pkg/beam/x/beamx"
 
@@ -89,8 +88,7 @@ func main() {
 	col := beam.ParDo(s, extractFn, lines)
 
 	// Using the cross-language transform
-	outputType := typex.NewKV(typex.New(reflectx.String), typex.New(reflectx.Int64))
-	counted := beam.CrossLanguageWithSingleInputOutput(s, "beam:transforms:xlang:count", nil, *expansionAddr, col, outputType)
+	counted := xlang.Count(s, *expansionAddr, col)
 
 	formatted := beam.ParDo(s, formatFn, counted)
 	passert.Equals(s, formatted, "a:4", "b:4", "c:5")

--- a/sdks/go/pkg/beam/core/graph/xlang.go
+++ b/sdks/go/pkg/beam/core/graph/xlang.go
@@ -24,15 +24,15 @@ import (
 )
 
 var (
-	// SourceInputTag is a constant random string used when an ExternalTransform
+	// UnnamedInputTag is a constant random string used when an ExternalTransform
 	// expects a single unnamed input. xlangx and graphx use it to explicitly
 	// bypass steps in pipeline construction meant for named inputs
-	SourceInputTag string
+	UnnamedInputTag string
 
-	// SinkOutputTag is a constant random string used when an ExternalTransform
+	// UnnamedOutputTag is a constant random string used when an ExternalTransform
 	// expects a single unnamed output. xlangx and graphx use it to explicitly
 	// bypass steps in pipeline construction meant for named outputs.
-	SinkOutputTag string
+	UnnamedOutputTag string
 
 	// NewNamespace is a utility random string generator used by the xlang to
 	// scope individual ExternalTransforms by a unique namespace
@@ -41,8 +41,8 @@ var (
 
 func init() {
 	NewNamespace = NewNamespaceGenerator(10)
-	SourceInputTag = NewNamespace()
-	SinkOutputTag = NewNamespace()
+	UnnamedInputTag = NewNamespace()
+	UnnamedOutputTag = NewNamespace()
 }
 
 // ExpandedTransform stores the expansion response associated to each

--- a/sdks/go/pkg/beam/core/runtime/graphx/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate.go
@@ -468,8 +468,8 @@ func (m *marshaller) expandCrossLanguage(namedEdge NamedEdge) (string, error) {
 		if _, err := m.addNode(n); err != nil {
 			return "", errors.Wrapf(err, "failed to expand cross language transform for edge: %v", namedEdge)
 		}
-		// Ignore tag if it is a dummy SourceInputTag
-		if tag == graph.SourceInputTag {
+		// Ignore tag if it is a dummy UnnamedInputTag
+		if tag == graph.UnnamedInputTag {
 			tag = fmt.Sprintf("i%v", edge.External.InputsMap[tag])
 		}
 		inputs[tag] = nodeID(n)

--- a/sdks/go/pkg/beam/core/runtime/xlangx/expand.go
+++ b/sdks/go/pkg/beam/core/runtime/xlangx/expand.go
@@ -20,15 +20,20 @@ import (
 
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 	jobpb "github.com/apache/beam/sdks/go/pkg/beam/model/jobmanagement_v1"
-	"github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
+	pipepb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 	"google.golang.org/grpc"
 )
 
-// Expand queries the expansion service to resolve the ExpansionRequest
+// Expand submits an external transform to be expanded by the expansion service.
+// The given transform should be the external transform, and the components are
+// any additional components necessary for the pipeline snippet.
+//
+// Users should generally call beam.CrossLanguage to access foreign transforms
+// rather than calling this function directly.
 func Expand(
 	ctx context.Context,
-	comps *pipeline_v1.Components,
-	transform *pipeline_v1.PTransform,
+	comps *pipepb.Components,
+	transform *pipepb.PTransform,
 	namespace string,
 	expansionAddr string) (*jobpb.ExpansionResponse, error) {
 	// Querying Expansion Service

--- a/sdks/go/pkg/beam/core/runtime/xlangx/expand.go
+++ b/sdks/go/pkg/beam/core/runtime/xlangx/expand.go
@@ -28,7 +28,7 @@ import (
 func Expand(
 	ctx context.Context,
 	comps *pipeline_v1.Components,
-	root *pipeline_v1.PTransform,
+	transform *pipeline_v1.PTransform,
 	namespace string,
 	expansionAddr string) (*jobpb.ExpansionResponse, error) {
 	// Querying Expansion Service
@@ -36,7 +36,7 @@ func Expand(
 	// Build expansion request proto.
 	req := &jobpb.ExpansionRequest{
 		Components: comps,
-		Transform:  root,
+		Transform:  transform,
 		Namespace:  namespace,
 	}
 

--- a/sdks/go/pkg/beam/core/runtime/xlangx/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/xlangx/translate.go
@@ -24,7 +24,7 @@ import (
 	pipepb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 )
 
-// MergeExpandedWithPipeline adds expanded components of all ExternalTransforms to the exisiting pipeline
+// MergeExpandedWithPipeline adds expanded components of all ExternalTransforms to the existing pipeline
 func MergeExpandedWithPipeline(edges []*graph.MultiEdge, p *pipepb.Pipeline) {
 	// Adding Expanded transforms to their counterparts in the Pipeline
 
@@ -91,7 +91,7 @@ func PurgeOutputInput(edges []*graph.MultiEdge, p *pipepb.Pipeline) {
 				}
 				expandedOutputs := transform.GetOutputs()
 				var pcolID string
-				if tag == graph.SinkOutputTag {
+				if tag == graph.UnnamedOutputTag {
 					for _, pcolID = range expandedOutputs {
 						// easiest way to access map with one entry (key,value)
 					}
@@ -131,10 +131,10 @@ func VerifyNamedOutputs(ext *graph.ExternalTransform) {
 
 	for tag := range ext.OutputsMap {
 		_, exists := expandedOutputs[tag]
-		if tag != graph.SinkOutputTag && !exists {
+		if tag != graph.UnnamedOutputTag && !exists {
 			panic(errors.Errorf("missing named output in expanded transform: %v is expected in %v", tag, expandedOutputs))
 		}
-		if tag == graph.SinkOutputTag && len(expandedOutputs) > 1 {
+		if tag == graph.UnnamedOutputTag && len(expandedOutputs) > 1 {
 			panic(errors.Errorf("mismatched number of unnamed outputs:\nreceived - %v\nexpected - 1", len(expandedOutputs)))
 		}
 	}
@@ -161,7 +161,7 @@ func ResolveOutputIsBounded(e *graph.MultiEdge, isBoundedUpdater func(*graph.Nod
 		isBounded := true
 
 		switch tag {
-		case graph.SinkOutputTag:
+		case graph.UnnamedOutputTag:
 			for _, id = range expandedOutputs {
 				// easiest way to access map with one entry (key,value)
 			}

--- a/sdks/go/pkg/beam/xlang.go
+++ b/sdks/go/pkg/beam/xlang.go
@@ -20,6 +20,7 @@ import (
 
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/pipelinex"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/xlangx"
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 )
@@ -89,24 +90,37 @@ func TryCrossLanguage(s Scope, ext *graph.ExternalTransform, ins []*graph.Inboun
 	// Build the ExpansionRequest
 
 	// Obtaining the components and transform proto representing this transform
+	// TODO(BEAM-11188): Move proto handling code into xlangx or graphx package.
 	p, err := graphx.Marshal([]*graph.MultiEdge{edge}, &graphx.Options{})
 	if err != nil {
 		return nil, errors.Wrapf(err, "unable to generate proto representation of %v", ext)
 	}
 
 	transforms := p.GetComponents().GetTransforms()
-	rootTransformID := p.GetRootTransformIds()[0] // External transform is the only root transform
-	rootTransform := transforms[rootTransformID]
+
+	// Transforms consist of only External transform and composites. Composites
+	// should be removed from proto before submitting expansion request.
+	extTransformID := p.GetRootTransformIds()[0]
+	extTransform := transforms[extTransformID]
+	for extTransform.UniqueName != "External" {
+		delete(transforms, extTransformID)
+		p, err := pipelinex.Normalize(p)
+		if err != nil {
+			return nil, err
+		}
+		extTransformID = p.GetRootTransformIds()[0]
+		extTransform = transforms[extTransformID]
+	}
 
 	// Scoping the ExternalTransform with respect to it's unique namespace, thus
 	// avoiding future collisions
-	xlangx.AddNamespace(rootTransform, p.GetComponents(), ext.Namespace)
+	xlangx.AddNamespace(extTransform, p.GetComponents(), ext.Namespace)
 
 	xlangx.AddFakeImpulses(p) // Inputs need to have sources
-	delete(transforms, rootTransformID)
+	delete(transforms, extTransformID)
 
 	// Querying the expansion service
-	res, err := xlangx.Expand(context.Background(), p.GetComponents(), rootTransform, ext.Namespace, ext.ExpansionAddr)
+	res, err := xlangx.Expand(context.Background(), p.GetComponents(), extTransform, ext.Namespace, ext.ExpansionAddr)
 	if err != nil {
 		return nil, err
 	}


### PR DESCRIPTION
Adds wrappers around each test xlang transform used in the examples, which show how xlang transforms are best implemented. Also adjusts the xlang fronte-end, specifically removing the misleadingly named Sink and Source versions of the methods, and adjusting the Input/Output tag naming to match and adding some helpers.

Note: Currently the CoGroupByKey, Partition, and MultiInputOutput examples are failing when run manually, however that seems unrelated to this PR. They fail identically if I run them in a clean repo. Still debugging that issue.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
