### PR TITLE
[BEAM-12057] Add missing populateDisplayData methods to ParquetIO

### DIFF
--- a/sdks/java/io/parquet/src/main/java/org/apache/beam/sdk/io/parquet/ParquetIO.java
+++ b/sdks/java/io/parquet/src/main/java/org/apache/beam/sdk/io/parquet/ParquetIO.java
@@ -31,6 +31,7 @@ import java.nio.channels.WritableByteChannel;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
+import java.util.Map.Entry;
 import javax.annotation.Nullable;
 import org.apache.avro.Schema;
 import org.apache.avro.generic.GenericData;
@@ -425,8 +426,24 @@ public class ParquetIO {
     @Override
     public void populateDisplayData(DisplayData.Builder builder) {
       super.populateDisplayData(builder);
-      builder.add(
-          DisplayData.item("filePattern", getFilepattern()).withLabel("Input File Pattern"));
+      builder
+          .addIfNotNull(
+              DisplayData.item("filePattern", getFilepattern()).withLabel("Input File Pattern"))
+          .addIfNotNull(DisplayData.item("schema", String.valueOf(getSchema())))
+          .add(
+              DisplayData.item("inferBeamSchema", getInferBeamSchema())
+                  .withLabel("Infer Beam Schema"))
+          .add(DisplayData.item("splittable", isSplittable()))
+          .addIfNotNull(DisplayData.item("projectionSchema", String.valueOf(getProjectionSchema())))
+          .addIfNotNull(DisplayData.item("avroDataModel", String.valueOf(getAvroDataModel())));
+      if (this.getConfiguration() != null) {
+        Configuration configuration = this.getConfiguration().get();
+        for (Entry<String, String> entry : configuration) {
+          if (entry.getKey().startsWith("parquet")) {
+            builder.addIfNotNull(DisplayData.item(entry.getKey(), entry.getValue()));
+          }
+        }
+      }
     }
   }
 
@@ -460,12 +477,12 @@ public class ParquetIO {
       abstract Parse<T> build();
     }
 
-    public Parse<T> from(ValueProvider<String> inputFiles) {
-      return toBuilder().setFilepattern(inputFiles).build();
+    public Parse<T> from(ValueProvider<String> filepattern) {
+      return toBuilder().setFilepattern(filepattern).build();
     }
 
-    public Parse<T> from(String inputFiles) {
-      return from(ValueProvider.StaticValueProvider.of(inputFiles));
+    public Parse<T> from(String filepattern) {
+      return from(ValueProvider.StaticValueProvider.of(filepattern));
     }
 
     /** Specify the output coder to use for output of the {@code ParseFn}. */
@@ -502,6 +519,27 @@ public class ParquetIO {
                   .setCoder(getCoder())
                   .setSplittable(isSplittable())
                   .build());
+    }
+
+    @Override
+    public void populateDisplayData(DisplayData.Builder builder) {
+      super.populateDisplayData(builder);
+      builder
+          .addIfNotNull(
+              DisplayData.item("filePattern", getFilepattern()).withLabel("Input File Pattern"))
+          .add(DisplayData.item("splittable", isSplittable()))
+          .add(DisplayData.item("parseFn", getParseFn().getClass()).withLabel("Parse function"));
+      if (this.getCoder() != null) {
+        builder.add(DisplayData.item("coder", getCoder().getClass()));
+      }
+      if (this.getConfiguration() != null) {
+        Configuration configuration = this.getConfiguration().get();
+        for (Entry<String, String> entry : configuration) {
+          if (entry.getKey().startsWith("parquet")) {
+            builder.addIfNotNull(DisplayData.item(entry.getKey(), entry.getValue()));
+          }
+        }
+      }
     }
   }
 
@@ -561,6 +599,25 @@ public class ParquetIO {
       return input
           .apply(ParDo.of(buildFileReadingFn()))
           .setCoder(inferCoder(input.getPipeline().getCoderRegistry()));
+    }
+
+    @Override
+    public void populateDisplayData(DisplayData.Builder builder) {
+      super.populateDisplayData(builder);
+      builder
+          .add(DisplayData.item("splittable", isSplittable()))
+          .add(DisplayData.item("parseFn", getParseFn().getClass()).withLabel("Parse function"));
+      if (this.getCoder() != null) {
+        builder.add(DisplayData.item("coder", getCoder().getClass()));
+      }
+      if (this.getConfiguration() != null) {
+        Configuration configuration = this.getConfiguration().get();
+        for (Entry<String, String> entry : configuration) {
+          if (entry.getKey().startsWith("parquet")) {
+            builder.addIfNotNull(DisplayData.item(entry.getKey(), entry.getValue()));
+          }
+        }
+      }
     }
 
     /** Returns Splittable or normal Parquet file reading DoFn. */
@@ -686,6 +743,27 @@ public class ParquetIO {
     public PCollection<GenericRecord> expand(PCollection<ReadableFile> input) {
       checkNotNull(getSchema(), "Schema can not be null");
       return input.apply(ParDo.of(getReaderFn())).setCoder(getCollectionCoder());
+    }
+
+    @Override
+    public void populateDisplayData(DisplayData.Builder builder) {
+      super.populateDisplayData(builder);
+      builder
+          .addIfNotNull(DisplayData.item("schema", String.valueOf(getSchema())))
+          .add(
+              DisplayData.item("inferBeamSchema", getInferBeamSchema())
+                  .withLabel("Infer Beam Schema"))
+          .add(DisplayData.item("splittable", isSplittable()))
+          .addIfNotNull(DisplayData.item("projectionSchema", String.valueOf(getProjectionSchema())))
+          .addIfNotNull(DisplayData.item("avroDataModel", String.valueOf(getAvroDataModel())));
+      if (this.getConfiguration() != null) {
+        Configuration configuration = this.getConfiguration().get();
+        for (Entry<String, String> entry : configuration) {
+          if (entry.getKey().startsWith("parquet")) {
+            builder.addIfNotNull(DisplayData.item(entry.getKey(), entry.getValue()));
+          }
+        }
+      }
     }
 
     /** Returns Parquet file reading function based on {@link #isSplittable()}. */

--- a/sdks/java/io/parquet/src/test/java/org/apache/beam/sdk/io/parquet/ParquetIOTest.java
+++ b/sdks/java/io/parquet/src/test/java/org/apache/beam/sdk/io/parquet/ParquetIOTest.java
@@ -386,9 +386,24 @@ public class ParquetIOTest implements Serializable {
 
   @Test
   public void testReadDisplayData() {
-    DisplayData displayData = DisplayData.from(ParquetIO.read(SCHEMA).from("foo.parquet"));
+    Configuration configuration = new Configuration();
+    configuration.set("parquet.foo", "foo");
+    DisplayData displayData =
+        DisplayData.from(
+            ParquetIO.read(SCHEMA)
+                .from("foo.parquet")
+                .withSplit()
+                .withProjection(REQUESTED_SCHEMA, SCHEMA)
+                .withAvroDataModel(GenericData.get())
+                .withConfiguration(configuration));
 
     assertThat(displayData, hasDisplayItem("filePattern", "foo.parquet"));
+    assertThat(displayData, hasDisplayItem("schema", SCHEMA.toString()));
+    assertThat(displayData, hasDisplayItem("inferBeamSchema", false));
+    assertThat(displayData, hasDisplayItem("splittable", true));
+    assertThat(displayData, hasDisplayItem("projectionSchema", REQUESTED_SCHEMA.toString()));
+    assertThat(displayData, hasDisplayItem("avroDataModel", GenericData.get().toString()));
+    assertThat(displayData, hasDisplayItem("parquet.foo", "foo"));
   }
 
   public static class TestRecord {


### PR DESCRIPTION
I added it to all the other transforms. The test is only for the Read to be consistent with `TextIO`, `AvroIO` and the rest.

R: @aromanenko-dev 
