### PR TITLE
Loosen typing extensions requirement

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -154,7 +154,7 @@ REQUIRED_PACKAGES = [
     'python-dateutil>=2.8.0,<3',
     'pytz>=2018.3',
     'requests>=2.24.0,<3.0.0',
-    'typing-extensions>=3.7.0,<3.8.0',
+    'typing-extensions>=3.7.0,<4',
     ]
 
 # [BEAM-8181] pyarrow cannot be installed on 32-bit Windows platforms.


### PR DESCRIPTION
I'm unsure why typing extensions has such a narrow package requirement. I use beam as a dependency and can't use newer type features due to the tightness. I'm unaware of any backwards incompatibility issues with typing extensions as normally new minor versions just add more things found in newer python versions.