### PR TITLE
Allow extension of SdkContainerImageBuilder

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -1036,7 +1036,6 @@ class SetupOptions(PipelineOptions):
             'the command line.'))
     parser.add_argument(
         '--prebuild_sdk_container_engine',
-        choices=['local_docker', 'cloud_build'],
         help=(
             'Prebuild sdk worker container image before job submission. If '
             'enabled, SDK invokes the boot sequence in SDK worker '

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -1044,7 +1044,9 @@ class SetupOptions(PipelineOptions):
             'environment. This may speed up pipeline execution. To enable, '
             'select the Docker build engine: local_docker using '
             'locally-installed Docker or cloud_build for using Google Cloud '
-            'Build (requires a GCP project with Cloud Build API enabled).'))
+            'Build (requires a GCP project with Cloud Build API enabled). You '
+            'can also subclass SdkContainerImageBuilder and use that to build '
+            'in other environments.'))
     parser.add_argument(
         '--prebuild_sdk_container_base_image',
         default=None,

--- a/sdks/python/apache_beam/runners/portability/sdk_container_builder.py
+++ b/sdks/python/apache_beam/runners/portability/sdk_container_builder.py
@@ -135,7 +135,7 @@ class SdkContainerImageBuilder(plugin.BeamPlugin):
     container_build_engine = setup_options.prebuild_sdk_container_engine
     builder_cls = cls._get_subclass_by_key(container_build_engine)
     builder = builder_cls(pipeline_options)
-    return builder.build()
+    return builder._build()
 
   @classmethod
   def _get_subclass_by_key(cls, key: str) -> Type['SdkContainerImageBuilder']:

--- a/sdks/python/apache_beam/runners/portability/sdk_container_builder_test.py
+++ b/sdks/python/apache_beam/runners/portability/sdk_container_builder_test.py
@@ -23,7 +23,9 @@ from __future__ import absolute_import
 
 import logging
 import unittest
+import unittest.mock
 
+from apache_beam.options import pipeline_options
 from apache_beam.runners.portability import sdk_container_builder
 
 
@@ -71,6 +73,20 @@ class SdkContainerBuilderTest(unittest.TestCase):
     local_builder = sdk_container_builder.SdkContainerImageBuilder.\
       _get_subclass_by_key(expected_key)
     self.assertEqual(local_builder, _PluginSdkBuilder)
+
+  @unittest.mock.patch(
+      'apache_beam.runners.portability.sdk_container_builder._SdkContainerImageLocalBuilder'  # pylint: disable=line-too-long
+  )
+  @unittest.mock.patch.object(
+      sdk_container_builder.SdkContainerImageBuilder, "_get_subclass_by_key")
+  def test_build_container_image_locates_subclass_invokes_build(
+      self, mock_get_subclass, mocked_local_builder):
+    mock_get_subclass.return_value = mocked_local_builder
+    options = pipeline_options.PipelineOptions()
+    sdk_container_builder.SdkContainerImageBuilder.build_container_image(
+        options)
+    mocked_local_builder.assert_called_once_with(options)
+    mocked_local_builder.return_value._build.assert_called_once_with()
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/runners/portability/sdk_container_builder_test.py
+++ b/sdks/python/apache_beam/runners/portability/sdk_container_builder_test.py
@@ -1,0 +1,79 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for the sdk container builder module."""
+
+# pytype: skip-file
+
+from __future__ import absolute_import
+
+import logging
+import unittest
+
+from apache_beam.runners.portability import sdk_container_builder
+
+
+class SdkContainerBuilderTest(unittest.TestCase):
+  def test_can_find_local_builder(self):
+    local_builder = sdk_container_builder.SdkContainerImageBuilder\
+      ._get_subclass_by_key('local_docker')
+    self.assertEqual(
+        local_builder, sdk_container_builder._SdkContainerImageLocalBuilder)
+
+  def test_can_find_cloud_builder(self):
+    local_builder = sdk_container_builder.SdkContainerImageBuilder.\
+      _get_subclass_by_key('cloud_build')
+    self.assertEqual(
+        local_builder, sdk_container_builder._SdkContainerImageCloudBuilder)
+
+  def test_missing_builder_key_throws_value_error(self):
+    with self.assertRaises(ValueError):
+      sdk_container_builder.SdkContainerImageBuilder._get_subclass_by_key(
+          'missing-id')
+
+  def test_multiple_matchings_keys_throws_value_error(self):
+    # pylint: disable=unused-variable
+    class _PluginSdkBuilder(sdk_container_builder.SdkContainerImageBuilder):
+      @classmethod
+      def _builder_key(cls):
+        return 'test-id'
+
+    class _PluginSdkBuilder2(sdk_container_builder.SdkContainerImageBuilder):
+      @classmethod
+      def _builder_key(cls):
+        return 'test-id'
+
+    # pylint: enable=unused-variable
+
+    with self.assertRaises(ValueError):
+      sdk_container_builder.SdkContainerImageBuilder._get_subclass_by_key(
+          'test-id')
+
+  def test_can_find_new_subclass(self):
+    class _PluginSdkBuilder(sdk_container_builder.SdkContainerImageBuilder):
+      pass
+
+    expected_key = f'{_PluginSdkBuilder.__module__}._PluginSdkBuilder'
+    local_builder = sdk_container_builder.SdkContainerImageBuilder.\
+      _get_subclass_by_key(expected_key)
+    self.assertEqual(local_builder, _PluginSdkBuilder)
+
+
+if __name__ == '__main__':
+  # Run the tests.
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/sdks/python/apache_beam/runners/portability/sdk_container_builder_test.py
+++ b/sdks/python/apache_beam/runners/portability/sdk_container_builder_test.py
@@ -21,6 +21,7 @@
 
 from __future__ import absolute_import
 
+import gc
 import logging
 import unittest
 import unittest.mock
@@ -30,6 +31,10 @@ from apache_beam.runners.portability import sdk_container_builder
 
 
 class SdkContainerBuilderTest(unittest.TestCase):
+  def tearDown(self):
+    # Ensures SdkContainerImageBuilder subclasses are cleared
+    gc.collect()
+
   def test_can_find_local_builder(self):
     local_builder = sdk_container_builder.SdkContainerImageBuilder\
       ._get_subclass_by_key('local_docker')

--- a/sdks/python/apache_beam/runners/portability/sdk_container_builder_test.py
+++ b/sdks/python/apache_beam/runners/portability/sdk_container_builder_test.py
@@ -36,14 +36,16 @@ class SdkContainerBuilderTest(unittest.TestCase):
     gc.collect()
 
   def test_can_find_local_builder(self):
-    local_builder = sdk_container_builder.SdkContainerImageBuilder\
-      ._get_subclass_by_key('local_docker')
+    local_builder = (
+        sdk_container_builder.SdkContainerImageBuilder._get_subclass_by_key(
+            'local_docker'))
     self.assertEqual(
         local_builder, sdk_container_builder._SdkContainerImageLocalBuilder)
 
   def test_can_find_cloud_builder(self):
-    local_builder = sdk_container_builder.SdkContainerImageBuilder.\
-      _get_subclass_by_key('cloud_build')
+    local_builder = (
+        sdk_container_builder.SdkContainerImageBuilder._get_subclass_by_key(
+            'cloud_build'))
     self.assertEqual(
         local_builder, sdk_container_builder._SdkContainerImageCloudBuilder)
 
@@ -75,8 +77,9 @@ class SdkContainerBuilderTest(unittest.TestCase):
       pass
 
     expected_key = f'{_PluginSdkBuilder.__module__}._PluginSdkBuilder'
-    local_builder = sdk_container_builder.SdkContainerImageBuilder.\
-      _get_subclass_by_key(expected_key)
+    local_builder = (
+        sdk_container_builder.SdkContainerImageBuilder._get_subclass_by_key(
+            expected_key))
     self.assertEqual(local_builder, _PluginSdkBuilder)
 
   @unittest.mock.patch(


### PR DESCRIPTION
The SdkContainerImageBuilder class currently only offers an option to build images locally or in google cloud build. I would like to be able to define my own subclass which I can use outside of GCP. There is an existing utility which allows this (BeamPlugin) and is used by filesystems to allow easy extension.

Existing functionality should be unchanged, however when another subclass is available, it should be able to be selected by specifying its module and class name, eg '--prebuild_sdk_container_engine=custom_beam_extension_package.submodule.CustomSdkContainerImageBuilder'

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
