### PR TITLE
Update httplib2 to version 1.19.1 on Python container

### DIFF
--- a/sdks/python/container/base_image_requirements.txt
+++ b/sdks/python/container/base_image_requirements.txt
@@ -30,7 +30,7 @@ dill==0.3.1.1
 future==0.18.2
 grpcio==1.32.0
 hdfs==2.5.8
-httplib2==0.18.1
+httplib2==0.19.1
 mock==2.0.0
 oauth2client==4.1.3
 protobuf==3.12.2


### PR DESCRIPTION
It seems the previous upgrade in #14379 of httplib2 to version 1.18.1 still have issues. Let's see if this works as expected.

R: @aaltay 
CC @kennknowles 