### PR TITLE
[BEAM-10277][BEAM-12198] Populate encoding positions to all matching schemas

### DIFF
--- a/model/pipeline/src/main/proto/schema.proto
+++ b/model/pipeline/src/main/proto/schema.proto
@@ -38,10 +38,6 @@ message Schema {
   string id = 2;
   repeated Option options = 3;
   // Indicates that encoding positions have been overridden.
-  // OPTIONAL. The position of this field's data when encoded, e.g. with beam:coder:row:v1.
-  // Used to support backwards compatibility with schema changes.
-  // If this Field is part of a Schema where encoding_positions_set is True then encoding_position must be
-  // defined, otherwise this field is ignored.
   bool encoding_positions_set = 4;
 }
 
@@ -58,6 +54,8 @@ message Field {
    // or all of them are. Used to support backwards compatibility with schema
    // changes.
    // If no fields have encoding position populated the order of encoding is the same as the order in the Schema.
+  // If this Field is part of a Schema where encoding_positions_set is True then encoding_position must be
+  // defined, otherwise this field is ignored.
   int32 encoding_position = 5;
   repeated Option options = 6;
 }

--- a/model/pipeline/src/main/proto/schema.proto
+++ b/model/pipeline/src/main/proto/schema.proto
@@ -37,6 +37,8 @@ message Schema {
   // REQUIRED. An RFC 4122 UUID.
   string id = 2;
   repeated Option options = 3;
+  // Indicates that encoding positions have been overridden.
+  bool encoding_positions_set = 4;
 }
 
 message Field {

--- a/model/pipeline/src/main/proto/schema.proto
+++ b/model/pipeline/src/main/proto/schema.proto
@@ -38,6 +38,10 @@ message Schema {
   string id = 2;
   repeated Option options = 3;
   // Indicates that encoding positions have been overridden.
+  // OPTIONAL. The position of this field's data when encoded, e.g. with beam:coder:row:v1.
+  // Used to support backwards compatibility with schema changes.
+  // If this Field is part of a Schema where encoding_positions_set is True then encoding_position must be
+  // defined, otherwise this field is ignored.
   bool encoding_positions_set = 4;
 }
 

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/RowCoderCloudObjectTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/RowCoderCloudObjectTranslator.java
@@ -59,6 +59,7 @@ public class RowCoderCloudObjectTranslator implements CloudObjectTranslator<RowC
       SchemaApi.Schema.Builder schemaBuilder = SchemaApi.Schema.newBuilder();
       JsonFormat.parser().merge(Structs.getString(cloudObject, SCHEMA), schemaBuilder);
       Schema schema = SchemaTranslation.schemaFromProto(schemaBuilder.build());
+      RowCoder.overrideEncodingPositions(schema.getUUID(), schema.getEncodingPositions());
       return RowCoder.of(schema);
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/RowCoderCloudObjectTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/RowCoderCloudObjectTranslator.java
@@ -59,7 +59,9 @@ public class RowCoderCloudObjectTranslator implements CloudObjectTranslator<RowC
       SchemaApi.Schema.Builder schemaBuilder = SchemaApi.Schema.newBuilder();
       JsonFormat.parser().merge(Structs.getString(cloudObject, SCHEMA), schemaBuilder);
       Schema schema = SchemaTranslation.schemaFromProto(schemaBuilder.build());
-      RowCoder.overrideEncodingPositions(schema.getUUID(), schema.getEncodingPositions());
+      if (schema.isEncodingPositionsOverridden()) {
+        RowCoder.overrideEncodingPositions(schema.getUUID(), schema.getEncodingPositions());
+      }
       return RowCoder.of(schema);
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/RowCoderCloudObjectTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/RowCoderCloudObjectTranslator.java
@@ -59,7 +59,7 @@ public class RowCoderCloudObjectTranslator implements CloudObjectTranslator<RowC
       SchemaApi.Schema.Builder schemaBuilder = SchemaApi.Schema.newBuilder();
       JsonFormat.parser().merge(Structs.getString(cloudObject, SCHEMA), schemaBuilder);
       Schema schema = SchemaTranslation.schemaFromProto(schemaBuilder.build());
-      if (schema.isEncodingPositionsOverridden()) {
+      if (schema.isEncodingPositionsOverridden() && schema.getUUID() != null) {
         RowCoder.overrideEncodingPositions(schema.getUUID(), schema.getEncodingPositions());
       }
       return RowCoder.of(schema);

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/RowCoderCloudObjectTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/RowCoderCloudObjectTranslator.java
@@ -18,6 +18,8 @@
 package org.apache.beam.runners.dataflow.util;
 
 import java.io.IOException;
+import java.util.UUID;
+import javax.annotation.Nullable;
 import org.apache.beam.model.pipeline.v1.SchemaApi;
 import org.apache.beam.runners.core.construction.SdkComponents;
 import org.apache.beam.sdk.annotations.Experimental;
@@ -59,8 +61,9 @@ public class RowCoderCloudObjectTranslator implements CloudObjectTranslator<RowC
       SchemaApi.Schema.Builder schemaBuilder = SchemaApi.Schema.newBuilder();
       JsonFormat.parser().merge(Structs.getString(cloudObject, SCHEMA), schemaBuilder);
       Schema schema = SchemaTranslation.schemaFromProto(schemaBuilder.build());
-      if (schema.isEncodingPositionsOverridden() && schema.getUUID() != null) {
-        RowCoder.overrideEncodingPositions(schema.getUUID(), schema.getEncodingPositions());
+      @Nullable UUID uuid = schema.getUUID();
+      if (schema.isEncodingPositionsOverridden() && uuid != null) {
+        RowCoder.overrideEncodingPositions(uuid, schema.getEncodingPositions());
       }
       return RowCoder.of(schema);
     } catch (IOException e) {

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/SchemaCoderCloudObjectTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/SchemaCoderCloudObjectTranslator.java
@@ -99,7 +99,9 @@ public class SchemaCoderCloudObjectTranslator implements CloudObjectTranslator<S
       SchemaApi.Schema.Builder schemaBuilder = SchemaApi.Schema.newBuilder();
       JsonFormat.parser().merge(Structs.getString(cloudObject, SCHEMA), schemaBuilder);
       Schema schema = SchemaTranslation.schemaFromProto(schemaBuilder.build());
-      SchemaCoder.overrideEncodingPositions(schema.getUUID(), schema.getEncodingPositions());
+      if (schema.isEncodingPositionsOverridden()) {
+        SchemaCoder.overrideEncodingPositions(schema.getUUID(), schema.getEncodingPositions());
+      }
       return SchemaCoder.of(schema, typeDescriptor, toRowFunction, fromRowFunction);
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/SchemaCoderCloudObjectTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/SchemaCoderCloudObjectTranslator.java
@@ -99,7 +99,7 @@ public class SchemaCoderCloudObjectTranslator implements CloudObjectTranslator<S
       SchemaApi.Schema.Builder schemaBuilder = SchemaApi.Schema.newBuilder();
       JsonFormat.parser().merge(Structs.getString(cloudObject, SCHEMA), schemaBuilder);
       Schema schema = SchemaTranslation.schemaFromProto(schemaBuilder.build());
-      if (schema.isEncodingPositionsOverridden()) {
+      if (schema.isEncodingPositionsOverridden() && schema.getUUID() != null) {
         SchemaCoder.overrideEncodingPositions(schema.getUUID(), schema.getEncodingPositions());
       }
       return SchemaCoder.of(schema, typeDescriptor, toRowFunction, fromRowFunction);

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/SchemaCoderCloudObjectTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/SchemaCoderCloudObjectTranslator.java
@@ -18,6 +18,8 @@
 package org.apache.beam.runners.dataflow.util;
 
 import java.io.IOException;
+import java.util.UUID;
+import javax.annotation.Nullable;
 import org.apache.beam.model.pipeline.v1.SchemaApi;
 import org.apache.beam.runners.core.construction.SdkComponents;
 import org.apache.beam.sdk.annotations.Experimental;
@@ -99,8 +101,9 @@ public class SchemaCoderCloudObjectTranslator implements CloudObjectTranslator<S
       SchemaApi.Schema.Builder schemaBuilder = SchemaApi.Schema.newBuilder();
       JsonFormat.parser().merge(Structs.getString(cloudObject, SCHEMA), schemaBuilder);
       Schema schema = SchemaTranslation.schemaFromProto(schemaBuilder.build());
-      if (schema.isEncodingPositionsOverridden() && schema.getUUID() != null) {
-        SchemaCoder.overrideEncodingPositions(schema.getUUID(), schema.getEncodingPositions());
+      @Nullable UUID uuid = schema.getUUID();
+      if (schema.isEncodingPositionsOverridden() && uuid != null) {
+        SchemaCoder.overrideEncodingPositions(uuid, schema.getEncodingPositions());
       }
       return SchemaCoder.of(schema, typeDescriptor, toRowFunction, fromRowFunction);
     } catch (IOException e) {

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/SchemaCoderCloudObjectTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/SchemaCoderCloudObjectTranslator.java
@@ -99,6 +99,7 @@ public class SchemaCoderCloudObjectTranslator implements CloudObjectTranslator<S
       SchemaApi.Schema.Builder schemaBuilder = SchemaApi.Schema.newBuilder();
       JsonFormat.parser().merge(Structs.getString(cloudObject, SCHEMA), schemaBuilder);
       Schema schema = SchemaTranslation.schemaFromProto(schemaBuilder.build());
+      SchemaCoder.overrideEncodingPositions(schema.getUUID(), schema.getEncodingPositions());
       return SchemaCoder.of(schema, typeDescriptor, toRowFunction, fromRowFunction);
     } catch (IOException e) {
       throw new RuntimeException(e);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoder.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.coders;
 
+import java.util.Map;
 import java.util.Objects;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
@@ -25,6 +26,7 @@ import org.apache.beam.sdk.schemas.SchemaCoder;
 import org.apache.beam.sdk.transforms.SerializableFunctions;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TypeDescriptors;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** A sub-class of SchemaCoder that can only encode {@link Row} instances. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoder.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.coders;
 
 import java.util.Map;
 import java.util.Objects;
+import java.util.UUID;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.schemas.Schema;
@@ -26,7 +27,6 @@ import org.apache.beam.sdk.schemas.SchemaCoder;
 import org.apache.beam.sdk.transforms.SerializableFunctions;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TypeDescriptors;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** A sub-class of SchemaCoder that can only encode {@link Row} instances. */
@@ -34,6 +34,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class RowCoder extends SchemaCoder<Row> {
   public static RowCoder of(Schema schema) {
     return new RowCoder(schema);
+  }
+
+  /** Override encoding positions for the given schema. */
+  public static void overrideEncodingPositions(UUID uuid, Map<String, Integer> encodingPositions) {
+    SchemaCoder.overrideEncodingPositions(uuid, encodingPositions);
   }
 
   private RowCoder(Schema schema) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoderGenerator.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoderGenerator.java
@@ -28,7 +28,6 @@ import java.util.Arrays;
 import java.util.BitSet;
 import java.util.Map;
 import java.util.UUID;
-import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
@@ -113,7 +112,8 @@ public abstract class RowCoderGenerator {
 
   // Cache for Coder class that are already generated.
   private static final Map<UUID, Coder<Row>> GENERATED_CODERS = Maps.newConcurrentMap();
-  private static final Map<UUID, Map<String, Integer>> ENCODING_POSITION_OVERRIDES = Maps.newConcurrentMap();
+  private static final Map<UUID, Map<String, Integer>> ENCODING_POSITION_OVERRIDES =
+      Maps.newConcurrentMap();
 
   private static final Logger LOG = LoggerFactory.getLogger(RowCoderGenerator.class);
 
@@ -134,8 +134,8 @@ public abstract class RowCoderGenerator {
       builder = implementMethods(schema, builder);
 
       int[] encodingPosToRowIndex = new int[schema.getFieldCount()];
-      Map<String, Integer> encodingPositions = ENCODING_POSITION_OVERRIDES.getOrDefault(
-              schema.getUUID(), schema.getEncodingPositions());
+      Map<String, Integer> encodingPositions =
+          ENCODING_POSITION_OVERRIDES.getOrDefault(schema.getUUID(), schema.getEncodingPositions());
       for (int recordIndex = 0; recordIndex < schema.getFieldCount(); ++recordIndex) {
         String name = schema.getField(recordIndex).getName();
         int encodingPosition = encodingPositions.get(name);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -398,6 +398,7 @@ public class Schema implements Serializable {
     builder.append(System.lineSeparator());
     builder.append("Options:");
     builder.append(options);
+    builder.append("UUID: " + uuid);
     return builder.toString();
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -96,6 +96,7 @@ public class Schema implements Serializable {
   // A mapping between field names an indices.
   private final BiMap<String, Integer> fieldIndices = HashBiMap.create();
   private Map<String, Integer> encodingPositions = Maps.newHashMap();
+  private boolean encodingPositionsOverridden = false;
 
   private final List<Field> fields;
   // Cache the hashCode, so it doesn't have to be recomputed. Schema objects are immutable, so this
@@ -287,9 +288,15 @@ public class Schema implements Serializable {
     return encodingPositions;
   }
 
+  /** Returns whether encoding positions have been explicitly overridden. */
+  public boolean isEncodingPositionsOverridden() {
+    return encodingPositionsOverridden;
+  }
+
   /** Sets the encoding positions for this schema. */
   public void setEncodingPositions(Map<String, Integer> encodingPositions) {
     this.encodingPositions = encodingPositions;
+    this.encodingPositionsOverridden = true;
   }
 
   /** Get this schema's UUID. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaCoder.java
@@ -37,7 +37,6 @@ import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.util.SerializableUtils;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TypeDescriptor;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -110,7 +109,6 @@ public class SchemaCoder<T> extends CustomCoder<T> {
   public SerializableFunction<T, Row> getToRowFunction() {
     return toRowFunction;
   }
-
 
   private Coder<Row> getDelegateCoder() {
     if (delegateCoder == null) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaCoder.java
@@ -22,6 +22,7 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
+import java.util.Map;
 import java.util.Objects;
 import java.util.UUID;
 import org.apache.beam.sdk.annotations.Experimental;
@@ -36,6 +37,7 @@ import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.util.SerializableUtils;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -89,6 +91,11 @@ public class SchemaCoder<T> extends CustomCoder<T> {
     return RowCoder.of(schema);
   }
 
+  /** Override encoding positions for the given schema. */
+  public static void overrideEncodingPositions(UUID uuid, Map<String, Integer> encodingPositions) {
+    RowCoderGenerator.overrideEncodingPositions(uuid, encodingPositions);
+  }
+
   /** Returns the schema associated with this type. */
   public Schema getSchema() {
     return schema;
@@ -103,6 +110,7 @@ public class SchemaCoder<T> extends CustomCoder<T> {
   public SerializableFunction<T, Row> getToRowFunction() {
     return toRowFunction;
   }
+
 
   private Coder<Row> getDelegateCoder() {
     if (delegateCoder == null) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java
@@ -225,7 +225,7 @@ public class SchemaTranslation {
       // but if it does happen, we expect none to be specified - in which case the should all be
       // zero.
       Preconditions.checkState(dinstictEncodingPositions == 1);
-    } else {
+    } else if (protoSchema.getEncodingPositionsSet()) {
       schema.setEncodingPositions(encodingLocationMap);
     }
     if (!protoSchema.getId().isEmpty()) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
@@ -613,6 +613,9 @@ public abstract class Row implements Serializable {
         }
         builder.append("}");
         break;
+      case BYTES:
+        builder.append(Arrays.toString((byte[]) value));
+        break;
       default:
         builder.append(value);
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
@@ -48,7 +48,6 @@ import org.apache.beam.sdk.values.RowUtils.FieldOverride;
 import org.apache.beam.sdk.values.RowUtils.FieldOverrides;
 import org.apache.beam.sdk.values.RowUtils.RowFieldMatcher;
 import org.apache.beam.sdk.values.RowUtils.RowPosition;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.DateTime;
@@ -579,7 +578,45 @@ public abstract class Row implements Serializable {
 
   @Override
   public String toString() {
-    return "Row:" + Arrays.deepToString(Iterables.toArray(getValues(), Object.class));
+    StringBuilder builder = new StringBuilder();
+    builder.append("Row: ");
+    builder.append(System.lineSeparator());
+    for (int i = 0; i < getSchema().getFieldCount(); ++i) {
+      Schema.Field field = getSchema().getField(i);
+      builder.append(field.getName() + ":");
+      builder.append(toString(field.getType(), getValue(i)));
+      builder.append(System.lineSeparator());
+    }
+    return builder.toString();
+  }
+
+  private String toString(Schema.FieldType fieldType, Object value) {
+    StringBuilder builder = new StringBuilder();
+    switch (fieldType.getTypeName()) {
+      case ARRAY:
+      case ITERABLE:
+        builder.append("[");
+        for (Object element : (Iterable<?>) value) {
+          builder.append(toString(fieldType.getCollectionElementType(), element));
+          builder.append(", ");
+        }
+        builder.append("]");
+        break;
+      case MAP:
+        builder.append("{");
+        for (Map.Entry<?, ?> entry : ((Map<?, ?>) value).entrySet()) {
+          builder.append("(");
+          builder.append(toString(fieldType.getMapKeyType(), entry.getKey()));
+          builder.append(", ");
+          builder.append(toString(fieldType.getMapValueType(), entry.getValue()));
+          builder.append("), ");
+        }
+        builder.append("}");
+        break;
+      default:
+        builder.append(value);
+    }
+    return builder.toString();
   }
 
   /**

--- a/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamSqlOutputToConsoleFn.java
+++ b/sdks/java/extensions/sql/src/main/java/org/apache/beam/sdk/extensions/sql/impl/transform/BeamSqlOutputToConsoleFn.java
@@ -32,6 +32,6 @@ public class BeamSqlOutputToConsoleFn extends DoFn<Row, Void> {
 
   @ProcessElement
   public void processElement(ProcessContext c) {
-    System.out.println("Output: " + c.element().getValues());
+    System.out.println("Output: " + c.element().toString());
   }
 }

--- a/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/TestUtils.java
+++ b/sdks/java/extensions/sql/src/test/java/org/apache/beam/sdk/extensions/sql/TestUtils.java
@@ -39,8 +39,8 @@ public class TestUtils {
   /** A {@code DoFn} to convert a {@code BeamSqlRow} to a comparable {@code String}. */
   public static class BeamSqlRow2StringDoFn extends DoFn<Row, String> {
     @ProcessElement
-    public void processElement(ProcessContext ctx) {
-      ctx.output(ctx.element().toString());
+    public void processElement(@Element Row row, OutputReceiver<String> o) {
+      o.output(row.toString(false));
     }
   }
 
@@ -48,7 +48,7 @@ public class TestUtils {
   public static List<String> beamSqlRows2Strings(List<Row> rows) {
     List<String> strs = new ArrayList<>();
     for (Row row : rows) {
-      strs.add(row.toString());
+      strs.add(row.toString(false));
     }
 
     return strs;


### PR DESCRIPTION
Beam often copies Coders via Java serialization, and keeps them in places outside of the core graph. For example, ReduceFnRunner will copy the input coder into an underlying bag state. This means that if the runner modifies a schema's encoding positions, Beam must make sure that all SchemaCoders for that schema (identified by UUID) receive the new encoding positions.

Also adds a better Row.toString for better debugging of such changes.