### PR TITLE
[BEAM-2791] OrderedListState for Flink

### DIFF
--- a/runners/flink/flink_runner.gradle
+++ b/runners/flink/flink_runner.gradle
@@ -226,7 +226,6 @@ def createValidatesRunnerTask(Map m) {
       excludeCategories 'org.apache.beam.sdk.testing.UsesCommittedMetrics'
       excludeCategories 'org.apache.beam.sdk.testing.UsesSystemMetrics'
       excludeCategories 'org.apache.beam.sdk.testing.UsesStrictTimerOrdering'
-      excludeCategories 'org.apache.beam.sdk.testing.UsesOrderedListState'
       excludeCategories 'org.apache.beam.sdk.testing.UsesLoopingTimer'
       if (config.streaming) {
         excludeCategories 'org.apache.beam.sdk.testing.UsesTimerMap'

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -2844,6 +2844,10 @@ public class ParDoTest implements Serializable {
             }
           };
 
+      if (unbounded) {
+        pipeline.getOptions().as(StreamingOptions.class).setStreaming(true);
+      }
+
       PCollection<Iterable<TimestampedValue<String>>> output =
           pipeline
               .apply(
@@ -2852,7 +2856,6 @@ public class ParDoTest implements Serializable {
                       KV.of("hello", TimestampedValue.of("b", Instant.ofEpochMilli(42))),
                       KV.of("hello", TimestampedValue.of("b", Instant.ofEpochMilli(52))),
                       KV.of("hello", TimestampedValue.of("c", Instant.ofEpochMilli(12)))))
-              .setIsBoundedInternal(unbounded ? IsBounded.UNBOUNDED : IsBounded.BOUNDED)
               .apply(ParDo.of(fn));
 
       List<TimestampedValue<String>> expected =
@@ -2906,6 +2909,10 @@ public class ParDoTest implements Serializable {
             }
           };
 
+      if (unbounded) {
+        pipeline.getOptions().as(StreamingOptions.class).setStreaming(true);
+      }
+
       PCollection<Iterable<TimestampedValue<String>>> output =
           pipeline
               .apply(
@@ -2914,7 +2921,6 @@ public class ParDoTest implements Serializable {
                       KV.of("hello", TimestampedValue.of("b", Instant.ofEpochMilli(42))),
                       KV.of("hello", TimestampedValue.of("b", Instant.ofEpochMilli(52))),
                       KV.of("hello", TimestampedValue.of("c", Instant.ofEpochMilli(12)))))
-              .setIsBoundedInternal(unbounded ? IsBounded.UNBOUNDED : IsBounded.BOUNDED)
               .apply(ParDo.of(fn));
 
       List<TimestampedValue<String>> expected1 = Lists.newArrayList();
@@ -2983,6 +2989,9 @@ public class ParDoTest implements Serializable {
             }
           };
 
+      if (unbounded) {
+        pipeline.getOptions().as(StreamingOptions.class).setStreaming(true);
+      }
       PCollection<Iterable<TimestampedValue<String>>> output =
           pipeline
               .apply(
@@ -2991,7 +3000,6 @@ public class ParDoTest implements Serializable {
                       KV.of("hello", TimestampedValue.of("b", Instant.ofEpochMilli(42))),
                       KV.of("hello", TimestampedValue.of("b", Instant.ofEpochMilli(52))),
                       KV.of("hello", TimestampedValue.of("c", Instant.ofEpochMilli(12)))))
-              .setIsBoundedInternal(unbounded ? IsBounded.UNBOUNDED : IsBounded.BOUNDED)
               .apply(ParDo.of(fn));
 
       List<TimestampedValue<String>> expected =
@@ -6409,7 +6417,6 @@ public class ParDoTest implements Serializable {
               Create.timestamped(
                   // first window
                   TimestampedValue.of(KV.of("hello", 7), new Instant(3)),
-
                   // second window
                   TimestampedValue.of(KV.of("hi", 35), new Instant(13))));
       if (!globalWindow) {


### PR DESCRIPTION
This is the initial implementation for Flink.Since Flink does not natively provide ordered state, this implementation is forced to sort in memory. A more efficient implementation will be possible if Flink provides a native ordered state.