### PR TITLE
[BEAM-12795] When using schemas, allow state/timers use without KV objects.

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformMatchers.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformMatchers.java
@@ -221,9 +221,33 @@ public class PTransformMatchers {
       public boolean matches(AppliedPTransform<?, ?, ?> application) {
         PTransform<?, ?> transform = application.getTransform();
         if (transform instanceof ParDo.SingleOutput) {
-          DoFn<?, ?> fn = ((ParDo.SingleOutput<?, ?>) transform).getFn();
+          ParDo.SingleOutput<?, ?> parDo = (ParDo.SingleOutput<?, ?>) transform;
+          DoFn<?, ?> fn = parDo.getFn();
           DoFnSignature signature = DoFnSignatures.signatureForDoFn(fn);
           return signature.usesState() || signature.usesTimers();
+        }
+        return false;
+      }
+
+      @Override
+      public String toString() {
+        return MoreObjects.toStringHelper("StateOrTimerParDoSingleMatcher").toString();
+      }
+    };
+  }
+
+  /**
+   * A {@link PTransformMatcher} that matches a {@link ParDo.SingleOutput} that does not have a key
+   * descriptor.
+   */
+  public static PTransformMatcher parDoSingle() {
+    return new PTransformMatcher() {
+      @Override
+      public boolean matches(AppliedPTransform<?, ?, ?> application) {
+        PTransform<?, ?> transform = application.getTransform();
+        if (transform instanceof ParDo.SingleOutput) {
+          ParDo.SingleOutput<?, ?> parDo = (ParDo.SingleOutput<?, ?>) transform;
+          return parDo.getKeyFieldsDescriptor() == null;
         }
         return false;
       }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PTransformTranslation.java
@@ -35,6 +35,7 @@ import org.apache.beam.model.pipeline.v1.RunnerApi.StandardPTransforms;
 import org.apache.beam.model.pipeline.v1.RunnerApi.StandardPTransforms.CombineComponents;
 import org.apache.beam.model.pipeline.v1.RunnerApi.StandardPTransforms.SplittableParDoComponents;
 import org.apache.beam.runners.core.construction.ExternalTranslation.ExternalTranslator;
+import org.apache.beam.runners.core.construction.ParDoTranslation.ParDoKeyFieldsTranslator;
 import org.apache.beam.runners.core.construction.ParDoTranslation.ParDoTranslator;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.io.Read;
@@ -223,6 +224,7 @@ public class PTransformTranslation {
         .add(new RawPTransformTranslator())
         .add(new KnownTransformPayloadTranslator())
         .add(ParDoTranslator.create())
+        .add(ParDoKeyFieldsTranslator.create())
         .add(ExternalTranslator.create())
         .build();
   }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SplittableParDoNaiveBounded.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/SplittableParDoNaiveBounded.java
@@ -449,6 +449,11 @@ public class SplittableParDoNaiveBounded {
       }
 
       @Override
+      public Object schemaKey(int index) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
       public Object sideInput(String tagId) {
         throw new UnsupportedOperationException();
       }

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/EnvironmentsTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/EnvironmentsTest.java
@@ -18,7 +18,6 @@
 package org.apache.beam.runners.core.construction;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
@@ -32,22 +31,11 @@ import org.apache.beam.model.pipeline.v1.RunnerApi.DockerPayload;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
 import org.apache.beam.model.pipeline.v1.RunnerApi.FunctionSpec;
 import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
-import org.apache.beam.model.pipeline.v1.RunnerApi.ParDoPayload;
 import org.apache.beam.model.pipeline.v1.RunnerApi.ProcessPayload;
 import org.apache.beam.model.pipeline.v1.RunnerApi.StandardEnvironments;
 import org.apache.beam.runners.core.construction.Environments.JavaVersion;
-import org.apache.beam.sdk.Pipeline;
-import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.PortablePipelineOptions;
-import org.apache.beam.sdk.transforms.DoFn;
-import org.apache.beam.sdk.transforms.DoFnSchemaInformation;
-import org.apache.beam.sdk.transforms.ParDo;
-import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollection.IsBounded;
-import org.apache.beam.sdk.values.TupleTag;
-import org.apache.beam.sdk.values.TupleTagList;
-import org.apache.beam.sdk.values.WindowingStrategy;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.junit.Rule;
 import org.junit.Test;
@@ -218,6 +206,7 @@ public class EnvironmentsTest implements Serializable {
 
   @Test
   public void getEnvironmentPTransform() throws IOException {
+    /*
     Pipeline p = Pipeline.create();
     SdkComponents components = SdkComponents.create();
     Environment env = Environments.createDockerEnvironment("java");
@@ -249,7 +238,7 @@ public class EnvironmentsTest implements Serializable {
     Environment env1 = Environments.getEnvironment(ptransform, rehydratedComponents).get();
     assertThat(
         env1,
-        equalTo(components.toComponents().getEnvironmentsOrThrow(ptransform.getEnvironmentId())));
+        equalTo(components.toComponents().getEnvironmentsOrThrow(ptransform.getEnvironmentId())));*/
   }
 
   @Test

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/EnvironmentsTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/EnvironmentsTest.java
@@ -206,7 +206,6 @@ public class EnvironmentsTest implements Serializable {
 
   @Test
   public void getEnvironmentPTransform() throws IOException {
-    /*
     Pipeline p = Pipeline.create();
     SdkComponents components = SdkComponents.create();
     Environment env = Environments.createDockerEnvironment("java");
@@ -238,7 +237,7 @@ public class EnvironmentsTest implements Serializable {
     Environment env1 = Environments.getEnvironment(ptransform, rehydratedComponents).get();
     assertThat(
         env1,
-        equalTo(components.toComponents().getEnvironmentsOrThrow(ptransform.getEnvironmentId())));*/
+        equalTo(components.toComponents().getEnvironmentsOrThrow(ptransform.getEnvironmentId())));
   }
 
   @Test

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectGraphVisitor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectGraphVisitor.java
@@ -122,6 +122,11 @@ class DirectGraphVisitor extends PipelineVisitor.Defaults {
     if (node.getTransform() instanceof ParDo.MultiOutput) {
       consumedViews.addAll(
           ((ParDo.MultiOutput<?, ?>) node.getTransform()).getSideInputs().values());
+    } else if (node.getTransform() instanceof ParDo.MultiOutputSchemaKeyFields) {
+      consumedViews.addAll(
+          ((ParDo.MultiOutputSchemaKeyFields<?, ?, ?>) node.getTransform())
+              .getSideInputs()
+              .values());
     } else if (node.getTransform() instanceof WriteView) {
       viewWriters.put(
           ((WriteView) node.getTransform()).getView(), node.toAppliedPTransform(getPipeline()));

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectWriteViewVisitor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/DirectWriteViewVisitor.java
@@ -64,6 +64,10 @@ class DirectWriteViewVisitor extends PipelineVisitor.Defaults {
     if (node.getTransform() instanceof ParDo.MultiOutput) {
       ParDo.MultiOutput<?, ?> parDo = (ParDo.MultiOutput<?, ?>) node.getTransform();
       viewsToWrite.addAll(parDo.getSideInputs().values());
+    } else if (node.getTransform() instanceof ParDo.MultiOutputSchemaKeyFields) {
+      ParDo.MultiOutputSchemaKeyFields<?, ?, ?> parDo =
+          (ParDo.MultiOutputSchemaKeyFields<?, ?, ?>) node.getTransform();
+      viewsToWrite.addAll(parDo.getSideInputs().values());
     }
   }
 

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/KeyedPValueTrackingVisitor.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/KeyedPValueTrackingVisitor.java
@@ -121,6 +121,10 @@ class KeyedPValueTrackingVisitor extends PipelineVisitor.Defaults {
     if (transform instanceof ParDo.MultiOutput) {
       ParDo.MultiOutput<?, ?> parDo = (ParDo.MultiOutput<?, ?>) transform;
       return parDo.getFn() instanceof ParDoMultiOverrideFactory.ToKeyedWorkItem;
+    } else if (transform instanceof ParDo.MultiOutputSchemaKeyFields) {
+      ParDo.MultiOutputSchemaKeyFields<?, ?, ?> parDo =
+          (ParDo.MultiOutputSchemaKeyFields<?, ?, ?>) transform;
+      return parDo.getFn() instanceof ParDoMultiOverrideFactory.ToKeyedWorkItem;
     } else {
       return false;
     }

--- a/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoEvaluator.java
+++ b/runners/direct-java/src/main/java/org/apache/beam/runners/direct/ParDoEvaluator.java
@@ -39,6 +39,7 @@ import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.runners.AppliedPTransform;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.DoFnSchemaInformation;
+import org.apache.beam.sdk.transforms.reflect.DoFnSignature;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignatures;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.UserCodeException;
@@ -100,7 +101,8 @@ class ParDoEvaluator<InputT> implements TransformEvaluator<InputT> {
               windowingStrategy,
               doFnSchemaInformation,
               sideInputMapping);
-      if (DoFnSignatures.signatureForDoFn(fn).usesState()) {
+      DoFnSignature signature = DoFnSignatures.signatureForDoFn(fn);
+      if (signature.usesState() || signature.onWindowExpiration() != null) {
         // the coder specified on the input PCollection doesn't match type
         // of elements processed by the StatefulDoFnRunner
         // that is internal detail of how DirectRunner processes stateful DoFns

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineRunner.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineRunner.java
@@ -89,7 +89,7 @@ public class FlinkPipelineRunner implements PortablePipelineRunner {
       PortablePipelineResult runPipelineWithTranslator(
           final Pipeline pipeline, JobInfo jobInfo, FlinkPortablePipelineTranslator<T> translator)
           throws Exception {
-    LOG.info("Translating pipeline to Flink program.");
+    LOG.info("Translating portable pipeline to Flink program.");
 
     // Expand any splittable ParDos within the graph to enable sizing and splitting of bundles.
     Pipeline pipelineWithSdfExpanded =

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
@@ -680,7 +680,6 @@ class FlinkStreamingTransformTranslators {
     public void translateNode(
         PTransform<PCollection<InputT>, PCollectionTuple> transform,
         FlinkStreamingTranslationContext context) {
-
       DoFn<InputT, OutputT> doFn;
       try {
         doFn = (DoFn<InputT, OutputT>) ParDoTranslation.getDoFn(context.getCurrentTransform());

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/BatchStatefulParDoOverrides.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/BatchStatefulParDoOverrides.java
@@ -218,7 +218,7 @@ public class BatchStatefulParDoOverrides {
       // ParDo does this in ParDo.MultiOutput.expand. However since we're replacing
       // ParDo.SingleOutput, the results
       // of the initial expansion of ParDo.MultiOutput are thrown away, so we need to add the key
-      // back Parin.
+      // back in.
       DoFnSignature signature = DoFnSignatures.getSignature(fn.getClass());
       @Nullable FieldAccessDescriptor keyFieldAccess = originalParDo.getKeyFieldsDescriptor();
       if (keyFieldAccess != null) {
@@ -268,7 +268,7 @@ public class BatchStatefulParDoOverrides {
       // is not registered by default, so we explicitly set the relevant coders.
       checkState(
           input.getCoder() instanceof KvCoder,
-          "Input to a %s using state requires a %s, but the coder was %s. PColleciton %s",
+          "Input to a %s using state requires a %s, but the coder was %s. PCollection %s",
           ParDo.class.getSimpleName(),
           KvCoder.class.getSimpleName(),
           input.getCoder(),

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -19,7 +19,6 @@ package org.apache.beam.runners.dataflow;
 
 import static java.nio.charset.StandardCharsets.UTF_8;
 import static org.apache.beam.runners.core.construction.resources.PipelineResources.detectClassPathResourcesToStage;
-import static org.apache.beam.sdk.options.ExperimentalOptions.hasExperiment;
 import static org.apache.beam.sdk.util.CoderUtils.encodeToByteArray;
 import static org.apache.beam.sdk.util.SerializableUtils.serializeToByteArray;
 import static org.apache.beam.sdk.util.StringUtils.byteArrayToJsonString;
@@ -635,8 +634,7 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
                 new PrimitiveCombineGroupedValuesOverrideFactory()))
         .add(
             PTransformOverride.of(
-                PTransformMatchers.classEqualTo(ParDo.SingleOutput.class),
-                new PrimitiveParDoSingleFactory()));
+                PTransformMatchers.parDoSingle(), new PrimitiveParDoSingleFactory()));
     return overridesBuilder.build();
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/SimpleParDoFn.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/SimpleParDoFn.java
@@ -329,7 +329,7 @@ public class SimpleParDoFn<InputT, OutputT> implements ParDoFn {
 
     WindowedValue<InputT> elem = (WindowedValue<InputT>) untypedElem;
 
-    // We use the state-cleanup timer to implementt onWindowExpiration, so make sure to set it if
+    // We use the state-cleanup timer to implement onWindowExpiration, so make sure to set it if
     // that callback has
     // been requested.
     if (fnSignature != null

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/SimpleParDoFn.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/SimpleParDoFn.java
@@ -329,7 +329,12 @@ public class SimpleParDoFn<InputT, OutputT> implements ParDoFn {
 
     WindowedValue<InputT> elem = (WindowedValue<InputT>) untypedElem;
 
-    if (fnSignature != null && fnSignature.stateDeclarations().size() > 0) {
+    // We use the state-cleanup timer to implementt onWindowExpiration, so make sure to set it if
+    // that callback has
+    // been requested.
+    if (fnSignature != null
+        && (!fnSignature.stateDeclarations().isEmpty()
+            || fnSignature.onWindowExpiration() != null)) {
       registerStateCleanup(
           (WindowingStrategy<?, BoundedWindow>) getDoFnInfo().getWindowingStrategy(),
           (Collection<BoundedWindow>) elem.getWindows());

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/state/StateKeySpec.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/state/StateKeySpec.java
@@ -17,23 +17,28 @@
  */
 package org.apache.beam.sdk.state;
 
+import java.io.Serializable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.schemas.FieldAccessDescriptor;
 
 @Experimental(Kind.SCHEMAS)
-public class StateKeySpec {
+public class StateKeySpec implements Serializable {
   private final FieldAccessDescriptor keyDescriptor;
 
   private StateKeySpec(FieldAccessDescriptor keyDescriptor) {
     this.keyDescriptor = keyDescriptor;
   }
 
-  public static StateKeySpec fields(String fieldNames) {
+  public static StateKeySpec fields(String... fieldNames) {
     return new StateKeySpec(FieldAccessDescriptor.withFieldNames(fieldNames));
   }
 
   public static StateKeySpec fields(FieldAccessDescriptor fieldAccessDescriptor) {
     return new StateKeySpec(fieldAccessDescriptor);
+  }
+
+  public FieldAccessDescriptor getKeyDescriptor() {
+    return keyDescriptor;
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -371,7 +371,7 @@ public abstract class DoFn<InputT extends @Nullable Object, OutputT extends @Nul
    *
    *  {@literal @ProcessElement}
    *   public void processElement(
-   *       {@literal @Element InputT element},
+   *       {@literal @Element KV<Key, Foo> element},
    *      {@literal @StateId("my-state-id") ValueState<MyState> myState}) {
    *     myState.read();
    *     myState.write(...);
@@ -396,6 +396,33 @@ public abstract class DoFn<InputT extends @Nullable Object, OutputT extends @Nul
     String value();
   }
 
+  /**
+   * Annotation for declaring schema fields to be used as the grouping key for state.
+   *
+   * <p>State cells and timers are always segregated per key. If the input PCollection has a schema
+   * known to Beam, then this annotation can be used to specify how to select the key from the input
+   * record. An ordered list of fields is specified, which will be used as the key. See the
+   * following code for and example:
+   *
+   * <pre><code>{@literal new DoFn<InputT, Baz>()} {
+   *
+   *  {@literal @StateId("my-state-id")}
+   *  {@literal private final StateSpec<ValueState<MyState>>} myStateSpec =
+   *       StateSpecs.value(new MyStateCoder());
+   *
+   *  {@literal private final StateKeySpec} keySpec = StateKeySpec.fields("userId", "location.country");
+   *
+   *  {@literal @ProcessElement}
+   *   public void processElement(
+   *       {@literal @Element InputT element},
+   *       {@literal @Key Row key},
+   *      {@literal @StateId("my-state-id") ValueState<MyState> myState}) {
+   *     myState.read();
+   *     myState.write(...);
+   *   }
+   * }
+   * </code></pre>
+   */
   @Documented
   @Retention(RetentionPolicy.RUNTIME)
   @Target({ElementType.FIELD, ElementType.PARAMETER})
@@ -494,8 +521,11 @@ public abstract class DoFn<InputT extends @Nullable Object, OutputT extends @Nul
   }
 
   /**
-   * Parameter annotation for dereferencing input element key in {@link
-   * org.apache.beam.sdk.values.KV} pair.
+   * Parameter annotation for dereferencing input element key. If the input has a schema ana a
+   * {@link StateKeyFields} parameter is specified, this parameter is extracted from the input row
+   * and the type can be any Java type that has the same schema as the extracted key. Otherwise it
+   * is assumed that the input is of type {@link org.apache.beam.sdk.values.KV}, and the key field
+   * is extracted.
    */
   @Documented
   @Retention(RetentionPolicy.RUNTIME)

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFn.java
@@ -396,6 +396,12 @@ public abstract class DoFn<InputT extends @Nullable Object, OutputT extends @Nul
     String value();
   }
 
+  @Documented
+  @Retention(RetentionPolicy.RUNTIME)
+  @Target({ElementType.FIELD, ElementType.PARAMETER})
+  @Experimental(Kind.STATE)
+  public @interface StateKeyFields {}
+
   /////////////////////////////////////////////////////////////////////////////
 
   /**

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnSchemaInformation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/DoFnSchemaInformation.java
@@ -21,6 +21,8 @@ import com.google.auto.value.AutoValue;
 import java.io.Serializable;
 import java.util.Collections;
 import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.annotations.Internal;
@@ -35,6 +37,8 @@ import org.apache.beam.sdk.schemas.utils.SelectHelpers.RowSelectorContainer;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
 
 /** Represents information about how a DoFn extracts schemas. */
 @Experimental(Kind.SCHEMAS)
@@ -51,10 +55,26 @@ public abstract class DoFnSchemaInformation implements Serializable {
    */
   public abstract List<SerializableFunction<?, ?>> getElementConverters();
 
+  public abstract List<SerializableFunction<?, ?>> getKeyConvertersProcessElement();
+
+  public abstract List<SerializableFunction<?, ?>> getKeyConvertersOnWindowExpiration();
+
+  public abstract Map<String, List<SerializableFunction<?, ?>>> getKeyConvertersOnTimer();
+
+  public abstract Map<String, List<SerializableFunction<?, ?>>> getKeyConvertersOnTimerFamily();
+
+  @Nullable
+  public abstract FieldAccessDescriptor getKeyFieldsDescriptor();
+
   /** Create an instance. */
   public static DoFnSchemaInformation create() {
     return new AutoValue_DoFnSchemaInformation.Builder()
+        .setKeyFieldsDescriptor(null)
         .setElementConverters(Collections.emptyList())
+        .setKeyConvertersProcessElement(Collections.emptyList())
+        .setKeyConvertersOnWindowExpiration(Collections.emptyList())
+        .setKeyConvertersOnTimer(Collections.emptyMap())
+        .setKeyConvertersOnTimerFamily(Collections.emptyMap())
         .build();
   }
 
@@ -63,10 +83,195 @@ public abstract class DoFnSchemaInformation implements Serializable {
   public abstract static class Builder {
     abstract Builder setElementConverters(List<SerializableFunction<?, ?>> converters);
 
+    abstract Builder setKeyConvertersProcessElement(List<SerializableFunction<?, ?>> converters);
+
+    abstract Builder setKeyConvertersOnWindowExpiration(
+        List<SerializableFunction<?, ?>> converters);
+
+    abstract Builder setKeyConvertersOnTimer(
+        Map<String, List<SerializableFunction<?, ?>>> converters);
+
+    abstract Builder setKeyConvertersOnTimerFamily(
+        Map<String, List<SerializableFunction<?, ?>>> converters);
+
+    abstract Builder setKeyFieldsDescriptor(@Nullable FieldAccessDescriptor fieldAccessDescriptor);
+
     abstract DoFnSchemaInformation build();
   }
 
   public abstract Builder toBuilder();
+
+  public DoFnSchemaInformation withStateKeyFieldsDescriptor(FieldAccessDescriptor keyDescriptor) {
+    return toBuilder().setKeyFieldsDescriptor(keyDescriptor).build();
+  }
+
+  List<SerializableFunction<?, ?>> addConverterParameter(
+      List<SerializableFunction<?, ?>> existingConverters,
+      Schema schema,
+      Schema outputSchema,
+      SerializableFunction<?, Row> toRowFunction,
+      SerializableFunction<Row, ?> fromRowFunction,
+      FieldAccessDescriptor fieldAccessDescriptor,
+      boolean unbox) {
+    List<SerializableFunction<?, ?>> converters =
+        ImmutableList.<SerializableFunction<?, ?>>builder()
+            .addAll(existingConverters)
+            .add(
+                ConversionFunction.of(
+                    schema,
+                    toRowFunction,
+                    fromRowFunction,
+                    fieldAccessDescriptor,
+                    outputSchema,
+                    unbox))
+            .build();
+    return converters;
+  }
+
+  List<SerializableFunction<?, ?>> addUnboxPrimitiveParameter(
+      List<SerializableFunction<?, ?>> existingConverters,
+      Schema schema,
+      Schema outputSchema,
+      SerializableFunction<?, Row> toRowFunction,
+      FieldAccessDescriptor fieldAccessDescriptor,
+      TypeDescriptor<?> elementT) {
+    if (outputSchema.getFieldCount() != 1) {
+      throw new RuntimeException("Parameter has no schema and the input is not a simple type.");
+    }
+    FieldType fieldType = outputSchema.getField(0).getType();
+    if (fieldType.getTypeName().isCompositeType()) {
+      throw new RuntimeException("Parameter has no schema and the input is not a primitive type.");
+    }
+
+    List<SerializableFunction<?, ?>> converters =
+        ImmutableList.<SerializableFunction<?, ?>>builder()
+            .addAll(existingConverters)
+            .add(
+                UnboxingConversionFunction.of(
+                    schema, toRowFunction, fieldAccessDescriptor, outputSchema, elementT))
+            .build();
+    return converters;
+  }
+
+  public DoFnSchemaInformation withProcessElementSchemaKeyParameter(
+      Schema keySchema, SchemaCoder<?> parameterCoder, boolean unbox) {
+    List<SerializableFunction<?, ?>> converters =
+        addConverterParameter(
+            getKeyConvertersProcessElement(),
+            keySchema,
+            keySchema,
+            SerializableFunctions.identity(),
+            parameterCoder.getFromRowFunction(),
+            FieldAccessDescriptor.withAllFields(),
+            unbox);
+    return toBuilder().setKeyConvertersProcessElement(converters).build();
+  }
+
+  public DoFnSchemaInformation withProcessElementUnboxPrimitiveKeyParameter(
+      Schema keySchema, TypeDescriptor<?> elementT) {
+    List<SerializableFunction<?, ?>> converters =
+        addUnboxPrimitiveParameter(
+            getKeyConvertersProcessElement(),
+            keySchema,
+            keySchema,
+            SerializableFunctions.identity(),
+            FieldAccessDescriptor.withAllFields(),
+            elementT);
+    return toBuilder().setKeyConvertersProcessElement(converters).build();
+  }
+
+  public DoFnSchemaInformation withOnWindowExpirationSchemaKeyParameter(
+      Schema keySchema, SchemaCoder<?> parameterCoder, boolean unbox) {
+    List<SerializableFunction<?, ?>> converters =
+        addConverterParameter(
+            getKeyConvertersOnWindowExpiration(),
+            keySchema,
+            keySchema,
+            SerializableFunctions.identity(),
+            parameterCoder.getFromRowFunction(),
+            FieldAccessDescriptor.withAllFields(),
+            unbox);
+    return toBuilder().setKeyConvertersOnWindowExpiration(converters).build();
+  }
+
+  public DoFnSchemaInformation withOnWindowExpirationUnboxPrimitiveKeyParameter(
+      Schema keySchema, TypeDescriptor<?> elementT) {
+    List<SerializableFunction<?, ?>> converters =
+        addUnboxPrimitiveParameter(
+            getKeyConvertersOnWindowExpiration(),
+            keySchema,
+            keySchema,
+            SerializableFunctions.identity(),
+            FieldAccessDescriptor.withAllFields(),
+            elementT);
+    return toBuilder().setKeyConvertersOnWindowExpiration(converters).build();
+  }
+
+  public DoFnSchemaInformation withOnTimerSchemaKeyParameter(
+      String timerId, Schema keySchema, SchemaCoder<?> parameterCoder, boolean unbox) {
+    Map<String, List<SerializableFunction<?, ?>>> onTimerConverters =
+        Maps.newHashMap(getKeyConvertersOnTimer());
+    List<SerializableFunction<?, ?>> converters =
+        addConverterParameter(
+            onTimerConverters.computeIfAbsent(timerId, t -> Lists.newArrayList()),
+            keySchema,
+            keySchema,
+            SerializableFunctions.identity(),
+            parameterCoder.getFromRowFunction(),
+            FieldAccessDescriptor.withAllFields(),
+            unbox);
+    onTimerConverters.put(timerId, converters);
+    return toBuilder().setKeyConvertersOnTimer(onTimerConverters).build();
+  }
+
+  public DoFnSchemaInformation withOnTimerUnboxPrimitiveKeyParameter(
+      String timerId, Schema keySchema, TypeDescriptor<?> elementT) {
+    Map<String, List<SerializableFunction<?, ?>>> onTimerConverters =
+        Maps.newHashMap(getKeyConvertersOnTimer());
+    List<SerializableFunction<?, ?>> converters =
+        addUnboxPrimitiveParameter(
+            onTimerConverters.computeIfAbsent(timerId, t -> Lists.newArrayList()),
+            keySchema,
+            keySchema,
+            SerializableFunctions.identity(),
+            FieldAccessDescriptor.withAllFields(),
+            elementT);
+    onTimerConverters.put(timerId, converters);
+    return toBuilder().setKeyConvertersOnTimer(onTimerConverters).build();
+  }
+
+  public DoFnSchemaInformation withOnTimerFamilySchemaKeyParameter(
+      String timerFamily, Schema keySchema, SchemaCoder<?> parameterCoder, boolean unbox) {
+    Map<String, List<SerializableFunction<?, ?>>> onTimerFamilyConverters =
+        Maps.newHashMap(getKeyConvertersOnTimerFamily());
+    List<SerializableFunction<?, ?>> converters =
+        addConverterParameter(
+            onTimerFamilyConverters.computeIfAbsent(timerFamily, t -> Lists.newArrayList()),
+            keySchema,
+            keySchema,
+            SerializableFunctions.identity(),
+            parameterCoder.getFromRowFunction(),
+            FieldAccessDescriptor.withAllFields(),
+            unbox);
+    onTimerFamilyConverters.put(timerFamily, converters);
+    return toBuilder().setKeyConvertersOnTimerFamily(onTimerFamilyConverters).build();
+  }
+
+  public DoFnSchemaInformation withOnTimerFamilyUnboxPrimitiveKeyParameter(
+      String timerFamily, Schema keySchema, TypeDescriptor<?> elementT) {
+    Map<String, List<SerializableFunction<?, ?>>> onTimerFamilyConverters =
+        Maps.newHashMap(getKeyConvertersOnTimerFamily());
+    List<SerializableFunction<?, ?>> converters =
+        addUnboxPrimitiveParameter(
+            onTimerFamilyConverters.computeIfAbsent(timerFamily, t -> Lists.newArrayList()),
+            keySchema,
+            keySchema,
+            SerializableFunctions.identity(),
+            FieldAccessDescriptor.withAllFields(),
+            elementT);
+    onTimerFamilyConverters.put(timerFamily, converters);
+    return toBuilder().setKeyConvertersOnTimerFamily(onTimerFamilyConverters).build();
+  }
 
   /**
    * Specified a parameter that is a selection from an input schema (specified using FieldAccess).
@@ -82,25 +287,21 @@ public abstract class DoFnSchemaInformation implements Serializable {
    *     unboxed.
    * @return
    */
-  DoFnSchemaInformation withSelectFromSchemaParameter(
+  public DoFnSchemaInformation withSelectFromSchemaElementParameter(
       SchemaCoder<?> inputCoder,
       FieldAccessDescriptor selectDescriptor,
       Schema selectOutputSchema,
       SchemaCoder<?> parameterCoder,
       boolean unbox) {
     List<SerializableFunction<?, ?>> converters =
-        ImmutableList.<SerializableFunction<?, ?>>builder()
-            .addAll(getElementConverters())
-            .add(
-                ConversionFunction.of(
-                    inputCoder.getSchema(),
-                    inputCoder.getToRowFunction(),
-                    parameterCoder.getFromRowFunction(),
-                    selectDescriptor,
-                    selectOutputSchema,
-                    unbox))
-            .build();
-
+        addConverterParameter(
+            getElementConverters(),
+            inputCoder.getSchema(),
+            selectOutputSchema,
+            inputCoder.getToRowFunction(),
+            parameterCoder.getFromRowFunction(),
+            selectDescriptor,
+            unbox);
     return toBuilder().setElementConverters(converters).build();
   }
 
@@ -116,31 +317,19 @@ public abstract class DoFnSchemaInformation implements Serializable {
    * @param elementT The type of the method's input parameter.
    * @return
    */
-  DoFnSchemaInformation withUnboxPrimitiveParameter(
+  public DoFnSchemaInformation withUnboxPrimitiveElementParameter(
       SchemaCoder inputCoder,
       FieldAccessDescriptor selectDescriptor,
       Schema selectOutputSchema,
       TypeDescriptor<?> elementT) {
-    if (selectOutputSchema.getFieldCount() != 1) {
-      throw new RuntimeException("Parameter has no schema and the input is not a simple type.");
-    }
-    FieldType fieldType = selectOutputSchema.getField(0).getType();
-    if (fieldType.getTypeName().isCompositeType()) {
-      throw new RuntimeException("Parameter has no schema and the input is not a primitive type.");
-    }
-
     List<SerializableFunction<?, ?>> converters =
-        ImmutableList.<SerializableFunction<?, ?>>builder()
-            .addAll(getElementConverters())
-            .add(
-                UnboxingConversionFunction.of(
-                    inputCoder.getSchema(),
-                    inputCoder.getToRowFunction(),
-                    selectDescriptor,
-                    selectOutputSchema,
-                    elementT))
-            .build();
-
+        addUnboxPrimitiveParameter(
+            getElementConverters(),
+            inputCoder.getSchema(),
+            selectOutputSchema,
+            inputCoder.getToRowFunction(),
+            selectDescriptor,
+            elementT);
     return toBuilder().setElementConverters(converters).build();
   }
 
@@ -152,7 +341,7 @@ public abstract class DoFnSchemaInformation implements Serializable {
     private final FieldAccessDescriptor selectDescriptor;
     private final Schema selectOutputSchema;
     private final boolean unbox;
-    private final RowSelector rowSelector;
+    private final @Nullable RowSelector rowSelector;
 
     private ConversionFunction(
         Schema inputSchema,

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/ParDo.java
@@ -442,7 +442,8 @@ public class ParDo {
     if (fieldAccessDescriptor == null) {
       checkArgument(
           inputCoder instanceof KvCoder,
-          "%s requires its input to either use %s or have a schema input in order to use state and timers.",
+          "%s requires its input to either use %s or have a schema input in order to use state and timers. "
+              + "If the input has a schema, then the key fields must also be specified.",
           ParDo.class.getSimpleName(),
           KvCoder.class.getSimpleName());
 
@@ -947,7 +948,7 @@ public class ParDo {
           fn, sideInputs, fnDisplayData, doFnSchemaInformation, fieldAccessDescriptor);
     }
 
-    public SingleOutput<InputT, OutputT> withKeyFields(String keyFields) {
+    public SingleOutput<InputT, OutputT> withKeyFields(String... keyFields) {
       return new SingleOutput<>(
           fn,
           sideInputs,
@@ -1163,7 +1164,7 @@ public class ParDo {
           fieldAccessDescriptor);
     }
 
-    public MultiOutput<InputT, OutputT> withKeyFields(String keyFields) {
+    public MultiOutput<InputT, OutputT> withKeyFields(String... keyFields) {
       return new MultiOutput<>(
           fn,
           sideInputs,
@@ -1187,9 +1188,6 @@ public class ParDo {
       DoFnSignature signature = DoFnSignatures.getSignature(fn.getClass());
 
       validateSideInputTypes(sideInputs, fn);
-
-      // VALIDATE NO SCHEMA ELEMENT IF NO SCHEMA
-      // VALIDAE SCHEMA KEYS
 
       if (getKeyFieldsDescriptor() != null) {
         if (!input.hasSchema()) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnInvoker.java
@@ -182,6 +182,12 @@ public interface DoFnInvoker<InputT, OutputT> {
      */
     Object key();
 
+    /**
+     * Provide a reference to the input element key as extracted from the schema. @Key argument
+     * position specified by index.
+     */
+    Object schemaKey(int index);
+
     /** Provide a reference to the input sideInput with the specified tag. */
     Object sideInput(String tagId);
 
@@ -274,6 +280,12 @@ public interface DoFnInvoker<InputT, OutputT> {
 
     @Override
     public Object key() {
+      throw new UnsupportedOperationException(
+          "Cannot access key as parameter outside of @OnTimer method.");
+    }
+
+    @Override
+    public Object schemaKey(int index) {
       throw new UnsupportedOperationException(
           "Cannot access key as parameter outside of @OnTimer method.");
     }
@@ -474,6 +486,11 @@ public interface DoFnInvoker<InputT, OutputT> {
     @Override
     public Object key() {
       return delegate.key();
+    }
+
+    @Override
+    public Object schemaKey(int index) {
+      return delegate.schemaKey(index);
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignature.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.transforms.reflect;
 
 import com.google.auto.value.AutoValue;
+import com.google.auto.value.AutoValue.Builder;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.util.Collections;
@@ -41,6 +42,7 @@ import org.apache.beam.sdk.transforms.DoFn.TruncateRestriction;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.OutputReceiverParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.RestrictionTrackerParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.SchemaElementParameter;
+import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.SchemaKeyParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.SideInputParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.StateParameter;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature.Parameter.TimerFamilyParameter;
@@ -92,6 +94,8 @@ public abstract class DoFnSignature {
 
   /** Details about this {@link DoFn}'s {@link DoFn.OnWindowExpiration} method. */
   public abstract @Nullable OnWindowExpirationMethod onWindowExpiration();
+
+  public abstract @Nullable StateKeyFieldsDeclaration stateKeyFieldsDeclaration();
 
   /** Timer declarations present on the {@link DoFn} class. Immutable. */
   public abstract Map<String, TimerDeclaration> timerDeclarations();
@@ -193,6 +197,9 @@ public abstract class DoFnSignature {
 
     abstract Builder setGetWatermarkEstimatorStateCoder(
         GetWatermarkEstimatorStateCoderMethod getWatermarkEstimatorStateCoder);
+
+    abstract Builder setStateKeyFieldsDeclaration(
+        StateKeyFieldsDeclaration stateKeyFieldsDeclaration);
 
     abstract Builder setStateDeclarations(Map<String, StateDeclaration> stateDeclarations);
 
@@ -313,6 +320,8 @@ public abstract class DoFnSignature {
         return cases.dispatch((BundleFinalizerParameter) this);
       } else if (this instanceof KeyParameter) {
         return cases.dispatch((KeyParameter) this);
+      } else if (this instanceof SchemaKeyParameter) {
+        return cases.dispatch((SchemaKeyParameter) this);
       } else {
         throw new IllegalStateException(
             String.format(
@@ -370,6 +379,8 @@ public abstract class DoFnSignature {
       ResultT dispatch(BundleFinalizerParameter p);
 
       ResultT dispatch(KeyParameter p);
+
+      ResultT dispatch(SchemaKeyParameter p);
 
       /** A base class for a visitor with a default method for cases it is not interested in. */
       abstract class WithDefault<ResultT> implements Cases<ResultT> {
@@ -495,6 +506,11 @@ public abstract class DoFnSignature {
         public ResultT dispatch(KeyParameter p) {
           return dispatchDefault(p);
         }
+
+        @Override
+        public ResultT dispatch(SchemaKeyParameter p) {
+          return dispatchDefault(p);
+        }
       }
     }
 
@@ -605,8 +621,16 @@ public abstract class DoFnSignature {
     }
 
     /** Returns a {@link KeyParameter}. */
-    public static KeyParameter keyT(TypeDescriptor<?> keyT) {
+    public static KeyParameter key(TypeDescriptor<?> keyT) {
       return new AutoValue_DoFnSignature_Parameter_KeyParameter(keyT);
+    }
+
+    /** Returns a {@link KeyParameter}. */
+    public static SchemaKeyParameter schemaKey(TypeDescriptor<?> keyT, int index) {
+      return new AutoValue_DoFnSignature_Parameter_SchemaKeyParameter.Builder()
+          .setKeyT(keyT)
+          .setIndex(index)
+          .build();
     }
 
     /** Returns a {@link PipelineOptionsParameter}. */
@@ -757,6 +781,26 @@ public abstract class DoFnSignature {
       KeyParameter() {}
 
       public abstract TypeDescriptor<?> keyT();
+    }
+
+    @AutoValue
+    public abstract static class SchemaKeyParameter extends Parameter {
+      SchemaKeyParameter() {}
+
+      public abstract TypeDescriptor<?> keyT();
+
+      public abstract int index();
+
+      @AutoValue.Builder
+      public abstract static class Builder {
+        public abstract SchemaKeyParameter.Builder setKeyT(TypeDescriptor<?> keyT);
+
+        public abstract SchemaKeyParameter.Builder setIndex(int index);
+
+        public abstract SchemaKeyParameter build();
+      }
+
+      public abstract SchemaKeyParameter.Builder toBuilder();
     }
 
     /**
@@ -1009,6 +1053,13 @@ public abstract class DoFnSignature {
           .collect(Collectors.toList());
     }
 
+    public @Nullable List<SchemaKeyParameter> getSchemaKeyParameters() {
+      return extraParameters().stream()
+          .filter(Predicates.instanceOf(SchemaKeyParameter.class)::apply)
+          .map(SchemaKeyParameter.class::cast)
+          .collect(Collectors.toList());
+    }
+
     public @Nullable List<SideInputParameter> getSideInputParameters() {
       return extraParameters().stream()
           .filter(Predicates.instanceOf(SideInputParameter.class)::apply)
@@ -1073,13 +1124,20 @@ public abstract class DoFnSignature {
           windowT,
           Collections.unmodifiableList(extraParameters));
     }
+
+    public @Nullable List<SchemaKeyParameter> getSchemaKeyParameters() {
+      return extraParameters().stream()
+          .filter(Predicates.instanceOf(SchemaKeyParameter.class)::apply)
+          .map(SchemaKeyParameter.class::cast)
+          .collect(Collectors.toList());
+    }
   }
 
   /** Describes a {@link DoFn.OnTimerFamily} method. */
   @AutoValue
   public abstract static class OnTimerFamilyMethod implements MethodWithExtraParameters {
 
-    /** The id on the method's {@link DoFn.TimerId} annotation. */
+    /** The id on the method's {@link DoFn.TimerFamily} annotation. */
     public abstract String id();
 
     /** The annotated method itself. */
@@ -1114,6 +1172,13 @@ public abstract class DoFnSignature {
           windowT,
           Collections.unmodifiableList(extraParameters));
     }
+
+    public @Nullable List<SchemaKeyParameter> getSchemaKeyParameters() {
+      return extraParameters().stream()
+          .filter(Predicates.instanceOf(SchemaKeyParameter.class)::apply)
+          .map(SchemaKeyParameter.class::cast)
+          .collect(Collectors.toList());
+    }
   }
 
   /** Describes a {@link DoFn.OnWindowExpiration} method. */
@@ -1140,6 +1205,13 @@ public abstract class DoFnSignature {
     @Override
     public abstract List<Parameter> extraParameters();
 
+    public @Nullable List<SchemaKeyParameter> getSchemaKeyParameters() {
+      return extraParameters().stream()
+          .filter(Predicates.instanceOf(SchemaKeyParameter.class)::apply)
+          .map(SchemaKeyParameter.class::cast)
+          .collect(Collectors.toList());
+    }
+
     static OnWindowExpirationMethod create(
         Method targetMethod,
         boolean requiresStableInput,
@@ -1153,6 +1225,14 @@ public abstract class DoFnSignature {
     }
   }
 
+  @AutoValue
+  public abstract static class StateKeyFieldsDeclaration {
+    public abstract Field field();
+
+    static StateKeyFieldsDeclaration create(Field field) {
+      return new AutoValue_DoFnSignature_StateKeyFieldsDeclaration(field);
+    }
+  }
   /**
    * Describes a timer declaration; a field of type {@link TimerSpec} annotated with {@link
    * DoFn.TimerId}.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/reflect/DoFnSignatures.java
@@ -19,7 +19,6 @@ package org.apache.beam.sdk.transforms.reflect;
 
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkState;
 
-import avro.shaded.com.google.common.collect.Iterables;
 import com.google.auto.value.AutoValue;
 import java.lang.annotation.Annotation;
 import java.lang.reflect.Field;
@@ -100,6 +99,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.Visi
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Predicates;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.Instant;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoSchemaTest.java
@@ -28,8 +28,8 @@ import java.util.Comparator;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
-import java.util.stream.Stream;
 import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.options.StreamingOptions;
 import org.apache.beam.sdk.schemas.AutoValueSchema;
 import org.apache.beam.sdk.schemas.FieldAccessDescriptor;
 import org.apache.beam.sdk.schemas.NoSuchSchemaException;
@@ -41,14 +41,25 @@ import org.apache.beam.sdk.state.BagState;
 import org.apache.beam.sdk.state.CombiningState;
 import org.apache.beam.sdk.state.MapState;
 import org.apache.beam.sdk.state.SetState;
+import org.apache.beam.sdk.state.StateKeySpec;
 import org.apache.beam.sdk.state.StateSpec;
 import org.apache.beam.sdk.state.StateSpecs;
+import org.apache.beam.sdk.state.TimeDomain;
+import org.apache.beam.sdk.state.Timer;
+import org.apache.beam.sdk.state.TimerMap;
+import org.apache.beam.sdk.state.TimerSpec;
+import org.apache.beam.sdk.state.TimerSpecs;
+import org.apache.beam.sdk.state.ValueState;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.UsesMapState;
+import org.apache.beam.sdk.testing.UsesOnWindowExpiration;
 import org.apache.beam.sdk.testing.UsesSchema;
 import org.apache.beam.sdk.testing.UsesStatefulParDo;
+import org.apache.beam.sdk.testing.UsesTimerMap;
+import org.apache.beam.sdk.testing.UsesTimersInParDo;
+import org.apache.beam.sdk.testing.UsesUnboundedPCollections;
 import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
@@ -59,6 +70,7 @@ import org.apache.beam.sdk.values.TupleTagList;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
+import org.joda.time.Duration;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -652,26 +664,29 @@ public class ParDoSchemaTest implements Serializable {
   }
 
   @Test
-  @Category({NeedsRunner.class, UsesStatefulParDo.class})
+  @Category({ValidatesRunner.class, UsesStatefulParDo.class})
   public void testRowBagState() {
     final String stateId = "foo";
 
     Schema type =
-        Stream.of(Schema.Field.of("f_string", FieldType.STRING)).collect(Schema.toSchema());
+        Schema.builder()
+            .addField(Schema.Field.of("f_string", FieldType.STRING))
+            .addField(Schema.Field.of("key", FieldType.STRING))
+            .build();
+
     Schema outputType = Schema.of(Field.of("values", FieldType.array(FieldType.row(type))));
 
-    DoFn<KV<String, Row>, Row> fn =
-        new DoFn<KV<String, Row>, Row>() {
-
+    DoFn<Row, Row> fn =
+        new DoFn<Row, Row>() {
           @StateId(stateId)
           private final StateSpec<BagState<Row>> bufferState = StateSpecs.rowBag(type);
 
+          @StateKeyFields private final StateKeySpec keySpec = StateKeySpec.fields("key");
+
           @ProcessElement
           public void processElement(
-              @Element KV<String, Row> element,
-              @StateId(stateId) BagState<Row> state,
-              OutputReceiver<Row> o) {
-            state.add(element.getValue());
+              @Element Row element, @StateId(stateId) BagState<Row> state, OutputReceiver<Row> o) {
+            state.add(element);
             Iterable<Row> currentValue = state.read();
             if (Iterables.size(currentValue) >= 4) {
               List<Row> sorted = Lists.newArrayList(currentValue);
@@ -681,28 +696,347 @@ public class ParDoSchemaTest implements Serializable {
           }
         };
 
+    TupleTag<Row> mainTag = new TupleTag<>();
     PCollection<Row> output =
         pipeline
             .apply(
+                "Create values",
                 Create.of(
-                    KV.of("hello", Row.withSchema(type).addValue("a").build()),
-                    KV.of("hello", Row.withSchema(type).addValue("b").build()),
-                    KV.of("hello", Row.withSchema(type).addValue("c").build()),
-                    KV.of("hello", Row.withSchema(type).addValue("d").build())))
-            .apply(ParDo.of(fn))
+                        Row.withSchema(type).addValues("a", "hello").build(),
+                        Row.withSchema(type).addValues("b", "hello").build(),
+                        Row.withSchema(type).addValues("c", "hello").build(),
+                        Row.withSchema(type).addValues("d", "hello").build())
+                    .withRowSchema(type))
+            .apply("run statetful fn", ParDo.of(fn).withOutputTags(mainTag, TupleTagList.empty()))
+            .get(mainTag)
             .setRowSchema(outputType);
     PAssert.that(output)
         .containsInAnyOrder(
             Row.withSchema(outputType)
                 .addArray(
                     Lists.newArrayList(
-                        Row.withSchema(type).addValue("a").build(),
-                        Row.withSchema(type).addValue("b").build(),
-                        Row.withSchema(type).addValue("c").build(),
-                        Row.withSchema(type).addValue("d").build()))
+                        Row.withSchema(type).addValues("a", "hello").build(),
+                        Row.withSchema(type).addValues("b", "hello").build(),
+                        Row.withSchema(type).addValues("c", "hello").build(),
+                        Row.withSchema(type).addValues("d", "hello").build()))
                 .build());
 
     pipeline.run();
+  }
+
+  @DefaultSchema(AutoValueSchema.class)
+  @AutoValue
+  abstract static class testRowBagStateKeyValue {
+    public abstract String getKey();
+  }
+
+  public void testSchemaKeyProcessTimer(boolean isBounded) {
+    final String timerId = "timer";
+
+    Schema type =
+        Schema.builder()
+            .addField(Schema.Field.of("f_string", FieldType.STRING))
+            .addField(Schema.Field.of("key", FieldType.STRING))
+            .build();
+
+    Schema outputType =
+        Schema.builder()
+            .addField(Field.of("source", FieldType.STRING))
+            .addField(Field.of("key", FieldType.STRING))
+            .build();
+
+    DoFn<Row, Row> fn =
+        new DoFn<Row, Row>() {
+          @TimerId(timerId)
+          private final TimerSpec timerSpec = TimerSpecs.timer(TimeDomain.EVENT_TIME);
+
+          @StateKeyFields private final StateKeySpec keySpec = StateKeySpec.fields("key");
+
+          @ProcessElement
+          public void processElement(
+              @Key Row key,
+              @Key String stringKey,
+              @Key testRowBagStateKeyValue autoValueKey,
+              @Element Row element,
+              @TimerId(timerId) Timer timer,
+              OutputReceiver<Row> o) {
+            assertEquals(key.getValue(0), stringKey);
+            assertEquals(stringKey, autoValueKey.getKey());
+            assertEquals(autoValueKey.getKey(), element.getValue("key"));
+            o.output(
+                Row.withSchema(outputType)
+                    .withFieldValue("source", "processElement")
+                    .withFieldValue("key", stringKey)
+                    .build());
+            timer.offset(Duration.standardSeconds(1)).setRelative();
+          }
+
+          @OnTimer(timerId)
+          public void onTimer(
+              @Key Row key,
+              @Key String stringKey,
+              @Key testRowBagStateKeyValue autoValueKey,
+              OutputReceiver<Row> o) {
+            assertEquals(key.getValue(0), stringKey);
+            assertEquals(stringKey, autoValueKey.getKey());
+            o.output(
+                Row.withSchema(outputType)
+                    .withFieldValue("source", "onTimer")
+                    .withFieldValue("key", stringKey)
+                    .build());
+          }
+        };
+
+    PCollection<Row> output =
+        pipeline
+            .apply(
+                Create.of(
+                        Row.withSchema(type).addValues("a", "key1").build(),
+                        Row.withSchema(type).addValues("b", "key2").build(),
+                        Row.withSchema(type).addValues("c", "key3").build())
+                    .withRowSchema(type))
+            .apply(ParDo.of(fn))
+            .setRowSchema(outputType);
+    PAssert.that(output)
+        .containsInAnyOrder(
+            Lists.newArrayList(
+                Row.withSchema(type).addValues("processElement", "key1").build(),
+                Row.withSchema(type).addValues("processElement", "key2").build(),
+                Row.withSchema(type).addValues("processElement", "key3").build(),
+                Row.withSchema(type).addValues("onTimer", "key1").build(),
+                Row.withSchema(type).addValues("onTimer", "key2").build(),
+                Row.withSchema(type).addValues("onTimer", "key3").build()));
+    if (!isBounded) {
+      pipeline.getOptions().as(StreamingOptions.class).setStreaming(true);
+    }
+
+    pipeline.run();
+  }
+
+  public void testSchemaKeyProcessTimerFamily(boolean isBounded) {
+    final String timerId = "timer";
+    final String timerFamilyId = "timerFamily";
+
+    Schema type =
+        Schema.builder()
+            .addField(Schema.Field.of("f_string", FieldType.STRING))
+            .addField(Schema.Field.of("key", FieldType.STRING))
+            .build();
+
+    Schema outputType =
+        Schema.builder()
+            .addField(Field.of("source", FieldType.STRING))
+            .addField(Field.of("key", FieldType.STRING))
+            .build();
+
+    DoFn<Row, Row> fn =
+        new DoFn<Row, Row>() {
+          @TimerFamily(timerFamilyId)
+          private final TimerSpec timerMapSpec = TimerSpecs.timerMap(TimeDomain.EVENT_TIME);
+
+          @StateKeyFields private final StateKeySpec keySpec = StateKeySpec.fields("key");
+
+          @ProcessElement
+          public void processElement(
+              @Key Row key,
+              @Key String stringKey,
+              @Key testRowBagStateKeyValue autoValueKey,
+              @Element Row element,
+              @TimerFamily(timerFamilyId) TimerMap timerMap,
+              OutputReceiver<Row> o) {
+            assertEquals(key.getValue(0), stringKey);
+            assertEquals(stringKey, autoValueKey.getKey());
+            assertEquals(autoValueKey.getKey(), element.getValue("key"));
+            o.output(
+                Row.withSchema(outputType)
+                    .withFieldValue("source", "processElement")
+                    .withFieldValue("key", stringKey)
+                    .build());
+            timerMap.get(timerId).offset(Duration.standardSeconds(1)).setRelative();
+          }
+
+          @OnTimerFamily(timerFamilyId)
+          public void onTimerFamily(
+              @Key Row key,
+              @Key String stringKey,
+              @Key testRowBagStateKeyValue autoValueKey,
+              OutputReceiver<Row> o) {
+            assertEquals(key.getValue(0), stringKey);
+            assertEquals(stringKey, autoValueKey.getKey());
+            o.output(
+                Row.withSchema(outputType)
+                    .withFieldValue("source", "onTimerFamily")
+                    .withFieldValue("key", stringKey)
+                    .build());
+          }
+        };
+
+    TupleTag<Row> mainTag = new TupleTag<>();
+    PCollection<Row> output =
+        pipeline
+            .apply(
+                Create.of(
+                        Row.withSchema(type).addValues("a", "key1").build(),
+                        Row.withSchema(type).addValues("b", "key2").build(),
+                        Row.withSchema(type).addValues("c", "key3").build())
+                    .withRowSchema(type))
+            .apply(ParDo.of(fn).withOutputTags(mainTag, TupleTagList.empty())) // Force MultiOutput
+            .get(mainTag)
+            .setRowSchema(outputType);
+    PAssert.that(output)
+        .containsInAnyOrder(
+            Lists.newArrayList(
+                Row.withSchema(type).addValues("processElement", "key1").build(),
+                Row.withSchema(type).addValues("processElement", "key2").build(),
+                Row.withSchema(type).addValues("processElement", "key3").build(),
+                Row.withSchema(type).addValues("onTimerFamily", "key1").build(),
+                Row.withSchema(type).addValues("onTimerFamily", "key2").build(),
+                Row.withSchema(type).addValues("onTimerFamily", "key3").build()));
+
+    if (!isBounded) {
+      pipeline.getOptions().as(StreamingOptions.class).setStreaming(true);
+    }
+    pipeline.run();
+  }
+
+  public void testSchemaKeyOnWindowExpiration(boolean isBounded) {
+    final String timerId = "timer";
+    final String timerFamilyId = "timerFamily";
+
+    Schema type =
+        Schema.builder()
+            .addField(Schema.Field.of("f_string", FieldType.STRING))
+            .addField(Schema.Field.of("key", FieldType.STRING))
+            .build();
+
+    Schema outputType =
+        Schema.builder()
+            .addField(Field.of("source", FieldType.STRING))
+            .addField(Field.of("key", FieldType.STRING))
+            .build();
+
+    DoFn<Row, Row> fn =
+        new DoFn<Row, Row>() {
+          final @StateId("foo") StateSpec<ValueState<Integer>> stateSpec = StateSpecs.value();
+          @StateKeyFields private final StateKeySpec keySpec = StateKeySpec.fields("key");
+
+          @ProcessElement
+          public void processElement(
+              @Key Row key,
+              @Key String stringKey,
+              @Key testRowBagStateKeyValue autoValueKey,
+              @Element Row element,
+              OutputReceiver<Row> o) {
+            assertEquals(key.getValue(0), stringKey);
+            assertEquals(stringKey, autoValueKey.getKey());
+            assertEquals(autoValueKey.getKey(), element.getValue("key"));
+            o.output(
+                Row.withSchema(outputType)
+                    .withFieldValue("source", "processElement")
+                    .withFieldValue("key", stringKey)
+                    .build());
+          }
+
+          @OnWindowExpiration
+          public void onWindowExpiration(
+              @Key Row key,
+              @Key String stringKey,
+              @Key testRowBagStateKeyValue autoValueKey,
+              OutputReceiver<Row> o) {
+            assertEquals(key.getValue(0), stringKey);
+            assertEquals(stringKey, autoValueKey.getKey());
+            o.output(
+                Row.withSchema(outputType)
+                    .withFieldValue("source", "onWindowExpiration")
+                    .withFieldValue("key", stringKey)
+                    .build());
+          }
+        };
+
+    TupleTag<Row> mainTag = new TupleTag<>();
+    PCollection<Row> output =
+        pipeline
+            .apply(
+                Create.of(
+                        Row.withSchema(type).addValues("a", "key1").build(),
+                        Row.withSchema(type).addValues("b", "key2").build(),
+                        Row.withSchema(type).addValues("c", "key3").build())
+                    .withRowSchema(type))
+            .apply(ParDo.of(fn).withOutputTags(mainTag, TupleTagList.empty()))
+            .get(mainTag)
+            .setRowSchema(outputType);
+    PAssert.that(output)
+        .containsInAnyOrder(
+            Lists.newArrayList(
+                Row.withSchema(type).addValues("processElement", "key1").build(),
+                Row.withSchema(type).addValues("processElement", "key2").build(),
+                Row.withSchema(type).addValues("processElement", "key3").build(),
+                Row.withSchema(type).addValues("onWindowExpiration", "key1").build(),
+                Row.withSchema(type).addValues("onWindowExpiration", "key2").build(),
+                Row.withSchema(type).addValues("onWindowExpiration", "key3").build()));
+
+    if (!isBounded) {
+      pipeline.getOptions().as(StreamingOptions.class).setStreaming(true);
+    }
+
+    pipeline.run();
+  }
+
+  @Test
+  @Category({
+    ValidatesRunner.class,
+    UsesStatefulParDo.class,
+    UsesTimersInParDo.class,
+  })
+  public void testSchemaKeyProcessTimerBounded() {
+    testSchemaKeyProcessTimer(true);
+  }
+
+  @Test
+  @Category({
+    ValidatesRunner.class,
+    UsesStatefulParDo.class,
+    UsesTimersInParDo.class,
+    UsesUnboundedPCollections.class
+  })
+  public void testSchemaKeyProcessTimerUnbounded() {
+    testSchemaKeyProcessTimer(false);
+  }
+
+  @Test
+  @Category({
+    ValidatesRunner.class,
+    UsesStatefulParDo.class,
+    UsesTimersInParDo.class,
+    UsesTimerMap.class
+  })
+  public void testSchemaKeyProcessTimerFamilyBounded() {
+    testSchemaKeyProcessTimerFamily(true);
+  }
+
+  @Test
+  @Category({
+    ValidatesRunner.class,
+    UsesStatefulParDo.class,
+    UsesTimersInParDo.class,
+    UsesTimerMap.class,
+    UsesUnboundedPCollections.class
+  })
+  public void testSchemaKeyProcessTimerFamilyUnbounded() {
+    testSchemaKeyProcessTimerFamily(false);
+  }
+
+  @Test
+  @Category({ValidatesRunner.class, UsesOnWindowExpiration.class})
+  public void testSchemaKeyOnWindowExpirationBounded() {
+    testSchemaKeyOnWindowExpiration(true);
+    ;
+  }
+
+  @Test
+  @Category({ValidatesRunner.class, UsesOnWindowExpiration.class, UsesUnboundedPCollections.class})
+  public void testSchemaKeyOnWindowExpirationUnbounded() {
+    testSchemaKeyOnWindowExpiration(false);
   }
 
   @DefaultSchema(AutoValueSchema.class)

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoSchemaTest.java
@@ -707,7 +707,7 @@ public class ParDoSchemaTest implements Serializable {
                         Row.withSchema(type).addValues("c", "hello").build(),
                         Row.withSchema(type).addValues("d", "hello").build())
                     .withRowSchema(type))
-            .apply("run statetful fn", ParDo.of(fn).withOutputTags(mainTag, TupleTagList.empty()))
+            .apply("Run statetful fn", ParDo.of(fn).withOutputTags(mainTag, TupleTagList.empty()))
             .get(mainTag)
             .setRowSchema(outputType);
     PAssert.that(output)

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -5916,7 +5916,8 @@ public class ParDoTest implements Serializable {
     public void testKeyInOnTimerWithoutKV() throws Exception {
 
       thrown.expect(IllegalArgumentException.class);
-      thrown.expectMessage("@Key argument is expected to be use with input element of type KV.");
+      thrown.expectMessage(
+          "ParDo requires its input to either use KvCoder or have a schema input in order to use state and timers.");
 
       final String timerId = "foo";
 


### PR DESCRIPTION
When using state/timers on schema PCollection, we want to avoid the need to convert first into a KV object. It's unnecessary, and the fact that KV doesn't have a schema (since KvCoder can't be a SchemaCoder) makes it awkward to use in a schema world.

We introduce a new StateKeyFields annotation that can be used inside a state/timers using DoFn to specify which fields of the input schema should be used as the key. For example, the following DoFn will keep state per user and country pair.

```java
pc.apply(new DoFn<InputT, OutputT>() {
  @StateKeyFields private final StateKeySpec keySpec = StateKeySpec.fields("userId", "location.country")
  final @StateId("state") StateSpec<ValueState<Integer>> stateSpec = StateSpecs.value();

  @ProcessElement
   public static process(@Element InputT input, @Key UserCountry userCountry) {
  }
});
```

Note that the `@Key` parameter annotation can be used to retrieve the current key. Any user type that has a schema matching the selected key can be used as a Key parameter (in the above example, the UserCountry type), and Beam will automatically convert the key to that type. If the key is a singleton field such as a String, you can also pass in the appropriate primitive type. You can also specify the parameter using a Row type; this all parallels the `@Element` parameter, which can also take any matching schema type.

One can also specify the key fields in the ParDo application, e.g. ParDo.of(doFn).withKeyFields("userId", "location.country"). This is useful when programmatically generating pipelines.

The automatic type conversion code already existed in DoFnSchemaInformation, and we simply extended that code to apply to key fields as well. We add a new primitive DoFn - ParDo.MultiOutputSchemaKeyFields - that is used only when key fields are specified. This is not a new primitive from the perspective of the portable model - it is simply a different type of ParDo, and shares the same URN.