### PR TITLE
[BEAM-12088] Make file staging uniform among Spark Runners

### DIFF
--- a/runners/spark/2/src/main/java/org/apache/beam/runners/spark/structuredstreaming/SparkStructuredStreamingRunner.java
+++ b/runners/spark/2/src/main/java/org/apache/beam/runners/spark/structuredstreaming/SparkStructuredStreamingRunner.java
@@ -18,6 +18,8 @@
 package org.apache.beam.runners.spark.structuredstreaming;
 
 import static org.apache.beam.runners.core.construction.resources.PipelineResources.detectClassPathResourcesToStage;
+import static org.apache.beam.runners.spark.SparkCommonPipelineOptions.isLocalSparkMaster;
+import static org.apache.beam.runners.spark.SparkCommonPipelineOptions.prepareFilesToStage;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
@@ -112,8 +114,7 @@ public final class SparkStructuredStreamingRunner
     SparkStructuredStreamingPipelineOptions sparkOptions =
         PipelineOptionsValidator.validate(SparkStructuredStreamingPipelineOptions.class, options);
 
-    if (sparkOptions.getFilesToStage() == null
-        && !PipelineTranslator.isLocalSparkMaster(sparkOptions)) {
+    if (sparkOptions.getFilesToStage() == null && !isLocalSparkMaster(sparkOptions)) {
       sparkOptions.setFilesToStage(
           detectClassPathResourcesToStage(
               SparkStructuredStreamingRunner.class.getClassLoader(), options));
@@ -196,7 +197,7 @@ public final class SparkStructuredStreamingRunner
     }
 
     PipelineTranslator.replaceTransforms(pipeline, options);
-    PipelineTranslator.prepareFilesToStageForRemoteClusterExecution(options);
+    prepareFilesToStage(options);
     PipelineTranslator pipelineTranslator =
         options.isStreaming()
             ? new PipelineTranslatorStreaming(options)

--- a/runners/spark/2/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/PipelineTranslator.java
+++ b/runners/spark/2/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/PipelineTranslator.java
@@ -18,8 +18,6 @@
 package org.apache.beam.runners.spark.structuredstreaming.translation;
 
 import org.apache.beam.runners.core.construction.PTransformTranslation;
-import org.apache.beam.runners.core.construction.resources.PipelineResources;
-import org.apache.beam.runners.spark.structuredstreaming.SparkStructuredStreamingPipelineOptions;
 import org.apache.beam.runners.spark.structuredstreaming.translation.batch.PipelineTranslatorBatch;
 import org.apache.beam.runners.spark.structuredstreaming.translation.streaming.PipelineTranslatorStreaming;
 import org.apache.beam.sdk.Pipeline;
@@ -49,20 +47,6 @@ public abstract class PipelineTranslator extends Pipeline.PipelineVisitor.Defaul
   // --------------------------------------------------------------------------------------------
   //  Pipeline preparation methods
   // --------------------------------------------------------------------------------------------
-  /**
-   * Local configurations work in the same JVM and have no problems with improperly formatted files
-   * on classpath (eg. directories with .class files or empty directories). Prepare files for
-   * staging only when using remote cluster (passing the master address explicitly).
-   */
-  public static void prepareFilesToStageForRemoteClusterExecution(
-      SparkStructuredStreamingPipelineOptions options) {
-    if (!PipelineTranslator.isLocalSparkMaster(options)) {
-      options.setFilesToStage(
-          PipelineResources.prepareFilesForStaging(
-              options.getFilesToStage(), options.getTempLocation()));
-    }
-  }
-
   public static void replaceTransforms(Pipeline pipeline, StreamingOptions options) {
     pipeline.replaceAll(SparkTransformOverrides.getDefaultOverrides(options.isStreaming()));
   }
@@ -136,11 +120,6 @@ public abstract class PipelineTranslator extends Pipeline.PipelineVisitor.Defaul
       builder.append("|   ");
     }
     return builder.toString();
-  }
-
-  /** Detects if the pipeline is run in local spark mode. */
-  public static boolean isLocalSparkMaster(SparkStructuredStreamingPipelineOptions options) {
-    return options.getSparkMaster().matches("local\\[?\\d*]?");
   }
 
   /** Get a {@link TransformTranslator} for the given {@link TransformHierarchy.Node}. */

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkCommonPipelineOptions.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkCommonPipelineOptions.java
@@ -17,13 +17,18 @@
  */
 package org.apache.beam.runners.spark;
 
+import java.io.File;
 import java.util.List;
+import java.util.stream.Collectors;
+import org.apache.beam.runners.core.construction.resources.PipelineResources;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.options.ApplicationNameOptions;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.DefaultValueFactory;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.StreamingOptions;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects;
 
 /**
  * Spark runner {@link PipelineOptions} handles Spark execution-related configurations, such as the
@@ -75,6 +80,37 @@ public interface SparkCommonPipelineOptions
     @Override
     public String create(PipelineOptions options) {
       return "/tmp/" + options.getJobName();
+    }
+  }
+
+  /** Detects if the pipeline is run in spark local mode. */
+  @Internal
+  static boolean isLocalSparkMaster(SparkCommonPipelineOptions options) {
+    return options.getSparkMaster().matches("local\\[?\\d*]?");
+  }
+
+  /**
+   * Classpath contains non jar files (eg. directories with .class files or empty directories) will
+   * cause exception in running log. Though the {@link org.apache.spark.SparkContext} can handle
+   * this when running in local master, it's better not to include non-jars files in classpath.
+   */
+  @Internal
+  static void prepareFilesToStage(SparkCommonPipelineOptions options) {
+    if (!isLocalSparkMaster(options)) {
+      List<String> filesToStage =
+          options.getFilesToStage().stream()
+              .map(File::new)
+              .filter(File::exists)
+              .map(
+                  file -> {
+                    return file.getAbsolutePath();
+                  })
+              .collect(Collectors.toList());
+      options.setFilesToStage(
+          PipelineResources.prepareFilesForStaging(
+              filesToStage,
+              MoreObjects.firstNonNull(
+                  options.getTempLocation(), System.getProperty("java.io.tmpdir"))));
     }
   }
 }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkPipelineOptions.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkPipelineOptions.java
@@ -17,16 +17,10 @@
  */
 package org.apache.beam.runners.spark;
 
-import java.io.File;
-import java.util.List;
-import java.util.stream.Collectors;
-import org.apache.beam.runners.core.construction.resources.PipelineResources;
 import org.apache.beam.sdk.annotations.Experimental;
-import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.options.Default;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.PipelineOptions;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects;
 
 /**
  * Spark runner {@link PipelineOptions} handles Spark execution-related configurations, such as the
@@ -100,35 +94,4 @@ public interface SparkPipelineOptions extends SparkCommonPipelineOptions {
   boolean isCacheDisabled();
 
   void setCacheDisabled(boolean value);
-
-  /** Detects if the pipeline is run in spark local mode. */
-  @Internal
-  static boolean isLocalSparkMaster(SparkPipelineOptions options) {
-    return options.getSparkMaster().matches("local\\[?\\d*]?");
-  }
-
-  /**
-   * Classpath contains non jar files (eg. directories with .class files or empty directories) will
-   * cause exception in running log. Though the {@link org.apache.spark.SparkContext} can handle
-   * this when running in local master, it's better not to include non-jars files in classpath.
-   */
-  @Internal
-  static void prepareFilesToStage(SparkPipelineOptions options) {
-    if (!isLocalSparkMaster(options)) {
-      List<String> filesToStage =
-          options.getFilesToStage().stream()
-              .map(File::new)
-              .filter(File::exists)
-              .map(
-                  file -> {
-                    return file.getAbsolutePath();
-                  })
-              .collect(Collectors.toList());
-      options.setFilesToStage(
-          PipelineResources.prepareFilesForStaging(
-              filesToStage,
-              MoreObjects.firstNonNull(
-                  options.getTempLocation(), System.getProperty("java.io.tmpdir"))));
-    }
-  }
 }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkPipelineRunner.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkPipelineRunner.java
@@ -19,7 +19,7 @@ package org.apache.beam.runners.spark;
 
 import static org.apache.beam.runners.core.construction.resources.PipelineResources.detectClassPathResourcesToStage;
 import static org.apache.beam.runners.fnexecution.translation.PipelineTranslatorUtils.hasUnboundedPCollections;
-import static org.apache.beam.runners.spark.SparkPipelineOptions.prepareFilesToStage;
+import static org.apache.beam.runners.spark.SparkCommonPipelineOptions.prepareFilesToStage;
 import static org.apache.beam.runners.spark.util.SparkCommon.startEventLoggingListener;
 
 import java.util.UUID;

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkRunner.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkRunner.java
@@ -18,7 +18,8 @@
 package org.apache.beam.runners.spark;
 
 import static org.apache.beam.runners.core.construction.resources.PipelineResources.detectClassPathResourcesToStage;
-import static org.apache.beam.runners.spark.SparkPipelineOptions.prepareFilesToStage;
+import static org.apache.beam.runners.spark.SparkCommonPipelineOptions.isLocalSparkMaster;
+import static org.apache.beam.runners.spark.SparkCommonPipelineOptions.prepareFilesToStage;
 import static org.apache.beam.runners.spark.util.SparkCommon.startEventLoggingListener;
 
 import java.util.Collection;
@@ -136,8 +137,7 @@ public final class SparkRunner extends PipelineRunner<SparkPipelineResult> {
     SparkPipelineOptions sparkOptions =
         PipelineOptionsValidator.validate(SparkPipelineOptions.class, options);
 
-    if (sparkOptions.getFilesToStage() == null
-        && !SparkPipelineOptions.isLocalSparkMaster(sparkOptions)) {
+    if (sparkOptions.getFilesToStage() == null && !isLocalSparkMaster(sparkOptions)) {
       sparkOptions.setFilesToStage(
           detectClassPathResourcesToStage(SparkRunner.class.getClassLoader(), options));
       LOG.info(


### PR DESCRIPTION
This solves a deployment issue for Spark Structured Streaming runner on YARN and reduces and makes code more consistent among runners.

R: @ibzib 