### PR TITLE
[BEAM-11707] Change WindmillStateCache cache invalidation to be based…

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WindmillStateInternals.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WindmillStateInternals.java
@@ -43,7 +43,6 @@ import org.apache.beam.runners.core.StateTable;
 import org.apache.beam.runners.core.StateTag;
 import org.apache.beam.runners.core.StateTag.StateBinder;
 import org.apache.beam.runners.core.StateTags;
-import org.apache.beam.runners.dataflow.worker.WindmillStateCache.ForKey;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.SortedListEntry;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.SortedListRange;
@@ -120,7 +119,7 @@ class WindmillStateInternals<K> implements StateInternals {
     private final @Nullable K key;
     private final String stateFamily;
     private final WindmillStateReader reader;
-    private final WindmillStateCache.ForKey cache;
+    private final WindmillStateCache.ForKeyAndFamily cache;
     private final boolean isSystemTable;
     boolean isNewKey;
     private final Supplier<Closeable> scopedReadStateSupplier;
@@ -130,7 +129,7 @@ class WindmillStateInternals<K> implements StateInternals {
         @Nullable K key,
         String stateFamily,
         WindmillStateReader reader,
-        WindmillStateCache.ForKey cache,
+        WindmillStateCache.ForKeyAndFamily cache,
         boolean isSystemTable,
         boolean isNewKey,
         Supplier<Closeable> scopedReadStateSupplier,
@@ -254,7 +253,7 @@ class WindmillStateInternals<K> implements StateInternals {
     }
   }
 
-  private WindmillStateCache.ForKey cache;
+  private WindmillStateCache.ForKeyAndFamily cache;
   Supplier<Closeable> scopedReadStateSupplier;
   private StateTable workItemState;
   private StateTable workItemDerivedState;
@@ -264,7 +263,7 @@ class WindmillStateInternals<K> implements StateInternals {
       String stateFamily,
       WindmillStateReader reader,
       boolean isNewKey,
-      WindmillStateCache.ForKey cache,
+      WindmillStateCache.ForKeyAndFamily cache,
       Supplier<Closeable> scopedReadStateSupplier) {
     this.key = key;
     this.cache = cache;
@@ -329,6 +328,8 @@ class WindmillStateInternals<K> implements StateInternals {
       }
       throw new RuntimeException("Failed to retrieve Windmill state during persist()", exc);
     }
+
+    cache.persist();
   }
 
   /** Encodes the given namespace and address as {@code &lt;namespace&gt;+&lt;address&gt;}. */
@@ -368,7 +369,7 @@ class WindmillStateInternals<K> implements StateInternals {
      * Return an asynchronously computed {@link WorkItemCommitRequest}. The request should be of a
      * form that can be merged with others (only add to repeated fields).
      */
-    abstract Future<WorkItemCommitRequest> persist(WindmillStateCache.ForKey cache)
+    abstract Future<WorkItemCommitRequest> persist(WindmillStateCache.ForKeyAndFamily cache)
         throws IOException;
 
     /**
@@ -401,7 +402,7 @@ class WindmillStateInternals<K> implements StateInternals {
    */
   private abstract static class SimpleWindmillState extends WindmillState {
     @Override
-    public final Future<WorkItemCommitRequest> persist(WindmillStateCache.ForKey cache)
+    public final Future<WorkItemCommitRequest> persist(WindmillStateCache.ForKeyAndFamily cache)
         throws IOException {
       return Futures.immediateFuture(persistDirectly(cache));
     }
@@ -409,8 +410,8 @@ class WindmillStateInternals<K> implements StateInternals {
     /**
      * Returns a {@link WorkItemCommitRequest} that can be used to persist this state to Windmill.
      */
-    protected abstract WorkItemCommitRequest persistDirectly(WindmillStateCache.ForKey cache)
-        throws IOException;
+    protected abstract WorkItemCommitRequest persistDirectly(
+        WindmillStateCache.ForKeyAndFamily cache) throws IOException;
   }
 
   @Override
@@ -497,7 +498,7 @@ class WindmillStateInternals<K> implements StateInternals {
     }
 
     @Override
-    protected WorkItemCommitRequest persistDirectly(WindmillStateCache.ForKey cache)
+    protected WorkItemCommitRequest persistDirectly(WindmillStateCache.ForKeyAndFamily cache)
         throws IOException {
       if (!valueIsKnown) {
         // The value was never read, written or cleared.
@@ -764,8 +765,7 @@ class WindmillStateInternals<K> implements StateInternals {
       if (availableIdsForTsRange != null) {
         availableIdsForTsRange.removeAll(idsUsed);
       }
-      idsAvailableValue.write(idsAvailable);
-      subRangeDeletionsValue.write(subRangeDeletions);
+      writeValues(idsAvailable, subRangeDeletions);
     }
 
     // Remove a timestamp range. Returns ids freed up.
@@ -797,8 +797,22 @@ class WindmillStateInternals<K> implements StateInternals {
           subRangeDeletions.remove(current);
         }
       }
-      idsAvailableValue.write(idsAvailable);
-      subRangeDeletionsValue.write(subRangeDeletions);
+      writeValues(idsAvailable, subRangeDeletions);
+    }
+
+    private void writeValues(
+        Map<Range<Instant>, RangeSet<Long>> idsAvailable,
+        Map<Range<Instant>, RangeSet<Instant>> subRangeDeletions) {
+      if (idsAvailable.isEmpty()) {
+        idsAvailable.clear();
+      } else {
+        idsAvailableValue.write(idsAvailable);
+      }
+      if (subRangeDeletions.isEmpty()) {
+        subRangeDeletionsValue.clear();
+      } else {
+        subRangeDeletionsValue.write(subRangeDeletions);
+      }
     }
   }
 
@@ -997,10 +1011,14 @@ class WindmillStateInternals<K> implements StateInternals {
     }
 
     @Override
-    public WorkItemCommitRequest persistDirectly(ForKey cache) throws IOException {
+    public WorkItemCommitRequest persistDirectly(WindmillStateCache.ForKeyAndFamily cache)
+        throws IOException {
       WorkItemCommitRequest.Builder commitBuilder = WorkItemCommitRequest.newBuilder();
       TagSortedListUpdateRequest.Builder updatesBuilder =
-          commitBuilder.addSortedListUpdatesBuilder().setStateFamily(stateFamily).setTag(stateKey);
+          commitBuilder
+              .addSortedListUpdatesBuilder()
+              .setStateFamily(cache.getStateFamily())
+              .setTag(stateKey);
       try {
         if (cleared) {
           // Default range.
@@ -1186,7 +1204,7 @@ class WindmillStateInternals<K> implements StateInternals {
     }
 
     @Override
-    public WorkItemCommitRequest persistDirectly(WindmillStateCache.ForKey cache)
+    public WorkItemCommitRequest persistDirectly(WindmillStateCache.ForKeyAndFamily cache)
         throws IOException {
       WorkItemCommitRequest.Builder commitBuilder = WorkItemCommitRequest.newBuilder();
 
@@ -1369,7 +1387,7 @@ class WindmillStateInternals<K> implements StateInternals {
     }
 
     @Override
-    public Future<WorkItemCommitRequest> persist(final WindmillStateCache.ForKey cache) {
+    public Future<WorkItemCommitRequest> persist(final WindmillStateCache.ForKeyAndFamily cache) {
 
       Future<WorkItemCommitRequest> result;
 
@@ -1508,7 +1526,7 @@ class WindmillStateInternals<K> implements StateInternals {
         String stateFamily,
         Coder<AccumT> accumCoder,
         CombineFn<InputT, AccumT, OutputT> combineFn,
-        WindmillStateCache.ForKey cache,
+        WindmillStateCache.ForKeyAndFamily cache,
         boolean isNewKey) {
       StateTag<BagState<AccumT>> internalBagAddress = StateTags.convertToBagTagInternal(address);
       WindmillBag<AccumT> cachedBag =
@@ -1559,7 +1577,7 @@ class WindmillStateInternals<K> implements StateInternals {
     }
 
     @Override
-    public Future<WorkItemCommitRequest> persist(WindmillStateCache.ForKey cache)
+    public Future<WorkItemCommitRequest> persist(WindmillStateCache.ForKeyAndFamily cache)
         throws IOException {
       if (hasLocalAdditions) {
         if (COMPACT_NOW.get().get() || bag.valuesAreCached()) {

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WindmillStateCacheTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WindmillStateCacheTest.java
@@ -144,7 +144,7 @@ public class WindmillStateCacheTest {
   }
 
   WindmillStateCache cache;
-  WindmillStateCache.ForKey keyCache;
+  WindmillStateCache.ForKeyAndFamily keyCache;
 
   @Before
   public void setUp() {
@@ -160,15 +160,22 @@ public class WindmillStateCacheTest {
     assertNull(keyCache.get(windowNamespace(0), new TestStateTag("tag2")));
     assertNull(keyCache.get(triggerNamespace(0, 0), new TestStateTag("tag3")));
     assertNull(keyCache.get(triggerNamespace(0, 0), new TestStateTag("tag2")));
+    assertEquals(0, cache.getWeight());
 
     keyCache.put(StateNamespaces.global(), new TestStateTag("tag1"), new TestState("g1"), 2);
-    assertEquals(129, cache.getWeight());
     keyCache.put(windowNamespace(0), new TestStateTag("tag2"), new TestState("w2"), 2);
-    assertEquals(258, cache.getWeight());
+
+    assertEquals(0, cache.getWeight());
+    keyCache.persist();
+    assertEquals(254, cache.getWeight());
+
     keyCache.put(triggerNamespace(0, 0), new TestStateTag("tag3"), new TestState("t3"), 2);
-    assertEquals(276, cache.getWeight());
     keyCache.put(triggerNamespace(0, 0), new TestStateTag("tag2"), new TestState("t2"), 2);
-    assertEquals(294, cache.getWeight());
+
+    // Observes updated weight in entries, though cache will not know about it.
+    assertEquals(290, cache.getWeight());
+    keyCache.persist();
+    assertEquals(290, cache.getWeight());
 
     keyCache = cache.forComputation(COMPUTATION).forKey(COMPUTATION_KEY, STATE_FAMILY, 0L, 2L);
     assertEquals(
@@ -192,16 +199,16 @@ public class WindmillStateCacheTest {
     keyCache = cache.forComputation(COMPUTATION).forKey(COMPUTATION_KEY, STATE_FAMILY, 0L, 1L);
     assertNull(keyCache.get(StateNamespaces.global(), new TestStateTag("tag1")));
     keyCache.put(StateNamespaces.global(), new TestStateTag("tag1"), new TestState("g1"), 2);
+    keyCache.persist();
 
     keyCache = cache.forComputation(COMPUTATION).forKey(COMPUTATION_KEY, STATE_FAMILY, 0L, 2L);
-    assertEquals(129, cache.getWeight());
+    assertEquals(127, cache.getWeight());
     assertEquals(
         new TestState("g1"), keyCache.get(StateNamespaces.global(), new TestStateTag("tag1")));
 
     keyCache = cache.forComputation(COMPUTATION).forKey(COMPUTATION_KEY, STATE_FAMILY, 1L, 3L);
-    assertEquals(129, cache.getWeight());
     assertNull(keyCache.get(StateNamespaces.global(), new TestStateTag("tag1")));
-    assertEquals(0, cache.getWeight());
+    assertEquals(127, cache.getWeight());
   }
 
   /** Verifies that the cache is invalidated when the cache token changes. */
@@ -209,9 +216,10 @@ public class WindmillStateCacheTest {
   public void testEviction() throws Exception {
     keyCache = cache.forComputation(COMPUTATION).forKey(COMPUTATION_KEY, STATE_FAMILY, 0L, 1L);
     keyCache.put(windowNamespace(0), new TestStateTag("tag2"), new TestState("w2"), 2);
-    assertEquals(129, cache.getWeight());
     keyCache.put(triggerNamespace(0, 0), new TestStateTag("tag3"), new TestState("t3"), 2000000000);
+    keyCache.persist();
     assertEquals(0, cache.getWeight());
+
     // Eviction is atomic across the whole window.
     keyCache = cache.forComputation(COMPUTATION).forKey(COMPUTATION_KEY, STATE_FAMILY, 0L, 2L);
     assertNull(keyCache.get(windowNamespace(0), new TestStateTag("tag2")));
@@ -225,9 +233,13 @@ public class WindmillStateCacheTest {
 
     keyCache = cache.forComputation(COMPUTATION).forKey(COMPUTATION_KEY, STATE_FAMILY, 0L, 2L);
     keyCache.put(windowNamespace(0), tag, new TestState("w2"), 2);
-    assertEquals(129, cache.getWeight());
+
     // Same cache.
-    assertNull(keyCache.get(windowNamespace(0), tag));
+    assertEquals(new TestState("w2"), keyCache.get(windowNamespace(0), tag));
+    assertEquals(0, cache.getWeight());
+    keyCache.persist();
+    assertEquals(127, cache.getWeight());
+    assertEquals(new TestState("w2"), keyCache.get(windowNamespace(0), tag));
 
     // Previous work token.
     keyCache = cache.forComputation(COMPUTATION).forKey(COMPUTATION_KEY, STATE_FAMILY, 0L, 1L);
@@ -238,7 +250,7 @@ public class WindmillStateCacheTest {
     assertNull(keyCache.get(windowNamespace(0), tag));
 
     keyCache = cache.forComputation(COMPUTATION).forKey(COMPUTATION_KEY, STATE_FAMILY, 0L, 10L);
-    assertEquals(new TestState("w2"), keyCache.get(windowNamespace(0), tag));
+    assertNull(keyCache.get(windowNamespace(0), tag));
     keyCache.put(windowNamespace(0), tag, new TestState("w3"), 2);
 
     // Ensure that second put updated work token.
@@ -246,7 +258,7 @@ public class WindmillStateCacheTest {
     assertNull(keyCache.get(windowNamespace(0), tag));
 
     keyCache = cache.forComputation(COMPUTATION).forKey(COMPUTATION_KEY, STATE_FAMILY, 0L, 15L);
-    assertEquals(new TestState("w3"), keyCache.get(windowNamespace(0), tag));
+    assertNull(keyCache.get(windowNamespace(0), tag));
   }
 
   /** Verifies that caches are kept independently per-key. */
@@ -254,22 +266,24 @@ public class WindmillStateCacheTest {
   public void testMultipleKeys() throws Exception {
     TestStateTag tag = new TestStateTag("tag1");
 
-    WindmillStateCache.ForKey keyCache1 =
+    WindmillStateCache.ForKeyAndFamily keyCache1 =
         cache
             .forComputation("comp1")
             .forKey(computationKey("comp1", "key1", SHARDING_KEY), STATE_FAMILY, 0L, 0L);
-    WindmillStateCache.ForKey keyCache2 =
+    WindmillStateCache.ForKeyAndFamily keyCache2 =
         cache
             .forComputation("comp1")
             .forKey(computationKey("comp1", "key2", SHARDING_KEY), STATE_FAMILY, 0L, 10L);
-    WindmillStateCache.ForKey keyCache3 =
+    WindmillStateCache.ForKeyAndFamily keyCache3 =
         cache
             .forComputation("comp2")
             .forKey(computationKey("comp2", "key1", SHARDING_KEY), STATE_FAMILY, 0L, 0L);
 
     TestState state1 = new TestState("g1");
     keyCache1.put(StateNamespaces.global(), tag, state1, 2);
-    assertNull(keyCache1.get(StateNamespaces.global(), tag));
+    assertEquals(state1, keyCache1.get(StateNamespaces.global(), tag));
+    keyCache1.persist();
+
     keyCache1 =
         cache
             .forComputation("comp1")
@@ -280,7 +294,8 @@ public class WindmillStateCacheTest {
 
     TestState state2 = new TestState("g2");
     keyCache2.put(StateNamespaces.global(), tag, state2, 2);
-    assertNull(keyCache2.get(StateNamespaces.global(), tag));
+    keyCache2.persist();
+    assertEquals(state2, keyCache2.get(StateNamespaces.global(), tag));
     keyCache2 =
         cache
             .forComputation("comp1")
@@ -294,25 +309,24 @@ public class WindmillStateCacheTest {
   @Test
   public void testMultipleShardsOfKey() throws Exception {
     TestStateTag tag = new TestStateTag("tag1");
-    ByteString key1 = ByteString.copyFromUtf8("key1");
-    ByteString key2 = ByteString.copyFromUtf8("key2");
 
-    WindmillStateCache.ForKey key1CacheShard1 =
+    WindmillStateCache.ForKeyAndFamily key1CacheShard1 =
         cache
             .forComputation(COMPUTATION)
             .forKey(computationKey(COMPUTATION, "key1", 1), STATE_FAMILY, 0L, 0L);
-    WindmillStateCache.ForKey key1CacheShard2 =
+    WindmillStateCache.ForKeyAndFamily key1CacheShard2 =
         cache
             .forComputation(COMPUTATION)
             .forKey(computationKey(COMPUTATION, "key1", 2), STATE_FAMILY, 0L, 0L);
-    WindmillStateCache.ForKey key2CacheShard1 =
+    WindmillStateCache.ForKeyAndFamily key2CacheShard1 =
         cache
             .forComputation(COMPUTATION)
             .forKey(computationKey(COMPUTATION, "key2", 1), STATE_FAMILY, 0L, 0L);
 
     TestState state1 = new TestState("g1");
     key1CacheShard1.put(StateNamespaces.global(), tag, state1, 2);
-    assertNull(key1CacheShard1.get(StateNamespaces.global(), tag));
+    key1CacheShard1.persist();
+    assertEquals(state1, key1CacheShard1.get(StateNamespaces.global(), tag));
     key1CacheShard1 =
         cache
             .forComputation(COMPUTATION)
@@ -323,7 +337,8 @@ public class WindmillStateCacheTest {
 
     TestState state2 = new TestState("g2");
     key1CacheShard2.put(StateNamespaces.global(), tag, state2, 2);
-    assertNull(key1CacheShard2.get(StateNamespaces.global(), tag));
+    assertEquals(state2, key1CacheShard2.get(StateNamespaces.global(), tag));
+    key1CacheShard2.persist();
     key1CacheShard2 =
         cache
             .forComputation(COMPUTATION)
@@ -336,27 +351,31 @@ public class WindmillStateCacheTest {
   /** Verifies explicit invalidation does indeed invalidate the correct entries. */
   @Test
   public void testExplicitInvalidation() throws Exception {
-    WindmillStateCache.ForKey keyCache1 =
+    WindmillStateCache.ForKeyAndFamily keyCache1 =
         cache
             .forComputation("comp1")
             .forKey(computationKey("comp1", "key1", 1), STATE_FAMILY, 0L, 0L);
-    WindmillStateCache.ForKey keyCache2 =
+    WindmillStateCache.ForKeyAndFamily keyCache2 =
         cache
             .forComputation("comp1")
             .forKey(computationKey("comp1", "key2", SHARDING_KEY), STATE_FAMILY, 0L, 0L);
-    WindmillStateCache.ForKey keyCache3 =
+    WindmillStateCache.ForKeyAndFamily keyCache3 =
         cache
             .forComputation("comp2")
             .forKey(computationKey("comp2", "key1", SHARDING_KEY), STATE_FAMILY, 0L, 0L);
-    WindmillStateCache.ForKey keyCache4 =
+    WindmillStateCache.ForKeyAndFamily keyCache4 =
         cache
             .forComputation("comp1")
             .forKey(computationKey("comp1", "key1", 2), STATE_FAMILY, 0L, 0L);
 
     keyCache1.put(StateNamespaces.global(), new TestStateTag("tag1"), new TestState("g1"), 1);
+    keyCache1.persist();
     keyCache2.put(StateNamespaces.global(), new TestStateTag("tag2"), new TestState("g2"), 2);
+    keyCache2.persist();
     keyCache3.put(StateNamespaces.global(), new TestStateTag("tag3"), new TestState("g3"), 3);
+    keyCache3.persist();
     keyCache4.put(StateNamespaces.global(), new TestStateTag("tag4"), new TestState("g4"), 4);
+    keyCache4.persist();
     keyCache1 =
         cache
             .forComputation("comp1")
@@ -384,6 +403,10 @@ public class WindmillStateCacheTest {
 
     // Invalidation of key 1 shard 1 does not affect another shard of key 1 or other keys.
     cache.forComputation("comp1").invalidate(ByteString.copyFromUtf8("key1"), 1);
+    keyCache1 =
+        cache
+            .forComputation("comp1")
+            .forKey(computationKey("comp1", "key1", 1), STATE_FAMILY, 0L, 2L);
 
     assertNull(keyCache1.get(StateNamespaces.global(), new TestStateTag("tag1")));
     assertEquals(
@@ -427,11 +450,12 @@ public class WindmillStateCacheTest {
    */
   @Test
   public void testBadCoderEquality() throws Exception {
-    WindmillStateCache.ForKey keyCache1 =
+    WindmillStateCache.ForKeyAndFamily keyCache1 =
         cache.forComputation(COMPUTATION).forKey(COMPUTATION_KEY, STATE_FAMILY, 0L, 0L);
 
     StateTag<TestState> tag = new TestStateTagWithBadEquality("tag1");
     keyCache1.put(StateNamespaces.global(), tag, new TestState("g1"), 1);
+    keyCache1.persist();
 
     keyCache1 = cache.forComputation(COMPUTATION).forKey(COMPUTATION_KEY, STATE_FAMILY, 0L, 1L);
     assertEquals(new TestState("g1"), keyCache1.get(StateNamespaces.global(), tag));

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WindmillStateInternalsTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WindmillStateInternalsTest.java
@@ -28,6 +28,7 @@ import static org.mockito.Mockito.never;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.when;
 
+import com.google.common.base.Charsets;
 import com.google.common.collect.Iterables;
 import java.io.Closeable;
 import java.util.ArrayList;
@@ -135,7 +136,8 @@ public class WindmillStateInternalsTest {
             cache
                 .forComputation("comp")
                 .forKey(
-                    WindmillComputationKey.create("comp", ByteString.EMPTY, 123),
+                    WindmillComputationKey.create(
+                        "comp", ByteString.copyFrom("dummyKey", Charsets.UTF_8), 123),
                     STATE_FAMILY,
                     17L,
                     workToken),
@@ -149,7 +151,8 @@ public class WindmillStateInternalsTest {
             cache
                 .forComputation("comp")
                 .forKey(
-                    WindmillComputationKey.create("comp", ByteString.EMPTY, 123),
+                    WindmillComputationKey.create(
+                        "comp", ByteString.copyFrom("dummyNewKey", Charsets.UTF_8), 123),
                     STATE_FAMILY,
                     17L,
                     workToken),
@@ -1222,7 +1225,7 @@ public class WindmillStateInternalsTest {
     value.write("Hi");
     underTest.persist(Windmill.WorkItemCommitRequest.newBuilder());
 
-    assertEquals(126, cache.getWeight());
+    assertEquals(132, cache.getWeight());
 
     resetUnderTest();
     value = underTest.state(NAMESPACE, addr);
@@ -1230,7 +1233,7 @@ public class WindmillStateInternalsTest {
     value.clear();
     underTest.persist(Windmill.WorkItemCommitRequest.newBuilder());
 
-    assertEquals(124, cache.getWeight());
+    assertEquals(130, cache.getWeight());
 
     resetUnderTest();
     value = underTest.state(NAMESPACE, addr);
@@ -1262,7 +1265,7 @@ public class WindmillStateInternalsTest {
 
     underTest.persist(Windmill.WorkItemCommitRequest.newBuilder());
 
-    assertEquals(134, cache.getWeight());
+    assertEquals(140, cache.getWeight());
 
     resetUnderTest();
     bag = underTest.state(NAMESPACE, addr);
@@ -1282,7 +1285,7 @@ public class WindmillStateInternalsTest {
 
     underTest.persist(Windmill.WorkItemCommitRequest.newBuilder());
 
-    assertEquals(127, cache.getWeight());
+    assertEquals(133, cache.getWeight());
 
     resetUnderTest();
     bag = underTest.state(NAMESPACE, addr);
@@ -1293,7 +1296,7 @@ public class WindmillStateInternalsTest {
 
     underTest.persist(Windmill.WorkItemCommitRequest.newBuilder());
 
-    assertEquals(128, cache.getWeight());
+    assertEquals(134, cache.getWeight());
 
     resetUnderTest();
     bag = underTest.state(NAMESPACE, addr);
@@ -1324,7 +1327,7 @@ public class WindmillStateInternalsTest {
 
     underTest.persist(Windmill.WorkItemCommitRequest.newBuilder());
 
-    assertEquals(132, cache.getWeight());
+    assertEquals(138, cache.getWeight());
 
     resetUnderTest();
     hold = underTest.state(NAMESPACE, addr);
@@ -1333,7 +1336,7 @@ public class WindmillStateInternalsTest {
 
     underTest.persist(Windmill.WorkItemCommitRequest.newBuilder());
 
-    assertEquals(132, cache.getWeight());
+    assertEquals(138, cache.getWeight());
 
     resetUnderTest();
     hold = underTest.state(NAMESPACE, addr);
@@ -1364,7 +1367,7 @@ public class WindmillStateInternalsTest {
 
     underTest.persist(Windmill.WorkItemCommitRequest.newBuilder());
 
-    assertEquals(125, cache.getWeight());
+    assertEquals(131, cache.getWeight());
 
     resetUnderTest();
     value = underTest.state(NAMESPACE, COMBINING_ADDR);
@@ -1375,7 +1378,7 @@ public class WindmillStateInternalsTest {
 
     underTest.persist(Windmill.WorkItemCommitRequest.newBuilder());
 
-    assertEquals(124, cache.getWeight());
+    assertEquals(130, cache.getWeight());
 
     resetUnderTest();
     value = underTest.state(NAMESPACE, COMBINING_ADDR);


### PR DESCRIPTION
… upon

reference invalidation instead of expensive set management. Reduce
operations of shared cache by caching per-key object sets locally and
flushing as groups to shared cache. Remove byte tracking which could
be racy based upon background evictions in favor of just iterating
for rendering the status page. Since we render only once every 10 minutes
by default this seems fine.
This also lets us capture more stats.

This previously showed up as 6% cpu on benchmarks and dropped to 1.25% with this change with throughput increase as well.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
