### PR TITLE
[BEAM-9547] Add groupby doctests

### DIFF
--- a/sdks/python/apache_beam/dataframe/doctests.py
+++ b/sdks/python/apache_beam/dataframe/doctests.py
@@ -619,14 +619,6 @@ def teststrings(texts, report=False, **runner_kwargs):
   return runner.summary().result()
 
 
-def testfile(*args, **kwargs):
-  return _run_patched(doctest.testfile, *args, **kwargs)
-
-
-def testmod(*args, **kwargs):
-  return _run_patched(doctest.testmod, *args, **kwargs)
-
-
 def set_pandas_options():
   # See
   # https://github.com/pandas-dev/pandas/blob/a00202d12d399662b8045a8dd3fdac04f18e1e55/doc/source/conf.py#L319
@@ -666,3 +658,53 @@ def _run_patched(func, *args, **kwargs):
           *args, extraglobs=extraglobs, optionflags=optionflags, **kwargs)
   finally:
     doctest.DocTestRunner = original_doc_test_runner
+
+
+def with_run_patched_docstring(target=None):
+  assert target is not None
+  def wrapper(fn):
+    fn.__doc__ = f"""Run all pandas doctests in the specified {target}.
+
+    Arguments `skip`, `wont_implement_ok`, `not_implemented_ok` are all in the
+    format::
+
+      {{
+         "module.Class.method": ['*'],
+         "module.Class.other_method": [
+           'instance.other_method(bad_input)',
+           'observe_result_of_bad_input()',
+         ],
+      }}
+
+    `'*'` indicates all examples should be matched, otherwise the list is a list
+    of specific input strings that should be matched.
+
+    All arguments are kwargs.
+
+    Args:
+      optionflags (int): Passed through to doctests.
+      extraglobs (Dict[str,Any]): Passed through to doctests.
+      use_beam (bool): If true, run a Beam pipeline with partitioned input to
+        verify the examples, else use PartitioningSession to simulate
+        distributed execution.
+      skip (Dict[str,str]): A set of examples to skip entirely.
+      wont_implement_ok (Dict[str,str]): A set of examples that are allowed to
+        raise WontImplementError.
+      not_implemented_ok (Dict[str,str]): A set of examples that are allowed to
+        raise NotImplementedError.
+
+    Returns:
+      ~doctest.TestResult: A doctest result describing the passed/failed tests.
+    """
+    return fn
+  return wrapper
+
+
+@with_run_patched_docstring(target="file")
+def testfile(*args, **kwargs):
+  return _run_patched(doctest.testfile, *args, **kwargs)
+
+
+@with_run_patched_docstring(target="module")
+def testmod(*args, **kwargs):
+  return _run_patched(doctest.testmod, *args, **kwargs)

--- a/sdks/python/apache_beam/dataframe/doctests.py
+++ b/sdks/python/apache_beam/dataframe/doctests.py
@@ -662,6 +662,7 @@ def _run_patched(func, *args, **kwargs):
 
 def with_run_patched_docstring(target=None):
   assert target is not None
+
   def wrapper(fn):
     fn.__doc__ = f"""Run all pandas doctests in the specified {target}.
 
@@ -694,9 +695,10 @@ def with_run_patched_docstring(target=None):
         raise NotImplementedError.
 
     Returns:
-      ~doctest.TestResult: A doctest result describing the passed/failed tests.
+      ~doctest.TestResults: A doctest result describing the passed/failed tests.
     """
     return fn
+
   return wrapper
 
 

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -247,6 +247,8 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
   index = property(
       _get_index, frame_base.not_implemented_method('index (setter)'))
 
+  hist = frame_base.wont_implement_method('plot')
+
 
 @populate_not_implemented(pd.Series)
 @frame_base.DeferredFrame._register_for(pd.Series)
@@ -1637,8 +1639,19 @@ class DeferredGroupBy(frame_base.DeferredFrame):
 
   aggregate = agg
 
-  first = last = head = tail = frame_base.wont_implement_method(
-      'order sensitive')
+  hist = frame_base.wont_implement_method('plot')
+  plot = frame_base.wont_implement_method('plot')
+
+  first = frame_base.wont_implement_method('order sensitive')
+  last = frame_base.wont_implement_method('order sensitive')
+  head = frame_base.wont_implement_method('order sensitive')
+  tail = frame_base.wont_implement_method('order sensitive')
+  nth = frame_base.wont_implement_method('order sensitive')
+  cumcount = frame_base.wont_implement_method('order sensitive')
+  cummax = frame_base.wont_implement_method('order sensitive')
+  cummin = frame_base.wont_implement_method('order sensitive')
+  cumsum = frame_base.wont_implement_method('order sensitive')
+  cumprod = frame_base.wont_implement_method('order sensitive')
 
   # TODO(robertwb): Consider allowing this for categorical keys.
   __len__ = frame_base.wont_implement_method('non-deferred')

--- a/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
@@ -428,6 +428,8 @@ class DoctestTest(unittest.TestCase):
             'pandas.core.groupby.groupby.GroupBy.sample': ['*'],
             'pandas.core.groupby.groupby.GroupBy.quantile': ['*'],
             'pandas.core.groupby.groupby.BaseGroupBy.pipe': ['*'],
+            # pipe tests are in a different location in pandas 1.1.x
+            'pandas.core.groupby.groupby._GroupBy.pipe': ['*'],
             'pandas.core.groupby.groupby.GroupBy.nth': [
                 "df.groupby('A', as_index=False).nth(1)",
             ],

--- a/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
@@ -426,7 +426,6 @@ class DoctestTest(unittest.TestCase):
             'pandas.core.groupby.groupby.GroupBy.ngroup': ['*'],
             'pandas.core.groupby.groupby.GroupBy.resample': ['*'],
             'pandas.core.groupby.groupby.GroupBy.sample': ['*'],
-            'pandas.core.groupby.groupby.GroupBy.resample': ['*'],
             'pandas.core.groupby.groupby.GroupBy.quantile': ['*'],
             'pandas.core.groupby.groupby.BaseGroupBy.pipe': ['*'],
             'pandas.core.groupby.groupby.GroupBy.nth': [

--- a/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
@@ -411,6 +411,96 @@ class DoctestTest(unittest.TestCase):
         })
     self.assertEqual(result.failed, 0)
 
+  def test_groupby_tests(self):
+    result = doctests.testmod(
+        pd.core.groupby.groupby,
+        use_beam=False,
+        wont_implement_ok={
+            'pandas.core.groupby.groupby.GroupBy.head': ['*'],
+            'pandas.core.groupby.groupby.GroupBy.tail': ['*'],
+            'pandas.core.groupby.groupby.GroupBy.nth': ['*'],
+            'pandas.core.groupby.groupby.GroupBy.cumcount': ['*'],
+        },
+        not_implemented_ok={
+            'pandas.core.groupby.groupby.GroupBy.describe': ['*'],
+            'pandas.core.groupby.groupby.GroupBy.ngroup': ['*'],
+            'pandas.core.groupby.groupby.GroupBy.resample': ['*'],
+            'pandas.core.groupby.groupby.GroupBy.sample': ['*'],
+            'pandas.core.groupby.groupby.GroupBy.resample': ['*'],
+            'pandas.core.groupby.groupby.GroupBy.quantile': ['*'],
+            'pandas.core.groupby.groupby.BaseGroupBy.pipe': ['*'],
+            'pandas.core.groupby.groupby.GroupBy.nth': [
+                "df.groupby('A', as_index=False).nth(1)",
+            ],
+        },
+        skip={
+            # Uses iloc to mutate a DataFrame
+            'pandas.core.groupby.groupby.GroupBy.resample': [
+                'df.iloc[2, 0] = 5',
+                'df',
+            ],
+            # TODO: Raise wont implement for list passed as a grouping column
+            # Currently raises unhashable type: list
+            'pandas.core.groupby.groupby.GroupBy.ngroup': [
+                'df.groupby(["A", [1,1,2,3,2,1]]).ngroup()'
+            ],
+        })
+    self.assertEqual(result.failed, 0)
+
+    result = doctests.testmod(
+        pd.core.groupby.generic,
+        use_beam=False,
+        wont_implement_ok={
+            # Returns an array by default, not a Series. WontImplement
+            # (non-deferred)
+            'pandas.core.groupby.generic.SeriesGroupBy.unique': ['*'],
+            # TODO: Is take actually deprecated?
+            'pandas.core.groupby.generic.DataFrameGroupBy.take': ['*'],
+            'pandas.core.groupby.generic.SeriesGroupBy.take': ['*'],
+            'pandas.core.groupby.generic.SeriesGroupBy.nsmallest': [
+                "s.nsmallest(3, keep='last')",
+                "s.nsmallest(3)",
+                "s.nsmallest()",
+            ],
+            'pandas.core.groupby.generic.SeriesGroupBy.nlargest': [
+                "s.nlargest(3, keep='last')",
+                "s.nlargest(3)",
+                "s.nlargest()",
+            ],
+            'pandas.core.groupby.generic.DataFrameGroupBy.diff': ['*'],
+            'pandas.core.groupby.generic.SeriesGroupBy.diff': ['*'],
+            'pandas.core.groupby.generic.DataFrameGroupBy.hist': ['*'],
+        },
+        not_implemented_ok={
+            'pandas.core.groupby.generic.DataFrameGroupBy.transform': ['*'],
+            'pandas.core.groupby.generic.DataFrameGroupBy.idxmax': ['*'],
+            'pandas.core.groupby.generic.DataFrameGroupBy.idxmin': ['*'],
+            'pandas.core.groupby.generic.DataFrameGroupBy.filter': ['*'],
+            'pandas.core.groupby.generic.DataFrameGroupBy.nunique': ['*'],
+            'pandas.core.groupby.generic.SeriesGroupBy.transform': ['*'],
+            'pandas.core.groupby.generic.SeriesGroupBy.idxmax': ['*'],
+            'pandas.core.groupby.generic.SeriesGroupBy.idxmin': ['*'],
+            'pandas.core.groupby.generic.SeriesGroupBy.filter': ['*'],
+            'pandas.core.groupby.generic.SeriesGroupBy.describe': ['*'],
+        },
+        skip={
+            'pandas.core.groupby.generic.SeriesGroupBy.cov': [
+                # Floating point comparison fails
+                's1.cov(s2)',
+            ],
+            'pandas.core.groupby.generic.DataFrameGroupBy.cov': [
+                # Mutates input DataFrame with loc
+                # TODO: Replicate in frames_test.py
+                "df.loc[df.index[:5], 'a'] = np.nan",
+                "df.loc[df.index[5:10], 'b'] = np.nan",
+                "df.cov(min_periods=12)",
+            ],
+            # These examples rely on grouping by a list
+            'pandas.core.groupby.generic.SeriesGroupBy.aggregate': ['*'],
+            'pandas.core.groupby.generic.DataFrameGroupBy.aggregate': ['*'],
+        })
+    self.assertEqual(result.failed, 0)
+
   def test_top_level(self):
     tests = {
         name: func.__doc__


### PR DESCRIPTION
Adds a new test method in pandas_doctests_test.py that runs the doctests from groupby objects.

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
