### PR TITLE
[BEAM-9547] Fill in some trivial compliance gaps

### DIFF
--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -133,7 +133,13 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
   def ffill(self, **kwargs):
     return self.fillna(method='ffill', **kwargs)
 
+  @frame_base.args_to_kwargs(pd.DataFrame)
+  @frame_base.populate_defaults(pd.DataFrame)
+  def bfill(self, **kwargs):
+    return self.fillna(method='bfill', **kwargs)
+
   pad = ffill
+  backfill = bfill
 
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -517,7 +517,7 @@ class DeferredSeries(DeferredDataFrameOrSeries):
 
   isin = frame_base._elementwise_method('isin')
 
-  isna = frame_base._elementwise_method('isna')
+  isnull = isna = frame_base._elementwise_method('isna')
   notnull = notna = frame_base._elementwise_method('notna')
 
   to_numpy = to_string = frame_base.wont_implement_method('non-deferred value')
@@ -1182,7 +1182,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
   def query(self, expr, inplace, **kwargs):
     return self._eval_or_query('query', expr, inplace, **kwargs)
 
-  isna = frame_base._elementwise_method('isna')
+  isnull = isna = frame_base._elementwise_method('isna')
   notnull = notna = frame_base._elementwise_method('notna')
 
   items = itertuples = iterrows = iteritems = frame_base.wont_implement_method(

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -283,6 +283,9 @@ class DeferredSeries(DeferredDataFrameOrSeries):
       # be more surprising than a clear error.
       raise frame_base.WontImplementError('non-deferred')
 
+  def keys(self):
+    return self.index
+
   @frame_base.args_to_kwargs(pd.Series)
   @frame_base.populate_defaults(pd.Series)
   def append(self, to_append, ignore_index, verify_integrity, **kwargs):
@@ -709,6 +712,9 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             set_columns, [self._expr],
             requires_partition_by=partitionings.Nothing(),
             preserves_partition_by=partitionings.Singleton()))
+
+  def keys(self):
+    return self.columns
 
   def __getattr__(self, name):
     # Column attribute access.

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -566,6 +566,8 @@ class DeferredSeries(DeferredDataFrameOrSeries):
   max = frame_base._agg_method('max')
   prod = product = frame_base._agg_method('prod')
   sum = frame_base._agg_method('sum')
+  mean = frame_base._agg_method('mean')
+  median = frame_base._agg_method('median')
 
   cummax = cummin = cumsum = cumprod = frame_base.wont_implement_method(
       'order-sensitive')
@@ -952,9 +954,6 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
   memory_usage = frame_base.wont_implement_method('non-deferred value')
   info = frame_base.wont_implement_method('non-deferred value')
 
-  all = frame_base._agg_method('all')
-  any = frame_base._agg_method('any')
-
   clip = frame_base._elementwise_method(
       'clip', restrictions={'axis': lambda axis: axis in (0, 'index')})
 
@@ -1115,9 +1114,6 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
   __matmul__ = dot
 
   head = tail = frame_base.wont_implement_method('order-sensitive')
-
-  max = frame_base._agg_method('max')
-  min = frame_base._agg_method('min')
 
   def mode(self, axis=0, *args, **kwargs):
     if axis == 1 or axis == 'columns':
@@ -1397,8 +1393,6 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             requires_partition_by=partitionings.Nothing())
     return result
 
-  prod = product = frame_base._agg_method('prod')
-
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)
   def quantile(self, axis, **kwargs):
@@ -1538,7 +1532,14 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
 
   stack = frame_base._elementwise_method('stack')
 
+  all = frame_base._agg_method('all')
+  any = frame_base._agg_method('any')
+  max = frame_base._agg_method('max')
+  min = frame_base._agg_method('min')
+  prod = product = frame_base._agg_method('prod')
   sum = frame_base._agg_method('sum')
+  mean = frame_base._agg_method('mean')
+  median = frame_base._agg_method('median')
 
   take = frame_base.wont_implement_method('deprecated')
 

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -520,7 +520,8 @@ class DeferredSeries(DeferredDataFrameOrSeries):
   isnull = isna = frame_base._elementwise_method('isna')
   notnull = notna = frame_base._elementwise_method('notna')
 
-  to_numpy = to_string = frame_base.wont_implement_method('non-deferred value')
+  tolist = to_numpy = to_string = frame_base.wont_implement_method(
+      'non-deferred value')
 
   def aggregate(self, func, axis=0, *args, **kwargs):
     if isinstance(func, list) and len(func) > 1:

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -376,9 +376,13 @@ class DeferredSeries(DeferredDataFrameOrSeries):
 
   __matmul__ = dot
 
+  def std(self, *args, **kwargs):
+    # Compute variance (deferred scalar) with same args, then sqrt it
+    return self.var(*args, **kwargs).apply(lambda var: math.sqrt(var))
+
   @frame_base.args_to_kwargs(pd.Series)
   @frame_base.populate_defaults(pd.Series)
-  def std(self, axis, skipna, level, ddof, **kwargs):
+  def var(self, axis, skipna, level, ddof, **kwargs):
     if level is not None:
       raise NotImplementedError("per-level aggregation")
     if skipna is None or skipna:
@@ -409,7 +413,7 @@ class DeferredSeries(DeferredDataFrameOrSeries):
       if n <= ddof:
         return float('nan')
       else:
-        return math.sqrt(m / (n - ddof))
+        return m / (n - ddof)
 
     moments = expressions.ComputedExpression(
         'compute_moments',

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -73,8 +73,9 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
         index = None
         columns = labels
       else:
-        raise ValueError("axis must be one of (0, 1, 'index', 'columns'), "
-                         "got '%s'" % axis)
+        raise ValueError(
+            "axis must be one of (0, 1, 'index', 'columns'), "
+            "got '%s'" % axis)
 
     if columns is not None:
       # Compute the proxy based on just the columns that are dropped.
@@ -89,13 +90,17 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
     else:
       requires = partitionings.Nothing()
 
-    return frame_base.DeferredFrame.wrap(expressions.ComputedExpression(
-        'drop',
-        lambda df: df.drop(axis=axis, index=index, columns=columns,
-                           errors=errors, **kwargs),
-        [self._expr],
-        proxy=proxy,
-        requires_partition_by=requires))
+    return frame_base.DeferredFrame.wrap(
+        expressions.ComputedExpression(
+            'drop',
+            lambda df: df.drop(
+                axis=axis,
+                index=index,
+                columns=columns,
+                errors=errors,
+                **kwargs), [self._expr],
+            proxy=proxy,
+            requires_partition_by=requires))
 
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)
@@ -306,12 +311,12 @@ class DeferredSeries(DeferredDataFrameOrSeries):
     return frame_base.DeferredFrame.wrap(
         expressions.ComputedExpression(
             'append',
-            lambda s, to_append: s.append(to_append, verify_integrity=verify_integrity, **kwargs),
+            lambda s,
+            to_append: s.append(
+                to_append, verify_integrity=verify_integrity, **kwargs),
             [self._expr, to_append._expr],
             requires_partition_by=requires,
-            preserves_partition_by=partitionings.Index()
-        )
-    )
+            preserves_partition_by=partitionings.Index()))
 
   @frame_base.args_to_kwargs(pd.Series)
   @frame_base.populate_defaults(pd.Series)

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -304,6 +304,8 @@ class DeferredSeries(DeferredDataFrameOrSeries):
 
     if verify_integrity:
       # verifying output has a unique index requires global index.
+      # TODO(BEAM-11839): Attach an explanation to the Singleton partitioning
+      # requirement, and include it in raised errors.
       requires = partitionings.Singleton()
     else:
       requires = partitionings.Nothing()
@@ -448,6 +450,8 @@ class DeferredSeries(DeferredDataFrameOrSeries):
               lambda df,
               other: df.corr(other, method=method, min_periods=min_periods),
               [self._expr, other._expr],
+              # TODO(BEAM-11839): Attach an explanation to the Singleton
+              # partitioning requirement, and include it in raised errors.
               requires_partition_by=partitionings.Singleton()))
 
   def _corr_aligned(self, other, min_periods):

--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -439,6 +439,20 @@ class DeferredFrameTest(unittest.TestCase):
       self._run_test(lambda s: s.agg(['mean']), s)
       self._run_test(lambda s: s.agg('mean'), s)
 
+  def test_append_sort(self):
+    df1 = pd.DataFrame({'int': [1, 2, 3], 'str': ['a', 'b', 'c']},
+                       columns=['int', 'str'],
+                       index=[1, 3, 5])
+    df2 = pd.DataFrame({'int': [4, 5, 6], 'str': ['d', 'e', 'f']},
+                       columns=['str', 'int'],
+                       index=[2, 4, 6])
+
+    self._run_test(lambda df1, df2: df1.append(df2, sort=True), df1, df2)
+    self._run_test(lambda df1, df2: df1.append(df2, sort=False), df1, df2)
+    self._run_test(lambda df1, df2: df2.append(df1, sort=True), df1, df2)
+    self._run_test(lambda df1, df2: df2.append(df1, sort=False), df1, df2)
+
+
   @unittest.skipIf(sys.version_info < (3, 6), 'Nondeterministic dict ordering.')
   def test_dataframe_agg(self):
     df = pd.DataFrame({'A': [1, 2, 3, 4], 'B': [2, 3, 5, 7]})

--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -476,6 +476,7 @@ class DeferredFrameTest(unittest.TestCase):
               pd.Series(range(100)),
               pd.Series([x**3 for x in range(-50, 50)])]:
       self._run_test(lambda s: s.std(), s)
+      self._run_test(lambda s: s.var(), s)
       self._run_test(lambda s: s.corr(s), s)
       self._run_test(lambda s: s.corr(s + 1), s)
       self._run_test(lambda s: s.corr(s * s), s)

--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -242,6 +242,40 @@ class DeferredFrameTest(unittest.TestCase):
         df,
         expect_error=True)
 
+  def test_series_drop_ignore_errors(self):
+    midx = pd.MultiIndex(levels=[['lama', 'cow', 'falcon'],
+                              ['speed', 'weight', 'length']],
+                      codes=[[0, 0, 0, 1, 1, 1, 2, 2, 2],
+                             [0, 1, 2, 0, 1, 2, 0, 1, 2]])
+    s = pd.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
+                  index=midx)
+
+    # drop() requires singleton partitioning unless errors are ignored
+    # Add some additional tests here to make sure the implementation works in
+    # non-singleton partitioning.
+    self._run_test(lambda s: s.drop('lama', level=0, errors='ignore'), s)
+    self._run_test(lambda s: s.drop(('cow', 'speed'), errors='ignore'), s)
+    self._run_test(lambda s: s.drop('falcon', level=0, errors='ignore'), s)
+
+
+  def test_dataframe_drop_ignore_errors(self):
+    midx = pd.MultiIndex(levels=[['lama', 'cow', 'falcon'],
+                                 ['speed', 'weight', 'length']],
+                         codes=[[0, 0, 0, 1, 1, 1, 2, 2, 2],
+                                [0, 1, 2, 0, 1, 2, 0, 1, 2]])
+    df = pd.DataFrame(index=midx, columns=['big', 'small'],
+                      data=[[45, 30], [200, 100], [1.5, 1], [30, 20],
+                            [250, 150], [1.5, 0.8], [320, 250],
+                            [1, 0.8], [0.3, 0.2]])
+
+    # drop() requires singleton partitioning unless errors are ignored
+    # Add some additional tests here to make sure the implementation works in
+    # non-singleton partitioning.
+    self._run_test(lambda df: df.drop(index='lama', level=0, errors='ignore'), df)
+    self._run_test(lambda df: df.drop(index=('cow', 'speed'), errors='ignore'), df)
+    self._run_test(lambda df: df.drop(index='falcon', level=0, errors='ignore'), df)
+    self._run_test(lambda df: df.drop(index='cow', columns='small', errors='ignore'), df)
+
   def test_merge(self):
     # This is from the pandas doctests, but fails due to re-indexing being
     # order-sensitive.

--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -243,12 +243,10 @@ class DeferredFrameTest(unittest.TestCase):
         expect_error=True)
 
   def test_series_drop_ignore_errors(self):
-    midx = pd.MultiIndex(levels=[['lama', 'cow', 'falcon'],
-                              ['speed', 'weight', 'length']],
-                      codes=[[0, 0, 0, 1, 1, 1, 2, 2, 2],
-                             [0, 1, 2, 0, 1, 2, 0, 1, 2]])
-    s = pd.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3],
-                  index=midx)
+    midx = pd.MultiIndex(
+        levels=[['lama', 'cow', 'falcon'], ['speed', 'weight', 'length']],
+        codes=[[0, 0, 0, 1, 1, 1, 2, 2, 2], [0, 1, 2, 0, 1, 2, 0, 1, 2]])
+    s = pd.Series([45, 200, 1.2, 30, 250, 1.5, 320, 1, 0.3], index=midx)
 
     # drop() requires singleton partitioning unless errors are ignored
     # Add some additional tests here to make sure the implementation works in
@@ -257,24 +255,27 @@ class DeferredFrameTest(unittest.TestCase):
     self._run_test(lambda s: s.drop(('cow', 'speed'), errors='ignore'), s)
     self._run_test(lambda s: s.drop('falcon', level=0, errors='ignore'), s)
 
-
   def test_dataframe_drop_ignore_errors(self):
-    midx = pd.MultiIndex(levels=[['lama', 'cow', 'falcon'],
-                                 ['speed', 'weight', 'length']],
-                         codes=[[0, 0, 0, 1, 1, 1, 2, 2, 2],
-                                [0, 1, 2, 0, 1, 2, 0, 1, 2]])
-    df = pd.DataFrame(index=midx, columns=['big', 'small'],
-                      data=[[45, 30], [200, 100], [1.5, 1], [30, 20],
-                            [250, 150], [1.5, 0.8], [320, 250],
-                            [1, 0.8], [0.3, 0.2]])
+    midx = pd.MultiIndex(
+        levels=[['lama', 'cow', 'falcon'], ['speed', 'weight', 'length']],
+        codes=[[0, 0, 0, 1, 1, 1, 2, 2, 2], [0, 1, 2, 0, 1, 2, 0, 1, 2]])
+    df = pd.DataFrame(
+        index=midx,
+        columns=['big', 'small'],
+        data=[[45, 30], [200, 100], [1.5, 1], [30, 20], [250, 150], [1.5, 0.8],
+              [320, 250], [1, 0.8], [0.3, 0.2]])
 
     # drop() requires singleton partitioning unless errors are ignored
     # Add some additional tests here to make sure the implementation works in
     # non-singleton partitioning.
-    self._run_test(lambda df: df.drop(index='lama', level=0, errors='ignore'), df)
-    self._run_test(lambda df: df.drop(index=('cow', 'speed'), errors='ignore'), df)
-    self._run_test(lambda df: df.drop(index='falcon', level=0, errors='ignore'), df)
-    self._run_test(lambda df: df.drop(index='cow', columns='small', errors='ignore'), df)
+    self._run_test(
+        lambda df: df.drop(index='lama', level=0, errors='ignore'), df)
+    self._run_test(
+        lambda df: df.drop(index=('cow', 'speed'), errors='ignore'), df)
+    self._run_test(
+        lambda df: df.drop(index='falcon', level=0, errors='ignore'), df)
+    self._run_test(
+        lambda df: df.drop(index='cow', columns='small', errors='ignore'), df)
 
   def test_merge(self):
     # This is from the pandas doctests, but fails due to re-indexing being
@@ -451,7 +452,6 @@ class DeferredFrameTest(unittest.TestCase):
     self._run_test(lambda df1, df2: df1.append(df2, sort=False), df1, df2)
     self._run_test(lambda df1, df2: df2.append(df1, sort=True), df1, df2)
     self._run_test(lambda df1, df2: df2.append(df1, sort=False), df1, df2)
-
 
   @unittest.skipIf(sys.version_info < (3, 6), 'Nondeterministic dict ordering.')
   def test_dataframe_agg(self):

--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -441,12 +441,14 @@ class DeferredFrameTest(unittest.TestCase):
       self._run_test(lambda s: s.agg('mean'), s)
 
   def test_append_sort(self):
+    # yapf: disable
     df1 = pd.DataFrame({'int': [1, 2, 3], 'str': ['a', 'b', 'c']},
                        columns=['int', 'str'],
                        index=[1, 3, 5])
     df2 = pd.DataFrame({'int': [4, 5, 6], 'str': ['d', 'e', 'f']},
                        columns=['str', 'int'],
                        index=[2, 4, 6])
+    # yapf: enable
 
     self._run_test(lambda df1, df2: df1.append(df2, sort=True), df1, df2)
     self._run_test(lambda df1, df2: df1.append(df2, sort=False), df1, df2)

--- a/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
@@ -76,6 +76,10 @@ class DoctestTest(unittest.TestCase):
             'pandas.core.frame.DataFrame.mode': [
                 "df.mode(axis='columns', numeric_only=True)"
             ],
+            'pandas.core.frame.DataFrame.append': [
+                'df.append(df2, ignore_index=True)',
+                "for i in range(5):\n    df = df.append({'A': i}, ignore_index=True)",
+            ],
         },
         not_implemented_ok={
             'pandas.core.frame.DataFrame.transform': ['*'],
@@ -108,9 +112,6 @@ class DoctestTest(unittest.TestCase):
             # for axis=rows.
             # Difficult to determine proxy, need to inspect function
             'pandas.core.frame.DataFrame.apply': ['*'],
-
-            # In theory this is possible for bounded inputs?
-            'pandas.core.frame.DataFrame.append': ['*'],
 
             # Cross-join not implemented
             'pandas.core.frame.DataFrame.merge': [
@@ -261,6 +262,9 @@ class DoctestTest(unittest.TestCase):
             'pandas.core.series.Series.unstack': ['*'],
             'pandas.core.series.Series.values': ['*'],
             'pandas.core.series.Series.view': ['*'],
+            'pandas.core.series.Series.append': [
+                's1.append(s2, ignore_index=True)',
+            ],
         },
         not_implemented_ok={
             'pandas.core.series.Series.transform': ['*'],
@@ -274,9 +278,12 @@ class DoctestTest(unittest.TestCase):
             'pandas.core.series.Series.reindex': ['*'],
         },
         skip={
+            # error formatting
+            'pandas.core.series.Series.append': [
+                's1.append(s2, verify_integrity=True)',
+            ],
             # Throws NotImplementedError when modifying df
             'pandas.core.series.Series.transform': ['df'],
-            'pandas.core.series.Series.append': ['*'],
             'pandas.core.series.Series.argmax': ['*'],
             'pandas.core.series.Series.argmin': ['*'],
             'pandas.core.series.Series.autocorr': ['*'],

--- a/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
@@ -288,7 +288,6 @@ class DoctestTest(unittest.TestCase):
                 # Differs in LSB on jenkins.
                 "s1.cov(s2)",
             ],
-            'pandas.core.series.Series.drop': ['*'],
             'pandas.core.series.Series.drop_duplicates': ['*'],
             'pandas.core.series.Series.duplicated': ['*'],
             'pandas.core.series.Series.explode': ['*'],

--- a/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
@@ -78,7 +78,8 @@ class DoctestTest(unittest.TestCase):
             ],
             'pandas.core.frame.DataFrame.append': [
                 'df.append(df2, ignore_index=True)',
-                "for i in range(5):\n    df = df.append({'A': i}, ignore_index=True)",
+                "for i in range(5):\n" +
+                "    df = df.append({'A': i}, ignore_index=True)",
             ],
         },
         not_implemented_ok={


### PR DESCRIPTION
Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
