### PR TITLE
[BEAM-11476] Resolve flaky tests

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/interactive_environment_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_environment_test.py
@@ -180,53 +180,45 @@ class InteractiveEnvironmentTest(unittest.TestCase):
       self, mocked_cleanup):
     ie._interactive_beam_env = None
     ie.new_env()
-    mocked_cleanup.assert_not_called()
     ie.new_env()
-    mocked_cleanup.assert_called_once()
+    mocked_cleanup.assert_called()
 
-  @patch(
-      'apache_beam.runners.interactive.interactive_environment'
-      '.InteractiveEnvironment.cleanup')
-  def test_cleanup_not_invoked_when_cm_changed_from_none(self, mocked_cleanup):
-    ie._interactive_beam_env = None
+  def test_cleanup_not_invoked_when_cm_changed_from_none(self):
     ie.new_env()
-    dummy_pipeline = 'dummy'
-    self.assertIsNone(ie.current_env().get_cache_manager(dummy_pipeline))
-    cache_manager = cache.FileBasedCacheManager()
-    ie.current_env().set_cache_manager(cache_manager, dummy_pipeline)
-    mocked_cleanup.assert_not_called()
-    self.assertIs(
-        ie.current_env().get_cache_manager(dummy_pipeline), cache_manager)
+    with patch('apache_beam.runners.interactive.interactive_environment'
+               '.InteractiveEnvironment.cleanup') as mocked_cleanup:
+      dummy_pipeline = 'dummy'
+      self.assertIsNone(ie.current_env().get_cache_manager(dummy_pipeline))
+      cache_manager = cache.FileBasedCacheManager()
+      ie.current_env().set_cache_manager(cache_manager, dummy_pipeline)
+      mocked_cleanup.assert_not_called()
+      self.assertIs(
+          ie.current_env().get_cache_manager(dummy_pipeline), cache_manager)
 
-  @patch(
-      'apache_beam.runners.interactive.interactive_environment'
-      '.InteractiveEnvironment.cleanup')
-  def test_cleanup_invoked_when_not_none_cm_changed(self, mocked_cleanup):
-    ie._interactive_beam_env = None
+  def test_cleanup_invoked_when_not_none_cm_changed(self):
     ie.new_env()
-    dummy_pipeline = 'dummy'
-    ie.current_env().set_cache_manager(
-        cache.FileBasedCacheManager(), dummy_pipeline)
-    mocked_cleanup.assert_not_called()
-    ie.current_env().set_cache_manager(
-        cache.FileBasedCacheManager(), dummy_pipeline)
-    mocked_cleanup.assert_called_once()
+    with patch('apache_beam.runners.interactive.interactive_environment'
+               '.InteractiveEnvironment.cleanup') as mocked_cleanup:
+      dummy_pipeline = 'dummy'
+      ie.current_env().set_cache_manager(
+          cache.FileBasedCacheManager(), dummy_pipeline)
+      mocked_cleanup.assert_not_called()
+      ie.current_env().set_cache_manager(
+          cache.FileBasedCacheManager(), dummy_pipeline)
+      mocked_cleanup.assert_called_once()
 
-  @patch(
-      'apache_beam.runners.interactive.interactive_environment'
-      '.InteractiveEnvironment.cleanup')
-  def test_noop_when_cm_is_not_changed(self, mocked_cleanup):
-    ie._interactive_beam_env = None
+  def test_noop_when_cm_is_not_changed(self):
     cache_manager = cache.FileBasedCacheManager()
     dummy_pipeline = 'dummy'
     ie.new_env()
-    ie.current_env()._cache_managers[str(id(dummy_pipeline))] = cache_manager
-    mocked_cleanup.assert_not_called()
-    ie.current_env().set_cache_manager(cache_manager, dummy_pipeline)
-    mocked_cleanup.assert_not_called()
+    with patch('apache_beam.runners.interactive.interactive_environment'
+               '.InteractiveEnvironment.cleanup') as mocked_cleanup:
+      ie.current_env()._cache_managers[str(id(dummy_pipeline))] = cache_manager
+      mocked_cleanup.assert_not_called()
+      ie.current_env().set_cache_manager(cache_manager, dummy_pipeline)
+      mocked_cleanup.assert_not_called()
 
   def test_get_cache_manager_creates_cache_manager_if_absent(self):
-    ie._interactive_beam_env = None
     ie.new_env()
     dummy_pipeline = 'dummy'
     self.assertIsNone(ie.current_env().get_cache_manager(dummy_pipeline))
@@ -234,37 +226,35 @@ class InteractiveEnvironmentTest(unittest.TestCase):
         ie.current_env().get_cache_manager(
             dummy_pipeline, create_if_absent=True))
 
-  @patch(
-      'apache_beam.runners.interactive.interactive_environment'
-      '.InteractiveEnvironment.cleanup')
-  def test_track_user_pipeline_cleanup_non_inspectable_pipeline(
-      self, mocked_cleanup):
-    ie._interactive_beam_env = None
+  def test_track_user_pipeline_cleanup_non_inspectable_pipeline(self):
     ie.new_env()
-    dummy_pipeline_1 = beam.Pipeline()
-    dummy_pipeline_2 = beam.Pipeline()
-    dummy_pipeline_3 = beam.Pipeline()
-    dummy_pipeline_4 = beam.Pipeline()
-    dummy_pcoll = dummy_pipeline_4 | beam.Create([1])
-    dummy_pipeline_5 = beam.Pipeline()
-    dummy_non_inspectable_pipeline = 'dummy'
-    ie.current_env().watch(locals())
-    from apache_beam.runners.interactive.background_caching_job import BackgroundCachingJob
-    ie.current_env().set_background_caching_job(
-        dummy_pipeline_1,
-        BackgroundCachingJob(
-            runner.PipelineResult(runner.PipelineState.DONE), limiters=[]))
-    ie.current_env().set_test_stream_service_controller(dummy_pipeline_2, None)
-    ie.current_env().set_cache_manager(
-        cache.FileBasedCacheManager(), dummy_pipeline_3)
-    ie.current_env().mark_pcollection_computed([dummy_pcoll])
-    ie.current_env().set_cached_source_signature(
-        dummy_non_inspectable_pipeline, None)
-    ie.current_env().set_pipeline_result(
-        dummy_pipeline_5, runner.PipelineResult(runner.PipelineState.RUNNING))
-    mocked_cleanup.assert_not_called()
-    ie.current_env().track_user_pipelines()
-    mocked_cleanup.assert_called_once()
+    with patch('apache_beam.runners.interactive.interactive_environment'
+               '.InteractiveEnvironment.cleanup') as mocked_cleanup:
+      dummy_pipeline_1 = beam.Pipeline()
+      dummy_pipeline_2 = beam.Pipeline()
+      dummy_pipeline_3 = beam.Pipeline()
+      dummy_pipeline_4 = beam.Pipeline()
+      dummy_pcoll = dummy_pipeline_4 | beam.Create([1])
+      dummy_pipeline_5 = beam.Pipeline()
+      dummy_non_inspectable_pipeline = 'dummy'
+      ie.current_env().watch(locals())
+      from apache_beam.runners.interactive.background_caching_job import BackgroundCachingJob
+      ie.current_env().set_background_caching_job(
+          dummy_pipeline_1,
+          BackgroundCachingJob(
+              runner.PipelineResult(runner.PipelineState.DONE), limiters=[]))
+      ie.current_env().set_test_stream_service_controller(
+          dummy_pipeline_2, None)
+      ie.current_env().set_cache_manager(
+          cache.FileBasedCacheManager(), dummy_pipeline_3)
+      ie.current_env().mark_pcollection_computed([dummy_pcoll])
+      ie.current_env().set_cached_source_signature(
+          dummy_non_inspectable_pipeline, None)
+      ie.current_env().set_pipeline_result(
+          dummy_pipeline_5, runner.PipelineResult(runner.PipelineState.RUNNING))
+      mocked_cleanup.assert_not_called()
+      ie.current_env().track_user_pipelines()
+      mocked_cleanup.assert_called_once()
 
   def test_evict_pcollections(self):
     """Tests the evicton logic in the InteractiveEnvironment."""

--- a/sdks/python/apache_beam/runners/interactive/interactive_environment_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_environment_test.py
@@ -170,7 +170,7 @@ class InteractiveEnvironmentTest(unittest.TestCase):
 
   def test_cleanup_registered_when_creating_new_env(self):
     with patch('atexit.register') as mocked_atexit:
-      a_new_env = ie.InteractiveEnvironment()
+      _ = ie.InteractiveEnvironment()
       mocked_atexit.assert_called_once()
 
   def test_cleanup_invoked_when_new_env_replace_not_none_env(self):

--- a/sdks/python/apache_beam/runners/interactive/interactive_environment_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_environment_test.py
@@ -168,20 +168,18 @@ class InteractiveEnvironmentTest(unittest.TestCase):
     self.assertIs(ie.current_env().is_terminated(self._p), True)
     self.assertIs(ie.current_env().evict_pipeline_result(self._p), None)
 
-  @patch('atexit.register')
-  def test_cleanup_registered_when_creating_new_env(self, mocked_atexit):
-    ie.new_env()
-    mocked_atexit.assert_called_once()
+  def test_cleanup_registered_when_creating_new_env(self):
+    with patch('atexit.register') as mocked_atexit:
+      a_new_env = ie.InteractiveEnvironment()
+      mocked_atexit.assert_called_once()
 
-  @patch(
-      'apache_beam.runners.interactive.interactive_environment'
-      '.InteractiveEnvironment.cleanup')
-  def test_cleanup_invoked_when_new_env_replace_not_none_env(
-      self, mocked_cleanup):
+  def test_cleanup_invoked_when_new_env_replace_not_none_env(self):
     ie._interactive_beam_env = None
     ie.new_env()
-    ie.new_env()
-    mocked_cleanup.assert_called()
+    with patch('apache_beam.runners.interactive.interactive_environment'
+               '.InteractiveEnvironment.cleanup') as mocked_cleanup:
+      ie.new_env()
+      mocked_cleanup.assert_called_once()
 
   def test_cleanup_not_invoked_when_cm_changed_from_none(self):
     ie.new_env()


### PR DESCRIPTION
Moved cleanup patch into each test method after each new_env() instance
creation to avoid cleanup invocation in new_env() call when there could be
race conditions in tests running on Jenkins.



------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
