### PR TITLE
Revert "Update Dataflow worker harness container image version."

### DIFF
--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -45,7 +45,7 @@ processResources {
   filter org.apache.tools.ant.filters.ReplaceTokens, tokens: [
     'dataflow.legacy_environment_major_version' : '8',
     'dataflow.fnapi_environment_major_version' : '8',
-    'dataflow.container_version' : 'beam-master-20210107'
+    'dataflow.container_version' : 'beam-master-20200629'
   ]
 }
 


### PR DESCRIPTION
Reverts apache/beam#13699. The new image causes performance regressions.