### PR TITLE
[BEAM-12223] Fix javadoc bug in JdbcIO.java

### DIFF
--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
@@ -114,7 +114,7 @@ import org.slf4j.LoggerFactory;
  * <p>Query parameters can be configured using a user-provided {@link StatementPreparator}. For
  * example:
  *
- * <pre>{@code
+ * <pre><code>
  * pipeline.apply(JdbcIO.<KV<Integer, String>>read()
  *   .withDataSourceConfiguration(JdbcIO.DataSourceConfiguration.create(
  *       "com.mysql.jdbc.Driver", "jdbc:mysql://hostname:3306/mydb",
@@ -132,13 +132,13 @@ import org.slf4j.LoggerFactory;
  *     }
  *   })
  * );
- * }</pre>
+ * }</code></pre>
  *
  * <p>To customize the building of the {@link DataSource} we can provide a {@link
  * SerializableFunction}. For example if you need to provide a {@link PoolingDataSource} from an
  * existing {@link DataSourceConfiguration}: you can use a {@link PoolableDataSourceProvider}:
  *
- * <pre>{@code
+ * <pre><code>
  * pipeline.apply(JdbcIO.<KV<Integer, String>>read()
  *   .withDataSourceProviderFn(JdbcIO.PoolableDataSourceProvider.of(
  *       JdbcIO.DataSourceConfiguration.create(
@@ -146,17 +146,17 @@ import org.slf4j.LoggerFactory;
  *           "username", "password")))
  *    // ...
  * );
- * }</pre>
+ * }</code></pre>
  *
  * <p>By default, the provided function requests a DataSource per execution thread. In some
  * circumstances this can quickly overwhelm the database by requesting too many connections. In that
  * case you should look into sharing a single instance of a {@link PoolingDataSource} across all the
  * execution threads. For example:
  *
- * <pre>{@code
- * private static class MyDataSourceProviderFn implements SerializableFunction<Void, DataSource> {
+ * <pre><code>
+ * private static class MyDataSourceProviderFn implements {@literal SerializableFunction<Void, DataSource> {
  *   private static transient DataSource dataSource;
- *   @Override
+ *   {@literal @Override}
  *   public synchronized DataSource apply(Void input) {
  *     if (dataSource == null) {
  *       dataSource = ... build data source ...
@@ -164,12 +164,12 @@ import org.slf4j.LoggerFactory;
  *     return dataSource;
  *   }
  * }
- *
+ * {@literal
  * pipeline.apply(JdbcIO.<KV<Integer, String>>read()
  *   .withDataSourceProviderFn(new MyDataSourceProviderFn())
  *   // ...
  * );
- * }</pre>
+ * }</code></pre>
  *
  * <h3>Writing to JDBC datasource</h3>
  *
@@ -179,7 +179,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Like the source, to configure the sink, you have to provide a {@link DataSourceConfiguration}.
  *
- * <pre>{@code
+ * <pre><code>
  * pipeline
  *   .apply(...)
  *   .apply(JdbcIO.<KV<Integer, String>>write()
@@ -196,7 +196,7 @@ import org.slf4j.LoggerFactory;
  *        }
  *      })
  *    );
- * }</pre>
+ * }</code></pre>
  *
  * <p>NB: in case of transient failures, Beam runners may execute parts of JdbcIO.Write multiple
  * times for fault tolerance. Because of that, you should avoid using {@code INSERT} statements,

--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
@@ -114,7 +114,7 @@ import org.slf4j.LoggerFactory;
  * <p>Query parameters can be configured using a user-provided {@link StatementPreparator}. For
  * example:
  *
- * <pre><code>
+ * <pre>{@code
  * pipeline.apply(JdbcIO.<KV<Integer, String>>read()
  *   .withDataSourceConfiguration(JdbcIO.DataSourceConfiguration.create(
  *       "com.mysql.jdbc.Driver", "jdbc:mysql://hostname:3306/mydb",
@@ -132,13 +132,13 @@ import org.slf4j.LoggerFactory;
  *     }
  *   })
  * );
- * }</code></pre>
+ * }</pre>
  *
  * <p>To customize the building of the {@link DataSource} we can provide a {@link
  * SerializableFunction}. For example if you need to provide a {@link PoolingDataSource} from an
  * existing {@link DataSourceConfiguration}: you can use a {@link PoolableDataSourceProvider}:
  *
- * <pre><code>
+ * <pre>{@code
  * pipeline.apply(JdbcIO.<KV<Integer, String>>read()
  *   .withDataSourceProviderFn(JdbcIO.PoolableDataSourceProvider.of(
  *       JdbcIO.DataSourceConfiguration.create(
@@ -146,7 +146,7 @@ import org.slf4j.LoggerFactory;
  *           "username", "password")))
  *    // ...
  * );
- * }</code></pre>
+ * }</pre>
  *
  * <p>By default, the provided function requests a DataSource per execution thread. In some
  * circumstances this can quickly overwhelm the database by requesting too many connections. In that
@@ -154,9 +154,10 @@ import org.slf4j.LoggerFactory;
  * execution threads. For example:
  *
  * <pre><code>
- * private static class MyDataSourceProviderFn implements {@literal SerializableFunction<Void, DataSource> {
+ * private static class MyDataSourceProviderFn implements{@literal SerializableFunction<Void, DataSource>} {
  *   private static transient DataSource dataSource;
- *   {@literal @Override}
+ *
+ *  {@literal @Override}
  *   public synchronized DataSource apply(Void input) {
  *     if (dataSource == null) {
  *       dataSource = ... build data source ...
@@ -179,7 +180,7 @@ import org.slf4j.LoggerFactory;
  *
  * <p>Like the source, to configure the sink, you have to provide a {@link DataSourceConfiguration}.
  *
- * <pre><code>
+ * <pre>{@code
  * pipeline
  *   .apply(...)
  *   .apply(JdbcIO.<KV<Integer, String>>write()
@@ -196,7 +197,7 @@ import org.slf4j.LoggerFactory;
  *        }
  *      })
  *    );
- * }</code></pre>
+ * }</pre>
  *
  * <p>NB: in case of transient failures, Beam runners may execute parts of JdbcIO.Write multiple
  * times for fault tolerance. Because of that, you should avoid using {@code INSERT} statements,

--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
@@ -156,7 +156,6 @@ import org.slf4j.LoggerFactory;
  * <pre>{@code
  * private static class MyDataSourceProviderFn implements SerializableFunction<Void, DataSource> {
  *   private static transient DataSource dataSource;
- *
  *   @Override
  *   public synchronized DataSource apply(Void input) {
  *     if (dataSource == null) {


### PR DESCRIPTION
The blank line in the example `private static class MyDataSourceProviderFn` in the "Reading from JDBC datasource" causes javadoc to terminate prematurely. While this is probably a bug in javadoc, it causes the documentation to be missing everything after that spot -- including the rather important "how to write to a JDBC datasource" section.. If you take out this line the javadoc builds correctly. This bug was not in 2.23.0 but was in 2.24.0

I removed the blank line; this allows the doc to build correctly.

R: @turb 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).
