### PR TITLE
[BEAM-11324] Add additional verification in PartitioningSession

### DIFF
--- a/sdks/python/apache_beam/dataframe/expressions.py
+++ b/sdks/python/apache_beam/dataframe/expressions.py
@@ -17,8 +17,8 @@
 from __future__ import absolute_import
 
 import contextlib
-import threading
 import random
+import threading
 from typing import Any
 from typing import Callable
 from typing import Iterable

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -469,9 +469,11 @@ class DeferredSeries(DeferredDataFrameOrSeries):
       # We're only handling a single column.
       base_func = func[0] if isinstance(func, list) else func
       if _is_associative(base_func) and not args and not kwargs:
-        intermediate = expressions.elementwise_expression(
+        intermediate = expressions.ComputedExpression(
             'pre_aggregate',
-            lambda s: s.agg([base_func], *args, **kwargs), [self._expr])
+            lambda s: s.agg([base_func], *args, **kwargs), [self._expr],
+            requires_partition_by=partitionings.Nothing(),
+            preserves_partition_by=partitionings.Nothing())
         allow_nonparallel_final = True
       else:
         intermediate = self._expr

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -138,7 +138,7 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
           'map_index',
           map_index, [self._expr],
           requires_partition_by=partitionings.Nothing(),
-          preserves_partition_by=partitionings.Singleton())
+          preserves_partition_by=partitionings.Nothing())
 
     elif isinstance(by, DeferredSeries):
 

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -1403,17 +1403,20 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
   def reset_index(self, level=None, **kwargs):
     if level is not None and not isinstance(level, (tuple, list)):
       level = [level]
+
     if level is None or len(level) == self._expr.proxy().index.nlevels:
       # TODO: Could do distributed re-index with offsets.
       requires_partition_by = partitionings.Singleton()
     else:
       requires_partition_by = partitionings.Nothing()
+
+
     return frame_base.DeferredFrame.wrap(
         expressions.ComputedExpression(
             'reset_index',
             lambda df: df.reset_index(level=level, **kwargs),
             [self._expr],
-            preserves_partition_by=partitionings.Singleton(),
+            preserves_partition_by=partitionings.Nothing(),
             requires_partition_by=requires_partition_by))
 
   round = frame_base._elementwise_method('round')

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -142,7 +142,9 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
 
     elif isinstance(by, DeferredSeries):
 
-      raise NotImplementedError("grouping by a Series is not yet implemented. You can group by a DataFrame column by specifying its name.")
+      raise NotImplementedError(
+          "grouping by a Series is not yet implemented. You can group by a DataFrame column by specifying its name."
+      )
 
     elif isinstance(by, np.ndarray):
       raise frame_base.WontImplementError('order sensitive')

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -1403,14 +1403,11 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
   def reset_index(self, level=None, **kwargs):
     if level is not None and not isinstance(level, (tuple, list)):
       level = [level]
-
     if level is None or len(level) == self._expr.proxy().index.nlevels:
       # TODO: Could do distributed re-index with offsets.
       requires_partition_by = partitionings.Singleton()
     else:
       requires_partition_by = partitionings.Nothing()
-
-
     return frame_base.DeferredFrame.wrap(
         expressions.ComputedExpression(
             'reset_index',

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -143,8 +143,8 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
     elif isinstance(by, DeferredSeries):
 
       raise NotImplementedError(
-          "grouping by a Series is not yet implemented. You can group by a DataFrame column by specifying its name."
-      )
+          "grouping by a Series is not yet implemented. You can group by a "
+          "DataFrame column by specifying its name.")
 
     elif isinstance(by, np.ndarray):
       raise frame_base.WontImplementError('order sensitive')

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -142,25 +142,7 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
 
     elif isinstance(by, DeferredSeries):
 
-      if isinstance(self, DeferredSeries):
-
-        def set_index(s, by):
-          df = pd.DataFrame(s)
-          df, by = df.align(by, axis=0, join='inner')
-          return df.set_index(by).iloc[:, 0]
-
-      else:
-
-        def set_index(df, by):  # type: ignore
-          df, by = df.align(by, axis=0, join='inner')
-          return df.set_index(by)
-
-      to_group = expressions.ComputedExpression(
-          'set_index',
-          set_index,  #
-          [self._expr, by._expr],
-          requires_partition_by=partitionings.Index(),
-          preserves_partition_by=partitionings.Nothing())
+      raise NotImplementedError("grouping by a Series is not yet implemented. You can group by a DataFrame column by specifying its name.")
 
     elif isinstance(by, np.ndarray):
       raise frame_base.WontImplementError('order sensitive')

--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -123,7 +123,6 @@ class DeferredFrameTest(unittest.TestCase):
 
     self._run_test(lambda df: df.groupby(['second', 'A']).sum(), df)
 
-
   @unittest.skipIf(sys.version_info <= (3, ), 'differing signature')
   def test_merge(self):
     # This is from the pandas doctests, but fails due to re-indexing being

--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -106,9 +106,10 @@ class DeferredFrameTest(unittest.TestCase):
     self._run_test(lambda df: df[df.value > 30].groupby('group').mean(), df)
     self._run_test(lambda df: df[df.value > 30].groupby('group').size(), df)
 
-    self._run_test(lambda df: df[df.value > 40].groupby(df.group).sum(), df)
-    self._run_test(lambda df: df[df.value > 40].groupby(df.group).mean(), df)
-    self._run_test(lambda df: df[df.value > 40].groupby(df.group).size(), df)
+    # Grouping by a series is not currently supported
+    #self._run_test(lambda df: df[df.value > 40].groupby(df.group).sum(), df)
+    #self._run_test(lambda df: df[df.value > 40].groupby(df.group).mean(), df)
+    #self._run_test(lambda df: df[df.value > 40].groupby(df.group).size(), df)
 
     # Example from https://pandas.pydata.org/docs/user_guide/groupby.html
     arrays = [['bar', 'bar', 'baz', 'baz', 'foo', 'foo', 'qux', 'qux'],

--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -30,7 +30,7 @@ from apache_beam.dataframe import frames  # pylint: disable=unused-import
 
 
 class DeferredFrameTest(unittest.TestCase):
-  def _run_test(self, func, *args, distributed=False):
+  def _run_test(self, func, *args, distributed=True):
     deferred_args = [
         frame_base.DeferredFrame.wrap(
             expressions.ConstantExpression(arg, arg[0:0])) for arg in args
@@ -93,42 +93,22 @@ class DeferredFrameTest(unittest.TestCase):
         'group': ['a' if i % 5 == 0 or i % 3 == 0 else 'b' for i in range(100)],
         'value': [None if i % 11 == 0 else i for i in range(100)]
     })
-    self._run_test(
-        lambda df: df.groupby('group').agg(sum), df, distributed=True)
-    self._run_test(lambda df: df.groupby('group').sum(), df, distributed=True)
-    self._run_test(
-        lambda df: df.groupby('group').median(), df, distributed=True)
-    self._run_test(lambda df: df.groupby('group').size(), df, distributed=True)
-    self._run_test(lambda df: df.groupby('group').count(), df, distributed=True)
-    self._run_test(lambda df: df.groupby('group').max(), df, distributed=True)
-    self._run_test(lambda df: df.groupby('group').min(), df, distributed=True)
-    self._run_test(lambda df: df.groupby('group').mean(), df, distributed=True)
+    self._run_test(lambda df: df.groupby('group').agg(sum), df)
+    self._run_test(lambda df: df.groupby('group').sum(), df)
+    self._run_test(lambda df: df.groupby('group').median(), df)
+    self._run_test(lambda df: df.groupby('group').size(), df)
+    self._run_test(lambda df: df.groupby('group').count(), df)
+    self._run_test(lambda df: df.groupby('group').max(), df)
+    self._run_test(lambda df: df.groupby('group').min(), df)
+    self._run_test(lambda df: df.groupby('group').mean(), df)
 
-    self._run_test(
-        lambda df: df[df.value > 30].groupby('group').sum(),
-        df,
-        distributed=True)
-    self._run_test(
-        lambda df: df[df.value > 30].groupby('group').mean(),
-        df,
-        distributed=True)
-    self._run_test(
-        lambda df: df[df.value > 30].groupby('group').size(),
-        df,
-        distributed=True)
+    self._run_test(lambda df: df[df.value > 30].groupby('group').sum(), df)
+    self._run_test(lambda df: df[df.value > 30].groupby('group').mean(), df)
+    self._run_test(lambda df: df[df.value > 30].groupby('group').size(), df)
 
-    self._run_test(
-        lambda df: df[df.value > 40].groupby(df.group).sum(),
-        df,
-        distributed=True)
-    self._run_test(
-        lambda df: df[df.value > 40].groupby(df.group).mean(),
-        df,
-        distributed=True)
-    self._run_test(
-        lambda df: df[df.value > 40].groupby(df.group).size(),
-        df,
-        distributed=True)
+    self._run_test(lambda df: df[df.value > 40].groupby(df.group).sum(), df)
+    self._run_test(lambda df: df[df.value > 40].groupby(df.group).mean(), df)
+    self._run_test(lambda df: df[df.value > 40].groupby(df.group).size(), df)
 
   @unittest.skipIf(sys.version_info <= (3, ), 'differing signature')
   def test_merge(self):
@@ -160,24 +140,24 @@ class DeferredFrameTest(unittest.TestCase):
 
   def test_series_getitem(self):
     s = pd.Series([x**2 for x in range(10)])
-    self._run_test(lambda s: s[...], s, distributed=True)
-    self._run_test(lambda s: s[:], s, distributed=True)
-    self._run_test(lambda s: s[s < 10], s, distributed=True)
-    self._run_test(lambda s: s[lambda s: s < 10], s, distributed=True)
+    self._run_test(lambda s: s[...], s)
+    self._run_test(lambda s: s[:], s)
+    self._run_test(lambda s: s[s < 10], s)
+    self._run_test(lambda s: s[lambda s: s < 10], s)
 
     s.index = s.index.map(float)
-    self._run_test(lambda s: s[1.5:6], s, distributed=True)
+    self._run_test(lambda s: s[1.5:6], s)
 
   def test_dataframe_getitem(self):
     df = pd.DataFrame({'A': [x**2 for x in range(6)], 'B': list('abcdef')})
-    self._run_test(lambda df: df['A'], df, distributed=True)
-    self._run_test(lambda df: df[['A', 'B']], df, distributed=True)
+    self._run_test(lambda df: df['A'], df)
+    self._run_test(lambda df: df[['A', 'B']], df)
 
-    self._run_test(lambda df: df[:], df, distributed=True)
-    self._run_test(lambda df: df[df.A < 10], df, distributed=True)
+    self._run_test(lambda df: df[:], df)
+    self._run_test(lambda df: df[df.A < 10], df)
 
     df.index = df.index.map(float)
-    self._run_test(lambda df: df[1.5:4], df, distributed=True)
+    self._run_test(lambda df: df[1.5:4], df)
 
   def test_loc(self):
     dates = pd.date_range('1/1/2000', periods=8)
@@ -222,27 +202,23 @@ class DeferredFrameTest(unittest.TestCase):
     for s in [pd.Series([1, 2, 3]),
               pd.Series(range(100)),
               pd.Series([x**3 for x in range(-50, 50)])]:
-      self._run_test(lambda s: s.std(), s, distributed=True)
-      self._run_test(lambda s: s.corr(s), s, distributed=True)
-      self._run_test(lambda s: s.corr(s + 1), s, distributed=True)
-      self._run_test(lambda s: s.corr(s * s), s, distributed=True)
-      self._run_test(lambda s: s.cov(s * s), s, distributed=True)
+      self._run_test(lambda s: s.std(), s)
+      self._run_test(lambda s: s.corr(s), s)
+      self._run_test(lambda s: s.corr(s + 1), s)
+      self._run_test(lambda s: s.corr(s * s), s)
+      self._run_test(lambda s: s.cov(s * s), s)
 
   def test_dataframe_cov_corr(self):
     df = pd.DataFrame(np.random.randn(20, 3), columns=['a', 'b', 'c'])
     df.loc[df.index[:5], 'a'] = np.nan
     df.loc[df.index[5:10], 'b'] = np.nan
-    self._run_test(lambda df: df.corr().round(8), df, distributed=True)
-    self._run_test(lambda df: df.cov().round(8), df, distributed=True)
+    self._run_test(lambda df: df.corr().round(8), df)
+    self._run_test(lambda df: df.cov().round(8), df)
+    self._run_test(lambda df: df.corr(min_periods=12).round(8), df)
+    self._run_test(lambda df: df.cov(min_periods=12).round(8), df)
+    self._run_test(lambda df: df.corrwith(df.a).round(8), df)
     self._run_test(
-        lambda df: df.corr(min_periods=12).round(8), df, distributed=True)
-    self._run_test(
-        lambda df: df.cov(min_periods=12).round(8), df, distributed=True)
-    self._run_test(lambda df: df.corrwith(df.a).round(8), df, distributed=True)
-    self._run_test(
-        lambda df: df[['a', 'b']].corrwith(df[['b', 'c']]).round(8),
-        df,
-        distributed=True)
+        lambda df: df[['a', 'b']].corrwith(df[['b', 'c']]).round(8), df)
 
   def test_categorical_groupby(self):
     df = pd.DataFrame({'A': np.arange(6), 'B': list('aabbca')})
@@ -251,20 +227,19 @@ class DeferredFrameTest(unittest.TestCase):
     # TODO(BEAM-11190): These aggregations can be done in index partitions, but
     # it will require a little more complex logic
     with beam.dataframe.allow_non_parallel_operations():
-      self._run_test(lambda df: df.groupby(level=0).sum(), df, distributed=True)
-      self._run_test(
-          lambda df: df.groupby(level=0).mean(), df, distributed=True)
+      self._run_test(lambda df: df.groupby(level=0).sum(), df)
+      self._run_test(lambda df: df.groupby(level=0).mean(), df)
 
   def test_dataframe_eval_query(self):
     df = pd.DataFrame(np.random.randn(20, 3), columns=['a', 'b', 'c'])
-    self._run_test(lambda df: df.eval('foo = a + b - c'), df, distributed=True)
-    self._run_test(lambda df: df.query('a > b + c'), df, distributed=True)
+    self._run_test(lambda df: df.eval('foo = a + b - c'), df)
+    self._run_test(lambda df: df.query('a > b + c'), df)
 
     def eval_inplace(df):
       df.eval('foo = a + b - c', inplace=True)
       return df.foo
 
-    self._run_test(eval_inplace, df, distributed=True)
+    self._run_test(eval_inplace, df)
 
     # Verify that attempting to access locals raises a useful error
     deferred_df = frame_base.DeferredFrame.wrap(

--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -110,7 +110,7 @@ class DeferredFrameTest(unittest.TestCase):
     self._run_test(lambda df: df[df.value > 40].groupby(df.group).mean(), df)
     self._run_test(lambda df: df[df.value > 40].groupby(df.group).size(), df)
 
-    # Example from https://pandas.pydata.org/docs/user_guide/groupby.html#grouping-dataframe-with-index-levels-and-columns
+    # Example from https://pandas.pydata.org/docs/user_guide/groupby.html
     arrays = [['bar', 'bar', 'baz', 'baz', 'foo', 'foo', 'qux', 'qux'],
               ['one', 'two', 'one', 'two', 'one', 'two', 'one', 'two']]
 

--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -112,12 +112,13 @@ class DeferredFrameTest(unittest.TestCase):
 
     # Example from https://pandas.pydata.org/docs/user_guide/groupby.html#grouping-dataframe-with-index-levels-and-columns
     arrays = [['bar', 'bar', 'baz', 'baz', 'foo', 'foo', 'qux', 'qux'],
-           ['one', 'two', 'one', 'two', 'one', 'two', 'one', 'two']]
+              ['one', 'two', 'one', 'two', 'one', 'two', 'one', 'two']]
 
     index = pd.MultiIndex.from_arrays(arrays, names=['first', 'second'])
 
-    df = pd.DataFrame({'A': [1, 1, 1, 1, 2, 2, 3, 3],
-                       'B': np.arange(8)},
+    df = pd.DataFrame({
+        'A': [1, 1, 1, 1, 2, 2, 3, 3], 'B': np.arange(8)
+    },
                       index=index)
 
     self._run_test(lambda df: df.groupby(['second', 'A']).sum(), df)

--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -110,6 +110,19 @@ class DeferredFrameTest(unittest.TestCase):
     self._run_test(lambda df: df[df.value > 40].groupby(df.group).mean(), df)
     self._run_test(lambda df: df[df.value > 40].groupby(df.group).size(), df)
 
+    # Example from https://pandas.pydata.org/docs/user_guide/groupby.html#grouping-dataframe-with-index-levels-and-columns
+    arrays = [['bar', 'bar', 'baz', 'baz', 'foo', 'foo', 'qux', 'qux'],
+           ['one', 'two', 'one', 'two', 'one', 'two', 'one', 'two']]
+
+    index = pd.MultiIndex.from_arrays(arrays, names=['first', 'second'])
+
+    df = pd.DataFrame({'A': [1, 1, 1, 1, 2, 2, 3, 3],
+                       'B': np.arange(8)},
+                      index=index)
+
+    self._run_test(lambda df: df.groupby(['second', 'A']).sum(), df)
+
+
   @unittest.skipIf(sys.version_info <= (3, ), 'differing signature')
   def test_merge(self):
     # This is from the pandas doctests, but fails due to re-indexing being

--- a/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
@@ -234,6 +234,8 @@ class DoctestTest(unittest.TestCase):
                 'ser.groupby(["a", "b", "a", "b"]).mean()',
                 'ser.groupby(["a", "b", "a", np.nan]).mean()',
                 'ser.groupby(["a", "b", "a", np.nan], dropna=False).mean()',
+                # Grouping by a series is not supported
+                'ser.groupby(ser > 100).mean()',
             ],
             'pandas.core.series.Series.reindex': ['*'],
         },

--- a/sdks/python/apache_beam/dataframe/partitionings.py
+++ b/sdks/python/apache_beam/dataframe/partitionings.py
@@ -116,6 +116,9 @@ class Index(Partitioning):
       yield key, df[hashes % num_partitions == key]
 
   def check(self, dfs):
+    # TODO(BEAM-11324): This check should be stronger, it should verify that
+    # running partition_fn on the concatenation of dfs yields the same
+    # partitions.
     if self._levels is None:
 
       def get_index_set(df):

--- a/sdks/python/apache_beam/dataframe/partitionings.py
+++ b/sdks/python/apache_beam/dataframe/partitionings.py
@@ -115,6 +115,23 @@ class Index(Partitioning):
     for key in range(num_partitions):
       yield key, df[hashes % num_partitions == key]
 
+  def check(self, dfs):
+    if self._levels is None:
+
+      def get_index_set(df):
+        return set(df.index)
+    else:
+
+      def get_index_set(df):
+        return set(zip(df.index.level[level] for level in self._levels))
+
+    index_sets = [get_index_set(df) for df in dfs]
+    for i, index_set in enumerate(index_sets[:-1]):
+      if not index_set.isdisjoint(set.union(*index_sets[i + 1:])):
+        return False
+
+    return True
+
 
 class Singleton(Partitioning):
   """A partitioning of all the data into a single partition.
@@ -133,6 +150,9 @@ class Singleton(Partitioning):
 
   def partition_fn(self, df, num_partitions):
     yield None, df
+
+  def check(self, dfs):
+    return len(dfs) <= 1
 
 
 class Nothing(Partitioning):
@@ -162,3 +182,6 @@ class Nothing(Partitioning):
     part = pd.Series(shuffled(range(len(df))), index=df.index) % num_partitions
     for k in range(num_partitions):
       yield k, df[part == k]
+
+  def check(self, dfs):
+    return True


### PR DESCRIPTION
This PR modifies `PartitioningSession` so it re-executes expressions with a variety of partitioned inputs, determined by the expression's `requires_partition_by` specification. It also verifies that the output for each type of partitioned input is partitioned consistent with the expression's `preserves_partition_by` specification.

This detected the issue fixed in https://github.com/apache/beam/pull/13398, and detected an additional issue with Series.agg's pre-aggregation, fixed in ac1e3a.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
