### PR TITLE
[BEAM-11948] Add deprecation warning for Flink 1.8/1.9 support removal

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -102,6 +102,7 @@
 ## Deprecations
 
 * X behavior is deprecated and will be removed in X versions ([BEAM-X](https://issues.apache.org/jira/browse/BEAM-X)).
+* Support for Flink 1.8 and 1.9 will be removed in the next release (2.30.0) ([BEAM-11948](https://issues.apache.org/jira/browse/BEAM-11948)).
 
 ## Known Issues
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineRunner.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineRunner.java
@@ -46,6 +46,7 @@ import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.vendor.grpc.v1p26p0.com.google.protobuf.Struct;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.flink.api.common.JobExecutionResult;
+import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.kohsuke.args4j.CmdLineException;
 import org.kohsuke.args4j.CmdLineParser;
@@ -74,6 +75,13 @@ public class FlinkPipelineRunner implements PortablePipelineRunner {
   @Override
   public PortablePipelineResult run(final Pipeline pipeline, JobInfo jobInfo) throws Exception {
     MetricsEnvironment.setMetricsSupported(false);
+
+    final String flinkVersion = EnvironmentInformation.getVersion();
+    if (flinkVersion.startsWith("1.8") || flinkVersion.startsWith("1.9")) {
+      LOG.warn(
+          "You are running Flink {}. Support for Flink 1.8.x and 1.9.x will be removed from Beam in version 2.30.0. Please consider upgrading to a more recent Flink version.",
+          flinkVersion);
+    }
 
     FlinkPortablePipelineTranslator<?> translator;
     if (!pipelineOptions.isStreaming() && !hasUnboundedPCollections(pipeline)) {

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkRunner.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkRunner.java
@@ -37,6 +37,7 @@ import org.apache.beam.sdk.transforms.View;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.runtime.jobgraph.JobGraph;
+import org.apache.flink.runtime.util.EnvironmentInformation;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -79,6 +80,12 @@ public class FlinkRunner extends PipelineRunner<PipelineResult> {
 
     MetricsEnvironment.setMetricsSupported(true);
 
+    final String flinkVersion = EnvironmentInformation.getVersion();
+    if (flinkVersion.startsWith("1.8") || flinkVersion.startsWith("1.9")) {
+      LOG.warn(
+          "You are running Flink {}. Support for Flink 1.8.x and 1.9.x will be removed from Beam in version 2.30.0. Please consider upgrading to a more recent Flink version.",
+          flinkVersion);
+    }
     LOG.info("Executing pipeline using FlinkRunner.");
 
     if (!options.getFasterCopy()) {


### PR DESCRIPTION
As you suggested in the ML (it should be cherry picked I suppose).

R: @kennknowles 