### PR TITLE
[BEAM-13617] don't close streams in finalize

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
@@ -173,17 +173,6 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
         this.useDefaultStream = useDefaultStream;
       }
 
-      void close() {
-        if (streamAppendClient != null) {
-          try {
-            streamAppendClient.close();
-            streamAppendClient = null;
-          } catch (Exception e) {
-            throw new RuntimeException(e);
-          }
-        }
-      }
-
       String getDefaultStreamName() {
         return BigQueryHelpers.stripPartitionDecorator(tableUrn) + "/streams/_default";
       }
@@ -403,9 +392,6 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
 
     @Teardown
     public void teardown() {
-      for (DestinationState state : destinations.values()) {
-        state.close();
-      }
       destinations.clear();
       try {
         if (datasetService != null) {


### PR DESCRIPTION
The stream is stored in a static cache, so closing it in finalize results in use of a closed stream. The cache itself should close the stream.