### PR TITLE
[BEAM-12405] Reduce tail latency in Storage API writes

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -522,7 +522,7 @@ class BeamModulePlugin implements Plugin<Project> {
         google_auth_library_credentials             : "com.google.auth:google-auth-library-credentials", // google_cloud_platform_libraries_bom sets version
         google_auth_library_oauth2_http             : "com.google.auth:google-auth-library-oauth2-http", // google_cloud_platform_libraries_bom sets version
         google_cloud_bigquery                       : "com.google.cloud:google-cloud-bigquery", // google_cloud_platform_libraries_bom sets version
-        google_cloud_bigquery_storage               : "com.google.cloud:google-cloud-bigquerystorage:1.18.1",
+        google_cloud_bigquery_storage               : "com.google.cloud:google-cloud-bigquerystorage:1.21.1",
         google_cloud_bigtable_client_core           : "com.google.cloud.bigtable:bigtable-client-core:1.19.1",
         google_cloud_bigtable_emulator              : "com.google.cloud:google-cloud-bigtable-emulator:0.125.2",
         google_cloud_core                           : "com.google.cloud:google-cloud-core", // google_cloud_platform_libraries_bom sets version

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -2846,7 +2846,6 @@ public class BigQueryIO {
         StorageApiLoads<DestinationT, T> storageApiLoads =
             new StorageApiLoads<DestinationT, T>(
                 destinationCoder,
-                elementCoder,
                 storageApiDynamicDestinations,
                 getCreateDisposition(),
                 getKmsKey(),

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiConvertMessages.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiConvertMessages.java
@@ -1,0 +1,76 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.bigquery;
+
+import org.apache.beam.sdk.io.gcp.bigquery.StorageApiDynamicDestinations.MessageConverter;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+
+/**
+ * A transform that converts messages to protocol buffers in preparation for writing to BigQuery.
+ */
+public class StorageApiConvertMessages<DestinationT, ElementT>
+    extends PTransform<
+        PCollection<KV<DestinationT, ElementT>>, PCollection<KV<DestinationT, byte[]>>> {
+  private final StorageApiDynamicDestinations<ElementT, DestinationT> dynamicDestinations;
+
+  public StorageApiConvertMessages(
+      StorageApiDynamicDestinations<ElementT, DestinationT> dynamicDestinations) {
+    this.dynamicDestinations = dynamicDestinations;
+  }
+
+  @Override
+  public PCollection<KV<DestinationT, byte[]>> expand(
+      PCollection<KV<DestinationT, ElementT>> input) {
+    String operationName = input.getName() + "/" + getName();
+
+    return input.apply(
+        "Convert to message",
+        ParDo.of(new ConvertMessagesDoFn<>(dynamicDestinations, operationName))
+            .withSideInputs(dynamicDestinations.getSideInputs()));
+  }
+
+  public static class ConvertMessagesDoFn<DestinationT, ElementT>
+      extends DoFn<KV<DestinationT, ElementT>, KV<DestinationT, byte[]>> {
+    private final StorageApiDynamicDestinations<ElementT, DestinationT> dynamicDestinations;
+    private TwoLevelMessageConverterCache<DestinationT, ElementT> messageConverters;
+
+    ConvertMessagesDoFn(
+        StorageApiDynamicDestinations<ElementT, DestinationT> dynamicDestinations,
+        String operationName) {
+      this.dynamicDestinations = dynamicDestinations;
+      this.messageConverters = new TwoLevelMessageConverterCache<>(operationName);
+    }
+
+    @ProcessElement
+    public void processElement(
+        ProcessContext c,
+        @Element KV<DestinationT, ElementT> element,
+        OutputReceiver<KV<DestinationT, byte[]>> o)
+        throws Exception {
+      dynamicDestinations.setSideInputAccessorFromProcessContext(c);
+      MessageConverter<ElementT> messageConverter =
+          messageConverters.get(element.getKey(), dynamicDestinations);
+      o.output(
+          KV.of(element.getKey(), messageConverter.toMessage(element.getValue()).toByteArray()));
+    }
+  }
+}


### PR DESCRIPTION
Several improvements
   - Reduce cache timeout to a value smaller than the server-side timeout. This prevents us from hitting errors when we try to use a StreamWriter that has timed out on the server.
   - Reduce maximum retry interval to 10 seconds.
   -  Bound the bundle size to the StorageApiWriteXXXRecords classes by using GroupIntoBatches. Previously we would sometimes get very large bundles, and due to the design of the sink we cannot flush the writes until the entire bundle has been written. Bounding the bundle size allows us to flush these items more quickly.