### PR TITLE
[BEAM-12074] Define docstrings for all DataFrame operations

### DIFF
--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -2115,11 +2115,18 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
               requires_partition_by=partitionings.Singleton(),
               proxy=proxy))
 
+  @frame_base.with_docs_from(pd.DataFrame)
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)
   def corrwith(self, other, axis, drop, method):
-    if axis not in (0, 'index'):
-      raise NotImplementedError('corrwith(axis=%r)' % axis)
+    if axis in (1, 'columns'):
+      return self._elementwise(
+          lambda df, other: df.corrwith(other, axis=axis, drop=drop,
+                                        method=method),
+          'corrwith',
+          other_args=(other,))
+
+
     if not isinstance(other, frame_base.DeferredFrame):
       other = frame_base.DeferredFrame.wrap(
           expressions.ConstantExpression(other))

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -2023,6 +2023,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
       pd.DataFrame, 'info', reason="non-deferred-result")
 
 
+  @frame_base.with_docs_from(pd.DataFrame)
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)
   @frame_base.maybe_inplace

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -1638,7 +1638,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)
   def align(self, other, join, axis, copy, level, method, **kwargs):
-    """Aligning per-level is not yet supported. Only the default,
+    """Aligning per level is not yet supported. Only the default,
     ``level=None``, is allowed.
 
     Filling NaN values via ``method`` is not supported, because it is
@@ -1647,7 +1647,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
     default, ``method=None``, is allowed.
 
     ``copy=False`` is not supported because its behavior (whether or not it is
-    an inplace oepration) depends on the data."""
+    an inplace operation) depends on the data."""
     if not copy:
       raise frame_base.WontImplementError(
           "align(copy=False) is not supported because it might be an inplace "

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -484,7 +484,8 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
         "result. Consider using df.length() instead.",
         reason="non-deferred-result")
 
-  @property
+  @property  # type: ignore
+  @frame_base.with_docs_from(pd.DataFrame)
   def empty(self):
     empties = expressions.ComputedExpression(
         'get_empties',
@@ -834,10 +835,8 @@ class DeferredSeries(DeferredDataFrameOrSeries):
     ``level=None``, is allowed.
 
     Filling NaN values via ``method`` is not supported, because it is
-    sensitive to the order of the data
-    (see https://s.apache.org/dataframe-order-sensitive-operations). Only the
-    default, ``method=None``, is allowed.
-    """
+    `order-sensitive <https://s.apache.org/dataframe-order-sensitive-operatons>`_.
+    Only the default, ``method=None``, is allowed."""
     if level is not None:
       raise NotImplementedError('per-level align')
     if method is not None:
@@ -1553,11 +1552,8 @@ class DeferredSeries(DeferredDataFrameOrSeries):
 @populate_not_implemented(pd.DataFrame)
 @frame_base.DeferredFrame._register_for(pd.DataFrame)
 class DeferredDataFrame(DeferredDataFrameOrSeries):
-  @property
-  def T(self):
-    return self.transpose()
-
-  @property
+  @property  # type: ignore
+  @frame_base.with_docs_from(pd.DataFrame)
   def columns(self):
     return self._expr.proxy().columns
 
@@ -1575,6 +1571,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             requires_partition_by=partitionings.Arbitrary(),
             preserves_partition_by=partitionings.Arbitrary()))
 
+  @frame_base.with_docs_from(pd.DataFrame)
   def keys(self):
     return self.columns
 
@@ -1636,9 +1633,19 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
     else:
       raise NotImplementedError(key)
 
+  @frame_base.with_docs_from(pd.DataFrame)
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)
   def align(self, other, join, axis, copy, level, method, **kwargs):
+    """Aligning per-level is not yet supported. Only the default,
+    ``level=None``, is allowed.
+
+    Filling NaN values via ``method`` is not supported, because it is
+    `order-sensitive <https://s.apache.org/dataframe-order-sensitive-operatons>`_.
+    Only the default, ``method=None``, is allowed.
+
+    ``copy=False`` is not supported because its behavior (whether or not it is
+    an inplace oepration) depends on the data."""
     if not copy:
       raise frame_base.WontImplementError(
           "align(copy=False) is not supported because it might be an inplace "
@@ -1669,9 +1676,12 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             requires_partition_by=requires_partition_by,
             preserves_partition_by=partitionings.Arbitrary()))
 
+  @frame_base.with_docs_from(pd.DataFrame)
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)
   def append(self, other, ignore_index, verify_integrity, sort, **kwargs):
+    """``ignore_index=True`` is not supported, because it requires generating an
+    order-sensitive index."""
     if not isinstance(other, DeferredDataFrame):
       raise frame_base.WontImplementError(
           "append() only accepts DeferredDataFrame instances, received " +
@@ -1700,17 +1710,21 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
         )
     )
 
+  @frame_base.with_docs_from(pd.DataFrame)
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)
   @frame_base.maybe_inplace
   def set_index(self, keys, **kwargs):
+    """``keys`` must be a ``str`` or ``List[str]``. Passing an Index or Series
+    is not yet supported (`BEAM-11711
+    <https://issues.apache.org/jira/browse/BEAM-11711>`_)."""
     if isinstance(keys, str):
       keys = [keys]
 
     if any(isinstance(k, (_DeferredIndex, frame_base.DeferredFrame))
            for k in keys):
       raise NotImplementedError("set_index with Index or Series instances is "
-                                "not yet supported (BEAM-11711)")
+                                "not yet supported (BEAM-11711).")
 
     return frame_base.DeferredFrame.wrap(
       expressions.ComputedExpression(
@@ -1720,23 +1734,33 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
           requires_partition_by=partitionings.Arbitrary(),
           preserves_partition_by=partitionings.Singleton()))
 
-  @property
+  @property  # type: ignore
+  @frame_base.with_docs_from(pd.DataFrame)
   def loc(self):
     return _DeferredLoc(self)
 
-  @property
+  @property  # type: ignore
+  @frame_base.with_docs_from(pd.DataFrame)
   def iloc(self):
+    """Position-based indexing with `iloc` is order-sensitive in almost every
+    case. Beam DataFrame users should prefer label-based indexing with `loc`.
+    """
     return _DeferredILoc(self)
 
-  @property
+  @property  # type: ignore
+  @frame_base.with_docs_from(pd.DataFrame)
   def axes(self):
     return (self.index, self.columns)
 
-  @property
+  @property  # type: ignore
+  @frame_base.with_docs_from(pd.DataFrame)
   def dtypes(self):
     return self._expr.proxy().dtypes
 
+  @frame_base.with_docs_from(pd.DataFrame)
   def assign(self, **kwargs):
+    """``value`` must be a ``callable`` or :class:`DeferredSeries`. Other types
+    make this operation order-sensitive."""
     for name, value in kwargs.items():
       if not callable(value) and not isinstance(value, DeferredSeries):
         raise frame_base.WontImplementError(
@@ -1749,6 +1773,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
         'assign',
         other_kwargs=kwargs)
 
+  @frame_base.with_docs_from(pd.DataFrame)
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)
   def explode(self, column, ignore_index):
@@ -1763,9 +1788,12 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             preserves_partition_by=preserves,
             requires_partition_by=partitionings.Arbitrary()))
 
+  @frame_base.with_docs_from(pd.DataFrame)
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)
   def insert(self, value, **kwargs):
+    """``value`` cannot be a ``List`` because aligning it with this
+    DeferredDataFrame is order-sensitive."""
     if isinstance(value, list):
       raise frame_base.WontImplementMethod(
           "insert(value=list) is not supported because it joins the input "
@@ -2055,6 +2083,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
               [self._expr],
               requires_partition_by=partitionings.Singleton(reason=reason)))
 
+  @frame_base.with_docs_from(pd.DataFrame)
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)
   def cov(self, min_periods, ddof):
@@ -2158,6 +2187,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
   tail = frame_base.wont_implement_method(pd.DataFrame, 'tail',
                                           reason='order-sensitive')
 
+  @frame_base.with_docs_from(pd.DataFrame)
   def dot(self, other):
     # We want to broadcast the right hand side to all partitions of the left.
     # This is OK, as its index must be the same size as the columns set of self,
@@ -2189,7 +2219,15 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
 
   __matmul__ = dot
 
+  @frame_base.with_docs_from(pd.DataFrame)
   def mode(self, axis=0, *args, **kwargs):
+    """mode with axis="columns" is not implemented because it produces
+    non-deferred columns.
+
+    mode with axis="index" is not currently parallelizable. An approximate,
+    parallelizable implementation of mode may be added in the future
+    (`BEAM-12181 <https://issues.apache.org/jira/BEAM-12181>`_)."""
+
     if axis == 1 or axis == 'columns':
       # Number of columns is max(number mode values for each row), so we can't
       # determine how many there will be before looking at the data.
@@ -2210,10 +2248,12 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             )),
             preserves_partition_by=partitionings.Singleton()))
 
+  @frame_base.with_docs_from(pd.DataFrame)
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)
   @frame_base.maybe_inplace
   def dropna(self, axis, **kwargs):
+    """dropna with axis="columns" specified cannot be parallelized."""
     # TODO(robertwb): This is a common pattern. Generalize?
     if axis in (1, 'columns'):
       requires_partition_by = partitionings.Singleton(reason=(
@@ -2254,14 +2294,26 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
       return frame_base.DeferredFrame.wrap(result_expr)
 
 
+  @frame_base.with_docs_from(pd.DataFrame)
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)
   def eval(self, expr, inplace, **kwargs):
+    """Accessing local variables with ``@<varname>`` is not yet supported
+    (`BEAM-11202 <https://issues.apache.org/jira/browse/BEAM-11202>`_).
+
+    Arguments ``local_dict``, ``global_dict``, ``level``, ``target``, and
+    ``resolvers`` are not yet supported."""
     return self._eval_or_query('eval', expr, inplace, **kwargs)
 
+  @frame_base.with_docs_from(pd.DataFrame)
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)
   def query(self, expr, inplace, **kwargs):
+    """Accessing local variables with ``@<varname>`` is not yet supported
+    (`BEAM-11202 <https://issues.apache.org/jira/browse/BEAM-11202>`_).
+
+    Arguments ``local_dict``, ``global_dict``, ``level``, ``target``, and
+    ``resolvers`` are not yet supported."""
     return self._eval_or_query('query', expr, inplace, **kwargs)
 
   isnull = isna = frame_base._elementwise_method('isna', base=pd.DataFrame)
@@ -2303,6 +2355,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
               requires_partition_by=partitionings.Arbitrary()))
     return reindex, revert
 
+  @frame_base.with_docs_from(pd.DataFrame)
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)
   def join(self, other, on, **kwargs):
@@ -2337,6 +2390,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             preserves_partition_by=partitionings.Arbitrary(),
             requires_partition_by=partitionings.Index()))
 
+  @frame_base.with_docs_from(pd.DataFrame)
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)
   def merge(
@@ -2349,6 +2403,15 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
       right_index,
       suffixes,
       **kwargs):
+    """merge is not parallelizable unless ``left_index`` or ``right_index`` is
+    ``True`, because it requires generating an entirely new unique index.
+    See notes on :meth:`DeferredDataFrame.reset_index`. It is recommended to
+    move the join key for one of your columns to the index to avoid this issue.
+    For an example see the enrich pipeline in
+    :mod:`apache_beam.examples.dataframe.taxiride`.
+
+    ``how="cross"`` is not yet supported.
+    """
     self_proxy = self._expr.proxy()
     right_proxy = right._expr.proxy()
     # Validate with a pandas call.
@@ -2409,7 +2472,6 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
     if left_index or right_index:
       return merged
     else:
-
       return merged.reset_index(drop=True)
 
   @frame_base.with_docs_from(pd.DataFrame)
@@ -2479,6 +2541,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
   plot = frame_base.wont_implement_method(pd.DataFrame, 'plot',
                                                       reason="plotting-tools")
 
+  @frame_base.with_docs_from(pd.DataFrame)
   def pop(self, item):
     result = self[item]
 
@@ -2528,9 +2591,13 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             requires_partition_by=requires,
             preserves_partition_by=partitionings.Singleton()))
 
+  @frame_base.with_docs_from(pd.DataFrame)
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.maybe_inplace
   def rename(self, **kwargs):
+    """rename is not parallelizable when ``axis="index"`` and
+    ``errors="raise"``. It requires collecting all data on a single
+    node in order to detect if one of the index values is missing."""
     rename_index = (
         'index' in kwargs
         or kwargs.get('axis', None) in (0, 'index')
@@ -2583,30 +2650,16 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
 
   rename_axis = frame_base._elementwise_method('rename_axis', base=pd.DataFrame)
 
-  @frame_base.args_to_kwargs(pd.DataFrame)
-  @frame_base.populate_defaults(pd.DataFrame)
-  @frame_base.maybe_inplace
-  def replace(self, limit, **kwargs):
-    if limit is None:
-      requires_partition_by = partitionings.Arbitrary()
-    else:
-      requires_partition_by = partitionings.Singleton(reason=(
-         f"replace(limit={limit!r}) cannot currently be parallelized. It "
-         "requires collecting all data on a single node."))
-    return frame_base.DeferredFrame.wrap(
-        expressions.ComputedExpression(
-            'replace',
-            lambda df: df.replace(limit=limit, **kwargs),
-            [self._expr],
-            preserves_partition_by=partitionings.Singleton(),
-            requires_partition_by=requires_partition_by))
-
+  @frame_base.with_docs_from(pd.DataFrame)
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)
   @frame_base.maybe_inplace
   def reset_index(self, level=None, **kwargs):
-    # TODO: Docs should note that the index is not in the same order as it would
-    # be with pandas. Technically an order sensitive operation
+    """Dropping the entire index (e.g. with ``reset_index(level=None)``) is
+    not parallelizable. It is also only guaranteed that the newly generated
+    index values will be unique. The Beam DataFrame API makes no guarantee
+    that the same index values as the equivalent pandas operation will be
+    generated, because that implementation is order-sensitive."""
     if level is not None and not isinstance(level, (tuple, list)):
       level = [level]
     if level is None or len(level) == self._expr.proxy().index.nlevels:
@@ -2625,6 +2678,7 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
             preserves_partition_by=partitionings.Singleton(),
             requires_partition_by=requires_partition_by))
 
+  @frame_base.with_docs_from(pd.DataFrame)
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)
   def round(self, decimals, *args, **kwargs):
@@ -2649,9 +2703,13 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
   select_dtypes = frame_base._elementwise_method('select_dtypes',
                                                  base=pd.DataFrame)
 
+  @frame_base.with_docs_from(pd.DataFrame)
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)
   def shift(self, axis, freq, **kwargs):
+    """shift with ``axis="index" is only supported with ``freq`` specified and
+    ``fill_value`` undefined. Other configurations make this operation
+    order-sensitive."""
     if axis in (1, 'columns'):
       preserves = partitionings.Arbitrary()
       proxy = None
@@ -2719,8 +2777,15 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
 
   transpose = frame_base.wont_implement_method(
       pd.DataFrame, 'transpose', reason='non-deferred-columns')
+  T = property(frame_base.wont_implement_method(
+      pd.DataFrame, 'T', reason='non-deferred-columns'))
 
+
+  @frame_base.with_docs_from(pd.DataFrame)
   def unstack(self, *args, **kwargs):
+    """unstack cannot be used on :class:`DeferredDataFrame` instances with
+    multiple index levels, because the columns in the output depend on the
+    data."""
     if self._expr.proxy().index.nlevels == 1:
       return frame_base.DeferredFrame.wrap(
         expressions.ComputedExpression(
@@ -2747,9 +2812,12 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
   style = property(frame_base.wont_implement_method(
       pd.DataFrame, 'style', reason="non-deferred-result"))
 
+  @frame_base.with_docs_from(pd.DataFrame)
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)
   def melt(self, ignore_index, **kwargs):
+    """``ignore_index=True`` is not supported, because it requires generating an
+    order-sensitive index."""
     if ignore_index:
       raise frame_base.WontImplementError(
           "melt(ignore_index=True) is order sensitive because it requires "

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -2135,13 +2135,14 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
           expressions.ConstantExpression(other))
 
     if isinstance(other, DeferredSeries):
-      proxy = self._expr.proxy().corrwith(other._expr.proxy(), method=method)
+      proxy = self._expr.proxy().corrwith(other._expr.proxy(), axis=axis,
+                                          drop=drop, method=method)
       self, other = self.align(other, axis=0, join='inner')
       col_names = proxy.index
       other_cols = [other] * len(col_names)
     elif isinstance(other, DeferredDataFrame):
       proxy = self._expr.proxy().corrwith(
-          other._expr.proxy(), method=method, drop=drop)
+          other._expr.proxy(), axis=axis, method=method, drop=drop)
       self, other = self.align(other, axis=0, join='inner')
       col_names = list(
           set(self.columns)
@@ -2150,7 +2151,9 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
       other_cols = [other[col_name] for col_name in col_names]
     else:
       # Raise the right error.
-      self._expr.proxy().corrwith(other._expr.proxy())
+      self._expr.proxy().corrwith(other._expr.proxy(), axis=axis, drop=drop,
+                                  method=method)
+
       # Just in case something else becomes valid.
       raise NotImplementedError('corrwith(%s)' % type(other._expr.proxy))
 

--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -872,7 +872,8 @@ class DeferredSeries(DeferredDataFrameOrSeries):
     ``level=None``, is allowed.
 
     Filling NaN values via ``method`` is not supported, because it is
-    `order-sensitive <https://s.apache.org/dataframe-order-sensitive-operatons>`_.
+    `order-sensitive
+    <https://s.apache.org/dataframe-order-sensitive-operatons>`_.
     Only the default, ``method=None``, is allowed."""
     if level is not None:
       raise NotImplementedError('per-level align')
@@ -1641,8 +1642,9 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
     ``level=None``, is allowed.
 
     Filling NaN values via ``method`` is not supported, because it is
-    `order-sensitive <https://s.apache.org/dataframe-order-sensitive-operatons>`_.
-    Only the default, ``method=None``, is allowed.
+    `order-sensitive
+    <https://s.apache.org/dataframe-order-sensitive-operatons>`_. Only the
+    default, ``method=None``, is allowed.
 
     ``copy=False`` is not supported because its behavior (whether or not it is
     an inplace oepration) depends on the data."""

--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -1462,7 +1462,7 @@ class ConstructionTimeTest(unittest.TestCase):
 
 class DocstringTest(unittest.TestCase):
   @parameterized.expand([
-      #(frames.DeferredDataFrame, pd.DataFrame),
+      (frames.DeferredDataFrame, pd.DataFrame),
       (frames.DeferredSeries, pd.Series),
       #(frames._DeferredIndex, pd.Index),
       (frames._DeferredStringMethods, pd.core.strings.StringMethods),

--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -602,6 +602,9 @@ class DeferredFrameTest(_AbstractFrameTest):
     self._run_test(lambda df: df.corrwith(df.a), df)
     self._run_test(lambda df: df[['a', 'b']].corrwith(df[['b', 'c']]), df)
 
+    df2 = pd.DataFrame(np.random.randn(20, 3), columns=['a', 'b', 'c'])
+    self._run_test(lambda df, df2: df.corrwith(df2, axis=1), df, df2)
+
   @unittest.skipIf(PD_VERSION < (1, 2), "na_action added in pandas 1.2.0")
   def test_applymap_na_action(self):
     # Replicates a doctest for na_action which is incompatible with

--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -605,6 +605,11 @@ class DeferredFrameTest(_AbstractFrameTest):
     df2 = pd.DataFrame(np.random.randn(20, 3), columns=['a', 'b', 'c'])
     self._run_test(lambda df, df2: df.corrwith(df2, axis=1), df, df2)
 
+  def test_corrwith_bad_axis(self):
+    df = pd.DataFrame({'a': range(3), 'b': range(3, 6), 'c': range(6, 9)})
+    self._run_error_test(lambda df: df.corrwith(df.a, axis=2), df)
+    self._run_error_test(lambda df: df.corrwith(df, axis=5), df)
+
   @unittest.skipIf(PD_VERSION < (1, 2), "na_action added in pandas 1.2.0")
   def test_applymap_na_action(self):
     # Replicates a doctest for na_action which is incompatible with

--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -766,6 +766,18 @@ class DeferredFrameTest(_AbstractFrameTest):
         lambda df: df.drop_duplicates(subset=['brand', 'style'], keep=False),
         df)
 
+  def test_replace(self):
+    # verify a replace() doctest case that doesn't quite work in Beam as it uses
+    # the default method='pad'
+    df = pd.DataFrame({'A': ['bat', 'foo', 'bait'], 'B': ['abc', 'bar', 'xyz']})
+
+    self._run_test(
+        lambda df: df.replace(
+            regex={
+                r'^ba.$': 'new', 'foo': 'xyz'
+            }, method=None),
+        df)
+
 
 class GroupByTest(_AbstractFrameTest):
   """Tests for DataFrame/Series GroupBy operations."""

--- a/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
+++ b/sdks/python/apache_beam/dataframe/pandas_doctests_test.py
@@ -64,6 +64,10 @@ class DoctestTest(unittest.TestCase):
                 "s.replace([1, 2], method='bfill')",
                 # Relies on method='pad'
                 "s.replace('a', None)",
+                # Implicitly uses method='pad', but output doesn't rely on that
+                # behavior. Verified indepently in
+                # frames_test.py::DeferredFrameTest::test_replace
+                "df.replace(regex={r'^ba.$': 'new', 'foo': 'xyz'})"
             ],
             'pandas.core.generic.NDFrame.fillna': [
                 "df.fillna(method='ffill')",
@@ -183,6 +187,10 @@ class DoctestTest(unittest.TestCase):
                 "s.replace([1, 2], method='bfill')",
                 # Relies on method='pad'
                 "s.replace('a', None)",
+                # Implicitly uses method='pad', but output doesn't rely on that
+                # behavior. Verified indepently in
+                # frames_test.py::DeferredFrameTest::test_replace
+                "df.replace(regex={r'^ba.$': 'new', 'foo': 'xyz'})"
             ],
             'pandas.core.frame.DataFrame.to_records': ['*'],
             'pandas.core.frame.DataFrame.to_dict': ['*'],
@@ -407,6 +415,15 @@ class DoctestTest(unittest.TestCase):
             'pandas.core.series.Series.append': [
                 's1.append(s2, ignore_index=True)',
             ],
+            'pandas.core.series.Series.replace': [
+                "s.replace([1, 2], method='bfill')",
+                # Relies on method='pad'
+                "s.replace('a', None)",
+                # Implicitly uses method='pad', but output doesn't rely on that
+                # behavior. Verified indepently in
+                # frames_test.py::DeferredFrameTest::test_replace
+                "df.replace(regex={r'^ba.$': 'new', 'foo': 'xyz'})"
+            ],
             'pandas.core.series.Series.sort_index': ['*'],
             'pandas.core.series.Series.sort_values': ['*'],
             'pandas.core.series.Series.argmax': ['*'],
@@ -449,7 +466,10 @@ class DoctestTest(unittest.TestCase):
             'pandas.core.series.Series.idxmin': ['*'],
             'pandas.core.series.Series.nonzero': ['*'],
             'pandas.core.series.Series.pop': ['ser'],  # testing side effect
-            'pandas.core.series.Series.replace': ['*'],
+            # Raises right exception, but testing framework has matching issues.
+            'pandas.core.series.Series.replace': [
+                "df.replace({'a string': 'new value', True: False})  # raises"
+            ],
             'pandas.core.series.Series.reset_index': ['*'],
             'pandas.core.series.Series.searchsorted': [
                 # This doctest seems to be incorrectly parsed.


### PR DESCRIPTION
This PR primarily just adds docstrings for all undocumented DataFrame operations. It also makes fixes some unhandled edge cases in replace (e9e4e8c) and corrwith (49b1377), to avoid having to document those divergences. 

`ValidatesRunner` compliance status (on master branch)
--------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>Lang</th>
      <th>ULR</th>
      <th>Dataflow</th>
      <th>Flink</th>
      <th>Samza</th>
      <th>Spark</th>
      <th>Twister2</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Go</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon">
        </a>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
    </tr>
    <tr>
      <td>Java</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_ULR/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_ULR/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon?subject=V1">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming/lastCompletedBuild/badge/icon?subject=V1+Streaming">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon?subject=V1+Java+11">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/badge/icon?subject=V2">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2_Streaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2_Streaming/lastCompletedBuild/badge/icon?subject=V2+Streaming">
        </a><br>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon?subject=Java+8">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon?subject=Java+11">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon?subject=Portable">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon?subject=Portable+Streaming">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Samza/lastCompletedBuild/badge/icon?subject=Portable">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon?subject=Portable">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon?subject=Structured+Streaming">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon">
        </a>
      </td>
    </tr>
    <tr>
      <td>Python</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon?subject=V1">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon?subject=V2">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon?subject=ValCont">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon?subject=Portable">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
    </tr>
    <tr>
      <td>XLang</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
    </tr>
  </tbody>
</table>

Examples testing status on various runners
--------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>Lang</th>
      <th>ULR</th>
      <th>Dataflow</th>
      <th>Flink</th>
      <th>Samza</th>
      <th>Spark</th>
      <th>Twister2</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Go</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
    <tr>
      <td>Java</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Cron/lastCompletedBuild/badge/icon?subject=V1">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Java11_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Java11_Cron/lastCompletedBuild/badge/icon?subject=V1+Java11">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_Examples_Dataflow_V2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_Examples_Dataflow_V2/lastCompletedBuild/badge/icon?subject=V2">
        </a><br>
      </td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
    <tr>
      <td>Python</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
    <tr>
      <td>XLang</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
  </tbody>
</table>

Post-Commit SDK/Transform Integration Tests Status (on master branch)
------------------------------------------------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>Go</th>
      <th>Java</th>
      <th>Python</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon?subject=3.6">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon?subject=3.7">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon?subject=3.8">
        </a>
      </td>
    </tr>
  </tbody>
</table>

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>---</th>
      <th>Java</th>
      <th>Python</th>
      <th>Go</th>
      <th>Website</th>
      <th>Whitespace</th>
      <th>Typescript</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Non-portable</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon">
        </a><br>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon?subject=Tests">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon?subject=Lint">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon?subject=Docker">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon?subject=Docs">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
    </tr>
    <tr>
      <td>Portable</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_GoPortable_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_GoPortable_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
  </tbody>
</table>

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
