### PR TITLE
Further dataframe batch consolidation.

### DIFF
--- a/sdks/python/apache_beam/dataframe/transforms.py
+++ b/sdks/python/apache_beam/dataframe/transforms.py
@@ -236,6 +236,7 @@ class _DataframeExpressionsTransform(transforms.PTransform):
         # Actually evaluate the expressions.
         def evaluate(partition, stage=self.stage, **side_inputs):
           def lookup(expr):
+            # Use proxy if there's no data in this partition
             return expr.proxy(
             ).iloc[:0] if partition[expr._id] is None else partition[expr._id]
 

--- a/sdks/python/apache_beam/dataframe/transforms.py
+++ b/sdks/python/apache_beam/dataframe/transforms.py
@@ -201,11 +201,23 @@ class _DataframeExpressionsTransform(transforms.PTransform):
                           MIN_PARTITIONS,
                           min(MAX_PARTITIONS, size // TARGET_PARTITION_SIZE))))
 
+          partition_fn = self.stage.partitioning.partition_fn
+
+          class Partition(beam.PTransform):
+            def expand(self, pcoll):
+              return (
+                  pcoll
+                  # Attempt to create batches of reasonable size.
+                  | beam.ParDo(_PreBatch())
+                  # Actually partition.
+                  | beam.FlatMap(partition_fn, num_partitions)
+                  # Don't bother shuffling empty partitions.
+                  | beam.Filter(lambda k_df: len(k_df[1])))
+
           # Arrange such that partitioned_pcoll is properly partitioned.
           main_pcolls = {
               expr._id: pcolls[expr._id] | 'Partition_%s_%s' %
-              (self.stage.partitioning, expr._id) >> beam.FlatMap(
-                  self.stage.partitioning.partition_fn, num_partitions)
+              (self.stage.partitioning, expr._id) >> Partition()
               for expr in tabular_inputs
           } | beam.CoGroupByKey()
           partitioned_pcoll = main_pcolls | beam.ParDo(_ReBatch())
@@ -223,8 +235,12 @@ class _DataframeExpressionsTransform(transforms.PTransform):
 
         # Actually evaluate the expressions.
         def evaluate(partition, stage=self.stage, **side_inputs):
+          def lookup(expr):
+            return expr.proxy(
+            ).iloc[:0] if partition[expr._id] is None else partition[expr._id]
+
           session = expressions.Session(
-              dict([(expr, partition[expr._id]) for expr in tabular_inputs] +
+              dict([(expr, lookup(expr)) for expr in tabular_inputs] +
                    [(expr, side_inputs[expr._id]) for expr in scalar_inputs]))
           for expr in stage.outputs:
             yield beam.pvalue.TaggedOutput(expr._id, expr.evaluate_at(session))
@@ -410,6 +426,35 @@ def _total_memory_usage(frame):
     float('inf')
 
 
+class _PreBatch(beam.DoFn):
+  def __init__(self, target_size=TARGET_PARTITION_SIZE):
+    self._target_size = target_size
+
+  def start_bundle(self):
+    self._parts = collections.defaultdict(list)
+    self._running_size = 0
+
+  def process(
+      self,
+      part,
+      window=beam.DoFn.WindowParam,
+      timestamp=beam.DoFn.TimestampParam):
+    part_size = _total_memory_usage(part)
+    if part_size >= self._target_size:
+      yield part
+    else:
+      self._running_size += part_size
+      self._parts[window, timestamp].append(part)
+      if self._running_size >= self._target_size:
+        yield from self.finish_bundle()
+
+  def finish_bundle(self):
+    for (window, timestamp), parts in self._parts.items():
+      yield windowed_value.WindowedValue(
+          pd.concat(parts), timestamp, (window, ))
+    self.start_bundle()
+
+
 class _ReBatch(beam.DoFn):
   """Groups all the parts from various workers into the same dataframe.
 
@@ -438,10 +483,12 @@ class _ReBatch(beam.DoFn):
 
   def finish_bundle(self):
     for (window, timestamp), tagged_parts in self._parts.items():
-      yield windowed_value.WindowedValue(
-          {tag: pd.concat(parts)
-           for tag, parts in tagged_parts.items()},
-          timestamp, (window, ))
+      yield windowed_value.WindowedValue(  # yapf break
+      {
+          tag: pd.concat(parts) if parts else None
+          for (tag, parts) in tagged_parts.items()
+      },
+      timestamp, (window, ))
     self.start_bundle()
 
 

--- a/sdks/python/apache_beam/dataframe/transforms_test.py
+++ b/sdks/python/apache_beam/dataframe/transforms_test.py
@@ -81,7 +81,7 @@ class TransformTest(unittest.TestCase):
   def run_scenario(self, input, func):
     expected = func(input)
 
-    empty = input[0:0]
+    empty = input.iloc[0:0]
     input_placeholder = expressions.PlaceholderExpression(empty)
     input_deferred = frame_base.DeferredFrame.wrap(input_placeholder)
     actual_deferred = func(input_deferred)._expr.evaluate_at(
@@ -90,17 +90,18 @@ class TransformTest(unittest.TestCase):
     check_correct(expected, actual_deferred)
 
     with beam.Pipeline() as p:
-      input_pcoll = p | beam.Create([input[::2], input[1::2]])
+      input_pcoll = p | beam.Create([input.iloc[::2], input.iloc[1::2]])
       input_df = convert.to_dataframe(input_pcoll, proxy=empty)
       output_df = func(input_df)
 
       output_proxy = output_df._expr.proxy()
       if isinstance(output_proxy, pd.core.generic.NDFrame):
         self.assertTrue(
-            output_proxy[:0].equals(expected[:0]),
+            output_proxy.iloc[:0].equals(expected.iloc[:0]),
             (
                 'Output proxy is incorrect:\n'
-                f'Expected:\n{expected[:0]}\n\nActual:\n{output_proxy[:0]}'))
+                f'Expected:\n{expected.iloc[:0]}\n\n'
+                f'Actual:\n{output_proxy.iloc[:0]}'))
       else:
         self.assertEqual(type(output_proxy), type(expected))
 
@@ -160,6 +161,14 @@ class TransformTest(unittest.TestCase):
         'Size': ['Small', 'Extra Small', 'Large', 'Medium']
     })
     self.run_scenario(df, lambda df: df[['Speed', 'Size']])
+
+  def test_offset_elementwise(self):
+    s = pd.Series(range(10)).astype(float)
+    df = pd.DataFrame({'value': s, 'square': s * s, 'cube': s * s * s})
+    # Only those values that are both squares and cubes will intersect.
+    self.run_scenario(
+        df,
+        lambda df: df.set_index('square').value + df.set_index('cube').value)
 
   def test_batching_named_tuple_input(self):
     with beam.Pipeline() as p:


### PR DESCRIPTION
* Concatenate small dataframe before shuffle.
* Omit shuffling of empty partitions.
    - This requires some adjustment to use the proxy object
      if *all* partitions from all workers are empty.
    
Projections, filterings, and aggregations are common operations that often greatly reduce the size of a dataframe, and can result in small output batches which have high relative overhead.

This is in reaction to looking at the number of (relatively tiny) elements in the dataflow ui. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
