### PR TITLE
Revert "[BEAM-9112] Bump jboss-module to 1.11.0.Final"

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/GrpcVendoring_1_26_0.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/GrpcVendoring_1_26_0.groovy
@@ -42,7 +42,7 @@ class GrpcVendoring_1_26_0 {
   static def alpn_api_version = "1.1.2.v20150522"
   static def npn_api_version = "1.1.1.v20141010"
   static def jboss_marshalling_version = "1.4.11.Final"
-  static def jboss_modules_version = "1.11.0.Final"
+  static def jboss_modules_version = "1.1.0.Beta1"
 
   /** Returns the list of compile time dependencies. */
   static List<String> dependencies() {


### PR DESCRIPTION
This reverts commit 2bdeeb3f247f73e293a5a0dd347dc2f5b3309156.

This is the cherry-pick for 2.30.0, this should not affect one but help you pass the breaking vendor tests.

R: @ihji 
