### PR TITLE
[BEAM-11159] Use GCP pubsub client for TestPubsub

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -410,6 +410,7 @@ class BeamModulePlugin implements Plugin<Project> {
     def classgraph_version = "4.8.65"
     def google_clients_version = "1.30.10"
     def google_cloud_bigdataoss_version = "2.1.5"
+    def google_cloud_pubsub_version = "1.108.6"
     def google_cloud_pubsublite_version = "0.4.1"
     def google_code_gson_version = "2.8.6"
     def google_oauth_clients_version = "1.31.0"
@@ -502,6 +503,7 @@ class BeamModulePlugin implements Plugin<Project> {
         google_cloud_datacatalog_v1beta1            : "com.google.cloud:google-cloud-datacatalog", // google_cloud_platform_libraries_bom sets version
         google_cloud_dataflow_java_proto_library_all: "com.google.cloud.dataflow:google-cloud-dataflow-java-proto-library-all:0.5.160304",
         google_cloud_datastore_v1_proto_client      : "com.google.cloud.datastore:datastore-v1-proto-client:1.6.3",
+        google_cloud_pubsub                         : "com.google.cloud:google-cloud-pubsub:$google_cloud_pubsub_version",
         google_cloud_pubsublite                     : "com.google.cloud:google-cloud-pubsublite:$google_cloud_pubsublite_version",
         // The GCP Libraries BOM dashboard shows the versions set by the BOM:
         // https://storage.googleapis.com/cloud-opensource-java-dashboard/com.google.cloud/libraries-bom/12.0.0/artifact_details.html

--- a/sdks/java/io/google-cloud-platform/build.gradle
+++ b/sdks/java/io/google-cloud-platform/build.gradle
@@ -55,6 +55,8 @@ dependencies {
   }
   compile library.java.google_cloud_datastore_v1_proto_client
   compile library.java.google_cloud_pubsublite
+  // GCP PubSub client is used in TestPubSub
+  compile library.java.google_cloud_pubsub
   compile library.java.google_cloud_spanner
   compile library.java.google_http_client
   compile library.java.google_http_client_jackson2

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubGrpcClient.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubGrpcClient.java
@@ -50,8 +50,6 @@ import io.grpc.netty.GrpcSslContexts;
 import io.grpc.netty.NegotiationType;
 import io.grpc.netty.NettyChannelBuilder;
 import java.io.IOException;
-import java.net.MalformedURLException;
-import java.net.URL;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -72,33 +70,9 @@ public class PubsubGrpcClient extends PubsubClient {
   private static final int DEFAULT_TIMEOUT_S = 60;
 
   private static ManagedChannel channelForRootUrl(String urlString) throws IOException {
-    URL url;
-    try {
-      url = new URL(urlString);
-    } catch (MalformedURLException e) {
-      throw new IllegalArgumentException(
-          String.format("Could not parse pubsub root url \"%s\"", urlString), e);
-    }
+    String format = PubsubOptions.targetForRootUrl(urlString);
 
-    int port = url.getPort();
-
-    if (port < 0) {
-      switch (url.getProtocol()) {
-        case "https":
-          port = 443;
-          break;
-        case "http":
-          port = 80;
-          break;
-        default:
-          throw new IllegalArgumentException(
-              String.format(
-                  "Could not determine port for pubsub root url \"%s\". You must either specify the port or use the protocol \"https\" or \"http\"",
-                  urlString));
-      }
-    }
-
-    return NettyChannelBuilder.forAddress(url.getHost(), port)
+    return NettyChannelBuilder.forTarget(format)
         .negotiationType(NegotiationType.TLS)
         .sslContext(GrpcSslContexts.forClient().ciphers(null).build())
         .build();

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/TestPubsub.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/TestPubsub.java
@@ -45,6 +45,7 @@ import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.SubscriptionPath;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.TopicPath;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.TestPipelineOptions;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hamcrest.Matcher;
@@ -227,13 +228,13 @@ public class TestPubsub implements TestRule {
   }
 
   private Iterable<String> listSubscriptions(TopicPath topicPath) {
-    assert topicAdmin != null;
+    Preconditions.checkNotNull(topicAdmin);
     return topicAdmin.listTopicSubscriptions(topicPath.getPath()).iterateAll();
   }
 
   /** Publish messages to {@link #topicPath()}. */
   public void publish(List<PubsubMessage> messages) {
-    assert eventsTopicPath != null;
+    Preconditions.checkNotNull(eventsTopicPath);
     Publisher eventPublisher;
     try {
       eventPublisher =
@@ -274,7 +275,7 @@ public class TestPubsub implements TestRule {
    */
   public List<PubsubMessage> waitForNMessages(int n, Duration timeoutDuration)
       throws IOException, InterruptedException {
-    assert subscriptionPath != null;
+    Preconditions.checkNotNull(subscriptionPath);
 
     BlockingQueue<com.google.pubsub.v1.PubsubMessage> receivedMessages =
         new LinkedBlockingDeque<>(n);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/TestPubsub.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/TestPubsub.java
@@ -17,24 +17,35 @@
  */
 package org.apache.beam.sdk.io.gcp.pubsub;
 
-import static java.util.stream.Collectors.toList;
-import static org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.projectPathFromPath;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 
+import com.google.api.core.ApiFuture;
+import com.google.api.core.ApiFutures;
+import com.google.cloud.pubsub.v1.AckReplyConsumer;
+import com.google.cloud.pubsub.v1.MessageReceiver;
+import com.google.cloud.pubsub.v1.Publisher;
+import com.google.cloud.pubsub.v1.Subscriber;
+import com.google.cloud.pubsub.v1.SubscriptionAdminClient;
+import com.google.cloud.pubsub.v1.SubscriptionAdminSettings;
+import com.google.cloud.pubsub.v1.TopicAdminClient;
+import com.google.cloud.pubsub.v1.TopicAdminSettings;
 import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PushConfig;
+import com.google.pubsub.v1.Subscription;
 import java.io.IOException;
-import java.util.ArrayList;
 import java.util.List;
+import java.util.concurrent.BlockingQueue;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.LinkedBlockingDeque;
 import java.util.concurrent.ThreadLocalRandom;
 import java.util.concurrent.TimeoutException;
-import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.IncomingMessage;
-import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.ProjectPath;
+import java.util.stream.Collectors;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.SubscriptionPath;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.TopicPath;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.TestPipelineOptions;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hamcrest.Matcher;
 import org.joda.time.DateTime;
@@ -61,13 +72,13 @@ public class TestPubsub implements TestRule {
       DateTimeFormat.forPattern("YYYY-MM-dd-HH-mm-ss-SSS");
   private static final String EVENTS_TOPIC_NAME = "events";
   private static final String TOPIC_PREFIX = "integ-test-";
-  private static final String NO_ID_ATTRIBUTE = null;
-  private static final String NO_TIMESTAMP_ATTRIBUTE = null;
   private static final Integer DEFAULT_ACK_DEADLINE_SECONDS = 60;
 
   private final TestPubsubOptions pipelineOptions;
+  private final String pubsubEndpoint;
 
-  private @Nullable PubsubClient pubsub = null;
+  private @Nullable TopicAdminClient topicAdmin = null;
+  private @Nullable SubscriptionAdminClient subscriptionAdmin = null;
   private @Nullable TopicPath eventsTopicPath = null;
   private @Nullable SubscriptionPath subscriptionPath = null;
 
@@ -83,6 +94,7 @@ public class TestPubsub implements TestRule {
 
   private TestPubsub(TestPubsubOptions pipelineOptions) {
     this.pipelineOptions = pipelineOptions;
+    this.pubsubEndpoint = PubsubOptions.targetForRootUrl(this.pipelineOptions.getPubsubRootUrl());
   }
 
   @Override
@@ -90,9 +102,9 @@ public class TestPubsub implements TestRule {
     return new Statement() {
       @Override
       public void evaluate() throws Throwable {
-        if (TestPubsub.this.pubsub != null) {
+        if (TestPubsub.this.topicAdmin != null || TestPubsub.this.subscriptionAdmin != null) {
           throw new AssertionError(
-              "Pubsub client was not shutdown in previous test. "
+              "Pubsub client was not shutdown after previous test. "
                   + "Topic path is'"
                   + eventsTopicPath
                   + "'. "
@@ -111,44 +123,63 @@ public class TestPubsub implements TestRule {
   }
 
   private void initializePubsub(Description description) throws IOException {
-    pubsub =
-        PubsubGrpcClient.FACTORY.newClient(
-            NO_TIMESTAMP_ATTRIBUTE, NO_ID_ATTRIBUTE, pipelineOptions);
+    topicAdmin =
+        TopicAdminClient.create(
+            TopicAdminSettings.newBuilder()
+                .setCredentialsProvider(pipelineOptions::getGcpCredential)
+                .setEndpoint(pubsubEndpoint)
+                .build());
+    subscriptionAdmin =
+        SubscriptionAdminClient.create(
+            SubscriptionAdminSettings.newBuilder()
+                .setCredentialsProvider(pipelineOptions::getGcpCredential)
+                .setEndpoint(pubsubEndpoint)
+                .build());
     TopicPath eventsTopicPathTmp =
         PubsubClient.topicPathFromName(
             pipelineOptions.getProject(), createTopicName(description, EVENTS_TOPIC_NAME));
-
-    pubsub.createTopic(eventsTopicPathTmp);
+    topicAdmin.createTopic(eventsTopicPathTmp.getPath());
 
     eventsTopicPath = eventsTopicPathTmp;
+
+    String subscriptionName =
+        topicPath().getName() + "_beam_" + ThreadLocalRandom.current().nextLong();
     subscriptionPath =
-        pubsub.createRandomSubscription(
-            projectPathFromPath(String.format("projects/%s", pipelineOptions.getProject())),
-            topicPath(),
+        new SubscriptionPath(
+            String.format(
+                "projects/%s/subscriptions/%s", pipelineOptions.getProject(), subscriptionName));
+
+    Subscription subscription =
+        subscriptionAdmin.createSubscription(
+            subscriptionPath.getPath(),
+            topicPath().getPath(),
+            PushConfig.getDefaultInstance(),
             DEFAULT_ACK_DEADLINE_SECONDS);
   }
 
   private void tearDown() throws IOException {
-    if (pubsub == null) {
+    if (subscriptionAdmin == null || topicAdmin == null) {
       return;
     }
 
     try {
       if (subscriptionPath != null) {
-        pubsub.deleteSubscription(subscriptionPath);
-      }
-      for (SubscriptionPath subscriptionPath :
-          pubsub.listSubscriptions(
-              projectPathFromPath(String.format("projects/%s", pipelineOptions.getProject())),
-              eventsTopicPath)) {
-        pubsub.deleteSubscription(subscriptionPath);
+        subscriptionAdmin.deleteSubscription(subscriptionPath.getPath());
       }
       if (eventsTopicPath != null) {
-        pubsub.deleteTopic(eventsTopicPath);
+        for (String subscriptionPath :
+            topicAdmin.listTopicSubscriptions(eventsTopicPath.getPath()).iterateAll()) {
+          subscriptionAdmin.deleteSubscription(subscriptionPath);
+        }
+        topicAdmin.deleteTopic(eventsTopicPath.getPath());
       }
     } finally {
-      pubsub.close();
-      pubsub = null;
+      subscriptionAdmin.close();
+      topicAdmin.close();
+
+      subscriptionAdmin = null;
+      topicAdmin = null;
+
       eventsTopicPath = null;
       subscriptionPath = null;
     }
@@ -195,43 +226,46 @@ public class TestPubsub implements TestRule {
     return subscriptionPath;
   }
 
-  private List<SubscriptionPath> listSubscriptions(ProjectPath projectPath, TopicPath topicPath)
-      throws IOException {
-    return pubsub.listSubscriptions(projectPath, topicPath).stream()
-        .filter((path) -> !path.equals(subscriptionPath))
-        .collect(ImmutableList.toImmutableList());
+  private Iterable<String> listSubscriptions(TopicPath topicPath) {
+    assert topicAdmin != null;
+    return topicAdmin.listTopicSubscriptions(topicPath.getPath()).iterateAll();
   }
 
   /** Publish messages to {@link #topicPath()}. */
-  public void publish(List<PubsubMessage> messages) throws IOException {
-    List<PubsubClient.OutgoingMessage> outgoingMessages =
-        messages.stream().map(this::toOutgoingMessage).collect(toList());
-    pubsub.publish(eventsTopicPath, outgoingMessages);
-  }
-
-  /** Pull up to 100 messages from {@link #subscriptionPath()}. */
-  public List<PubsubMessage> pull() throws IOException {
-    return pull(100);
-  }
-
-  /** Pull up to {@code maxBatchSize} messages from {@link #subscriptionPath()}. */
-  public List<PubsubMessage> pull(int maxBatchSize) throws IOException {
-    List<PubsubClient.IncomingMessage> messages =
-        pubsub.pull(0, subscriptionPath, maxBatchSize, true);
-    if (!messages.isEmpty()) {
-      pubsub.acknowledge(
-          subscriptionPath,
-          messages.stream().map(IncomingMessage::ackId).collect(ImmutableList.toImmutableList()));
+  public void publish(List<PubsubMessage> messages) {
+    assert eventsTopicPath != null;
+    Publisher eventPublisher;
+    try {
+      eventPublisher =
+          Publisher.newBuilder(eventsTopicPath.getPath())
+              .setCredentialsProvider(pipelineOptions::getGcpCredential)
+              .setEndpoint(pubsubEndpoint)
+              .build();
+    } catch (IOException e) {
+      throw new RuntimeException("Error creating event publisher", e);
     }
 
-    return messages.stream()
-        .map(
-            msg ->
-                new PubsubMessage(
-                    msg.message().getData().toByteArray(),
-                    msg.message().getAttributesMap(),
-                    msg.recordId()))
-        .collect(ImmutableList.toImmutableList());
+    List<ApiFuture<String>> futures =
+        messages.stream()
+            .map(
+                (message) -> {
+                  com.google.pubsub.v1.PubsubMessage.Builder builder =
+                      com.google.pubsub.v1.PubsubMessage.newBuilder()
+                          .setData(ByteString.copyFrom(message.getPayload()))
+                          .putAllAttributes(message.getAttributeMap());
+                  return eventPublisher.publish(builder.build());
+                })
+            .collect(Collectors.toList());
+
+    try {
+      ApiFutures.allAsList(futures).get();
+    } catch (ExecutionException e) {
+      throw new RuntimeException("Error publishing a test message", e);
+    } catch (InterruptedException e) {
+      throw new RuntimeException("Interrupted while waiting for messages to publish", e);
+    }
+
+    eventPublisher.shutdown();
   }
 
   /**
@@ -240,20 +274,48 @@ public class TestPubsub implements TestRule {
    */
   public List<PubsubMessage> waitForNMessages(int n, Duration timeoutDuration)
       throws IOException, InterruptedException {
-    List<PubsubMessage> receivedMessages = new ArrayList<>(n);
+    assert subscriptionPath != null;
+
+    BlockingQueue<com.google.pubsub.v1.PubsubMessage> receivedMessages =
+        new LinkedBlockingDeque<>(n);
+
+    MessageReceiver receiver =
+        (com.google.pubsub.v1.PubsubMessage message, AckReplyConsumer replyConsumer) -> {
+          if (receivedMessages.offer(message)) {
+            replyConsumer.ack();
+          } else {
+            replyConsumer.nack();
+          }
+        };
+
+    Subscriber subscriber =
+        Subscriber.newBuilder(subscriptionPath.getPath(), receiver)
+            .setCredentialsProvider(pipelineOptions::getGcpCredential)
+            .setEndpoint(pubsubEndpoint)
+            .build();
+    subscriber.startAsync();
 
     DateTime startTime = new DateTime();
     int timeoutSeconds = timeoutDuration.toStandardSeconds().getSeconds();
-
-    receivedMessages.addAll(pull(n - receivedMessages.size()));
-
     while (receivedMessages.size() < n
         && Seconds.secondsBetween(startTime, new DateTime()).getSeconds() < timeoutSeconds) {
-      Thread.sleep(1000);
-      receivedMessages.addAll(pull(n - receivedMessages.size()));
+      try {
+        Thread.sleep(1000);
+      } catch (InterruptedException ignored) {
+      }
     }
 
-    return receivedMessages;
+    subscriber.stopAsync();
+    subscriber.awaitTerminated();
+
+    return receivedMessages.stream()
+        .map(
+            (message) ->
+                new PubsubMessage(
+                    message.getData().toByteArray(),
+                    message.getAttributesMap(),
+                    message.getMessageId()))
+        .collect(Collectors.toList());
   }
 
   /**
@@ -318,9 +380,7 @@ public class TestPubsub implements TestRule {
             < timeoutDuration.toStandardSeconds().getSeconds()) {
       // Sleep 1 sec
       Thread.sleep(1000);
-      sizeOfSubscriptionList =
-          listSubscriptions(projectPathFromPath(String.format("projects/%s", project)), topicPath())
-              .size();
+      sizeOfSubscriptionList = Iterables.size(listSubscriptions(topicPath()));
     }
 
     if (sizeOfSubscriptionList > 0) {


### PR DESCRIPTION
The official GCP client has better tuned timeouts and retry configs for this application, using it should reduce flakiness.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
