### PR TITLE
[BEAM-11216] Fix ReaderCache to not resume from a cached reader for w…

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -1609,6 +1609,9 @@ public class StreamingDataflowWorker {
         request,
         (Windmill.CommitStatus status) -> {
           if (status != Windmill.CommitStatus.OK) {
+            readerCache.invalidateReader(
+                WindmillComputationKey.create(
+                    state.computationId, request.getKey(), request.getShardingKey()));
             stateCache
                 .forComputation(state.computationId)
                 .invalidate(request.getKey(), request.getShardingKey());

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingModeExecutionContext.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingModeExecutionContext.java
@@ -344,7 +344,8 @@ public class StreamingModeExecutionContext extends DataflowExecutionContext<Step
    * The caller is responsible for the reader and should appropriately close it as required.
    */
   public UnboundedSource.UnboundedReader<?> getCachedReader() {
-    return readerCache.acquireReader(getComputationKey(), getWork().getCacheToken());
+    return readerCache.acquireReader(
+        getComputationKey(), getWork().getCacheToken(), getWork().getWorkToken());
   }
 
   public void setActiveReader(UnboundedSource.UnboundedReader<?> reader) {
@@ -429,7 +430,8 @@ public class StreamingModeExecutionContext extends DataflowExecutionContext<Step
       }
       outputBuilder.setSourceBacklogBytes(backlogBytes);
 
-      readerCache.cacheReader(getComputationKey(), getWork().getCacheToken(), activeReader);
+      readerCache.cacheReader(
+          getComputationKey(), getWork().getCacheToken(), getWork().getWorkToken(), activeReader);
       activeReader = null;
     }
     return callbacks;

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/FakeWindmillServer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/FakeWindmillServer.java
@@ -372,6 +372,11 @@ class FakeWindmillServer extends WindmillServerStub {
     return commitsReceived;
   }
 
+  public void clearCommitsReceived() {
+    commitsRequested = 0;
+    commitsReceived.clear();
+  }
+
   public void waitForDroppedCommits(int droppedCommits) {
     LOG.debug("waitForDroppedCommits: {}", droppedCommits);
     int maxTries = 10;

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/ReaderCacheTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/ReaderCacheTest.java
@@ -69,20 +69,25 @@ public class ReaderCacheTest {
   public void testReaderCache() throws IOException {
     // Test basic caching expectations
 
-    readerCache.cacheReader(WindmillComputationKey.create(C_ID, KEY_1, SHARDING_KEY), 1, reader1);
-    readerCache.cacheReader(WindmillComputationKey.create(C_ID, KEY_2, SHARDING_KEY), 2, reader2);
+    readerCache.cacheReader(
+        WindmillComputationKey.create(C_ID, KEY_1, SHARDING_KEY), 1, 0, reader1);
+    readerCache.cacheReader(
+        WindmillComputationKey.create(C_ID, KEY_2, SHARDING_KEY), 2, 0, reader2);
 
     assertEquals(
         reader1,
-        readerCache.acquireReader(WindmillComputationKey.create(C_ID, KEY_1, SHARDING_KEY), 1));
+        readerCache.acquireReader(WindmillComputationKey.create(C_ID, KEY_1, SHARDING_KEY), 1, 1));
     assertNull(
-        readerCache.acquireReader(WindmillComputationKey.create(C_ID_1, KEY_1, SHARDING_KEY), 1));
+        readerCache.acquireReader(
+            WindmillComputationKey.create(C_ID_1, KEY_1, SHARDING_KEY), 1, 1));
     assertNull(
-        readerCache.acquireReader(WindmillComputationKey.create(C_ID, KEY_1, SHARDING_KEY_1), 1));
+        readerCache.acquireReader(
+            WindmillComputationKey.create(C_ID, KEY_1, SHARDING_KEY_1), 1, 1));
 
     // Trying to override existing reader should throw
     try {
-      readerCache.cacheReader(WindmillComputationKey.create(C_ID, KEY_2, SHARDING_KEY), 2, reader1);
+      readerCache.cacheReader(
+          WindmillComputationKey.create(C_ID, KEY_2, SHARDING_KEY), 2, 2, reader1);
       fail("Exception should have been thrown");
     } catch (RuntimeException expected) {
       // expected
@@ -91,31 +96,38 @@ public class ReaderCacheTest {
     // And it should not have overwritten the old value
     assertEquals(
         reader2,
-        readerCache.acquireReader(WindmillComputationKey.create(C_ID, KEY_2, SHARDING_KEY), 2));
+        readerCache.acquireReader(WindmillComputationKey.create(C_ID, KEY_2, SHARDING_KEY), 2, 3));
 
     assertNull(
         "acquireReader(WindmillComputationKey.create() should remove matching entry",
-        readerCache.acquireReader(WindmillComputationKey.create(C_ID, KEY_2, SHARDING_KEY), 2));
+        readerCache.acquireReader(WindmillComputationKey.create(C_ID, KEY_2, SHARDING_KEY), 2, 4));
 
     // Make sure computationId is part of the cache key
-    readerCache.cacheReader(WindmillComputationKey.create(C_ID_1, KEY_1, SHARDING_KEY), 1, reader2);
+    readerCache.cacheReader(
+        WindmillComputationKey.create(C_ID_1, KEY_1, SHARDING_KEY), 1, 5, reader2);
     assertEquals(
         reader2,
-        readerCache.acquireReader(WindmillComputationKey.create(C_ID_1, KEY_1, SHARDING_KEY), 1));
+        readerCache.acquireReader(
+            WindmillComputationKey.create(C_ID_1, KEY_1, SHARDING_KEY), 1, 6));
 
     // Make sure sharding key is part of the cache key
-    readerCache.cacheReader(WindmillComputationKey.create(C_ID, KEY_1, SHARDING_KEY_1), 1, reader3);
+    readerCache.cacheReader(
+        WindmillComputationKey.create(C_ID, KEY_1, SHARDING_KEY_1), 1, 0, reader3);
     assertEquals(
         reader3,
-        readerCache.acquireReader(WindmillComputationKey.create(C_ID, KEY_1, SHARDING_KEY_1), 1));
+        readerCache.acquireReader(
+            WindmillComputationKey.create(C_ID, KEY_1, SHARDING_KEY_1), 1, 1));
   }
 
   @Test
   public void testInvalidation() throws IOException {
 
-    readerCache.cacheReader(WindmillComputationKey.create(C_ID, KEY_1, SHARDING_KEY), 1, reader1);
-    readerCache.cacheReader(WindmillComputationKey.create(C_ID, KEY_2, SHARDING_KEY), 2, reader2);
-    readerCache.cacheReader(WindmillComputationKey.create(C_ID, KEY_2, SHARDING_KEY_1), 2, reader3);
+    readerCache.cacheReader(
+        WindmillComputationKey.create(C_ID, KEY_1, SHARDING_KEY), 1, 0, reader1);
+    readerCache.cacheReader(
+        WindmillComputationKey.create(C_ID, KEY_2, SHARDING_KEY), 2, 0, reader2);
+    readerCache.cacheReader(
+        WindmillComputationKey.create(C_ID, KEY_2, SHARDING_KEY_1), 2, 0, reader3);
 
     readerCache.invalidateReader(WindmillComputationKey.create(C_ID, KEY_1, SHARDING_KEY));
     verify(reader1).close();
@@ -142,8 +154,10 @@ public class ReaderCacheTest {
     // Create a cache with short expiry period.
     ReaderCache readerCache = new ReaderCache(cacheDuration);
 
-    readerCache.cacheReader(WindmillComputationKey.create(C_ID, KEY_1, SHARDING_KEY), 1, reader1);
-    readerCache.cacheReader(WindmillComputationKey.create(C_ID, KEY_2, SHARDING_KEY), 2, reader2);
+    readerCache.cacheReader(
+        WindmillComputationKey.create(C_ID, KEY_1, SHARDING_KEY), 1, 0, reader1);
+    readerCache.cacheReader(
+        WindmillComputationKey.create(C_ID, KEY_2, SHARDING_KEY), 2, 0, reader2);
 
     Stopwatch stopwatch = Stopwatch.createStarted();
     while (stopwatch.elapsed(TimeUnit.MILLISECONDS) < 2 * cacheDuration.getMillis()) {
@@ -151,8 +165,33 @@ public class ReaderCacheTest {
     }
 
     // Trigger clean up with a lookup, non-existing key is ok.
-    readerCache.acquireReader(WindmillComputationKey.create(C_ID, KEY_3, SHARDING_KEY), 3);
+    readerCache.acquireReader(WindmillComputationKey.create(C_ID, KEY_3, SHARDING_KEY), 3, 0);
 
     verify(reader1).close();
+  }
+
+  @Test
+  public void testReaderCacheRetries() throws IOException, InterruptedException {
+    ReaderCache readerCache = new ReaderCache();
+
+    readerCache.cacheReader(
+        WindmillComputationKey.create(C_ID, KEY_1, SHARDING_KEY), 1, 1, reader1);
+    // Same cache token should not recover the reader from the cache.
+    assertNull(
+        readerCache.acquireReader(WindmillComputationKey.create(C_ID, KEY_1, SHARDING_KEY), 1, 1));
+
+    readerCache.cacheReader(
+        WindmillComputationKey.create(C_ID, KEY_1, SHARDING_KEY), 1, 1, reader2);
+    assertEquals(
+        reader2,
+        readerCache.acquireReader(WindmillComputationKey.create(C_ID, KEY_1, SHARDING_KEY), 1, 20));
+    readerCache.cacheReader(
+        WindmillComputationKey.create(C_ID, KEY_1, SHARDING_KEY), 1, 20, reader2);
+    // Stale cache token should not recover the reader from the cache.
+    assertNull(
+        readerCache.acquireReader(WindmillComputationKey.create(C_ID, KEY_1, SHARDING_KEY), 1, 3));
+
+    verify(reader1).close();
+    verify(reader2).close();
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
@@ -2228,6 +2228,136 @@ public class StreamingDataflowWorkerTest {
     assertThat(finalizeTracker, contains(0));
   }
 
+  // Regression test to ensure that a reader is not used from the cache
+  // on work item retry.
+  @Test
+  public void testUnboundedSourceWorkRetry() throws Exception {
+    List<Integer> finalizeTracker = Lists.newArrayList();
+    TestCountingSource.setFinalizeTracker(finalizeTracker);
+
+    FakeWindmillServer server = new FakeWindmillServer(errorCollector);
+    StreamingDataflowWorkerOptions options = createTestingPipelineOptions(server);
+    options.setWorkerCacheMb(0); // Disable state cache so it doesn't detect retry.
+    StreamingDataflowWorker worker =
+        makeWorker(makeUnboundedSourcePipeline(), options, false /* publishCounters */);
+    worker.start();
+
+    // Test new key.
+    Windmill.GetWorkResponse work =
+        buildInput(
+            "work {"
+                + "  computation_id: \"computation\""
+                + "  input_data_watermark: 0"
+                + "  work {"
+                + "    key: \"0000000000000001\""
+                + "    sharding_key: 1"
+                + "    work_token: 1"
+                + "    cache_token: 1"
+                + "  }"
+                + "}",
+            null);
+    server.addWorkToOffer(work);
+
+    Map<Long, Windmill.WorkItemCommitRequest> result = server.waitForAndGetCommits(1);
+    Iterable<CounterUpdate> counters = worker.buildCounters();
+    Windmill.WorkItemCommitRequest commit = result.get(1L);
+    UnsignedLong finalizeId =
+        UnsignedLong.fromLongBits(commit.getSourceStateUpdates().getFinalizeIds(0));
+
+    Windmill.WorkItemCommitRequest expectedCommit =
+        setMessagesMetadata(
+                PaneInfo.NO_FIRING,
+                CoderUtils.encodeToByteArray(
+                    CollectionCoder.of(GlobalWindow.Coder.INSTANCE),
+                    Arrays.asList(GlobalWindow.INSTANCE)),
+                parseCommitRequest(
+                    "key: \"0000000000000001\" "
+                        + "sharding_key: 1 "
+                        + "work_token: 1 "
+                        + "cache_token: 1 "
+                        + "source_backlog_bytes: 7 "
+                        + "output_messages {"
+                        + "  destination_stream_id: \"out\""
+                        + "  bundles {"
+                        + "    key: \"0000000000000001\""
+                        + "    messages {"
+                        + "      timestamp: 0"
+                        + "      data: \"0:0\""
+                        + "    }"
+                        + "    messages_ids: \"\""
+                        + "  }"
+                        + "} "
+                        + "source_state_updates {"
+                        + "  state: \"\000\""
+                        + "  finalize_ids: "
+                        + finalizeId
+                        + "} "
+                        + "source_watermark: 1000"))
+            .build();
+
+    assertThat(commit, equalTo(expectedCommit));
+    assertEquals(
+        18L, splitIntToLong(getCounter(counters, "dataflow_input_size-computation").getInteger()));
+
+    // Test retry of work item, it should return the same result and not start the reader from the
+    // position it was left at.
+    server.clearCommitsReceived();
+    server.addWorkToOffer(work);
+    result = server.waitForAndGetCommits(1);
+    commit = result.get(1L);
+    finalizeId = UnsignedLong.fromLongBits(commit.getSourceStateUpdates().getFinalizeIds(0));
+    Windmill.WorkItemCommitRequest.Builder commitBuilder = expectedCommit.toBuilder();
+    commitBuilder
+        .getSourceStateUpdatesBuilder()
+        .setFinalizeIds(0, commit.getSourceStateUpdates().getFinalizeIds(0));
+    expectedCommit = commitBuilder.build();
+    assertThat(commit, equalTo(expectedCommit));
+
+    // Continue with processing.
+    server.addWorkToOffer(
+        buildInput(
+            "work {"
+                + "  computation_id: \"computation\""
+                + "  input_data_watermark: 0"
+                + "  work {"
+                + "    key: \"0000000000000001\""
+                + "    sharding_key: 1"
+                + "    work_token: 2"
+                + "    cache_token: 1"
+                + "    source_state {"
+                + "      state: \"\001\""
+                + "      finalize_ids: "
+                + finalizeId
+                + "    } "
+                + "  }"
+                + "}",
+            null));
+
+    result = server.waitForAndGetCommits(1);
+
+    commit = result.get(2L);
+    finalizeId = UnsignedLong.fromLongBits(commit.getSourceStateUpdates().getFinalizeIds(0));
+
+    assertThat(
+        commit,
+        equalTo(
+            parseCommitRequest(
+                    "key: \"0000000000000001\" "
+                        + "sharding_key: 1 "
+                        + "work_token: 2 "
+                        + "cache_token: 1 "
+                        + "source_backlog_bytes: 7 "
+                        + "source_state_updates {"
+                        + "  state: \"\000\""
+                        + "  finalize_ids: "
+                        + finalizeId
+                        + "} "
+                        + "source_watermark: 1000")
+                .build()));
+
+    assertThat(finalizeTracker, contains(0));
+  }
+
   private static class MockWork extends StreamingDataflowWorker.Work {
 
     public MockWork(long workToken) {


### PR DESCRIPTION
…ork item retries.

Such retries can occur particularly in autoscaling with Streaming Engine enabled
when the original commit for the work item is sent to the wrong backend and is
dropped. Then the retry would have the same cache token but would incorrectly
resume from where the reader last stopped instead of the checkpoint within the
request.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
