### PR TITLE
Update venv creation commands in release scripts.

### DIFF
--- a/.test-infra/jenkins/dependency_check/generate_report.sh
+++ b/.test-infra/jenkins/dependency_check/generate_report.sh
@@ -44,10 +44,9 @@ REPORT_DESCRIPTION="
 # Virtualenv for the rest of the script to run setup
 $PYTHON -m venv dependency/check
 
-. dependency/check/bin/activate
-pip install --upgrade google-cloud-bigquery
-pip install --upgrade google-cloud-bigtable
-pip install --upgrade google-cloud-core
+. ./dependency/check/bin/activate
+pip install --upgrade pip setuptools wheel
+pip install --upgrade google-cloud-bigquery google-cloud-bigtable google-cloud-core
 rm -f build/dependencyUpdates/beam-dependency-check-report.txt
 
 # Insall packages and run the unit tests of the report generator and the jira manager

--- a/.test-infra/jenkins/job_00_seed.groovy
+++ b/.test-infra/jenkins/job_00_seed.groovy
@@ -108,7 +108,8 @@ job('beam_SeedJob') {
       command("""
         ( cd .test-infra/jenkins/committers_list_generator &&
         python3.8 -m venv ve3 && source ve3/bin/activate &&
-        pip install -r requirements.txt &&
+        pip install --retries 10 --upgrade pip setuptools wheel &&
+        pip install --retries 10 -r requirements.txt &&
         python main.py -o .. &&
         deactivate ) ||
         { echo "ERROR: Failed to fetch committers"; exit 3; }

--- a/.test-infra/jenkins/job_seed_standalone.groovy
+++ b/.test-infra/jenkins/job_seed_standalone.groovy
@@ -107,8 +107,9 @@ job('beam_SeedJob_Standalone') {
     shell {
       command("""
         ( cd .test-infra/jenkins/committers_list_generator &&
-        python3.8 -m venv ve3 && source ve3/bin/activate &&
-        pip install -r requirements.txt &&
+        python3.8 -m venv ve3 && source ./ve3/bin/activate &&
+        pip install --retries 10 --upgrade pip setuptools wheel &&
+        pip install --retries 10 -r requirements.txt &&
         python main.py -o .. &&
         deactivate ) ||
         { echo "ERROR: Failed to fetch committers"; exit 3; }

--- a/release/src/main/python-release/python_release_automation_utils.sh
+++ b/release/src/main/python-release/python_release_automation_utils.sh
@@ -161,7 +161,8 @@ function install_sdk() {
   gsutil version -l
   rm -rf ./temp_virtualenv_${2}
   $2 -m venv temp_virtualenv_${2}
-  . temp_virtualenv_${2}/bin/activate
+  . ./temp_virtualenv_${2}/bin/activate
+  pip install --upgrade pip setuptools wheel
   gcloud_version=$(gcloud --version | head -1 | awk '{print $4}')
   if [[ "$gcloud_version" < "189" ]]; then
     update_gcloud

--- a/release/src/main/scripts/build_release_candidate.sh
+++ b/release/src/main/scripts/build_release_candidate.sh
@@ -271,7 +271,7 @@ if [[ $confirmation = "y" ]]; then
   echo '-------------------Creating Python Virtualenv-----------------'
   python3 -m venv "${LOCAL_PYTHON_VIRTUALENV}"
   source "${LOCAL_PYTHON_VIRTUALENV}/bin/activate"
-  pip install -U pip
+  pip install --upgrade pip setuptools wheel
   pip install requests python-dateutil
 
   echo '--------------Fetching GitHub Actions Artifacts--------------'
@@ -356,6 +356,7 @@ if [[ $confirmation = "y" ]]; then
   echo "------------------Building Python Doc------------------------"
   python3 -m venv "${LOCAL_PYTHON_VIRTUALENV}"
   source "${LOCAL_PYTHON_VIRTUALENV}/bin/activate"
+  pip install --upgrade pip setuptools wheel
   cd ${LOCAL_PYTHON_DOC}
   pip install -U pip
   pip install tox

--- a/release/src/main/scripts/deploy_pypi.sh
+++ b/release/src/main/scripts/deploy_pypi.sh
@@ -43,6 +43,7 @@ cd ${LOCAL_CLONE_DIR}
 
 python3 -m venv deploy_pypi_env
 source ./deploy_pypi_env/bin/activate
+pip install --upgrade pip setuptools wheel
 pip install twine
 
 wget -r --no-parent -A zip,whl "https://dist.apache.org/repos/dist/dev/beam/${RELEASE}/python"

--- a/release/src/main/scripts/deploy_release_candidate_pypi.sh
+++ b/release/src/main/scripts/deploy_release_candidate_pypi.sh
@@ -129,7 +129,7 @@ echo "================Download python artifacts======================"
 PYTHON_ARTIFACTS_DIR="${LOCAL_CLONE_DIR_ROOT}/python"
 python3 -m venv deploy_pypi_env
 source ./deploy_pypi_env/bin/activate
-pip install -U pip
+pip install --upgrade pip setuptools wheel
 pip install requests python-dateutil
 python3 "${SCRIPT_DIR}/download_github_actions_artifacts.py" \
   --github-user "${USER_GITHUB_ID}" \

--- a/runners/portability/test_flink_uber_jar.sh
+++ b/runners/portability/test_flink_uber_jar.sh
@@ -82,6 +82,7 @@ docker images --format "{{.Repository}}:{{.Tag}}" | grep "$PYTHON_CONTAINER_IMAG
 # Set up Python environment
 python$PYTHON_VERSION -m venv "$ENV_DIR"
 . $ENV_DIR/bin/activate
+pip install --retries 10 --upgrade pip setuptools wheel
 pip install --retries 10 -e "$PYTHON_ROOT_DIR"
 
 # Hacky python script to find a free port. Note there is a small chance the chosen port could

--- a/runners/portability/test_pipeline_jar.sh
+++ b/runners/portability/test_pipeline_jar.sh
@@ -74,6 +74,7 @@ docker images --format "{{.Repository}}:{{.Tag}}" | grep $PYTHON_CONTAINER_IMAGE
 # Set up Python environment
 python$PYTHON_VERSION -m venv $ENV_DIR
 . $ENV_DIR/bin/activate
+pip install --retries 10 --upgrade pip setuptools wheel
 pip install --retries 10 -e $PYTHON_ROOT_DIR
 
 PIPELINE_PY="

--- a/sdks/java/container/license_scripts/license_script.sh
+++ b/sdks/java/container/license_scripts/license_script.sh
@@ -41,9 +41,10 @@ mkdir -p "$DOWNLOAD_DIR"
 cp -r "${EXISTING_LICENSE_DIR}"/*.jar "${DOWNLOAD_DIR}"
 
 $PYTHON -m venv ${ENV_DIR} && . ${ENV_DIR}/bin/activate
+pip install --retries 10 --upgrade pip setuptools wheel
 
 # install packages
-${ENV_DIR}/bin/pip install -r ${SCRIPT_DIR}/requirement.txt
+pip install --retries 10 -r ${SCRIPT_DIR}/requirement.txt
 
 # pull licenses, notices and source code
 FLAGS="--license_index=${INDEX_FILE} \

--- a/sdks/python/apache_beam/examples/kafkataxi/README.md
+++ b/sdks/python/apache_beam/examples/kafkataxi/README.md
@@ -149,8 +149,9 @@ instructions regarding setting up other types of Python virtual environments.
 
 ```sh
 cd ..  # Creating the virtual environment in the top level work directory.
-python -m venv env
-source env/bin/activate
+python3 -m venv env
+source ./env/bin/activate
+pip install --upgrade pip setuptools wheel
 ```
 
 Install Beam and dependencies and build a Beam distribution.

--- a/sdks/python/apache_beam/runners/interactive/README.md
+++ b/sdks/python/apache_beam/runners/interactive/README.md
@@ -84,24 +84,13 @@ a quick reference). For a more general and complete getting started guide, see
 *   Install [GraphViz](https://www.graphviz.org/download/) with your favorite
     system package manager.
 
--   Install [JupyterLab](https://jupyter.org/install.html). You can use
-    either **conda** or **pip**.
-
-    * conda
-        ```bash
-        conda install -c conda-forge jupyterlab
-        ```
-    * pip
-        ```bash
-        pip install jupyterlab
-        ```
-
--   Install, create and activate your [venv](https://docs.python.org/3/library/venv.html).
+*   Install, create and activate your [venv](https://docs.python.org/3/library/venv.html).
     (optional but recommended)
 
     ```bash
     python3 -m venv /path/to/beam_venv_dir
     source /path/to/beam_venv_dir/bin/activate
+    pip install --upgrade pip setuptools wheel
     ```
 
     If you are using shells other than bash (e.g. fish, csh), check
@@ -114,6 +103,18 @@ a quick reference). For a more general and complete getting started guide, see
     which python  # This sould point to beam_venv_dir/bin/python
     ```
 
+*   Install [JupyterLab](https://jupyter.org/install.html). You can use
+    either **conda** or **pip**.
+
+    * conda
+        ```bash
+        conda install -c conda-forge jupyterlab
+        ```
+    * pip
+        ```bash
+        pip install jupyterlab
+        ```
+
 *   Set up Apache Beam Python. **Make sure the virtual environment is activated
     when you run `setup.py`**
 
@@ -123,7 +124,7 @@ a quick reference). For a more general and complete getting started guide, see
     python setup.py install
     ```
 
--   Install an IPython kernel for the virtual environment you've just created.
+*   Install an IPython kernel for the virtual environment you've just created.
     **Make sure the virtual environment is activate when you do this.** You can
     skip this step if not using venv.
 
@@ -139,7 +140,7 @@ a quick reference). For a more general and complete getting started guide, see
     jupyter kernelspec list
     ```
 
--   Extend JupyterLab through labextension. **Note**: labextension is different from nbextension
+*   Extend JupyterLab through labextension. **Note**: labextension is different from nbextension
     from pre-lab jupyter notebooks.
 
     All jupyter labextensions need nodejs

--- a/sdks/python/container/run_generate_requirements.sh
+++ b/sdks/python/container/run_generate_requirements.sh
@@ -55,8 +55,7 @@ ENV_PATH="$PWD/build/python${PY_VERSION/./}_requirements_gen"
 rm -rf $ENV_PATH 2>/dev/null || true
 python${PY_VERSION} -m venv $ENV_PATH
 source $ENV_PATH/bin/activate
-pip install --upgrade pip
-pip install wheel
+pip install --upgrade pip setuptools wheel
 
 # Install gcp extra deps since these deps are commonly used with Apache Beam.
 # Install dataframe deps to add have Dataframe support in released images.

--- a/website/www/site/content/en/contribute/release-guide.md
+++ b/website/www/site/content/en/contribute/release-guide.md
@@ -369,24 +369,8 @@ There are some projects that don't produce the artifacts, e.g. `beam-test-tools`
 To triage the failures and narrow things down you may want to look at `settings.gradle.kts` and run the build only for the projects you're interested at the moment, e.g. `./gradlew :runners:java-fn-execution`.
 
 #### (Alternative) Run release build manually (locally)
-* **Pre-installation for python build**
-  1. Install pip
-
-      ```
-      curl https://bootstrap.pypa.io/get-pip.py -o get-pip.py
-      python get-pip.py
-      ```
-  1. Cython
-
-      ```
-      sudo pip install cython
-      sudo apt-get install gcc
-      sudo apt-get install python-dev
-      sudo apt-get install python3-dev
-      sudo apt-get install python3.5-dev
-      sudo apt-get install python3.6-dev
-      sudo apt-get install python3.7-dev
-      ```
+You will need to have Python interpreters for all supported Python minor
+versions to run Python tests. See Python installation tips in [Developer Wiki](https://cwiki.apache.org/confluence/display/BEAM/Python+Tips#PythonTips-InstallingPythoninterpreters).
 
 * **Run gradle release build**
 
@@ -934,10 +918,9 @@ _Note_: -Prepourl and -Pver can be found in the RC vote email sent by Release Ma
   * **Setup virtual environment**
 
     ```
-    pip install --upgrade pip
-    pip install --upgrade setuptools
-    python -m venv beam_env
-     . beam_env/bin/activate
+    python3 -m venv beam_env
+    . ./beam_env/bin/activate
+    pip install --upgrade pip setuptools wheel
     ```
   * **Install SDK**
 

--- a/website/www/site/content/en/documentation/sdks/python-dependencies.md
+++ b/website/www/site/content/en/documentation/sdks/python-dependencies.md
@@ -44,7 +44,7 @@ You can also retrieve the dependency list from the command line using the follow
 1.  Create a clean virtual environment on your local machine using a supported python version.
 
     ```
-    $ python -m venv env && source env/bin/activate
+    $ python3 -m venv env && source ./env/bin/activate && pip install --upgrade pip setuptools wheel
     ```
 
 2. [Install the Beam Python SDK](/get-started/quickstart-py/#download-and-install).


### PR DESCRIPTION
Changes:

- Prepend venv dir path with ./ where applicable when sourcing activation script (sourcing silently failed for me on some Ubuntu versions without this) 
- Install `wheel` when we create venv (necessary follow up for https://github.com/apache/beam/pull/15819), otherwise Beam fails to install from sources. BEAM-8954 would be a cleaner solution.)
- Misc wording updates & corrections in release guide.
- Driveby fixes for similar changes outside of release scripts.
- Another drive-by fix: Retry pip installs in scripts that might be running periodically on Jenkins to reduce flakiness.