### PR TITLE
Go Quickstart: switch to Spark 3 JobServer for better out-of-box experience using embedded Spark cluster

### DIFF
--- a/website/www/site/content/en/get-started/quickstart-go.md
+++ b/website/www/site/content/en/get-started/quickstart-go.md
@@ -72,7 +72,7 @@ $ wordcount --input gs://dataflow-samples/shakespeare/kinglear.txt \
 {{< runner spark >}}
 # Build and run the Spark job server from Beam source.
 # -PsparkMasterUrl is optional. If it is unset the job will be run inside an embedded Spark cluster.
-$ ./gradlew :runners:spark:2:job-server:runShadow -PsparkMasterUrl=spark://localhost:7077
+$ ./gradlew :runners:spark:3:job-server:runShadow -PsparkMasterUrl=spark://localhost:7077
 
 # In a separate terminal, run:
 $ go install github.com/apache/beam/sdks/go/examples/wordcount


### PR DESCRIPTION
As discussed in https://lists.apache.org/thread/mrrq04nhkfm5j60y4t92bhnjk15t3dts, this change addresses the problem I encountered following the Go Quickstart, where the Spark 2 JobServer seems to not be compatible with the embedded Spark cluster, and produces:
```
2021/11/04 23:07:26  (): java.lang.IllegalArgumentException: Unsupported
class file major version 55
```
This change is to show the reader using the Spark 3 job server instead, to get the intended result.

