### PR TITLE
[BEAM-11457] Add option to skip key-value clone

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -60,6 +60,7 @@
 
 * ParquetIO add methods _readGenericRecords_ and _readFilesGenericRecords_ can read files with an unknown schema. See [PR-13554](https://github.com/apache/beam/pull/13554) and ([BEAM-11460](https://issues.apache.org/jira/browse/BEAM-11460))
 * Added support for thrift in KafkaTableProvider ([BEAM-11482](https://issues.apache.org/jira/browse/BEAM-11482))
+* Added support for HadoopFormatIO to skip key/value clone ([BEAM-11457](https://issues.apache.org/jira/browse/BEAM-11457))
 * X feature added (Java/Python) ([BEAM-X](https://issues.apache.org/jira/browse/BEAM-X)).
 
 ## Breaking Changes

--- a/sdks/java/io/hadoop-format/src/main/java/org/apache/beam/sdk/io/hadoop/format/HadoopFormatIO.java
+++ b/sdks/java/io/hadoop-format/src/main/java/org/apache/beam/sdk/io/hadoop/format/HadoopFormatIO.java
@@ -199,6 +199,21 @@ import org.slf4j.LoggerFactory;
  *              .withValueTranslation(myOutputValueType);
  * }</pre>
  *
+ * <p> Hadoop formats typically work with Writable data structures which are mutable and instances
+ * are reused by the input format reader. Therefore, to not to have elements which can change value
+ * after they are emitted from read, this IO will clone each key value read from underlying hadoop
+ * input format (unless they are in the list of well known immutable types). However, in cases where
+ * used input format does not reuse instances for key/value or translation functions are used which
+ * already output immutable types, such clone of values can be needless penalty. In these cases IO
+ * can be instructed to skip key/value cloning.
+ *
+ * <pre>{@code
+ *  HadoopFormatIO.Read<InputFormatKeyClass, MyValueClass> read = ...
+ *  p.apply("read", read
+ *      .withSkipKeyClone(true)
+ *      .withSkipValueClone(true));
+ * }</pre>
+ *
  * <p>IMPORTANT! In case of using {@code DBInputFormat} to read data from RDBMS, Beam parallelizes
  * the process by using LIMIT and OFFSET clauses of SQL query to fetch different ranges of records
  * (as a split) by different workers. To guarantee the same order and proper split of results you
@@ -331,7 +346,10 @@ public class HadoopFormatIO {
    * HadoopFormatIO.Read#withKeyTranslation}/ {@link HadoopFormatIO.Read#withValueTranslation}.
    */
   public static <K, V> Read<K, V> read() {
-    return new AutoValue_HadoopFormatIO_Read.Builder<K, V>().build();
+    return new AutoValue_HadoopFormatIO_Read.Builder<K, V>()
+        .setSkipKeyClone(false)
+        .setSkipValueClone(false)
+        .build();
   }
 
   /**
@@ -374,7 +392,9 @@ public class HadoopFormatIO {
 
     public abstract @Nullable Coder<V> getValueCoder();
 
-    public abstract @Nullable Boolean getSkipKeyValueClone();
+    public abstract @Nullable Boolean getSkipKeyClone();
+
+    public abstract @Nullable Boolean getSkipValueClone();
 
     public abstract @Nullable TypeDescriptor<?> getinputFormatClass();
 
@@ -400,7 +420,9 @@ public class HadoopFormatIO {
 
       abstract Builder<K, V> setValueCoder(Coder<V> valueCoder);
 
-      abstract Builder<K, V> setSkipKeyValueClone(Boolean value);
+      abstract Builder<K, V> setSkipKeyClone(Boolean value);
+
+      abstract Builder<K, V> setSkipValueClone(Boolean value);
 
       abstract Builder<K, V> setInputFormatClass(TypeDescriptor<?> inputFormatClass);
 
@@ -479,16 +501,14 @@ public class HadoopFormatIO {
       return withValueTranslation(function).toBuilder().setValueCoder(coder).build();
     }
 
-    /**
-     * Determines if key-value clone should be skipped or not (default is 'false'). Hadoop formats
-     * typically work with Writable data structures which are mutable. Therefore, this IO will clone
-     * read key-values if they are not in the list of well known immutable types. However, in case
-     * user does use key/value translation functions, resulting key-values might already be
-     * immutable. In such case, additional copy is unnecessary overhead and can be avoided by
-     * setting skip to 'true'.
-     */
-    public Read<K, V> withSkipKeyValueClone(boolean value) {
-      return toBuilder().setSkipKeyValueClone(value).build();
+    /** Determines if key clone should be skipped or not (default is 'false'). */
+    public Read<K, V> withSkipKeyClone(boolean value) {
+      return toBuilder().setSkipKeyClone(value).build();
+    }
+
+    /** Determines if value clone should be skipped or not (default is 'false'). */
+    public Read<K, V> withSkipValueClone(boolean value) {
+      return toBuilder().setSkipValueClone(value).build();
     }
 
     @Override
@@ -504,7 +524,6 @@ public class HadoopFormatIO {
       if (valueCoder == null) {
         valueCoder = getDefaultCoder(getValueTypeDescriptor(), coderRegistry);
       }
-      boolean skipKeyValueClone = getSkipKeyValueClone() == null ? false : getSkipKeyValueClone();
 
       HadoopInputFormatBoundedSource<K, V> source =
           new HadoopInputFormatBoundedSource<>(
@@ -513,7 +532,8 @@ public class HadoopFormatIO {
               valueCoder,
               getKeyTranslationFunction(),
               getValueTranslationFunction(),
-              skipKeyValueClone);
+              getSkipKeyClone(),
+              getSkipValueClone());
       return input.getPipeline().apply(org.apache.beam.sdk.io.Read.from(source));
     }
 
@@ -601,7 +621,8 @@ public class HadoopFormatIO {
     private final @Nullable SimpleFunction<?, K> keyTranslationFunction;
     private final @Nullable SimpleFunction<?, V> valueTranslationFunction;
     private final SerializableSplit inputSplit;
-    private final boolean skipKeyValueClone;
+    private final boolean skipKeyClone;
+    private final boolean skipValueClone;
     private transient List<SerializableSplit> inputSplits;
     private long boundedSourceEstimatedSize = 0;
     private transient InputFormat<?, ?> inputFormatObj;
@@ -626,7 +647,8 @@ public class HadoopFormatIO {
         Coder<V> valueCoder,
         @Nullable SimpleFunction<?, K> keyTranslationFunction,
         @Nullable SimpleFunction<?, V> valueTranslationFunction,
-        boolean skipKeyValueClone) {
+        boolean skipKeyClone,
+        boolean skipValueClone) {
       this(
           conf,
           keyCoder,
@@ -634,7 +656,8 @@ public class HadoopFormatIO {
           keyTranslationFunction,
           valueTranslationFunction,
           null,
-          skipKeyValueClone);
+          skipKeyClone,
+          skipValueClone);
     }
 
     @SuppressWarnings("WeakerAccess")
@@ -645,14 +668,16 @@ public class HadoopFormatIO {
         @Nullable SimpleFunction<?, K> keyTranslationFunction,
         @Nullable SimpleFunction<?, V> valueTranslationFunction,
         SerializableSplit inputSplit,
-        boolean skipKeyValueClone) {
+        boolean skipKeyClone,
+        boolean skipValueClone) {
       this.conf = conf;
       this.inputSplit = inputSplit;
       this.keyCoder = keyCoder;
       this.valueCoder = valueCoder;
       this.keyTranslationFunction = keyTranslationFunction;
       this.valueTranslationFunction = valueTranslationFunction;
-      this.skipKeyValueClone = skipKeyValueClone;
+      this.skipKeyClone = skipKeyClone;
+      this.skipValueClone = skipValueClone;
     }
 
     @SuppressWarnings("WeakerAccess")
@@ -709,7 +734,8 @@ public class HadoopFormatIO {
                       keyTranslationFunction,
                       valueTranslationFunction,
                       serializableInputSplit,
-                      skipKeyValueClone))
+                      skipKeyClone,
+                      skipValueClone))
           .collect(Collectors.toList());
     }
 
@@ -912,11 +938,16 @@ public class HadoopFormatIO {
         V value;
         try {
           // Transform key if translation function is provided.
-          key = transformKeyOrValue(recordReader.getCurrentKey(), keyTranslationFunction, keyCoder);
+          key =
+              transformKeyOrValue(
+                  recordReader.getCurrentKey(), keyTranslationFunction, keyCoder, skipKeyClone);
           // Transform value if translation function is provided.
           value =
               transformKeyOrValue(
-                  recordReader.getCurrentValue(), valueTranslationFunction, valueCoder);
+                  recordReader.getCurrentValue(),
+                  valueTranslationFunction,
+                  valueCoder,
+                  skipValueClone);
         } catch (IOException | InterruptedException e) {
           LOG.error("Unable to read data: ", e);
           throw new IllegalStateException("Unable to read data: " + "{}", e);
@@ -927,7 +958,10 @@ public class HadoopFormatIO {
       /** Returns the serialized output of transformed key or value object. */
       @SuppressWarnings("unchecked")
       private <T, T3> T3 transformKeyOrValue(
-          T input, @Nullable SimpleFunction<T, T3> simpleFunction, Coder<T3> coder)
+          T input,
+          @Nullable SimpleFunction<T, T3> simpleFunction,
+          Coder<T3> coder,
+          boolean skipClone)
           throws CoderException, ClassCastException {
         T3 output;
         if (null != simpleFunction) {
@@ -935,7 +969,7 @@ public class HadoopFormatIO {
         } else {
           output = (T3) input;
         }
-        return cloneIfPossiblyMutable(output, coder);
+        return skipClone ? output : cloneIfPossiblyMutable(output, coder);
       }
 
       /**
@@ -945,7 +979,7 @@ public class HadoopFormatIO {
       private <T> T cloneIfPossiblyMutable(T input, Coder<T> coder)
           throws CoderException, ClassCastException {
         // If the input object is not of known immutable type, clone the object.
-        if (!skipKeyValueClone && !isKnownImmutable(input)) {
+        if (!isKnownImmutable(input)) {
           input = CoderUtils.clone(coder, input);
         }
         return input;

--- a/sdks/java/io/hadoop-format/src/main/java/org/apache/beam/sdk/io/hadoop/format/HadoopFormatIO.java
+++ b/sdks/java/io/hadoop-format/src/main/java/org/apache/beam/sdk/io/hadoop/format/HadoopFormatIO.java
@@ -199,7 +199,7 @@ import org.slf4j.LoggerFactory;
  *              .withValueTranslation(myOutputValueType);
  * }</pre>
  *
- * <p> Hadoop formats typically work with Writable data structures which are mutable and instances
+ * <p>Hadoop formats typically work with Writable data structures which are mutable and instances
  * are reused by the input format reader. Therefore, to not to have elements which can change value
  * after they are emitted from read, this IO will clone each key value read from underlying hadoop
  * input format (unless they are in the list of well known immutable types). However, in cases where
@@ -208,10 +208,10 @@ import org.slf4j.LoggerFactory;
  * can be instructed to skip key/value cloning.
  *
  * <pre>{@code
- *  HadoopFormatIO.Read<InputFormatKeyClass, MyValueClass> read = ...
- *  p.apply("read", read
- *      .withSkipKeyClone(true)
- *      .withSkipValueClone(true));
+ * HadoopFormatIO.Read<InputFormatKeyClass, MyValueClass> read = ...
+ * p.apply("read", read
+ *     .withSkipKeyClone(true)
+ *     .withSkipValueClone(true));
  * }</pre>
  *
  * <p>IMPORTANT! In case of using {@code DBInputFormat} to read data from RDBMS, Beam parallelizes

--- a/sdks/java/io/hadoop-format/src/test/java/org/apache/beam/sdk/io/hadoop/format/HadoopFormatIOReadTest.java
+++ b/sdks/java/io/hadoop-format/src/test/java/org/apache/beam/sdk/io/hadoop/format/HadoopFormatIOReadTest.java
@@ -25,6 +25,7 @@ import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisp
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertThat;
 import static org.junit.Assert.assertTrue;
 
@@ -60,6 +61,7 @@ import org.apache.hadoop.mapreduce.InputSplit;
 import org.apache.hadoop.mapreduce.JobContext;
 import org.apache.hadoop.mapreduce.TaskAttemptContext;
 import org.apache.hadoop.mapreduce.lib.db.DBInputFormat;
+import org.junit.Assert;
 import org.junit.BeforeClass;
 import org.junit.Rule;
 import org.junit.Test;
@@ -376,6 +378,18 @@ public class HadoopFormatIOReadTest {
     read.validateTransform();
   }
 
+  @Test
+  public void testReadObjectCreationWithSkipKeyValueClone() {
+    HadoopFormatIO.Read<String, Employee> read = HadoopFormatIO.read();
+    assertNull(read.getSkipKeyValueClone());
+
+    read = read.withSkipKeyValueClone(true);
+    assertEquals(true, read.getSkipKeyValueClone());
+
+    read = read.withSkipKeyValueClone(false);
+    assertEquals(false, read.getSkipKeyValueClone());
+  }
+
   /**
    * This test validates functionality of {@link
    * HadoopFormatIO.Read#withConfiguration(Configuration) withConfiguration(Configuration)} function
@@ -519,7 +533,8 @@ public class HadoopFormatIOReadTest {
             AvroCoder.of(Employee.class),
             null, // No key translation required.
             null, // No value translation required.
-            new SerializableSplit());
+            new SerializableSplit(),
+            false);
     DisplayData displayData = DisplayData.from(boundedSource);
     assertThat(
         displayData,
@@ -550,7 +565,8 @@ public class HadoopFormatIOReadTest {
             AvroCoder.of(Employee.class),
             null, // No key translation required.
             null, // No value translation required.
-            new SerializableSplit());
+            new SerializableSplit(),
+            false);
     boundedSource.setInputFormatObj(mockInputFormat);
     SourceTestUtils.readFromSource(boundedSource, p.getOptions());
   }
@@ -577,7 +593,8 @@ public class HadoopFormatIOReadTest {
             AvroCoder.of(Employee.class),
             null, // No key translation required.
             null, // No value translation required.
-            new SerializableSplit());
+            new SerializableSplit(),
+            false);
     boundedSource.setInputFormatObj(mockInputFormat);
     SourceTestUtils.readFromSource(boundedSource, p.getOptions());
   }
@@ -604,7 +621,8 @@ public class HadoopFormatIOReadTest {
             AvroCoder.of(Employee.class),
             null, // No key translation required.
             null, // No value translation required.
-            new SerializableSplit(mockInputSplit));
+            new SerializableSplit(mockInputSplit),
+            false);
     boundedSource.setInputFormatObj(mockInputFormat);
     BoundedReader<KV<Text, Employee>> reader = boundedSource.createReader(p.getOptions());
     assertFalse(reader.start());
@@ -625,7 +643,8 @@ public class HadoopFormatIOReadTest {
             Text.class,
             Employee.class,
             WritableCoder.of(Text.class),
-            AvroCoder.of(Employee.class));
+            AvroCoder.of(Employee.class),
+            false);
     long estimatedSize = hifSource.getEstimatedSizeBytes(p.getOptions());
     // Validate if estimated size is equal to the size of records.
     assertEquals(referenceRecords.size(), estimatedSize);
@@ -687,7 +706,8 @@ public class HadoopFormatIOReadTest {
             AvroCoder.of(Employee.class),
             null, // No key translation required.
             null, // No value translation required.
-            new SerializableSplit(mockInputSplit));
+            new SerializableSplit(mockInputSplit),
+            false);
     boundedSource.setInputFormatObj(mockInputFormat);
     BoundedReader<KV<Text, Employee>> reader = boundedSource.createReader(p.getOptions());
     assertEquals(Double.valueOf(0), reader.getFractionConsumed());
@@ -718,7 +738,8 @@ public class HadoopFormatIOReadTest {
             AvroCoder.of(Employee.class),
             null, // No key translation required.
             null, // No value translation required.
-            new SerializableSplit(mockInputSplit));
+            new SerializableSplit(mockInputSplit),
+            false);
     BoundedReader<KV<Text, Employee>> reader = boundedSource.createReader(p.getOptions());
     SourceTestUtils.assertUnstartedReaderReadsSameAsItsSource(reader, p.getOptions());
   }
@@ -738,7 +759,8 @@ public class HadoopFormatIOReadTest {
             AvroCoder.of(Employee.class),
             null, // No key translation required.
             null, // No value translation required.
-            split);
+            split,
+            false);
     BoundedReader<KV<Text, Employee>> hifReader = source.createReader(p.getOptions());
     BoundedSource<KV<Text, Employee>> hifSource = hifReader.getCurrentSource();
     assertEquals(hifSource, source);
@@ -757,7 +779,8 @@ public class HadoopFormatIOReadTest {
             Text.class,
             Employee.class,
             WritableCoder.of(Text.class),
-            AvroCoder.of(Employee.class));
+            AvroCoder.of(Employee.class),
+            false);
     thrown.expect(IOException.class);
     thrown.expectMessage("Cannot create reader as source is not split yet.");
     hifSource.createReader(p.getOptions());
@@ -781,7 +804,8 @@ public class HadoopFormatIOReadTest {
             AvroCoder.of(Employee.class),
             null, // No key translation required.
             null, // No value translation required.
-            mockInputSplit);
+            mockInputSplit,
+            false);
     thrown.expect(IOException.class);
     thrown.expectMessage("Error in computing splits, getSplits() returns a empty list");
     hifSource.setInputFormatObj(mockInputFormat);
@@ -806,7 +830,8 @@ public class HadoopFormatIOReadTest {
             AvroCoder.of(Employee.class),
             null, // No key translation required.
             null, // No value translation required.
-            mockInputSplit);
+            mockInputSplit,
+            false);
     thrown.expect(IOException.class);
     thrown.expectMessage("Error in computing splits, getSplits() returns null.");
     hifSource.setInputFormatObj(mockInputFormat);
@@ -837,7 +862,8 @@ public class HadoopFormatIOReadTest {
             AvroCoder.of(Employee.class),
             null, // No key translation required.
             null, // No value translation required.
-            new SerializableSplit());
+            new SerializableSplit(),
+            false);
     thrown.expect(IOException.class);
     thrown.expectMessage(
         "Error in computing splits, split is null in InputSplits list populated "
@@ -858,7 +884,8 @@ public class HadoopFormatIOReadTest {
             Text.class,
             Employee.class,
             WritableCoder.of(Text.class),
-            AvroCoder.of(Employee.class));
+            AvroCoder.of(Employee.class),
+            false);
     List<KV<Text, Employee>> bundleRecords = new ArrayList<>();
     for (BoundedSource<KV<Text, Employee>> source : boundedSourceList) {
       List<KV<Text, Employee>> elems = SourceTestUtils.readFromSource(source, p.getOptions());
@@ -880,7 +907,8 @@ public class HadoopFormatIOReadTest {
             Text.class,
             Employee.class,
             WritableCoder.of(Text.class),
-            AvroCoder.of(Employee.class));
+            AvroCoder.of(Employee.class),
+            false);
     for (BoundedSource<KV<Text, Employee>> source : boundedSourceList) {
       // Cast to HadoopInputFormatBoundedSource to access getInputFormat().
       HadoopInputFormatBoundedSource<Text, Employee> hifSource =
@@ -905,7 +933,8 @@ public class HadoopFormatIOReadTest {
             Text.class,
             Employee.class,
             WritableCoder.of(Text.class),
-            AvroCoder.of(Employee.class));
+            AvroCoder.of(Employee.class),
+            false);
     List<KV<Text, Employee>> bundleRecords = new ArrayList<>();
     for (BoundedSource<KV<Text, Employee>> source : boundedSourceList) {
       List<KV<Text, Employee>> elems = SourceTestUtils.readFromSource(source, p.getOptions());
@@ -913,6 +942,57 @@ public class HadoopFormatIOReadTest {
     }
     List<KV<Text, Employee>> referenceRecords = TestEmployeeDataSet.getEmployeeData();
     assertThat(bundleRecords, containsInAnyOrder(referenceRecords.toArray()));
+  }
+
+  /**
+   * This test validates that in case reader is instructed to not to clone key value records, then
+   * key value records are exactly the same as output from the source no mater if they are mutable
+   * or immutable. This override setting is useful to turn on when using key-value translation
+   * functions and avoid possibly unnecessary copy.
+   */
+  @Test
+  public void testSkipKeyValueClone() throws Exception {
+
+    SerializableConfiguration serConf =
+        loadTestConfiguration(EmployeeInputFormat.class, Text.class, Employee.class);
+
+    // with skip clone 'true' it should produce different instances of value
+    List<BoundedSource<KV<Text, Employee>>> sources =
+        new HadoopInputFormatBoundedSource<>(
+                serConf,
+                WritableCoder.of(Text.class),
+                AvroCoder.of(Employee.class),
+                null,
+                new SingletonEmployeeFn(),
+                true)
+            .split(0, p.getOptions());
+
+    for (BoundedSource<KV<Text, Employee>> source : sources) {
+      List<KV<Text, Employee>> elems = SourceTestUtils.readFromSource(source, p.getOptions());
+      for (KV<Text, Employee> elem : elems) {
+        Assert.assertSame(SingletonEmployeeFn.EMPLOYEE, elem.getValue());
+        Assert.assertEquals(SingletonEmployeeFn.EMPLOYEE, elem.getValue());
+      }
+    }
+
+    // with skip clone 'false' it should produce different instances of value
+    sources =
+        new HadoopInputFormatBoundedSource<>(
+                serConf,
+                WritableCoder.of(Text.class),
+                AvroCoder.of(Employee.class),
+                null,
+                new SingletonEmployeeFn(),
+                false)
+            .split(0, p.getOptions());
+
+    for (BoundedSource<KV<Text, Employee>> source : sources) {
+      List<KV<Text, Employee>> elems = SourceTestUtils.readFromSource(source, p.getOptions());
+      for (KV<Text, Employee> elem : elems) {
+        Assert.assertNotSame(SingletonEmployeeFn.EMPLOYEE, elem.getValue());
+        Assert.assertEquals(SingletonEmployeeFn.EMPLOYEE, elem.getValue());
+      }
+    }
   }
 
   @Test
@@ -943,7 +1023,8 @@ public class HadoopFormatIOReadTest {
       Class<K> inputFormatKeyClass,
       Class<V> inputFormatValueClass,
       Coder<K> keyCoder,
-      Coder<V> valueCoder) {
+      Coder<V> valueCoder,
+      boolean skipKeyValueClone) {
     SerializableConfiguration serConf =
         loadTestConfiguration(inputFormatClass, inputFormatKeyClass, inputFormatValueClass);
     return new HadoopInputFormatBoundedSource<>(
@@ -951,7 +1032,8 @@ public class HadoopFormatIOReadTest {
         keyCoder,
         valueCoder,
         null, // No key translation required.
-        null); // No value translation required.
+        null, // No value translation required.
+        skipKeyValueClone);
   }
 
   private <K, V> List<BoundedSource<KV<K, V>>> getBoundedSourceList(
@@ -959,11 +1041,27 @@ public class HadoopFormatIOReadTest {
       Class<K> inputFormatKeyClass,
       Class<V> inputFormatValueClass,
       Coder<K> keyCoder,
-      Coder<V> valueCoder)
+      Coder<V> valueCoder,
+      boolean skipKeyValueClone)
       throws Exception {
     HadoopInputFormatBoundedSource<K, V> boundedSource =
         getTestHIFSource(
-            inputFormatClass, inputFormatKeyClass, inputFormatValueClass, keyCoder, valueCoder);
+            inputFormatClass,
+            inputFormatKeyClass,
+            inputFormatValueClass,
+            keyCoder,
+            valueCoder,
+            skipKeyValueClone);
     return boundedSource.split(0, p.getOptions());
+  }
+
+  private static class SingletonEmployeeFn extends SimpleFunction<Employee, Employee> {
+
+    static final Employee EMPLOYEE = new Employee("Name", "Address");
+
+    @Override
+    public Employee apply(Employee input) {
+      return EMPLOYEE;
+    }
   }
 }


### PR DESCRIPTION


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
