### PR TITLE
[BEAM-12464] Change ProtoSchemaTranslator beam schema creation to match the order for protobufs containing Oneof fields

### DIFF
--- a/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslator.java
+++ b/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslator.java
@@ -156,14 +156,18 @@ class ProtoSchemaTranslator {
   }
 
   static Schema getSchema(Descriptors.Descriptor descriptor) {
-    Set<Integer> oneOfFields = Sets.newHashSet();
-    Map<Integer, Field> oneOfFieldLocationMap = Maps.newHashMap();
+    /* OneOfComponentFields refers to the field number of the protobuf in the protobuf where the component subfields
+     * are. This is needed to prevent double inclusion of the component fields.*/
+    Set<Integer> oneOfComponentFields = Sets.newHashSet();
+    /* OneOfFieldLocation stores the field number of the first field in the OneOf. Using this, we can use the location
+    of the first field in the OneOf as the location of the entire OneOf.*/
+    Map<Integer, Field> oneOfFieldLocation = Maps.newHashMap();
     List<Field> fields = Lists.newArrayListWithCapacity(descriptor.getFields().size());
     for (OneofDescriptor oneofDescriptor : descriptor.getOneofs()) {
       List<Field> subFields = Lists.newArrayListWithCapacity(oneofDescriptor.getFieldCount());
       Map<String, Integer> enumIds = Maps.newHashMap();
       for (FieldDescriptor fieldDescriptor : oneofDescriptor.getFields()) {
-        oneOfFields.add(fieldDescriptor.getNumber());
+        oneOfComponentFields.add(fieldDescriptor.getNumber());
         // Store proto field number in a field option.
         FieldType fieldType = beamFieldTypeFromProtoField(fieldDescriptor);
         subFields.add(
@@ -173,21 +177,23 @@ class ProtoSchemaTranslator {
             enumIds.putIfAbsent(fieldDescriptor.getName(), fieldDescriptor.getNumber()) == null);
       }
       FieldType oneOfType = FieldType.logicalType(OneOfType.create(subFields, enumIds));
-      oneOfFieldLocationMap.put(
+      oneOfFieldLocation.put(
           oneofDescriptor.getFields().get(0).getNumber(),
           Field.of(oneofDescriptor.getName(), oneOfType));
     }
 
     for (Descriptors.FieldDescriptor fieldDescriptor : descriptor.getFields()) {
       int fieldDescriptorNumber = fieldDescriptor.getNumber();
-      if (!oneOfFields.contains(fieldDescriptorNumber)) {
+      if (!oneOfComponentFields.contains(fieldDescriptorNumber)) {
         // Store proto field number in metadata.
         FieldType fieldType = beamFieldTypeFromProtoField(fieldDescriptor);
         fields.add(
             withFieldNumber(Field.of(fieldDescriptor.getName(), fieldType), fieldDescriptorNumber)
                 .withOptions(getFieldOptions(fieldDescriptor)));
-      } else if (oneOfFieldLocationMap.containsKey(fieldDescriptorNumber)) {
-        Field oneOfField = oneOfFieldLocationMap.get(fieldDescriptorNumber);
+        /* Note that descriptor.getFields() returns an iterator in the order of the fields in the .proto file, not
+         * in field number order. Therefore we can safely insert the OneOfField at the field of its first component.*/
+      } else if (oneOfFieldLocation.containsKey(fieldDescriptorNumber)) {
+        Field oneOfField = oneOfFieldLocation.get(fieldDescriptorNumber);
         if (oneOfField != null) {
           fields.add(oneOfField);
         }

--- a/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslator.java
+++ b/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslator.java
@@ -156,7 +156,7 @@ class ProtoSchemaTranslator {
   }
 
   static Schema getSchema(Descriptors.Descriptor descriptor) {
-    /* OneOfComponentFields refers to the field number of the protobuf in the protobuf where the component subfields
+    /* OneOfComponentFields refers to the field number in the protobuf where the component subfields
      * are. This is needed to prevent double inclusion of the component fields.*/
     Set<Integer> oneOfComponentFields = Sets.newHashSet();
     /* OneOfFieldLocation stores the field number of the first field in the OneOf. Using this, we can use the location

--- a/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslator.java
+++ b/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslator.java
@@ -192,7 +192,7 @@ class ProtoSchemaTranslator {
                 .withOptions(getFieldOptions(fieldDescriptor)));
         /* Note that descriptor.getFields() returns an iterator in the order of the fields in the .proto file, not
          * in field number order. Therefore we can safely insert the OneOfField at the field of its first component.*/
-      } else if (oneOfFieldLocation.containsKey(fieldDescriptorNumber)) {
+      } else {
         Field oneOfField = oneOfFieldLocation.get(fieldDescriptorNumber);
         if (oneOfField != null) {
           fields.add(oneOfField);

--- a/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/ProtoDynamicMessageSchemaTest.java
+++ b/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/ProtoDynamicMessageSchemaTest.java
@@ -45,6 +45,15 @@ import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.PRIMITIVE
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REPEATED_PROTO;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REPEATED_ROW;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REPEATED_SCHEMA;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REVERSED_ONEOF_PROTO_BOOL;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REVERSED_ONEOF_PROTO_INT32;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REVERSED_ONEOF_PROTO_PRIMITIVE;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REVERSED_ONEOF_PROTO_STRING;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REVERSED_ONEOF_ROW_BOOL;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REVERSED_ONEOF_ROW_INT32;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REVERSED_ONEOF_ROW_PRIMITIVE;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REVERSED_ONEOF_ROW_STRING;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REVERSED_ONEOF_SCHEMA;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.WKT_MESSAGE_PROTO;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.WKT_MESSAGE_ROW;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.WKT_MESSAGE_SCHEMA;
@@ -65,6 +74,7 @@ import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.OneOf;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.OuterOneOf;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.Primitive;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.RepeatPrimitive;
+import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.ReversedOneOf;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.WktMessage;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.logicaltypes.EnumerationType;
@@ -254,6 +264,49 @@ public class ProtoDynamicMessageSchemaTest {
     assertEquals(ONEOF_PROTO_BOOL.toString(), fromRow.apply(ONEOF_ROW_BOOL).toString());
     assertEquals(ONEOF_PROTO_STRING.toString(), fromRow.apply(ONEOF_ROW_STRING).toString());
     assertEquals(ONEOF_PROTO_PRIMITIVE.toString(), fromRow.apply(ONEOF_ROW_PRIMITIVE).toString());
+  }
+
+  @Test
+  public void testReversedOneOfSchema() {
+    ProtoDynamicMessageSchema schemaProvider = schemaFromDescriptor(ReversedOneOf.getDescriptor());
+    Schema schema = schemaProvider.getSchema();
+    assertEquals(REVERSED_ONEOF_SCHEMA, schema);
+  }
+
+  @Test
+  public void testReversedOneOfProtoToRow() throws InvalidProtocolBufferException {
+    ProtoDynamicMessageSchema schemaProvider = schemaFromDescriptor(ReversedOneOf.getDescriptor());
+    SerializableFunction<DynamicMessage, Row> toRow = schemaProvider.getToRowFunction();
+    // equality doesn't work between dynamic messages and other,
+    // so we compare string representation
+    assertEquals(
+        REVERSED_ONEOF_ROW_INT32.toString(),
+        toRow.apply(toDynamic(REVERSED_ONEOF_PROTO_INT32)).toString());
+    assertEquals(
+        REVERSED_ONEOF_ROW_BOOL.toString(),
+        toRow.apply(toDynamic(REVERSED_ONEOF_PROTO_BOOL)).toString());
+    assertEquals(
+        REVERSED_ONEOF_ROW_STRING.toString(),
+        toRow.apply(toDynamic(REVERSED_ONEOF_PROTO_STRING)).toString());
+    assertEquals(
+        REVERSED_ONEOF_ROW_PRIMITIVE.toString(),
+        toRow.apply(toDynamic(REVERSED_ONEOF_PROTO_PRIMITIVE)).toString());
+  }
+
+  @Test
+  public void testReversedOneOfRowToProto() {
+    ProtoDynamicMessageSchema schemaProvider = schemaFromDescriptor(ReversedOneOf.getDescriptor());
+    SerializableFunction<Row, DynamicMessage> fromRow = schemaProvider.getFromRowFunction();
+    assertEquals(
+        REVERSED_ONEOF_PROTO_INT32.toString(), fromRow.apply(REVERSED_ONEOF_ROW_INT32).toString());
+    assertEquals(
+        REVERSED_ONEOF_PROTO_BOOL.toString(), fromRow.apply(REVERSED_ONEOF_ROW_BOOL).toString());
+    assertEquals(
+        REVERSED_ONEOF_PROTO_STRING.toString(),
+        fromRow.apply(REVERSED_ONEOF_ROW_STRING).toString());
+    assertEquals(
+        REVERSED_ONEOF_PROTO_PRIMITIVE.toString(),
+        fromRow.apply(REVERSED_ONEOF_ROW_PRIMITIVE).toString());
   }
 
   @Test

--- a/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/ProtoDynamicMessageSchemaTest.java
+++ b/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/ProtoDynamicMessageSchemaTest.java
@@ -23,6 +23,9 @@ import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.MAP_PRIMI
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.NESTED_PROTO;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.NESTED_ROW;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.NESTED_SCHEMA;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.NONCONTIGUOUS_ONEOF_PROTO;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.NONCONTIGUOUS_ONEOF_ROW;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.NONCONTIGUOUS_ONEOF_SCHEMA;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.NULL_MAP_PRIMITIVE_PROTO;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.NULL_MAP_PRIMITIVE_ROW;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.NULL_REPEATED_PROTO;
@@ -70,6 +73,7 @@ import com.google.protobuf.TextFormat.ParseException;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.EnumMessage;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.MapPrimitive;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.Nested;
+import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.NonContiguousOneOf;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.OneOf;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.OuterOneOf;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.Primitive;
@@ -307,6 +311,35 @@ public class ProtoDynamicMessageSchemaTest {
     assertEquals(
         REVERSED_ONEOF_PROTO_PRIMITIVE.toString(),
         fromRow.apply(REVERSED_ONEOF_ROW_PRIMITIVE).toString());
+  }
+
+  @Test
+  public void testNonContiguousOneOfSchema() {
+    ProtoDynamicMessageSchema schemaProvider =
+        schemaFromDescriptor(NonContiguousOneOf.getDescriptor());
+    Schema schema = schemaProvider.getSchema();
+    assertEquals(NONCONTIGUOUS_ONEOF_SCHEMA, schema);
+  }
+
+  @Test
+  public void testNonContiguousOneOfProtoToRow() throws InvalidProtocolBufferException {
+    ProtoDynamicMessageSchema schemaProvider =
+        schemaFromDescriptor(NonContiguousOneOf.getDescriptor());
+    SerializableFunction<DynamicMessage, Row> toRow = schemaProvider.getToRowFunction();
+    // equality doesn't work between dynamic messages and other,
+    // so we compare string representation
+    assertEquals(
+        NONCONTIGUOUS_ONEOF_ROW.toString(),
+        toRow.apply(toDynamic(NONCONTIGUOUS_ONEOF_PROTO)).toString());
+  }
+
+  @Test
+  public void testNonContiguousOneOfRowToProto() {
+    ProtoDynamicMessageSchema schemaProvider =
+        schemaFromDescriptor(NonContiguousOneOf.getDescriptor());
+    SerializableFunction<Row, DynamicMessage> fromRow = schemaProvider.getFromRowFunction();
+    assertEquals(
+        NONCONTIGUOUS_ONEOF_PROTO.toString(), fromRow.apply(NONCONTIGUOUS_ONEOF_ROW).toString());
   }
 
   @Test

--- a/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/ProtoMessageSchemaTest.java
+++ b/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/ProtoMessageSchemaTest.java
@@ -23,6 +23,8 @@ import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.MAP_PRIMI
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.NESTED_PROTO;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.NESTED_ROW;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.NESTED_SCHEMA;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.NONCONTIGUOUS_ONEOF_PROTO;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.NONCONTIGUOUS_ONEOF_ROW;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.NULL_MAP_PRIMITIVE_PROTO;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.NULL_MAP_PRIMITIVE_ROW;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.NULL_REPEATED_PROTO;
@@ -72,6 +74,7 @@ import org.apache.beam.sdk.extensions.protobuf.Proto2SchemaMessages.RequiredPrim
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.EnumMessage;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.MapPrimitive;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.Nested;
+import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.NonContiguousOneOf;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.OneOf;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.OuterOneOf;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.Primitive;
@@ -306,6 +309,20 @@ public class ProtoMessageSchemaTest {
     assertEquals(REVERSED_ONEOF_PROTO_BOOL, fromRow.apply(REVERSED_ONEOF_ROW_BOOL));
     assertEquals(REVERSED_ONEOF_PROTO_STRING, fromRow.apply(REVERSED_ONEOF_ROW_STRING));
     assertEquals(REVERSED_ONEOF_PROTO_PRIMITIVE, fromRow.apply(REVERSED_ONEOF_ROW_PRIMITIVE));
+  }
+
+  @Test
+  public void testNonContiguousOneOfProtoToRow() {
+    SerializableFunction<NonContiguousOneOf, Row> toRow =
+        new ProtoMessageSchema().toRowFunction(TypeDescriptor.of(NonContiguousOneOf.class));
+    assertEquals(NONCONTIGUOUS_ONEOF_ROW, toRow.apply(NONCONTIGUOUS_ONEOF_PROTO));
+  }
+
+  @Test
+  public void testNonContiguousOneOfRowToProto() {
+    SerializableFunction<Row, NonContiguousOneOf> fromRow =
+        new ProtoMessageSchema().fromRowFunction(TypeDescriptor.of(NonContiguousOneOf.class));
+    assertEquals(NONCONTIGUOUS_ONEOF_PROTO, fromRow.apply(NONCONTIGUOUS_ONEOF_ROW));
   }
 
   private static final EnumerationType ENUM_TYPE =

--- a/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/ProtoMessageSchemaTest.java
+++ b/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/ProtoMessageSchemaTest.java
@@ -51,6 +51,14 @@ import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REPEATED_
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REQUIRED_PRIMITIVE_PROTO;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REQUIRED_PRIMITIVE_ROW;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REQUIRED_PRIMITIVE_SCHEMA;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REVERSED_ONEOF_PROTO_BOOL;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REVERSED_ONEOF_PROTO_INT32;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REVERSED_ONEOF_PROTO_PRIMITIVE;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REVERSED_ONEOF_PROTO_STRING;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REVERSED_ONEOF_ROW_BOOL;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REVERSED_ONEOF_ROW_INT32;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REVERSED_ONEOF_ROW_PRIMITIVE;
+import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.REVERSED_ONEOF_ROW_STRING;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.WKT_MESSAGE_PROTO;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.WKT_MESSAGE_ROW;
 import static org.apache.beam.sdk.extensions.protobuf.TestProtoSchemas.WKT_MESSAGE_SCHEMA;
@@ -68,6 +76,7 @@ import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.OneOf;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.OuterOneOf;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.Primitive;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.RepeatPrimitive;
+import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.ReversedOneOf;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.WktMessage;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
@@ -277,6 +286,26 @@ public class ProtoMessageSchemaTest {
     SerializableFunction<Row, OuterOneOf> fromRow =
         new ProtoMessageSchema().fromRowFunction(TypeDescriptor.of(OuterOneOf.class));
     assertEquals(OUTER_ONEOF_PROTO, fromRow.apply(OUTER_ONEOF_ROW));
+  }
+
+  @Test
+  public void testReversedOneOfProtoToRow() {
+    SerializableFunction<ReversedOneOf, Row> toRow =
+        new ProtoMessageSchema().toRowFunction(TypeDescriptor.of(ReversedOneOf.class));
+    assertEquals(REVERSED_ONEOF_ROW_INT32, toRow.apply(REVERSED_ONEOF_PROTO_INT32));
+    assertEquals(REVERSED_ONEOF_ROW_BOOL, toRow.apply(REVERSED_ONEOF_PROTO_BOOL));
+    assertEquals(REVERSED_ONEOF_ROW_STRING, toRow.apply(REVERSED_ONEOF_PROTO_STRING));
+    assertEquals(REVERSED_ONEOF_ROW_PRIMITIVE, toRow.apply(REVERSED_ONEOF_PROTO_PRIMITIVE));
+  }
+
+  @Test
+  public void testReversedOneOfRowToProto() {
+    SerializableFunction<Row, ReversedOneOf> fromRow =
+        new ProtoMessageSchema().fromRowFunction(TypeDescriptor.of(ReversedOneOf.class));
+    assertEquals(REVERSED_ONEOF_PROTO_INT32, fromRow.apply(REVERSED_ONEOF_ROW_INT32));
+    assertEquals(REVERSED_ONEOF_PROTO_BOOL, fromRow.apply(REVERSED_ONEOF_ROW_BOOL));
+    assertEquals(REVERSED_ONEOF_PROTO_STRING, fromRow.apply(REVERSED_ONEOF_ROW_STRING));
+    assertEquals(REVERSED_ONEOF_PROTO_PRIMITIVE, fromRow.apply(REVERSED_ONEOF_ROW_PRIMITIVE));
   }
 
   private static final EnumerationType ENUM_TYPE =

--- a/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslatorTest.java
+++ b/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslatorTest.java
@@ -84,6 +84,13 @@ public class ProtoSchemaTranslatorTest {
   }
 
   @Test
+  public void testReversedOneOfSchema() {
+    assertEquals(
+        TestProtoSchemas.REVERSED_ONEOF_SCHEMA,
+        ProtoSchemaTranslator.getSchema(Proto3SchemaMessages.ReversedOneOf.class));
+  }
+
+  @Test
   public void testNestedOneOfSchema() {
     assertEquals(
         TestProtoSchemas.OUTER_ONEOF_SCHEMA,

--- a/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslatorTest.java
+++ b/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslatorTest.java
@@ -91,6 +91,13 @@ public class ProtoSchemaTranslatorTest {
   }
 
   @Test
+  public void testNonContiguousOneOfSchema() {
+    assertEquals(
+        TestProtoSchemas.NONCONTIGUOUS_ONEOF_SCHEMA,
+        ProtoSchemaTranslator.getSchema(Proto3SchemaMessages.NonContiguousOneOf.class));
+  }
+
+  @Test
   public void testNestedOneOfSchema() {
     assertEquals(
         TestProtoSchemas.OUTER_ONEOF_SCHEMA,

--- a/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/TestProtoSchemas.java
+++ b/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/TestProtoSchemas.java
@@ -384,8 +384,8 @@ class TestProtoSchemas {
   static final OneOfType ONE_OF_TYPE = OneOfType.create(ONEOF_FIELDS, ONE_OF_ENUM_MAP);
   static final Schema ONEOF_SCHEMA =
       Schema.builder()
-          .addField("special_oneof", FieldType.logicalType(ONE_OF_TYPE))
           .addField(withFieldNumber("place1", FieldType.STRING, 1))
+          .addField("special_oneof", FieldType.logicalType(ONE_OF_TYPE))
           .addField(withFieldNumber("place2", FieldType.INT32, 6))
           .setOptions(withTypeName("proto3_schema_messages.OneOf"))
           .build();
@@ -393,19 +393,19 @@ class TestProtoSchemas {
   // Sample row instances for each OneOf case.
   static final Row ONEOF_ROW_INT32 =
       Row.withSchema(ONEOF_SCHEMA)
-          .addValues(ONE_OF_TYPE.createValue("oneof_int32", 1), "foo", 0)
+          .addValues("foo", ONE_OF_TYPE.createValue("oneof_int32", 1), 0)
           .build();
   static final Row ONEOF_ROW_BOOL =
       Row.withSchema(ONEOF_SCHEMA)
-          .addValues(ONE_OF_TYPE.createValue("oneof_bool", true), "foo", 0)
+          .addValues("foo", ONE_OF_TYPE.createValue("oneof_bool", true), 0)
           .build();
   static final Row ONEOF_ROW_STRING =
       Row.withSchema(ONEOF_SCHEMA)
-          .addValues(ONE_OF_TYPE.createValue("oneof_string", "foo"), "foo", 0)
+          .addValues("foo", ONE_OF_TYPE.createValue("oneof_string", "foo"), 0)
           .build();
   static final Row ONEOF_ROW_PRIMITIVE =
       Row.withSchema(ONEOF_SCHEMA)
-          .addValues(ONE_OF_TYPE.createValue("oneof_primitive", PRIMITIVE_ROW), "foo", 0)
+          .addValues("foo", ONE_OF_TYPE.createValue("oneof_primitive", PRIMITIVE_ROW), 0)
           .build();
 
   // Sample proto instances for each oneof case.

--- a/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/TestProtoSchemas.java
+++ b/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/TestProtoSchemas.java
@@ -433,6 +433,30 @@ class TestProtoSchemas {
           .setOptions(withTypeName("proto3_schema_messages.OuterOneOf"))
           .build();
 
+  // The schema for the ReversedOneOf proto.
+  // The schema for the OneOf proto.
+  private static final List<Field> ONEOF_FIELDS_REVERSED =
+      ImmutableList.of(
+          withFieldNumber("oneof_int32", FieldType.INT32, 5),
+          withFieldNumber("oneof_bool", FieldType.BOOLEAN, 4),
+          withFieldNumber("oneof_string", FieldType.STRING, 3),
+          withFieldNumber("oneof_primitive", FieldType.row(PRIMITIVE_SCHEMA), 2));
+
+  private static final Map<String, Integer> ONE_OF_ENUM_MAP_REVERSED =
+      ONEOF_FIELDS_REVERSED.stream()
+          .collect(Collectors.toMap(Field::getName, f -> getFieldNumber(f)));
+  static final OneOfType ONE_OF_TYPE_REVERSED =
+      OneOfType.create(ONEOF_FIELDS_REVERSED, ONE_OF_ENUM_MAP_REVERSED);
+
+  //  static final OneOfType ONE_OF_TYPE = OneOfType.create(ONEOF_FIELDS, ONE_OF_ENUM_MAP);
+  static final Schema REVERSED_ONEOF_SCHEMA =
+      Schema.builder()
+          .addField(withFieldNumber("place1", FieldType.STRING, 6))
+          .addField("oneof_reversed", FieldType.logicalType(ONE_OF_TYPE_REVERSED))
+          .addField(withFieldNumber("place2", FieldType.INT32, 1))
+          .setOptions(withTypeName("proto3_schema_messages.ReversedOneOf"))
+          .build();
+
   // A sample instance of the Row.
   static final Row OUTER_ONEOF_ROW =
       Row.withSchema(OUTER_ONEOF_SCHEMA)

--- a/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/TestProtoSchemas.java
+++ b/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/TestProtoSchemas.java
@@ -434,27 +434,65 @@ class TestProtoSchemas {
           .build();
 
   // The schema for the ReversedOneOf proto.
-  // The schema for the OneOf proto.
-  private static final List<Field> ONEOF_FIELDS_REVERSED =
+  private static final List<Field> REVERSED_ONEOF_FIELDS =
       ImmutableList.of(
           withFieldNumber("oneof_int32", FieldType.INT32, 5),
           withFieldNumber("oneof_bool", FieldType.BOOLEAN, 4),
           withFieldNumber("oneof_string", FieldType.STRING, 3),
           withFieldNumber("oneof_primitive", FieldType.row(PRIMITIVE_SCHEMA), 2));
 
-  private static final Map<String, Integer> ONE_OF_ENUM_MAP_REVERSED =
-      ONEOF_FIELDS_REVERSED.stream()
+  private static final Map<String, Integer> REVERSED_ONE_OF_ENUM_MAP =
+      REVERSED_ONEOF_FIELDS.stream()
           .collect(Collectors.toMap(Field::getName, f -> getFieldNumber(f)));
-  static final OneOfType ONE_OF_TYPE_REVERSED =
-      OneOfType.create(ONEOF_FIELDS_REVERSED, ONE_OF_ENUM_MAP_REVERSED);
+  static final OneOfType REVERSED_ONE_OF_TYPE =
+      OneOfType.create(REVERSED_ONEOF_FIELDS, REVERSED_ONE_OF_ENUM_MAP);
 
-  //  static final OneOfType ONE_OF_TYPE = OneOfType.create(ONEOF_FIELDS, ONE_OF_ENUM_MAP);
   static final Schema REVERSED_ONEOF_SCHEMA =
       Schema.builder()
           .addField(withFieldNumber("place1", FieldType.STRING, 6))
-          .addField("oneof_reversed", FieldType.logicalType(ONE_OF_TYPE_REVERSED))
+          .addField("oneof_reversed", FieldType.logicalType(REVERSED_ONE_OF_TYPE))
           .addField(withFieldNumber("place2", FieldType.INT32, 1))
           .setOptions(withTypeName("proto3_schema_messages.ReversedOneOf"))
+          .build();
+
+  // The schema for the NonContiguousOneOf proto.
+  private static final List<Field> NONCONTIGUOUS_ONE_ONEOF_FIELDS =
+      ImmutableList.of(
+          withFieldNumber("oneof_one_int32", FieldType.INT32, 55),
+          withFieldNumber("oneof_one_bool", FieldType.BOOLEAN, 1),
+          withFieldNumber("oneof_one_string", FieldType.STRING, 189),
+          withFieldNumber("oneof_one_primitive", FieldType.row(PRIMITIVE_SCHEMA), 22));
+
+  private static final List<Field> NONCONTIGUOUS_TWO_ONEOF_FIELDS =
+      ImmutableList.of(
+          withFieldNumber("oneof_two_first_string", FieldType.STRING, 981),
+          withFieldNumber("oneof_two_int32", FieldType.INT32, 2),
+          withFieldNumber("oneof_two_second_string", FieldType.STRING, 44));
+
+  private static final Map<String, Integer> NONCONTIGUOUS_ONE_ONE_OF_ENUM_MAP =
+      NONCONTIGUOUS_ONE_ONEOF_FIELDS.stream()
+          .collect(Collectors.toMap(Field::getName, f -> getFieldNumber(f)));
+
+  private static final Map<String, Integer> NONCONTIGUOUS_TWO_ONE_OF_ENUM_MAP =
+      NONCONTIGUOUS_TWO_ONEOF_FIELDS.stream()
+          .collect(Collectors.toMap(Field::getName, f -> getFieldNumber(f)));
+
+  static final OneOfType NONCONTIGUOUS_ONE_ONE_OF_TYPE =
+      OneOfType.create(NONCONTIGUOUS_ONE_ONEOF_FIELDS, NONCONTIGUOUS_ONE_ONE_OF_ENUM_MAP);
+
+  static final OneOfType NONCONTIGUOUS_TWO_ONE_OF_TYPE =
+      OneOfType.create(NONCONTIGUOUS_TWO_ONEOF_FIELDS, NONCONTIGUOUS_TWO_ONE_OF_ENUM_MAP);
+
+  static final Schema NONCONTIGUOUS_ONEOF_SCHEMA =
+      Schema.builder()
+          .addField(withFieldNumber("place1", FieldType.STRING, 76))
+          .addField(
+              "oneof_non_contiguous_one", FieldType.logicalType(NONCONTIGUOUS_ONE_ONE_OF_TYPE))
+          .addField(withFieldNumber("place2", FieldType.INT32, 33))
+          .addField(
+              "oneof_non_contiguous_two", FieldType.logicalType(NONCONTIGUOUS_TWO_ONE_OF_TYPE))
+          .addField(withFieldNumber("place3", FieldType.INT32, 63))
+          .setOptions(withTypeName("proto3_schema_messages.NonContiguousOneOf"))
           .build();
 
   // A sample instance of the Row.

--- a/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/TestProtoSchemas.java
+++ b/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/TestProtoSchemas.java
@@ -43,6 +43,7 @@ import org.apache.beam.sdk.extensions.protobuf.Proto2SchemaMessages.RequiredNest
 import org.apache.beam.sdk.extensions.protobuf.Proto2SchemaMessages.RequiredPrimitive;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.MapPrimitive;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.Nested;
+import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.NonContiguousOneOf;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.OneOf;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.OuterOneOf;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.Primitive;
@@ -536,6 +537,25 @@ class TestProtoSchemas {
               "oneof_non_contiguous_two", FieldType.logicalType(NONCONTIGUOUS_TWO_ONE_OF_TYPE))
           .addField(withFieldNumber("place3", FieldType.INT32, 63))
           .setOptions(withTypeName("proto3_schema_messages.NonContiguousOneOf"))
+          .build();
+
+  static final Row NONCONTIGUOUS_ONEOF_ROW =
+      Row.withSchema(NONCONTIGUOUS_ONEOF_SCHEMA)
+          .addValues(
+              "foo",
+              NONCONTIGUOUS_ONE_ONE_OF_TYPE.createValue("oneof_one_int32", 1),
+              0,
+              NONCONTIGUOUS_TWO_ONE_OF_TYPE.createValue("oneof_two_second_string", "bar"),
+              343)
+          .build();
+
+  static final NonContiguousOneOf NONCONTIGUOUS_ONEOF_PROTO =
+      NonContiguousOneOf.newBuilder()
+          .setOneofOneInt32(1)
+          .setPlace1("foo")
+          .setPlace2(0)
+          .setOneofTwoSecondString("bar")
+          .setPlace3(343)
           .build();
 
   static final Schema WKT_MESSAGE_SCHEMA =

--- a/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/TestProtoSchemas.java
+++ b/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/TestProtoSchemas.java
@@ -467,7 +467,7 @@ class TestProtoSchemas {
           .setOptions(withTypeName("proto3_schema_messages.ReversedOneOf"))
           .build();
 
-  // Sample row instances for each OneOf case.
+  // Sample row instances for each ReversedOneOf case.
   static final Row REVERSED_ONEOF_ROW_INT32 =
       Row.withSchema(REVERSED_ONEOF_SCHEMA)
           .addValues("foo", REVERSED_ONE_OF_TYPE.createValue("oneof_int32", 1), 0)
@@ -485,7 +485,7 @@ class TestProtoSchemas {
           .addValues("foo", REVERSED_ONE_OF_TYPE.createValue("oneof_primitive", PRIMITIVE_ROW), 0)
           .build();
 
-  // Sample proto instances for each reversedOneOf case.
+  // Sample proto instances for each ReversedOneOf case.
   static final ReversedOneOf REVERSED_ONEOF_PROTO_INT32 =
       ReversedOneOf.newBuilder().setOneofInt32(1).setPlace1("foo").setPlace2(0).build();
   static final ReversedOneOf REVERSED_ONEOF_PROTO_BOOL =

--- a/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/TestProtoSchemas.java
+++ b/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/TestProtoSchemas.java
@@ -47,6 +47,7 @@ import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.OneOf;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.OuterOneOf;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.Primitive;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.RepeatPrimitive;
+import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.ReversedOneOf;
 import org.apache.beam.sdk.extensions.protobuf.Proto3SchemaMessages.WktMessage;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.Fixed32;
 import org.apache.beam.sdk.extensions.protobuf.ProtoSchemaLogicalTypes.Fixed64;
@@ -433,6 +434,16 @@ class TestProtoSchemas {
           .setOptions(withTypeName("proto3_schema_messages.OuterOneOf"))
           .build();
 
+  // A sample instance of the Row.
+  static final Row OUTER_ONEOF_ROW =
+      Row.withSchema(OUTER_ONEOF_SCHEMA)
+          .addValues(OUTER_ONEOF_TYPE.createValue("oneof_oneof", ONEOF_ROW_PRIMITIVE))
+          .build();
+
+  // A sample instance of the proto.
+  static final OuterOneOf OUTER_ONEOF_PROTO =
+      OuterOneOf.newBuilder().setOneofOneof(ONEOF_PROTO_PRIMITIVE).build();
+
   // The schema for the ReversedOneOf proto.
   private static final List<Field> REVERSED_ONEOF_FIELDS =
       ImmutableList.of(
@@ -453,6 +464,38 @@ class TestProtoSchemas {
           .addField("oneof_reversed", FieldType.logicalType(REVERSED_ONE_OF_TYPE))
           .addField(withFieldNumber("place2", FieldType.INT32, 1))
           .setOptions(withTypeName("proto3_schema_messages.ReversedOneOf"))
+          .build();
+
+  // Sample row instances for each OneOf case.
+  static final Row REVERSED_ONEOF_ROW_INT32 =
+      Row.withSchema(REVERSED_ONEOF_SCHEMA)
+          .addValues("foo", REVERSED_ONE_OF_TYPE.createValue("oneof_int32", 1), 0)
+          .build();
+  static final Row REVERSED_ONEOF_ROW_BOOL =
+      Row.withSchema(REVERSED_ONEOF_SCHEMA)
+          .addValues("foo", REVERSED_ONE_OF_TYPE.createValue("oneof_bool", true), 0)
+          .build();
+  static final Row REVERSED_ONEOF_ROW_STRING =
+      Row.withSchema(REVERSED_ONEOF_SCHEMA)
+          .addValues("foo", REVERSED_ONE_OF_TYPE.createValue("oneof_string", "foo"), 0)
+          .build();
+  static final Row REVERSED_ONEOF_ROW_PRIMITIVE =
+      Row.withSchema(REVERSED_ONEOF_SCHEMA)
+          .addValues("foo", REVERSED_ONE_OF_TYPE.createValue("oneof_primitive", PRIMITIVE_ROW), 0)
+          .build();
+
+  // Sample proto instances for each reversedOneOf case.
+  static final ReversedOneOf REVERSED_ONEOF_PROTO_INT32 =
+      ReversedOneOf.newBuilder().setOneofInt32(1).setPlace1("foo").setPlace2(0).build();
+  static final ReversedOneOf REVERSED_ONEOF_PROTO_BOOL =
+      ReversedOneOf.newBuilder().setOneofBool(true).setPlace1("foo").setPlace2(0).build();
+  static final ReversedOneOf REVERSED_ONEOF_PROTO_STRING =
+      ReversedOneOf.newBuilder().setOneofString("foo").setPlace1("foo").setPlace2(0).build();
+  static final ReversedOneOf REVERSED_ONEOF_PROTO_PRIMITIVE =
+      ReversedOneOf.newBuilder()
+          .setOneofPrimitive(PRIMITIVE_PROTO)
+          .setPlace1("foo")
+          .setPlace2(0)
           .build();
 
   // The schema for the NonContiguousOneOf proto.
@@ -494,16 +537,6 @@ class TestProtoSchemas {
           .addField(withFieldNumber("place3", FieldType.INT32, 63))
           .setOptions(withTypeName("proto3_schema_messages.NonContiguousOneOf"))
           .build();
-
-  // A sample instance of the Row.
-  static final Row OUTER_ONEOF_ROW =
-      Row.withSchema(OUTER_ONEOF_SCHEMA)
-          .addValues(OUTER_ONEOF_TYPE.createValue("oneof_oneof", ONEOF_ROW_PRIMITIVE))
-          .build();
-
-  // A sample instance of the proto.
-  static final OuterOneOf OUTER_ONEOF_PROTO =
-      OuterOneOf.newBuilder().setOneofOneof(ONEOF_PROTO_PRIMITIVE).build();
 
   static final Schema WKT_MESSAGE_SCHEMA =
       Schema.builder()

--- a/sdks/java/extensions/protobuf/src/test/proto/proto3_schema_messages.proto
+++ b/sdks/java/extensions/protobuf/src/test/proto/proto3_schema_messages.proto
@@ -111,6 +111,23 @@ message ReversedOneOf {
     int32 place2 = 1;
 }
 
+message NonContiguousOneOf {
+  string place1 = 76;
+    oneof oneof_non_contiguous_one {
+        int32 oneof_one_int32 = 55;
+        bool oneof_one_bool = 1;
+        string oneof_one_string = 189;
+        Primitive oneof_one_primitive = 22;
+    }
+    int32 place2 = 33;
+    oneof oneof_non_contiguous_two {
+        string oneof_two_first_string = 981;
+        int32 oneof_two_int32 = 2;
+        string oneof_two_second_string = 44;
+    }
+    int32 place3 = 63;
+}
+
 message EnumMessage {
   enum Enum {
     ZERO  = 0;

--- a/sdks/java/extensions/protobuf/src/test/proto/proto3_schema_messages.proto
+++ b/sdks/java/extensions/protobuf/src/test/proto/proto3_schema_messages.proto
@@ -100,6 +100,17 @@ message OuterOneOf {
   }
 }
 
+message ReversedOneOf {
+  string place1 = 6;
+    oneof oneof_reversed {
+        int32 oneof_int32 = 5;
+        bool oneof_bool = 4;
+        string oneof_string = 3;
+        Primitive oneof_primitive = 2;
+    }
+    int32 place2 = 1;
+}
+
 message EnumMessage {
   enum Enum {
     ZERO  = 0;


### PR DESCRIPTION
Currently, when ProtoSchemaTranslator creates the beam schema from a protobuf definition it always puts the Oneofs at the start of the beam schema due to oneofs always being created first.  This means that the order of the fields doesn't match the order of the protobuf definition. As the schema generation is used when converting from beam rows to protobufs, it additionally means that it is impossible to convert from a beam row where the oneof fields are not the first fields in the beamrow.

This change orders the resultant beam schema to match the order in the protobuf definition. 

Additionally, this PR updates the test protos so that the beam schema in the oneof tests matches the protobuf definition, as opposed to the beam row having the Oneofs first. 

 
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-12464] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

`ValidatesRunner` compliance status (on master branch)
--------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>Lang</th>
      <th>ULR</th>
      <th>Dataflow</th>
      <th>Flink</th>
      <th>Samza</th>
      <th>Spark</th>
      <th>Twister2</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Go</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon">
        </a>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
    </tr>
    <tr>
      <td>Java</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_ULR/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_ULR/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon?subject=V1">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming/lastCompletedBuild/badge/icon?subject=V1+Streaming">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon?subject=V1+Java+11">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/badge/icon?subject=V2">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2_Streaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2_Streaming/lastCompletedBuild/badge/icon?subject=V2+Streaming">
        </a><br>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon?subject=Java+8">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon?subject=Java+11">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon?subject=Portable">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon?subject=Portable+Streaming">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Samza/lastCompletedBuild/badge/icon?subject=Portable">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon?subject=Portable">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon?subject=Structured+Streaming">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon">
        </a>
      </td>
    </tr>
    <tr>
      <td>Python</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon?subject=V1">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon?subject=V2">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon?subject=ValCont">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon?subject=Portable">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
    </tr>
    <tr>
      <td>XLang</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
    </tr>
  </tbody>
</table>

Examples testing status on various runners
--------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>Lang</th>
      <th>ULR</th>
      <th>Dataflow</th>
      <th>Flink</th>
      <th>Samza</th>
      <th>Spark</th>
      <th>Twister2</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Go</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
    <tr>
      <td>Java</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Cron/lastCompletedBuild/badge/icon?subject=V1">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Java11_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Java11_Cron/lastCompletedBuild/badge/icon?subject=V1+Java11">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_Examples_Dataflow_V2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_Examples_Dataflow_V2/lastCompletedBuild/badge/icon?subject=V2">
        </a><br>
      </td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
    <tr>
      <td>Python</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
    <tr>
      <td>XLang</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
  </tbody>
</table>

Post-Commit SDK/Transform Integration Tests Status (on master branch)
------------------------------------------------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>Go</th>
      <th>Java</th>
      <th>Python</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon?subject=3.6">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon?subject=3.7">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon?subject=3.8">
        </a>
      </td>
    </tr>
  </tbody>
</table>

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>---</th>
      <th>Java</th>
      <th>Python</th>
      <th>Go</th>
      <th>Website</th>
      <th>Whitespace</th>
      <th>Typescript</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Non-portable</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon">
        </a><br>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon?subject=Tests">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon?subject=Lint">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon?subject=Docker">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon?subject=Docs">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
    </tr>
    <tr>
      <td>Portable</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_GoPortable_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_GoPortable_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
  </tbody>
</table>

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
