### PR TITLE
[BEAM-13434] Pin transitive log4j dependencies to 2.17.0 in :sdks:java:io:hcatalog and :sdks:java:extensions:sql:hcatalog

### DIFF
--- a/sdks/java/extensions/sql/hcatalog/build.gradle
+++ b/sdks/java/extensions/sql/hcatalog/build.gradle
@@ -28,6 +28,20 @@ applyJavaNature(
 def hive_version = "2.1.0"
 def netty_version = "4.1.51.Final"
 
+configurations.all {
+  resolutionStrategy {
+    // Pin log4j as workaround for CVE-2021-44228
+    // HIVE-25804 should address this upstream, but only in 4.0
+    // TODO(BEAM-9351): Upgrade Hive and remove this pin
+    def log4j_version = "2.17.0"
+    force "org.apache.logging.log4j:log4j-api:${log4j_version}"
+    force "org.apache.logging.log4j:log4j-core:${log4j_version}"
+    force "org.apache.logging.log4j:log4j-slf4j-impl:${log4j_version}"
+    force "org.apache.logging.log4j:log4j-1.2-api:${log4j_version}"
+    force "org.apache.logging.log4j:log4j-web:${log4j_version}"
+  }
+}
+
 dependencies {
   provided project(":sdks:java:extensions:sql")
   provided project(":sdks:java:io:hcatalog")

--- a/sdks/java/io/hcatalog/build.gradle
+++ b/sdks/java/io/hcatalog/build.gradle
@@ -41,11 +41,17 @@ test {
   ignoreFailures true
 }
 
-configurations.testRuntimeClasspath {
+configurations.all {
   resolutionStrategy {
-    def log4j_version = "2.16.0"
+    // Pin log4j as workaround for CVE-2021-44228
+    // HIVE-25804 should address this upstream, but only in 4.0
+    // TODO(BEAM-9351): Upgrade Hive and remove this pin
+    def log4j_version = "2.17.0"
     force "org.apache.logging.log4j:log4j-api:${log4j_version}"
     force "org.apache.logging.log4j:log4j-core:${log4j_version}"
+    force "org.apache.logging.log4j:log4j-slf4j-impl:${log4j_version}"
+    force "org.apache.logging.log4j:log4j-1.2-api:${log4j_version}"
+    force "org.apache.logging.log4j:log4j-web:${log4j_version}"
   }
 }
 


### PR DESCRIPTION
Note this doesn't override the transitive dependency, end users can still pull in a vulnerable log4j if they fulfill the provided dependency by adding a hive/hcatalog dependency and they don't pin log4j. This just:
1. Ensures we don't need a vulnerable log4j to build Beam
2. Makes CI verify the artifacts will work with a newer log4j

Tests locally with unit tests, and confirmed that all log4j 2 dependencies are force upgraded via the dependency report:
```
❯ grep -rnw --include=dependencies.txt -e '.*log4j-.*:2.*' sdks/java/extensions/sql/hcatalog sdks/java/io/hcatalog                                                                                                                      
sdks/java/extensions/sql/hcatalog/build/reports/project/dependencies.txt:412:|    |    |    |    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.4.1 -> 2.17.0
sdks/java/extensions/sql/hcatalog/build/reports/project/dependencies.txt:414:|    |    |    |    |    |    \--- org.apache.logging.log4j:log4j-api:2.17.0
sdks/java/extensions/sql/hcatalog/build/reports/project/dependencies.txt:606:|    |    |    +--- org.apache.logging.log4j:log4j-1.2-api:2.4.1 -> 2.17.0
sdks/java/extensions/sql/hcatalog/build/reports/project/dependencies.txt:607:|    |    |    |    \--- org.apache.logging.log4j:log4j-api:2.17.0
sdks/java/extensions/sql/hcatalog/build/reports/project/dependencies.txt:608:|    |    |    +--- org.apache.logging.log4j:log4j-web:2.4.1 -> 2.17.0
sdks/java/extensions/sql/hcatalog/build/reports/project/dependencies.txt:609:|    |    |    |    +--- org.apache.logging.log4j:log4j-api:2.17.0    
sdks/java/extensions/sql/hcatalog/build/reports/project/dependencies.txt:610:|    |    |    |    \--- org.apache.logging.log4j:log4j-core:2.17.0     
sdks/java/extensions/sql/hcatalog/build/reports/project/dependencies.txt:611:|    |    |    |         \--- org.apache.logging.log4j:log4j-api:2.17.0    
sdks/java/extensions/sql/hcatalog/build/reports/project/dependencies.txt:612:|    |    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.4.1 -> 2.17.0 (*)
sdks/java/extensions/sql/hcatalog/build/reports/project/dependencies.txt:870:|    |    |    |    +--- org.apache.logging.log4j:log4j-1.2-api:2.4.1 -> 2.17.0 (*)
sdks/java/extensions/sql/hcatalog/build/reports/project/dependencies.txt:871:|    |    |    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.4.1 -> 2.17.0 (*)
sdks/java/extensions/sql/hcatalog/build/reports/project/dependencies.txt:1157:     |    |    |    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.4.1 -> 2.17.0
sdks/java/extensions/sql/hcatalog/build/reports/project/dependencies.txt:1159:     |    |    |    |    |    +--- org.apache.logging.log4j:log4j-api:2.17.0
sdks/java/extensions/sql/hcatalog/build/reports/project/dependencies.txt:1160:     |    |    |    |    |    \--- org.apache.logging.log4j:log4j-core:2.17.0
sdks/java/extensions/sql/hcatalog/build/reports/project/dependencies.txt:1161:     |    |    |    |    |         \--- org.apache.logging.log4j:log4j-api:2.17.0
sdks/java/extensions/sql/hcatalog/build/reports/project/dependencies.txt:1479:     |    |    +--- org.apache.logging.log4j:log4j-1.2-api:2.4.1 -> 2.17.0
sdks/java/extensions/sql/hcatalog/build/reports/project/dependencies.txt:1480:     |    |    |    \--- org.apache.logging.log4j:log4j-api:2.17.0
sdks/java/extensions/sql/hcatalog/build/reports/project/dependencies.txt:1481:     |    |    +--- org.apache.logging.log4j:log4j-web:2.4.1 -> 2.17.0
sdks/java/extensions/sql/hcatalog/build/reports/project/dependencies.txt:1482:     |    |    |    +--- org.apache.logging.log4j:log4j-api:2.17.0
sdks/java/extensions/sql/hcatalog/build/reports/project/dependencies.txt:1483:     |    |    |    \--- org.apache.logging.log4j:log4j-core:2.17.0 (*)
sdks/java/extensions/sql/hcatalog/build/reports/project/dependencies.txt:1484:     |    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.4.1 -> 2.17.0 (*)
sdks/java/extensions/sql/hcatalog/build/reports/project/dependencies.txt:1696:     |    |    |    +--- org.apache.logging.log4j:log4j-1.2-api:2.4.1 -> 2.17.0 (*)
sdks/java/extensions/sql/hcatalog/build/reports/project/dependencies.txt:1697:     |    |    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.4.1 -> 2.17.0 (*)
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:792:|    |    |    |    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.4.1 -> 2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:794:|    |    |    |    |    |    +--- org.apache.logging.log4j:log4j-api:2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:795:|    |    |    |    |    |    \--- org.apache.logging.log4j:log4j-core:2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:796:|    |    |    |    |    |         \--- org.apache.logging.log4j:log4j-api:2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:980:|    |    |    +--- org.apache.logging.log4j:log4j-1.2-api:2.4.1 -> 2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:981:|    |    |    |    \--- org.apache.logging.log4j:log4j-api:2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:982:|    |    |    +--- org.apache.logging.log4j:log4j-web:2.4.1 -> 2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:983:|    |    |    |    +--- org.apache.logging.log4j:log4j-api:2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:984:|    |    |    |    \--- org.apache.logging.log4j:log4j-core:2.17.0 (*)
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:985:|    |    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.4.1 -> 2.17.0 (*)
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:1043:|    +--- org.apache.logging.log4j:log4j-1.2-api:2.4.1 -> 2.17.0 (*)
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:1044:|    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.4.1 -> 2.17.0 (*)
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:1638:|    |    |    |    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.4.1 -> 2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:1640:|    |    |    |    |    |    \--- org.apache.logging.log4j:log4j-api:2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:1816:|    |    |    +--- org.apache.logging.log4j:log4j-1.2-api:2.4.1 -> 2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:1817:|    |    |    |    \--- org.apache.logging.log4j:log4j-api:2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:1818:|    |    |    +--- org.apache.logging.log4j:log4j-web:2.4.1 -> 2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:1819:|    |    |    |    +--- org.apache.logging.log4j:log4j-api:2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:1820:|    |    |    |    \--- org.apache.logging.log4j:log4j-core:2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:1821:|    |    |    |         \--- org.apache.logging.log4j:log4j-api:2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:1822:|    |    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.4.1 -> 2.17.0 (*)
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:2078:|    |    |    |    +--- org.apache.logging.log4j:log4j-1.2-api:2.4.1 -> 2.17.0 (*)
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:2079:|    |    |    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.4.1 -> 2.17.0 (*)
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:2422:|    |    |    |    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.4.1 -> 2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:2424:|    |    |    |    |    |    +--- org.apache.logging.log4j:log4j-api:2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:2425:|    |    |    |    |    |    \--- org.apache.logging.log4j:log4j-core:2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:2426:|    |    |    |    |    |         \--- org.apache.logging.log4j:log4j-api:2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:2728:|    |    |    +--- org.apache.logging.log4j:log4j-1.2-api:2.4.1 -> 2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:2729:|    |    |    |    \--- org.apache.logging.log4j:log4j-api:2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:2730:|    |    |    +--- org.apache.logging.log4j:log4j-web:2.4.1 -> 2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:2731:|    |    |    |    +--- org.apache.logging.log4j:log4j-api:2.17.0
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:2732:|    |    |    |    \--- org.apache.logging.log4j:log4j-core:2.17.0 (*)
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:2733:|    |    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.4.1 -> 2.17.0 (*)
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:2943:|    |    |    |    +--- org.apache.logging.log4j:log4j-1.2-api:2.4.1 -> 2.17.0 (*)
sdks/java/io/hcatalog/build/reports/project/dependencies.txt:2944:|    |    |    |    +--- org.apache.logging.log4j:log4j-slf4j-impl:2.4.1 -> 2.17.0 (*)
```

`ValidatesRunner` compliance status (on master branch)
--------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>Lang</th>
      <th>ULR</th>
      <th>Dataflow</th>
      <th>Flink</th>
      <th>Samza</th>
      <th>Spark</th>
      <th>Twister2</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Go</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon">
        </a>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Samza/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
    </tr>
    <tr>
      <td>Java</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_ULR/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_ULR/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon?subject=V1">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming/lastCompletedBuild/badge/icon?subject=V1+Streaming">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon?subject=V1+Java+11">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/badge/icon?subject=V2">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2_Streaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2_Streaming/lastCompletedBuild/badge/icon?subject=V2+Streaming">
        </a><br>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon?subject=Java+8">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon?subject=Java+11">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon?subject=Portable">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon?subject=Portable+Streaming">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Samza/lastCompletedBuild/badge/icon?subject=Portable">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon?subject=Portable">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon?subject=Structured+Streaming">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon">
        </a>
      </td>
    </tr>
    <tr>
      <td>Python</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon?subject=V1">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon?subject=V2">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon?subject=ValCont">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon?subject=Portable">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Samza/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
    </tr>
    <tr>
      <td>XLang</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Samza/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
    </tr>
  </tbody>
</table>

Examples testing status on various runners
--------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>Lang</th>
      <th>ULR</th>
      <th>Dataflow</th>
      <th>Flink</th>
      <th>Samza</th>
      <th>Spark</th>
      <th>Twister2</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Go</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
    <tr>
      <td>Java</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Cron/lastCompletedBuild/badge/icon?subject=V1">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Java11_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Java11_Cron/lastCompletedBuild/badge/icon?subject=V1+Java11">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_Examples_Dataflow_V2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_Examples_Dataflow_V2/lastCompletedBuild/badge/icon?subject=V2">
        </a><br>
      </td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
    <tr>
      <td>Python</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
    <tr>
      <td>XLang</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
  </tbody>
</table>

Post-Commit SDK/Transform Integration Tests Status (on master branch)
------------------------------------------------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>Go</th>
      <th>Java</th>
      <th>Python</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon?subject=3.6">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon?subject=3.7">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon?subject=3.8">
        </a>
      </td>
    </tr>
  </tbody>
</table>

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>---</th>
      <th>Java</th>
      <th>Python</th>
      <th>Go</th>
      <th>Website</th>
      <th>Whitespace</th>
      <th>Typescript</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Non-portable</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon">
        </a><br>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon?subject=Tests">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon?subject=Lint">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon?subject=Docker">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon?subject=Docs">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
    </tr>
    <tr>
      <td>Portable</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_GoPortable_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_GoPortable_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
  </tbody>
</table>

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
