### PR TITLE
[BEAM-9918] Support Tagged external PTransforms

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/graphx/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate.go
@@ -459,7 +459,34 @@ func (m *marshaller) addMultiEdge(edge NamedEdge) ([]string, error) {
 		spec = &pipepb.FunctionSpec{Urn: URNWindow, Payload: protox.MustEncode(payload)}
 
 	case graph.External:
-		spec = &pipepb.FunctionSpec{Urn: edge.Edge.Payload.URN, Payload: edge.Edge.Payload.Data}
+		pyld := edge.Edge.Payload
+		spec = &pipepb.FunctionSpec{Urn: pyld.URN, Payload: pyld.Data}
+
+		if len(pyld.InputsMap) != 0 {
+			if got, want := len(pyld.InputsMap), len(edge.Edge.Input); got != want {
+				return handleErr(errors.Errorf("mismatch'd counts between External tags (%v) and inputs (%v)", got, want))
+			}
+			inputs = make(map[string]string)
+			for tag, in := range InboundTagToNode(pyld.InputsMap, edge.Edge.Input) {
+				if _, err := m.addNode(in); err != nil {
+					return handleErr(err)
+				}
+				inputs[tag] = nodeID(in)
+			}
+		}
+
+		if len(pyld.OutputsMap) != 0 {
+			if got, want := len(pyld.OutputsMap), len(edge.Edge.Output); got != want {
+				return handleErr(errors.Errorf("mismatch'd counts between External tags (%v) and outputs (%v)", got, want))
+			}
+			outputs = make(map[string]string)
+			for tag, out := range OutboundTagToNode(pyld.OutputsMap, edge.Edge.Output) {
+				if _, err := m.addNode(out); err != nil {
+					return handleErr(err)
+				}
+				outputs[tag] = nodeID(out)
+			}
+		}
 
 	default:
 		err := errors.Errorf("unexpected opcode: %v", edge.Edge.Op)

--- a/sdks/go/pkg/beam/core/runtime/graphx/xlang.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/xlang.go
@@ -258,10 +258,14 @@ func ExpandedTransform(exp *graph.ExpandedTransform) (*pipepb.PTransform, error)
 // pcollection) of input nodes with respect to the map (tag -> index of Inbound
 // in MultiEdge.Input) of named inputs
 func ExternalInputs(e *graph.MultiEdge) map[string]*graph.Node {
-	inputs := make(map[string]*graph.Node)
+	return InboundTagToNode(e.External.InputsMap, e.Input)
+}
 
-	for tag, id := range e.External.InputsMap {
-		inputs[tag] = e.Input[id].From
+// InboundTagToNode relates the tags from inbound links to their respective nodes.
+func InboundTagToNode(inputsMap map[string]int, inbound []*graph.Inbound) map[string]*graph.Node {
+	inputs := make(map[string]*graph.Node)
+	for tag, id := range inputsMap {
+		inputs[tag] = inbound[id].From
 	}
 	return inputs
 }
@@ -270,10 +274,14 @@ func ExternalInputs(e *graph.MultiEdge) map[string]*graph.Node {
 // pcollection) of output nodes with respect to the map (tag -> index of
 // Outbound in MultiEdge.Output) of named outputs
 func ExternalOutputs(e *graph.MultiEdge) map[string]*graph.Node {
-	outputs := make(map[string]*graph.Node)
+	return OutboundTagToNode(e.External.OutputsMap, e.Output)
+}
 
-	for tag, id := range e.External.OutputsMap {
-		outputs[tag] = e.Output[id].To
+// OutboundTagToNode relates the tags from outbound links to their respective nodes.
+func OutboundTagToNode(outputsMap map[string]int, outbound []*graph.Outbound) map[string]*graph.Node {
+	outputs := make(map[string]*graph.Node)
+	for tag, id := range outputsMap {
+		outputs[tag] = outbound[id].To
 	}
 	return outputs
 }

--- a/sdks/go/pkg/beam/external.go
+++ b/sdks/go/pkg/beam/external.go
@@ -17,21 +17,25 @@ package beam
 
 import (
 	"github.com/apache/beam/sdks/go/pkg/beam/core/graph"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx"
 	"github.com/apache/beam/sdks/go/pkg/beam/internal/errors"
 )
 
 // External defines a Beam external transform. The interpretation of this primitive is runner
 // specific. The runner is responsible for parsing the payload based on the
-// spec provided to implement the behavior of the operation. Transform
+// URN provided to implement the behavior of the operation. Transform
 // libraries should expose an API that captures the user's intent and serialize
 // the payload as a byte slice that the runner will deserialize.
-func External(s Scope, spec string, payload []byte, in []PCollection, out []FullType, bounded bool) []PCollection {
-	return MustN(TryExternal(s, spec, payload, in, out, bounded))
+//
+// Use ExternalTagged if the runner will need to associate the PTransforms local PCollection tags
+// with values in the payload.
+func External(s Scope, urn string, payload []byte, in []PCollection, out []FullType, bounded bool) []PCollection {
+	return MustN(TryExternal(s, urn, payload, in, out, bounded))
 }
 
-// TryExternal attempts to perform the work of External, returning an error indicating why the operation
-// failed.
-func TryExternal(s Scope, spec string, payload []byte, in []PCollection, out []FullType, bounded bool) ([]PCollection, error) {
+// TryExternal attempts to perform the work of External, returning an error indicating
+// why the operation failed.
+func TryExternal(s Scope, urn string, payload []byte, in []PCollection, out []FullType, bounded bool) ([]PCollection, error) {
 	if !s.IsValid() {
 		return nil, errors.New("invalid scope")
 	}
@@ -45,7 +49,7 @@ func TryExternal(s Scope, spec string, payload []byte, in []PCollection, out []F
 	for _, col := range in {
 		ins = append(ins, col.n)
 	}
-	edge := graph.NewExternal(s.real, s.scope, &graph.Payload{URN: spec, Data: payload}, ins, out, bounded)
+	edge := graph.NewExternal(s.real, s.scope, &graph.Payload{URN: urn, Data: payload}, ins, out, bounded)
 
 	var ret []PCollection
 	for _, out := range edge.Output {
@@ -54,4 +58,51 @@ func TryExternal(s Scope, spec string, payload []byte, in []PCollection, out []F
 		ret = append(ret, c)
 	}
 	return ret, nil
+}
+
+// ExternalTagged defines an external PTransform, and allows re-specifying the tags for the input
+// and output PCollections. The interpretation of this primitive is runner specific.
+// The runner is responsible for parsing the payload based on the URN provided to implement
+// the behavior of the operation. Transform libraries should expose an API that captures
+// the user's intent and serialize the payload as a byte slice that the runner will deserialize.
+//
+// Use ExternalTagged if the runner will need to associate the PTransforms local PCollection tags
+// with values in the payload. Otherwise, prefer External.
+func ExternalTagged(
+	s Scope,
+	urn string,
+	payload []byte,
+	namedInputs map[string]PCollection,
+	namedOutputTypes map[string]FullType,
+	bounded bool) map[string]PCollection {
+	return MustTaggedN(TryExternalTagged(s, urn, payload, namedInputs, namedOutputTypes, bounded))
+}
+
+// TryExternalTagged attempts to perform the work of ExternalTagged, returning an error
+// indicating why the operation failed.
+func TryExternalTagged(
+	s Scope,
+	urn string,
+	payload []byte,
+	namedInputs map[string]PCollection,
+	namedOutputTypes map[string]FullType,
+	bounded bool) (map[string]PCollection, error) {
+	if !s.IsValid() {
+		return nil, errors.New("invalid scope")
+	}
+
+	inputsMap, inboundLinks := graph.NamedInboundLinks(mapPCollectionToNode(namedInputs))
+	outputsMap, outboundLinks := graph.NamedOutboundLinks(s.real, namedOutputTypes)
+
+	ext := graph.Payload{
+		URN:        urn,
+		Data:       payload,
+		InputsMap:  inputsMap,
+		OutputsMap: outputsMap,
+	}
+
+	edge := graph.NewTaggedExternal(s.real, s.scope, &ext, inboundLinks, outboundLinks, bounded)
+
+	namedOutputs := graphx.OutboundTagToNode(edge.Payload.OutputsMap, edge.Output)
+	return mapNodeToPCollection(namedOutputs), nil
 }

--- a/sdks/go/pkg/beam/external_test.go
+++ b/sdks/go/pkg/beam/external_test.go
@@ -1,0 +1,104 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package beam
+
+import (
+	"bytes"
+	"context"
+	"strings"
+	"testing"
+
+	"github.com/apache/beam/sdks/go/pkg/beam/core/runtime/graphx"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/typex"
+	"github.com/apache/beam/sdks/go/pkg/beam/core/util/reflectx"
+	"github.com/apache/beam/sdks/go/pkg/beam/options/jobopts"
+)
+
+func TestExternalTagged(t *testing.T) {
+	urn := "my::test::urn"
+	payload := []byte("expected_payload")
+	inTag := "inTag"
+	outTag := "outTag"
+
+	p := NewPipeline()
+	s := p.Root()
+
+	col := Impulse(s)
+	ft := typex.New(reflectx.ByteSlice)
+	outMap := ExternalTagged(s, urn, payload, map[string]PCollection{inTag: col}, map[string]FullType{outTag: ft}, true)
+
+	// Validate the in-construction PCollection types for ExternalTagged.
+	if len(outMap) != 1 {
+		t.Fatalf("ExternalTagged = %v, want 1 output with tag %q", outMap, outTag)
+	}
+	out, ok := outMap[outTag]
+	if !ok {
+		t.Fatalf("ExternalTagged = %v, want 1 output with tag %q", outMap, outTag)
+	}
+	if !typex.IsEqual(out.Type(), ft) {
+		t.Fatalf("ExternalTagged()[%q].Type() = %v, want %v", outTag, out.Type(), ft)
+	}
+
+	// Validate the post-construction pipeline protocol buffer contents.
+
+	ctx := context.Background()
+	envUrn := jobopts.GetEnvironmentUrn(ctx)
+	getEnvCfg := jobopts.GetEnvironmentConfig
+	environment, err := graphx.CreateEnvironment(ctx, envUrn, getEnvCfg)
+	if err != nil {
+		t.Fatalf("Couldn't create environment build: %v", err)
+	}
+
+	edges, _, err := p.Build()
+	if err != nil {
+		t.Fatalf("Pipeline couldn't build: %v", err)
+	}
+	pb, err := graphx.Marshal(edges, &graphx.Options{Environment: environment})
+	if err != nil {
+		t.Fatalf("Couldn't graphx.Marshal edges: %v", err)
+	}
+	components := pb.GetComponents()
+	transforms := components.GetTransforms()
+
+	foundExternalTagged := false
+	for _, transform := range transforms {
+		spec := transform.GetSpec()
+		if strings.Contains(spec.GetUrn(), urn) {
+			foundExternalTagged = true
+			if bytes.Compare(spec.GetPayload(), payload) != 0 {
+				t.Errorf("Payload value: got %v, want %v", spec.GetPayload(), payload)
+			}
+		}
+		if !foundExternalTagged {
+			continue
+		}
+		if got, want := len(transform.GetInputs()), 1; got != want {
+			t.Errorf("transform.Inputs has size %v, want %v: %v", got, want, transform.GetInputs())
+		} else if _, ok := transform.GetInputs()[inTag]; !ok {
+			t.Errorf("transform.Inputs doesn't contain %v tag, got %v", inTag, transform.GetInputs())
+		}
+
+		if got, want := len(transform.GetOutputs()), 1; got != want {
+			t.Errorf("transform.Outputs has size %v, want %v: %v", got, want, transform.GetOutputs())
+		} else if _, ok := transform.GetOutputs()[outTag]; !ok {
+			t.Errorf("transform.Outputs doesn't contain %v tag, got %v", outTag, transform.GetOutputs())
+		}
+		break
+	}
+	if !foundExternalTagged {
+		t.Errorf("Couldn't find PTransform with urn %q in graph %v", urn, transforms)
+	}
+}

--- a/sdks/go/pkg/beam/util.go
+++ b/sdks/go/pkg/beam/util.go
@@ -106,6 +106,14 @@ func MustN(list []PCollection, err error) []PCollection {
 	return list
 }
 
+// MustTaggedN returns the input, but panics if err != nil.
+func MustTaggedN(ret map[string]PCollection, err error) map[string]PCollection {
+	if err != nil {
+		panic(err)
+	}
+	return ret
+}
+
 // Must returns the input, but panics if err != nil.
 func Must(a PCollection, err error) PCollection {
 	if err != nil {


### PR DESCRIPTION
Support user side direction of cross language or external transforms.

Often the runners have their own mechanism for interpretting a URN + Payload, but that payload may contain data to specify how to route the inputs and outputs. ExternalTagged permits users to provide local tags for the input PCollections and output PCollection types to assist with this routing.

Later changes may want to add variadic Options to External and ExternalTagged to support Artifact provisioning, and Environment setting, though preferablly without using the beam protos directly in the API. (Similarly for ParDo as well).

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
