### PR TITLE
[BEAM-11343] Make ExpansionServiceClient accesible outside of core-construction-java

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/DefaultExpansionServiceClientFactory.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/DefaultExpansionServiceClientFactory.java
@@ -30,10 +30,15 @@ public class DefaultExpansionServiceClientFactory implements ExpansionServiceCli
   private Map<Endpoints.ApiServiceDescriptor, ExpansionServiceClient> expansionServiceMap;
   private Function<Endpoints.ApiServiceDescriptor, ManagedChannel> channelFactory;
 
-  DefaultExpansionServiceClientFactory(
+  private DefaultExpansionServiceClientFactory(
       Function<Endpoints.ApiServiceDescriptor, ManagedChannel> channelFactory) {
     this.expansionServiceMap = new ConcurrentHashMap<>();
     this.channelFactory = channelFactory;
+  }
+
+  public static DefaultExpansionServiceClientFactory create(
+      Function<Endpoints.ApiServiceDescriptor, ManagedChannel> channelFactory) {
+    return new DefaultExpansionServiceClientFactory(channelFactory);
   }
 
   @Override

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ExpansionServiceClient.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ExpansionServiceClient.java
@@ -20,6 +20,6 @@ package org.apache.beam.runners.core.construction;
 import org.apache.beam.model.expansion.v1.ExpansionApi;
 
 /** A high-level client for a cross-language expansion service. */
-interface ExpansionServiceClient extends AutoCloseable {
+public interface ExpansionServiceClient extends AutoCloseable {
   ExpansionApi.ExpansionResponse expand(ExpansionApi.ExpansionRequest request);
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ExpansionServiceClientFactory.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ExpansionServiceClientFactory.java
@@ -23,6 +23,6 @@ import org.apache.beam.model.pipeline.v1.Endpoints;
  * A factory for generating {@link ExpansionServiceClient} from {@link
  * org.apache.beam.model.pipeline.v1.Endpoints.ApiServiceDescriptor}.
  */
-interface ExpansionServiceClientFactory extends AutoCloseable {
+public interface ExpansionServiceClientFactory extends AutoCloseable {
   ExpansionServiceClient getExpansionServiceClient(Endpoints.ApiServiceDescriptor endpoint);
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/External.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/External.java
@@ -78,7 +78,7 @@ public class External {
   private static AtomicInteger namespaceCounter = new AtomicInteger(0);
 
   private static final ExpansionServiceClientFactory DEFAULT =
-      new DefaultExpansionServiceClientFactory(
+     DefaultExpansionServiceClientFactory.create(
           endPoint -> ManagedChannelBuilder.forTarget(endPoint.getUrl()).usePlaintext().build());
 
   private static int getFreshNamespaceIndex() {


### PR DESCRIPTION
I found this inaccessibility issue while trying to use ExpansionService outside of the external transform. 

R: @ibzib 