### PR TITLE
Revert "Update test_error_message_includes_stage test"

### DIFF
--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
@@ -825,15 +825,11 @@ class FnApiRunnerTest(unittest.TestCase):
             | beam.Create(['a', 'b'])
             | 'StageA' >> beam.Map(lambda x: x)
             | 'StageB' >> beam.Map(lambda x: x)
-            | 'FusionBreakBeforeRaise' >> beam.Reshuffle()
             | 'StageC' >> beam.Map(raise_error)
-            | 'FusionBreakAfterRaise' >> beam.Reshuffle()
             | 'StageD' >> beam.Map(lambda x: x))
     message = e_cm.exception.args[0]
     self.assertIn('StageC', message)
-    self.assertNotIn('StageA', message)
     self.assertNotIn('StageB', message)
-    self.assertNotIn('StageD', message)
 
   def test_error_traceback_includes_user_code(self):
     def first(x):


### PR DESCRIPTION
Reverts apache/beam#14819. Because "The point of this test was that we implicated the right stage despite fusion."