### PR TITLE
[BEAM-12795] In preparation for implementing BEAM-12795, create a new ParDo primitive 

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformMatchers.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformMatchers.java
@@ -166,8 +166,8 @@ public class PTransformMatchers {
       @Override
       public boolean matches(AppliedPTransform<?, ?, ?> application) {
         PTransform<?, ?> transform = application.getTransform();
-        if (transform instanceof ParDo.MultiOutput) {
-          DoFn<?, ?> fn = ((ParDo.MultiOutput<?, ?>) transform).getFn();
+        if (transform instanceof ParDo.MultiOutputPrimitive) {
+          DoFn<?, ?> fn = ((ParDo.MultiOutputPrimitive<?, ?>) transform).getFn();
           DoFnSignature signature = DoFnSignatures.signatureForDoFn(fn);
           return signature.processElement().requiresStableInput();
         }
@@ -236,16 +236,16 @@ public class PTransformMatchers {
   }
 
   /**
-   * A {@link PTransformMatcher} that matches a {@link ParDo.MultiOutput} containing a {@link DoFn}
-   * that is splittable, as signified by {@link ProcessElementMethod#isSplittable()}.
+   * A {@link PTransformMatcher} that matches a {@link ParDo.MultiOutputPrimitive} containing a
+   * {@link DoFn} that is splittable, as signified by {@link ProcessElementMethod#isSplittable()}.
    */
   public static PTransformMatcher splittableParDoMulti() {
     return new PTransformMatcher() {
       @Override
       public boolean matches(AppliedPTransform<?, ?, ?> application) {
         PTransform<?, ?> transform = application.getTransform();
-        if (transform instanceof ParDo.MultiOutput) {
-          DoFn<?, ?> fn = ((ParDo.MultiOutput<?, ?>) transform).getFn();
+        if (transform instanceof ParDo.MultiOutputPrimitive) {
+          DoFn<?, ?> fn = ((ParDo.MultiOutputPrimitive<?, ?>) transform).getFn();
           DoFnSignature signature = DoFnSignatures.signatureForDoFn(fn);
           return signature.processElement().isSplittable();
         }
@@ -398,7 +398,7 @@ public class PTransformMatchers {
 
   /**
    * A {@link PTransformMatcher} which matches a {@link ParDo.SingleOutput} or {@link
-   * ParDo.MultiOutput} where the {@link DoFn} is of the provided type.
+   * ParDo.MultiOutputPrimitive} where the {@link DoFn} is of the provided type.
    */
   public static PTransformMatcher parDoWithFnType(final Class<? extends DoFn> fnType) {
     return new PTransformMatcher() {
@@ -407,8 +407,8 @@ public class PTransformMatchers {
         DoFn<?, ?> fn;
         if (application.getTransform() instanceof ParDo.SingleOutput) {
           fn = ((ParDo.SingleOutput) application.getTransform()).getFn();
-        } else if (application.getTransform() instanceof ParDo.MultiOutput) {
-          fn = ((ParDo.MultiOutput) application.getTransform()).getFn();
+        } else if (application.getTransform() instanceof ParDo.MultiOutputPrimitive) {
+          fn = ((ParDo.MultiOutputPrimitive) application.getTransform()).getFn();
         } else {
           return false;
         }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ParDoTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ParDoTranslation.java
@@ -724,11 +724,12 @@ public class ParDoTranslation {
       FunctionSpec fnSpec) {
     checkArgument(
         fnSpec.getUrn().equals(CUSTOM_JAVA_DO_FN_URN),
-        "Expected %s to be %s with URN %s, but URN was %s",
+        "Expected %s to be %s with URN %s, but URN was %s for fnSpec %s",
         DoFn.class.getSimpleName(),
         FunctionSpec.class.getSimpleName(),
         CUSTOM_JAVA_DO_FN_URN,
-        fnSpec.getUrn());
+        fnSpec.getUrn(),
+        fnSpec);
     byte[] serializedFn = fnSpec.getPayload().toByteArray();
     return (DoFnWithExecutionInformation)
         SerializableUtils.deserializeFromByteArray(serializedFn, "Custom DoFn With Execution Info");

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SplittableParDo.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SplittableParDo.java
@@ -52,7 +52,6 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.DoFnSchemaInformation;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
-import org.apache.beam.sdk.transforms.ParDo.MultiOutput;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.WithKeys;
 import org.apache.beam.sdk.transforms.display.DisplayData;
@@ -110,10 +109,11 @@ public class SplittableParDo<InputT, OutputT, RestrictionT, WatermarkEstimatorSt
    */
   public static class OverrideFactory<InputT, OutputT>
       implements PTransformOverrideFactory<
-          PCollection<InputT>, PCollectionTuple, MultiOutput<InputT, OutputT>> {
+          PCollection<InputT>, PCollectionTuple, ParDo.MultiOutputPrimitive<InputT, OutputT>> {
     @Override
     public PTransformReplacement<PCollection<InputT>, PCollectionTuple> getReplacementTransform(
-        AppliedPTransform<PCollection<InputT>, PCollectionTuple, MultiOutput<InputT, OutputT>>
+        AppliedPTransform<
+                PCollection<InputT>, PCollectionTuple, ParDo.MultiOutputPrimitive<InputT, OutputT>>
             transform) {
       return PTransformReplacement.of(
           PTransformReplacements.getSingletonMainInput(transform), forAppliedParDo(transform));

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/PipelineValidator.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/graph/PipelineValidator.java
@@ -231,9 +231,10 @@ public class PipelineValidator {
     for (String sideInputId : payload.getSideInputsMap().keySet()) {
       checkArgument(
           transform.containsInputs(sideInputId),
-          "Transform %s side input %s is not listed in the transform's inputs",
+          "Transform %s side input %s is not listed in the transform's inputs %s",
           id,
-          sideInputId);
+          sideInputId,
+          transform.getInputsMap());
     }
     if (payload.getStateSpecsCount() > 0 || payload.getTimerFamilySpecsCount() > 0) {
       checkArgument(requirements.contains(ParDoTranslation.REQUIRES_STATEFUL_PROCESSING_URN));

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/ParDoTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/ParDoTranslationTest.java
@@ -123,7 +123,7 @@ public class ParDoTranslationTest {
     }
 
     @Parameter(0)
-    public ParDo.MultiOutputPrimitive<KV<Long, String>, Void> parDo;
+    public ParDo.MultiOutput<KV<Long, String>, Void> parDo;
 
     @Test
     public void testToProto() throws Exception {
@@ -170,7 +170,11 @@ public class ParDoTranslationTest {
                       "foo",
                       inputs,
                       PValues.expandOutput(output),
-                      parDo,
+                      MultiOutputPrimitive.of(
+                          parDo.getFn(),
+                          parDo.getMainOutputTag(),
+                          parDo.getAdditionalOutputTags(),
+                          parDo.getSideInputs()),
                       ResourceHints.create(),
                       p),
               sdkComponents);

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PipelineTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/PipelineTranslationTest.java
@@ -205,8 +205,8 @@ public class PipelineTranslationTest {
         final DoFn<?, ?> doFn;
         if (node.getTransform() instanceof ParDo.SingleOutput) {
           doFn = ((ParDo.SingleOutput) node.getTransform()).getFn();
-        } else if (node.getTransform() instanceof ParDo.MultiOutput) {
-          doFn = ((ParDo.MultiOutput) node.getTransform()).getFn();
+        } else if (node.getTransform() instanceof ParDo.MultiOutputPrimitive) {
+          doFn = ((ParDo.MultiOutputPrimitive) node.getTransform()).getFn();
         } else {
           throw new IllegalStateException(
               "Unexpected type of ParDo " + node.getTransform().getClass());

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/SplittableParDoTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/SplittableParDoTest.java
@@ -46,6 +46,7 @@ import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.ParDo.MultiOutputPrimitive;
 import org.apache.beam.sdk.transforms.resourcehints.ResourceHints;
 import org.apache.beam.sdk.transforms.splittabledofn.HasDefaultTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
@@ -152,7 +153,11 @@ public class SplittableParDoTest {
             "ParDo",
             PValues.expandInput(input),
             PValues.expandOutput(output),
-            multiOutput,
+            MultiOutputPrimitive.of(
+                multiOutput.getFn(),
+                multiOutput.getMainOutputTag(),
+                multiOutput.getAdditionalOutputTags(),
+                multiOutput.getSideInputs()),
             ResourceHints.create(),
             pipeline);
     return input.apply(name, SplittableParDo.forAppliedParDo(transform)).get(MAIN_OUTPUT_TAG);

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/SplittableParDoExpanderTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/graph/SplittableParDoExpanderTest.java
@@ -33,8 +33,6 @@ import org.apache.beam.sdk.transforms.DoFn.UnboundedPerElement;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
 import org.apache.beam.sdk.values.KV;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -80,15 +78,12 @@ public class SplittableParDoExpanderTest {
         .apply("TestSDF", ParDo.of(new PairStringWithIndexToLengthBase()));
 
     RunnerApi.Pipeline proto = PipelineTranslation.toProto(p);
-    String transformName =
-        Iterables.getOnlyElement(
-            Maps.filterValues(
-                    proto.getComponents().getTransformsMap(),
-                    (RunnerApi.PTransform transform) ->
-                        transform
-                            .getUniqueName()
-                            .contains(PairStringWithIndexToLengthBase.class.getSimpleName()))
-                .keySet());
+    RunnerApi.PTransform outerTransform =
+        proto
+            .getComponents()
+            .getTransformsOrThrow(
+                proto.getComponents().getTransformsOrThrow(("TestSDF")).getSubtransforms(0));
+    String transformName = outerTransform.getSubtransforms(0);
 
     RunnerApi.Pipeline updatedProto =
         ProtoOverrides.updateTransform(
@@ -129,15 +124,12 @@ public class SplittableParDoExpanderTest {
         .apply("TestSDF", ParDo.of(new PairStringWithIndexToLengthBase()));
 
     RunnerApi.Pipeline proto = PipelineTranslation.toProto(p);
-    String transformName =
-        Iterables.getOnlyElement(
-            Maps.filterValues(
-                    proto.getComponents().getTransformsMap(),
-                    (RunnerApi.PTransform transform) ->
-                        transform
-                            .getUniqueName()
-                            .contains(PairStringWithIndexToLengthBase.class.getSimpleName()))
-                .keySet());
+    RunnerApi.PTransform outerTransform =
+        proto
+            .getComponents()
+            .getTransformsOrThrow(
+                proto.getComponents().getTransformsOrThrow(("TestSDF")).getSubtransforms(0));
+    String transformName = outerTransform.getSubtransforms(0);
 
     RunnerApi.Pipeline updatedProto =
         ProtoOverrides.updateTransform(

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectGraphVisitor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectGraphVisitor.java
@@ -119,9 +119,9 @@ class DirectGraphVisitor extends PipelineVisitor.Defaults {
         allConsumers.put(value, appliedTransform);
       }
     }
-    if (node.getTransform() instanceof ParDo.MultiOutput) {
+    if (node.getTransform() instanceof ParDo.MultiOutputPrimitive) {
       consumedViews.addAll(
-          ((ParDo.MultiOutput<?, ?>) node.getTransform()).getSideInputs().values());
+          ((ParDo.MultiOutputPrimitive<?, ?>) node.getTransform()).getSideInputs().values());
     } else if (node.getTransform() instanceof WriteView) {
       viewWriters.put(
           ((WriteView) node.getTransform()).getView(), node.toAppliedPTransform(getPipeline()));

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectWriteViewVisitor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectWriteViewVisitor.java
@@ -61,8 +61,9 @@ class DirectWriteViewVisitor extends PipelineVisitor.Defaults {
 
   @Override
   public void visitPrimitiveTransform(TransformHierarchy.Node node) {
-    if (node.getTransform() instanceof ParDo.MultiOutput) {
-      ParDo.MultiOutput<?, ?> parDo = (ParDo.MultiOutput<?, ?>) node.getTransform();
+    if (node.getTransform() instanceof ParDo.MultiOutputPrimitive) {
+      ParDo.MultiOutputPrimitive<?, ?> parDo =
+          (ParDo.MultiOutputPrimitive<?, ?>) node.getTransform();
       viewsToWrite.addAll(parDo.getSideInputs().values());
     }
   }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/KeyedPValueTrackingVisitor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/KeyedPValueTrackingVisitor.java
@@ -118,8 +118,8 @@ class KeyedPValueTrackingVisitor extends PipelineVisitor.Defaults {
     // The most obvious alternative would be a package-private marker interface, but
     // better to make this obviously hacky so it is less likely to proliferate. Meanwhile
     // we intend to allow explicit expression of key-preserving DoFn in the model.
-    if (transform instanceof ParDo.MultiOutput) {
-      ParDo.MultiOutput<?, ?> parDo = (ParDo.MultiOutput<?, ?>) transform;
+    if (transform instanceof ParDo.MultiOutputPrimitive) {
+      ParDo.MultiOutputPrimitive<?, ?> parDo = (ParDo.MultiOutputPrimitive<?, ?>) transform;
       return parDo.getFn() instanceof ParDoMultiOverrideFactory.ToKeyedWorkItem;
     } else {
       return false;

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoEvaluatorFactory.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoEvaluatorFactory.java
@@ -38,7 +38,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.cache.LoadingCac
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
-/** A {@link TransformEvaluatorFactory} for {@link ParDo.MultiOutput}. */
+/** A {@link TransformEvaluatorFactory} for {@link ParDo.MultiOutputPrimitive}. */
 @SuppressWarnings({
   "nullness" // TODO(https://issues.apache.org/jira/browse/BEAM-10402)
 })

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
@@ -468,7 +468,7 @@ class FlinkStreamingTransformTranslators {
   }
 
   /**
-   * Helper for translating {@code ParDo.MultiOutput} and {@link
+   * Helper for translating {@code ParDo.MultiOutputPrimitive} and {@link
    * SplittableParDoViaKeyedWorkItems.ProcessElements}.
    */
   static class ParDoTranslationHelper {

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowPipelineTranslator.java
@@ -968,15 +968,15 @@ public class DataflowPipelineTranslator {
         });
 
     registerTransformTranslator(
-        ParDo.MultiOutput.class,
-        new TransformTranslator<ParDo.MultiOutput>() {
+        ParDo.MultiOutputPrimitive.class,
+        new TransformTranslator<ParDo.MultiOutputPrimitive>() {
           @Override
-          public void translate(ParDo.MultiOutput transform, TranslationContext context) {
+          public void translate(ParDo.MultiOutputPrimitive transform, TranslationContext context) {
             translateMultiHelper(transform, context);
           }
 
           private <InputT, OutputT> void translateMultiHelper(
-              ParDo.MultiOutput<InputT, OutputT> transform, TranslationContext context) {
+              ParDo.MultiOutputPrimitive<InputT, OutputT> transform, TranslationContext context) {
             StepTranslationContext stepContext = context.addStep(transform, "ParallelDo");
             DoFnSchemaInformation doFnSchemaInformation;
             doFnSchemaInformation =

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/RequiresStableInputParDoOverrides.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/RequiresStableInputParDoOverrides.java
@@ -50,7 +50,7 @@ class RequiresStableInputParDoOverrides {
    */
   static <InputT, OutputT>
       PTransformOverrideFactory<
-              PCollection<InputT>, PCollectionTuple, ParDo.MultiOutput<InputT, OutputT>>
+              PCollection<InputT>, PCollectionTuple, ParDo.MultiOutputPrimitive<InputT, OutputT>>
           multiOutputOverrideFactory() {
     return new MultiOutputOverrideFactory<>();
   }
@@ -85,11 +85,12 @@ class RequiresStableInputParDoOverrides {
 
   private static class MultiOutputOverrideFactory<InputT, OutputT>
       implements PTransformOverrideFactory<
-          PCollection<InputT>, PCollectionTuple, ParDo.MultiOutput<InputT, OutputT>> {
+          PCollection<InputT>, PCollectionTuple, ParDo.MultiOutputPrimitive<InputT, OutputT>> {
 
     @Override
     public PTransformReplacement<PCollection<InputT>, PCollectionTuple> getReplacementTransform(
-        AppliedPTransform<PCollection<InputT>, PCollectionTuple, ParDo.MultiOutput<InputT, OutputT>>
+        AppliedPTransform<
+                PCollection<InputT>, PCollectionTuple, ParDo.MultiOutputPrimitive<InputT, OutputT>>
             appliedTransform) {
       return PTransformReplacement.of(
           PTransformReplacements.getSingletonMainInput(appliedTransform),

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/SplittableParDoOverrides.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/SplittableParDoOverrides.java
@@ -56,10 +56,11 @@ class SplittableParDoOverrides {
 
   static class SplittableParDoOverrideFactory<InputT, OutputT, RestrictionT>
       implements PTransformOverrideFactory<
-          PCollection<InputT>, PCollectionTuple, ParDo.MultiOutput<InputT, OutputT>> {
+          PCollection<InputT>, PCollectionTuple, ParDo.MultiOutputPrimitive<InputT, OutputT>> {
     @Override
     public PTransformReplacement<PCollection<InputT>, PCollectionTuple> getReplacementTransform(
-        AppliedPTransform<PCollection<InputT>, PCollectionTuple, ParDo.MultiOutput<InputT, OutputT>>
+        AppliedPTransform<
+                PCollection<InputT>, PCollectionTuple, ParDo.MultiOutputPrimitive<InputT, OutputT>>
             appliedTransform) {
       return PTransformReplacement.of(
           PTransformReplacements.getSingletonMainInput(appliedTransform),

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
@@ -802,7 +802,7 @@ public class RemoteExecutionTest implements Serializable {
               (Coder<WindowedValue<?>>) remoteOutputCoder.getValue(), outputContents::add));
     }
 
-    final String testPTransformId = "create-ParMultiDo-Metrics-";
+    final String testPTransformId = "create-ParMultiDo-Metrics--ParDo-MultiOutputPrimitive";
     BundleProgressHandler progressHandler =
         new BundleProgressHandler() {
           @Override
@@ -964,7 +964,8 @@ public class RemoteExecutionTest implements Serializable {
             builder = new SimpleMonitoringInfoBuilder();
             builder.setUrn(MonitoringInfoConstants.Urns.ELEMENT_COUNT);
             builder.setLabel(
-                MonitoringInfoConstants.Labels.PCOLLECTION, "create/ParMultiDo(Metrics).output");
+                MonitoringInfoConstants.Labels.PCOLLECTION,
+                "create/ParMultiDo(Metrics)/ParDo.MultiOutputPrimitive.output");
             builder.setInt64SumValue(3);
             matchers.add(MonitoringInfoMatchers.matchSetFields(builder.build()));
 
@@ -973,7 +974,7 @@ public class RemoteExecutionTest implements Serializable {
             builder.setUrn(MonitoringInfoConstants.Urns.ELEMENT_COUNT);
             builder.setLabel(
                 MonitoringInfoConstants.Labels.PCOLLECTION,
-                "processA/ParMultiDo(Anonymous).output");
+                "processA/ParMultiDo(Anonymous)/ParDo.MultiOutputPrimitive.output");
             builder.setInt64SumValue(6);
             matchers.add(MonitoringInfoMatchers.matchSetFields(builder.build()));
 
@@ -981,7 +982,7 @@ public class RemoteExecutionTest implements Serializable {
             builder.setUrn(MonitoringInfoConstants.Urns.ELEMENT_COUNT);
             builder.setLabel(
                 MonitoringInfoConstants.Labels.PCOLLECTION,
-                "processB/ParMultiDo(Anonymous).output");
+                "processB/ParMultiDo(Anonymous)/ParDo.MultiOutputPrimitive.output");
             builder.setInt64SumValue(6);
             matchers.add(MonitoringInfoMatchers.matchSetFields(builder.build()));
 

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/SdkHarnessClientTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/SdkHarnessClientTest.java
@@ -141,7 +141,11 @@ public class SdkHarnessClientTest {
             .getCoder();
     pbdBuilder.putCoders("wire_coder", fullValueCoder);
 
-    PTransform targetProcessor = userProto.getComponents().getTransformsOrThrow("proc");
+    PTransform targetProcessor =
+        userProto
+            .getComponents()
+            .getTransformsOrThrow(
+                userProto.getComponents().getTransformsOrThrow("proc").getSubtransforms(0));
     RemoteGrpcPort port =
         RemoteGrpcPort.newBuilder()
             .setApiServiceDescriptor(harness.dataEndpoint())

--- a/runners/jet/src/main/java/org/apache/beam/runners/jet/Utils.java
+++ b/runners/jet/src/main/java/org/apache/beam/runners/jet/Utils.java
@@ -153,8 +153,8 @@ public class Utils {
 
   static Collection<PCollectionView<?>> getSideInputs(AppliedPTransform<?, ?, ?> appliedTransform) {
     PTransform<?, ?> transform = appliedTransform.getTransform();
-    if (transform instanceof ParDo.MultiOutput) {
-      ParDo.MultiOutput multiParDo = (ParDo.MultiOutput) transform;
+    if (transform instanceof ParDo.MultiOutputPrimitive) {
+      ParDo.MultiOutputPrimitive multiParDo = (ParDo.MultiOutputPrimitive) transform;
       return (List) multiParDo.getSideInputs().values().stream().collect(Collectors.toList());
     } else if (transform instanceof ParDo.SingleOutput) {
       ParDo.SingleOutput singleParDo = (ParDo.SingleOutput) transform;

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/ParDoBoundMultiTranslator.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/translation/ParDoBoundMultiTranslator.java
@@ -73,16 +73,16 @@ import org.apache.samza.operators.functions.WatermarkFunction;
 import org.joda.time.Instant;
 
 /**
- * Translates {@link org.apache.beam.sdk.transforms.ParDo.MultiOutput} or ExecutableStage in
- * portable api to Samza {@link DoFnOp}.
+ * Translates {@link org.apache.beam.sdk.transforms.ParDo.MultiOutputPrimitive} or ExecutableStage
+ * in portable api to Samza {@link DoFnOp}.
  */
 @SuppressWarnings({
   "rawtypes", // TODO(https://issues.apache.org/jira/browse/BEAM-10556)
   "nullness" // TODO(https://issues.apache.org/jira/browse/BEAM-10402)
 })
 class ParDoBoundMultiTranslator<InT, OutT>
-    implements TransformTranslator<ParDo.MultiOutput<InT, OutT>>,
-        TransformConfigGenerator<ParDo.MultiOutput<InT, OutT>> {
+    implements TransformTranslator<ParDo.MultiOutputPrimitive<InT, OutT>>,
+        TransformConfigGenerator<ParDo.MultiOutputPrimitive<InT, OutT>> {
 
   private final SamzaDoFnInvokerRegistrar doFnInvokerRegistrar;
 
@@ -94,7 +94,7 @@ class ParDoBoundMultiTranslator<InT, OutT>
 
   @Override
   public void translate(
-      ParDo.MultiOutput<InT, OutT> transform,
+      ParDo.MultiOutputPrimitive<InT, OutT> transform,
       TransformHierarchy.Node node,
       TranslationContext ctx) {
     doTranslate(transform, node, ctx);
@@ -102,7 +102,7 @@ class ParDoBoundMultiTranslator<InT, OutT>
 
   // static for serializing anonymous functions
   private static <InT, OutT> void doTranslate(
-      ParDo.MultiOutput<InT, OutT> transform,
+      ParDo.MultiOutputPrimitive<InT, OutT> transform,
       TransformHierarchy.Node node,
       TranslationContext ctx) {
     final PCollection<? extends InT> input = ctx.getInput(transform);
@@ -353,7 +353,9 @@ class ParDoBoundMultiTranslator<InT, OutT>
 
   @Override
   public Map<String, String> createConfig(
-      ParDo.MultiOutput<InT, OutT> transform, TransformHierarchy.Node node, ConfigContext ctx) {
+      ParDo.MultiOutputPrimitive<InT, OutT> transform,
+      TransformHierarchy.Node node,
+      ConfigContext ctx) {
     final Map<String, String> config = new HashMap<>();
     final DoFnSignature signature = DoFnSignatures.getSignature(transform.getFn().getClass());
     final SamzaPipelineOptions options = ctx.getPipelineOptions();

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/PipelineTranslatorBatch.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/PipelineTranslatorBatch.java
@@ -75,7 +75,7 @@ public class PipelineTranslatorBatch extends PipelineTranslator {
 
     TRANSFORM_TRANSLATORS.put(Window.Assign.class, new WindowAssignTranslatorBatch());
 
-    TRANSFORM_TRANSLATORS.put(ParDo.MultiOutput.class, new ParDoTranslatorBatch());
+    TRANSFORM_TRANSLATORS.put(ParDo.MultiOutputPrimitive.class, new ParDoTranslatorBatch());
 
     TRANSFORM_TRANSLATORS.put(
         SplittableParDo.PrimitiveBoundedRead.class, new ReadSourceTranslatorBatch());

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/streaming/PipelineTranslatorStreaming.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/streaming/PipelineTranslatorStreaming.java
@@ -67,7 +67,7 @@ public class PipelineTranslatorStreaming extends PipelineTranslator {
     //
     //    TRANSFORM_TRANSLATORS.put(Window.Assign.class, new WindowAssignTranslatorBatch());
     //
-    //    TRANSFORM_TRANSLATORS.put(ParDo.MultiOutput.class, new ParDoTranslatorBatch());
+    //    TRANSFORM_TRANSLATORS.put(ParDo.MultiOutputPrimitive.class, new ParDoTranslatorBatch());
 
     TRANSFORM_TRANSLATORS.put(
         SplittableParDo.PrimitiveUnboundedRead.class, new ReadSourceTranslatorStreaming());

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TransformTranslator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/TransformTranslator.java
@@ -346,12 +346,12 @@ public final class TransformTranslator {
     };
   }
 
-  private static <InputT, OutputT> TransformEvaluator<ParDo.MultiOutput<InputT, OutputT>> parDo() {
-    return new TransformEvaluator<ParDo.MultiOutput<InputT, OutputT>>() {
+  private static <InputT, OutputT> TransformEvaluator<ParDo.MultiOutputPrimitive<InputT, OutputT>> parDo() {
+    return new TransformEvaluator<ParDo.MultiOutputPrimitive<InputT, OutputT>>() {
       @Override
       @SuppressWarnings("unchecked")
       public void evaluate(
-          ParDo.MultiOutput<InputT, OutputT> transform, EvaluationContext context) {
+          ParDo.MultiOutputPrimitive<InputT, OutputT> transform, EvaluationContext context) {
         String stepName = context.getCurrentTransform().getFullName();
         DoFn<InputT, OutputT> doFn = transform.getFn();
         checkState(

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/StreamingTransformTranslator.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/StreamingTransformTranslator.java
@@ -405,11 +405,11 @@ public final class StreamingTransformTranslator {
     };
   }
 
-  private static <InputT, OutputT> TransformEvaluator<ParDo.MultiOutput<InputT, OutputT>> parDo() {
-    return new TransformEvaluator<ParDo.MultiOutput<InputT, OutputT>>() {
+  private static <InputT, OutputT> TransformEvaluator<ParDo.MultiOutputPrimitive<InputT, OutputT>> parDo() {
+    return new TransformEvaluator<ParDo.MultiOutputPrimitive<InputT, OutputT>>() {
       @Override
       public void evaluate(
-          final ParDo.MultiOutput<InputT, OutputT> transform, final EvaluationContext context) {
+          final ParDo.MultiOutputPrimitive<InputT, OutputT> transform, final EvaluationContext context) {
         final DoFn<InputT, OutputT> doFn = transform.getFn();
         checkArgument(
             !DoFnSignatures.signatureForDoFn(doFn).processElement().isSplittable(),

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/TrackStreamingSourcesTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/TrackStreamingSourcesTest.java
@@ -84,7 +84,7 @@ public class TrackStreamingSourcesTest {
 
     p.apply(emptyStream).apply(ParDo.of(new PassthroughFn<>()));
 
-    p.traverseTopologically(new StreamingSourceTracker(jssc, p, ParDo.MultiOutput.class, 0));
+    p.traverseTopologically(new StreamingSourceTracker(jssc, p, ParDo.MultiOutputPrimitive.class, 0));
     assertThat(StreamingSourceTracker.numAssertions, equalTo(1));
   }
 
@@ -111,7 +111,7 @@ public class TrackStreamingSourcesTest {
         PCollectionList.of(pcol1).and(pcol2).apply(Flatten.pCollections());
     flattened.apply(ParDo.of(new PassthroughFn<>()));
 
-    p.traverseTopologically(new StreamingSourceTracker(jssc, p, ParDo.MultiOutput.class, 0, 1));
+    p.traverseTopologically(new StreamingSourceTracker(jssc, p, ParDo.MultiOutputPrimitive.class, 0, 1));
     assertThat(StreamingSourceTracker.numAssertions, equalTo(1));
   }
 

--- a/runners/twister2/src/main/java/org/apache/beam/runners/twister2/translators/batch/ParDoMultiOutputTranslatorBatch.java
+++ b/runners/twister2/src/main/java/org/apache/beam/runners/twister2/translators/batch/ParDoMultiOutputTranslatorBatch.java
@@ -49,11 +49,12 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
   "nullness" // TODO(https://issues.apache.org/jira/browse/BEAM-10402)
 })
 public class ParDoMultiOutputTranslatorBatch<InputT, OutputT>
-    implements BatchTransformTranslator<ParDo.MultiOutput<InputT, OutputT>> {
+    implements BatchTransformTranslator<ParDo.MultiOutputPrimitive<InputT, OutputT>> {
 
   @Override
   public void translateNode(
-      ParDo.MultiOutput<InputT, OutputT> transform, Twister2BatchTranslationContext context) {
+      ParDo.MultiOutputPrimitive<InputT, OutputT> transform,
+      Twister2BatchTranslationContext context) {
     DoFn<InputT, OutputT> doFn;
     doFn = transform.getFn();
     if (DoFnSignatures.signatureForDoFn(doFn).processElement().isSplittable()) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
@@ -952,7 +952,6 @@ public class ParDo {
 
       PCollectionTuple outputs =
           input.apply(
-              "Primitive",
               new MultiOutputPrimitive<>(
                   getFn(),
                   getMainOutputTag(),

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
@@ -1054,6 +1054,7 @@ public class ParDo {
         });
   }
 
+  /** Primitive transform implementing ParDo.MultiOutput. */
   public static class MultiOutputPrimitive<InputT, OutputT>
       extends PTransform<PCollection<? extends InputT>, PCollectionTuple> {
     private final DoFn<InputT, OutputT> fn;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollection.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollection.java
@@ -185,7 +185,8 @@ public class PCollection<T> extends PValueBase implements PValue {
         // and provide a better error message if so. Unfortunately, this information is not
         // directly available from the TypeDescriptor, so infer based on the type of the PTransform
         // and the error message itself.
-        if (transform instanceof ParDo.MultiOutput && exc.getReason() == ReasonCode.TYPE_ERASURE) {
+        if (transform instanceof ParDo.MultiOutputPrimitive
+            && exc.getReason() == ReasonCode.TYPE_ERASURE) {
           inferFromTokenException =
               new CannotProvideCoderException(
                   exc.getMessage()

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TFRecordIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TFRecordIOTest.java
@@ -144,10 +144,10 @@ public class TFRecordIOTest {
     Create.Values<ReadableFile> create = Create.of(new ReadableFile(metadata, Compression.AUTO));
 
     assertEquals(
-        "TFRecordIO.ReadFiles/Read all via FileBasedSource/Read ranges/ParMultiDo(ReadFileRanges).output",
+        "TFRecordIO.ReadFiles/Read all via FileBasedSource/Read ranges/ParMultiDo(ReadFileRanges)/ParDo.MultiOutputPrimitive.output",
         readPipeline.apply(create).apply(TFRecordIO.readFiles()).getName());
     assertEquals(
-        "MyRead/Read all via FileBasedSource/Read ranges/ParMultiDo(ReadFileRanges).output",
+        "MyRead/Read all via FileBasedSource/Read ranges/ParMultiDo(ReadFileRanges)/ParDo.MultiOutputPrimitive.output",
         readPipeline.apply(create).apply("MyRead", TFRecordIO.readFiles()).getName());
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -1385,11 +1385,19 @@ public class ParDoTest implements Serializable {
                               .and(additionalOutputTagUnwritten)
                               .and(additionalOutputTag2)));
 
-      assertEquals("MyParDo.main", outputs.get(mainOutputTag).getName());
-      assertEquals("MyParDo.output1", outputs.get(additionalOutputTag1).getName());
-      assertEquals("MyParDo.output2", outputs.get(additionalOutputTag2).getName());
-      assertEquals("MyParDo.output3", outputs.get(additionalOutputTag3).getName());
-      assertEquals("MyParDo.unwrittenOutput", outputs.get(additionalOutputTagUnwritten).getName());
+      assertEquals("MyParDo/ParDo.MultiOutputPrimitive.main", outputs.get(mainOutputTag).getName());
+      assertEquals(
+          "MyParDo/ParDo.MultiOutputPrimitive.output1",
+          outputs.get(additionalOutputTag1).getName());
+      assertEquals(
+          "MyParDo/ParDo.MultiOutputPrimitive.output2",
+          outputs.get(additionalOutputTag2).getName());
+      assertEquals(
+          "MyParDo/ParDo.MultiOutputPrimitive.output3",
+          outputs.get(additionalOutputTag3).getName());
+      assertEquals(
+          "MyParDo/ParDo.MultiOutputPrimitive.unwrittenOutput",
+          outputs.get(additionalOutputTagUnwritten).getName());
     }
 
     @Test

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
@@ -244,7 +244,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
       RunnerApi.Pipeline pProto = PipelineTranslation.toProto(p, sdkComponents);
       String inputPCollectionId = sdkComponents.registerPCollection(valuePCollection);
       String outputPCollectionId = sdkComponents.registerPCollection(outputPCollection);
-      RunnerApi.PTransform pTransform =
+      RunnerApi.PTransform outerPTransform =
           pProto
               .getComponents()
               .getTransformsOrThrow(
@@ -252,6 +252,8 @@ public class FnApiDoFnRunnerTest implements Serializable {
                       .getComponents()
                       .getTransformsOrThrow(TEST_TRANSFORM_ID)
                       .getSubtransforms(0));
+      RunnerApi.PTransform pTransform =
+          pProto.getComponents().getTransformsOrThrow(outerPTransform.getSubtransforms(0));
 
       FakeBeamFnStateClient fakeClient =
           new FakeBeamFnStateClient(
@@ -427,8 +429,10 @@ public class FnApiDoFnRunnerTest implements Serializable {
       String additionalPCollectionId =
           sdkComponents.registerPCollection(outputPCollection.get(additionalOutput));
 
-      RunnerApi.PTransform pTransform =
+      RunnerApi.PTransform outerPTransform =
           pProto.getComponents().getTransformsOrThrow(TEST_TRANSFORM_ID);
+      RunnerApi.PTransform pTransform =
+          pProto.getComponents().getTransformsOrThrow(outerPTransform.getSubtransforms(0));
 
       ImmutableMap<StateKey, ByteString> stateData =
           ImmutableMap.of(
@@ -564,9 +568,10 @@ public class FnApiDoFnRunnerTest implements Serializable {
       String additionalPCollectionId =
           sdkComponents.registerPCollection(outputPCollection.get(additionalOutput));
 
-      RunnerApi.PTransform pTransform =
+      RunnerApi.PTransform outerPTransform =
           pProto.getComponents().getTransformsOrThrow(TEST_TRANSFORM_ID);
-
+      RunnerApi.PTransform pTransform =
+          pProto.getComponents().getTransformsOrThrow(outerPTransform.getSubtransforms(0));
       List<WindowedValue<String>> mainOutputValues = new ArrayList<>();
       List<WindowedValue<String>> additionalOutputValues = new ArrayList<>();
       MetricsContainerStepMap metricsContainerRegistry = new MetricsContainerStepMap();
@@ -713,7 +718,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
       String inputPCollectionId = sdkComponents.registerPCollection(valuePCollection);
       String outputPCollectionId = sdkComponents.registerPCollection(outputPCollection);
 
-      RunnerApi.PTransform pTransform =
+      RunnerApi.PTransform outerPTransform =
           pProto
               .getComponents()
               .getTransformsOrThrow(
@@ -721,6 +726,8 @@ public class FnApiDoFnRunnerTest implements Serializable {
                       .getComponents()
                       .getTransformsOrThrow(TEST_TRANSFORM_ID)
                       .getSubtransforms(0));
+      RunnerApi.PTransform pTransform =
+          pProto.getComponents().getTransformsOrThrow(outerPTransform.getSubtransforms(0));
 
       ImmutableMap<StateKey, ByteString> stateData =
           ImmutableMap.of(
@@ -981,16 +988,16 @@ public class FnApiDoFnRunnerTest implements Serializable {
       String inputPCollectionId = sdkComponents.registerPCollection(valuePCollection);
       String outputPCollectionId = sdkComponents.registerPCollection(outputPCollection);
 
-      RunnerApi.PTransform pTransform =
+      RunnerApi.PTransform outerPTransform =
           pProto
               .getComponents()
               .getTransformsOrThrow(
                   pProto
                       .getComponents()
                       .getTransformsOrThrow(TEST_TRANSFORM_ID)
-                      .getSubtransforms(0))
-              .toBuilder()
-              .build();
+                      .getSubtransforms(0));
+      RunnerApi.PTransform pTransform =
+          pProto.getComponents().getTransformsOrThrow(outerPTransform.getSubtransforms(0));
 
       FakeBeamFnStateClient fakeStateClient =
           new FakeBeamFnStateClient(

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOExternalTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOExternalTest.java
@@ -175,7 +175,13 @@ public class PubsubIOExternalTest {
 
     // test_namespacetest/PubsubUnboundedSink/PubsubSink/PubsubUnboundedSink.Writer/ParMultiDo(Writer)
     RunnerApi.PTransform writeParDo =
-        result.getComponents().getTransformsOrThrow(writeComposite3.getSubtransforms(0));
+        result
+            .getComponents()
+            .getTransformsOrThrow(
+                result
+                    .getComponents()
+                    .getTransformsOrThrow(writeComposite3.getSubtransforms(0))
+                    .getSubtransforms(0));
 
     RunnerApi.ParDoPayload parDoPayload =
         RunnerApi.ParDoPayload.parseFrom(writeParDo.getSpec().getPayload());

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOExternalTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOExternalTest.java
@@ -333,7 +333,7 @@ public class KafkaIOExternalTest {
 
     RunnerApi.PTransform writeComposite =
         result.getComponents().getTransformsOrThrow(transform.getSubtransforms(1));
-    RunnerApi.PTransform writeParDo =
+    RunnerApi.PTransform writeParDoOuter =
         result
             .getComponents()
             .getTransformsOrThrow(
@@ -341,6 +341,8 @@ public class KafkaIOExternalTest {
                     .getComponents()
                     .getTransformsOrThrow(writeComposite.getSubtransforms(0))
                     .getSubtransforms(0));
+    RunnerApi.PTransform writeParDo =
+        result.getComponents().getTransformsOrThrow(writeParDoOuter.getSubtransforms(0));
 
     RunnerApi.ParDoPayload parDoPayload =
         RunnerApi.ParDoPayload.parseFrom(writeParDo.getSpec().getPayload());


### PR DESCRIPTION
In order to implement BEAM-12795, we need to add non-trivial expansion to ParDo.MultiOuput. This cannot be done today since runners treat MultiOutput as a primitive and replace it wholesale. In this PR we create a new ParDo.MultiOutputPrimitive and update runners to replace that instead.

All runners in the Beam codebase have been updated. Any runners outside the Beam codebase will need to start replacing MultiOutputPrimitive before updating to the next Beam release.