### PR TITLE
[BEAM-11408] Integrate Python BigQuery sink with GroupIntoBatches

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -1268,8 +1268,7 @@ class BigQueryWriteFn(DoFn):
     else:
       # The input is already batched per destination, flush the rows now.
       batched_rows = element[1]
-      for row in batched_rows:
-        self._rows_buffer[destination].append(row)
+      self._rows_buffer[destination].extend(batched_rows)
       return self._flush_batch(destination)
 
   def finish_bundle(self):
@@ -1418,8 +1417,7 @@ class _StreamToBigQuery(PTransform):
         test_client=self.test_client,
         additional_bq_parameters=self.additional_bq_parameters,
         ignore_insert_ids=self.ignore_insert_ids,
-        with_batched_input=(
-            not self.ignore_insert_ids and self.with_auto_sharding))
+        with_batched_input=self.with_auto_sharding)
 
     def _add_random_shard(element):
       key = element[0]
@@ -1512,6 +1510,7 @@ class WriteToBigQuery(PTransform):
       validate=True,
       temp_file_format=None,
       ignore_insert_ids=False,
+      # TODO(BEAM-11857): Switch the default when the feature is mature.
       with_auto_sharding=False):
     """Initialize a WriteToBigQuery transform.
 

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -362,8 +362,6 @@ Template for BigQuery jobs created by BigQueryIO. This template is:
 NOTE: This job name template does not have backwards compatibility guarantees.
 """
 BQ_JOB_NAME_TEMPLATE = "beam_bq_job_{job_type}_{job_id}_{step_id}{random}"
-"""The number of shards per destination when writing via streaming inserts."""
-DEFAULT_SHARDS_PER_DESTINATION = 500
 
 
 @deprecated(since='2.11.0', current="bigquery_tools.parse_table_reference")
@@ -1081,7 +1079,8 @@ class BigQueryWriteFn(DoFn):
       max_buffered_rows=None,
       retry_strategy=None,
       additional_bq_parameters=None,
-      ignore_insert_ids=False):
+      ignore_insert_ids=False,
+      with_batched_input=False):
     """Initialize a WriteToBigQuery transform.
 
     Args:
@@ -1122,6 +1121,9 @@ class BigQueryWriteFn(DoFn):
         duplication of data inserted to BigQuery, set `ignore_insert_ids`
         to True to increase the throughput for BQ writing. See:
         https://cloud.google.com/bigquery/streaming-data-into-bigquery#disabling_best_effort_de-duplication
+      with_batched_input: Whether the input has already been batched per
+        destination. If not, perform best-effort batching per destination within
+        a bunble.
     """
     self.schema = schema
     self.test_client = test_client
@@ -1142,6 +1144,7 @@ class BigQueryWriteFn(DoFn):
         max_buffered_rows or BigQueryWriteFn.DEFAULT_MAX_BUFFERED_ROWS)
     self._retry_strategy = retry_strategy or RetryStrategy.RETRY_ALWAYS
     self.ignore_insert_ids = ignore_insert_ids
+    self.with_batched_input = with_batched_input
 
     self.additional_bq_parameters = additional_bq_parameters or {}
 
@@ -1254,13 +1257,20 @@ class BigQueryWriteFn(DoFn):
 
     destination = bigquery_tools.get_hashable_destination(destination)
 
-    row_and_insert_id = element[1]
-    self._rows_buffer[destination].append(row_and_insert_id)
-    self._total_buffered_rows += 1
-    if len(self._rows_buffer[destination]) >= self._max_batch_size:
+    if not self.with_batched_input:
+      row_and_insert_id = element[1]
+      self._rows_buffer[destination].append(row_and_insert_id)
+      self._total_buffered_rows += 1
+      if len(self._rows_buffer[destination]) >= self._max_batch_size:
+        return self._flush_batch(destination)
+      elif self._total_buffered_rows >= self._max_buffered_rows:
+        return self._flush_all_batches()
+    else:
+      # The input is already batched per destination, flush the rows now.
+      batched_rows = element[1]
+      for row in batched_rows:
+        self._rows_buffer[destination].append(row)
       return self._flush_batch(destination)
-    elif self._total_buffered_rows >= self._max_buffered_rows:
-      return self._flush_all_batches()
 
   def finish_bundle(self):
     bigquery_tools.BigQueryWrapper.HISTOGRAM_METRIC_LOGGER.log_metrics(
@@ -1348,6 +1358,12 @@ class BigQueryWriteFn(DoFn):
     ]
 
 
+"""The number of shards per destination when writing via streaming inserts."""
+DEFAULT_SHARDS_PER_DESTINATION = 500
+"""The max duration a batch of elements is allowed to be buffered before being flushed to BigQuery."""
+DEFAULT_BATCH_BUFFERING_DURATION_LIMIT_SEC = 0.2
+
+
 class _StreamToBigQuery(PTransform):
   def __init__(
       self,
@@ -1362,6 +1378,7 @@ class _StreamToBigQuery(PTransform):
       retry_strategy,
       additional_bq_parameters,
       ignore_insert_ids,
+      with_auto_sharding,
       test_client=None):
     self.table_reference = table_reference
     self.table_side_inputs = table_side_inputs
@@ -1375,11 +1392,9 @@ class _StreamToBigQuery(PTransform):
     self.test_client = test_client
     self.additional_bq_parameters = additional_bq_parameters
     self.ignore_insert_ids = ignore_insert_ids
+    self.with_auto_sharding = with_auto_sharding
 
   class InsertIdPrefixFn(DoFn):
-    def __init__(self, shards=DEFAULT_SHARDS_PER_DESTINATION):
-      self.shards = shards
-
     def start_bundle(self):
       self.prefix = str(uuid.uuid4())
       self._row_count = 0
@@ -1387,8 +1402,6 @@ class _StreamToBigQuery(PTransform):
     def process(self, element):
       key = element[0]
       value = element[1]
-      key = (key, random.randint(0, self.shards))
-
       insert_id = '%s-%s' % (self.prefix, self._row_count)
       self._row_count += 1
       yield (key, (value, insert_id))
@@ -1403,27 +1416,59 @@ class _StreamToBigQuery(PTransform):
         retry_strategy=self.retry_strategy,
         test_client=self.test_client,
         additional_bq_parameters=self.additional_bq_parameters,
-        ignore_insert_ids=self.ignore_insert_ids)
+        ignore_insert_ids=self.ignore_insert_ids,
+        with_batched_input=(
+            not self.ignore_insert_ids and self.with_auto_sharding))
 
-    def drop_shard(elms):
-      key_and_shard = elms[0]
-      key = key_and_shard[0]
-      value = elms[1]
-      return (key, value)
+    def _add_random_shard(element):
+      key = element[0]
+      value = element[1]
+      return ((key, random.randint(0, DEFAULT_SHARDS_PER_DESTINATION)), value)
 
-    sharded_data = (
+    def _to_hashable_table_ref(table_ref_elem_kv):
+      table_ref = table_ref_elem_kv[0]
+      hashable_table_ref = bigquery_tools.get_hashable_destination(table_ref)
+      return (hashable_table_ref, table_ref_elem_kv[1])
+
+    def _restore_table_ref(sharded_table_ref_elems_kv):
+      sharded_table_ref = sharded_table_ref_elems_kv[0]
+      table_ref = bigquery_tools.parse_table_reference(sharded_table_ref.key)
+      return (table_ref, sharded_table_ref_elems_kv[1])
+
+    tagged_data = (
         input
         | 'AppendDestination' >> beam.ParDo(
             bigquery_tools.AppendDestinationsFn(self.table_reference),
             *self.table_side_inputs)
-        | 'AddInsertIdsWithRandomKeys' >> beam.ParDo(
-            _StreamToBigQuery.InsertIdPrefixFn()))
+        | 'AddInsertIds' >> beam.ParDo(_StreamToBigQuery.InsertIdPrefixFn()))
 
-    sharded_data = (sharded_data | 'CommitInsertIds' >> ReshufflePerKey())
+    if not self.ignore_insert_ids:
+      if not self.with_auto_sharding:
+        tagged_data = (
+            tagged_data
+            | 'WithFixedSharding' >> beam.Map(_add_random_shard)
+            | 'CommitInsertIds' >> ReshufflePerKey()
+            | 'DropShard' >> beam.Map(lambda kv: (kv[0][0], kv[1])))
+      else:
+        # Auto-sharding is achieved via GroupIntoBatches.WithShardedKey
+        # transform which shards, groups and at the same time batches the table
+        # rows to be inserted to BigQuery.
+
+        # Firstly the keys of tagged_data (table references) are converted to a
+        # hashable format. This is needed to work with the keyed states used by
+        # GroupIntoBatches. After grouping and batching is done, original table
+        # references are restored.
+        tagged_data = (
+            tagged_data
+            | 'ToHashableTableRef' >> beam.Map(_to_hashable_table_ref)
+            | 'WithAutoSharding' >> beam.GroupIntoBatches.WithShardedKey(
+                (self.batch_size or BigQueryWriteFn.DEFAULT_MAX_BUFFERED_ROWS),
+                DEFAULT_BATCH_BUFFERING_DURATION_LIMIT_SEC)
+            |
+            'FromHashableTableRefAndDropShard' >> beam.Map(_restore_table_ref))
 
     return (
-        sharded_data
-        | 'DropShard' >> beam.Map(drop_shard)
+        tagged_data
         | 'StreamInsertRows' >> ParDo(
             bigquery_write_fn, *self.schema_side_inputs).with_outputs(
                 BigQueryWriteFn.FAILED_ROWS, main='main'))
@@ -1467,7 +1512,8 @@ class WriteToBigQuery(PTransform):
       triggering_frequency=None,
       validate=True,
       temp_file_format=None,
-      ignore_insert_ids=False):
+      ignore_insert_ids=False,
+      with_auto_sharding=False):
     """Initialize a WriteToBigQuery transform.
 
     Args:
@@ -1490,8 +1536,8 @@ class WriteToBigQuery(PTransform):
       schema (str,dict,ValueProvider,callable): The schema to be used if the
         BigQuery table to write has to be created. This can be either specified
         as a :class:`~apache_beam.io.gcp.internal.clients.bigquery.\
-bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
-        or a python dictionary, or the string or dictionary itself,
+        bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON
+        string, or a python dictionary, or the string or dictionary itself,
         object or a single string  of the form
         ``'field1:type1,field2:type2,field3:type3'`` that defines a comma
         separated list of fields. Here ``'type'`` should specify the BigQuery
@@ -1524,7 +1570,6 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
         tables.
       batch_size (int): Number of rows to be written to BQ per streaming API
         insert. The default is 500.
-        insert.
       test_client: Override the default bigquery client used for testing.
       max_file_size (int): The maximum size for a file to be written and then
         loaded into BigQuery. The default value is 4TB, which is 80% of the
@@ -1591,6 +1636,10 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
         duplication of data inserted to BigQuery, set `ignore_insert_ids`
         to True to increase the throughput for BQ writing. See:
         https://cloud.google.com/bigquery/streaming-data-into-bigquery#disabling_best_effort_de-duplication
+      with_auto_sharding: Experimental. If true, enables using a dynamically
+        determined number of shards to write to BigQuery. This can be used for
+        both FILE_LOADS and STREAMING_INSERTS. Only applicable to unbounded
+        input.
     """
     self._table = table
     self._dataset = dataset
@@ -1615,6 +1664,7 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
     self.max_files_per_bundle = max_files_per_bundle
     self.method = method or WriteToBigQuery.Method.DEFAULT
     self.triggering_frequency = triggering_frequency
+    self.with_auto_sharding = with_auto_sharding
     self.insert_retry_strategy = insert_retry_strategy
     self._validate = validate
     self._temp_file_format = temp_file_format or bigquery_tools.FileFormat.JSON
@@ -1649,10 +1699,14 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
       self.table_reference.projectId = pcoll.pipeline.options.view_as(
           GoogleCloudOptions).project
 
-    experiments = p.options.view_as(DebugOptions).experiments or []
     # TODO(pabloem): Use a different method to determine if streaming or batch.
     is_streaming_pipeline = p.options.view_as(StandardOptions).streaming
 
+    if not is_streaming_pipeline and self.with_auto_sharding:
+      raise ValueError(
+          'with_auto_sharding is not applicable to batch pipelines.')
+
+    experiments = p.options.view_as(DebugOptions).experiments or []
     method_to_use = self._compute_method(experiments, is_streaming_pipeline)
 
     if method_to_use == WriteToBigQuery.Method.STREAMING_INSERTS:
@@ -1667,17 +1721,18 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
             'FILE_LOADS method of writing to BigQuery.')
 
       outputs = pcoll | _StreamToBigQuery(
-          self.table_reference,
-          self.table_side_inputs,
-          self.schema_side_inputs,
-          self.schema,
-          self.batch_size,
-          self.create_disposition,
-          self.write_disposition,
-          self.kms_key,
-          self.insert_retry_strategy,
-          self.additional_bq_parameters,
-          self._ignore_insert_ids,
+          table_reference=self.table_reference,
+          table_side_inputs=self.table_side_inputs,
+          schema_side_inputs=self.schema_side_inputs,
+          schema=self.schema,
+          batch_size=self.batch_size,
+          create_disposition=self.create_disposition,
+          write_disposition=self.write_disposition,
+          kms_key=self.kms_key,
+          retry_strategy=self.insert_retry_strategy,
+          additional_bq_parameters=self.additional_bq_parameters,
+          ignore_insert_ids=self._ignore_insert_ids,
+          with_auto_sharding=self.with_auto_sharding,
           test_client=self.test_client)
 
       return {BigQueryWriteFn.FAILED_ROWS: outputs[BigQueryWriteFn.FAILED_ROWS]}
@@ -1701,6 +1756,7 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
           create_disposition=self.create_disposition,
           write_disposition=self.write_disposition,
           triggering_frequency=self.triggering_frequency,
+          with_auto_sharding=self.with_auto_sharding,
           temp_file_format=self._temp_file_format,
           max_file_size=self.max_file_size,
           max_files_per_bundle=self.max_files_per_bundle,
@@ -1759,6 +1815,8 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
         'triggering_frequency': self.triggering_frequency,
         'validate': self._validate,
         'temp_file_format': self._temp_file_format,
+        'ignore_insert_ids': self._ignore_insert_ids,
+        'with_auto_sharding': self.with_auto_sharding,
     }
     return 'beam:transform:write_to_big_query:v0', pickler.dumps(config)
 

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -46,6 +46,7 @@ from apache_beam.options import value_provider as vp
 from apache_beam.options.pipeline_options import GoogleCloudOptions
 from apache_beam.transforms import trigger
 from apache_beam.transforms.display import DisplayDataItem
+from apache_beam.transforms.util import GroupIntoBatches
 from apache_beam.transforms.window import GlobalWindows
 
 _LOGGER = logging.getLogger(__name__)
@@ -641,6 +642,7 @@ class BigQueryBatchFileLoads(beam.PTransform):
       create_disposition=None,
       write_disposition=None,
       triggering_frequency=None,
+      with_auto_sharding=False,
       temp_file_format=None,
       max_file_size=None,
       max_files_per_bundle=None,
@@ -656,6 +658,7 @@ class BigQueryBatchFileLoads(beam.PTransform):
     self.create_disposition = create_disposition
     self.write_disposition = write_disposition
     self.triggering_frequency = triggering_frequency
+    self.with_auto_sharding = with_auto_sharding
     self.max_file_size = max_file_size or _DEFAULT_MAX_FILE_SIZE
     self.max_files_per_bundle = (
         max_files_per_bundle or _DEFAULT_MAX_WRITERS_PER_BUNDLE)
@@ -708,6 +711,9 @@ class BigQueryBatchFileLoads(beam.PTransform):
       raise ValueError(
           'triggering_frequency can only be used with file'
           'loads in streaming')
+    if not self.is_streaming_pipeline and self.with_auto_sharding:
+      return ValueError(
+          'with_auto_sharding can only be used with file loads in streaming.')
 
   def _window_fn(self):
     """Set the correct WindowInto PTransform"""
@@ -719,7 +725,11 @@ class BigQueryBatchFileLoads(beam.PTransform):
     # that the files are written if a threshold number of records are ready.
     # We use only the user-supplied trigger on the actual BigQuery load.
     # This allows us to offload the data to the filesystem.
-    if self.is_streaming_pipeline:
+    #
+    # In the case of auto sharding, however, we use a default triggering and
+    # instead apply the user supplied triggering_frequency to the transfrom that
+    # performs sharding.
+    if self.is_streaming_pipeline and not self.with_auto_sharding:
       return beam.WindowInto(beam.window.GlobalWindows(),
                              trigger=trigger.Repeatedly(
                                  trigger.AfterAny(
@@ -731,6 +741,21 @@ class BigQueryBatchFileLoads(beam.PTransform):
                                  .DISCARDING)
     else:
       return beam.WindowInto(beam.window.GlobalWindows())
+
+  def _maybe_apply_user_trigger(self, destination_file_kv_pc):
+    if self.is_streaming_pipeline:
+      # Apply the user's trigger back before we start triggering load jobs
+      return (
+          destination_file_kv_pc
+          | "ApplyUserTrigger" >> beam.WindowInto(
+              beam.window.GlobalWindows(),
+              trigger=trigger.Repeatedly(
+                  trigger.AfterAll(
+                      trigger.AfterProcessingTime(self.triggering_frequency),
+                      trigger.AfterCount(1))),
+              accumulation_mode=trigger.AccumulationMode.DISCARDING))
+    else:
+      return destination_file_kv_pc
 
   def _write_files(self, destination_data_kv_pc, file_prefix_pcv):
     outputs = (
@@ -774,19 +799,35 @@ class BigQueryBatchFileLoads(beam.PTransform):
         (destination_files_kv_pc, more_destination_files_kv_pc)
         | "DestinationFilesUnion" >> beam.Flatten()
         | "IdentityWorkaround" >> beam.Map(lambda x: x))
+    return self._maybe_apply_user_trigger(all_destination_file_pairs_pc)
 
-    if self.is_streaming_pipeline:
-      # Apply the user's trigger back before we start triggering load jobs
-      all_destination_file_pairs_pc = (
-          all_destination_file_pairs_pc
-          | "ApplyUserTrigger" >> beam.WindowInto(
-              beam.window.GlobalWindows(),
-              trigger=trigger.Repeatedly(
-                  trigger.AfterAll(
-                      trigger.AfterProcessingTime(self.triggering_frequency),
-                      trigger.AfterCount(1))),
-              accumulation_mode=trigger.AccumulationMode.DISCARDING))
-    return all_destination_file_pairs_pc
+  def _write_files_with_auto_sharding(
+      self, destination_data_kv_pc, file_prefix_pcv):
+    # Auto-sharding is achieved via GroupIntoBatches.WithShardedKey
+    # transform which shards, groups and at the same time batches the table rows
+    # to be inserted to BigQuery.
+
+    # Firstly, the keys of tagged_data (table references) are converted to a
+    # hashable format. This is needed to work with the keyed states used by.
+    # GroupIntoBatches. After grouping and batching is done, table references
+    # are restored.
+    destination_files_kv_pc = (
+        destination_data_kv_pc
+        | 'ToHashableTableRef' >> beam.Map(
+            lambda kv: (bigquery_tools.get_hashable_destination(kv[0]), kv[1]))
+        | 'WithAutoSharding' >> GroupIntoBatches.WithShardedKey(
+            batch_size=_FILE_TRIGGERING_RECORD_COUNT,
+            max_buffering_duration_secs=self.triggering_frequency)
+        | 'FromHashableTableRefAndDropShard' >> beam.Map(
+            lambda kvs:
+            (bigquery_tools.parse_table_reference(kvs[0].key), kvs[1]))
+        | beam.ParDo(
+            WriteGroupedRecordsToFile(
+                schema=self.schema, file_format=self._temp_file_format),
+            file_prefix_pcv,
+            *self.schema_side_inputs))
+
+    return self._maybe_apply_user_trigger(destination_files_kv_pc)
 
   def _load_data(
       self,
@@ -933,8 +974,12 @@ class BigQueryBatchFileLoads(beam.PTransform):
             bigquery_tools.AppendDestinationsFn(self.destination),
             *self.table_side_inputs))
 
-    all_destination_file_pairs_pc = self._write_files(
-        destination_data_kv_pc, file_prefix_pcv)
+    if not self.with_auto_sharding:
+      all_destination_file_pairs_pc = self._write_files(
+          destination_data_kv_pc, file_prefix_pcv)
+    else:
+      all_destination_file_pairs_pc = self._write_files_with_auto_sharding(
+          destination_data_kv_pc, file_prefix_pcv)
 
     grouped_files_pc = (
         all_destination_file_pairs_pc

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
@@ -826,10 +826,8 @@ class BigQueryFileLoadsIT(unittest.TestCase):
               max_file_size=20,
               max_files_per_bundle=-1))
 
-  @parameterized.expand(
-      [param(with_auto_sharding=False), param(with_auto_sharding=True)])
   @attr('IT')
-  def test_bqfl_streaming(self, with_auto_sharding):
+  def test_bqfl_streaming(self):
     if isinstance(self.test_pipeline.runner, TestDataflowRunner):
       self.skipTest("TestStream is not supported on TestDataflowRunner")
     output_table = '%s_%s' % (self.output_table, 'ints')
@@ -862,8 +860,7 @@ class BigQueryFileLoadsIT(unittest.TestCase):
                                       schema=schema,
                                       method=bigquery.WriteToBigQuery \
                                         .Method.FILE_LOADS,
-                                      triggering_frequency=100,
-                                      with_auto_sharding=with_auto_sharding))
+                                      triggering_frequency=100))
 
   @attr('IT')
   def test_one_job_fails_all_jobs_fail(self):

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
@@ -719,7 +719,7 @@ class BigQueryFileLoadsIT(unittest.TestCase):
   @parameterized.expand(
       [param(with_auto_sharding=False), param(with_auto_sharding=True)])
   @attr('IT')
-  def test_bqfl_streaming(self):
+  def test_bqfl_streaming(self, with_auto_sharding):
     if isinstance(self.test_pipeline.runner, TestDataflowRunner):
       self.skipTest("TestStream is not supported on TestDataflowRunner")
     output_table = '%s_%s' % (self.output_table, 'ints')

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
@@ -716,6 +716,8 @@ class BigQueryFileLoadsIT(unittest.TestCase):
               max_file_size=20,
               max_files_per_bundle=-1))
 
+  @parameterized.expand(
+      [param(with_auto_sharding=False), param(with_auto_sharding=True)])
   @attr('IT')
   def test_bqfl_streaming(self):
     if isinstance(self.test_pipeline.runner, TestDataflowRunner):
@@ -750,7 +752,8 @@ class BigQueryFileLoadsIT(unittest.TestCase):
                                       schema=schema,
                                       method=bigquery.WriteToBigQuery \
                                         .Method.FILE_LOADS,
-                                      triggering_frequency=100))
+                                      triggering_frequency=100,
+                                      with_auto_sharding=with_auto_sharding))
 
   @attr('IT')
   def test_one_job_fails_all_jobs_fail(self):

--- a/sdks/python/apache_beam/io/gcp/bigquery_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_test.py
@@ -38,6 +38,8 @@ import hamcrest as hc
 import mock
 import pytz
 from nose.plugins.attrib import attr
+from parameterized import param
+from parameterized import parameterized
 
 import apache_beam as beam
 from apache_beam.internal import pickler
@@ -77,8 +79,6 @@ from apache_beam.transforms.display_test import DisplayDataItemMatcher
 
 # Protect against environments where bigquery library is not available.
 # pylint: disable=wrong-import-order, wrong-import-position
-from parameterized import param
-from parameterized import parameterized
 try:
   from apitools.base.py.exceptions import HttpError
 except ImportError:

--- a/sdks/python/apache_beam/io/gcp/bigquery_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_test.py
@@ -79,7 +79,6 @@ from apache_beam.transforms.display_test import DisplayDataItemMatcher
 # pylint: disable=wrong-import-order, wrong-import-position
 from parameterized import param
 from parameterized import parameterized
-
 try:
   from apitools.base.py.exceptions import HttpError
 except ImportError:

--- a/sdks/python/apache_beam/io/gcp/bigquery_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_test.py
@@ -77,6 +77,9 @@ from apache_beam.transforms.display_test import DisplayDataItemMatcher
 
 # Protect against environments where bigquery library is not available.
 # pylint: disable=wrong-import-order, wrong-import-position
+from parameterized import param
+from parameterized import parameterized
+
 try:
   from apitools.base.py.exceptions import HttpError
 except ImportError:
@@ -892,6 +895,41 @@ class BigQueryStreamingInsertTransformTests(unittest.TestCase):
     # InsertRows not called in finish bundle as no records
     self.assertFalse(client.tabledata.InsertAll.called)
 
+  def test_with_batched_input(self):
+    client = mock.Mock()
+    client.tables.Get.return_value = bigquery.Table(
+        tableReference=bigquery.TableReference(
+            projectId='project_id', datasetId='dataset_id', tableId='table_id'))
+    client.tabledata.InsertAll.return_value = \
+      bigquery.TableDataInsertAllResponse(insertErrors=[])
+    create_disposition = beam.io.BigQueryDisposition.CREATE_IF_NEEDED
+    write_disposition = beam.io.BigQueryDisposition.WRITE_APPEND
+
+    fn = beam.io.gcp.bigquery.BigQueryWriteFn(
+        batch_size=10,
+        create_disposition=create_disposition,
+        write_disposition=write_disposition,
+        kms_key=None,
+        with_batched_input=True,
+        test_client=client)
+
+    fn.start_bundle()
+
+    # Destination is a tuple of (destination, schema) to ensure the table is
+    # created.
+    fn.process((
+        'project_id:dataset_id.table_id',
+        [({
+            'month': 1
+        }, 'insertid3'), ({
+            'month': 2
+        }, 'insertid2'), ({
+            'month': 3
+        }, 'insertid1')]))
+
+    # InsertRows called since the input is already batched.
+    self.assertTrue(client.tabledata.InsertAll.called)
+
 
 @unittest.skipIf(HttpError is None, 'GCP dependencies are not installed')
 class PipelineBasedStreamingInsertTest(_TestCaseWithTempDirCleanUp):
@@ -937,18 +975,88 @@ class PipelineBasedStreamingInsertTest(_TestCaseWithTempDirCleanUp):
               'columnA': 'value5', 'columnB': 'value6'
           }])
           | _StreamToBigQuery(
-              'project:dataset.table', [], [],
-              'anyschema',
-              None,
-              'CREATE_NEVER',
-              None,
-              None,
-              None, [],
+              table_reference='project:dataset.table',
+              table_side_inputs=[],
+              schema_side_inputs=[],
+              schema='anyschema',
+              batch_size=None,
+              create_disposition='CREATE_NEVER',
+              write_disposition=None,
+              kms_key=None,
+              retry_strategy=None,
+              additional_bq_parameters=[],
               ignore_insert_ids=False,
+              with_auto_sharding=False,
               test_client=client))
 
     with open(file_name_1) as f1, open(file_name_2) as f2:
       self.assertEqual(json.load(f1), json.load(f2))
+
+  @parameterized.expand([
+      param(with_auto_sharding=False),
+      param(with_auto_sharding=True),
+  ])
+  def test_batch_size_with_auto_sharding(self, with_auto_sharding):
+    tempdir = '%s%s' % (self._new_tempdir(), os.sep)
+    file_name_1 = os.path.join(tempdir, 'file1')
+    file_name_2 = os.path.join(tempdir, 'file2')
+
+    def store_callback(arg):
+      insert_ids = [r.insertId for r in arg.tableDataInsertAllRequest.rows]
+      colA_values = [
+          r.json.additionalProperties[0].value.string_value
+          for r in arg.tableDataInsertAllRequest.rows
+      ]
+      json_output = {'insertIds': insert_ids, 'colA_values': colA_values}
+      # Expect two batches of rows will be inserted. Store them separately.
+      if not os.path.exists(file_name_1):
+        with open(file_name_1, 'w') as f:
+          json.dump(json_output, f)
+      else:
+        with open(file_name_2, 'w') as f:
+          json.dump(json_output, f)
+
+      res = mock.Mock()
+      res.insertErrors = []
+      return res
+
+    client = mock.Mock()
+    client.tabledata.InsertAll = mock.Mock(side_effect=store_callback)
+
+    # Using the bundle based direct runner to avoid pickling problems
+    # with mocks.
+    with beam.Pipeline(runner='BundleBasedDirectRunner') as p:
+      _ = (
+          p
+          | beam.Create([{
+              'columnA': 'value1', 'columnB': 'value2'
+          }, {
+              'columnA': 'value3', 'columnB': 'value4'
+          }, {
+              'columnA': 'value5', 'columnB': 'value6'
+          }])
+          | _StreamToBigQuery(
+              table_reference='project:dataset.table',
+              table_side_inputs=[],
+              schema_side_inputs=[],
+              schema='anyschema',
+              # Set a batch size such that the input elements will be inserted
+              # in 2 batches.
+              batch_size=2,
+              create_disposition='CREATE_NEVER',
+              write_disposition=None,
+              kms_key=None,
+              retry_strategy=None,
+              additional_bq_parameters=[],
+              ignore_insert_ids=False,
+              with_auto_sharding=with_auto_sharding,
+              test_client=client))
+
+    with open(file_name_1) as f1, open(file_name_2) as f2:
+      out1 = json.load(f1)
+      self.assertEqual(out1['colA_values'], ['value1', 'value3'])
+      out2 = json.load(f2)
+      self.assertEqual(out2['colA_values'], ['value5'])
 
 
 class BigQueryStreamingInsertTransformIntegrationTests(unittest.TestCase):

--- a/sdks/python/apache_beam/transforms/util.py
+++ b/sdks/python/apache_beam/transforms/util.py
@@ -811,12 +811,14 @@ class GroupIntoBatches(PTransform):
     override the default sharding to do a better load balancing during the
     execution time.
     """
-    def __init__(self, batch_size, max_buffering_duration_secs=None):
+    def __init__(
+        self, batch_size, max_buffering_duration_secs=None, clock=time.time):
       """Create a new GroupIntoBatches with sharded output.
       See ``GroupIntoBatches`` transform for a description of input parameters.
       """
       self.params = _GroupIntoBatchesParams(
           batch_size, max_buffering_duration_secs)
+      self.clock = clock
 
     _shard_id_prefix = uuid.uuid4().bytes
 
@@ -836,7 +838,9 @@ class GroupIntoBatches(PTransform):
       return (
           sharded_pcoll
           | GroupIntoBatches(
-              self.params.batch_size, self.params.max_buffering_duration_secs))
+              self.params.batch_size,
+              self.params.max_buffering_duration_secs,
+              self.clock))
 
     def to_runner_api_parameter(
         self,


### PR DESCRIPTION
This is a parity of Java changes (#13496 and #13859).

Use `GroupIntoBatches.WithShardedKey` API to group and batch write before streaming to BigQuery service. Currently batching is done best-effort upon bundle finalization.

This PR adds an option to `WriteToBigQuery` to toggle between the existing and new implementation for both streaming inserts and file loads.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
