### PR TITLE
[BEAM-11881] Fix partitioning ordering for DataFrames

### DIFF
--- a/sdks/python/apache_beam/dataframe/expressions.py
+++ b/sdks/python/apache_beam/dataframe/expressions.py
@@ -146,10 +146,10 @@ def output_partitioning(expr, input_partitioning):
   For internal use only; No backward compatibility guarantees """
   assert expr.requires_partition_by().is_subpartitioning_of(input_partitioning)
 
-  if input_partitioning.is_subpartitioning_of(expr.preserves_partition_by()):
-    return partitionings.Nothing()
-  else:
+  if expr.preserves_partition_by().is_subpartitioning_of(input_partitioning):
     return min(input_partitioning, expr.preserves_partition_by())
+  else:
+    return partitionings.Nothing()
 
 
 class Expression(object):

--- a/sdks/python/apache_beam/dataframe/expressions.py
+++ b/sdks/python/apache_beam/dataframe/expressions.py
@@ -177,15 +177,15 @@ class Expression(object):
   For example, let's look at an "element-wise operation", that has no
   partitioning requirement, and preserves any partitioning given to it::
 
-    requires_partition_by = Arbitrary() -------------------------------+
+    requires_partition_by = Arbitrary() -----------------------------+
                                                                      |
              +-----------+-------------+---------- ... ----+---------|
              |           |             |                   |         |
         Singleton() < Index([i]) < Index([i, j]) < ... < Index() < Arbitrary()
-             |           |             |                   |
-             +-----------+-------------+---------- ... ----|
-                                                           |
-    preserves_partition_by = Index() ----------------------+
+             |           |             |                   |         |
+             +-----------+-------------+---------- ... ----+---------|
+                                                                     |
+    preserves_partition_by = Arbitrary() ----------------------------+
 
   As a more interesting example, consider this expression, which requires Index
   partitioning, and preserves just Singleton partitioning::
@@ -319,7 +319,7 @@ class ConstantExpression(Expression):
     return partitionings.Arbitrary()
 
   def preserves_partition_by(self):
-    return partitionings.Index()
+    return partitionings.Arbitrary()
 
 
 class ComputedExpression(Expression):
@@ -350,11 +350,6 @@ class ComputedExpression(Expression):
       requires_partition_by: The required (common) partitioning of the args.
       preserves_partition_by: The level of partitioning preserved.
     """
-    assert preserves_partition_by != partitionings.Arbitrary(), (
-        "Preserving Arbitrary() partitioning is not allowed. Any expression "
-        "can trivially preserve at least Singleton() partitioning. If you "
-        "intend to indicate this expression can preserve _any_ partioning, use "
-        "Index() instead.")
     if (not _get_allow_non_parallel() and
         requires_partition_by == partitionings.Singleton()):
       raise NonParallelOperation(
@@ -392,7 +387,7 @@ def elementwise_expression(name, func, args):
       func,
       args,
       requires_partition_by=partitionings.Arbitrary(),
-      preserves_partition_by=partitionings.Index())
+      preserves_partition_by=partitionings.Arbitrary())
 
 
 _ALLOW_NON_PARALLEL = threading.local()

--- a/sdks/python/apache_beam/dataframe/expressions_test.py
+++ b/sdks/python/apache_beam/dataframe/expressions_test.py
@@ -77,7 +77,7 @@ class ExpressionTest(unittest.TestCase):
 
     for partitioning in (partitionings.Index([0]),
                          partitionings.Index(),
-                         partitionings.Nothing()):
+                         partitionings.Arbitrary()):
       self.assertEqual(
           expressions.output_partitioning(
               preserves_only_singleton, partitioning),
@@ -112,7 +112,7 @@ class ExpressionTest(unittest.TestCase):
 
     for partitioning in (partitionings.Index([0, 1, 2]),
                          partitionings.Index(),
-                         partitionings.Nothing()):
+                         partitionings.Arbitrary()):
       self.assertEqual(
           expressions.output_partitioning(
               preserves_partial_index, partitioning),

--- a/sdks/python/apache_beam/dataframe/expressions_test.py
+++ b/sdks/python/apache_beam/dataframe/expressions_test.py
@@ -16,7 +16,10 @@
 
 import unittest
 
+import pandas as pd
+
 from apache_beam.dataframe import expressions
+from apache_beam.dataframe import partitionings
 
 
 class ExpressionTest(unittest.TestCase):
@@ -50,6 +53,71 @@ class ExpressionTest(unittest.TestCase):
     b = expressions.PlaceholderExpression('s')
     with self.assertRaises(TypeError):
       expressions.ComputedExpression('add', lambda a, b: a + b, [a, b])
+
+  def test_preserves_singleton_output_partitioning(self):
+    # Empty DataFrame with one column and two index levels
+    input_expr = expressions.ConstantExpression(
+        pd.DataFrame(columns=["column"], index=[[], []]))
+
+    preserves_only_singleton = expressions.ComputedExpression(
+        'preserves_only_singleton',
+        # index is replaced with an entirely new one, so
+        # if we were partitioned by Index we're not anymore.
+        lambda df: df.set_index('column'),
+        [input_expr],
+        requires_partition_by=partitionings.Arbitrary(),
+        preserves_partition_by=partitionings.Singleton())
+
+    for partitioning in (partitionings.Singleton(), ):
+      self.assertEqual(
+          expressions.output_partitioning(
+              preserves_only_singleton, partitioning),
+          partitioning,
+          f"Should preserve {partitioning}")
+
+    for partitioning in (partitionings.Index([0]),
+                         partitionings.Index(),
+                         partitionings.Nothing()):
+      self.assertEqual(
+          expressions.output_partitioning(
+              preserves_only_singleton, partitioning),
+          partitionings.Arbitrary(),
+          f"Should NOT preserve {partitioning}")
+
+  def test_preserves_index_output_partitioning(self):
+    # Empty DataFrame with two columns and two index levels
+    input_expr = expressions.ConstantExpression(
+        pd.DataFrame(columns=["foo", "bar"], index=[[], []]))
+
+    preserves_partial_index = expressions.ComputedExpression(
+        'preserves_partial_index',
+        # This adds an additional index  level, so we'd only preserve
+        # partitioning on the two index levels that existed before.
+        lambda df: df.set_index('foo', append=True),
+        [input_expr],
+        requires_partition_by=partitionings.Arbitrary(),
+        preserves_partition_by=partitionings.Index([0, 1]))
+
+    for partitioning in (
+        partitionings.Singleton(),
+        partitionings.Index([0]),
+        partitionings.Index([1]),
+        partitionings.Index([0, 1]),
+    ):
+      self.assertEqual(
+          expressions.output_partitioning(
+              preserves_partial_index, partitioning),
+          partitioning,
+          f"Should preserve {partitioning}")
+
+    for partitioning in (partitionings.Index([0, 1, 2]),
+                         partitionings.Index(),
+                         partitionings.Nothing()):
+      self.assertEqual(
+          expressions.output_partitioning(
+              preserves_partial_index, partitioning),
+          partitionings.Arbitrary(),
+          f"Should NOT preserve {partitioning}")
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/dataframe/frame_base.py
+++ b/sdks/python/apache_beam/dataframe/frame_base.py
@@ -272,9 +272,9 @@ def _proxy_function(
 
       return actual_func(*full_args, **full_kwargs)
 
-    if (not requires_partition_by.is_subpartitioning_of(partitionings.Index())
-        and sum(isinstance(arg.proxy(), pd.core.generic.NDFrame)
-                for arg in deferred_exprs) > 1):
+    if (requires_partition_by.is_subpartitioning_of(partitionings.Index()) and
+        sum(isinstance(arg.proxy(), pd.core.generic.NDFrame)
+            for arg in deferred_exprs) > 1):
       # Implicit join on index if there is more than one indexed input.
       actual_requires_partition_by = partitionings.Index()
     else:

--- a/sdks/python/apache_beam/dataframe/frame_base.py
+++ b/sdks/python/apache_beam/dataframe/frame_base.py
@@ -56,7 +56,7 @@ class DeferredBase(object):
             'get_%d' % ix,
             lambda t: t[ix],
             [expr],
-            requires_partition_by=partitionings.Nothing(),
+            requires_partition_by=partitionings.Arbitrary(),
             preserves_partition_by=partitionings.Singleton())
 
       return tuple([cls.wrap(get(ix)) for ix in range(len(expr.proxy()))])
@@ -137,7 +137,7 @@ def _elementwise_method(func, name=None, restrictions=None, inplace=False):
       name,
       restrictions,
       inplace,
-      requires_partition_by=partitionings.Nothing(),
+      requires_partition_by=partitionings.Arbitrary(),
       preserves_partition_by=partitionings.Singleton())
 
 
@@ -147,7 +147,7 @@ def _proxy_method(
     restrictions=None,
     inplace=False,
     requires_partition_by=partitionings.Singleton(),
-    preserves_partition_by=partitionings.Nothing()):
+    preserves_partition_by=partitionings.Arbitrary()):
   if name is None:
     name, func = name_and_func(func)
   if restrictions is None:
@@ -167,7 +167,7 @@ def _elementwise_function(func, name=None, restrictions=None, inplace=False):
       name,
       restrictions,
       inplace,
-      requires_partition_by=partitionings.Nothing(),
+      requires_partition_by=partitionings.Arbitrary(),
       preserves_partition_by=partitionings.Singleton())
 
 
@@ -177,7 +177,7 @@ def _proxy_function(
       restrictions=None,  # type: Optional[Dict[str, Union[Any, List[Any], Callable[[Any], bool]]]]
       inplace=False,  # type: bool
       requires_partition_by=partitionings.Singleton(),  # type: partitionings.Partitioning
-      preserves_partition_by=partitionings.Nothing(),  # type: partitionings.Partitioning
+      preserves_partition_by=partitionings.Arbitrary(),  # type: partitionings.Partitioning
 ):
 
   if name is None:
@@ -230,7 +230,7 @@ def _proxy_function(
                 lambda ix: ix.index.to_series(),  # yapf break
                 [arg._frame._expr],
                 preserves_partition_by=partitionings.Singleton(),
-                requires_partition_by=partitionings.Nothing()))
+                requires_partition_by=partitionings.Arbitrary()))
       elif isinstance(arg, pd.core.generic.NDFrame):
         deferred_arg_indices.append(ix)
         deferred_arg_exprs.append(expressions.ConstantExpression(arg, arg[0:0]))

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -1401,14 +1401,17 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
   def nunique(self, **kwargs):
     if kwargs.get('axis', None) in (1, 'columns'):
       requires_partition_by = partitionings.Nothing()
+      preserves_partition_by = partitionings.Index()
     else:
+      # TODO: This could be implemented in a distributed fashion
       requires_partition_by = partitionings.Singleton()
+      preserves_partition_by = partitionings.Singleton()
     return frame_base.DeferredFrame.wrap(
         expressions.ComputedExpression(
             'nunique',
             lambda df: df.nunique(**kwargs),
             [self._expr],
-            preserves_partition_by=partitionings.Singleton(),
+            preserves_partition_by=preserves_partition_by,
             requires_partition_by=requires_partition_by))
 
   plot = property(frame_base.wont_implement_method('plot'))

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -1438,7 +1438,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             'quantile',
             lambda df: df.quantile(axis=axis, **kwargs),
             [self._expr],
-            #TODO(robertwb): Approximate quantiles?
+            #TODO(robertwb): distributed approximate quantiles?
             requires_partition_by=partitionings.Singleton(),
             preserves_partition_by=partitionings.Singleton()))
 
@@ -1510,6 +1510,8 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
   @frame_base.populate_defaults(pd.DataFrame)
   @frame_base.maybe_inplace
   def reset_index(self, level=None, **kwargs):
+    # TODO: Docs should note that the index is not in the same order as it would
+    # be with pandas. Technically an order-sensitive operation
     if level is not None and not isinstance(level, (tuple, list)):
       level = [level]
     if level is None or len(level) == self._expr.proxy().index.nlevels:

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -195,7 +195,7 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
           'map_index',
           map_index, [self._expr],
           requires_partition_by=partitionings.Nothing(),
-          preserves_partition_by=partitionings.Index())
+          preserves_partition_by=partitionings.Singleton())
 
     elif isinstance(by, DeferredSeries):
 

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -108,7 +108,7 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
             'droplevel',
             lambda df: df.droplevel(level, axis=axis), [self._expr],
             requires_partition_by=partitionings.Arbitrary(),
-            preserves_partition_by=partitionings.Index()
+            preserves_partition_by=partitionings.Arbitrary()
             if axis in (1, 'column') else partitionings.Singleton()))
 
   @frame_base.args_to_kwargs(pd.DataFrame)
@@ -136,7 +136,7 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
             lambda df,
             value: df.fillna(value, method=method, axis=axis, **kwargs),
             [self._expr, value_expr],
-            preserves_partition_by=partitionings.Index(),
+            preserves_partition_by=partitionings.Arbitrary(),
             requires_partition_by=partitionings.Arbitrary()))
 
   @frame_base.args_to_kwargs(pd.DataFrame)
@@ -166,7 +166,7 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
               'groupbycols',
               lambda df: df.groupby(by, axis=axis, **kwargs), [self._expr],
               requires_partition_by=partitionings.Arbitrary(),
-              preserves_partition_by=partitionings.Index()))
+              preserves_partition_by=partitionings.Arbitrary()))
 
     if level is None and by is None:
       raise TypeError("You have to supply one of 'by' and 'level'")
@@ -233,7 +233,7 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
             lambda df: df.groupby(
                 level=list(range(df.index.nlevels)), **kwargs), [to_group],
             requires_partition_by=partitionings.Index(),
-            preserves_partition_by=partitionings.Index()),
+            preserves_partition_by=partitionings.Arbitrary()),
         kwargs,
         to_group)
 
@@ -275,7 +275,7 @@ class DeferredSeries(DeferredDataFrameOrSeries):
               lambda df: df[key],
               [self._expr],
               requires_partition_by=partitionings.Arbitrary(),
-              preserves_partition_by=partitionings.Index()))
+              preserves_partition_by=partitionings.Arbitrary()))
 
     elif isinstance(key, DeferredSeries) and key._expr.proxy().dtype == bool:
       return frame_base.DeferredFrame.wrap(
@@ -286,7 +286,7 @@ class DeferredSeries(DeferredDataFrameOrSeries):
               indexer: df[indexer],
               [self._expr, key._expr],
               requires_partition_by=partitionings.Index(),
-              preserves_partition_by=partitionings.Index()))
+              preserves_partition_by=partitionings.Arbitrary()))
 
     elif pd.core.series.is_iterator(key) or pd.core.common.is_bool_indexer(key):
       raise frame_base.WontImplementError('order sensitive')
@@ -326,7 +326,7 @@ class DeferredSeries(DeferredDataFrameOrSeries):
                 to_append, verify_integrity=verify_integrity, **kwargs),
             [self._expr, to_append._expr],
             requires_partition_by=requires,
-            preserves_partition_by=partitionings.Index()))
+            preserves_partition_by=partitionings.Arbitrary()))
 
   @frame_base.args_to_kwargs(pd.Series)
   @frame_base.populate_defaults(pd.Series)
@@ -344,7 +344,7 @@ class DeferredSeries(DeferredDataFrameOrSeries):
             y: pd.concat([x, y], axis=1, join='inner'),
             [self._expr, other._expr],
             requires_partition_by=partitionings.Index(),
-            preserves_partition_by=partitionings.Index()))
+            preserves_partition_by=partitionings.Arbitrary()))
     return aligned.iloc[:, 0], aligned.iloc[:, 1]
 
   array = property(frame_base.wont_implement_method('non-deferred value'))
@@ -359,7 +359,7 @@ class DeferredSeries(DeferredDataFrameOrSeries):
           'to_dataframe',
           pd.DataFrame, [other._expr],
           requires_partition_by=partitionings.Arbitrary(),
-          preserves_partition_by=partitionings.Index())
+          preserves_partition_by=partitionings.Arbitrary())
       right_is_series = True
     elif isinstance(other, DeferredDataFrame):
       right = other._expr
@@ -527,7 +527,7 @@ class DeferredSeries(DeferredDataFrameOrSeries):
         expressions.ComputedExpression(
             'dropna',
             lambda df: df.dropna(**kwargs), [self._expr],
-            preserves_partition_by=partitionings.Index(),
+            preserves_partition_by=partitionings.Arbitrary(),
             requires_partition_by=partitionings.Arbitrary()))
 
   items = iteritems = frame_base.wont_implement_method('non-lazy')
@@ -566,7 +566,7 @@ class DeferredSeries(DeferredDataFrameOrSeries):
             expressions.ComputedExpression(
                 'aggregate',
                 lambda s: s.agg(func, *args, **kwargs), [intermediate],
-                preserves_partition_by=partitionings.Index(),
+                preserves_partition_by=partitionings.Arbitrary(),
                 requires_partition_by=partitionings.Singleton()))
 
   agg = aggregate
@@ -614,14 +614,14 @@ class DeferredSeries(DeferredDataFrameOrSeries):
     per_partition = expressions.ComputedExpression(
         'nlargest-per-partition',
         lambda df: df.nlargest(**kwargs), [self._expr],
-        preserves_partition_by=partitionings.Index(),
+        preserves_partition_by=partitionings.Arbitrary(),
         requires_partition_by=partitionings.Arbitrary())
     with expressions.allow_non_parallel_operations(True):
       return frame_base.DeferredFrame.wrap(
           expressions.ComputedExpression(
               'nlargest',
               lambda df: df.nlargest(**kwargs), [per_partition],
-              preserves_partition_by=partitionings.Index(),
+              preserves_partition_by=partitionings.Arbitrary(),
               requires_partition_by=partitionings.Singleton()))
 
   @frame_base.args_to_kwargs(pd.Series)
@@ -635,14 +635,14 @@ class DeferredSeries(DeferredDataFrameOrSeries):
     per_partition = expressions.ComputedExpression(
         'nsmallest-per-partition',
         lambda df: df.nsmallest(**kwargs), [self._expr],
-        preserves_partition_by=partitionings.Index(),
+        preserves_partition_by=partitionings.Arbitrary(),
         requires_partition_by=partitionings.Arbitrary())
     with expressions.allow_non_parallel_operations(True):
       return frame_base.DeferredFrame.wrap(
           expressions.ComputedExpression(
               'nsmallest',
               lambda df: df.nsmallest(**kwargs), [per_partition],
-              preserves_partition_by=partitionings.Index(),
+              preserves_partition_by=partitionings.Arbitrary(),
               requires_partition_by=partitionings.Singleton()))
 
   plot = property(frame_base.wont_implement_method('plot'))
@@ -705,7 +705,7 @@ class DeferredSeries(DeferredDataFrameOrSeries):
         'update',
         lambda df,
         other: df.update(other) or df, [self._expr, other._expr],
-        preserves_partition_by=partitionings.Index(),
+        preserves_partition_by=partitionings.Arbitrary(),
         requires_partition_by=partitionings.Index())
 
   unstack = frame_base.wont_implement_method('non-deferred column values')
@@ -748,7 +748,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             'set_columns',
             set_columns, [self._expr],
             requires_partition_by=partitionings.Arbitrary(),
-            preserves_partition_by=partitionings.Index()))
+            preserves_partition_by=partitionings.Arbitrary()))
 
   def keys(self):
     return self.columns
@@ -833,7 +833,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             lambda df, other: df.align(other, join=join, axis=axis),
             [self._expr, other._expr],
             requires_partition_by=requires_partition_by,
-            preserves_partition_by=partitionings.Index()))
+            preserves_partition_by=partitionings.Arbitrary()))
 
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)
@@ -855,7 +855,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             lambda s, other: s.append(other, sort=sort, **kwargs),
             [self._expr, other._expr],
             requires_partition_by=partitionings.Arbitrary(),
-            preserves_partition_by=partitionings.Index()
+            preserves_partition_by=partitionings.Arbitrary()
         )
     )
 
@@ -1138,7 +1138,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             lambda left, right: left @ right.value,
             [self._expr, side],
             requires_partition_by=partitionings.Arbitrary(),
-            preserves_partition_by=partitionings.Index(),
+            preserves_partition_by=partitionings.Arbitrary(),
             proxy=proxy))
 
   __matmul__ = dot
@@ -1173,7 +1173,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             'dropna',
             lambda df: df.dropna(axis=axis, **kwargs),
             [self._expr],
-            preserves_partition_by=partitionings.Index(),
+            preserves_partition_by=partitionings.Arbitrary(),
             requires_partition_by=requires_partition_by))
 
   def _eval_or_query(self, name, expr, inplace, **kwargs):
@@ -1191,7 +1191,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
         lambda df: getattr(df, name)(expr, **kwargs),
         [self._expr],
         requires_partition_by=partitionings.Arbitrary(),
-        preserves_partition_by=partitionings.Index())
+        preserves_partition_by=partitionings.Arbitrary())
 
     if inplace:
       self._expr = result_expr
@@ -1273,7 +1273,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             lambda df, *deferred_others: df.join(
                 fill_placeholders(deferred_others), **kwargs),
             [self._expr] + other_exprs,
-            preserves_partition_by=partitionings.Index(),
+            preserves_partition_by=partitionings.Arbitrary(),
             requires_partition_by=partitionings.Index()))
 
   @frame_base.args_to_kwargs(pd.DataFrame)
@@ -1342,7 +1342,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
                                            suffixes=suffixes,
                                            **kwargs),
             [indexed_left._expr, indexed_right._expr],
-            preserves_partition_by=partitionings.Index(),
+            preserves_partition_by=partitionings.Arbitrary(),
             requires_partition_by=partitionings.Index()))
 
     if left_index or right_index:
@@ -1363,7 +1363,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             'nlargest-per-partition',
             lambda df: df.nlargest(**kwargs),
             [self._expr],
-            preserves_partition_by=partitionings.Index(),
+            preserves_partition_by=partitionings.Arbitrary(),
             requires_partition_by=partitionings.Arbitrary())
     with expressions.allow_non_parallel_operations(True):
       return frame_base.DeferredFrame.wrap(
@@ -1386,7 +1386,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             'nsmallest-per-partition',
             lambda df: df.nsmallest(**kwargs),
             [self._expr],
-            preserves_partition_by=partitionings.Index(),
+            preserves_partition_by=partitionings.Arbitrary(),
             requires_partition_by=partitionings.Arbitrary())
     with expressions.allow_non_parallel_operations(True):
       return frame_base.DeferredFrame.wrap(
@@ -1423,7 +1423,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             'popped',
             lambda df: df.drop(columns=[item]),
             [self._expr],
-            preserves_partition_by=partitionings.Index(),
+            preserves_partition_by=partitionings.Arbitrary(),
             requires_partition_by=partitionings.Arbitrary())
     return result
 
@@ -1622,7 +1622,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
       'update',
       inplace=True,
       requires_partition_by=partitionings.Index(),
-      preserves_partition_by=partitionings.Index())
+      preserves_partition_by=partitionings.Arbitrary())
 
   values = property(frame_base.wont_implement_method('non-deferred value'))
 
@@ -1654,7 +1654,7 @@ class DeferredGroupBy(frame_base.DeferredFrame):
             'groupby_project',
             lambda gb: getattr(gb, name), [self._expr],
             requires_partition_by=partitionings.Arbitrary(),
-            preserves_partition_by=partitionings.Index()),
+            preserves_partition_by=partitionings.Arbitrary()),
         self._kwargs,
         self._ungrouped,
         name)
@@ -1665,7 +1665,7 @@ class DeferredGroupBy(frame_base.DeferredFrame):
             'groupby_project',
             lambda gb: gb[name], [self._expr],
             requires_partition_by=partitionings.Arbitrary(),
-            preserves_partition_by=partitionings.Index()),
+            preserves_partition_by=partitionings.Arbitrary()),
         self._kwargs,
         self._ungrouped,
         name)
@@ -1681,7 +1681,7 @@ class DeferredGroupBy(frame_base.DeferredFrame):
             'agg',
             lambda df: df.agg(fn), [self._expr],
             requires_partition_by=partitionings.Index(),
-            preserves_partition_by=partitionings.Index()))
+            preserves_partition_by=partitionings.Arbitrary()))
 
   aggregate = agg
 
@@ -1741,7 +1741,7 @@ def _liftable_agg(meth, postagg_meth=None):
         ), **kwargs),
         [self._ungrouped],
         requires_partition_by=partitionings.Arbitrary(),
-        preserves_partition_by=partitionings.Index())
+        preserves_partition_by=partitionings.Arbitrary())
 
     post_agg = expressions.ComputedExpression(
         'post_combine_' + post_agg_name,
@@ -1752,7 +1752,7 @@ def _liftable_agg(meth, postagg_meth=None):
         requires_partition_by=(partitionings.Singleton()
                                if is_categorical_grouping
                                else partitionings.Index()),
-        preserves_partition_by=partitionings.Index())
+        preserves_partition_by=partitionings.Arbitrary())
     return frame_base.DeferredFrame.wrap(post_agg)
 
   return wrapper
@@ -1780,7 +1780,7 @@ def _unliftable_agg(meth):
         requires_partition_by=(partitionings.Singleton()
                                if is_categorical_grouping
                                else partitionings.Index()),
-        preserves_partition_by=partitionings.Index())
+        preserves_partition_by=partitionings.Arbitrary())
     return frame_base.DeferredFrame.wrap(post_agg)
 
   return wrapper
@@ -1929,7 +1929,7 @@ class _DeferredLoc(object):
                 partitionings.Index()
                 if len(args) > 1
                 else partitionings.Arbitrary()),
-            preserves_partition_by=partitionings.Index()))
+            preserves_partition_by=partitionings.Arbitrary()))
 
   __setitem__ = frame_base.not_implemented_method('loc.setitem')
 
@@ -1949,7 +1949,7 @@ class _DeferredILoc(object):
               lambda df: df.iloc[index],
               [self._frame._expr],
               requires_partition_by=partitionings.Arbitrary(),
-              preserves_partition_by=partitionings.Index()))
+              preserves_partition_by=partitionings.Arbitrary()))
     else:
       raise frame_base.WontImplementError('order-sensitive')
 
@@ -1993,7 +1993,7 @@ class _DeferredStringMethods(frame_base.DeferredBase):
             func,
             args,
             requires_partition_by=requires,
-            preserves_partition_by=partitionings.Index()))
+            preserves_partition_by=partitionings.Arbitrary()))
 
   @frame_base.args_to_kwargs(pd.core.strings.StringMethods)
   def repeat(self, repeats):
@@ -2008,7 +2008,7 @@ class _DeferredStringMethods(frame_base.DeferredBase):
               # fix.
               proxy=self._expr.proxy(),
               requires_partition_by=partitionings.Arbitrary(),
-              preserves_partition_by=partitionings.Index()))
+              preserves_partition_by=partitionings.Arbitrary()))
     elif isinstance(repeats, frame_base.DeferredBase):
       return frame_base.DeferredFrame.wrap(
           expressions.ComputedExpression(
@@ -2020,7 +2020,7 @@ class _DeferredStringMethods(frame_base.DeferredBase):
               # fix.
               proxy=self._expr.proxy(),
               requires_partition_by=partitionings.Index(),
-              preserves_partition_by=partitionings.Index()))
+              preserves_partition_by=partitionings.Arbitrary()))
     elif isinstance(repeats, list):
       raise frame_base.WontImplementError("repeats must be an integer or a "
                                           "Series.")

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -86,7 +86,7 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
       # need to collect the entire dataframe.
       requires = partitionings.Singleton()
     else:
-      requires = partitionings.Nothing()
+      requires = partitionings.Arbitrary()
 
     return frame_base.DeferredFrame.wrap(
         expressions.ComputedExpression(
@@ -107,7 +107,7 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
         expressions.ComputedExpression(
             'droplevel',
             lambda df: df.droplevel(level, axis=axis), [self._expr],
-            requires_partition_by=partitionings.Nothing(),
+            requires_partition_by=partitionings.Arbitrary(),
             preserves_partition_by=partitionings.Index()
             if axis in (1, 'column') else partitionings.Singleton()))
 
@@ -137,7 +137,7 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
             value: df.fillna(value, method=method, axis=axis, **kwargs),
             [self._expr, value_expr],
             preserves_partition_by=partitionings.Index(),
-            requires_partition_by=partitionings.Nothing()))
+            requires_partition_by=partitionings.Arbitrary()))
 
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)
@@ -165,7 +165,7 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
           expressions.ComputedExpression(
               'groupbycols',
               lambda df: df.groupby(by, axis=axis, **kwargs), [self._expr],
-              requires_partition_by=partitionings.Nothing(),
+              requires_partition_by=partitionings.Arbitrary(),
               preserves_partition_by=partitionings.Index()))
 
     if level is None and by is None:
@@ -194,7 +194,7 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
       to_group = expressions.ComputedExpression(
           'map_index',
           map_index, [self._expr],
-          requires_partition_by=partitionings.Nothing(),
+          requires_partition_by=partitionings.Arbitrary(),
           preserves_partition_by=partitionings.Singleton())
 
     elif isinstance(by, DeferredSeries):
@@ -274,7 +274,7 @@ class DeferredSeries(DeferredDataFrameOrSeries):
               'getitem',
               lambda df: df[key],
               [self._expr],
-              requires_partition_by=partitionings.Nothing(),
+              requires_partition_by=partitionings.Arbitrary(),
               preserves_partition_by=partitionings.Index()))
 
     elif isinstance(key, DeferredSeries) and key._expr.proxy().dtype == bool:
@@ -316,7 +316,7 @@ class DeferredSeries(DeferredDataFrameOrSeries):
       # requirement, and include it in raised errors.
       requires = partitionings.Singleton()
     else:
-      requires = partitionings.Nothing()
+      requires = partitionings.Arbitrary()
 
     return frame_base.DeferredFrame.wrap(
         expressions.ComputedExpression(
@@ -358,7 +358,7 @@ class DeferredSeries(DeferredDataFrameOrSeries):
       right = expressions.ComputedExpression(
           'to_dataframe',
           pd.DataFrame, [other._expr],
-          requires_partition_by=partitionings.Nothing(),
+          requires_partition_by=partitionings.Arbitrary(),
           preserves_partition_by=partitionings.Index())
       right_is_series = True
     elif isinstance(other, DeferredDataFrame):
@@ -433,7 +433,7 @@ class DeferredSeries(DeferredDataFrameOrSeries):
     moments = expressions.ComputedExpression(
         'compute_moments',
         compute_moments, [self._expr],
-        requires_partition_by=partitionings.Nothing())
+        requires_partition_by=partitionings.Arbitrary())
     with expressions.allow_non_parallel_operations(True):
       return frame_base.DeferredFrame.wrap(
           expressions.ComputedExpression(
@@ -528,7 +528,7 @@ class DeferredSeries(DeferredDataFrameOrSeries):
             'dropna',
             lambda df: df.dropna(**kwargs), [self._expr],
             preserves_partition_by=partitionings.Index(),
-            requires_partition_by=partitionings.Nothing()))
+            requires_partition_by=partitionings.Arbitrary()))
 
   items = iteritems = frame_base.wont_implement_method('non-lazy')
 
@@ -555,7 +555,7 @@ class DeferredSeries(DeferredDataFrameOrSeries):
         intermediate = expressions.ComputedExpression(
             'pre_aggregate',
             lambda s: s.agg([base_func], *args, **kwargs), [self._expr],
-            requires_partition_by=partitionings.Nothing(),
+            requires_partition_by=partitionings.Arbitrary(),
             preserves_partition_by=partitionings.Singleton())
         allow_nonparallel_final = True
       else:
@@ -615,7 +615,7 @@ class DeferredSeries(DeferredDataFrameOrSeries):
         'nlargest-per-partition',
         lambda df: df.nlargest(**kwargs), [self._expr],
         preserves_partition_by=partitionings.Index(),
-        requires_partition_by=partitionings.Nothing())
+        requires_partition_by=partitionings.Arbitrary())
     with expressions.allow_non_parallel_operations(True):
       return frame_base.DeferredFrame.wrap(
           expressions.ComputedExpression(
@@ -636,7 +636,7 @@ class DeferredSeries(DeferredDataFrameOrSeries):
         'nsmallest-per-partition',
         lambda df: df.nsmallest(**kwargs), [self._expr],
         preserves_partition_by=partitionings.Index(),
-        requires_partition_by=partitionings.Nothing())
+        requires_partition_by=partitionings.Arbitrary())
     with expressions.allow_non_parallel_operations(True):
       return frame_base.DeferredFrame.wrap(
           expressions.ComputedExpression(
@@ -662,7 +662,7 @@ class DeferredSeries(DeferredDataFrameOrSeries):
       raise frame_base.WontImplementError("order-sensitive")
 
     if limit is None:
-      requires_partition_by = partitionings.Nothing()
+      requires_partition_by = partitionings.Arbitrary()
     else:
       requires_partition_by = partitionings.Singleton()
     return frame_base.DeferredFrame.wrap(
@@ -747,7 +747,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
         expressions.ComputedExpression(
             'set_columns',
             set_columns, [self._expr],
-            requires_partition_by=partitionings.Nothing(),
+            requires_partition_by=partitionings.Arbitrary(),
             preserves_partition_by=partitionings.Index()))
 
   def keys(self):
@@ -824,7 +824,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
       # Could probably get by partitioning on the used levels.
       requires_partition_by = partitionings.Singleton()
     elif axis in ('columns', 1):
-      requires_partition_by = partitionings.Nothing()
+      requires_partition_by = partitionings.Arbitrary()
     else:
       requires_partition_by = partitionings.Index()
     return frame_base.DeferredFrame.wrap(
@@ -854,7 +854,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             'append',
             lambda s, other: s.append(other, sort=sort, **kwargs),
             [self._expr, other._expr],
-            requires_partition_by=partitionings.Nothing(),
+            requires_partition_by=partitionings.Arbitrary(),
             preserves_partition_by=partitionings.Index()
         )
     )
@@ -876,7 +876,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
           'set_index',
           lambda df: df.set_index(keys, **kwargs),
           [self._expr],
-          requires_partition_by=partitionings.Nothing(),
+          requires_partition_by=partitionings.Arbitrary(),
           preserves_partition_by=partitionings.Singleton()))
 
   @property
@@ -916,7 +916,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             lambda df: df.explode(column, ignore_index),
             [self._expr],
             preserves_partition_by=preserves,
-            requires_partition_by=partitionings.Nothing()))
+            requires_partition_by=partitionings.Arbitrary()))
 
 
 
@@ -933,7 +933,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
               'aggregate',
               lambda df: df.agg(func, axis=1, *args, **kwargs),
               [self._expr],
-              requires_partition_by=partitionings.Nothing()))
+              requires_partition_by=partitionings.Arbitrary()))
     elif len(self._expr.proxy().columns) == 0 or args or kwargs:
       # For these corner cases, just colocate everything.
       return frame_base.DeferredFrame.wrap(
@@ -1137,7 +1137,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             'dot',
             lambda left, right: left @ right.value,
             [self._expr, side],
-            requires_partition_by=partitionings.Nothing(),
+            requires_partition_by=partitionings.Arbitrary(),
             preserves_partition_by=partitionings.Index(),
             proxy=proxy))
 
@@ -1167,7 +1167,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
     if axis == 1 or axis == 'columns':
       requires_partition_by = partitionings.Singleton()
     else:
-      requires_partition_by = partitionings.Nothing()
+      requires_partition_by = partitionings.Arbitrary()
     return frame_base.DeferredFrame.wrap(
         expressions.ComputedExpression(
             'dropna',
@@ -1190,7 +1190,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
         name,
         lambda df: getattr(df, name)(expr, **kwargs),
         [self._expr],
-        requires_partition_by=partitionings.Nothing(),
+        requires_partition_by=partitionings.Arbitrary(),
         preserves_partition_by=partitionings.Index())
 
     if inplace:
@@ -1229,7 +1229,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
                   .reset_index().set_index(cols),
               [df._expr],
               preserves_partition_by=partitionings.Singleton(),
-              requires_partition_by=partitionings.Nothing()))
+              requires_partition_by=partitionings.Arbitrary()))
     def revert(df):
       return frame_base.DeferredFrame.wrap(
           expressions.ComputedExpression(
@@ -1239,7 +1239,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
                   .rename_axis(index=original_index_names, copy=False),
               [df._expr],
               preserves_partition_by=partitionings.Singleton(),
-              requires_partition_by=partitionings.Nothing()))
+              requires_partition_by=partitionings.Arbitrary()))
     return reindex, revert
 
   @frame_base.args_to_kwargs(pd.DataFrame)
@@ -1364,7 +1364,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             lambda df: df.nlargest(**kwargs),
             [self._expr],
             preserves_partition_by=partitionings.Index(),
-            requires_partition_by=partitionings.Nothing())
+            requires_partition_by=partitionings.Arbitrary())
     with expressions.allow_non_parallel_operations(True):
       return frame_base.DeferredFrame.wrap(
           expressions.ComputedExpression(
@@ -1387,7 +1387,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             lambda df: df.nsmallest(**kwargs),
             [self._expr],
             preserves_partition_by=partitionings.Index(),
-            requires_partition_by=partitionings.Nothing())
+            requires_partition_by=partitionings.Arbitrary())
     with expressions.allow_non_parallel_operations(True):
       return frame_base.DeferredFrame.wrap(
           expressions.ComputedExpression(
@@ -1400,7 +1400,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
   @frame_base.args_to_kwargs(pd.DataFrame)
   def nunique(self, **kwargs):
     if kwargs.get('axis', None) in (1, 'columns'):
-      requires_partition_by = partitionings.Nothing()
+      requires_partition_by = partitionings.Arbitrary()
       preserves_partition_by = partitionings.Index()
     else:
       # TODO: This could be implemented in a distributed fashion
@@ -1424,8 +1424,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             lambda df: df.drop(columns=[item]),
             [self._expr],
             preserves_partition_by=partitionings.Index(),
-            requires_partition_by=partitionings.Nothing())
-
+            requires_partition_by=partitionings.Arbitrary())
     return result
 
   @frame_base.args_to_kwargs(pd.DataFrame)
@@ -1464,7 +1463,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
       # Renaming index with checking requires global index.
       requires_partition_by = partitionings.Singleton()
     else:
-      requires_partition_by = partitionings.Nothing()
+      requires_partition_by = partitionings.Arbitrary()
 
     proxy = None
     if rename_index:
@@ -1495,7 +1494,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
   @frame_base.maybe_inplace
   def replace(self, limit, **kwargs):
     if limit is None:
-      requires_partition_by = partitionings.Nothing()
+      requires_partition_by = partitionings.Arbitrary()
     else:
       requires_partition_by = partitionings.Singleton()
     return frame_base.DeferredFrame.wrap(
@@ -1518,7 +1517,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
       # TODO: Could do distributed re-index with offsets.
       requires_partition_by = partitionings.Singleton()
     else:
-      requires_partition_by = partitionings.Nothing()
+      requires_partition_by = partitionings.Arbitrary()
     return frame_base.DeferredFrame.wrap(
         expressions.ComputedExpression(
             'reset_index',
@@ -1543,7 +1542,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             'round',
             lambda df: df.round(decimals, *args, **kwargs),
             [self._expr],
-            requires_partition_by=partitionings.Nothing(),
+            requires_partition_by=partitionings.Arbitrary(),
             preserves_partition_by=partitionings.Index()
         )
     )
@@ -1556,7 +1555,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
     if 'freq' in kwargs:
       raise frame_base.WontImplementError('data-dependent')
     if axis == 1 or axis == 'columns':
-      requires_partition_by = partitionings.Nothing()
+      requires_partition_by = partitionings.Arbitrary()
     else:
       requires_partition_by = partitionings.Singleton()
     return frame_base.DeferredFrame.wrap(
@@ -1576,7 +1575,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
   @frame_base.maybe_inplace
   def sort_values(self, axis, **kwargs):
     if axis == 1 or axis == 'columns':
-      requires_partition_by = partitionings.Nothing()
+      requires_partition_by = partitionings.Arbitrary()
     else:
       requires_partition_by = partitionings.Singleton()
     return frame_base.DeferredFrame.wrap(
@@ -1654,7 +1653,7 @@ class DeferredGroupBy(frame_base.DeferredFrame):
         expressions.ComputedExpression(
             'groupby_project',
             lambda gb: getattr(gb, name), [self._expr],
-            requires_partition_by=partitionings.Nothing(),
+            requires_partition_by=partitionings.Arbitrary(),
             preserves_partition_by=partitionings.Index()),
         self._kwargs,
         self._ungrouped,
@@ -1665,7 +1664,7 @@ class DeferredGroupBy(frame_base.DeferredFrame):
         expressions.ComputedExpression(
             'groupby_project',
             lambda gb: gb[name], [self._expr],
-            requires_partition_by=partitionings.Nothing(),
+            requires_partition_by=partitionings.Arbitrary(),
             preserves_partition_by=partitionings.Index()),
         self._kwargs,
         self._ungrouped,
@@ -1741,7 +1740,7 @@ def _liftable_agg(meth, postagg_meth=None):
                    **preagg_groupby_kwargs),
         ), **kwargs),
         [self._ungrouped],
-        requires_partition_by=partitionings.Nothing(),
+        requires_partition_by=partitionings.Arbitrary(),
         preserves_partition_by=partitionings.Index())
 
     post_agg = expressions.ComputedExpression(
@@ -1929,7 +1928,7 @@ class _DeferredLoc(object):
             requires_partition_by=(
                 partitionings.Index()
                 if len(args) > 1
-                else partitionings.Nothing()),
+                else partitionings.Arbitrary()),
             preserves_partition_by=partitionings.Index()))
 
   __setitem__ = frame_base.not_implemented_method('loc.setitem')
@@ -1949,7 +1948,7 @@ class _DeferredILoc(object):
               'iloc',
               lambda df: df.iloc[index],
               [self._frame._expr],
-              requires_partition_by=partitionings.Nothing(),
+              requires_partition_by=partitionings.Arbitrary(),
               preserves_partition_by=partitionings.Index()))
     else:
       raise frame_base.WontImplementError('order-sensitive')
@@ -2008,7 +2007,7 @@ class _DeferredStringMethods(frame_base.DeferredBase):
               # Currently it incorrectly infers dtype bool, may require upstream
               # fix.
               proxy=self._expr.proxy(),
-              requires_partition_by=partitionings.Nothing(),
+              requires_partition_by=partitionings.Arbitrary(),
               preserves_partition_by=partitionings.Index()))
     elif isinstance(repeats, frame_base.DeferredBase):
       return frame_base.DeferredFrame.wrap(

--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -236,6 +236,12 @@ class DeferredFrameTest(unittest.TestCase):
     self._run_test(
         lambda df: df.groupby('bad').foo.sum(), df, expect_error=True)
 
+  def test_groupby_callable(self):
+    df = GROUPBY_DF
+
+    self._run_test(lambda df: df.groupby(lambda x: x % 2).foo.sum(), df)
+    self._run_test(lambda df: df.groupby(lambda x: x % 5).median(), df)
+
   def test_set_index(self):
     df = pd.DataFrame({
         # [19, 18, ..]

--- a/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
@@ -56,7 +56,6 @@ class DoctestTest(unittest.TestCase):
                 "df.nsmallest(3, ['population', 'GDP'])",
                 "df.nsmallest(3, 'population', keep='last')",
             ],
-            'pandas.core.frame.DataFrame.nunique': ['*'],
             'pandas.core.frame.DataFrame.replace': [
                 "s.replace([1, 2], method='bfill')",
                 # Relies on method='pad'

--- a/sdks/python/apache_beam/dataframe/pandas_top_level_functions.py
+++ b/sdks/python/apache_beam/dataframe/pandas_top_level_functions.py
@@ -107,6 +107,16 @@ class DeferredPandasModule(object):
       objs = [objs[k] for k in keys]
     else:
       objs = list(objs)
+
+    if keys is None:
+      preserves_partitioning = partitionings.Arbitrary()
+    else:
+      # Index 0 will be a new index for keys, only partitioning by the original
+      # indexes (1 to N) will be preserved.
+      nlevels = min(o._expr.proxy().index.nlevels for o in objs)
+      preserves_partitioning = partitionings.Index(
+          [i for i in range(1, nlevels + 1)])
+
     deferred_none = expressions.ConstantExpression(None)
     exprs = [deferred_none if o is None else o._expr for o in objs]
 
@@ -131,7 +141,7 @@ class DeferredPandasModule(object):
                 verify_integrity=verify_integrity),  # yapf break
             exprs,
             requires_partition_by=required_partitioning,
-            preserves_partition_by=partitionings.Arbitrary()))
+            preserves_partition_by=preserves_partitioning))
 
   date_range = _defer_to_pandas('date_range')
   describe_option = _defer_to_pandas('describe_option')

--- a/sdks/python/apache_beam/dataframe/pandas_top_level_functions.py
+++ b/sdks/python/apache_beam/dataframe/pandas_top_level_functions.py
@@ -115,7 +115,7 @@ class DeferredPandasModule(object):
     elif verify_integrity:
       required_partitioning = partitionings.Index()
     else:
-      required_partitioning = partitionings.Nothing()
+      required_partitioning = partitionings.Arbitrary()
 
     return frame_base.DeferredBase.wrap(
         expressions.ComputedExpression(

--- a/sdks/python/apache_beam/dataframe/pandas_top_level_functions.py
+++ b/sdks/python/apache_beam/dataframe/pandas_top_level_functions.py
@@ -131,7 +131,7 @@ class DeferredPandasModule(object):
                 verify_integrity=verify_integrity),  # yapf break
             exprs,
             requires_partition_by=required_partitioning,
-            preserves_partition_by=partitionings.Index()))
+            preserves_partition_by=partitionings.Arbitrary()))
 
   date_range = _defer_to_pandas('date_range')
   describe_option = _defer_to_pandas('describe_option')

--- a/sdks/python/apache_beam/dataframe/partitionings.py
+++ b/sdks/python/apache_beam/dataframe/partitionings.py
@@ -41,6 +41,12 @@ class Partitioning(object):
     """
     raise NotImplementedError
 
+  def __lt__(self, other):
+    return self != other and self <= other
+
+  def __le__(self, other):
+    return not self.is_subpartitioning_of(other)
+
   def partition_fn(self, df, num_partitions):
     # type: (Frame, int) -> Iterable[Tuple[Any, Frame]]
 

--- a/sdks/python/apache_beam/dataframe/partitionings.py
+++ b/sdks/python/apache_beam/dataframe/partitionings.py
@@ -63,7 +63,7 @@ class Index(Partitioning):
 
   These form a partial order, given by
 
-      Nothing() < Index([i]) < Index([i, j]) < ... < Index() < Singleton()
+      Singleton() < Index([i]) < Index([i, j]) < ... < Index() < Nothing()
 
   The ordering is implemented via the is_subpartitioning_of method, where the
   examples on the right are subpartitionings of the examples on the left above.
@@ -90,7 +90,7 @@ class Index(Partitioning):
       return hash(type(self))
 
   def is_subpartitioning_of(self, other):
-    if isinstance(other, Nothing):
+    if isinstance(other, Singleton):
       return True
     elif isinstance(other, Index):
       if self._levels is None:
@@ -99,8 +99,10 @@ class Index(Partitioning):
         return False
       else:
         return all(level in other._levels for level in self._levels)
-    else:
+    elif isinstance(other, Nothing):
       return False
+    else:
+      raise ValueError(f"Encountered unknown type {other!r}")
 
   def partition_fn(self, df, num_partitions):
     if self._levels is None:
@@ -147,7 +149,7 @@ class Singleton(Partitioning):
     return hash(type(self))
 
   def is_subpartitioning_of(self, other):
-    return True
+    return isinstance(other, Singleton)
 
   def partition_fn(self, df, num_partitions):
     yield None, df
@@ -169,7 +171,7 @@ class Nothing(Partitioning):
     return hash(type(self))
 
   def is_subpartitioning_of(self, other):
-    return isinstance(other, Nothing)
+    return True
 
   def test_partition_fn(self, df):
     num_partitions = 10

--- a/sdks/python/apache_beam/dataframe/partitionings.py
+++ b/sdks/python/apache_beam/dataframe/partitionings.py
@@ -69,7 +69,7 @@ class Index(Partitioning):
 
   These form a partial order, given by
 
-      Singleton() < Index([i]) < Index([i, j]) < ... < Index() < Nothing()
+      Singleton() < Index([i]) < Index([i, j]) < ... < Index() < Arbitrary()
 
   The ordering is implemented via the is_subpartitioning_of method, where the
   examples on the right are subpartitionings of the examples on the left above.
@@ -105,7 +105,7 @@ class Index(Partitioning):
         return False
       else:
         return all(level in self._levels for level in other._levels)
-    elif isinstance(other, Nothing):
+    elif isinstance(other, Arbitrary):
       return False
     else:
       raise ValueError(f"Encountered unknown type {other!r}")
@@ -170,7 +170,7 @@ class Singleton(Partitioning):
     return len(dfs) <= 1
 
 
-class Nothing(Partitioning):
+class Arbitrary(Partitioning):
   """A partitioning imposing no constraints on the actual partitioning.
   """
   def __eq__(self, other):

--- a/sdks/python/apache_beam/dataframe/partitionings.py
+++ b/sdks/python/apache_beam/dataframe/partitionings.py
@@ -104,7 +104,7 @@ class Index(Partitioning):
       elif other._levels is None:
         return False
       else:
-        return all(level in other._levels for level in self._levels)
+        return all(level in self._levels for level in other._levels)
     elif isinstance(other, Nothing):
       return False
     else:

--- a/sdks/python/apache_beam/dataframe/partitionings_test.py
+++ b/sdks/python/apache_beam/dataframe/partitionings_test.py
@@ -18,8 +18,8 @@ import unittest
 
 import pandas as pd
 
+from apache_beam.dataframe.partitionings import Arbitrary
 from apache_beam.dataframe.partitionings import Index
-from apache_beam.dataframe.partitionings import Nothing
 from apache_beam.dataframe.partitionings import Singleton
 
 
@@ -34,7 +34,9 @@ class PartitioningsTest(unittest.TestCase):
   }).set_index(['shape', 'color', 'size'])
 
   def test_index_is_subpartition(self):
-    ordered_list = [Singleton(), Index([3]), Index([1, 3]), Index(), Nothing()]
+    ordered_list = [
+        Singleton(), Index([3]), Index([1, 3]), Index(), Arbitrary()
+    ]
     for loose, strict in zip(ordered_list[:-1], ordered_list[1:]):
       self.assertTrue(strict.is_subpartitioning_of(loose), (strict, loose))
       self.assertFalse(loose.is_subpartitioning_of(strict), (loose, strict))
@@ -64,11 +66,11 @@ class PartitioningsTest(unittest.TestCase):
 
   def test_nothing_subpartition(self):
     for p in [Index([1]), Index([1, 2]), Index(), Singleton()]:
-      self.assertTrue(Nothing().is_subpartitioning_of(p), p)
+      self.assertTrue(Arbitrary().is_subpartitioning_of(p), p)
 
   def test_singleton_subpartition(self):
     self.assertTrue(Singleton().is_subpartitioning_of(Singleton()))
-    for p in [Nothing(), Index([1]), Index([1, 2]), Index()]:
+    for p in [Arbitrary(), Index([1]), Index([1, 2]), Index()]:
       self.assertFalse(Singleton().is_subpartitioning_of(p), p)
 
   def test_singleton_partition(self):

--- a/sdks/python/apache_beam/dataframe/partitionings_test.py
+++ b/sdks/python/apache_beam/dataframe/partitionings_test.py
@@ -34,7 +34,7 @@ class PartitioningsTest(unittest.TestCase):
   }).set_index(['shape', 'color', 'size'])
 
   def test_index_is_subpartition(self):
-    ordered_list = [Nothing(), Index([3]), Index([1, 3]), Index(), Singleton()]
+    ordered_list = [Singleton(), Index([3]), Index([1, 3]), Index(), Nothing()]
     for loose, strict in zip(ordered_list[:1], ordered_list[1:]):
       self.assertTrue(strict.is_subpartitioning_of(loose), (strict, loose))
       self.assertFalse(loose.is_subpartitioning_of(strict), (loose, strict))
@@ -63,13 +63,13 @@ class PartitioningsTest(unittest.TestCase):
     self._check_partition(Index(), 7, 24)
 
   def test_nothing_subpartition(self):
-    self.assertTrue(Nothing().is_subpartitioning_of(Nothing()))
     for p in [Index([1]), Index([1, 2]), Index(), Singleton()]:
-      self.assertFalse(Nothing().is_subpartitioning_of(p), p)
+      self.assertTrue(Nothing().is_subpartitioning_of(p), p)
 
   def test_singleton_subpartition(self):
-    for p in [Nothing(), Index([1]), Index([1, 2]), Index(), Singleton()]:
-      self.assertTrue(Singleton().is_subpartitioning_of(p), p)
+    self.assertTrue(Singleton().is_subpartitioning_of(Singleton()))
+    for p in [Nothing(), Index([1]), Index([1, 2]), Index()]:
+      self.assertFalse(Singleton().is_subpartitioning_of(p), p)
 
   def test_singleton_partition(self):
     parts = list(Singleton().partition_fn(pd.Series(range(10)), 1000))

--- a/sdks/python/apache_beam/dataframe/partitionings_test.py
+++ b/sdks/python/apache_beam/dataframe/partitionings_test.py
@@ -35,7 +35,7 @@ class PartitioningsTest(unittest.TestCase):
 
   def test_index_is_subpartition(self):
     ordered_list = [Singleton(), Index([3]), Index([1, 3]), Index(), Nothing()]
-    for loose, strict in zip(ordered_list[:1], ordered_list[1:]):
+    for loose, strict in zip(ordered_list[:-1], ordered_list[1:]):
       self.assertTrue(strict.is_subpartitioning_of(loose), (strict, loose))
       self.assertFalse(loose.is_subpartitioning_of(strict), (loose, strict))
     # Incomparable.

--- a/sdks/python/apache_beam/dataframe/transforms.py
+++ b/sdks/python/apache_beam/dataframe/transforms.py
@@ -280,30 +280,42 @@ class _DataframeExpressionsTransform(transforms.PTransform):
                 self.outputs))
 
     # First define some helper functions.
-    def output_is_partitioned_by(expr, stage, partitioning):
-      if partitioning == partitionings.Nothing():
-        # Always satisfied.
-        return True
-      elif stage.partitioning == partitionings.Singleton():
-        # Within a stage, the singleton partitioning is trivially preserved.
-        return True
-      elif expr in stage.inputs:
+    def output_partitioning_in_stage(expr, stage):
+      """Return the output partitioning of expr when computed in stage,
+      or returns None if the expression cannot be computed in this stage.
+      """
+      if expr in stage.inputs or expr in inputs:
         # Inputs are all partitioned by stage.partitioning.
-        return stage.partitioning.is_subpartitioning_of(partitioning)
-      elif expr.preserves_partition_by().is_subpartitioning_of(partitioning):
-        # Here expr preserves at least the requested partitioning; its outputs
-        # will also have this partitioning iff its inputs do.
-        if expr.requires_partition_by().is_subpartitioning_of(partitioning):
-          # If expr requires at least this partitioning, we will arrange such
-          # that its inputs satisfy this.
-          return True
-        else:
-          # Otherwise, recursively check all the inputs.
-          return all(
-              output_is_partitioned_by(arg, stage, partitioning)
-              for arg in expr.args())
-      else:
-        return False
+        return stage.partitioning
+
+      # Anything that's not an input must have arguments
+      assert len(expr.args())
+
+      arg_partitionings = set(
+          output_partitioning_in_stage(arg, stage) for arg in expr.args()
+          if not is_scalar(arg))
+
+      if len(arg_partitionings) == 0:
+        # All inputs are scalars, output partitioning isn't dependent on the
+        # input.
+        return expr.preserves_partition_by()
+
+      if len(arg_partitionings) > 1:
+        # Arguments must be identically partitioned, can't compute this
+        # expression here.
+        return None
+
+      arg_partitioning = arg_partitionings.pop()
+
+      if not expr.requires_partition_by().is_subpartitioning_of(
+          arg_partitioning):
+        # Arguments aren't partitioned sufficiently for this expression
+        return None
+
+      return expressions.output_partitioning(expr, arg_partitioning)
+
+    def is_computable_in_stage(expr, stage):
+      return output_partitioning_in_stage(expr, stage) is not None
 
     def common_stages(stage_lists):
       # Set intersection, with a preference for earlier items in the list.
@@ -329,8 +341,7 @@ class _DataframeExpressionsTransform(transforms.PTransform):
       required_partitioning = expr.requires_partition_by()
       for stage in common_stages([expr_to_stages(arg) for arg in expr.args()
                                   if arg not in inputs]):
-        if all(output_is_partitioned_by(arg, stage, required_partitioning)
-               for arg in expr.args() if not is_scalar(arg)):
+        if is_computable_in_stage(expr, stage):
           break
       else:
         # Otherwise, compute this expression as part of a new stage.

--- a/sdks/python/apache_beam/dataframe/transforms.py
+++ b/sdks/python/apache_beam/dataframe/transforms.py
@@ -171,7 +171,7 @@ class _DataframeExpressionsTransform(transforms.PTransform):
         if len(tabular_inputs) == 0:
           partitioned_pcoll = next(pcolls.values()).pipeline | beam.Create([{}])
 
-        elif self.stage.partitioning != partitionings.Nothing():
+        elif self.stage.partitioning != partitionings.Arbitrary():
           # Partitioning required for these operations.
           # Compute the number of partitions to use for the inputs based on
           # the estimated size of the inputs.
@@ -255,7 +255,7 @@ class _DataframeExpressionsTransform(transforms.PTransform):
       """
       def __init__(self, inputs, partitioning):
         self.inputs = set(inputs)
-        if len(self.inputs) > 1 and partitioning == partitionings.Nothing():
+        if len(self.inputs) > 1 and partitioning == partitionings.Arbitrary():
           # We have to shuffle to co-locate, might as well partition.
           self.partitioning = partitionings.Index()
         else:
@@ -400,7 +400,7 @@ class _DataframeExpressionsTransform(transforms.PTransform):
         expr_stage = expr_to_stage(expr)
         # If the stage doesn't start with a shuffle, it's not safe to fuse
         # the computation into its parent either.
-        has_shuffle = expr_stage.partitioning != partitionings.Nothing()
+        has_shuffle = expr_stage.partitioning != partitionings.Arbitrary()
         # We assume the size of an expression is the sum of the size of its
         # inputs, which may be off by quite a bit, but the goal is to get
         # within an order of magnitude or two.


### PR DESCRIPTION
This modifies the ordering defined by is_subpartitioning_of from:
```
Nothing() < Index([i]) < Index([i, j]) < ... < Index() < Singleton()
```
to:
```
Singleton() < Index([i]) < Index([i, j]) < ... < Index() < Nothing()
```

Which is more logical, since `Singleton()` is equivalent to `Index([])`. The rest of the PR deals with the fallout from this change, which largely entails updating `preserves_partition_by` specs for computed expressions (e0aba2d), and updating the logic for fusing stages (29f41c0). It also includes a patch to have `Index.check` make a strong assertion about partioning, as discussed in BEAM-11324 (29f41c0), and removes the "difficulty" ordering key used in `PartitioningSession`, as this is now equivalent to the standard ordering.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
