### PR TITLE
[BEAM-11913] Add support for Hadoop configuration on ParquetIO

### DIFF
--- a/sdks/java/io/parquet/src/main/java/org/apache/beam/sdk/io/parquet/ParquetIO.java
+++ b/sdks/java/io/parquet/src/main/java/org/apache/beam/sdk/io/parquet/ParquetIO.java
@@ -370,7 +370,14 @@ public class ParquetIO {
 
     /** Specify Hadoop configuration for ParquetReader. */
     public Read withConfiguration(Map<String, String> configuration) {
+      checkArgument(configuration != null, "configuration can not be null");
       return toBuilder().setConfiguration(SerializableConfiguration.fromMap(configuration)).build();
+    }
+
+    /** Specify Hadoop configuration for ParquetReader. */
+    public Read withConfiguration(Configuration configuration) {
+      checkArgument(configuration != null, "configuration can not be null");
+      return toBuilder().setConfiguration(new SerializableConfiguration(configuration)).build();
     }
 
     @Experimental(Kind.SCHEMAS)
@@ -399,20 +406,19 @@ public class ParquetIO {
                   "Create filepattern", Create.ofProvider(getFilepattern(), StringUtf8Coder.of()))
               .apply(FileIO.matchAll())
               .apply(FileIO.readMatches());
-      if (isSplittable()) {
-        return inputFiles.apply(
-            readFiles(getSchema())
-                .withSplit()
-                .withBeamSchemas(getInferBeamSchema())
-                .withAvroDataModel(getAvroDataModel())
-                .withProjection(getProjectionSchema(), getEncoderSchema())
-                .withConfiguration(getConfiguration()));
-      }
-      return inputFiles.apply(
+
+      ReadFiles readFiles =
           readFiles(getSchema())
               .withBeamSchemas(getInferBeamSchema())
-              .withAvroDataModel(getAvroDataModel())
-              .withConfiguration(getConfiguration()));
+              .withAvroDataModel(getAvroDataModel());
+      if (isSplittable()) {
+        readFiles = readFiles.withSplit().withProjection(getProjectionSchema(), getEncoderSchema());
+      }
+      if (getConfiguration() != null) {
+        readFiles = readFiles.withConfiguration(getConfiguration().get());
+      }
+
+      return inputFiles.apply(readFiles);
     }
 
     @Override
@@ -468,7 +474,14 @@ public class ParquetIO {
 
     /** Specify Hadoop configuration for ParquetReader. */
     public Parse<T> withConfiguration(Map<String, String> configuration) {
+      checkArgument(configuration != null, "configuration can not be null");
       return toBuilder().setConfiguration(SerializableConfiguration.fromMap(configuration)).build();
+    }
+
+    /** Specify Hadoop configuration for ParquetReader. */
+    public Parse<T> withConfiguration(Configuration configuration) {
+      checkArgument(configuration != null, "configuration can not be null");
+      return toBuilder().setConfiguration(new SerializableConfiguration(configuration)).build();
     }
 
     public Parse<T> withSplit() {
@@ -526,7 +539,14 @@ public class ParquetIO {
 
     /** Specify Hadoop configuration for ParquetReader. */
     public ParseFiles<T> withConfiguration(Map<String, String> configuration) {
+      checkArgument(configuration != null, "configuration can not be null");
       return toBuilder().setConfiguration(SerializableConfiguration.fromMap(configuration)).build();
+    }
+
+    /** Specify Hadoop configuration for ParquetReader. */
+    public ParseFiles<T> withConfiguration(Configuration configuration) {
+      checkArgument(configuration != null, "configuration can not be null");
+      return toBuilder().setConfiguration(new SerializableConfiguration(configuration)).build();
     }
 
     public ParseFiles<T> withSplit() {
@@ -641,11 +661,14 @@ public class ParquetIO {
 
     /** Specify Hadoop configuration for ParquetReader. */
     public ReadFiles withConfiguration(Map<String, String> configuration) {
+      checkArgument(configuration != null, "configuration can not be null");
       return toBuilder().setConfiguration(SerializableConfiguration.fromMap(configuration)).build();
     }
 
-    public ReadFiles withConfiguration(SerializableConfiguration configuration) {
-      return toBuilder().setConfiguration(configuration).build();
+    /** Specify Hadoop configuration for ParquetReader. */
+    public ReadFiles withConfiguration(Configuration configuration) {
+      checkArgument(configuration != null, "configuration can not be null");
+      return toBuilder().setConfiguration(new SerializableConfiguration(configuration)).build();
     }
 
     @Experimental(Kind.SCHEMAS)
@@ -1064,7 +1087,14 @@ public class ParquetIO {
 
     /** Specifies configuration to be passed into the sink's writer. */
     public Sink withConfiguration(Map<String, String> configuration) {
+      checkArgument(configuration != null, "configuration can not be null");
       return toBuilder().setConfiguration(SerializableConfiguration.fromMap(configuration)).build();
+    }
+
+    /** Specify Hadoop configuration for ParquetReader. */
+    public Sink withConfiguration(Configuration configuration) {
+      checkArgument(configuration != null, "configuration can not be null");
+      return toBuilder().setConfiguration(new SerializableConfiguration(configuration)).build();
     }
 
     private transient @Nullable ParquetWriter<GenericRecord> writer;

--- a/sdks/java/io/parquet/src/test/java/org/apache/beam/sdk/io/parquet/ParquetIOTest.java
+++ b/sdks/java/io/parquet/src/test/java/org/apache/beam/sdk/io/parquet/ParquetIOTest.java
@@ -53,7 +53,12 @@ import org.apache.beam.sdk.transforms.Values;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
+import org.apache.hadoop.conf.Configuration;
+import org.apache.parquet.filter2.predicate.FilterApi;
+import org.apache.parquet.filter2.predicate.FilterPredicate;
+import org.apache.parquet.hadoop.ParquetInputFormat;
 import org.apache.parquet.hadoop.metadata.BlockMetaData;
+import org.apache.parquet.io.api.Binary;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TemporaryFolder;
@@ -339,7 +344,7 @@ public class ParquetIOTest implements Serializable {
   }
 
   private List<GenericRecord> generateGenericRecords(long count) {
-    ArrayList<GenericRecord> data = new ArrayList<>();
+    List<GenericRecord> data = new ArrayList<>();
     GenericRecordBuilder builder = new GenericRecordBuilder(SCHEMA);
     for (int i = 0; i < count; i++) {
       int index = i % SCIENTISTS.length;
@@ -465,6 +470,32 @@ public class ParquetIOTest implements Serializable {
                 .from(temporaryFolder.getRoot().getAbsolutePath() + "/*"));
 
     PAssert.that(readBack).containsInAnyOrder(records);
+    readPipeline.run().waitUntilFinish();
+  }
+
+  @Test
+  public void testWriteAndReadWithConfiguration() {
+    List<GenericRecord> records = generateGenericRecords(10);
+    List<GenericRecord> expectedRecords = generateGenericRecords(1);
+
+    mainPipeline
+        .apply(Create.of(records).withCoder(AvroCoder.of(SCHEMA)))
+        .apply(
+            FileIO.<GenericRecord>write()
+                .via(ParquetIO.sink(SCHEMA))
+                .to(temporaryFolder.getRoot().getAbsolutePath()));
+    mainPipeline.run().waitUntilFinish();
+
+    Configuration configuration = new Configuration();
+    FilterPredicate filterPredicate =
+        FilterApi.eq(FilterApi.binaryColumn("id"), Binary.fromString("0"));
+    ParquetInputFormat.setFilterPredicate(configuration, filterPredicate);
+    PCollection<GenericRecord> readBack =
+        readPipeline.apply(
+            ParquetIO.read(SCHEMA)
+                .from(temporaryFolder.getRoot().getAbsolutePath() + "/*")
+                .withConfiguration(configuration));
+    PAssert.that(readBack).containsInAnyOrder(expectedRecords);
     readPipeline.run().waitUntilFinish();
   }
 


### PR DESCRIPTION
We should expose only Hadoop's Configuration as we do in other IOs. This also helps the Beam API to be compatible with the Parquet APIs. I introduced here a test that uses Parquet to do a filter predicates for example.

R: @aromanenko-dev 
CC: @TheNeuralBit for awareness