### PR TITLE
[DO NOT MERGE] [BEAM-12135] Use ValueOnlyWindowedValueCoder if windowStrategy is based on GlobalWindow on Spark runner

### DIFF
--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/coders/CoderHelpers.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/coders/CoderHelpers.java
@@ -32,6 +32,13 @@ import java.util.stream.StreamSupport;
 import javax.annotation.Nonnull;
 import org.apache.beam.runners.spark.util.ByteArray;
 import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
+import org.apache.beam.sdk.transforms.windowing.WindowFn;
+import org.apache.beam.sdk.util.WindowedValue.FullWindowedValueCoder;
+import org.apache.beam.sdk.util.WindowedValue.ValueOnlyWindowedValueCoder;
+import org.apache.beam.sdk.util.WindowedValue.WindowedValueCoder;
+import org.apache.beam.sdk.values.WindowingStrategy;
 import org.apache.spark.api.java.function.Function;
 import org.apache.spark.api.java.function.PairFunction;
 import org.joda.time.Instant;
@@ -249,5 +256,19 @@ public final class CoderHelpers {
             StreamSupport.stream(tuple._2().spliterator(), false)
                 .map(bytes -> fromByteArray(bytes, valueCoder))
                 .collect(Collectors.toList()));
+  }
+
+  /**
+   * @return a {@link WindowedValueCoder} depending on the given {@link WindowingStrategy} coder, if
+   *     it is based on {@link GlobalWindows} it creates a {@link ValueOnlyWindowedValueCoder} to
+   *     optimize encoding, otherwise it creates a {@link FullWindowedValueCoder}.
+   */
+  public static <T> WindowedValueCoder<T> windowedValueCoder(
+      Coder<T> valueCoder, WindowingStrategy<?, ?> windowingStrategy) {
+    WindowFn<?, ?> windowFn = windowingStrategy.getWindowFn();
+    Coder<? extends BoundedWindow> windowCoder = windowFn.windowCoder();
+    return (windowFn instanceof GlobalWindows)
+        ? ValueOnlyWindowedValueCoder.of(valueCoder)
+        : FullWindowedValueCoder.of(valueCoder, windowCoder);
   }
 }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/io/SparkUnboundedSource.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/io/SparkUnboundedSource.java
@@ -42,6 +42,7 @@ import org.apache.beam.sdk.metrics.MetricsEnvironment;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.beam.sdk.util.WindowedValue.FullWindowedValueCoder;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Splitter;
 import org.apache.spark.api.java.JavaRDD;
 import org.apache.spark.api.java.JavaSparkContext$;
@@ -120,9 +121,8 @@ public class SparkUnboundedSource {
         .register();
 
     // output the actual (deserialized) stream.
-    WindowedValue.FullWindowedValueCoder<T> coder =
-        WindowedValue.FullWindowedValueCoder.of(
-            source.getOutputCoder(), GlobalWindow.Coder.INSTANCE);
+    FullWindowedValueCoder<T> coder =
+        FullWindowedValueCoder.of(source.getOutputCoder(), GlobalWindow.Coder.INSTANCE);
     JavaDStream<WindowedValue<T>> readUnboundedStream =
         mapWithStateDStream
             .flatMap(new Tuple2byteFlatMapFunction())

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/stateful/SparkGroupAlsoByWindowViaWindowSet.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/stateful/SparkGroupAlsoByWindowViaWindowSet.java
@@ -52,6 +52,7 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.util.WindowedValue.FullWindowedValueCoder;
+import org.apache.beam.sdk.util.WindowedValue.WindowedValueCoder;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.WindowingStrategy;
@@ -368,7 +369,7 @@ public class SparkGroupAlsoByWindowViaWindowSet implements Serializable {
       }
     }
 
-    private final FullWindowedValueCoder<InputT> wvCoder;
+    private final WindowedValueCoder<InputT> wvCoder;
     private final Coder<K> keyCoder;
     private final List<Integer> sourceIds;
     private final TimerInternals.TimerDataCoderV2 timerDataCoder;
@@ -394,10 +395,7 @@ public class SparkGroupAlsoByWindowViaWindowSet implements Serializable {
       this.itrWvCoder = IterableCoder.of(wvCoder);
       this.logPrefix = logPrefix;
       this.wvKvIterCoder =
-          windowedValueKeyValueCoderOf(
-              keyCoder,
-              wvCoder.getValueCoder(),
-              ((FullWindowedValueCoder<InputT>) wvCoder).getWindowCoder());
+          windowedValueKeyValueCoderOf(keyCoder, wvCoder.getValueCoder(), wvCoder.getWindowCoder());
     }
 
     @Override

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/stateful/StateSpecFunctions.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/stateful/StateSpecFunctions.java
@@ -38,6 +38,7 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.beam.sdk.util.WindowedValue.FullWindowedValueCoder;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Optional;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Stopwatch;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterators;
@@ -164,9 +165,8 @@ public class StateSpecFunctions {
 
           // read microbatch as a serialized collection.
           final List<byte[]> readValues = new ArrayList<>();
-          WindowedValue.FullWindowedValueCoder<T> coder =
-              WindowedValue.FullWindowedValueCoder.of(
-                  source.getOutputCoder(), GlobalWindow.Coder.INSTANCE);
+          FullWindowedValueCoder<T> coder =
+              FullWindowedValueCoder.of(source.getOutputCoder(), GlobalWindow.Coder.INSTANCE);
           try {
             // measure how long a read takes per-partition.
             boolean finished = !microbatchReader.start();

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/EvaluationContext.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/EvaluationContext.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.spark.translation;
 
+import static org.apache.beam.runners.spark.coders.CoderHelpers.windowedValueCoder;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
 
 import java.util.HashMap;
@@ -34,8 +35,8 @@ import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.runners.AppliedPTransform;
 import org.apache.beam.sdk.transforms.GroupByKey;
 import org.apache.beam.sdk.transforms.PTransform;
-import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.beam.sdk.util.WindowedValue.WindowedValueCoder;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.PValue;
@@ -201,9 +202,9 @@ public class EvaluationContext {
     if (shouldCache(transform, pvalue)) {
       // we cache only PCollection
       Coder<?> coder = ((PCollection<?>) pvalue).getCoder();
-      Coder<? extends BoundedWindow> wCoder =
-          ((PCollection<?>) pvalue).getWindowingStrategy().getWindowFn().windowCoder();
-      dataset.cache(storageLevel(), WindowedValue.getFullCoder(coder, wCoder));
+      WindowedValueCoder<?> wvCoder =
+          windowedValueCoder(coder, ((PCollection<?>) pvalue).getWindowingStrategy());
+      dataset.cache(storageLevel(), wvCoder);
     }
     datasets.put(pvalue, dataset);
     leaves.add(dataset);

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkStreamingPortablePipelineTranslator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/SparkStreamingPortablePipelineTranslator.java
@@ -23,7 +23,6 @@ import static org.apache.beam.runners.fnexecution.translation.PipelineTranslator
 import static org.apache.beam.runners.fnexecution.translation.PipelineTranslatorUtils.getOutputId;
 import static org.apache.beam.runners.fnexecution.translation.PipelineTranslatorUtils.getWindowedValueCoder;
 import static org.apache.beam.runners.fnexecution.translation.PipelineTranslatorUtils.getWindowingStrategy;
-import static org.apache.beam.runners.spark.coders.CoderHelpers.windowedValueCoder;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -198,14 +197,11 @@ public class SparkStreamingPortablePipelineTranslator
     WindowedValueCoder<KV<K, V>> inputCoder = getWindowedValueCoder(inputId, components);
     KvCoder<K, V> inputKvCoder = (KvCoder<K, V>) inputCoder.getValueCoder();
     WindowingStrategy windowingStrategy = getWindowingStrategy(inputId, components);
-    WindowedValueCoder<V> wvCoder =
-        windowedValueCoder(inputKvCoder.getValueCoder(), windowingStrategy);
 
     JavaDStream<WindowedValue<KV<K, Iterable<V>>>> outStream =
         SparkGroupAlsoByWindowViaWindowSet.groupByKeyAndWindow(
             inputDataset.getDStream(),
-            inputKvCoder.getKeyCoder(),
-            wvCoder,
+            inputKvCoder,
             windowingStrategy,
             context.getSerializableOptions(),
             streamSources,

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/StreamingTransformTranslator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/StreamingTransformTranslator.java
@@ -324,18 +324,15 @@ public final class StreamingTransformTranslator {
             (UnboundedDataset<KV<K, V>>) context.borrowDataset(transform);
         List<Integer> streamSources = inputDataset.getStreamSources();
         JavaDStream<WindowedValue<KV<K, V>>> dStream = inputDataset.getDStream();
-        final KvCoder<K, V> coder = (KvCoder<K, V>) context.getInput(transform).getCoder();
+        final KvCoder<K, V> kvCoder = (KvCoder<K, V>) context.getInput(transform).getCoder();
         @SuppressWarnings("unchecked")
         final WindowingStrategy<?, W> windowingStrategy =
             (WindowingStrategy<?, W>) context.getInput(transform).getWindowingStrategy();
-        final WindowedValueCoder<V> wvCoder =
-            windowedValueCoder(coder.getValueCoder(), windowingStrategy);
 
         JavaDStream<WindowedValue<KV<K, Iterable<V>>>> outStream =
             SparkGroupAlsoByWindowViaWindowSet.groupByKeyAndWindow(
                 dStream,
-                coder.getKeyCoder(),
-                wvCoder,
+                kvCoder,
                 windowingStrategy,
                 context.getSerializableOptions(),
                 streamSources,

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/metrics/SparkMetricsPusherTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/metrics/SparkMetricsPusherTest.java
@@ -117,12 +117,12 @@ public class SparkMetricsPusherTest {
   @Category(UsesMetricsPusher.class)
   @Test
   public void testInBatchMode() throws Exception {
-    pipeline.apply(Create.of(1, 2, 3, 4, 5, 6)).apply(ParDo.of(new CountingDoFn()));
+    pipeline.apply(Create.of(1)).apply(ParDo.of(new CountingDoFn()));
 
     pipeline.run();
     // give metrics pusher time to push
     Thread.sleep(
         (pipeline.getOptions().as(MetricsOptions.class).getMetricsPushPeriod() + 1L) * 1000);
-    assertThat(TestMetricsSink.getCounterValue(COUNTER_NAME), is(6L));
+    assertThat(TestMetricsSink.getCounterValue(COUNTER_NAME), is(1L));
   }
 }

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/TransformTranslatorTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/TransformTranslatorTest.java
@@ -29,6 +29,8 @@ import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.beam.sdk.util.WindowedValue.FullWindowedValueCoder;
+import org.apache.beam.sdk.util.WindowedValue.WindowedValueCoder;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterators;
@@ -56,8 +58,8 @@ public class TransformTranslatorTest {
   @Test
   public void testSplitBySameKey() {
     VarIntCoder coder = VarIntCoder.of();
-    WindowedValue.WindowedValueCoder<Integer> wvCoder =
-        WindowedValue.FullWindowedValueCoder.of(coder, GlobalWindow.Coder.INSTANCE);
+    WindowedValueCoder<Integer> wvCoder =
+        FullWindowedValueCoder.of(coder, GlobalWindow.Coder.INSTANCE);
     Instant now = Instant.now();
     List<GlobalWindow> window = Arrays.asList(GlobalWindow.INSTANCE);
     PaneInfo paneInfo = PaneInfo.NO_FIRING;

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/ValueAndCoderLazySerializableTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/ValueAndCoderLazySerializableTest.java
@@ -31,9 +31,8 @@ import java.util.Arrays;
 import org.apache.beam.sdk.coders.BigEndianIntegerCoder;
 import org.apache.beam.sdk.coders.IterableCoder;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
-import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.util.WindowedValue;
-import org.joda.time.Instant;
+import org.apache.beam.sdk.util.WindowedValue.FullWindowedValueCoder;
 import org.junit.Test;
 
 /** Unit tests of {@link ValueAndCoderLazySerializable}. */
@@ -46,11 +45,14 @@ public class ValueAndCoderLazySerializableTest {
   public void serializableAccumulatorSerializationTest()
       throws IOException, ClassNotFoundException {
     Iterable<WindowedValue<Integer>> accumulatedValue =
-        Arrays.asList(winVal(0), winVal(1), winVal(3), winVal(4));
+        Arrays.asList(
+            WindowedValue.valueInGlobalWindow(0),
+            WindowedValue.valueInGlobalWindow(1),
+            WindowedValue.valueInGlobalWindow(3),
+            WindowedValue.valueInGlobalWindow(4));
 
-    final WindowedValue.FullWindowedValueCoder<Integer> wvaCoder =
-        WindowedValue.FullWindowedValueCoder.of(
-            BigEndianIntegerCoder.of(), GlobalWindow.Coder.INSTANCE);
+    final FullWindowedValueCoder<Integer> wvaCoder =
+        FullWindowedValueCoder.of(BigEndianIntegerCoder.of(), GlobalWindow.Coder.INSTANCE);
 
     final IterableCoder<WindowedValue<Integer>> iterAccumCoder = IterableCoder.of(wvaCoder);
 
@@ -72,11 +74,14 @@ public class ValueAndCoderLazySerializableTest {
   @Test
   public void serializableAccumulatorKryoTest() {
     Iterable<WindowedValue<Integer>> accumulatedValue =
-        Arrays.asList(winVal(0), winVal(1), winVal(3), winVal(4));
+        Arrays.asList(
+            WindowedValue.valueInGlobalWindow(0),
+            WindowedValue.valueInGlobalWindow(1),
+            WindowedValue.valueInGlobalWindow(3),
+            WindowedValue.valueInGlobalWindow(4));
 
-    final WindowedValue.FullWindowedValueCoder<Integer> wvaCoder =
-        WindowedValue.FullWindowedValueCoder.of(
-            BigEndianIntegerCoder.of(), GlobalWindow.Coder.INSTANCE);
+    final FullWindowedValueCoder<Integer> wvaCoder =
+        FullWindowedValueCoder.of(BigEndianIntegerCoder.of(), GlobalWindow.Coder.INSTANCE);
 
     final IterableCoder<WindowedValue<Integer>> iterAccumCoder = IterableCoder.of(wvaCoder);
 
@@ -101,9 +106,5 @@ public class ValueAndCoderLazySerializableTest {
     input.close();
 
     assertEquals(accumulatedValue, materialized.getOrDecode(iterAccumCoder));
-  }
-
-  private <T> WindowedValue<T> winVal(T val) {
-    return WindowedValue.of(val, Instant.now(), GlobalWindow.INSTANCE, PaneInfo.NO_FIRING);
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/GroupByKeyTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/GroupByKeyTest.java
@@ -60,6 +60,7 @@ import org.apache.beam.sdk.transforms.windowing.AfterProcessingTime;
 import org.apache.beam.sdk.transforms.windowing.AfterWatermark;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.transforms.windowing.Repeatedly;
 import org.apache.beam.sdk.transforms.windowing.Sessions;
@@ -70,8 +71,10 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TimestampedValue;
+import org.apache.beam.sdk.values.TypeDescriptors;
 import org.apache.beam.sdk.values.WindowingStrategy;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Streams;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hamcrest.Matcher;
 import org.joda.time.Duration;
@@ -582,6 +585,46 @@ public class GroupByKeyTest implements Serializable {
           .satisfies(containsKvs(kv("foo", 9)));
 
       p.run();
+    }
+
+    @Test
+    @Category(ValidatesRunner.class)
+    public void testRewindowWithTimestampCombiner() {
+      PCollection<KV<String, Integer>> input =
+          p.apply(
+                  Create.timestamped(
+                      TimestampedValue.of(KV.of("foo", 1), new Instant(1)),
+                      TimestampedValue.of(KV.of("foo", 4), new Instant(4)),
+                      TimestampedValue.of(KV.of("bar", 3), new Instant(3)),
+                      TimestampedValue.of(KV.of("foo", 9), new Instant(9))))
+              .apply(
+                  "globalWindow",
+                  Window.<KV<String, Integer>>into(new GlobalWindows())
+                      .withAllowedLateness(Duration.ZERO)
+                      .discardingFiredPanes()
+                      .withTimestampCombiner(TimestampCombiner.LATEST));
+
+      PCollection<KV<String, Integer>> result =
+          input
+              .apply(GroupByKey.create())
+              .apply(
+                  MapElements.into(
+                          TypeDescriptors.kvs(
+                              TypeDescriptors.strings(), TypeDescriptors.integers()))
+                      .via(kv -> KV.of(kv.getKey(), sum(kv.getValue()))))
+              .apply("fixedWindow", Window.into(FixedWindows.of(Duration.millis(1))));
+
+      PAssert.that(result)
+          .inWindow(new IntervalWindow(new Instant(9), new Instant(10)))
+          .containsInAnyOrder(KV.of("foo", 14))
+          .inWindow(new IntervalWindow(new Instant(3), new Instant(4)))
+          .containsInAnyOrder(KV.of("bar", 3));
+
+      p.run();
+    }
+
+    private static int sum(Iterable<Integer> parts) {
+      return Streams.stream(parts).mapToInt(e -> e).sum();
     }
 
     @Test


### PR DESCRIPTION
This PR optimizes how we encode the records by choosing the specific WindowedValueCoder to use depending on the type of windowing used in the PCollections, if the associated windowing function is in global windows it uses the optimized encoding via `ValueOnlyWindowedValueCoder` to only convert the value to bytes instead of the full WindowedValue (value, timestamp, windows, pane) as FullWindowedValueCoder does.

This takes advantage of the fact that (timestamp, windows and pane) do not really matter for the final computation in Batch mode and brings the benefits of smaller shuffled data (Beam basically is adding ~13 extra bytes per record) and smaller memory footprint beause the decoded `WindowedValue` representation relies on existing static objects: BoundedWindow.TIMESTAMP_MIN_VALUE and GlobalWindow.INSTANCE.

R: @je-ik @ibzib 