### PR TITLE
[BEAM-11429] User-friendly names for packed combiners

### DIFF
--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
@@ -950,11 +950,11 @@ def pack_combiners(stages, context):
 
     def make_pack_name(names):
       """Return the packed Transform or Stage name.
-      
+
       The output name will contain the input names' common prefix, the infix
-      '/PackedCombinePerKey', and the input names' suffixes in parantheses.
+      '/Packed', and the input names' suffixes in square brackets.
       For example, if the input names are 'a/b/c1/d1' and 'a/b/c2/d2, then
-      the output name is 'a/b/Packed(c1/d1,c2/d2)'.
+      the output name is 'a/b/Packed[c1/d1, c2/d2]'.
       """
       assert names
       tokens_in_names = [name.split('/') for name in names]
@@ -973,10 +973,10 @@ def pack_combiners(stages, context):
         for tokens in tokens_in_names:
           tokens.pop(0)
 
-      common_prefix_tokens.append('PackedCombinePerKey')
+      common_prefix_tokens.append('Packed')
       common_prefix = '/'.join(common_prefix_tokens)
       suffixes = ['/'.join(tokens) for tokens in tokens_in_names]
-      return '%s(%s)' % (common_prefix, ','.join(suffixes))
+      return '%s[%s]' % (common_prefix, ', '.join(suffixes))
 
     pack_stage_name = make_pack_name([stage.name for stage in packable_stages])
     pack_transform_name = make_pack_name([

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
@@ -973,9 +973,10 @@ def pack_combiners(stages, context):
         for tokens in tokens_in_names:
           tokens.pop(0)
 
+      common_prefix_tokens.append('PackedCombinePerKey')
       common_prefix = '/'.join(common_prefix_tokens)
       suffixes = ['/'.join(tokens) for tokens in tokens_in_names]
-      return '%s/PackedCombinePerKey(%s)' % (common_prefix, ','.join(suffixes))
+      return '%s(%s)' % (common_prefix, ','.join(suffixes))
 
     pack_stage_name = make_pack_name([stage.name for stage in packable_stages])
     pack_transform_name = make_pack_name([

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
@@ -960,6 +960,7 @@ def pack_combiners(stages, context):
       tokens_in_names = [name.split('/') for name in names]
       common_prefix_tokens = []
 
+      # Find the longest common prefix of tokens.
       while True:
         first_token_in_names = set()
         for tokens in tokens_in_names:
@@ -968,10 +969,10 @@ def pack_combiners(stages, context):
           first_token_in_names.add(tokens[0])
         if len(first_token_in_names) != 1:
           break
-
         common_prefix_tokens.append(next(iter(first_token_in_names)))
         for tokens in tokens_in_names:
           tokens.pop(0)
+
       common_prefix = '/'.join(common_prefix_tokens)
       suffixes = ['/'.join(tokens) for tokens in tokens_in_names]
       return '%s/PackedCombinePerKey(%s)' % (common_prefix, ','.join(suffixes))

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
@@ -104,9 +104,9 @@ class TranslationsTest(unittest.TestCase):
     # the beam:combinefn:packed_python:v1 capability.
     self.assertEqual(len(combine_per_key_stages), 2)
     for combine_per_key_stage in combine_per_key_stages:
-      self.assertNotIn('PackedCombinePerKey', combine_per_key_stage.name)
+      self.assertNotIn('Packed', combine_per_key_stage.name)
       self.assertNotIn(
-          'PackedCombinePerKey',
+          'Packed',
           combine_per_key_stage.transforms[0].unique_name)
 
   def test_pack_global_combiners(self):
@@ -140,9 +140,9 @@ class TranslationsTest(unittest.TestCase):
         if transform.spec.urn == common_urns.composites.COMBINE_PER_KEY.urn:
           combine_per_key_stages.append(stage)
     self.assertEqual(len(combine_per_key_stages), 1)
-    self.assertIn('PackedCombinePerKey', combine_per_key_stages[0].name)
+    self.assertIn('Packed', combine_per_key_stages[0].name)
     self.assertIn(
-        'PackedCombinePerKey',
+        'Packed',
         combine_per_key_stages[0].transforms[0].unique_name)
     self.assertIn('multiple-combines', combine_per_key_stages[0].parent)
     self.assertNotIn('-globally', combine_per_key_stages[0].parent)

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
@@ -74,9 +74,9 @@ class TranslationsTest(unittest.TestCase):
         if transform.spec.urn == common_urns.composites.COMBINE_PER_KEY.urn:
           combine_per_key_stages.append(stage)
     self.assertEqual(len(combine_per_key_stages), 1)
-    self.assertIn('PackedCombinePerKey', combine_per_key_stages[0].name)
+    self.assertIn('Packed', combine_per_key_stages[0].name)
     self.assertIn(
-        'PackedCombinePerKey',
+        'Packed',
         combine_per_key_stages[0].transforms[0].unique_name)
     self.assertIn('multiple-combines', combine_per_key_stages[0].parent)
     self.assertNotIn('-perkey', combine_per_key_stages[0].parent)

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
@@ -74,7 +74,10 @@ class TranslationsTest(unittest.TestCase):
         if transform.spec.urn == common_urns.composites.COMBINE_PER_KEY.urn:
           combine_per_key_stages.append(stage)
     self.assertEqual(len(combine_per_key_stages), 1)
-    self.assertIn('/Pack', combine_per_key_stages[0].name)
+    self.assertIn('PackedCombinePerKey', combine_per_key_stages[0].name)
+    self.assertIn(
+        'PackedCombinePerKey',
+        combine_per_key_stages[0].transforms[0].unique_name)
     self.assertIn('multiple-combines', combine_per_key_stages[0].parent)
     self.assertNotIn('-perkey', combine_per_key_stages[0].parent)
 
@@ -101,7 +104,10 @@ class TranslationsTest(unittest.TestCase):
     # the beam:combinefn:packed_python:v1 capability.
     self.assertEqual(len(combine_per_key_stages), 2)
     for combine_per_key_stage in combine_per_key_stages:
-      self.assertNotIn('/Pack', combine_per_key_stage.name)
+      self.assertNotIn('PackedCombinePerKey', combine_per_key_stage.name)
+      self.assertNotIn(
+          'PackedCombinePerKey',
+          combine_per_key_stage.transforms[0].unique_name)
 
   def test_pack_global_combiners(self):
     class MultipleCombines(beam.PTransform):
@@ -134,7 +140,10 @@ class TranslationsTest(unittest.TestCase):
         if transform.spec.urn == common_urns.composites.COMBINE_PER_KEY.urn:
           combine_per_key_stages.append(stage)
     self.assertEqual(len(combine_per_key_stages), 1)
-    self.assertIn('/Pack', combine_per_key_stages[0].name)
+    self.assertIn('PackedCombinePerKey', combine_per_key_stages[0].name)
+    self.assertIn(
+        'PackedCombinePerKey',
+        combine_per_key_stages[0].transforms[0].unique_name)
     self.assertIn('multiple-combines', combine_per_key_stages[0].parent)
     self.assertNotIn('-globally', combine_per_key_stages[0].parent)
 

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
@@ -75,9 +75,7 @@ class TranslationsTest(unittest.TestCase):
           combine_per_key_stages.append(stage)
     self.assertEqual(len(combine_per_key_stages), 1)
     self.assertIn('Packed', combine_per_key_stages[0].name)
-    self.assertIn(
-        'Packed',
-        combine_per_key_stages[0].transforms[0].unique_name)
+    self.assertIn('Packed', combine_per_key_stages[0].transforms[0].unique_name)
     self.assertIn('multiple-combines', combine_per_key_stages[0].parent)
     self.assertNotIn('-perkey', combine_per_key_stages[0].parent)
 
@@ -106,8 +104,7 @@ class TranslationsTest(unittest.TestCase):
     for combine_per_key_stage in combine_per_key_stages:
       self.assertNotIn('Packed', combine_per_key_stage.name)
       self.assertNotIn(
-          'Packed',
-          combine_per_key_stage.transforms[0].unique_name)
+          'Packed', combine_per_key_stage.transforms[0].unique_name)
 
   def test_pack_global_combiners(self):
     class MultipleCombines(beam.PTransform):
@@ -141,9 +138,7 @@ class TranslationsTest(unittest.TestCase):
           combine_per_key_stages.append(stage)
     self.assertEqual(len(combine_per_key_stages), 1)
     self.assertIn('Packed', combine_per_key_stages[0].name)
-    self.assertIn(
-        'Packed',
-        combine_per_key_stages[0].transforms[0].unique_name)
+    self.assertIn('Packed', combine_per_key_stages[0].transforms[0].unique_name)
     self.assertIn('multiple-combines', combine_per_key_stages[0].parent)
     self.assertNotIn('-globally', combine_per_key_stages[0].parent)
 


### PR DESCRIPTION
This improves the readability of the stage and transform names for transforms and stages resulting from the `translations.eliminate_common_key_with_none` and `translations.pack_combiners`. This also fixes an issue where the transform name was incorrectly set to the stage name.

For example, for `TranslationsTest.test_pack_combiners`, previously both the Pack transform and stage  were set to `(ref_AppliedPTransform_multiple-combines/mean-perkey/CombinePerKey(MeanCombineFn)_16)+(ref_AppliedPTransform_multiple-combines/count-perkey/CombinePerKey(CountCombineFn)_21)/Pack`. After this change, the Pack transform name is set to `multiple-combines/Packed[mean-perkey/CombinePerKey(MeanCombineFn), count-perkey/CombinePerKey(CountCombineFn)]/Pack` and the Pack stage name is set to `ref_AppliedPTransform_multiple-combines/Packed[mean-perkey/CombinePerKey(MeanCombineFn)_16, count-perkey/CombinePerKey(CountCombineFn)_21]/Pack`. The Unpack transform and stage are named similarly, but with the suffix `/Unpack` instead of `/Pack`.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
