### PR TITLE
Go SDK Combine load tests

### DIFF
--- a/.test-infra/jenkins/job_LoadTests_Combine_Flink_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Combine_Flink_Go.groovy
@@ -1,0 +1,131 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+import CommonJobProperties as commonJobProperties
+import CommonTestProperties
+import LoadTestsBuilder as loadTestsBuilder
+import PhraseTriggeringPostCommitBuilder
+import Flink
+import InfluxDBCredentialsHelper
+
+import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY
+
+String now = new Date().format('MMddHHmmss', TimeZone.getTimeZone('UTC'))
+
+def batchScenarios = {
+  [
+      [
+        title          : 'Load test: 2GB of 10B records',
+        test           : 'combine',
+        runner         : CommonTestProperties.Runner.FLINK,
+        pipelineOptions: [
+          job_name             : "load-tests-go-flink-batch-combine-1-${now}",
+          influx_measurement   : 'go_batch_combine_1',
+          input_options        : """
+                                   {
+                                     "num_records": 200000000,
+                                     "key_size": 1,
+                                     "value_size": 9
+                                   }
+                               """.trim().replaceAll("\\s", ""),
+          fanout               : 1,
+          top_count            : 20,
+          parallelism          : 5,
+          endpoint             : 'localhost:8099',
+          environment_type     : 'DOCKER',
+          environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        ]
+      ],
+      [
+        title          : 'Load test: fanout 4 times with 2GB 10-byte records total',
+        test           : 'combine',
+        runner         : CommonTestProperties.Runner.FLINK,
+        pipelineOptions: [
+          job_name             : "load-tests-go-flink-batch-combine-1-${now}",
+          influx_measurement   : 'go_batch_combine_1',
+          input_options        : """
+                                   {
+                                     "num_records": 5000000,
+                                     "key_size": 10,
+                                     "value_size": 90
+                                   }
+                               """.trim().replaceAll("\\s", ""),
+          fanout               : 4,
+          top_count            : 20,
+          parallelism          : 16,
+          endpoint             : 'localhost:8099',
+          environment_type     : 'DOCKER',
+          environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        ]
+      ],
+      [
+        title          : 'Load test: fanout 8 times with 2GB 10-byte records total',
+        test           : 'combine',
+        runner         : CommonTestProperties.Runner.FLINK,
+        pipelineOptions: [
+          job_name             : "load-tests-go-flink-batch-combine-1-${now}",
+          influx_measurement   : 'go_batch_combine_1',
+          fanout               : 8,
+          top_count            : 20,
+          parallelism          : 16,
+          input_options        : """
+                                   {
+                                     "num_records": 2500000,
+                                     "key_size": 10,
+                                     "value_size": 90
+                                   }
+                               """.trim().replaceAll("\\s", ""),
+          endpoint             : 'localhost:8099',
+          environment_type     : 'DOCKER',
+          environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        ]
+      ],
+    ].each { test -> test.pipelineOptions.putAll(additionalPipelineArgs) }
+}
+
+def loadTestJob = { scope, triggeringContext, mode ->
+  def numberOfWorkers = 5
+
+  Flink flink = new Flink(scope, "beam_LoadTests_Go_Combine_Flink_${mode.capitalize()}")
+  flink.setUp(
+      [
+        "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest"
+      ],
+      numberOfWorkers,
+      "${DOCKER_CONTAINER_REGISTRY}/beam_flink1.10_job_server:latest")
+
+  loadTestsBuilder.loadTests(scope, CommonTestProperties.SDK.GO, batchScenarios(), 'combine', mode)
+}
+
+PhraseTriggeringPostCommitBuilder.postCommitJob(
+    'beam_LoadTests_Go_Combine_Flink_Batch',
+    'Run Load Tests Go Combine Flink Batch',
+    'Load Tests Go Combine Batch suite',
+    this
+    ) {
+      additionalPipelineArgs = [:]
+      loadTestJob(delegate, CommonTestProperties.TriggeringContext.PR, 'batch')
+    }
+
+CronJobBuilder.cronJob('beam_LoadTests_Go_Combine_Flink_Batch', 'H 10 * * *', this) {
+  additionalPipelineArgs = [
+    influx_db_name: InfluxDBCredentialsHelper.InfluxDBDatabaseName,
+    influx_hostname: InfluxDBCredentialsHelper.InfluxDBHostUrl,
+  ]
+  loadTestJob(delegate, CommonTestProperties.TriggeringContext.POST_COMMIT, 'batch')
+}

--- a/.test-infra/jenkins/job_LoadTests_Combine_Flink_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Combine_Flink_Go.groovy
@@ -30,7 +30,7 @@ String now = new Date().format('MMddHHmmss', TimeZone.getTimeZone('UTC'))
 def batchScenarios = {
   [
     [
-      title          : 'Group By Key Go Load test: 2GB of 10B records',
+      title          : 'Combine Go Load test: 2GB of 10B records',
       test           : 'combine',
       runner         : CommonTestProperties.Runner.FLINK,
       pipelineOptions: [
@@ -50,13 +50,13 @@ def batchScenarios = {
       ]
     ],
     [
-      title          : 'Group By Key Go Load test: fanout 4 times with 2GB 10-byte records total',
+      title          : 'Combine Go Load test: fanout 4 times with 2GB 10-byte records total',
       test           : 'combine',
       runner         : CommonTestProperties.Runner.FLINK,
       pipelineOptions: [
-        job_name             : "load-tests-go-flink-batch-combine-2-${now}",
+        job_name             : "load-tests-go-flink-batch-combine-4-${now}",
         influx_namespace     : 'flink',
-        influx_measurement   : 'go_batch_combine_2',
+        influx_measurement   : 'go_batch_combine_4',
         input_options        : '\'{' +
         '"num_records": 5000000,' +
         '"key_size": 10,' +
@@ -70,13 +70,13 @@ def batchScenarios = {
       ]
     ],
     [
-      title          : 'Group By Key Go Load test: fanout 8 times with 2GB 10-byte records total',
+      title          : 'Combine Go Load test: fanout 8 times with 2GB 10-byte records total',
       test           : 'combine',
       runner         : CommonTestProperties.Runner.FLINK,
       pipelineOptions: [
-        job_name             : "load-tests-go-flink-batch-combine-3-${now}",
+        job_name             : "load-tests-go-flink-batch-combine-5-${now}",
         influx_namespace     : 'flink',
-        influx_measurement   : 'go_batch_combine_3',
+        influx_measurement   : 'go_batch_combine_5',
         fanout               : 8,
         top_count            : 20,
         parallelism          : 16,
@@ -127,7 +127,7 @@ PhraseTriggeringPostCommitBuilder.postCommitJob(
       loadTestJob(delegate, CommonTestProperties.TriggeringContext.PR, 'batch')
     }
 
-CronJobBuilder.cronJob('beam_LoadTests_Go_Combine_Flink_Batch', 'H 10 * * *', this) {
+CronJobBuilder.cronJob('beam_LoadTests_Go_Combine_Flink_Batch', 'H 8 * * *', this) {
   additionalPipelineArgs = [
     influx_db_name: InfluxDBCredentialsHelper.InfluxDBDatabaseName,
     influx_hostname: InfluxDBCredentialsHelper.InfluxDBHostUrl,

--- a/.test-infra/jenkins/job_LoadTests_Combine_Flink_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Combine_Flink_Go.groovy
@@ -29,73 +29,73 @@ String now = new Date().format('MMddHHmmss', TimeZone.getTimeZone('UTC'))
 
 def batchScenarios = {
   [
-      [
-        title          : 'Load test: 2GB of 10B records',
-        test           : 'combine',
-        runner         : CommonTestProperties.Runner.FLINK,
-        pipelineOptions: [
-          job_name             : "load-tests-go-flink-batch-combine-1-${now}",
-          influx_measurement   : 'go_batch_combine_1',
-          input_options        : """
+    [
+      title          : 'Load test: 2GB of 10B records',
+      test           : 'combine',
+      runner         : CommonTestProperties.Runner.FLINK,
+      pipelineOptions: [
+        job_name             : "load-tests-go-flink-batch-combine-1-${now}",
+        influx_measurement   : 'go_batch_combine_1',
+        input_options        : """
                                    {
                                      "num_records": 200000000,
                                      "key_size": 1,
                                      "value_size": 9
                                    }
                                """.trim().replaceAll("\\s", ""),
-          fanout               : 1,
-          top_count            : 20,
-          parallelism          : 5,
-          endpoint             : 'localhost:8099',
-          environment_type     : 'DOCKER',
-          environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
-        ]
-      ],
-      [
-        title          : 'Load test: fanout 4 times with 2GB 10-byte records total',
-        test           : 'combine',
-        runner         : CommonTestProperties.Runner.FLINK,
-        pipelineOptions: [
-          job_name             : "load-tests-go-flink-batch-combine-1-${now}",
-          influx_measurement   : 'go_batch_combine_1',
-          input_options        : """
+        fanout               : 1,
+        top_count            : 20,
+        parallelism          : 5,
+        endpoint             : 'localhost:8099',
+        environment_type     : 'DOCKER',
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+      ]
+    ],
+    [
+      title          : 'Load test: fanout 4 times with 2GB 10-byte records total',
+      test           : 'combine',
+      runner         : CommonTestProperties.Runner.FLINK,
+      pipelineOptions: [
+        job_name             : "load-tests-go-flink-batch-combine-1-${now}",
+        influx_measurement   : 'go_batch_combine_1',
+        input_options        : """
                                    {
                                      "num_records": 5000000,
                                      "key_size": 10,
                                      "value_size": 90
                                    }
                                """.trim().replaceAll("\\s", ""),
-          fanout               : 4,
-          top_count            : 20,
-          parallelism          : 16,
-          endpoint             : 'localhost:8099',
-          environment_type     : 'DOCKER',
-          environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
-        ]
-      ],
-      [
-        title          : 'Load test: fanout 8 times with 2GB 10-byte records total',
-        test           : 'combine',
-        runner         : CommonTestProperties.Runner.FLINK,
-        pipelineOptions: [
-          job_name             : "load-tests-go-flink-batch-combine-1-${now}",
-          influx_measurement   : 'go_batch_combine_1',
-          fanout               : 8,
-          top_count            : 20,
-          parallelism          : 16,
-          input_options        : """
+        fanout               : 4,
+        top_count            : 20,
+        parallelism          : 16,
+        endpoint             : 'localhost:8099',
+        environment_type     : 'DOCKER',
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+      ]
+    ],
+    [
+      title          : 'Load test: fanout 8 times with 2GB 10-byte records total',
+      test           : 'combine',
+      runner         : CommonTestProperties.Runner.FLINK,
+      pipelineOptions: [
+        job_name             : "load-tests-go-flink-batch-combine-1-${now}",
+        influx_measurement   : 'go_batch_combine_1',
+        fanout               : 8,
+        top_count            : 20,
+        parallelism          : 16,
+        input_options        : """
                                    {
                                      "num_records": 2500000,
                                      "key_size": 10,
                                      "value_size": 90
                                    }
                                """.trim().replaceAll("\\s", ""),
-          endpoint             : 'localhost:8099',
-          environment_type     : 'DOCKER',
-          environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
-        ]
-      ],
-    ].each { test -> test.pipelineOptions.putAll(additionalPipelineArgs) }
+        endpoint             : 'localhost:8099',
+        environment_type     : 'DOCKER',
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+      ]
+    ],
+  ].each { test -> test.pipelineOptions.putAll(additionalPipelineArgs) }
 }
 
 def loadTestJob = { scope, triggeringContext, mode ->

--- a/sdks/go/test/load/build.gradle
+++ b/sdks/go/test/load/build.gradle
@@ -48,6 +48,7 @@ golang {
     targetPlatform = [getLocalPlatform(), 'linux-amd64']
     // Build all the tests
     go 'build -o ./build/bin/${GOOS}_${GOARCH}/pardo github.com/apache/beam/sdks/go/test/load/pardo'
+    go 'build -o ./build/bin/${GOOS}_${GOARCH}/combine github.com/apache/beam/sdks/go/test/load/combine'
   }
 }
 

--- a/sdks/go/test/load/combine/combine.go
+++ b/sdks/go/test/load/combine/combine.go
@@ -56,8 +56,8 @@ func compareLess(key []byte, value []byte) bool {
 	return bytes.Compare(key, value) < 0
 }
 
-func getElement(key []byte, value [][]byte, emit func([]byte, [][]byte)) {
-	emit(key, value)
+func getElement(key []byte, value [][]byte, emit func([]byte, []byte)) {
+	emit(key, value[0])
 }
 
 func main() {

--- a/sdks/go/test/load/combine/combine.go
+++ b/sdks/go/test/load/combine/combine.go
@@ -68,9 +68,9 @@ func main() {
 
 	p, s := beam.NewPipelineWithRoot()
 	src := synthetic.SourceSingle(s, parseSyntheticConfig())
-	pcoll := beam.ParDo(s, &load.RuntimeMonitor{}, src)
+	src = beam.ParDo(s, &load.RuntimeMonitor{}, src)
 	for i := 0; i < *fanout; i++ {
-		pcoll = top.LargestPerKey(s, pcoll, *topCount, compareLess)
+		pcoll := top.LargestPerKey(s, src, *topCount, compareLess)
 		pcoll = beam.ParDo(s, getElement, pcoll)
 		pcoll = beam.ParDo(s, &load.RuntimeMonitor{}, pcoll)
 	}

--- a/sdks/go/test/load/combine/combine.go
+++ b/sdks/go/test/load/combine/combine.go
@@ -56,7 +56,7 @@ func compareLess(key []byte, value []byte) bool {
 	return bytes.Compare(key, value) < 0
 }
 
-func getElement(ctx context.Context, key []byte, value []byte, emit func([]byte, []byte)) {
+func getElement(key []byte, value [][]byte, emit func([]byte, [][]byte)) {
 	emit(key, value)
 }
 

--- a/sdks/go/test/load/combine/combine.go
+++ b/sdks/go/test/load/combine/combine.go
@@ -29,12 +29,18 @@ import (
 )
 
 var (
-	fanout          = flag.Int("fanout", 1, "Fanout")
-	topCount        = flag.Int("top_count", 20, "Top count")
+	fanout          = flag.Int(
+		"fanout",
+		1,
+		"A number of combine operations to perform in parallel.")
+	topCount        = flag.Int(
+		"top_count",
+		20,
+		"A number passed to the combiner.")
 	syntheticConfig = flag.String(
 		"input_options",
 		"",
-		"A JSON object that describes the configuration for synthetic source")
+		"A JSON object that describes the configuration for synthetic source.")
 )
 
 func parseSyntheticConfig() synthetic.SourceConfig {
@@ -46,7 +52,7 @@ func parseSyntheticConfig() synthetic.SourceConfig {
 	}
 }
 
-func CompareLess(key []uint8, value []uint8) bool {
+func CompareLess(key []byte, value []byte) bool {
 	return bytes.Compare(key, value) < 0
 }
 

--- a/sdks/go/test/load/combine/combine.go
+++ b/sdks/go/test/load/combine/combine.go
@@ -1,0 +1,75 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"bytes"
+	"context"
+	"flag"
+
+	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/apache/beam/sdks/go/pkg/beam/io/synthetic"
+	"github.com/apache/beam/sdks/go/pkg/beam/log"
+	"github.com/apache/beam/sdks/go/pkg/beam/transforms/top"
+	"github.com/apache/beam/sdks/go/pkg/beam/x/beamx"
+	"github.com/apache/beam/sdks/go/test/load"
+)
+
+var (
+	fanout          = flag.Int("fanout", 1, "Fanout")
+	topCount        = flag.Int("top_count", 20, "Top count")
+	syntheticConfig = flag.String(
+		"input_options",
+		"",
+		"A JSON object that describes the configuration for synthetic source")
+)
+
+func parseSyntheticConfig() synthetic.SourceConfig {
+	if *syntheticConfig == "" {
+		panic("--input_options not provided")
+	} else {
+		encoded := []byte(*syntheticConfig)
+		return synthetic.DefaultSourceConfig().BuildFromJSON(encoded)
+	}
+}
+
+func CompareLess(key []uint8, value []uint8) bool {
+	return bytes.Compare(key, value) < 0
+}
+
+func main() {
+	flag.Parse()
+	beam.Init()
+
+	ctx := context.Background()
+
+	p, s := beam.NewPipelineWithRoot()
+	src := synthetic.SourceSingle(s, parseSyntheticConfig())
+	pcoll := beam.ParDo(s, &load.RuntimeMonitor{}, src)
+	for i := 0; i < *fanout; i++ {
+		pcoll = top.LargestPerKey(s, pcoll, *topCount, CompareLess)
+	}
+
+	presult, err := beamx.RunWithMetrics(ctx, p)
+	if err != nil {
+		log.Fatalf(ctx, "Failed to execute job: %v", err)
+	}
+
+	if presult != nil {
+		metrics := presult.Metrics().AllMetrics()
+		load.PublishMetrics(metrics)
+	}
+}

--- a/sdks/go/test/load/combine/combine.go
+++ b/sdks/go/test/load/combine/combine.go
@@ -72,7 +72,7 @@ func main() {
 	for i := 0; i < *fanout; i++ {
 		pcoll = top.LargestPerKey(s, pcoll, *topCount, compareLess)
 		pcoll = beam.ParDo(s, getElement, pcoll)
-		pcoll = beam.ParDo(s, &load.RuntimeMonitor{}, src)
+		pcoll = beam.ParDo(s, &load.RuntimeMonitor{}, pcoll)
 	}
 
 	presult, err := beamx.RunWithMetrics(ctx, p)


### PR DESCRIPTION
This PR adds Combine load tests for Go SDK.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
