### PR TITLE
Loosen typing extensions bound

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -152,7 +152,7 @@ REQUIRED_PACKAGES = [
     'python-dateutil>=2.8.0,<3',
     'pytz>=2018.3',
     'requests>=2.24.0,<3.0.0',
-    'typing-extensions>=3.7.0,<4',
+    'typing-extensions>=3.7.0',
 ]
 
 # [BEAM-8181] pyarrow cannot be installed on 32-bit Windows platforms.


### PR DESCRIPTION
Follow up to this [pr](https://github.com/apache/beam/pull/15233). A couple months ago we loosen typing extensions to any typing extensions <4. Well, typing extensions release a version 4 that is backwards compatible with 3 as they no longer want to follow python versions. The old versioning of typing extensions was based on python version (3.10 meant python 3.10 features). So we should support version 4 at least.

Typing extensions is about to release a version 5 too. The only backwards incompatible change is typing extensions version 5 drops support for 3.6 now that it is end of life. That should be safe as someone using 3.6 will automatically pick version 4 at most due to [python_requires](https://github.com/python/typing/blob/dea3e3eefb92748559fb8e2202f3e2d70a8d8517/typing_extensions/pyproject.toml#L25) line in typing extensions. I think backwards incompatible typing-extensions change except for EOL python is very unlikely as it would break typeshed/typing ecosystem. So I do not think beam needs to upper bound typing extensions. beam is only package out of 100s I depend on that upper bounds typing-extensions. 

The upper bound is currently blocking some usage of newer type features (pep [655](https://www.python.org/dev/peps/pep-0655/) requires typing extensions 4). I expect tensorflow/pytorch/numpy to all want to use TypeVarTuple in the near future because it allows proper tensor shape typing. That will be feature of typing extensions 5 in the near future.

@chadrik @udim @tvalentyn 