### PR TITLE
[BEAM-11628] Add initial support for GroupBy.apply

### DIFF
--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -173,16 +173,20 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
 
     elif level is not None:
       if isinstance(level, (list, tuple)):
-        levels = level
+        grouping_indexes = level
       else:
-        levels = [level]
+        grouping_indexes = [level]
       all_levels = self._expr.proxy().index.names
-      levels = [all_levels[i] if isinstance(i, int) else i for i in levels]
+      levels = [
+          all_levels[i] if isinstance(i, int) else i for i in grouping_indexes
+      ]
       levels_to_drop = self._expr.proxy().index.names.difference(levels)
       if levels_to_drop:
         to_group = self.droplevel(levels_to_drop)._expr
       else:
         to_group = self._expr
+      to_group_with_index = self._expr
+      grouping_columns = []
 
     elif callable(by):
 
@@ -197,6 +201,20 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
           requires_partition_by=partitionings.Arbitrary(),
           preserves_partition_by=partitionings.Singleton())
 
+      orig_nlevels = self._expr.proxy().index.nlevels
+      to_group_with_index = expressions.ComputedExpression(
+          'map_index_keep_orig',
+          lambda df: df.set_index([df.index.map(by), df.index]),
+          [self._expr],
+          requires_partition_by=partitionings.Arbitrary(),
+          # Partitioning by the original indexes is preserved
+          preserves_partition_by=partitionings.Index(
+              list(range(1, orig_nlevels + 1))))
+
+      grouping_columns = []
+      # The index we need to group by is the last one
+      grouping_indexes = [0]
+
     elif isinstance(by, DeferredSeries):
 
       raise NotImplementedError(
@@ -209,20 +227,40 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
     elif isinstance(self, DeferredDataFrame):
       if not isinstance(by, list):
         by = [by]
+      # Find the columns that we need to move into the index so we can group by
+      # them
+      column_names = self._expr.proxy().columns
+      grouping_columns = list(set(by).intersection(column_names))
       index_names = self._expr.proxy().index.names
       for label in by:
         if label not in index_names and label not in self._expr.proxy().columns:
           raise KeyError(label)
-      index_names_in_by = list(set(by).intersection(index_names))
-      if index_names_in_by:
+      grouping_indexes = list(set(by).intersection(index_names))
+
+      if grouping_indexes:
         if set(by) == set(index_names):
           to_group = self._expr
         elif set(by).issubset(index_names):
           to_group = self.droplevel(index_names.difference(by))._expr
         else:
-          to_group = self.reset_index(index_names_in_by).set_index(by)._expr
+          to_group = self.reset_index(grouping_indexes).set_index(by)._expr
       else:
         to_group = self.set_index(by)._expr
+
+      if grouping_columns:
+        # TODO(BEAM-11711): It should be possible to do this without creating an
+        # expression manually, by using DeferredDataFrame.set_index, i.e.:
+        #   to_group_with_index = self.set_index([self.index] +
+        #                                        grouping_columns)._expr
+        to_group_with_index = expressions.ComputedExpression(
+            'move_grouped_columns_to_index',
+            lambda df: df.set_index([df.index] + grouping_columns),
+            [self._expr],
+            requires_partition_by=partitionings.Arbitrary(),
+            preserves_partition_by=partitionings.Index(
+                list(range(self._expr.proxy().index.nlevels))))
+      else:
+        to_group_with_index = self._expr
 
     else:
       raise NotImplementedError(by)
@@ -235,7 +273,10 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
             requires_partition_by=partitionings.Index(),
             preserves_partition_by=partitionings.Arbitrary()),
         kwargs,
-        to_group)
+        to_group,
+        to_group_with_index,
+        grouping_columns=grouping_columns,
+        grouping_indexes=grouping_indexes)
 
   abs = frame_base._elementwise_method('abs')
   astype = frame_base._elementwise_method('astype')
@@ -1745,13 +1786,36 @@ for meth in ('filter', ):
 @populate_not_implemented(pd.core.groupby.generic.DataFrameGroupBy)
 class DeferredGroupBy(frame_base.DeferredFrame):
   def __init__(self, expr, kwargs,
-               ungrouped: DeferredDataFrameOrSeries, projection=None):
+               ungrouped: expressions.Expression,
+               ungrouped_with_index: expressions.Expression,
+               grouping_columns,
+               grouping_indexes,
+               projection=None):
+    """This object represents the result of::
+
+        ungrouped.groupby(level=[grouping_indexes + grouping_columns],
+                          **kwargs)[projection]
+
+    :param expr: An expression to compute a pandas GroupBy object. Convenient
+        for unliftable aggregations.
+    :param ungrouped: An expression to compute the DataFrame pre-grouping, the
+        (Multi)Index contains only the grouping columns/indexes.
+    :param ungrouped_with_index: Same as ungrouped, except the index includes
+        all of the original indexes as well as any grouping columns. This is
+        important for operations that expose the original index, e.g. .apply(),
+        but we only use it when necessary to avoid unnessary data transfer and
+        GBKs.
+    :param grouping_columns: list of column labels that were in the original
+        groupby(..) `by` parameter. Only relevant for grouped DataFrames.
+    :param grouping_indexes: list of index names (or index level numbers) to be
+        grouped.
+    :param kwargs: Keywords args passed to the original groupby(..) call."""
     super(DeferredGroupBy, self).__init__(expr)
-    # This object represents the result of:
-    # ungrouped.groupby(level=list(range(ungrouped.index.nlevels),
-    #                   **kwargs)[projection]
     self._ungrouped = ungrouped
+    self._ungrouped_with_index = ungrouped_with_index
     self._projection = projection
+    self._grouping_columns = grouping_columns
+    self._grouping_indexes = grouping_indexes
     self._kwargs = kwargs
 
   def __getattr__(self, name):
@@ -1763,7 +1827,10 @@ class DeferredGroupBy(frame_base.DeferredFrame):
             preserves_partition_by=partitionings.Arbitrary()),
         self._kwargs,
         self._ungrouped,
-        name)
+        self._ungrouped_with_index,
+        self._grouping_columns,
+        self._grouping_indexes,
+        projection=name)
 
   def __getitem__(self, name):
     return DeferredGroupBy(
@@ -1774,7 +1841,10 @@ class DeferredGroupBy(frame_base.DeferredFrame):
             preserves_partition_by=partitionings.Arbitrary()),
         self._kwargs,
         self._ungrouped,
-        name)
+        self._ungrouped_with_index,
+        self._grouping_columns,
+        self._grouping_indexes,
+        projection=name)
 
   def agg(self, fn):
     if not callable(fn):
@@ -1785,9 +1855,63 @@ class DeferredGroupBy(frame_base.DeferredFrame):
     return DeferredDataFrame(
         expressions.ComputedExpression(
             'agg',
-            lambda df: df.agg(fn), [self._expr],
+            lambda gb: gb.agg(fn), [self._expr],
             requires_partition_by=partitionings.Index(),
-            preserves_partition_by=partitionings.Arbitrary()))
+            preserves_partition_by=partitionings.Singleton()))
+
+  def apply(self, fn, *args, **kwargs):
+    if self._grouping_columns and not self._projection:
+      grouping_columns = self._grouping_columns
+      def fn_wrapper(x, *args, **kwargs):
+        # TODO(BEAM-11710): Moving a column to an index and back is lossy
+        # since indexes dont support as many dtypes. We should keep the original
+        # column in groupby() instead. We need it anyway in case the grouping
+        # column is projected, which is allowed.
+
+        # Move the columns back to columns
+        x = x.assign(**{col: x.index.get_level_values(col)
+                        for col in grouping_columns})
+        x = x.droplevel(grouping_columns)
+        return fn(x, *args, **kwargs)
+    else:
+      fn_wrapper = fn
+
+    project = _maybe_project_func(self._projection)
+
+    # Unfortunately pandas does not execute fn to determine the right proxy.
+    # We run user fn on a proxy here to detect the return type and generate the
+    # proxy.
+    result = fn_wrapper(project(self._ungrouped_with_index.proxy()))
+    if isinstance(result, pd.core.generic.NDFrame):
+      proxy = result[:0]
+
+      def index_to_arrays(index):
+        return [index.get_level_values(level)
+                for level in range(index.nlevels)]
+
+      # The final result will have the grouped indexes + the indexes from the
+      # result
+      proxy.index = pd.MultiIndex.from_arrays(
+          index_to_arrays(self._ungrouped.proxy().index) +
+          index_to_arrays(proxy.index),
+          names=self._ungrouped.proxy().index.names + proxy.index.names)
+    else:
+      dtype = pd.Series([result]).dtype
+      proxy = pd.Series([], dtype=dtype, index=self._ungrouped.proxy().index)
+
+    levels = self._grouping_indexes + self._grouping_columns
+
+    return DeferredDataFrame(
+        expressions.ComputedExpression(
+            'apply',
+            lambda df: project(df.groupby(level=levels)).apply(
+                fn_wrapper,
+                *args,
+                **kwargs),
+            [self._ungrouped_with_index],
+            proxy=proxy,
+            requires_partition_by=partitionings.Index(levels),
+            preserves_partition_by=partitionings.Index(levels)))
 
   aggregate = agg
 
@@ -1831,7 +1955,7 @@ def _liftable_agg(meth, postagg_meth=None):
 
     to_group = self._ungrouped.proxy().index
     is_categorical_grouping = any(to_group.get_level_values(i).is_categorical()
-                                  for i in range(to_group.nlevels))
+                                  for i in self._grouping_indexes)
     groupby_kwargs = self._kwargs
 
     # Don't include un-observed categorical values in the preagg
@@ -1842,7 +1966,7 @@ def _liftable_agg(meth, postagg_meth=None):
     pre_agg = expressions.ComputedExpression(
         'pre_combine_' + name,
         lambda df: agg_func(project(
-        df.groupby(level=list(range(df.index.nlevels)),
+            df.groupby(level=list(range(df.index.nlevels)),
                    **preagg_groupby_kwargs),
         ), **kwargs),
         [self._ungrouped],
@@ -1872,7 +1996,7 @@ def _unliftable_agg(meth):
 
     to_group = self._ungrouped.proxy().index
     is_categorical_grouping = any(to_group.get_level_values(i).is_categorical()
-                                  for i in range(to_group.nlevels))
+                                  for i in self._grouping_indexes)
 
     groupby_kwargs = self._kwargs
     project = _maybe_project_func(self._projection)

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -1896,6 +1896,8 @@ class DeferredGroupBy(frame_base.DeferredFrame):
           index_to_arrays(proxy.index),
           names=self._ungrouped.proxy().index.names + proxy.index.names)
     else:
+      # The user fn returns some non-pandas type. The expected result is a
+      # Series where each element is the result of one user fn call.
       dtype = pd.Series([result]).dtype
       proxy = pd.Series([], dtype=dtype, index=self._ungrouped.proxy().index)
 

--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -320,6 +320,8 @@ class DeferredFrameTest(unittest.TestCase):
     def median_sum_fn(x):
       return (x.foo + x.bar).median()
 
+    # Note this is the same as DataFrameGroupBy.describe. Using it here is
+    # just a convenient way to test apply() with a user fn that returns a Series
     describe = lambda df: df.describe()
 
     self._run_test(lambda df: df.groupby('group').foo.apply(describe), df)

--- a/sdks/python/apache_beam/dataframe/transforms_test.py
+++ b/sdks/python/apache_beam/dataframe/transforms_test.py
@@ -122,6 +122,30 @@ class TransformTest(unittest.TestCase):
     self.run_scenario(
         df, lambda df: df.loc[df.Speed > 25].groupby('Animal').sum())
 
+  def test_groupby_apply(self):
+    df = pd.DataFrame({
+        'group': ['a' if i % 5 == 0 or i % 3 == 0 else 'b' for i in range(100)],
+        'foo': [None if i % 11 == 0 else i for i in range(100)],
+        'bar': [None if i % 7 == 0 else 99 - i for i in range(100)],
+        'baz': [None if i % 13 == 0 else i * 2 for i in range(100)],
+    })
+
+    def median_sum_fn(x):
+      return (x.foo + x.bar).median()
+
+    describe = lambda df: df.describe()
+
+    self.run_scenario(df, lambda df: df.groupby('group').foo.apply(describe))
+    self.run_scenario(
+        df, lambda df: df.groupby('group')[['foo', 'bar']].apply(describe))
+    self.run_scenario(df, lambda df: df.groupby('group').apply(median_sum_fn))
+    self.run_scenario(
+        df,
+        lambda df: df.set_index('group').foo.groupby(level=0).apply(describe))
+    self.run_scenario(df, lambda df: df.groupby(level=0).apply(median_sum_fn))
+    self.run_scenario(
+        df, lambda df: df.groupby(lambda x: x % 3).apply(describe))
+
   def test_filter(self):
     df = pd.DataFrame({
         'Animal': ['Aardvark', 'Ant', 'Elephant', 'Zebra'],


### PR DESCRIPTION
This PR adds support for [GroupBy.apply](https://pandas.pydata.org/pandas-docs/stable/user_guide/groupby.html#flexible-apply). In general this is a pretty simple operation, just a very customizable unliftable aggregation, but there's one major complication: the frames passed to the apply function include the _original_ index, while our groupby(..) implementation overrides any existing index with just the grouping indexes/columns so we can conveniently use Index() partitioning.

There are a couple possible approaches to get the original index through, but neither is perfect:
1. Move the original indexes into columns, use set_index to move them back after grouping.
2. Don't remove the original indexes in groupby(..), instead just add any grouped columns, and keep all the original indexes. Then use Index(grouping_indexes + grouping_columns) partitioning.

I spent some time trying to get (1) to work, but the book-keeping proved to be too painful. Handling grouped Series is tough, since they need to be turned into DataFrames and back, and projections on the DeferredGroupBy are tricky as well.

This PR uses option (2), which was simpler to implement, but it would be the first application of `Index([i,j])` partitioning, which hasn't been well defined. In order to limit the effect the original to_group and ungrouped expressions are still used for operations that don't need the original index.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
