### PR TITLE
Revert "[BEAM-11934] Remove Dataflow override of streaming WriteFiles with runner determined sharding"

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -19,6 +19,7 @@ package org.apache.beam.runners.dataflow;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.beam.runners.core.construction.resources.PipelineResources.detectClassPathResourcesToStage;
+import static org.apache.beam.sdk.options.ExperimentalOptions.hasExperiment;
 import static org.apache.beam.sdk.util.CoderUtils.encodeToByteArray;
 import static org.apache.beam.sdk.util.SerializableUtils.serializeToByteArray;
 import static org.apache.beam.sdk.util.StringUtils.byteArrayToJsonString;
@@ -78,6 +79,7 @@ import org.apache.beam.runners.core.construction.SplittableParDo;
 import org.apache.beam.runners.core.construction.SplittableParDoNaiveBounded;
 import org.apache.beam.runners.core.construction.UnboundedReadFromBoundedSource;
 import org.apache.beam.runners.core.construction.UnconsumedReads;
+import org.apache.beam.runners.core.construction.WriteFilesTranslation;
 import org.apache.beam.runners.dataflow.DataflowPipelineTranslator.JobSpecification;
 import org.apache.beam.runners.dataflow.StreamingViewOverrides.StreamingCreatePCollectionViewFactory;
 import org.apache.beam.runners.dataflow.TransformTranslator.StepTranslationContext;
@@ -101,9 +103,12 @@ import org.apache.beam.sdk.coders.VoidCoder;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
 import org.apache.beam.sdk.extensions.gcp.storage.PathValidator;
 import org.apache.beam.sdk.io.BoundedSource;
+import org.apache.beam.sdk.io.FileBasedSink;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.Read;
 import org.apache.beam.sdk.io.UnboundedSource;
+import org.apache.beam.sdk.io.WriteFiles;
+import org.apache.beam.sdk.io.WriteFilesResult;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessage;
 import org.apache.beam.sdk.io.gcp.pubsub.PubsubMessageWithAttributesAndMessageIdCoder;
@@ -515,6 +520,11 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
       }
 
       overridesBuilder.add(KafkaIO.Read.KAFKA_READ_OVERRIDE);
+
+      overridesBuilder.add(
+          PTransformOverride.of(
+              PTransformMatchers.writeWithRunnerDeterminedSharding(),
+              new StreamingShardedWriteFactory(options)));
 
       overridesBuilder.add(
           PTransformOverride.of(
@@ -2097,6 +2107,69 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
     public Map<PCollection<?>, ReplacementOutput> mapOutputs(
         Map<TupleTag<?>, PCollection<?>> outputs, PDone newOutput) {
       return Collections.emptyMap();
+    }
+  }
+
+  @VisibleForTesting
+  static class StreamingShardedWriteFactory<UserT, DestinationT, OutputT>
+      implements PTransformOverrideFactory<
+          PCollection<UserT>,
+          WriteFilesResult<DestinationT>,
+          WriteFiles<UserT, DestinationT, OutputT>> {
+
+    // We pick 10 as a a default, as it works well with the default number of workers started
+    // by Dataflow.
+    static final int DEFAULT_NUM_SHARDS = 10;
+    DataflowPipelineWorkerPoolOptions options;
+
+    StreamingShardedWriteFactory(PipelineOptions options) {
+      this.options = options.as(DataflowPipelineWorkerPoolOptions.class);
+    }
+
+    @Override
+    public PTransformReplacement<PCollection<UserT>, WriteFilesResult<DestinationT>>
+        getReplacementTransform(
+            AppliedPTransform<
+                    PCollection<UserT>,
+                    WriteFilesResult<DestinationT>,
+                    WriteFiles<UserT, DestinationT, OutputT>>
+                transform) {
+      // By default, if numShards is not set WriteFiles will produce one file per bundle. In
+      // streaming, there are large numbers of small bundles, resulting in many tiny files.
+      // Instead we pick max workers * 2 to ensure full parallelism, but prevent too-many files.
+      // (current_num_workers * 2 might be a better choice, but that value is not easily available
+      // today).
+      // If the user does not set either numWorkers or maxNumWorkers, default to 10 shards.
+      int numShards;
+      if (options.getMaxNumWorkers() > 0) {
+        numShards = options.getMaxNumWorkers() * 2;
+      } else if (options.getNumWorkers() > 0) {
+        numShards = options.getNumWorkers() * 2;
+      } else {
+        numShards = DEFAULT_NUM_SHARDS;
+      }
+
+      try {
+        List<PCollectionView<?>> sideInputs =
+            WriteFilesTranslation.getDynamicDestinationSideInputs(transform);
+        FileBasedSink sink = WriteFilesTranslation.getSink(transform);
+        WriteFiles<UserT, DestinationT, OutputT> replacement =
+            WriteFiles.to(sink).withSideInputs(sideInputs);
+        if (WriteFilesTranslation.isWindowedWrites(transform)) {
+          replacement = replacement.withWindowedWrites();
+        }
+        return PTransformReplacement.of(
+            PTransformReplacements.getSingletonMainInput(transform),
+            replacement.withNumShards(numShards));
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    @Override
+    public Map<PCollection<?>, ReplacementOutput> mapOutputs(
+        Map<TupleTag<?>, PCollection<?>> outputs, WriteFilesResult<DestinationT> newOutput) {
+      return ReplacementOutputs.tagged(outputs, newOutput);
     }
   }
 

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowRunnerTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowRunnerTest.java
@@ -30,6 +30,7 @@ import static org.hamcrest.Matchers.hasKey;
 import static org.hamcrest.Matchers.hasProperty;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.Matchers.lessThanOrEqualTo;
+import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
@@ -89,6 +90,7 @@ import org.apache.beam.runners.core.construction.BeamUrns;
 import org.apache.beam.runners.core.construction.Environments;
 import org.apache.beam.runners.core.construction.PipelineTranslation;
 import org.apache.beam.runners.core.construction.SdkComponents;
+import org.apache.beam.runners.dataflow.DataflowRunner.StreamingShardedWriteFactory;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineDebugOptions;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineWorkerPoolOptions;
@@ -97,6 +99,7 @@ import org.apache.beam.runners.dataflow.util.PropertyNames;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.Pipeline.PipelineVisitor;
 import org.apache.beam.sdk.coders.BigEndianIntegerCoder;
+import org.apache.beam.sdk.coders.VoidCoder;
 import org.apache.beam.sdk.extensions.gcp.auth.NoopCredentialFactory;
 import org.apache.beam.sdk.extensions.gcp.auth.TestCredential;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
@@ -108,6 +111,7 @@ import org.apache.beam.sdk.io.FileBasedSink;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.io.WriteFiles;
+import org.apache.beam.sdk.io.WriteFilesResult;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.options.ExperimentalOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -116,6 +120,8 @@ import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.StreamingOptions;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
+import org.apache.beam.sdk.runners.AppliedPTransform;
+import org.apache.beam.sdk.runners.PTransformOverrideFactory.ReplacementOutput;
 import org.apache.beam.sdk.runners.TransformHierarchy;
 import org.apache.beam.sdk.runners.TransformHierarchy.Node;
 import org.apache.beam.sdk.state.MapState;
@@ -136,15 +142,15 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.SerializableFunctions;
 import org.apache.beam.sdk.transforms.SimpleFunction;
+import org.apache.beam.sdk.transforms.resourcehints.ResourceHints;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
-import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
 import org.apache.beam.sdk.transforms.windowing.Sessions;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.util.ShardedKey;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollection.IsBounded;
+import org.apache.beam.sdk.values.PValues;
 import org.apache.beam.sdk.values.TimestampedValue;
 import org.apache.beam.sdk.values.WindowingStrategy;
 import org.apache.beam.vendor.grpc.v1p36p0.com.google.protobuf.InvalidProtocolBufferException;
@@ -1655,6 +1661,19 @@ public class DataflowRunnerTest implements Serializable {
     }
   }
 
+  @Test
+  public void testStreamingWriteWithNoShardingReturnsNewTransform() {
+    PipelineOptions options = TestPipeline.testingPipelineOptions();
+    options.as(DataflowPipelineWorkerPoolOptions.class).setMaxNumWorkers(10);
+    testStreamingWriteOverride(options, 20);
+  }
+
+  @Test
+  public void testStreamingWriteWithNoShardingReturnsNewTransformMaxWorkersUnset() {
+    PipelineOptions options = TestPipeline.testingPipelineOptions();
+    testStreamingWriteOverride(options, StreamingShardedWriteFactory.DEFAULT_NUM_SHARDS);
+  }
+
   private void verifyMergingStatefulParDoRejected(PipelineOptions options) throws Exception {
     Pipeline p = Pipeline.create(options);
 
@@ -1919,67 +1938,40 @@ public class DataflowRunnerTest implements Serializable {
     verifyGroupIntoBatchesOverrideBytes(p, true, true);
   }
 
-  @Test
-  public void testStreamingWriteWithRunnerDeterminedSharding() throws IOException {
-    PipelineOptions options = buildPipelineOptions();
-    options.as(StreamingOptions.class).setStreaming(true);
-    DataflowPipelineOptions dataflowOptions = options.as(DataflowPipelineOptions.class);
-    ExperimentalOptions.addExperiment(dataflowOptions, "enable_streaming_engine");
-    Pipeline p = Pipeline.create(options);
-    testStreamingWriteFilesOverride(p, 0);
+  private void testStreamingWriteOverride(PipelineOptions options, int expectedNumShards) {
+    TestPipeline p = TestPipeline.fromOptions(options);
+
+    StreamingShardedWriteFactory<Object, Void, Object> factory =
+        new StreamingShardedWriteFactory<>(p.getOptions());
+    WriteFiles<Object, Void, Object> original = WriteFiles.to(new TestSink(tmpFolder.toString()));
+    PCollection<Object> objs = (PCollection) p.apply(Create.empty(VoidCoder.of()));
+    AppliedPTransform<PCollection<Object>, WriteFilesResult<Void>, WriteFiles<Object, Void, Object>>
+        originalApplication =
+            AppliedPTransform.of(
+                "writefiles",
+                PValues.expandInput(objs),
+                Collections.emptyMap(),
+                original,
+                ResourceHints.create(),
+                p);
+
+    WriteFiles<Object, Void, Object> replacement =
+        (WriteFiles<Object, Void, Object>)
+            factory.getReplacementTransform(originalApplication).getTransform();
+    assertThat(replacement, not(equalTo((Object) original)));
+    assertThat(replacement.getNumShardsProvider().get(), equalTo(expectedNumShards));
+
+    WriteFilesResult<Void> originalResult = objs.apply(original);
+    WriteFilesResult<Void> replacementResult = objs.apply(replacement);
+    Map<PCollection<?>, ReplacementOutput> res =
+        factory.mapOutputs(PValues.expandOutput(originalResult), replacementResult);
+    assertEquals(1, res.size());
+    assertEquals(
+        originalResult.getPerDestinationOutputFilenames(),
+        res.get(replacementResult.getPerDestinationOutputFilenames()).getOriginal().getValue());
   }
 
-  @Test
-  public void testStreamingWriteWithFixedNumShards() throws IOException {
-    PipelineOptions options = buildPipelineOptions();
-    options.as(StreamingOptions.class).setStreaming(true);
-    DataflowPipelineOptions dataflowOptions = options.as(DataflowPipelineOptions.class);
-    ExperimentalOptions.addExperiment(dataflowOptions, "enable_streaming_engine");
-    Pipeline p = Pipeline.create(options);
-    testStreamingWriteFilesOverride(p, 10);
-  }
-
-  private void testStreamingWriteFilesOverride(Pipeline p, int numFileShards) {
-    List<String> testValues = Arrays.asList("A", "C", "123", "foo");
-    PCollection<String> input = p.apply(Create.of(testValues));
-    WriteFiles<String, Void, String> write =
-        WriteFiles.<String, Void, String>to(new TestSink<>(tmpFolder.toString()))
-            .withWindowedWrites();
-    boolean withRunnerDeterminedSharding = numFileShards == 0;
-    if (withRunnerDeterminedSharding) {
-      write = write.withRunnerDeterminedSharding();
-    } else {
-      write = write.withNumShards(numFileShards);
-    }
-    input.setIsBoundedInternal(IsBounded.UNBOUNDED);
-    input.apply(Window.into(FixedWindows.of(Duration.standardSeconds(10)))).apply(write);
-    p.run();
-
-    p.traverseTopologically(
-        new PipelineVisitor.Defaults() {
-
-          @Override
-          public CompositeBehavior enterCompositeTransform(Node node) {
-            if (!(node.getTransform() instanceof WriteFiles)) {
-              return CompositeBehavior.ENTER_TRANSFORM;
-            }
-
-            if (p.getOptions().as(StreamingOptions.class).isStreaming()) {
-              if (withRunnerDeterminedSharding) {
-                assertThat(
-                    ((WriteFiles) node.getTransform()).getNumShardsProvider(), equalTo(null));
-              } else {
-                assertThat(
-                    ((WriteFiles) node.getTransform()).getNumShardsProvider().get(),
-                    equalTo(numFileShards));
-              }
-            }
-            return CompositeBehavior.ENTER_TRANSFORM;
-          }
-        });
-  }
-
-  private static class TestSink<UserT, OutputT> extends FileBasedSink<UserT, Void, OutputT> {
+  private static class TestSink extends FileBasedSink<Object, Void, Object> {
 
     @Override
     public void validate(PipelineOptions options) {}
@@ -2009,10 +2001,10 @@ public class DataflowRunnerTest implements Serializable {
     }
 
     @Override
-    public WriteOperation<Void, OutputT> createWriteOperation() {
-      return new WriteOperation<Void, OutputT>(this) {
+    public WriteOperation<Void, Object> createWriteOperation() {
+      return new WriteOperation<Void, Object>(this) {
         @Override
-        public Writer<Void, OutputT> createWriter() {
+        public Writer<Void, Object> createWriter() {
           throw new UnsupportedOperationException();
         }
       };

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileIO.java
@@ -159,10 +159,11 @@ import org.slf4j.LoggerFactory;
  *   <li><b>How many shards are generated per pane:</b> This is controlled by <i>sharding</i>, using
  *       {@link Write#withNumShards} or {@link Write#withSharding}. The default is runner-specific,
  *       so the number of shards will vary based on runner behavior, though at least 1 shard will
- *       always be produced for every non-empty pane. Runner-determined sharding is available for
- *       both bounded and unbounded data; support for unbounded data is limited (<a
- *       href="https://issues.apache.org/jira/browse/BEAM-12040">BEAM-12040</a>) and depends on the
- *       runners.
+ *       always be produced for every non-empty pane. Note that setting a fixed number of shards can
+ *       hurt performance: it adds an additional {@link GroupByKey} to the pipeline. However, it is
+ *       required to set it when writing an unbounded {@link PCollection} due to <a
+ *       href="https://issues.apache.org/jira/browse/BEAM-1438">BEAM-1438</a> and similar behavior
+ *       in other runners.
  *   <li><b>How the shards are named:</b> This is controlled by a {@link Write.FileNaming}:
  *       filenames can depend on a variety of inputs, e.g. the window, the pane, total number of
  *       shards, the current file's shard index, and compression. Controlling the file naming is


### PR DESCRIPTION
Reverts apache/beam#15178 as it possibly caused Java streaming word count test being flaky.