### PR TITLE
[BEAM-9615] Add Schema Logical Type Provider support

### DIFF
--- a/sdks/go/pkg/beam/coder.go
+++ b/sdks/go/pkg/beam/coder.go
@@ -35,6 +35,15 @@ import (
 	"google.golang.org/protobuf/reflect/protoreflect"
 )
 
+// EnableSchemas is a temporary configuration variable
+// to use Beam Schema encoding by default instead of JSON.
+// Before it is removed, it will be set to true by default
+// and then eventually removed.
+//
+// Only users who rely on default JSON marshalling behaviour should set
+// this explicitly.
+var EnableSchemas bool = false
+
 type jsonCoder interface {
 	json.Marshaler
 	json.Unmarshaler
@@ -183,6 +192,19 @@ func inferCoder(t FullType) (*coder.Coder, error) {
 			if c := coder.LookupCustomCoder(et); c != nil {
 				return coder.CoderFrom(c), nil
 			}
+
+			if EnableSchemas {
+				switch et.Kind() {
+				case reflect.Ptr:
+					if et.Elem().Kind() != reflect.Struct {
+						break
+					}
+					fallthrough
+				case reflect.Struct:
+					return &coder.Coder{Kind: coder.Row, T: t}, nil
+				}
+			}
+
 			// Interface types that implement JSON marshalling can be handled by the default coder.
 			// otherwise, inference needs to fail here.
 			if et.Kind() == reflect.Interface && !et.Implements(jsonCoderType) {

--- a/sdks/go/pkg/beam/core/graph/coder/registry_test.go
+++ b/sdks/go/pkg/beam/core/graph/coder/registry_test.go
@@ -131,7 +131,6 @@ func TestRegisterCoder(t *testing.T) {
 		t.Run(test.name, func(t *testing.T) {
 			defer func() {
 				if p := recover(); p != nil {
-					t.Log(p)
 					return
 				}
 				t.Fatalf("RegisterCoder(%v, %T, %T): want panic", msType, test.enc, test.dec)

--- a/sdks/go/pkg/beam/core/graph/coder/row.go
+++ b/sdks/go/pkg/beam/core/graph/coder/row.go
@@ -24,13 +24,33 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 )
 
+var (
+	defaultEnc RowEncoderBuilder
+	defaultDec RowDecoderBuilder
+
+	// RequireAllFieldsExported when set to true will have the default coder buildings using
+	// RowEncoderForStruct and RowDecoderForStruct fail if there are any unexported fields.
+	// When set false, unexported fields in default destination structs will be silently
+	// ignored when coding.
+	// This has no effect on types with registered coder providers.
+	RequireAllFieldsExported bool
+)
+
+// RegisterSchemaProviders Register Custom Schema providers.
+func RegisterSchemaProviders(rt reflect.Type, enc, dec interface{}) {
+	defaultEnc.RequireAllFieldsExported = RequireAllFieldsExported
+	defaultDec.RequireAllFieldsExported = RequireAllFieldsExported
+	defaultEnc.Register(rt, enc)
+	defaultDec.Register(rt, dec)
+}
+
 // RowEncoderForStruct returns an encoding function that encodes a struct type
 // or a pointer to a struct type using the beam row encoding.
 //
 // Returns an error if the given type is invalid or not encodable to a beam
 // schema row.
 func RowEncoderForStruct(rt reflect.Type) (func(interface{}, io.Writer) error, error) {
-	return (&RowEncoderBuilder{}).Build(rt)
+	return defaultEnc.Build(rt)
 }
 
 // RowDecoderForStruct returns a decoding function that decodes the beam row encoding
@@ -39,7 +59,7 @@ func RowEncoderForStruct(rt reflect.Type) (func(interface{}, io.Writer) error, e
 // Returns an error if the given type is invalid or not decodable from a beam
 // schema row.
 func RowDecoderForStruct(rt reflect.Type) (func(io.Reader) (interface{}, error), error) {
-	return (&RowDecoderBuilder{}).Build(rt)
+	return defaultDec.Build(rt)
 }
 
 func rowTypeValidation(rt reflect.Type, strictExportedFields bool) error {
@@ -93,6 +113,42 @@ func writeRowHeader(rv reflect.Value, w io.Writer) error {
 	return nil
 }
 
+// WriteRowHeader handles the field header for row encodings.
+func WriteRowHeader(n int, isNil func(int) bool, w io.Writer) error {
+	// Row/Structs are prefixed with the number of fields that are encoded in total.
+	if err := EncodeVarInt(int64(n), w); err != nil {
+		return err
+	}
+	// Followed by a packed bit array of the nil fields.
+	var curByte byte
+	var nils bool
+	var bytes = make([]byte, 0, n/8+1)
+	for i := 0; i < n; i++ {
+		shift := i % 8
+		if i != 0 && shift == 0 {
+			bytes = append(bytes, curByte)
+			curByte = 0
+		}
+		if isNil(i) {
+			curByte |= (1 << uint8(shift))
+			nils = true
+		}
+	}
+	if nils {
+		bytes = append(bytes, curByte)
+	} else {
+		// If there are no nils, we write a 0 length byte array instead.
+		bytes = bytes[:0]
+	}
+	if err := EncodeVarInt(int64(len(bytes)), w); err != nil {
+		return err
+	}
+	if _, err := ioutilx.WriteUnsafe(w, bytes); err != nil {
+		return err
+	}
+	return nil
+}
+
 // ReadRowHeader handles the field header for row decodings.
 //
 // This returns the number of encoded fileds, the raw bitpacked bytes and
@@ -113,6 +169,9 @@ func ReadRowHeader(r io.Reader) (int, []byte, error) {
 	if l == 0 {
 		// A zero length byte array means no nils.
 		return int(nf), nil, nil
+	}
+	if nf < l {
+		return int(nf), nil, fmt.Errorf("number of fields is less than byte array %v < %v", nf, l)
 	}
 	var buf [32]byte // should get stack allocated?
 	nils := buf[:l]

--- a/sdks/go/pkg/beam/core/graph/coder/row.go
+++ b/sdks/go/pkg/beam/core/graph/coder/row.go
@@ -27,19 +27,20 @@ import (
 var (
 	defaultEnc RowEncoderBuilder
 	defaultDec RowDecoderBuilder
-
-	// RequireAllFieldsExported when set to true will have the default coder buildings using
-	// RowEncoderForStruct and RowDecoderForStruct fail if there are any unexported fields.
-	// When set false, unexported fields in default destination structs will be silently
-	// ignored when coding.
-	// This has no effect on types with registered coder providers.
-	RequireAllFieldsExported bool
 )
+
+// RequireAllFieldsExported when set to true will have the default coder buildings using
+// RowEncoderForStruct and RowDecoderForStruct fail if there are any unexported fields.
+// When set false, unexported fields in default destination structs will be silently
+// ignored when coding.
+// This has no effect on types with registered coder providers.
+func RequireAllFieldsExported(require bool) {
+	defaultEnc.RequireAllFieldsExported = require
+	defaultDec.RequireAllFieldsExported = require
+}
 
 // RegisterSchemaProviders Register Custom Schema providers.
 func RegisterSchemaProviders(rt reflect.Type, enc, dec interface{}) {
-	defaultEnc.RequireAllFieldsExported = RequireAllFieldsExported
-	defaultDec.RequireAllFieldsExported = RequireAllFieldsExported
 	defaultEnc.Register(rt, enc)
 	defaultDec.Register(rt, dec)
 }

--- a/sdks/go/pkg/beam/core/graph/coder/row_test.go
+++ b/sdks/go/pkg/beam/core/graph/coder/row_test.go
@@ -362,7 +362,7 @@ func BenchmarkRowCoder_RoundTrip(b *testing.B) {
 		// We have 3 fields we use.
 		n, err := DecodeVarInt(r)
 		if err != nil {
-			return nil, fmt.Errorf("decoding header fieldcount: %v, %w", n, err)
+			return nil, fmt.Errorf("decoding header fieldcount: %v, %v", n, err)
 		}
 		if n != 3 {
 			return nil, fmt.Errorf("decoding header field count, got %v, want %v", n, 3)
@@ -370,22 +370,22 @@ func BenchmarkRowCoder_RoundTrip(b *testing.B) {
 		// Never nils, so we read the 0 byte header.
 		n, err = DecodeVarInt(r)
 		if err != nil {
-			return nil, fmt.Errorf("decoding header nils: %v, %w", n, err)
+			return nil, fmt.Errorf("decoding header nils: %v, %v", n, err)
 		}
 		if n != 0 {
 			return nil, fmt.Errorf("decoding header nils count, got %v, want %v", n, 0)
 		}
 		a, err := DecodeStringUTF8(r)
 		if err != nil {
-			return nil, fmt.Errorf("decoding string field A: %w", err)
+			return nil, fmt.Errorf("decoding string field A: %v", err)
 		}
 		b, err := DecodeVarInt(r)
 		if err != nil {
-			return nil, fmt.Errorf("decoding int field B: %w", err)
+			return nil, fmt.Errorf("decoding int field B: %v", err)
 		}
 		c, err := DecodeStringUTF8(r)
 		if err != nil {
-			return nil, fmt.Errorf("decoding string field C: %v, %w", c, err)
+			return nil, fmt.Errorf("decoding string field C: %v, %v", c, err)
 		}
 		return UserType1{
 			A: a,

--- a/sdks/go/pkg/beam/core/graph/coder/row_test.go
+++ b/sdks/go/pkg/beam/core/graph/coder/row_test.go
@@ -73,17 +73,26 @@ func TestReflectionRowCoderGeneration(t *testing.T) {
 				},
 			},
 		}, {
+			// embedded struct check
+			want: UserType4{
+				UserType1{
+					A: "marmalade",
+					B: 24,
+					C: "jam",
+				},
+			},
+		}, {
 			// All zeroes
 			want: struct {
 				V00 bool
-				V01 byte  // unsupported by spec (same as uint8)
-				V02 uint8 // unsupported by spec
+				V01 byte
+				V02 uint8
 				V03 int16
-				//	V04 uint16 // unsupported by spec
+				V04 uint16
 				V05 int32
-				//	V06 uint32 // unsupported by spec
+				V06 uint32
 				V07 int64
-				//	V08 uint64 // unsupported by spec
+				V08 uint64
 				V09 int
 				V10 struct{}
 				V11 *struct{}
@@ -100,14 +109,14 @@ func TestReflectionRowCoderGeneration(t *testing.T) {
 		}, {
 			want: struct {
 				V00 bool
-				V01 byte  // unsupported by spec (same as uint8)
-				V02 uint8 // unsupported by spec
+				V01 byte
+				V02 uint8
 				V03 int16
-				//	V04 uint16 // unsupported by spec
+				V04 uint16
 				V05 int32
-				//	V06 uint32 // unsupported by spec
+				V06 uint32
 				V07 int64
-				//	V08 uint64 // unsupported by spec
+				V08 uint64
 				V09 int
 				V10 struct{}
 				V11 *struct{}
@@ -119,15 +128,18 @@ func TestReflectionRowCoderGeneration(t *testing.T) {
 				V17 float64
 				V18 []byte
 				V19 [2]*int
-				V20 map[string]*int
+				V20 map[*string]*int
 				V21 []*int
 			}{
 				V00: true,
 				V01: 1,
 				V02: 2,
 				V03: 3,
+				V04: 4,
 				V05: 5,
+				V06: 6,
 				V07: 7,
+				V08: 8,
 				V09: 9,
 				V10: struct{}{},
 				V11: &struct{}{},
@@ -139,9 +151,8 @@ func TestReflectionRowCoderGeneration(t *testing.T) {
 				V17: 2.6e100,
 				V18: []byte{21, 17, 65, 255, 0, 16},
 				V19: [2]*int{nil, &num},
-				V20: map[string]*int{
-					"notnil": &num,
-					"nil":    nil,
+				V20: map[*string]*int{
+					nil: nil,
 				},
 				V21: []*int{nil, &num, nil},
 			},
@@ -190,6 +201,11 @@ type UserType2 struct {
 
 type UserType3 struct {
 	A UserType1
+}
+
+// Embedding check.
+type UserType4 struct {
+	UserType1
 }
 
 func ut1Enc(val interface{}, w io.Writer) error {
@@ -282,6 +298,15 @@ func TestRowCoder_CustomCoder(t *testing.T) {
 					C: "jam",
 				},
 			},
+		}, {
+			// embedded struct check
+			want: UserType4{
+				UserType1{
+					A: "marmalade",
+					B: 24,
+					C: "jam",
+				},
+			},
 		},
 	}
 	for _, test := range tests {
@@ -312,6 +337,62 @@ func TestRowCoder_CustomCoder(t *testing.T) {
 }
 
 func BenchmarkRowCoder_RoundTrip(b *testing.B) {
+	ut1Enc := func(val interface{}, w io.Writer) error {
+		elm := val.(UserType1)
+		// We have 3 fields we use.
+		if err := EncodeVarInt(3, w); err != nil {
+			return err
+		}
+		// Never nils, so we write the 0 byte header.
+		if err := EncodeVarInt(0, w); err != nil {
+			return err
+		}
+		if err := EncodeStringUTF8(elm.A, w); err != nil {
+			return err
+		}
+		if err := EncodeVarInt(int64(elm.B), w); err != nil {
+			return err
+		}
+		if err := EncodeStringUTF8(elm.C, w); err != nil {
+			return err
+		}
+		return nil
+	}
+	ut1Dec := func(r io.Reader) (interface{}, error) {
+		// We have 3 fields we use.
+		n, err := DecodeVarInt(r)
+		if err != nil {
+			return nil, fmt.Errorf("decoding header fieldcount: %v, %w", n, err)
+		}
+		if n != 3 {
+			return nil, fmt.Errorf("decoding header field count, got %v, want %v", n, 3)
+		}
+		// Never nils, so we read the 0 byte header.
+		n, err = DecodeVarInt(r)
+		if err != nil {
+			return nil, fmt.Errorf("decoding header nils: %v, %w", n, err)
+		}
+		if n != 0 {
+			return nil, fmt.Errorf("decoding header nils count, got %v, want %v", n, 0)
+		}
+		a, err := DecodeStringUTF8(r)
+		if err != nil {
+			return nil, fmt.Errorf("decoding string field A: %w", err)
+		}
+		b, err := DecodeVarInt(r)
+		if err != nil {
+			return nil, fmt.Errorf("decoding int field B: %w", err)
+		}
+		c, err := DecodeStringUTF8(r)
+		if err != nil {
+			return nil, fmt.Errorf("decoding string field C: %v, %w", c, err)
+		}
+		return UserType1{
+			A: a,
+			B: int(b),
+			C: c,
+		}, nil
+	}
 
 	num := 35
 	benches := []struct {
@@ -368,6 +449,18 @@ func BenchmarkRowCoder_RoundTrip(b *testing.B) {
 			// nested struct check
 			want: UserType3{
 				A: UserType1{
+					A: "marmalade",
+					B: 24,
+					C: "jam",
+				},
+			},
+			customRT:  reflect.TypeOf(UserType1{}),
+			customEnc: ut1Enc,
+			customDec: ut1Dec,
+		}, {
+			// embedded struct check
+			want: UserType4{
+				UserType1{
 					A: "marmalade",
 					B: 24,
 					C: "jam",

--- a/sdks/go/pkg/beam/core/runtime/genx/genx.go
+++ b/sdks/go/pkg/beam/core/runtime/genx/genx.go
@@ -28,6 +28,7 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/core/funcx"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx/schema"
 )
 
 // RegisterDoFn is a convenience function for registering DoFns.
@@ -46,6 +47,7 @@ func RegisterDoFn(dofn interface{}) {
 	}
 	for _, t := range ts {
 		runtime.RegisterType(t)
+		schema.RegisterType(t)
 	}
 }
 

--- a/sdks/go/pkg/beam/core/runtime/graphx/schema/logicaltypes.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/schema/logicaltypes.go
@@ -20,34 +20,12 @@ import (
 	"reflect"
 
 	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
+	pipepb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 )
 
 var (
-	// Maps logical type identifiers to their reflect.Type and the schema representation.
-	// the type identifier is the reflect.Type name, and included in the proto as well.
-	// We don't treat all types as "logical" types.
-	// ... why don't we treat all types as Logical types?
-	logicalTypes       = map[string]LogicalType{}
-	logicalIdentifiers = map[reflect.Type]string{}
+	defaultRegistry = NewRegistry()
 )
-
-// LogicalType is an interface between custom Go types, and schema storage types.
-//
-// A LogicalType is a way to define a new type that can be stored in a schema field
-// using a known underlying type for storage. The storage type must be comprised of
-// known schema field types, or pre-registered LogicalTypes. LogicalTypes may not be
-// mutually recursive at any level of indirection.
-type LogicalType interface {
-	ID() string
-	ArgumentType() reflect.Type
-	ArgumentValue() reflect.Value
-	GoType() reflect.Type
-	StorageType() reflect.Type
-	// ToStorageType converts an instance of the Go type to the schema storage type.
-	ToStorageType(input reflect.Value) reflect.Value
-	// ToGoType converts an instance of the given schema storage type to the Go type.
-	ToGoType(base reflect.Value) reflect.Value
-}
 
 // RegisterLogicalType registers a logical type with the beam schema system.
 // A logical type is a type that has distinct representations and storage.
@@ -55,67 +33,133 @@ type LogicalType interface {
 // RegisterLogicalType will panic if the storage type of the LogicalType
 // instance is not a valid storage type.
 func RegisterLogicalType(lt LogicalType) {
+	defaultRegistry.RegisterLogicalType(lt)
+}
+
+// RegisterLogicalTypeProvider allows registration of providers for interface types.
+func RegisterLogicalTypeProvider(rt reflect.Type, ltp LogicalTypeProvider) {
+	defaultRegistry.RegisterLogicalTypeProvider(rt, ltp)
+}
+
+// LogicalTypeProvider produces a logical type for a given Go type.
+//
+// If unable to produce a logical type, it instead produces an error.
+// Typically used to handle mapping LogicalTypes from interface types
+// to a concrete implementation. The provider will be passed a
+// type, and will produce an appropriate LogicalType for it.
+type LogicalTypeProvider = func(reflect.Type) (reflect.Type, error)
+
+// Registry retains mappings from go types to Schemas and LogicalTypes.
+type Registry struct {
+	lastShortID     int64
+	typeToSchema    map[reflect.Type]*pipepb.Schema
+	syntheticToUser map[reflect.Type]reflect.Type
+
+	logicalTypeProviders  map[reflect.Type]LogicalTypeProvider
+	logicalTypeInterfaces []reflect.Type
+
+	// Maps logical type identifiers to their reflect.Type and the schema representation.
+	// the type identifier is the reflect.Type name, and included in the proto as well.
+	// We don't treat all types as "logical" types.
+	// ... why don't we treat all types as Logical types?
+	logicalTypes           map[string]LogicalType
+	logicalTypeIdentifiers map[reflect.Type]string
+}
+
+// NewRegistry creates an initialized LogicalTypeRegistry.
+func NewRegistry() *Registry {
+	return &Registry{
+		typeToSchema:    map[reflect.Type]*pipepb.Schema{},
+		syntheticToUser: map[reflect.Type]reflect.Type{},
+
+		logicalTypes:           map[string]LogicalType{},
+		logicalTypeIdentifiers: map[reflect.Type]string{},
+		logicalTypeProviders:   map[reflect.Type]LogicalTypeProvider{},
+	}
+}
+
+// RegisterLogicalType a single logical type.
+func (r *Registry) RegisterLogicalType(lt LogicalType) {
 	// Validates that the storage type has known handling.
 	st := lt.StorageType()
-	_, err := reflectTypeToFieldType(st)
+	_, err := r.reflectTypeToFieldType(st)
 	if err != nil {
 		panic(fmt.Sprintf("LogicalType[%v] has an invalid StorageType %v: %v", lt.ID(), st, err))
 	}
-	logicalIdentifiers[lt.GoType()] = lt.ID()
-	logicalTypes[lt.ID()] = lt
+	// TODO add duplication checks.
+	r.logicalTypeIdentifiers[lt.GoType()] = lt.ID()
+	r.logicalTypes[lt.ID()] = lt
 }
 
-// convertibleLogicalType uses reflect.Value.Convert to change the Go
-// type to the schema storage type and back again. Does not support
-// type arguments.
+// RegisterLogicalTypeProvider allows registration of providers for interface types.
+func (r *Registry) RegisterLogicalTypeProvider(rt reflect.Type, ltp LogicalTypeProvider) {
+	if rt.Kind() != reflect.Interface {
+		panic(fmt.Sprintf("Logical Types must be registered with interface types. %v is not an interface type.", rt))
+	}
+	if rt.NumMethod() == 0 {
+		panic(fmt.Sprintf("Logical Types may not be registered with empty interface types. %v has no methods.", rt))
+	}
+	r.logicalTypeProviders[rt] = ltp
+	r.logicalTypeInterfaces = append(r.logicalTypeInterfaces, rt)
+}
+
+// LogicalType is a mapping between custom Go types, and their schema equivalent storage types.
 //
-// gotT and storageT must be convertible to each other.
-type convertibleLogicalType struct {
-	identifier    string
-	goT, storageT reflect.Type
+// A LogicalType is a way to define a type that can be stored in a schema field
+// using a known underlying type for storage. The storage type must be comprised of
+// known schema field types, or pre-registered LogicalTypes.
+//
+// LogicalTypes may not be mutually recursive at any level of indirection.
+// LogicalTypes must map from a Go type to a single Schema Equivalent storage type.
+type LogicalType struct {
+	identifier          string
+	goT, storageT, argT reflect.Type
+	argV                reflect.Value
+	toStorage, toGo     func(value reflect.Value) reflect.Value
 }
 
-func (l *convertibleLogicalType) ID() string {
+// ID is a unique identifier for the logical type.
+func (l *LogicalType) ID() string {
 	return l.identifier
 }
 
-func (l *convertibleLogicalType) ArgumentType() reflect.Type {
-	return nil
+// ArgumentType returns the Go type of the argument for parameterized types.
+func (l *LogicalType) ArgumentType() reflect.Type {
+	return l.argT
 }
 
-func (l *convertibleLogicalType) ArgumentValue() reflect.Value {
-	return reflect.Value{}
+// ArgumentValue returns the Go value of the argument for parameterized types.
+func (l *LogicalType) ArgumentValue() reflect.Value {
+	return l.argV
 }
 
-func (l *convertibleLogicalType) GoType() reflect.Type {
+// GoType returns the Go type of the logical type. This is the type in a Go
+// field.
+func (l *LogicalType) GoType() reflect.Type {
 	return l.goT
 }
 
-func (l *convertibleLogicalType) StorageType() reflect.Type {
+// StorageType is the schema equivalent representation of this logical type.
+// The storage type is how the logical type is encoded in bytes, and if the
+// logical type is unknown, can be decoded into a value of this type instead.
+func (l *LogicalType) StorageType() reflect.Type {
 	return l.storageT
 }
 
-func (l *convertibleLogicalType) ToStorageType(value reflect.Value) reflect.Value {
-	return value.Convert(l.storageT)
+// ToLogicalType creates a LogicalType, indicating that there's a conversion from one to the other.
+func ToLogicalType(identifier string, goType, storageType reflect.Type) LogicalType {
+	return LogicalType{identifier: identifier, goT: goType, storageT: storageType}
 }
 
-func (l *convertibleLogicalType) ToGoType(storage reflect.Value) reflect.Value {
-	return storage.Convert(l.goT)
-}
-
-// NewConvertibleLogicalType creates a LogicalType where the go type and storage representation
-// can be converted between each other with reflect.Value.Convert.
-func NewConvertibleLogicalType(identifier string, goType, storageType reflect.Type) LogicalType {
-	if !(goType.ConvertibleTo(storageType) && storageType.ConvertibleTo(goType)) {
-		panic(fmt.Sprintf("Can't create ConvertibleTo LogicalType: %v and %v are not convertable to each other", goType, storageType))
-	}
-	return &convertibleLogicalType{identifier: identifier, goT: goType, storageT: storageType}
+func preRegLogicalTypes(r *Registry) {
+	r.RegisterLogicalType(ToLogicalType("int", reflectx.Int, reflectx.Int64))
+	r.RegisterLogicalType(ToLogicalType("int8", reflectx.Int8, reflectx.Int64))
+	r.RegisterLogicalType(ToLogicalType("uint16", reflectx.Uint16, reflectx.Int16))
+	r.RegisterLogicalType(ToLogicalType("uint32", reflectx.Uint32, reflectx.Int32))
+	r.RegisterLogicalType(ToLogicalType("uint64", reflectx.Uint64, reflectx.Int64))
+	r.RegisterLogicalType(ToLogicalType("uint", reflectx.Uint, reflectx.Int64))
 }
 
 func init() {
-	RegisterLogicalType(NewConvertibleLogicalType("int", reflectx.Int, reflectx.Int64))
-	RegisterLogicalType(NewConvertibleLogicalType("uint32", reflectx.Uint32, reflectx.Int32))
-	RegisterLogicalType(NewConvertibleLogicalType("uint64", reflectx.Uint64, reflectx.Int64))
-	RegisterLogicalType(NewConvertibleLogicalType("uint16", reflectx.Uint16, reflectx.Int16))
-	RegisterLogicalType(NewConvertibleLogicalType("int8", reflectx.Int8, reflectx.Uint8))
+	preRegLogicalTypes(defaultRegistry)
 }

--- a/sdks/go/pkg/beam/core/runtime/graphx/schema/schema.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/schema/schema.go
@@ -38,42 +38,57 @@ import (
 	pipepb "github.com/apache/beam/sdks/go/pkg/beam/model/pipeline_v1"
 )
 
-var lastShortID int64
-
-// TODO(BEAM-9615): Replace with UUIDs.
-func getNextID() string {
-	id := atomic.AddInt64(&lastShortID, 1)
-	// No reason not to use the smallest string short ids possible.
-	return strconv.FormatInt(id, 36)
+// FromType returns a Beam Schema of the passed in type.
+// Returns an error if the type cannot be converted to a Schema.
+func FromType(ot reflect.Type) (*pipepb.Schema, error) {
+	return defaultRegistry.FromType(ot)
 }
 
-var (
-	// Maps types to schemas for reuse, caching the UUIDs.
-	typeToSchema = map[reflect.Type]*pipepb.Schema{}
-	// Maps synthetic types to user types. Keys must be generated from a schema.
-	// This works around using the generated type assertion shims failing to type assert.
-	// Type assertion isn't assignability, which is closer to how the reflection based
-	// shims operate.
-	// User types are mapped to themselves to also signify they've been registered.
-	syntheticToUser = map[reflect.Type]reflect.Type{}
-)
+// ToType returns a Go type of the passed in Schema.
+// Types returned by ToType are always of Struct kind.
+// Returns an error if the Schema cannot be converted to a type.
+func ToType(s *pipepb.Schema) (reflect.Type, error) {
+	return defaultRegistry.ToType(s)
+}
 
 // Registered returns whether the given type has been registered with
-// the schema package.
+// the default schema registry.
 func Registered(ut reflect.Type) bool {
-	_, ok := syntheticToUser[ut]
-	return ok
+	return defaultRegistry.Registered(ut)
 }
 
 // RegisterType converts the type to it's schema representation, and converts it back to
 // a synthetic type so we can map from the synthetic type back to the user type.
 // Recursively registers other named struct types in any component parts.
 func RegisterType(ut reflect.Type) {
-	registerType(ut, map[reflect.Type]struct{}{})
+	defaultRegistry.RegisterType(ut)
 }
 
-func registerType(ut reflect.Type, seen map[reflect.Type]struct{}) {
-	if _, ok := syntheticToUser[ut]; ok {
+var lastShortID int64
+
+// TODO(BEAM-9615): Replace with UUIDs.
+func (r *Registry) getNextID() string {
+	id := atomic.AddInt64(&r.lastShortID, 1)
+	// No reason not to use the smallest string short ids possible.
+	return strconv.FormatInt(id, 36)
+}
+
+// Registered returns whether the given type has been registered with
+// the schema package.
+func (r *Registry) Registered(ut reflect.Type) bool {
+	_, ok := r.syntheticToUser[ut]
+	return ok
+}
+
+// RegisterType converts the type to it's schema representation, and converts it back to
+// a synthetic type so we can map from the synthetic type back to the user type.
+// Recursively registers other named struct types in any component parts.
+func (r *Registry) RegisterType(ut reflect.Type) {
+	r.registerType(ut, map[reflect.Type]struct{}{})
+}
+
+func (r *Registry) registerType(ut reflect.Type, seen map[reflect.Type]struct{}) {
+	if _, ok := r.syntheticToUser[ut]; ok {
 		return
 	}
 	if _, ok := seen[ut]; ok {
@@ -83,12 +98,34 @@ func registerType(ut reflect.Type, seen map[reflect.Type]struct{}) {
 
 	// Lets do some recursion to register fundamental type parts.
 	t := ut
+
+	if lID, ok := r.logicalTypeIdentifiers[t]; ok {
+		lt := r.logicalTypes[lID]
+		r.addToMaps(lt.StorageType(), t)
+		return
+	}
+	for _, lti := range r.logicalTypeInterfaces {
+		if !t.Implements(lti) {
+			continue
+		}
+		p := r.logicalTypeProviders[lti]
+		st, err := p(t)
+		if err != nil {
+			panic(errors.Wrapf(err, "unable to convert LogicalType[%v] using provider for %v", t, lti))
+		}
+		if st == nil {
+			continue
+		}
+		r.RegisterLogicalType(ToLogicalType(t.String(), t, st))
+		r.addToMaps(st, t)
+	}
+
 	switch t.Kind() {
 	case reflect.Map:
-		registerType(t.Key(), seen)
+		r.registerType(t.Key(), seen)
 		fallthrough
 	case reflect.Array, reflect.Slice, reflect.Ptr:
-		registerType(t.Elem(), seen)
+		r.registerType(t.Elem(), seen)
 		return
 	case reflect.Struct: // What we expect here.
 	default:
@@ -98,32 +135,36 @@ func registerType(ut reflect.Type, seen map[reflect.Type]struct{}) {
 
 	for i := 0; i < t.NumField(); i++ {
 		sf := ut.Field(i)
-		registerType(sf.Type, seen)
+		r.registerType(sf.Type, seen)
 	}
 
-	schm, err := FromType(ut)
+	schm, err := r.FromType(ut)
 	if err != nil {
 		panic(errors.WithContextf(err, "converting %v to schema", ut))
 	}
-	synth, err := ToType(schm)
+	synth, err := r.ToType(schm)
 	if err != nil {
 		panic(errors.WithContextf(err, "converting %v's back to a synthetic type", ut))
 	}
+	r.addToMaps(synth, ut)
+}
+
+func (r *Registry) addToMaps(synth, ut reflect.Type) {
 	synth = reflectx.SkipPtr(synth)
 	ut = reflectx.SkipPtr(ut)
-	syntheticToUser[synth] = ut
-	syntheticToUser[reflect.PtrTo(synth)] = reflect.PtrTo(ut)
-	syntheticToUser[ut] = ut
-	syntheticToUser[reflect.PtrTo(ut)] = reflect.PtrTo(ut)
+	r.syntheticToUser[synth] = ut
+	r.syntheticToUser[reflect.PtrTo(synth)] = reflect.PtrTo(ut)
+	r.syntheticToUser[ut] = ut
+	r.syntheticToUser[reflect.PtrTo(ut)] = reflect.PtrTo(ut)
 }
 
 // FromType returns a Beam Schema of the passed in type.
 // Returns an error if the type cannot be converted to a Schema.
-func FromType(ot reflect.Type) (*pipepb.Schema, error) {
+func (r *Registry) FromType(ot reflect.Type) (*pipepb.Schema, error) {
 	if reflectx.SkipPtr(ot).Kind() != reflect.Struct {
 		return nil, errors.Errorf("cannot convert %v to schema. FromType only converts structs to schemas", ot)
 	}
-	schm, err := structToSchema(ot)
+	schm, err := r.structToSchema(ot)
 	if err != nil {
 		return nil, err
 	}
@@ -156,14 +197,33 @@ func checkOptions(opts []*pipepb.Option, urn string, rt reflect.Type) reflect.Ty
 	return nil
 }
 
-func structToSchema(ot reflect.Type) (*pipepb.Schema, error) {
-	if schm, ok := typeToSchema[ot]; ok {
+func (r *Registry) structToSchema(ot reflect.Type) (*pipepb.Schema, error) {
+	if schm, ok := r.typeToSchema[ot]; ok {
 		return schm, nil
 	}
+
 	t := reflectx.SkipPtr(ot)
+	// Check if a logical type was registered that matches this struct type directly
+	// and if so, extract the schema from it for use.
+	if lID, ok := r.logicalTypeIdentifiers[ot]; ok {
+		lt := r.logicalTypes[lID]
+		ftype, err := r.reflectTypeToFieldType(lt.StorageType())
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to convert LogicalType[%v]'s storage type %v for Go type of %v to a schema", lID, lt.StorageType(), lt.GoType())
+		}
+		schm := ftype.GetRowType().GetSchema()
+		r.typeToSchema[ot] = schm
+		return schm, nil
+	}
+
 	fields := make([]*pipepb.Field, 0, t.NumField())
 	for i := 0; i < t.NumField(); i++ {
-		f, err := structFieldToField(t.Field(i))
+		sf := t.Field(i)
+		isUnexported := sf.PkgPath != ""
+		if isUnexported {
+			continue // ignore unexported fields here.
+		}
+		f, err := r.structFieldToField(sf)
 		if err != nil {
 			return nil, errors.Wrapf(err, "cannot convert field %v to schema", t.Field(i).Name)
 		}
@@ -172,18 +232,18 @@ func structToSchema(ot reflect.Type) (*pipepb.Schema, error) {
 
 	schm := &pipepb.Schema{
 		Fields: fields,
-		Id:     getNextID(),
+		Id:     r.getNextID(),
 	}
-	typeToSchema[ot] = schm
+	r.typeToSchema[ot] = schm
 	return schm, nil
 }
 
-func structFieldToField(sf reflect.StructField) (*pipepb.Field, error) {
+func (r *Registry) structFieldToField(sf reflect.StructField) (*pipepb.Field, error) {
 	name := sf.Name
 	if tag := sf.Tag.Get("beam"); tag != "" {
 		name, _ = parseTag(tag)
 	}
-	ftype, err := reflectTypeToFieldType(sf.Type)
+	ftype, err := r.reflectTypeToFieldType(sf.Type)
 	if err != nil {
 		return nil, err
 	}
@@ -193,10 +253,10 @@ func structFieldToField(sf reflect.StructField) (*pipepb.Field, error) {
 	}, nil
 }
 
-func reflectTypeToFieldType(ot reflect.Type) (*pipepb.FieldType, error) {
-	if lID, ok := logicalIdentifiers[ot]; ok {
-		lt := logicalTypes[lID]
-		ftype, err := reflectTypeToFieldType(lt.StorageType())
+func (r *Registry) reflectTypeToFieldType(ot reflect.Type) (*pipepb.FieldType, error) {
+	if lID, ok := r.logicalTypeIdentifiers[ot]; ok {
+		lt := r.logicalTypes[lID]
+		ftype, err := r.reflectTypeToFieldType(lt.StorageType())
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to convert LogicalType[%v]'s storage type %v for Go type of %v to a schema field", lID, lt.StorageType(), lt.GoType())
 		}
@@ -204,6 +264,32 @@ func reflectTypeToFieldType(ot reflect.Type) (*pipepb.FieldType, error) {
 			TypeInfo: &pipepb.FieldType_LogicalType{
 				LogicalType: &pipepb.LogicalType{
 					Urn:            lID,
+					Representation: ftype,
+					// TODO(BEAM-9615): Handle type Arguments.
+				},
+			},
+		}, nil
+	}
+	for _, lti := range r.logicalTypeInterfaces {
+		if !ot.Implements(lti) {
+			continue
+		}
+		p := r.logicalTypeProviders[lti]
+		st, err := p(ot)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to convert LogicalType[%v] using provider for %v schema field", ot, lti)
+		}
+		if st == nil {
+			continue
+		}
+		ftype, err := r.reflectTypeToFieldType(st)
+		if err != nil {
+			return nil, errors.Wrapf(err, "unable to convert LogicalType[%v]'s storage type %v for Go type of %v to a schema field", lti, st, ot)
+		}
+		return &pipepb.FieldType{
+			TypeInfo: &pipepb.FieldType_LogicalType{
+				LogicalType: &pipepb.LogicalType{
+					Urn:            ot.String(),
 					Representation: ftype,
 					// TODO(BEAM-9615): Handle type Arguments.
 				},
@@ -219,11 +305,11 @@ func reflectTypeToFieldType(ot reflect.Type) (*pipepb.FieldType, error) {
 	}
 	switch t.Kind() {
 	case reflect.Map:
-		kt, err := reflectTypeToFieldType(t.Key())
+		kt, err := r.reflectTypeToFieldType(t.Key())
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to convert key of %v to schema field", ot)
 		}
-		vt, err := reflectTypeToFieldType(t.Elem())
+		vt, err := r.reflectTypeToFieldType(t.Elem())
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to convert value of %v to schema field", ot)
 		}
@@ -237,7 +323,7 @@ func reflectTypeToFieldType(ot reflect.Type) (*pipepb.FieldType, error) {
 			},
 		}, nil
 	case reflect.Struct:
-		sch, err := structToSchema(t)
+		sch, err := r.structToSchema(t)
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to convert %v to schema field", ot)
 		}
@@ -259,7 +345,7 @@ func reflectTypeToFieldType(ot reflect.Type) (*pipepb.FieldType, error) {
 				},
 			}, nil
 		}
-		vt, err := reflectTypeToFieldType(t.Elem())
+		vt, err := r.reflectTypeToFieldType(t.Elem())
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to convert element type of %v to schema field", ot)
 		}
@@ -300,17 +386,17 @@ var reflectTypeToAtomicTypeMap = map[reflect.Kind]pipepb.AtomicType{
 // ToType returns a Go type of the passed in Schema.
 // Types returned by ToType are always of Struct kind.
 // Returns an error if the Schema cannot be converted to a type.
-func ToType(s *pipepb.Schema) (reflect.Type, error) {
+func (r *Registry) ToType(s *pipepb.Schema) (reflect.Type, error) {
 	fields := make([]reflect.StructField, 0, len(s.GetFields()))
 	for _, sf := range s.GetFields() {
-		rf, err := fieldToStructField(sf)
+		rf, err := r.fieldToStructField(sf)
 		if err != nil {
 			return nil, errors.Wrapf(err, "cannot convert schema field %v to field", sf.GetName())
 		}
 		fields = append(fields, rf)
 	}
 	ret := reflect.StructOf(fields)
-	if ut, ok := syntheticToUser[ret]; ok {
+	if ut, ok := r.syntheticToUser[ret]; ok {
 		ret = ut
 	}
 	if t := nillableFromOptions(s.GetOptions(), ret); t != nil {
@@ -319,9 +405,9 @@ func ToType(s *pipepb.Schema) (reflect.Type, error) {
 	return ret, nil
 }
 
-func fieldToStructField(sf *pipepb.Field) (reflect.StructField, error) {
+func (r *Registry) fieldToStructField(sf *pipepb.Field) (reflect.StructField, error) {
 	name := sf.GetName()
-	rt, err := fieldTypeToReflectType(sf.GetType(), sf.Options)
+	rt, err := r.fieldTypeToReflectType(sf.GetType(), sf.Options)
 	if err != nil {
 		return reflect.StructField{}, err
 	}
@@ -349,7 +435,7 @@ var atomicTypeToReflectType = map[pipepb.AtomicType]reflect.Type{
 	pipepb.AtomicType_BYTES:   reflectx.ByteSlice,
 }
 
-func fieldTypeToReflectType(sft *pipepb.FieldType, opts []*pipepb.Option) (reflect.Type, error) {
+func (r *Registry) fieldTypeToReflectType(sft *pipepb.FieldType, opts []*pipepb.Option) (reflect.Type, error) {
 	var t reflect.Type
 	switch sft.GetTypeInfo().(type) {
 	case *pipepb.FieldType_AtomicType:
@@ -358,34 +444,34 @@ func fieldTypeToReflectType(sft *pipepb.FieldType, opts []*pipepb.Option) (refle
 			return nil, errors.Errorf("unknown atomic type: %v", sft.GetAtomicType())
 		}
 	case *pipepb.FieldType_ArrayType:
-		rt, err := fieldTypeToReflectType(sft.GetArrayType().GetElementType(), nil)
+		rt, err := r.fieldTypeToReflectType(sft.GetArrayType().GetElementType(), nil)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to convert array element type")
 		}
 		t = reflect.SliceOf(rt)
 	case *pipepb.FieldType_MapType:
-		kt, err := fieldTypeToReflectType(sft.GetMapType().GetKeyType(), nil)
+		kt, err := r.fieldTypeToReflectType(sft.GetMapType().GetKeyType(), nil)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to convert map key type")
 		}
-		vt, err := fieldTypeToReflectType(sft.GetMapType().GetValueType(), nil)
+		vt, err := r.fieldTypeToReflectType(sft.GetMapType().GetValueType(), nil)
 		if err != nil {
 			return nil, errors.Wrap(err, "unable to convert map value type")
 		}
 		t = reflect.MapOf(kt, vt) // Panics for invalid map keys (slices/iterables)
 	case *pipepb.FieldType_RowType:
-		rt, err := ToType(sft.GetRowType().GetSchema())
+		rt, err := r.ToType(sft.GetRowType().GetSchema())
 		if err != nil {
 			return nil, errors.Wrapf(err, "unable to convert row type: %v", sft.GetRowType().GetSchema().GetId())
 		}
 		t = rt
 	// case *pipepb.FieldType_IterableType:
-	// TODO(BEAM-9615): handle IterableTypes.
+	// TODO(BEAM-9615): handle IterableTypes (eg. CoGBK values)
 
 	case *pipepb.FieldType_LogicalType:
 		lst := sft.GetLogicalType()
 		identifier := lst.GetUrn()
-		lt, ok := logicalTypes[identifier]
+		lt, ok := r.logicalTypes[identifier]
 		if !ok {
 			return nil, errors.Errorf("unknown logical type: %v", identifier)
 		}

--- a/sdks/go/pkg/beam/core/runtime/graphx/schema/schema.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/schema/schema.go
@@ -118,6 +118,7 @@ func (r *Registry) registerType(ut reflect.Type, seen map[reflect.Type]struct{})
 		}
 		r.RegisterLogicalType(ToLogicalType(t.String(), t, st))
 		r.addToMaps(st, t)
+		return
 	}
 
 	switch t.Kind() {

--- a/sdks/go/pkg/beam/encoding_test.go
+++ b/sdks/go/pkg/beam/encoding_test.go
@@ -1,0 +1,127 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package beam
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/coder/testutil"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
+	"github.com/google/go-cmp/cmp"
+)
+
+type registeredTestType struct {
+	A int
+	B string
+	_ float64
+	D []byte
+	// Currently Not encodable by default, so validates the registration.
+	Foo [0]int
+	Bar map[string]int
+}
+
+var registeredTestTypeType = reflect.TypeOf((*registeredTestType)(nil)).Elem()
+
+func init() {
+	RegisterType(registeredTestTypeType)
+}
+
+func TestEncodedType(t *testing.T) {
+	var v testutil.SchemaCoder
+	v.CmpOptions = []cmp.Option{
+		cmp.Comparer(func(a reflect.Type, b reflect.Type) bool {
+			return a.AssignableTo(b)
+		}),
+	}
+	v.Validate(t, encodedTypeType, encodedTypeEnc, encodedTypeDec, struct{ Str string }{},
+		[]EncodedType{
+			{reflectx.String},
+			{reflectx.Int},
+			{reflectx.Int8},
+			{reflectx.Int16},
+			{reflectx.Int32},
+			{reflectx.Int64},
+			{reflectx.Uint},
+			{reflectx.Uint8},
+			{reflectx.Uint16},
+			{reflectx.Uint32},
+			{reflectx.Uint64},
+			{reflectx.Float32},
+			{reflectx.Float64},
+			{reflectx.ByteSlice},
+			{reflectx.Error},
+			{reflectx.Bool},
+			{reflectx.Context},
+
+			{reflect.PtrTo(reflectx.String)},
+			{reflect.PtrTo(reflectx.Int)},
+			{reflect.PtrTo(reflectx.Int8)},
+			{reflect.PtrTo(reflectx.Int16)},
+			{reflect.PtrTo(reflectx.Int32)},
+			{reflect.PtrTo(reflectx.Int64)},
+			{reflect.PtrTo(reflectx.Uint)},
+			{reflect.PtrTo(reflectx.Uint8)},
+			{reflect.PtrTo(reflectx.Uint16)},
+			{reflect.PtrTo(reflectx.Uint32)},
+			{reflect.PtrTo(reflectx.Uint64)},
+			{reflect.PtrTo(reflectx.Float32)},
+			{reflect.PtrTo(reflectx.Float64)},
+			{reflect.PtrTo(reflectx.ByteSlice)},
+			{reflect.PtrTo(reflectx.Error)},
+			{reflect.PtrTo(reflectx.Bool)},
+
+			{reflect.ChanOf(reflect.BothDir, reflectx.Bool)},
+			{reflect.ChanOf(reflect.RecvDir, reflectx.Float64)},
+			{reflect.ChanOf(reflect.SendDir, reflectx.ByteSlice)},
+
+			// Needs changes to Go SDK v1 type protos to support without registering.
+			//	{reflect.ArrayOf(0, reflectx.Int)},
+			//	{reflect.ArrayOf(7, reflectx.Int)},
+			// {reflect.MapOf(reflectx.String, reflectx.ByteSlice)},
+
+			{registeredTestTypeType},
+
+			{reflect.FuncOf([]reflect.Type{reflectx.Context, reflectx.String, reflectx.Int}, []reflect.Type{reflectx.Error}, false)},
+
+			{encodedTypeType},
+			{encodedFuncType},
+			{reflect.TypeOf((*struct{ A, B, C int })(nil))},
+			{reflect.TypeOf((*struct{ A, B, C int })(nil)).Elem()},
+		})
+}
+
+func registeredLocalTestFunction(_ string) int {
+	return 0
+}
+
+func init() {
+	// Functions must be registered anyway, in particular for unit tests.
+	RegisterFunction(registeredLocalTestFunction)
+}
+
+func TestEncodedFunc(t *testing.T) {
+	var v testutil.SchemaCoder
+	v.CmpOptions = []cmp.Option{
+		cmp.Comparer(func(a reflectx.Func, b reflectx.Func) bool {
+			return a.Type() == b.Type() && a.Name() == b.Name()
+		}),
+	}
+	v.Validate(t, encodedFuncType, encodedFuncEnc, encodedFuncDec, struct{ Str string }{},
+		[]EncodedFunc{
+			{reflectx.MakeFunc(registeredLocalTestFunction)},
+		})
+}

--- a/sdks/go/pkg/beam/example_schema_test.go
+++ b/sdks/go/pkg/beam/example_schema_test.go
@@ -1,0 +1,254 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package beam_test
+
+import (
+	"bytes"
+	"fmt"
+	"io"
+	"reflect"
+
+	"github.com/apache/beam/sdks/go/pkg/beam"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/coder"
+	"github.com/google/go-cmp/cmp"
+)
+
+// RegisterSchemaProvider must be called before beam.Init, and conventionally in a package init block.
+func init() {
+	beam.RegisterSchemaProvider(reflect.TypeOf((*Alphabet)(nil)).Elem(), &AlphabetProvider{})
+	// TODO(BEAM-9615): Registerying a self encoding type causes a cycle. Needs resolving.
+	// beam.RegisterType(reflect.TypeOf((*Cyrillic)(nil)))
+	beam.RegisterType(reflect.TypeOf((*Latin)(nil)))
+	beam.RegisterType(reflect.TypeOf((*Ελληνικά)(nil)))
+}
+
+type Alphabet interface {
+	alphabet() string
+}
+
+type Cyrillic struct {
+	A, B int
+}
+
+func (*Cyrillic) alphabet() string {
+	return "Cyrillic"
+}
+
+type Latin struct {
+	// Unexported fields are not serializable by beam schemas by default
+	// so we need to handle this ourselves.
+	c uint64
+	d *float32
+}
+
+func (*Latin) alphabet() string {
+	return "Latin"
+}
+
+type Ελληνικά struct {
+	q string
+	G func() string
+}
+
+func (*Ελληνικά) alphabet() string {
+	return "Ελληνικά"
+}
+
+// AlphabetProvider provides encodings for types that implement the Alphabet interface.
+type AlphabetProvider struct {
+	enc *coder.RowEncoderBuilder
+	dec *coder.RowDecoderBuilder
+}
+
+var (
+	typeCyrillic = reflect.TypeOf((*Cyrillic)(nil))
+	typeLatin    = reflect.TypeOf((*Latin)(nil))
+	typeΕλληνικά = reflect.TypeOf((*Ελληνικά)(nil))
+)
+
+func (p *AlphabetProvider) FromLogicalType(rt reflect.Type) (reflect.Type, error) {
+	// FromLogicalType produces schema representative types, which match the encoders
+	// and decoders that this function generates for this type.
+	// While this example uses statically assigned schema representative types, it's
+	// possible to generate the returned reflect.Type dynamically instead, using the
+	// reflect package.
+	switch rt {
+	// The Cyrillic type is able to be encoded by default, so we simply use it directly
+	// as it's own representative type.
+	case typeCyrillic:
+		return typeCyrillic, nil
+	case typeLatin:
+		// The Latin type only has unexported fields, so we need to make the equivalent
+		// have exported fields.
+		return reflect.TypeOf((*struct {
+			C uint64
+			D *float32
+		})(nil)).Elem(), nil
+	case typeΕλληνικά:
+		return reflect.TypeOf((*struct{ Q string })(nil)).Elem(), nil
+	}
+	return nil, fmt.Errorf("Unknown Alphabet: %v", rt)
+}
+
+// BuildEncoder returns beam schema encoder functions for types with the Alphabet interface.
+func (p *AlphabetProvider) BuildEncoder(rt reflect.Type) (func(interface{}, io.Writer) error, error) {
+	switch rt {
+	case typeCyrillic:
+		if p.enc == nil {
+			p.enc = &coder.RowEncoderBuilder{}
+		}
+		// Since Cyrillic is by default encodable, defer to the standard schema row decoder for the type.
+		return p.enc.Build(rt)
+	case typeLatin:
+		return func(iface interface{}, w io.Writer) error {
+			v := iface.(*Latin)
+			// Beam Schema Rows have a header that indicates which fields if any, are nil.
+			if err := coder.WriteRowHeader(2, func(i int) bool {
+				if i == 1 {
+					return v.d == nil
+				}
+				return false
+			}, w); err != nil {
+				return err
+			}
+			// Afterwards, each field is encoded using the appropriate helper.
+			if err := coder.EncodeVarUint64(v.c, w); err != nil {
+				return err
+			}
+			// Nil fields have nothing written for them other than the header.
+			if v.d != nil {
+				if err := coder.EncodeDouble(float64(*v.d), w); err != nil {
+					return err
+				}
+			}
+			return nil
+		}, nil
+	case typeΕλληνικά:
+		return func(iface interface{}, w io.Writer) error {
+			// Since the representation for Ελληνικά never has nil fields
+			// we can use the simple header helper.
+			if err := coder.WriteSimpleRowHeader(1, w); err != nil {
+				return err
+			}
+			v := iface.(*Ελληνικά)
+			if err := coder.EncodeStringUTF8(v.q, w); err != nil {
+				return fmt.Errorf("decoding string field A: %v", err)
+			}
+			return nil
+		}, nil
+	}
+	return nil, fmt.Errorf("Unknown Alphabet: %v", rt)
+}
+
+// BuildDecoder returns beam schema decoder functions for types with the Alphabet interface.
+func (p *AlphabetProvider) BuildDecoder(rt reflect.Type) (func(io.Reader) (interface{}, error), error) {
+	switch rt {
+	case typeCyrillic:
+		if p.dec == nil {
+			p.dec = &coder.RowDecoderBuilder{}
+		}
+		// Since Cyrillic is by default encodable, defer to the standard schema row decoder for the type.
+		return p.dec.Build(rt)
+	case typeLatin:
+		return func(r io.Reader) (interface{}, error) {
+			// Since the d field can be nil, we use the header get the nil bits.
+			n, nils, err := coder.ReadRowHeader(r)
+			if err != nil {
+				return nil, err
+			}
+			// Header returns the number of fields, so we check if it has what we
+			// expect. This allows schemas to evolve if necessary.
+			if n != 2 {
+				return nil, fmt.Errorf("expected 2 fields, but got %v", n)
+			}
+			c, err := coder.DecodeVarUint64(r)
+			if err != nil {
+				return nil, err
+			}
+			// Check if the field is nil before trying to decode a value for it.
+			var d *float32
+			if !coder.IsFieldNil(nils, 1) {
+				f, err := coder.DecodeDouble(r)
+				if err != nil {
+					return nil, err
+				}
+				f32 := float32(f)
+				d = &f32
+			}
+			return &Latin{
+				c: c,
+				d: d,
+			}, nil
+		}, nil
+	case typeΕλληνικά:
+		return func(r io.Reader) (interface{}, error) {
+			// Since the representation for Ελληνικά never has nil fields
+			// we can use the simple header helper. Returns an error if
+			// something unexpected occurs.
+			if err := coder.ReadSimpleRowHeader(1, r); err != nil {
+				return nil, err
+			}
+			q, err := coder.DecodeStringUTF8(r)
+			if err != nil {
+				return nil, fmt.Errorf("decoding string field A: %v", err)
+			}
+			return &Ελληνικά{
+				q: q,
+			}, nil
+		}, nil
+	}
+	return nil, nil
+}
+
+// Schema providers work on fields of schema encoded types.
+type translation struct {
+	C *Cyrillic
+	L *Latin
+	E *Ελληνικά
+}
+
+func ExampleRegisterSchemaProvider() {
+	f := float32(42.789)
+	want := translation{
+		C: &Cyrillic{A: 123, B: 456},
+		L: &Latin{c: 789, d: &f},
+		E: &Ελληνικά{q: "testing"},
+	}
+	rt := reflect.TypeOf((*translation)(nil)).Elem()
+	enc, err := coder.RowEncoderForStruct(rt)
+	if err != nil {
+		panic(err)
+	}
+	dec, err := coder.RowDecoderForStruct(rt)
+	if err != nil {
+		panic(err)
+	}
+	var buf bytes.Buffer
+	if err := enc(want, &buf); err != nil {
+		panic(err)
+	}
+	got, err := dec(&buf)
+	if err != nil {
+		panic(err)
+	}
+	if d := cmp.Diff(want, got,
+		cmp.AllowUnexported(Latin{}, Ελληνικά{})); d != "" {
+		fmt.Printf("diff in schema encoding translation: (-want,+got)\n%v\n", d)
+	} else {
+		fmt.Println("No diffs!")
+	}
+	// Output: No diffs!
+}

--- a/sdks/go/pkg/beam/forward.go
+++ b/sdks/go/pkg/beam/forward.go
@@ -21,6 +21,7 @@ import (
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/coder"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/genx"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx/schema"
 	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
 )
 
@@ -43,6 +44,7 @@ import (
 // facing copy for this important concept.
 func RegisterType(t reflect.Type) {
 	runtime.RegisterType(t)
+	schema.RegisterType(t)
 }
 
 // RegisterFunction allows function registration. It is beneficial for performance

--- a/sdks/go/pkg/beam/schema.go
+++ b/sdks/go/pkg/beam/schema.go
@@ -1,0 +1,72 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package beam
+
+import (
+	"io"
+	"reflect"
+
+	"github.com/apache/beam/sdks/go/pkg/beam/core/graph/coder"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx/schema"
+)
+
+// RegisterSchemaProvider allows pipeline authors to provide special handling
+// to convert types to schema representations, when those types are used as
+// fields in types being encoded as schema rows.
+//
+// At present, the only supported provider interface is SchemaProvider,
+// though this may change in the future.
+//
+// Providers only need to support a limited set of types for conversion,
+// specifically a single struct type or a pointer to struct type,
+// or an interface type, which they are registered with.
+//
+// Providers have three tasks with respect to a given supported logical type:
+//
+//   * Producing schema representative types for their logical types.
+//   * Producing schema encoders for values of that type, writing beam
+//   schema encoded bytes for a value, matching the schema representative type.
+//   * Producing schema decoders for values of that type, reading beam
+//   schema encoded bytes, and producing a value of that type.
+//
+// Representative Schema types must be structs with only exported fields.
+//
+// A provider should be thread safe, but it's not required that a produced
+// encoder or decoder is thread safe, since a separate encoder or decoder
+// will be used for simultaneously executed bundles.
+//
+// If the supported type is an interface, that interface must have a non-empty
+// method set. That is, it cannot be the empty interface.
+//
+// RegisterSchemaProvider must be called before beam.Init(), and conventionally
+// is called in a package init() function.
+func RegisterSchemaProvider(rt reflect.Type, provider interface{}) {
+	p := provider.(SchemaProvider)
+	schema.RegisterLogicalTypeProvider(rt, p.FromLogicalType)
+	coder.RegisterSchemaProviders(rt, p.BuildEncoder, p.BuildDecoder)
+}
+
+// SchemaProvider specializes schema handling for complex types, including conversion to a
+// valid schema base type,
+//
+// In particular, they are intended to handle schema for interface types.
+//
+// Sepearated out the acting type from the provider implementation is good.
+type SchemaProvider interface {
+	FromLogicalType(reflect.Type) (reflect.Type, error)
+	BuildEncoder(rt reflect.Type) (func(interface{}, io.Writer) error, error)
+	BuildDecoder(rt reflect.Type) (func(io.Reader) (interface{}, error), error)
+}

--- a/sdks/go/pkg/beam/transforms/top/top_test.go
+++ b/sdks/go/pkg/beam/transforms/top/top_test.go
@@ -124,13 +124,16 @@ func load(fn *combineFn, elms ...string) accum {
 func merge(t *testing.T, fn *combineFn, as ...accum) accum {
 	t.Helper()
 	a := fn.CreateAccumulator()
+	enc := accumEnc()
+	dec := accumDec()
+
 	for i, b := range as {
-		buf, err := b.MarshalJSON()
+		buf, err := enc(b)
 		if err != nil {
 			t.Fatalf("failure marshalling accum[%d]: %v, %+v", i, err, b)
 		}
-		var c accum
-		if err := c.UnmarshalJSON(buf); err != nil {
+		c, err := dec(buf)
+		if err != nil {
 			t.Fatalf("failure unmarshalling accum[%d]: %v, %+v", i, err, b)
 		}
 		a = fn.MergeAccumulators(a, c)
@@ -139,12 +142,15 @@ func merge(t *testing.T, fn *combineFn, as ...accum) accum {
 }
 
 func outputUnmarshal(t *testing.T, fn *combineFn, a accum) []string {
-	buf, err := a.MarshalJSON()
+	enc := accumEnc()
+	dec := accumDec()
+
+	buf, err := enc(a)
 	if err != nil {
 		t.Fatalf("failure marshalling accum: %v, %+v", err, a)
 	}
-	var b accum
-	if err := b.UnmarshalJSON(buf); err != nil {
+	b, err := dec(buf)
+	if err != nil {
 		t.Fatalf("failure unmarshalling accum: %v, %+v", err, b)
 	}
 	return output(fn, b)


### PR DESCRIPTION
This PR does a few things, but is the last non "carefully migrate" or cleanup step for Schema support in the Go SDK.

1. Theres' a toggle to enable Schema support, the package var `beam.EnableSchemas`. This will have your pipelines use the schema infrastructure to encode types that don't have an alternate custom coder registered. It's currently off, to permit graceful migration, though once remaining details are sorted out, it will switch to being default on instead.
2. Adds a way to conveniently RegisterSchemaProviders which is a helper on the beam package. There's a bit of cleanup to be done around the usability experience around schemas, however, this one is probably going to stick, as it demonstrates the mechanism and includes an example of registering custom providers for given types. This allows generally unencodable types to have a substitute schema equivalent type or storgage type provided, along with appropriate encoders and decoders. Still TODO is updating the Schema testutil to handle this more directly for better total testing of implementations.
3. Properly adds type handling for Uint fields (they are stored as varints, but use logical types to return to their appropriate bit interpretation).
4. A benchmark is now included comparing JSON with the default and custom registered schema encoders.  Generally, schema coding is 3x faster in most cases. `go test -benchmem -run=^$ -bench='^(BenchmarkRowCoder_RoundTrip)$' github.com/apache/beam/sdks/go/pkg/beam/core/graph/coder` 
5. There are now several examples in using helper methods from the graph/coder package to write your own custom coders. Still todo is a proper guide in their use and when to use which.
6. The helper meta types (beam.EncodedType, beam.EncodedFunc, beam.EncodedCoder) now support use with schemas.
7. The top accumulator type accum has been swapped away from a custom JSON encoder, to a custom coder based on the schema Row encoding.

Most of the above has been vetted against implementing a provider for protocol buffer types, which will be contributed to the SDK once complete.  As mentioned, there's additional cleanup around the user side of it to make it fully usable, but this set of changes has become wide ranging enough that I need to checkpoint it into the repo before I go any further. However, it should be enough for further experimentation purposes and commentary.



------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
