### PR TITLE
[BEAM-12378] GroupIntoBatches improvements

### DIFF
--- a/model/pipeline/src/main/proto/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/beam_runner_api.proto
@@ -754,8 +754,11 @@ message PubSubWritePayload {
 // Payload for GroupIntoBatches composite transform.
 message GroupIntoBatchesPayload {
 
-  // (Required) Max size of a batch.
+  // Max size of a batch.
   int64 batch_size = 1;
+
+  // Max byte size of a batch in element.
+  int64 batch_size_bytes = 3;
 
   // (Optional) Max duration a batch is allowed to be cached in states.
   int64 max_buffering_duration_millis = 2;

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/GroupIntoBatchesTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/GroupIntoBatchesTranslation.java
@@ -81,6 +81,7 @@ public class GroupIntoBatchesTranslation {
       GroupIntoBatches.BatchingParams params) {
     return RunnerApi.GroupIntoBatchesPayload.newBuilder()
         .setBatchSize(params.getBatchSize())
+        .setBatchSizeBytes(params.getBatchSizeBytes())
         .setMaxBufferingDurationMillis(params.getMaxBufferingDuration().getStandardSeconds() * 1000)
         .build();
   }

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/GroupIntoBatchesTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/GroupIntoBatchesTranslationTest.java
@@ -47,7 +47,8 @@ public class GroupIntoBatchesTranslationTest {
     return ImmutableList.of(
         GroupIntoBatches.ofSize(5),
         GroupIntoBatches.ofSize(5).withMaxBufferingDuration(Duration.ZERO),
-        GroupIntoBatches.ofSize(5).withMaxBufferingDuration(Duration.standardSeconds(10)));
+        GroupIntoBatches.ofSize(5).withMaxBufferingDuration(Duration.standardSeconds(10)),
+        GroupIntoBatches.ofByteSize(10).withMaxBufferingDuration(Duration.standardSeconds(10)));
   }
 
   @Parameter(0)
@@ -108,8 +109,9 @@ public class GroupIntoBatchesTranslationTest {
   }
 
   private void verifyPayload(
-      GroupIntoBatches.BatchingParams params, RunnerApi.GroupIntoBatchesPayload payload) {
+      GroupIntoBatches.BatchingParams<?> params, RunnerApi.GroupIntoBatchesPayload payload) {
     assertThat(payload.getBatchSize(), equalTo(params.getBatchSize()));
+    assertThat(payload.getBatchSizeBytes(), equalTo(params.getBatchSizeBytes()));
     assertThat(
         payload.getMaxBufferingDurationMillis(),
         equalTo(params.getMaxBufferingDuration().getStandardSeconds() * 1000));

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/GroupIntoBatches.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/GroupIntoBatches.java
@@ -35,12 +35,13 @@ import org.apache.beam.sdk.state.TimeDomain;
 import org.apache.beam.sdk.state.Timer;
 import org.apache.beam.sdk.state.TimerSpec;
 import org.apache.beam.sdk.state.TimerSpecs;
-import org.apache.beam.sdk.state.ValueState;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.ShardedKey;
+import org.apache.beam.sdk.util.common.ElementByteSizeObserver;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
@@ -51,9 +52,18 @@ import org.slf4j.LoggerFactory;
  * A {@link PTransform} that batches inputs to a desired batch size. Batches will contain only
  * elements of a single key.
  *
- * <p>Elements are buffered until there are {@code batchSize} elements, at which point they are
+ * <p>Elements are buffered until there are enough elements for a batch, at which point they are
  * emitted to the output {@link PCollection}. A {@code maxBufferingDuration} can be set to emit
  * output early and avoid waiting for a full batch forever.
+ *
+ * <p>Batches can be triggered either based on element count or byte size. {@link #ofSize} is used
+ * to specify a maximum element count while {@link #ofByteSize} is used to specify a maximum byte
+ * size. The single-argument {@link #ofByteSize} uses the input coder to determine the encoded byte
+ * size of each element. However, this may not always be what is desired. A user may want to control
+ * batching based on a different byte size (e.g. the memory usage of the decoded Java object) or the
+ * input coder may not be able to efficiently determine the elements' byte size. For these cases, we
+ * also provide the two-argument {@link #ofByteSize} allowing the user to pass in a function to be
+ * used to determine the byte size of an element.
  *
  * <p>Windows are preserved (batches contain elements from the same window). Batches may contain
  * elements from more than one bundle.
@@ -101,29 +111,69 @@ public class GroupIntoBatches<K, InputT>
    * GroupIntoBatches} and {@link GroupIntoBatches.WithShardedKey}.
    */
   @AutoValue
-  public abstract static class BatchingParams implements Serializable {
-    public static BatchingParams create(long batchSize, Duration maxBufferingDuration) {
-      return new AutoValue_GroupIntoBatches_BatchingParams(batchSize, maxBufferingDuration);
+  public abstract static class BatchingParams<InputT> implements Serializable {
+    public static <InputT> BatchingParams<InputT> create(
+        long batchSize,
+        long batchSizeBytes,
+        SerializableFunction<InputT, Long> elementByteSize,
+        Duration maxBufferingDuration) {
+      return new AutoValue_GroupIntoBatches_BatchingParams(
+          batchSize, batchSizeBytes, elementByteSize, maxBufferingDuration);
     }
 
     public abstract long getBatchSize();
 
+    public abstract long getBatchSizeBytes();
+
+    @Nullable
+    public abstract SerializableFunction<InputT, Long> getElementByteSize();
+
     public abstract Duration getMaxBufferingDuration();
   }
 
-  private final BatchingParams params;
+  private final BatchingParams<InputT> params;
   private static final UUID workerUuid = UUID.randomUUID();
 
-  private GroupIntoBatches(BatchingParams params) {
+  private GroupIntoBatches(BatchingParams<InputT> params) {
     this.params = params;
   }
 
+  /** Aim to create batches each with the specified element count. */
   public static <K, InputT> GroupIntoBatches<K, InputT> ofSize(long batchSize) {
-    return new GroupIntoBatches<>(BatchingParams.create(batchSize, Duration.ZERO));
+    Preconditions.checkState(batchSize < Long.MAX_VALUE);
+    return new GroupIntoBatches<>(
+        BatchingParams.create(batchSize, Long.MAX_VALUE, null, Duration.ZERO));
+  }
+
+  /**
+   * Aim to create batches each with the specified byte size.
+   *
+   * <p>This option uses the PCollection's coder to determine the byte size of each element. This
+   * may not always be what is desired (e.g. the encoded size is not the same as the memory usage of
+   * the Java object). This is also only recommended if the coder returns true for
+   * isRegisterByteSizeObserverCheap, otherwise the transform will perform a possibly-expensive
+   * encoding of each element in order to measure its byte size. An alternate approach is to use
+   * {@link #ofByteSize(long, SerializableFunction)} to specify code to calculate the byte size.
+   */
+  public static <K, InputT> GroupIntoBatches<K, InputT> ofByteSize(long batchSizeBytes) {
+    Preconditions.checkState(batchSizeBytes < Long.MAX_VALUE);
+    return new GroupIntoBatches<>(
+        BatchingParams.create(Long.MAX_VALUE, batchSizeBytes, null, Duration.ZERO));
+  }
+
+  /**
+   * Aim to create batches each with the specified byte size. The provided function is used to
+   * determine the byte size of each element.
+   */
+  public static <K, InputT> GroupIntoBatches<K, InputT> ofByteSize(
+      long batchSizeBytes, SerializableFunction<InputT, Long> getElementByteSize) {
+    Preconditions.checkState(batchSizeBytes < Long.MAX_VALUE);
+    return new GroupIntoBatches<>(
+        BatchingParams.create(Long.MAX_VALUE, batchSizeBytes, getElementByteSize, Duration.ZERO));
   }
 
   /** Returns user supplied parameters for batching. */
-  public BatchingParams getBatchingParams() {
+  public BatchingParams<InputT> getBatchingParams() {
     return params;
   }
 
@@ -136,7 +186,12 @@ public class GroupIntoBatches<K, InputT>
     checkArgument(
         duration != null && !duration.isShorterThan(Duration.ZERO),
         "max buffering duration should be a non-negative value");
-    return new GroupIntoBatches<>(BatchingParams.create(params.getBatchSize(), duration));
+    return new GroupIntoBatches<>(
+        BatchingParams.create(
+            params.getBatchSize(),
+            params.getBatchSizeBytes(),
+            params.getElementByteSize(),
+            duration));
   }
 
   /**
@@ -156,7 +211,7 @@ public class GroupIntoBatches<K, InputT>
     private WithShardedKey() {}
 
     /** Returns user supplied parameters for batching. */
-    public BatchingParams getBatchingParams() {
+    public BatchingParams<InputT> getBatchingParams() {
       return params;
     }
 
@@ -189,6 +244,19 @@ public class GroupIntoBatches<K, InputT>
     }
   }
 
+  private static class ByteSizeObserver extends ElementByteSizeObserver {
+    private long elementByteSize = 0;
+
+    @Override
+    protected void reportElementSize(long elementByteSize) {
+      this.elementByteSize += elementByteSize;
+    }
+
+    public long getElementByteSize() {
+      return this.elementByteSize;
+    }
+  };
+
   @Override
   public PCollection<KV<K, Iterable<InputT>>> expand(PCollection<KV<K, InputT>> input) {
     Duration allowedLateness = input.getWindowingStrategy().getAllowedLateness();
@@ -197,16 +265,35 @@ public class GroupIntoBatches<K, InputT>
         input.getCoder() instanceof KvCoder,
         "coder specified in the input PCollection is not a KvCoder");
     KvCoder<K, InputT> inputCoder = (KvCoder<K, InputT>) input.getCoder();
-    Coder<K> keyCoder = (Coder<K>) inputCoder.getCoderArguments().get(0);
-    Coder<InputT> valueCoder = (Coder<InputT>) inputCoder.getCoderArguments().get(1);
+    final Coder<InputT> valueCoder = (Coder<InputT>) inputCoder.getCoderArguments().get(1);
 
+    SerializableFunction<InputT, Long> weigher = params.getElementByteSize();
+    if (params.getBatchSizeBytes() < Long.MAX_VALUE) {
+      if (weigher == null) {
+        // If the user didn't specify a byte-size function, then use the Coder to determine the byte
+        // size.
+        // Note: if Coder.isRegisterByteSizeObserverCheap == false, then this will be expensive.
+        weigher =
+            (InputT element) -> {
+              try {
+                ByteSizeObserver observer = new ByteSizeObserver();
+                valueCoder.registerByteSizeObserver(element, observer);
+                observer.advance();
+                return observer.getElementByteSize();
+              } catch (Exception e) {
+                throw new RuntimeException(e);
+              }
+            };
+      }
+    }
     return input.apply(
         ParDo.of(
             new GroupIntoBatchesDoFn<>(
                 params.getBatchSize(),
+                params.getBatchSizeBytes(),
+                weigher,
                 allowedLateness,
                 params.getMaxBufferingDuration(),
-                keyCoder,
                 valueCoder)));
   }
 
@@ -215,58 +302,70 @@ public class GroupIntoBatches<K, InputT>
       extends DoFn<KV<K, InputT>, KV<K, Iterable<InputT>>> {
 
     private static final Logger LOG = LoggerFactory.getLogger(GroupIntoBatchesDoFn.class);
-    private static final String END_OF_WINDOW_ID = "endOFWindow";
-    private static final String END_OF_BUFFERING_ID = "endOfBuffering";
-    private static final String BATCH_ID = "batch";
-    private static final String NUM_ELEMENTS_IN_BATCH_ID = "numElementsInBatch";
-    private static final String KEY_ID = "key";
     private final long batchSize;
+    private final long batchSizeBytes;
+    @Nullable private final SerializableFunction<InputT, Long> weigher;
     private final Duration allowedLateness;
     private final Duration maxBufferingDuration;
+
+    // The following timer is no longer set. We maintain the spec for update compatibility.
+    private static final String END_OF_WINDOW_ID = "endOFWindow";
 
     @TimerId(END_OF_WINDOW_ID)
     private final TimerSpec windowTimer = TimerSpecs.timer(TimeDomain.EVENT_TIME);
 
+    private static final String END_OF_BUFFERING_ID = "endOfBuffering";
+
     @TimerId(END_OF_BUFFERING_ID)
     private final TimerSpec bufferingTimer = TimerSpecs.timer(TimeDomain.PROCESSING_TIME);
+
+    private static final String BATCH_ID = "batch";
 
     @StateId(BATCH_ID)
     private final StateSpec<BagState<InputT>> batchSpec;
 
-    @StateId(NUM_ELEMENTS_IN_BATCH_ID)
-    private final StateSpec<CombiningState<Long, long[], Long>> numElementsInBatchSpec;
+    private static final String NUM_ELEMENTS_IN_BATCH_ID = "numElementsInBatch";
 
-    @StateId(KEY_ID)
-    private final StateSpec<ValueState<K>> keySpec;
+    @StateId(NUM_ELEMENTS_IN_BATCH_ID)
+    private final StateSpec<CombiningState<Long, long[], Long>> batchSizeSpec;
+
+    private static final String NUM_BYTES_IN_BATCH_ID = "numBytesInBatch";
+
+    @StateId(NUM_BYTES_IN_BATCH_ID)
+    private final StateSpec<CombiningState<Long, long[], Long>> batchSizeBytesSpec;
 
     private final long prefetchFrequency;
 
     GroupIntoBatchesDoFn(
         long batchSize,
+        long batchSizeBytes,
+        @Nullable SerializableFunction<InputT, Long> weigher,
         Duration allowedLateness,
         Duration maxBufferingDuration,
-        Coder<K> inputKeyCoder,
         Coder<InputT> inputValueCoder) {
       this.batchSize = batchSize;
+      this.batchSizeBytes = batchSizeBytes;
+      this.weigher = weigher;
       this.allowedLateness = allowedLateness;
       this.maxBufferingDuration = maxBufferingDuration;
       this.batchSpec = StateSpecs.bag(inputValueCoder);
-      this.numElementsInBatchSpec =
-          StateSpecs.combining(
-              new Combine.BinaryCombineLongFn() {
 
-                @Override
-                public long identity() {
-                  return 0L;
-                }
+      Combine.BinaryCombineLongFn sumCombineFn =
+          new Combine.BinaryCombineLongFn() {
+            @Override
+            public long identity() {
+              return 0L;
+            }
 
-                @Override
-                public long apply(long left, long right) {
-                  return left + right;
-                }
-              });
+            @Override
+            public long apply(long left, long right) {
+              return left + right;
+            }
+          };
 
-      this.keySpec = StateSpecs.value(inputKeyCoder);
+      this.batchSizeSpec = StateSpecs.combining(sumCombineFn);
+      this.batchSizeBytesSpec = StateSpecs.combining(sumCombineFn);
+
       // Prefetch every 20% of batchSize elements. Do not prefetch if batchSize is too little
       this.prefetchFrequency = ((batchSize / 5) <= 1) ? Long.MAX_VALUE : (batchSize / 5);
     }
@@ -276,22 +375,25 @@ public class GroupIntoBatches<K, InputT>
         @TimerId(END_OF_WINDOW_ID) Timer windowTimer,
         @TimerId(END_OF_BUFFERING_ID) Timer bufferingTimer,
         @StateId(BATCH_ID) BagState<InputT> batch,
-        @StateId(NUM_ELEMENTS_IN_BATCH_ID) CombiningState<Long, long[], Long> numElementsInBatch,
-        @StateId(KEY_ID) ValueState<K> key,
+        @StateId(NUM_ELEMENTS_IN_BATCH_ID) CombiningState<Long, long[], Long> storedBatchSize,
+        @StateId(NUM_BYTES_IN_BATCH_ID) CombiningState<Long, long[], Long> storedBatchSizeBytes,
         @Element KV<K, InputT> element,
         BoundedWindow window,
         OutputReceiver<KV<K, Iterable<InputT>>> receiver) {
       Instant windowEnds = window.maxTimestamp().plus(allowedLateness);
       LOG.debug("*** SET TIMER *** to point in time {} for window {}", windowEnds, window);
       windowTimer.set(windowEnds);
-      key.write(element.getKey());
       LOG.debug("*** BATCH *** Add element for window {} ", window);
       batch.add(element.getValue());
       // Blind add is supported with combiningState
-      numElementsInBatch.add(1L);
+      storedBatchSize.add(1L);
+      if (weigher != null) {
+        storedBatchSizeBytes.add(weigher.apply(element.getValue()));
+        storedBatchSizeBytes.readLater();
+      }
 
-      long num = numElementsInBatch.read();
-      if (num == 1 && maxBufferingDuration.isLongerThan(Duration.ZERO)) {
+      long num = storedBatchSize.read();
+      if (maxBufferingDuration.isLongerThan(Duration.ZERO) && num == 1) {
         // This is the first element in batch. Start counting buffering time if a limit was set.
         bufferingTimer.offset(maxBufferingDuration).setRelative();
       }
@@ -299,9 +401,18 @@ public class GroupIntoBatches<K, InputT>
         // Prefetch data and modify batch state (readLater() modifies this)
         batch.readLater();
       }
-      if (num >= batchSize) {
+
+      if (num >= batchSize
+          || (batchSizeBytes != Long.MAX_VALUE && storedBatchSizeBytes.read() >= batchSizeBytes)) {
         LOG.debug("*** END OF BATCH *** for window {}", window.toString());
-        flushBatch(receiver, key, batch, numElementsInBatch, bufferingTimer);
+        flushBatch(receiver, element.getKey(), batch, storedBatchSize, storedBatchSizeBytes);
+        //  Reset the buffering timer (if not null) since the state is empty now and we want to
+        // release the watermark. It'll be extended again if a
+        // new element arrives prior to the expiration time set here.
+        // TODO(BEAM-10887): Use clear() when it's available.
+        if (maxBufferingDuration.isLongerThan(Duration.ZERO)) {
+          bufferingTimer.offset(maxBufferingDuration).setRelative();
+        }
       }
     }
 
@@ -309,54 +420,62 @@ public class GroupIntoBatches<K, InputT>
     public void onBufferingTimer(
         OutputReceiver<KV<K, Iterable<InputT>>> receiver,
         @Timestamp Instant timestamp,
-        @StateId(KEY_ID) ValueState<K> key,
+        @Key K key,
         @StateId(BATCH_ID) BagState<InputT> batch,
-        @StateId(NUM_ELEMENTS_IN_BATCH_ID) CombiningState<Long, long[], Long> numElementsInBatch,
+        @StateId(NUM_ELEMENTS_IN_BATCH_ID) CombiningState<Long, long[], Long> storedBatchSize,
+        @StateId(NUM_BYTES_IN_BATCH_ID) CombiningState<Long, long[], Long> storedBatchSizeBytes,
         @TimerId(END_OF_BUFFERING_ID) Timer bufferingTimer) {
       LOG.debug(
           "*** END OF BUFFERING *** for timer timestamp {} with buffering duration {}",
           timestamp,
           maxBufferingDuration);
-      flushBatch(receiver, key, batch, numElementsInBatch, null);
+      flushBatch(receiver, key, batch, storedBatchSize, storedBatchSizeBytes);
     }
 
+    @OnWindowExpiration
+    public void onWindowExpiration(
+        OutputReceiver<KV<K, Iterable<InputT>>> receiver,
+        @Key K key,
+        @StateId(BATCH_ID) BagState<InputT> batch,
+        @StateId(NUM_ELEMENTS_IN_BATCH_ID) CombiningState<Long, long[], Long> storedBatchSize,
+        @StateId(NUM_BYTES_IN_BATCH_ID) CombiningState<Long, long[], Long> storedBatchSizeBytes) {
+      flushBatch(receiver, key, batch, storedBatchSize, storedBatchSizeBytes);
+    }
+
+    // We no longer set this timer, since OnWindowExpiration takes care of his. However we leave the
+    // callback in place
+    // for existing jobs that have already set these timers.
     @OnTimer(END_OF_WINDOW_ID)
     public void onWindowTimer(
         OutputReceiver<KV<K, Iterable<InputT>>> receiver,
         @Timestamp Instant timestamp,
-        @StateId(KEY_ID) ValueState<K> key,
+        @Key K key,
         @StateId(BATCH_ID) BagState<InputT> batch,
-        @StateId(NUM_ELEMENTS_IN_BATCH_ID) CombiningState<Long, long[], Long> numElementsInBatch,
-        @TimerId(END_OF_BUFFERING_ID) Timer bufferingTimer,
+        @StateId(NUM_ELEMENTS_IN_BATCH_ID) CombiningState<Long, long[], Long> storedBatchSize,
+        @StateId(NUM_BYTES_IN_BATCH_ID) CombiningState<Long, long[], Long> storedBatchSizeBytes,
         BoundedWindow window) {
       LOG.debug(
           "*** END OF WINDOW *** for timer timestamp {} in windows {}",
           timestamp,
           window.toString());
-      flushBatch(receiver, key, batch, numElementsInBatch, bufferingTimer);
+      flushBatch(receiver, key, batch, storedBatchSize, storedBatchSizeBytes);
     }
 
     private void flushBatch(
         OutputReceiver<KV<K, Iterable<InputT>>> receiver,
-        ValueState<K> key,
+        K key,
         BagState<InputT> batch,
-        CombiningState<Long, long[], Long> numElementsInBatch,
-        @Nullable Timer bufferingTimer) {
+        CombiningState<Long, long[], Long> storedBatchSize,
+        CombiningState<Long, long[], Long> storedBatchSizeBytes) {
       Iterable<InputT> values = batch.read();
       // When the timer fires, batch state might be empty
       if (!Iterables.isEmpty(values)) {
-        receiver.output(KV.of(key.read(), values));
+        receiver.output(KV.of(key, values));
       }
       batch.clear();
       LOG.debug("*** BATCH *** clear");
-      numElementsInBatch.clear();
-      // We might reach here due to batch size being reached or window expiration. Reset the
-      // buffering timer (if not null) since the state is empty now. It'll be extended again if a
-      // new element arrives prior to the expiration time set here.
-      // TODO(BEAM-10887): Use clear() when it's available.
-      if (bufferingTimer != null && maxBufferingDuration.isLongerThan(Duration.ZERO)) {
-        bufferingTimer.offset(maxBufferingDuration).setRelative();
-      }
+      storedBatchSize.clear();
+      storedBatchSizeBytes.clear();
     }
   }
 }


### PR DESCRIPTION
A few improvements to GroupIntoBatches

1. Add GroupIntoBaches.ofByteSize, allowing the user to set the target byte size for a batch.
2. Use OnWindowExpiration instead of setting an explicit end-of-window timer.
3. Use injected key parameter instead of separately storing the key in state.