### PR TITLE
[BEAM-12240] Add Java 17 as a valid environment

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/Environments.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/Environments.java
@@ -91,7 +91,8 @@ public class Environments {
 
   public enum JavaVersion {
     java8("java", "1.8"),
-    java11("java11", "11");
+    java11("java11", "11"),
+    java17("java17", "17");
 
     // Legacy name, as used in container image
     private final String legacyName;


### PR DESCRIPTION
Not sure why we are so strict to validate this, but with this fix I was able to run pipelines on Direct Runner with Java 17 EA

R: @kennknowles 