### PR TITLE
[BEAM-11208] Fix for QUOTA_EXCEEDED failures in BQ Storage streams sp…

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
@@ -341,7 +341,6 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
                   + "the left of the split fraction {}.",
               source.readStream.getName(),
               fraction);
-          splitPossible = false;
           return null;
         } catch (Exception e) {
           Metrics.counter(
@@ -349,7 +348,6 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
                   "split-at-fraction-calls-failed-due-to-other-reasons")
               .inc();
           LOG.error("BigQuery Storage API stream split failed.", e);
-          splitPossible = false;
           return null;
         }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
@@ -301,8 +301,8 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
         if (!splitResponse.hasPrimaryStream() || !splitResponse.hasRemainderStream()) {
           // No more splits are possible!
           Metrics.counter(
-              BigQueryStorageStreamReader.class,
-              "split-at-fraction-calls-failed-due-to-impossible-split-point")
+                  BigQueryStorageStreamReader.class,
+                  "split-at-fraction-calls-failed-due-to-impossible-split-point")
               .inc();
           LOG.info(
               "BigQuery Storage API stream {} cannot be split at {}.",
@@ -331,8 +331,8 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
             // The current source has already moved past the split point, so this split attempt
             // is unsuccessful.
             Metrics.counter(
-                BigQueryStorageStreamReader.class,
-                "split-at-fraction-calls-failed-due-to-bad-split-point")
+                    BigQueryStorageStreamReader.class,
+                    "split-at-fraction-calls-failed-due-to-bad-split-point")
                 .inc();
             LOG.info(
                 "BigQuery Storage API split of stream {} abandoned because the primary stream is to "
@@ -343,8 +343,8 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
             return null;
           } catch (Exception e) {
             Metrics.counter(
-                BigQueryStorageStreamReader.class,
-                "split-at-fraction-calls-failed-due-to-other-reasons")
+                    BigQueryStorageStreamReader.class,
+                    "split-at-fraction-calls-failed-due-to-other-reasons")
                 .inc();
             LOG.error("BigQuery Storage API stream split failed.", e);
             splitPossible = false;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
@@ -163,7 +163,7 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
     private long currentOffset;
 
     // Values used for progress reporting.
-    private boolean splitPossible;
+    private boolean splitPossible = true;
     private double fractionConsumed;
     private double progressAtResponseStart;
     private double progressAtResponseEnd;
@@ -179,7 +179,6 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
       this.parseFn = source.parseFn;
       this.storageClient = source.bqServices.getStorageClient(options);
       this.tableSchema = fromJsonString(source.jsonTableSchema, TableSchema.class);
-      this.splitPossible = true;
       this.fractionConsumed = 0d;
       this.progressAtResponseStart = 0d;
       this.progressAtResponseEnd = 0d;
@@ -290,85 +289,85 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
         return null;
       }
 
-      if (splitPossible) {
-        SplitReadStreamRequest splitRequest =
-            SplitReadStreamRequest.newBuilder()
-                .setName(source.readStream.getName())
-                .setFraction((float) fraction)
-                .build();
+      if (!splitPossible) {
+        return null;
+      }
 
-        SplitReadStreamResponse splitResponse = storageClient.splitReadStream(splitRequest);
-        if (!splitResponse.hasPrimaryStream() || !splitResponse.hasRemainderStream()) {
-          // No more splits are possible!
+      SplitReadStreamRequest splitRequest =
+          SplitReadStreamRequest.newBuilder()
+              .setName(source.readStream.getName())
+              .setFraction((float) fraction)
+              .build();
+
+      SplitReadStreamResponse splitResponse = storageClient.splitReadStream(splitRequest);
+      if (!splitResponse.hasPrimaryStream() || !splitResponse.hasRemainderStream()) {
+        // No more splits are possible!
+        Metrics.counter(
+                BigQueryStorageStreamReader.class,
+                "split-at-fraction-calls-failed-due-to-impossible-split-point")
+            .inc();
+        LOG.info(
+            "BigQuery Storage API stream {} cannot be split at {}.",
+            source.readStream.getName(),
+            fraction);
+        splitPossible = false;
+        return null;
+      }
+
+      // We may be able to split this source. Before continuing, we pause the reader thread and
+      // replace its current source with the primary stream iff the reader has not moved past
+      // the split point.
+      synchronized (this) {
+        BigQueryServerStream<ReadRowsResponse> newResponseStream;
+        Iterator<ReadRowsResponse> newResponseIterator;
+        try {
+          newResponseStream =
+              storageClient.readRows(
+                  ReadRowsRequest.newBuilder()
+                      .setReadStream(splitResponse.getPrimaryStream().getName())
+                      .setOffset(currentOffset + 1)
+                      .build());
+          newResponseIterator = newResponseStream.iterator();
+          newResponseIterator.hasNext();
+        } catch (FailedPreconditionException e) {
+          // The current source has already moved past the split point, so this split attempt
+          // is unsuccessful.
           Metrics.counter(
                   BigQueryStorageStreamReader.class,
-                  "split-at-fraction-calls-failed-due-to-impossible-split-point")
+                  "split-at-fraction-calls-failed-due-to-bad-split-point")
               .inc();
           LOG.info(
-              "BigQuery Storage API stream {} cannot be split at {}.",
+              "BigQuery Storage API split of stream {} abandoned because the primary stream is to "
+                  + "the left of the split fraction {}.",
               source.readStream.getName(),
               fraction);
           splitPossible = false;
           return null;
+        } catch (Exception e) {
+          Metrics.counter(
+                  BigQueryStorageStreamReader.class,
+                  "split-at-fraction-calls-failed-due-to-other-reasons")
+              .inc();
+          LOG.error("BigQuery Storage API stream split failed.", e);
+          splitPossible = false;
+          return null;
         }
 
-        // We may be able to split this source. Before continuing, we pause the reader thread and
-        // replace its current source with the primary stream iff the reader has not moved past
-        // the split point.
-        synchronized (this) {
-          BigQueryServerStream<ReadRowsResponse> newResponseStream;
-          Iterator<ReadRowsResponse> newResponseIterator;
-          try {
-            newResponseStream =
-                storageClient.readRows(
-                    ReadRowsRequest.newBuilder()
-                        .setReadStream(splitResponse.getPrimaryStream().getName())
-                        .setOffset(currentOffset + 1)
-                        .build());
-            newResponseIterator = newResponseStream.iterator();
-            newResponseIterator.hasNext();
-          } catch (FailedPreconditionException e) {
-            // The current source has already moved past the split point, so this split attempt
-            // is unsuccessful.
-            Metrics.counter(
-                    BigQueryStorageStreamReader.class,
-                    "split-at-fraction-calls-failed-due-to-bad-split-point")
-                .inc();
-            LOG.info(
-                "BigQuery Storage API split of stream {} abandoned because the primary stream is to "
-                    + "the left of the split fraction {}.",
-                source.readStream.getName(),
-                fraction);
-            splitPossible = false;
-            return null;
-          } catch (Exception e) {
-            Metrics.counter(
-                    BigQueryStorageStreamReader.class,
-                    "split-at-fraction-calls-failed-due-to-other-reasons")
-                .inc();
-            LOG.error("BigQuery Storage API stream split failed.", e);
-            splitPossible = false;
-            return null;
-          }
-
-          // Cancels the parent stream before replacing it with the primary stream.
-          responseStream.cancel();
-          source = source.fromExisting(splitResponse.getPrimaryStream());
-          responseStream = newResponseStream;
-          responseIterator = newResponseIterator;
-          decoder = null;
-        }
-
-        Metrics.counter(BigQueryStorageStreamReader.class, "split-at-fraction-calls-successful")
-            .inc();
-        LOG.info(
-            "Successfully split BigQuery Storage API stream at {}. Split response: {}",
-            fraction,
-            splitResponse);
-        return source.fromExisting(splitResponse.getRemainderStream());
-      } else {
-        return null;
+        // Cancels the parent stream before replacing it with the primary stream.
+        responseStream.cancel();
+        source = source.fromExisting(splitResponse.getPrimaryStream());
+        responseStream = newResponseStream;
+        responseIterator = newResponseIterator;
+        decoder = null;
       }
+
+      Metrics.counter(BigQueryStorageStreamReader.class, "split-at-fraction-calls-successful")
+          .inc();
+      LOG.info(
+          "Successfully split BigQuery Storage API stream at {}. Split response: {}",
+          fraction,
+          splitResponse);
+      return source.fromExisting(splitResponse.getRemainderStream());
     }
 
     @Override


### PR DESCRIPTION
Fix for BigQuery storage streams failing with QUOTA_EXCEEDED errors in split.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
