### PR TITLE
[BEAM-11357] Copy Annotations when cloning PTransforms

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/pipelinex/clone.go
+++ b/sdks/go/pkg/beam/core/runtime/pipelinex/clone.go
@@ -49,6 +49,7 @@ func ShallowClonePTransform(t *pipepb.PTransform) *pipepb.PTransform {
 		UniqueName:  t.UniqueName,
 		Spec:        t.Spec,
 		DisplayData: t.DisplayData,
+		Annotations: t.Annotations,
 	}
 	ret.Subtransforms, _ = reflectx.ShallowClone(t.Subtransforms).([]string)
 	ret.Inputs, _ = reflectx.ShallowClone(t.Inputs).(map[string]string)


### PR DESCRIPTION
We need to copy Annotations field as well when doing a ShallowClonePTransform, otherwise we lose the Annotations. This is an issue when there multiple instances of the same DoFn with an annotation in the pipeline.

CREDITS=robertre@