### PR TITLE
[BEAM-11324] Impose consistent ordering on partitionings used in PartitioningSession

### DIFF
--- a/sdks/python/apache_beam/dataframe/expressions.py
+++ b/sdks/python/apache_beam/dataframe/expressions.py
@@ -68,6 +68,24 @@ class PartitioningSession(Session):
     def is_scalar(expr):
       return not isinstance(expr.proxy(), pd.core.generic.NDFrame)
 
+    def difficulty(partitioning):
+      """Imposes an ordering on partitionings where the largest schemes are the
+      most likely to reveal an error. This order is different from the one
+      defined by is_subpartitioning_of:
+
+        Nothing() > Index() > ... > Index([i,j]) > Index([j]) > Singleton()
+      """
+      if isinstance(partitioning, partitionings.Singleton):
+        return -float('inf')
+      elif isinstance(partitioning, partitionings.Index):
+        if partitioning._levels is None:
+          return 1_000_000
+        else:
+          return len(partitioning._levels)
+      elif isinstance(partitioning, partitionings.Nothing):
+        return float('inf')
+
+
     if expr not in self._bindings:
       if is_scalar(expr) or not expr.args():
         result = super(PartitioningSession, self).evaluate(expr)
@@ -116,17 +134,22 @@ class PartitioningSession(Session):
         # the expression is part of a test that relies on the random seed.
         random_state = random.getstate()
 
-        for input_partitioning in set([expr.requires_partition_by(),
-                                       partitionings.Nothing(),
-                                       partitionings.Index(),
-                                       partitionings.Singleton()]):
+        # Run with all supported partitionings in order of ascending
+        # "difficulty". This way the final result is computed with the
+        # most challenging partitioning. Avoids heisenbugs where sometimes
+        # the result is computed trivially with Singleton partitioning and
+        # passes.
+        for input_partitioning in sorted(set([expr.requires_partition_by(),
+                                              partitionings.Nothing(),
+                                              partitionings.Index(),
+                                              partitionings.Singleton()]),
+                                         key=difficulty):
           if not input_partitioning.is_subpartitioning_of(
               expr.requires_partition_by()):
             continue
 
           random.setstate(random_state)
 
-          # TODO(BEAM-11324): Consider verifying result is always the same
           result = evaluate_with(input_partitioning)
 
         self._bindings[expr] = result

--- a/sdks/python/apache_beam/dataframe/expressions.py
+++ b/sdks/python/apache_beam/dataframe/expressions.py
@@ -85,7 +85,6 @@ class PartitioningSession(Session):
       elif isinstance(partitioning, partitionings.Nothing):
         return float('inf')
 
-
     if expr not in self._bindings:
       if is_scalar(expr) or not expr.args():
         result = super(PartitioningSession, self).evaluate(expr)


### PR DESCRIPTION
Without this change, it's possible that an incorrectly specified expression can create a flaky test. Since we only keep the result from the last executed partitioning, it's possible to get a false positive if, say, Singleton partitioning was used last. This change ensures we always use the most challenging partitioning for the final result. 

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
