### PR TITLE
Add OffsetBasedSource in BQ Connector

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/OffsetBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/OffsetBasedSource.java
@@ -337,7 +337,7 @@ public abstract class OffsetBasedSource<T> extends BoundedSource<T> {
     }
 
     @Override
-    public final synchronized OffsetBasedSource<T> splitAtFraction(double fraction) {
+    public synchronized OffsetBasedSource<T> splitAtFraction(double fraction) {
       if (!allowsDynamicSplitting()) {
         return null;
       }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -1332,6 +1332,8 @@ public class BigQueryIO {
 
                                 BigQueryStorageStreamSource<T> streamSource =
                                     BigQueryStorageStreamSource.create(
+                                        0L,
+                                        Long.MAX_VALUE,
                                         readSession,
                                         readStream,
                                         tableSchema,

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageSourceBase.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageSourceBase.java
@@ -153,7 +153,14 @@ abstract class BigQueryStorageSourceBase<T> extends BoundedSource<T> {
     for (ReadStream readStream : readSession.getStreamsList()) {
       sources.add(
           BigQueryStorageStreamSource.create(
-              readSession, readStream, trimmedSchema, parseFn, outputCoder, bqServices));
+              0L,
+              Long.MAX_VALUE,
+              readSession,
+              readStream,
+              trimmedSchema,
+              parseFn,
+              outputCoder,
+              bqServices));
     }
 
     return ImmutableList.copyOf(sources);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
@@ -341,7 +341,6 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
                   + "the left of the split fraction {}.",
               source.readStream.getName(),
               fraction);
-          splitPossible = false;
           return null;
         } catch (Exception e) {
           Metrics.counter(
@@ -349,7 +348,6 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
                   "split-at-fraction-calls-failed-due-to-other-reasons")
               .inc();
           LOG.error("BigQuery Storage API stream split failed.", e);
-          splitPossible = false;
           return null;
         }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
@@ -301,8 +301,8 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
         if (!splitResponse.hasPrimaryStream() || !splitResponse.hasRemainderStream()) {
           // No more splits are possible!
           Metrics.counter(
-              BigQueryStorageStreamReader.class,
-              "split-at-fraction-calls-failed-due-to-impossible-split-point")
+                  BigQueryStorageStreamReader.class,
+                  "split-at-fraction-calls-failed-due-to-impossible-split-point")
               .inc();
           LOG.info(
               "BigQuery Storage API stream {} cannot be split at {}.",
@@ -331,8 +331,8 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
             // The current source has already moved past the split point, so this split attempt
             // is unsuccessful.
             Metrics.counter(
-                BigQueryStorageStreamReader.class,
-                "split-at-fraction-calls-failed-due-to-bad-split-point")
+                    BigQueryStorageStreamReader.class,
+                    "split-at-fraction-calls-failed-due-to-bad-split-point")
                 .inc();
             LOG.info(
                 "BigQuery Storage API split of stream {} abandoned because the primary stream is to "
@@ -343,8 +343,8 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
             return null;
           } catch (Exception e) {
             Metrics.counter(
-                BigQueryStorageStreamReader.class,
-                "split-at-fraction-calls-failed-due-to-other-reasons")
+                    BigQueryStorageStreamReader.class,
+                    "split-at-fraction-calls-failed-due-to-other-reasons")
                 .inc();
             LOG.error("BigQuery Storage API stream split failed.", e);
             splitPossible = false;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
@@ -163,7 +163,7 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
     private long currentOffset;
 
     // Values used for progress reporting.
-    private boolean splitPossible;
+    private boolean splitPossible = true;
     private double fractionConsumed;
     private double progressAtResponseStart;
     private double progressAtResponseEnd;
@@ -179,7 +179,6 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
       this.parseFn = source.parseFn;
       this.storageClient = source.bqServices.getStorageClient(options);
       this.tableSchema = fromJsonString(source.jsonTableSchema, TableSchema.class);
-      this.splitPossible = true;
       this.fractionConsumed = 0d;
       this.progressAtResponseStart = 0d;
       this.progressAtResponseEnd = 0d;
@@ -290,85 +289,85 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
         return null;
       }
 
-      if (splitPossible) {
-        SplitReadStreamRequest splitRequest =
-            SplitReadStreamRequest.newBuilder()
-                .setName(source.readStream.getName())
-                .setFraction((float) fraction)
-                .build();
+      if (!splitPossible) {
+        return null;
+      }
 
-        SplitReadStreamResponse splitResponse = storageClient.splitReadStream(splitRequest);
-        if (!splitResponse.hasPrimaryStream() || !splitResponse.hasRemainderStream()) {
-          // No more splits are possible!
+      SplitReadStreamRequest splitRequest =
+          SplitReadStreamRequest.newBuilder()
+              .setName(source.readStream.getName())
+              .setFraction((float) fraction)
+              .build();
+
+      SplitReadStreamResponse splitResponse = storageClient.splitReadStream(splitRequest);
+      if (!splitResponse.hasPrimaryStream() || !splitResponse.hasRemainderStream()) {
+        // No more splits are possible!
+        Metrics.counter(
+                BigQueryStorageStreamReader.class,
+                "split-at-fraction-calls-failed-due-to-impossible-split-point")
+            .inc();
+        LOG.info(
+            "BigQuery Storage API stream {} cannot be split at {}.",
+            source.readStream.getName(),
+            fraction);
+        splitPossible = false;
+        return null;
+      }
+
+      // We may be able to split this source. Before continuing, we pause the reader thread and
+      // replace its current source with the primary stream iff the reader has not moved past
+      // the split point.
+      synchronized (this) {
+        BigQueryServerStream<ReadRowsResponse> newResponseStream;
+        Iterator<ReadRowsResponse> newResponseIterator;
+        try {
+          newResponseStream =
+              storageClient.readRows(
+                  ReadRowsRequest.newBuilder()
+                      .setReadStream(splitResponse.getPrimaryStream().getName())
+                      .setOffset(currentOffset + 1)
+                      .build());
+          newResponseIterator = newResponseStream.iterator();
+          newResponseIterator.hasNext();
+        } catch (FailedPreconditionException e) {
+          // The current source has already moved past the split point, so this split attempt
+          // is unsuccessful.
           Metrics.counter(
                   BigQueryStorageStreamReader.class,
-                  "split-at-fraction-calls-failed-due-to-impossible-split-point")
+                  "split-at-fraction-calls-failed-due-to-bad-split-point")
               .inc();
           LOG.info(
-              "BigQuery Storage API stream {} cannot be split at {}.",
+              "BigQuery Storage API split of stream {} abandoned because the primary stream is to "
+                  + "the left of the split fraction {}.",
               source.readStream.getName(),
               fraction);
           splitPossible = false;
           return null;
+        } catch (Exception e) {
+          Metrics.counter(
+                  BigQueryStorageStreamReader.class,
+                  "split-at-fraction-calls-failed-due-to-other-reasons")
+              .inc();
+          LOG.error("BigQuery Storage API stream split failed.", e);
+          splitPossible = false;
+          return null;
         }
 
-        // We may be able to split this source. Before continuing, we pause the reader thread and
-        // replace its current source with the primary stream iff the reader has not moved past
-        // the split point.
-        synchronized (this) {
-          BigQueryServerStream<ReadRowsResponse> newResponseStream;
-          Iterator<ReadRowsResponse> newResponseIterator;
-          try {
-            newResponseStream =
-                storageClient.readRows(
-                    ReadRowsRequest.newBuilder()
-                        .setReadStream(splitResponse.getPrimaryStream().getName())
-                        .setOffset(currentOffset + 1)
-                        .build());
-            newResponseIterator = newResponseStream.iterator();
-            newResponseIterator.hasNext();
-          } catch (FailedPreconditionException e) {
-            // The current source has already moved past the split point, so this split attempt
-            // is unsuccessful.
-            Metrics.counter(
-                    BigQueryStorageStreamReader.class,
-                    "split-at-fraction-calls-failed-due-to-bad-split-point")
-                .inc();
-            LOG.info(
-                "BigQuery Storage API split of stream {} abandoned because the primary stream is to "
-                    + "the left of the split fraction {}.",
-                source.readStream.getName(),
-                fraction);
-            splitPossible = false;
-            return null;
-          } catch (Exception e) {
-            Metrics.counter(
-                    BigQueryStorageStreamReader.class,
-                    "split-at-fraction-calls-failed-due-to-other-reasons")
-                .inc();
-            LOG.error("BigQuery Storage API stream split failed.", e);
-            splitPossible = false;
-            return null;
-          }
-
-          // Cancels the parent stream before replacing it with the primary stream.
-          responseStream.cancel();
-          source = source.fromExisting(splitResponse.getPrimaryStream());
-          responseStream = newResponseStream;
-          responseIterator = newResponseIterator;
-          decoder = null;
-        }
-
-        Metrics.counter(BigQueryStorageStreamReader.class, "split-at-fraction-calls-successful")
-            .inc();
-        LOG.info(
-            "Successfully split BigQuery Storage API stream at {}. Split response: {}",
-            fraction,
-            splitResponse);
-        return source.fromExisting(splitResponse.getRemainderStream());
-      } else {
-        return null;
+        // Cancels the parent stream before replacing it with the primary stream.
+        responseStream.cancel();
+        source = source.fromExisting(splitResponse.getPrimaryStream());
+        responseStream = newResponseStream;
+        responseIterator = newResponseIterator;
+        decoder = null;
       }
+
+      Metrics.counter(BigQueryStorageStreamReader.class, "split-at-fraction-calls-successful")
+          .inc();
+      LOG.info(
+          "Successfully split BigQuery Storage API stream at {}. Split response: {}",
+          fraction,
+          splitResponse);
+      return source.fromExisting(splitResponse.getRemainderStream());
     }
 
     @Override

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
@@ -40,7 +40,7 @@ import org.apache.avro.io.BinaryDecoder;
 import org.apache.avro.io.DatumReader;
 import org.apache.avro.io.DecoderFactory;
 import org.apache.beam.sdk.coders.Coder;
-import org.apache.beam.sdk.io.BoundedSource;
+import org.apache.beam.sdk.io.OffsetBasedSource;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices.BigQueryServerStream;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices.StorageClient;
 import org.apache.beam.sdk.metrics.Metrics;
@@ -56,11 +56,13 @@ import org.slf4j.LoggerFactory;
 @SuppressWarnings({
   "nullness" // TODO(https://issues.apache.org/jira/browse/BEAM-10402)
 })
-public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
+public class BigQueryStorageStreamSource<T> extends OffsetBasedSource<T> {
 
   private static final Logger LOG = LoggerFactory.getLogger(BigQueryStorageStreamSource.class);
 
   public static <T> BigQueryStorageStreamSource<T> create(
+      long startOffset,
+      long endOffset,
       ReadSession readSession,
       ReadStream readStream,
       TableSchema tableSchema,
@@ -68,6 +70,8 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
       Coder<T> outputCoder,
       BigQueryServices bqServices) {
     return new BigQueryStorageStreamSource<>(
+        startOffset,
+        endOffset,
         readSession,
         readStream,
         toJsonString(checkNotNull(tableSchema, "tableSchema")),
@@ -82,9 +86,18 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
    */
   public BigQueryStorageStreamSource<T> fromExisting(ReadStream newReadStream) {
     return new BigQueryStorageStreamSource<>(
-        readSession, newReadStream, jsonTableSchema, parseFn, outputCoder, bqServices);
+        startOffset,
+        endOffset,
+        readSession,
+        newReadStream,
+        jsonTableSchema,
+        parseFn,
+        outputCoder,
+        bqServices);
   }
 
+  private final long startOffset;
+  private final long endOffset;
   private final ReadSession readSession;
   private final ReadStream readStream;
   private final String jsonTableSchema;
@@ -93,12 +106,17 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
   private final BigQueryServices bqServices;
 
   private BigQueryStorageStreamSource(
+      long startOffset,
+      long endOffset,
       ReadSession readSession,
       ReadStream readStream,
       String jsonTableSchema,
       SerializableFunction<SchemaAndRecord, T> parseFn,
       Coder<T> outputCoder,
       BigQueryServices bqServices) {
+    super(startOffset, endOffset, 1L);
+    this.startOffset = startOffset;
+    this.endOffset = endOffset;
     this.readSession = checkNotNull(readSession, "readSession");
     this.readStream = checkNotNull(readStream, "stream");
     this.jsonTableSchema = checkNotNull(jsonTableSchema, "jsonTableSchema");
@@ -129,7 +147,22 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
   }
 
   @Override
-  public List<? extends BoundedSource<T>> split(
+  public String toString() {
+    return readStream.toString();
+  }
+
+  @Override
+  public long getMaxEndOffset(PipelineOptions options) throws Exception {
+    return getEndOffset();
+  }
+
+  @Override
+  public OffsetBasedSource<T> createSourceForSubrange(long start, long end) {
+    return this;
+  }
+
+  @Override
+  public List<? extends OffsetBasedSource<T>> split(
       long desiredBundleSizeBytes, PipelineOptions options) {
     // A stream source can't be split without reading from it due to server-side liquid sharding.
     // TODO: Implement dynamic work rebalancing.
@@ -141,13 +174,9 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
     return new BigQueryStorageStreamReader<>(this, options.as(BigQueryOptions.class));
   }
 
-  @Override
-  public String toString() {
-    return readStream.toString();
-  }
-
   /** A {@link org.apache.beam.sdk.io.Source.Reader} which reads records from a stream. */
-  public static class BigQueryStorageStreamReader<T> extends BoundedSource.BoundedReader<T> {
+  public static class BigQueryStorageStreamReader<T>
+      extends OffsetBasedSource.OffsetBasedReader<T> {
 
     private final DatumReader<GenericRecord> datumReader;
     private final SerializableFunction<SchemaAndRecord, T> parseFn;
@@ -172,6 +201,7 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
 
     private BigQueryStorageStreamReader(
         BigQueryStorageStreamSource<T> source, BigQueryOptions options) throws IOException {
+      super(source);
       this.source = source;
       this.datumReader =
           new GenericDatumReader<>(
@@ -187,7 +217,12 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
     }
 
     @Override
-    public synchronized boolean start() throws IOException {
+    protected long getCurrentOffset() throws NoSuchElementException {
+      return currentOffset;
+    }
+
+    @Override
+    public synchronized boolean startImpl() throws IOException {
       BigQueryStorageStreamSource<T> source = getCurrentSource();
 
       ReadRowsRequest request =
@@ -203,7 +238,7 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
     }
 
     @Override
-    public synchronized boolean advance() throws IOException {
+    public synchronized boolean advanceImpl() throws IOException {
       currentOffset++;
       return readNextRecord();
     }
@@ -277,7 +312,7 @@ public class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
     }
 
     @Override
-    public BoundedSource<T> splitAtFraction(double fraction) {
+    public synchronized OffsetBasedSource<T> splitAtFraction(double fraction) {
       Metrics.counter(BigQueryStorageStreamReader.class, "split-at-fraction-calls").inc();
       LOG.debug(
           "Received BigQuery Storage API split request for stream {} at fraction {}.",

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageReadTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageReadTest.java
@@ -619,6 +619,8 @@ public class BigQueryIOStorageReadTest {
 
     BigQueryStorageStreamSource<TableRow> streamSource =
         BigQueryStorageStreamSource.create(
+            0L,
+            Long.MAX_VALUE,
             ReadSession.getDefaultInstance(),
             ReadStream.getDefaultInstance(),
             TABLE_SCHEMA,
@@ -634,6 +636,8 @@ public class BigQueryIOStorageReadTest {
 
     BigQueryStorageStreamSource<TableRow> streamSource =
         BigQueryStorageStreamSource.create(
+            0L,
+            Long.MAX_VALUE,
             ReadSession.getDefaultInstance(),
             ReadStream.getDefaultInstance(),
             TABLE_SCHEMA,
@@ -673,6 +677,8 @@ public class BigQueryIOStorageReadTest {
 
     BigQueryStorageStreamSource<TableRow> streamSource =
         BigQueryStorageStreamSource.create(
+            0L,
+            Long.MAX_VALUE,
             readSession,
             ReadStream.newBuilder().setName("readStream").build(),
             TABLE_SCHEMA,
@@ -729,6 +735,8 @@ public class BigQueryIOStorageReadTest {
 
     BigQueryStorageStreamSource<TableRow> streamSource =
         BigQueryStorageStreamSource.create(
+            0L,
+            Long.MAX_VALUE,
             readSession,
             ReadStream.newBuilder().setName("readStream").build(),
             TABLE_SCHEMA,
@@ -815,6 +823,8 @@ public class BigQueryIOStorageReadTest {
 
     BigQueryStorageStreamSource<TableRow> streamSource =
         BigQueryStorageStreamSource.create(
+            0L,
+            Long.MAX_VALUE,
             readSession,
             ReadStream.newBuilder().setName("parentStream").build(),
             TABLE_SCHEMA,
@@ -897,6 +907,8 @@ public class BigQueryIOStorageReadTest {
 
     BigQueryStorageStreamSource<TableRow> streamSource =
         BigQueryStorageStreamSource.create(
+            0L,
+            Long.MAX_VALUE,
             ReadSession.newBuilder()
                 .setName("readSession")
                 .setAvroSchema(AvroSchema.newBuilder().setSchema(AVRO_SCHEMA_STRING))
@@ -1032,6 +1044,8 @@ public class BigQueryIOStorageReadTest {
 
     BoundedSource<TableRow> source =
         BigQueryStorageStreamSource.create(
+            0L,
+            Long.MAX_VALUE,
             ReadSession.newBuilder()
                 .setName("readSession")
                 .setAvroSchema(AvroSchema.newBuilder().setSchema(AVRO_SCHEMA_STRING))
@@ -1096,6 +1110,8 @@ public class BigQueryIOStorageReadTest {
 
     BigQueryStorageStreamSource<TableRow> streamSource =
         BigQueryStorageStreamSource.create(
+            0L,
+            Long.MAX_VALUE,
             ReadSession.newBuilder()
                 .setName("readSession")
                 .setAvroSchema(AvroSchema.newBuilder().setSchema(AVRO_SCHEMA_STRING))
@@ -1184,6 +1200,8 @@ public class BigQueryIOStorageReadTest {
 
     BigQueryStorageStreamSource<TableRow> streamSource =
         BigQueryStorageStreamSource.create(
+            0L,
+            Long.MAX_VALUE,
             ReadSession.newBuilder()
                 .setName("readSession")
                 .setAvroSchema(AvroSchema.newBuilder().setSchema(AVRO_SCHEMA_STRING))


### PR DESCRIPTION
Replace BoundedSource with OffsetBasedSource in BigQuery connector.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
