### PR TITLE
Revert "Do not add unnecessary experiment use_multiple_sdk_containers."

### DIFF
--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py
@@ -210,6 +210,13 @@ class Environment(object):
           self.debug_options.add_experiment(
               'runner_harness_container_image=' + runner_harness_override)
       debug_options_experiments = self.debug_options.experiments
+      # Add use_multiple_sdk_containers flag if it's not already present. Do not
+      # add the flag if 'no_use_multiple_sdk_containers' is present.
+      # TODO: Cleanup use_multiple_sdk_containers once we deprecate Python SDK
+      # till version 2.4.
+      if ('use_multiple_sdk_containers' not in debug_options_experiments and
+          'no_use_multiple_sdk_containers' not in debug_options_experiments):
+        debug_options_experiments.append('use_multiple_sdk_containers')
     # FlexRS
     if self.google_cloud_options.flexrs_goal == 'COST_OPTIMIZED':
       self.proto.flexResourceSchedulingGoal = (

--- a/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/apiclient_test.py
@@ -786,6 +786,60 @@ class UtilTest(unittest.TestCase):
     self.assertEqual('key5', job.proto.labels.additionalProperties[4].key)
     self.assertEqual('', job.proto.labels.additionalProperties[4].value)
 
+  def test_experiment_use_multiple_sdk_containers(self):
+    pipeline_options = PipelineOptions([
+        '--project',
+        'test_project',
+        '--job_name',
+        'test_job_name',
+        '--temp_location',
+        'gs://test-location/temp',
+        '--experiments',
+        'beam_fn_api'
+    ])
+    environment = apiclient.Environment([],
+                                        pipeline_options,
+                                        1,
+                                        FAKE_PIPELINE_URL)
+    self.assertIn('use_multiple_sdk_containers', environment.proto.experiments)
+
+    pipeline_options = PipelineOptions([
+        '--project',
+        'test_project',
+        '--job_name',
+        'test_job_name',
+        '--temp_location',
+        'gs://test-location/temp',
+        '--experiments',
+        'beam_fn_api',
+        '--experiments',
+        'use_multiple_sdk_containers'
+    ])
+    environment = apiclient.Environment([],
+                                        pipeline_options,
+                                        1,
+                                        FAKE_PIPELINE_URL)
+    self.assertIn('use_multiple_sdk_containers', environment.proto.experiments)
+
+    pipeline_options = PipelineOptions([
+        '--project',
+        'test_project',
+        '--job_name',
+        'test_job_name',
+        '--temp_location',
+        'gs://test-location/temp',
+        '--experiments',
+        'beam_fn_api',
+        '--experiments',
+        'no_use_multiple_sdk_containers'
+    ])
+    environment = apiclient.Environment([],
+                                        pipeline_options,
+                                        1,
+                                        FAKE_PIPELINE_URL)
+    self.assertNotIn(
+        'use_multiple_sdk_containers', environment.proto.experiments)
+
   @mock.patch(
       'apache_beam.runners.dataflow.internal.apiclient.sys.version_info',
       (3, 8))


### PR DESCRIPTION
Reverts apache/beam#13475

Reason: for streaming jobs new codepath using UW (https://github.com/apache/beam/blob/9f97585160fae644d9b4a7f0dca6558c82c29723/sdks/python/apache_beam/runners/dataflow/internal/apiclient.py#L276) is not yet triggered by default. 

So, at this time Dataflow first need to change the behavior to not require `use_multiple_sdk_containers` for streaming pipelines, or we need to use UW codepath for all streaming pipelines in Beam.