### PR TITLE
[BEAM-12011] Eliminate WindowFn.getOutputTime method

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/WatermarkHold.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/WatermarkHold.java
@@ -113,10 +113,7 @@ class WatermarkHold<W extends BoundedWindow> implements Serializable {
    * output time function.
    */
   private Instant shift(Instant timestamp, W window) {
-    Instant shifted =
-        windowingStrategy
-            .getTimestampCombiner()
-            .assign(window, windowingStrategy.getWindowFn().getOutputTime(timestamp, window));
+    Instant shifted = windowingStrategy.getTimestampCombiner().assign(window, timestamp);
     // Don't call checkState(), to avoid calling BoundedWindow.formatTimestamp() every time
     if (shifted.isBefore(timestamp)) {
       throw new IllegalStateException(

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkNonMergingReduceFunction.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/FlinkNonMergingReduceFunction.java
@@ -84,10 +84,7 @@ public class FlinkNonMergingReduceFunction<K, InputT>
     final WindowedValue<KV<K, InputT>> first = iterator.peek();
     final BoundedWindow window = Iterables.getOnlyElement(first.getWindows());
     @SuppressWarnings("unchecked")
-    final Instant outputTimestamp =
-        ((WindowingStrategy) windowingStrategy)
-            .getWindowFn()
-            .getOutputTime(first.getTimestamp(), window);
+    final Instant outputTimestamp = first.getTimestamp();
     final Instant combinedTimestamp =
         windowingStrategy.getTimestampCombiner().assign(window, outputTimestamp);
     final Iterable<InputT> values;

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/HashingFlinkCombineRunner.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/HashingFlinkCombineRunner.java
@@ -59,7 +59,6 @@ public class HashingFlinkCombineRunner<K, InputT, AccumT, OutputT, W extends Bou
 
     @SuppressWarnings("unchecked")
     TimestampCombiner timestampCombiner = windowingStrategy.getTimestampCombiner();
-    WindowFn<Object, W> windowFn = windowingStrategy.getWindowFn();
 
     // Flink Iterable can be iterated over only once.
     List<WindowedValue<KV<K, InputT>>> inputs = new ArrayList<>();
@@ -86,8 +85,7 @@ public class HashingFlinkCombineRunner<K, InputT, AccumT, OutputT, W extends Bou
               flinkCombiner.firstInput(
                   key, currentValue.getValue().getValue(), options, sideInputReader, singletonW);
           Instant windowTimestamp =
-              timestampCombiner.assign(
-                  mergedWindow, windowFn.getOutputTime(currentValue.getTimestamp(), mergedWindow));
+              timestampCombiner.assign(mergedWindow, currentValue.getTimestamp());
           accumAndInstant = new Tuple2<>(accumT, windowTimestamp);
           mapState.put(mergedWindow, accumAndInstant);
         } else {
@@ -102,11 +100,7 @@ public class HashingFlinkCombineRunner<K, InputT, AccumT, OutputT, W extends Bou
           accumAndInstant.f1 =
               timestampCombiner.combine(
                   accumAndInstant.f1,
-                  timestampCombiner.assign(
-                      mergedWindow,
-                      windowingStrategy
-                          .getWindowFn()
-                          .getOutputTime(currentValue.getTimestamp(), mergedWindow)));
+                  timestampCombiner.assign(mergedWindow, currentValue.getTimestamp()));
         }
       }
       if (iterator.hasNext()) {

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/SortingFlinkCombineRunner.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/functions/SortingFlinkCombineRunner.java
@@ -26,7 +26,6 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.transforms.windowing.TimestampCombiner;
-import org.apache.beam.sdk.transforms.windowing.WindowFn;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.WindowingStrategy;
@@ -56,7 +55,6 @@ public class SortingFlinkCombineRunner<K, InputT, AccumT, OutputT, W extends Bou
     @SuppressWarnings("unchecked")
     TimestampCombiner timestampCombiner =
         (TimestampCombiner) windowingStrategy.getTimestampCombiner();
-    WindowFn<Object, W> windowFn = windowingStrategy.getWindowFn();
 
     // get all elements so that we can sort them, has to fit into
     // memory
@@ -90,9 +88,7 @@ public class SortingFlinkCombineRunner<K, InputT, AccumT, OutputT, W extends Bou
             key, firstValue, options, sideInputReader, currentValue.getWindows());
 
     // we use this to keep track of the timestamps assigned by the TimestampCombiner
-    Instant windowTimestamp =
-        timestampCombiner.assign(
-            currentWindow, windowFn.getOutputTime(currentValue.getTimestamp(), currentWindow));
+    Instant windowTimestamp = timestampCombiner.assign(currentWindow, currentValue.getTimestamp());
 
     while (iterator.hasNext()) {
       WindowedValue<KV<K, InputT>> nextValue = iterator.next();
@@ -108,10 +104,7 @@ public class SortingFlinkCombineRunner<K, InputT, AccumT, OutputT, W extends Bou
 
         windowTimestamp =
             timestampCombiner.combine(
-                windowTimestamp,
-                timestampCombiner.assign(
-                    currentWindow,
-                    windowFn.getOutputTime(nextValue.getTimestamp(), currentWindow)));
+                windowTimestamp, timestampCombiner.assign(currentWindow, nextValue.getTimestamp()));
 
       } else {
         // emit the value that we currently have
@@ -131,9 +124,7 @@ public class SortingFlinkCombineRunner<K, InputT, AccumT, OutputT, W extends Bou
         accumulator =
             flinkCombiner.firstInput(
                 key, value, options, sideInputReader, currentValue.getWindows());
-        windowTimestamp =
-            timestampCombiner.assign(
-                currentWindow, windowFn.getOutputTime(nextValue.getTimestamp(), currentWindow));
+        windowTimestamp = timestampCombiner.assign(currentWindow, nextValue.getTimestamp());
       }
     }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/BatchGroupAlsoByWindowAndCombineFn.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/BatchGroupAlsoByWindowAndCombineFn.java
@@ -134,11 +134,7 @@ class BatchGroupAlsoByWindowAndCombineFn<K, InputT, AccumT, OutputT, W extends B
       Collection<W> windows = (Collection<W>) e.getWindows();
       for (W window : windows) {
         Instant outputTime =
-            windowingStrategy
-                .getTimestampCombiner()
-                .assign(
-                    window,
-                    windowingStrategy.getWindowFn().getOutputTime(e.getTimestamp(), window));
+            windowingStrategy.getTimestampCombiner().assign(window, e.getTimestamp());
         Instant accumulatorOutputTime = accumulatorOutputTimestamps.get(window);
         if (accumulatorOutputTime == null) {
           accumulatorOutputTimestamps.put(window, outputTime);

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/BatchGroupAlsoByWindowViaIteratorsFn.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/BatchGroupAlsoByWindowViaIteratorsFn.java
@@ -127,11 +127,7 @@ class BatchGroupAlsoByWindowViaIteratorsFn<K, V, W extends BoundedWindow>
           windows.put(window.maxTimestamp(), window);
           output.outputWindowedValue(
               KV.of(key, (Iterable<V>) new WindowReiterable<V>(iterator, window)),
-              strategy
-                  .getTimestampCombiner()
-                  .assign(
-                      typedWindow,
-                      strategy.getWindowFn().getOutputTime(e.getTimestamp(), typedWindow)),
+              strategy.getTimestampCombiner().assign(typedWindow, e.getTimestamp()),
               Arrays.asList(window),
               PaneInfo.ON_TIME_AND_ONLY_FIRING);
         }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingGroupAlsoByWindowFnsTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingGroupAlsoByWindowFnsTest.java
@@ -314,16 +314,13 @@ public class StreamingGroupAlsoByWindowFnsTest {
                 isKv(equalTo(KEY), containsInAnyOrder("v0", "v1")),
                 equalTo(new Instant(2)),
                 equalTo(window(-10, 10))),
-
-            // For this sliding window, the minimum output timestmap was 10, since we didn't want to
-            // overlap with the previous window that was [-10, 10).
             WindowMatchers.isSingleWindowedValue(
                 isKv(equalTo(KEY), containsInAnyOrder("v0", "v1", "v2")),
-                equalTo(window(-10, 10).maxTimestamp().plus(1)),
+                equalTo(new Instant(2)),
                 equalTo(window(0, 20))),
             WindowMatchers.isSingleWindowedValue(
                 isKv(equalTo(KEY), containsInAnyOrder("v2")),
-                equalTo(window(0, 20).maxTimestamp().plus(1)),
+                equalTo(new Instant(15)),
                 equalTo(window(10, 30)))));
   }
 
@@ -402,16 +399,13 @@ public class StreamingGroupAlsoByWindowFnsTest {
                 isKv(equalTo(KEY), emptyIterable()),
                 equalTo(window(-10, 10).maxTimestamp()),
                 equalTo(window(-10, 10))),
-
-            // For this sliding window, the minimum output timestmap was 10, since we didn't want to
-            // overlap with the previous window that was [-10, 10).
             WindowMatchers.isSingleWindowedValue(
                 isKv(equalTo(KEY), containsInAnyOrder("v0", "v1", "v2")),
-                equalTo(window(-10, 10).maxTimestamp().plus(1)),
+                equalTo(new Instant(2)),
                 equalTo(window(0, 20))),
             WindowMatchers.isSingleWindowedValue(
                 isKv(equalTo(KEY), containsInAnyOrder("v2")),
-                equalTo(window(0, 20).maxTimestamp().plus(1)),
+                equalTo(new Instant(15)),
                 equalTo(window(10, 30)))));
 
     long droppedValues =

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/util/GroupAlsoByWindowProperties.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/util/GroupAlsoByWindowProperties.java
@@ -175,14 +175,12 @@ public class GroupAlsoByWindowProperties {
     TimestampedValue<KV<String, Iterable<String>>> item1 =
         getOnlyElementInWindow(result, window(0, 20));
     assertThat(item1.getValue().getValue(), containsInAnyOrder("v1", "v2"));
-    // Timestamp adjusted by WindowFn to exceed the end of the prior sliding window
-    assertThat(item1.getTimestamp(), equalTo(new Instant(10)));
+    assertThat(item1.getTimestamp(), equalTo(new Instant(5)));
 
     TimestampedValue<KV<String, Iterable<String>>> item2 =
         getOnlyElementInWindow(result, window(10, 30));
     assertThat(item2.getValue().getValue(), contains("v2"));
-    // Timestamp adjusted by WindowFn to exceed the end of the prior sliding window
-    assertThat(item2.getTimestamp(), equalTo(new Instant(20)));
+    assertThat(item2.getTimestamp(), equalTo(new Instant(15)));
   }
 
   /**
@@ -231,14 +229,12 @@ public class GroupAlsoByWindowProperties {
     TimestampedValue<KV<String, Long>> item1 = getOnlyElementInWindow(result, window(0, 20));
     assertThat(item1.getValue().getKey(), equalTo("k"));
     assertThat(item1.getValue().getValue(), equalTo(combineFn.apply(ImmutableList.of(1L, 2L, 4L))));
-    // Timestamp adjusted by WindowFn to exceed the end of the prior sliding window
-    assertThat(item1.getTimestamp(), equalTo(new Instant(10L)));
+    assertThat(item1.getTimestamp(), equalTo(new Instant(5L)));
 
     TimestampedValue<KV<String, Long>> item2 = getOnlyElementInWindow(result, window(10, 30));
     assertThat(item2.getValue().getKey(), equalTo("k"));
     assertThat(item2.getValue().getValue(), equalTo(combineFn.apply(ImmutableList.of(2L, 4L))));
-    // Timestamp adjusted by WindowFn to exceed the end of the prior sliding window
-    assertThat(item2.getTimestamp(), equalTo(new Instant(20L)));
+    assertThat(item2.getTimestamp(), equalTo(new Instant(15L)));
   }
 
   /**

--- a/runners/spark/2/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/AggregatorCombiner.java
+++ b/runners/spark/2/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/AggregatorCombiner.java
@@ -161,11 +161,7 @@ class AggregatorCombiner<K, InputT, AccumT, OutputT, W extends BoundedWindow>
         Tuple2<AccumT, Instant> accumAndInstant =
             new Tuple2<>(
                 accumT,
-                timestampCombiner.assign(
-                    mergedWindowForAccumulator,
-                    windowingStrategy
-                        .getWindowFn()
-                        .getOutputTime(accumulatorWv.getTimestamp(), mergedWindowForAccumulator)));
+                timestampCombiner.assign(mergedWindowForAccumulator, accumulatorWv.getTimestamp()));
         if (mergedWindowToAccumulators.get(mergedWindowForAccumulator) == null) {
           mergedWindowToAccumulators.put(
               mergedWindowForAccumulator, Lists.newArrayList(accumAndInstant));

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/GroupNonMergingWindowsFunctions.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/GroupNonMergingWindowsFunctions.java
@@ -250,13 +250,7 @@ public class GroupNonMergingWindowsFunctions {
       @SuppressWarnings("unchecked")
       final W window = (W) Iterables.getOnlyElement(windowedValue.getWindows());
       final Instant timestamp =
-          windowingStrategy
-              .getTimestampCombiner()
-              .assign(
-                  window,
-                  windowingStrategy
-                      .getWindowFn()
-                      .getOutputTime(windowedValue.getTimestamp(), window));
+          windowingStrategy.getTimestampCombiner().assign(window, windowedValue.getTimestamp());
       // BEAM-7341: Elements produced by GbK are always ON_TIME and ONLY_FIRING
       return WindowedValue.of(
           KV.of(key, value), timestamp, window, PaneInfo.ON_TIME_AND_ONLY_FIRING);

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkCombineFn.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkCombineFn.java
@@ -204,10 +204,7 @@ public class SparkCombineFn<InputT, ValueT, AccumT, OutputT> implements Serializ
       BoundedWindow window = getWindow(value);
       SparkCombineContext ctx = context.ctxtForValue(value);
       TimestampCombiner combiner = context.windowingStrategy.getTimestampCombiner();
-      Instant windowTimestamp =
-          combiner.assign(
-              window,
-              context.windowingStrategy.getWindowFn().getOutputTime(value.getTimestamp(), window));
+      Instant windowTimestamp = combiner.assign(window, value.getTimestamp());
       final AccumT acc;
       final Instant timestamp;
       if (windowAccumulator == null) {
@@ -301,10 +298,7 @@ public class SparkCombineFn<InputT, ValueT, AccumT, OutputT> implements Serializ
         SparkCombineContext ctx = context.ctxtForValue(v);
         BoundedWindow window = getWindow(v);
         TimestampCombiner combiner = context.windowingStrategy.getTimestampCombiner();
-        Instant windowTimestamp =
-            combiner.assign(
-                window,
-                context.windowingStrategy.getWindowFn().getOutputTime(v.getTimestamp(), window));
+        Instant windowTimestamp = combiner.assign(window, v.getTimestamp());
         map.compute(
             window,
             (w, windowAccumulator) -> {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/WindowFnTestUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/WindowFnTestUtils.java
@@ -20,12 +20,9 @@ package org.apache.beam.sdk.testing;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
-import static org.junit.Assert.assertFalse;
-import static org.junit.Assert.assertTrue;
 
 import java.util.ArrayList;
 import java.util.Collection;
-import java.util.Comparator;
 import java.util.HashMap;
 import java.util.HashSet;
 import java.util.List;
@@ -198,96 +195,6 @@ public class WindowFnTestUtils {
 
     public Set<V> get(W window) {
       return elements.get(window);
-    }
-  }
-
-  /**
-   * Assigns the given {@code timestamp} to windows using the specified {@code windowFn}, and
-   * verifies that result of {@code windowFn.getOutputTimestamp} for each window is within the
-   * proper bound.
-   */
-  public static <T, W extends BoundedWindow> void validateNonInterferingOutputTimes(
-      WindowFn<T, W> windowFn, long timestamp) throws Exception {
-    validateNonInterferingOutputTimesWithValue(
-        windowFn, TimestampedValue.of((T) null, new Instant(timestamp)));
-  }
-  /**
-   * Assigns the given {@code timestampedValue} to windows using the specified {@code windowFn}, and
-   * verifies that result of {@code windowFn.getOutputTimestamp} for each window is within the
-   * proper bound. This version allows passing a {@link TimestampedValue} in case the value is
-   * needed to assign windows.
-   */
-  public static <T, W extends BoundedWindow> void validateNonInterferingOutputTimesWithValue(
-      WindowFn<T, W> windowFn, TimestampedValue<T> timestampedValue) throws Exception {
-    Collection<W> windows = assignedWindowsWithValue(windowFn, timestampedValue);
-
-    Instant instant = timestampedValue.getTimestamp();
-    for (W window : windows) {
-      Instant outputTimestamp = windowFn.getOutputTime(instant, window);
-      assertFalse(
-          "getOutputTime must be greater than or equal to input timestamp",
-          outputTimestamp.isBefore(instant));
-      assertFalse(
-          "getOutputTime must be less than or equal to the max timestamp",
-          outputTimestamp.isAfter(window.maxTimestamp()));
-    }
-  }
-
-  /**
-   * Assigns the given {@code timestamp} to windows using the specified {@code windowFn}, and
-   * verifies that result of {@link WindowFn#getOutputTime windowFn.getOutputTime} for later windows
-   * (as defined by {@code maxTimestamp} won't prevent the watermark from passing the end of earlier
-   * windows.
-   *
-   * <p>This verifies that overlapping windows don't interfere at all. Depending on the {@code
-   * windowFn} this may be stricter than desired.
-   */
-  public static <T, W extends BoundedWindow> void validateGetOutputTimestamp(
-      WindowFn<T, W> windowFn, long timestamp) throws Exception {
-    validateGetOutputTimestampWithValue(
-        windowFn, TimestampedValue.of((T) null, new Instant(timestamp)));
-  }
-
-  /**
-   * Assigns the given {@code timestampedValue} to windows using the specified {@code windowFn}, and
-   * verifies that result of {@link WindowFn#getOutputTime windowFn.getOutputTime} for later windows
-   * (as defined by {@code maxTimestamp} won't prevent the watermark from passing the end of earlier
-   * windows.
-   *
-   * <p>This verifies that overlapping windows don't interfere at all. Depending on the {@code
-   * windowFn} this may be stricter than desired. This version allows passing a {@link
-   * TimestampedValue} in case the value is needed to assign windows.
-   */
-  public static <T, W extends BoundedWindow> void validateGetOutputTimestampWithValue(
-      WindowFn<T, W> windowFn, TimestampedValue<T> timestampedValue) throws Exception {
-    Collection<W> windows = assignedWindowsWithValue(windowFn, timestampedValue);
-    List<W> sortedWindows = new ArrayList<>(windows);
-    sortedWindows.sort(Comparator.comparing(BoundedWindow::maxTimestamp));
-
-    Instant instant = timestampedValue.getTimestamp();
-    Instant endOfPrevious = null;
-    for (W window : sortedWindows) {
-      Instant outputTimestamp = windowFn.getOutputTime(instant, window);
-      if (endOfPrevious == null) {
-        // If this is the first window, the output timestamp can be anything, as long as it is in
-        // the valid range.
-        assertFalse(
-            "getOutputTime must be greater than or equal to input timestamp",
-            outputTimestamp.isBefore(instant));
-        assertFalse(
-            "getOutputTime must be less than or equal to the max timestamp",
-            outputTimestamp.isAfter(window.maxTimestamp()));
-      } else {
-        // If this is a later window, the output timestamp must be after the end of the previous
-        // window
-        assertTrue(
-            "getOutputTime must be greater than the end of the previous window",
-            outputTimestamp.isAfter(endOfPrevious));
-        assertFalse(
-            "getOutputTime must be less than or equal to the max timestamp",
-            outputTimestamp.isAfter(window.maxTimestamp()));
-      }
-      endOfPrevious = window.maxTimestamp();
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/GlobalWindows.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/GlobalWindows.java
@@ -22,7 +22,6 @@ import java.util.Collection;
 import java.util.Collections;
 import org.apache.beam.sdk.coders.Coder;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.joda.time.Instant;
 
 /**
  * A {@link WindowFn} that assigns all data to the same window.
@@ -75,11 +74,6 @@ public class GlobalWindows extends NonMergingWindowFn<Object, GlobalWindow> {
     public GlobalWindow getSideInputWindow(BoundedWindow mainWindow) {
       return GlobalWindow.INSTANCE;
     }
-  }
-
-  @Override
-  public Instant getOutputTime(Instant inputTimestamp, GlobalWindow window) {
-    return inputTimestamp;
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/PartitioningWindowFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/PartitioningWindowFn.java
@@ -53,11 +53,6 @@ public abstract class PartitioningWindowFn<T, W extends BoundedWindow>
   }
 
   @Override
-  public Instant getOutputTime(Instant inputTimestamp, W window) {
-    return inputTimestamp;
-  }
-
-  @Override
   public final boolean assignsToOneWindow() {
     return true;
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/SlidingWindows.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/SlidingWindows.java
@@ -21,8 +21,6 @@ import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Objects;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -196,21 +194,6 @@ public class SlidingWindows extends NonMergingWindowFn<Object, IntervalWindow> {
 
   public Duration getOffset() {
     return offset;
-  }
-
-  /**
-   * Ensures that later sliding windows have an output time that is past the end of earlier windows.
-   *
-   * <p>If this is the earliest sliding window containing {@code inputTimestamp}, that's fine.
-   * Otherwise, we pick the earliest time that doesn't overlap with earlier windows.
-   */
-  @Experimental(Kind.OUTPUT_TIME)
-  @Override
-  public Instant getOutputTime(Instant inputTimestamp, IntervalWindow window) {
-    Instant startOfLastSegment = window.maxTimestamp().minus(period);
-    return startOfLastSegment.isBefore(inputTimestamp)
-        ? inputTimestamp
-        : startOfLastSegment.plus(1);
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/WindowFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/windowing/WindowFn.java
@@ -19,8 +19,6 @@ package org.apache.beam.sdk.transforms.windowing;
 
 import java.io.Serializable;
 import java.util.Collection;
-import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.display.HasDisplayData;
@@ -123,27 +121,6 @@ public abstract class WindowFn<T, W extends BoundedWindow> implements Serializab
    * that can be produced by this {@link WindowFn}.
    */
   public abstract WindowMappingFn<W> getDefaultWindowMappingFn();
-
-  /**
-   * Returns the output timestamp to use for data depending on the given {@code inputTimestamp} in
-   * the specified {@code window}.
-   *
-   * <p>The result of this method must be between {@code inputTimestamp} and {@code
-   * window.maxTimestamp()} (inclusive on both sides).
-   *
-   * <p>This function must be monotonic across input timestamps. Specifically, if {@code A < B},
-   * then {@code getOutputTime(A, window) <= getOutputTime(B, window)}.
-   *
-   * <p>For a {@link WindowFn} that doesn't produce overlapping windows, this can (and typically
-   * should) just return {@code inputTimestamp}. In the presence of overlapping windows, it is
-   * suggested that the result in later overlapping windows is past the end of earlier windows so
-   * that the later windows don't prevent the watermark from progressing past the end of the earlier
-   * window.
-   */
-  @Experimental(Kind.OUTPUT_TIME)
-  public Instant getOutputTime(Instant inputTimestamp, W window) {
-    return inputTimestamp;
-  }
 
   /** Returns true if this {@code WindowFn} never needs to merge any windows. */
   public boolean isNonMerging() {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/IdentityWindowFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/IdentityWindowFn.java
@@ -30,7 +30,6 @@ import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.transforms.windowing.WindowFn;
 import org.apache.beam.sdk.transforms.windowing.WindowMappingFn;
 import org.apache.beam.sdk.values.PCollection;
-import org.joda.time.Instant;
 
 /**
  * A {@link WindowFn} that leaves all associations between elements and windows unchanged.
@@ -104,11 +103,6 @@ public class IdentityWindowFn<T> extends NonMergingWindowFn<T, BoundedWindow> {
                 + " It is a private implementation detail of sdk utilities."
                 + " This message indicates a bug in the Beam SDK.",
             getClass().getCanonicalName()));
-  }
-
-  @Override
-  public Instant getOutputTime(Instant inputTimestamp, BoundedWindow window) {
-    return inputTimestamp;
   }
 
   @Override

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/FixedWindowsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/FixedWindowsTest.java
@@ -32,7 +32,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import org.apache.beam.sdk.testing.WindowFnTestUtils;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
@@ -156,13 +155,6 @@ public class FixedWindowsTest {
     FixedWindows.of(new Duration(10)).verifyCompatibility(FixedWindows.of(new Duration(10)));
     thrown.expect(IncompatibleWindowException.class);
     FixedWindows.of(new Duration(10)).verifyCompatibility(FixedWindows.of(new Duration(20)));
-  }
-
-  @Test
-  public void testValidOutputTimes() throws Exception {
-    for (long timestamp : Arrays.asList(200, 800, 700)) {
-      WindowFnTestUtils.validateGetOutputTimestamp(FixedWindows.of(new Duration(500)), timestamp);
-    }
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/SessionsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/SessionsTest.java
@@ -114,15 +114,6 @@ public class SessionsTest {
         .verifyCompatibility(FixedWindows.of(new Duration(10)));
   }
 
-  /** Validates that the output timestamp for aggregate data falls within the acceptable range. */
-  @Test
-  public void testValidOutputTimes() throws Exception {
-    for (long timestamp : Arrays.asList(200, 800, 700)) {
-      WindowFnTestUtils.validateGetOutputTimestamp(
-          Sessions.withGapDuration(Duration.millis(500)), timestamp);
-    }
-  }
-
   /**
    * Test to confirm that {@link Sessions} with the default {@link TimestampCombiner} holds up the
    * watermark potentially indefinitely.

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/SlidingWindowsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/SlidingWindowsTest.java
@@ -31,7 +31,6 @@ import java.util.Arrays;
 import java.util.HashMap;
 import java.util.Map;
 import java.util.Set;
-import org.apache.beam.sdk.testing.WindowFnTestUtils;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
@@ -188,22 +187,6 @@ public class SlidingWindowsTest {
     assertEquals(
         new IntervalWindow(new Instant(640), new Instant(1640)),
         mapping.getSideInputWindow(new IntervalWindow(new Instant(0), new Instant(1341))));
-  }
-
-  @Test
-  public void testValidOutputTimes() throws Exception {
-    for (long timestamp : Arrays.asList(200, 800, 499, 500, 501, 700, 1000)) {
-      WindowFnTestUtils.validateGetOutputTimestamp(
-          SlidingWindows.of(new Duration(1000)).every(new Duration(500)), timestamp);
-    }
-  }
-
-  @Test
-  public void testOutputTimesNonInterference() throws Exception {
-    for (long timestamp : Arrays.asList(200, 800, 700)) {
-      WindowFnTestUtils.validateNonInterferingOutputTimes(
-          SlidingWindows.of(new Duration(1000)).every(new Duration(500)), timestamp);
-    }
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/WindowingTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/windowing/WindowingTest.java
@@ -142,10 +142,10 @@ public class WindowingTest implements Serializable {
     PAssert.that(output)
         .containsInAnyOrder(
             output("a", 1, 1, -5, 5),
-            output("a", 2, 5, 0, 10),
-            output("a", 1, 10, 5, 15),
+            output("a", 2, 1, 0, 10),
+            output("a", 1, 7, 5, 15),
             output("b", 1, 8, 0, 10),
-            output("b", 1, 10, 5, 15));
+            output("b", 1, 8, 5, 15));
 
     p.run();
   }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
@@ -1166,11 +1166,6 @@ public class BigQueryIOWriteTest implements Serializable {
       throw new UnsupportedOperationException(
           "PartitionedGlobalWindows is not allowed in side inputs");
     }
-
-    @Override
-    public Instant getOutputTime(Instant inputTimestamp, PartitionedGlobalWindow window) {
-      return inputTimestamp;
-    }
   }
 
   /** Custom Window object that encodes a String value. */

--- a/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/WinningBids.java
+++ b/sdks/java/testing/nexmark/src/main/java/org/apache/beam/sdk/nexmark/queries/WinningBids.java
@@ -283,29 +283,6 @@ public class WinningBids extends PTransform<PCollection<Event>, PCollection<Auct
     public WindowMappingFn<AuctionOrBidWindow> getDefaultWindowMappingFn() {
       throw new UnsupportedOperationException("AuctionWindowFn not supported for side inputs");
     }
-
-    /**
-     * Below we will GBK auctions and bids on their auction ids. Then we will reduce those per id to
-     * emit {@code (auction, winning bid)} pairs for auctions which have expired with at least one
-     * valid bid. We would like those output pairs to have a timestamp of the auction's expiry
-     * (since that's the earliest we know for sure we have the correct winner). We would also like
-     * to make that winning results are available to following stages at the auction's expiry.
-     *
-     * <p>Each result of the GBK will have a timestamp of the min of the result of this object's
-     * assignOutputTime over all records which end up in one of its iterables. Thus we get the
-     * desired behavior if we ignore each record's timestamp and always return the auction window's
-     * 'maxTimestamp', which will correspond to the auction's expiry.
-     *
-     * <p>In contrast, if this object's assignOutputTime were to return 'inputTimestamp' (the usual
-     * implementation), then each GBK record will take as its timestamp the minimum of the
-     * timestamps of all bids and auctions within it, which will always be the auction's timestamp.
-     * An auction which expires well into the future would thus hold up the watermark of the GBK
-     * results until that auction expired. That in turn would hold up all winning pairs.
-     */
-    @Override
-    public Instant getOutputTime(Instant inputTimestamp, AuctionOrBidWindow window) {
-      return window.maxTimestamp();
-    }
   }
 
   private final AuctionOrBidWindowFn auctionOrBidWindowFn;


### PR DESCRIPTION
See [dev@ thread](https://lists.apache.org/thread.html/r99d0efa70f83815e17a1dbfb94effd16b38176046ac8ffbfe371c895%40%3Cdev.beam.apache.org%3E) where consensus is that the existence of this method is a _bug_ and it should be eliminated.

See next [user@ thread](https://lists.apache.org/thread.html/r7220ad2732e3d93e23e1f8af8051c5f6f6d72efdf556a467b9afb9fc%40%3Cuser.beam.apache.org%3E) where no one responded. Perhaps because it is complex and esoteric.

Important points to consider about this change, worth repeating in the PR:
- the method is annotated "experimental" but it has been around since the very early days of Beam so we should ignore that
- it was added as response to a _real user problem_: sliding windows + `EARLIEST` timestamp combiner delays downstream aggregations a lot
- but when that problem occurred, timestamp combiner `EARLIEST` was the default; with the change to how lateness is defined we changed the default to `END_OF_WINDOW`

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

Post-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

Lang | SDK | Dataflow | Flink | Samza | Spark | Twister2
--- | --- | --- | --- | --- | --- | ---
Go | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/) | ---
Java | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/)
Python | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/) | ---
XLang | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/) | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/) | ---

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

--- |Java | Python | Go | Website | Whitespace | Typescript
--- | --- | --- | --- | --- | --- | ---
Non-portable | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/)<br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/) <br>[![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/) | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/)
Portable | --- | [![Build Status](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon)](https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/) | --- | --- | --- | ---

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
