### PR TITLE
Fix Beam breakage

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WindmillStateInternals.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WindmillStateInternals.java
@@ -1115,7 +1115,7 @@ class WindmillStateInternals<K> implements StateInternals {
         StateTag<SetState<K>> address,
         String stateFamily,
         Coder<K> keyCoder,
-        WindmillStateCache.ForKey cache,
+        WindmillStateCache.ForKeyAndFamily cache,
         boolean isNewKey) {
       StateTag<MapState<K, Boolean>> internalMapAddress =
           StateTags.convertToMapTagInternal(address);
@@ -1134,7 +1134,8 @@ class WindmillStateInternals<K> implements StateInternals {
     }
 
     @Override
-    protected WorkItemCommitRequest persistDirectly(ForKey cache) throws IOException {
+    protected WorkItemCommitRequest persistDirectly(WindmillStateCache.ForKeyAndFamily cache)
+        throws IOException {
       return windmillMap.persistDirectly(cache);
     }
 
@@ -1260,7 +1261,8 @@ class WindmillStateInternals<K> implements StateInternals {
     }
 
     @Override
-    protected WorkItemCommitRequest persistDirectly(ForKey cache) throws IOException {
+    protected WorkItemCommitRequest persistDirectly(WindmillStateCache.ForKeyAndFamily cache)
+        throws IOException {
       if (!cleared && localAdditions.isEmpty() && localRemovals.isEmpty()) {
         // No changes, so return directly.
         return WorkItemCommitRequest.newBuilder().buildPartial();

--- a/sdks/java/testing/watermarks/src/main/java/org/apache/beam/sdk/testing/watermarks/WatermarkLatency.java
+++ b/sdks/java/testing/watermarks/src/main/java/org/apache/beam/sdk/testing/watermarks/WatermarkLatency.java
@@ -17,7 +17,8 @@
  */
 package org.apache.beam.sdk.testing.watermarks;
 
-import java.util.*;
+import java.util.ArrayList;
+import java.util.Collections;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.GenerateSequence;
 import org.apache.beam.sdk.options.Default;

--- a/sdks/java/testing/watermarks/src/main/java/org/apache/beam/sdk/testing/watermarks/package-info.java
+++ b/sdks/java/testing/watermarks/src/main/java/org/apache/beam/sdk/testing/watermarks/package-info.java
@@ -1,0 +1,19 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+/** Watermark latency benchmark. */
+package org.apache.beam.sdk.testing.watermarks;


### PR DESCRIPTION
Two independently passing PRs were merged today, however due to an overlap between them the merges broke the build. This fixes the build.