### PR TITLE
[BEAM-13534] Add automated port polling to expansion service runner if port isn't provided

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/process.go
+++ b/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/process.go
@@ -61,7 +61,7 @@ func (e *ExpansionServiceRunner) String() string {
 // GetPort returns the formatted port the ExpansionServiceRunner is set to start the expansion
 // service on.
 func (e *ExpansionServiceRunner) GetPort() string {
-	return e.servicePort
+	return "localhost:" + e.servicePort
 }
 
 // StartService starts the expansion service for a given ExpansionServiceRunner. If this is

--- a/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/process.go
+++ b/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/process.go
@@ -59,8 +59,8 @@ func (e *ExpansionServiceRunner) String() string {
 	return fmt.Sprintf("JAR: %v, Port: %v, Process: %v", e.jarPath, e.servicePort, e.serviceCommand.Process)
 }
 
-// GetPort returns the formatted port the ExpansionServiceRunner is set to start the expansion
-// service on.
+// Endpoint returns the formatted endpoint the ExpansionServiceRunner is set to start the expansion
+// service on. 
 func (e *ExpansionServiceRunner) Endpoint() string {
 	return "localhost:" + e.servicePort
 }

--- a/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/process.go
+++ b/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/process.go
@@ -17,6 +17,7 @@ package expansionx
 
 import (
 	"fmt"
+	"net"
 	"os/exec"
 	"time"
 )
@@ -30,18 +31,37 @@ type ExpansionServiceRunner struct {
 	serviceCommand *exec.Cmd
 }
 
+func findOpenPort() (int, error) {
+	listener, err := net.Listen("tcp", ":0")
+	if err != nil {
+		return 0, err
+	}
+	defer listener.Close()
+	return listener.Addr().(*net.TCPAddr).Port, nil
+}
+
 // NewExpansionServiceRunner builds an ExpansionServiceRunner struct for a given gradle target and
 // Beam version and returns a pointer to it.
-func NewExpansionServiceRunner(jarPath, servicePort string) *ExpansionServiceRunner {
+func NewExpansionServiceRunner(jarPath, servicePort string) (*ExpansionServiceRunner, error) {
 	if servicePort == "" {
-		servicePort = "8097"
+		port, err := findOpenPort()
+		if err != nil {
+			return nil, fmt.Errorf("failed to find open port for service, got %v", err)
+		}
+		servicePort = fmt.Sprintf("%d", port)
 	}
 	serviceCommand := exec.Command("java", "-jar", jarPath, servicePort)
-	return &ExpansionServiceRunner{jarPath: jarPath, servicePort: servicePort, serviceCommand: serviceCommand}
+	return &ExpansionServiceRunner{jarPath: jarPath, servicePort: servicePort, serviceCommand: serviceCommand}, nil
 }
 
 func (e *ExpansionServiceRunner) String() string {
 	return fmt.Sprintf("JAR: %v, Port: %v, Process: %v", e.jarPath, e.servicePort, e.serviceCommand.Process)
+}
+
+// GetPort returns the formatted port the ExpansionServiceRunner is set to start the expansion
+// service on.
+func (e *ExpansionServiceRunner) GetPort() string {
+	return e.servicePort
 }
 
 // StartService starts the expansion service for a given ExpansionServiceRunner. If this is

--- a/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/process.go
+++ b/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/process.go
@@ -41,7 +41,8 @@ func findOpenPort() (int, error) {
 }
 
 // NewExpansionServiceRunner builds an ExpansionServiceRunner struct for a given gradle target and
-// Beam version and returns a pointer to it.
+// Beam version and returns a pointer to it. Passing an empty string as servicePort will request an
+// open port to be assigned to the service.
 func NewExpansionServiceRunner(jarPath, servicePort string) (*ExpansionServiceRunner, error) {
 	if servicePort == "" {
 		port, err := findOpenPort()
@@ -60,7 +61,7 @@ func (e *ExpansionServiceRunner) String() string {
 
 // GetPort returns the formatted port the ExpansionServiceRunner is set to start the expansion
 // service on.
-func (e *ExpansionServiceRunner) GetPort() string {
+func (e *ExpansionServiceRunner) Endpoint() string {
 	return "localhost:" + e.servicePort
 }
 

--- a/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/process_test.go
+++ b/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/process_test.go
@@ -25,7 +25,7 @@ import (
 func TestFindOpenPort(t *testing.T) {
 	port, err := findOpenPort()
 	if err != nil {
-		t.Fatalf("failed to find open port, got %v", port)
+		t.Fatalf("failed to find open port, got %v", err)
 	}
 	if port < 1 || port > 65535 {
 		t.Errorf("port out of TCP range [1, 66535], got %d", port)
@@ -39,11 +39,11 @@ func TestNewExpansionServiceRunner(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExpansionServiceRunner failed, got %v", err)
 	}
-	if serviceRunner.jarPath != testPath {
-		t.Errorf("JAR path mismatch: wanted %v, got %v", testPath, serviceRunner.jarPath)
+	if got, want := serviceRunner.jarPath, testPath; got != want {
+		t.Errorf("got JAR path %v, want %v", got, want)
 	}
-	if serviceRunner.servicePort != testPort {
-		t.Errorf("service port mismatch: wanted %v, got %v", testPort, testPort)
+	if got, want := serviceRunner.servicePort, testPort; got != want {
+		t.Errorf("got service port %v, want %v", got, want)
 	}
 	commandString := strings.Join(serviceRunner.serviceCommand.Args, " ")
 	if !strings.Contains(commandString, "java") {
@@ -57,16 +57,15 @@ func TestNewExpansionServiceRunner(t *testing.T) {
 	}
 }
 
-func TestGetPort(t *testing.T) {
+func TestEndpoint(t *testing.T) {
 	testPort := "8097"
 	serviceRunner, err := NewExpansionServiceRunner("", testPort)
 	if err != nil {
 		t.Fatalf("NewExpansionServiceRunner failed, got %v", err)
 	}
-	observedPort := serviceRunner.GetPort()
 	expPort := "localhost:" + testPort
-	if observedPort != expPort {
-		t.Errorf("GetPort() returned mismatched value: wanted %v, got %v", observedPort, expPort)
+	if got, want := serviceRunner.Endpoint(), expPort; got != want {
+		t.Errorf("got port %v, want %v", got, want)
 	}
 }
 

--- a/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/process_test.go
+++ b/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/process_test.go
@@ -63,8 +63,8 @@ func TestEndpoint(t *testing.T) {
 	if err != nil {
 		t.Fatalf("NewExpansionServiceRunner failed, got %v", err)
 	}
-	expPort := "localhost:" + testPort
-	if got, want := serviceRunner.Endpoint(), expPort; got != want {
+	want := "localhost:" + testPort
+	if got := serviceRunner.Endpoint(); got != want {
 		t.Errorf("got port %v, want %v", got, want)
 	}
 }

--- a/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/process_test.go
+++ b/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/process_test.go
@@ -43,7 +43,7 @@ func TestNewExpansionServiceRunner(t *testing.T) {
 		t.Errorf("JAR path mismatch: wanted %v, got %v", testPath, serviceRunner.jarPath)
 	}
 	if serviceRunner.servicePort != testPort {
-		t.Errorf("service port mismatch: wanted %v, got %v", testPort, serviceRunner.servicePort)
+		t.Errorf("service port mismatch: wanted %v, got %v", testPort, testPort)
 	}
 	commandString := strings.Join(serviceRunner.serviceCommand.Args, " ")
 	if !strings.Contains(commandString, "java") {
@@ -64,8 +64,9 @@ func TestGetPort(t *testing.T) {
 		t.Fatalf("NewExpansionServiceRunner failed, got %v", err)
 	}
 	observedPort := serviceRunner.GetPort()
-	if observedPort != testPort {
-		t.Errorf("GetPort() returned mismatched value: wanted %v, got %v", observedPort, testPort)
+	expPort := "localhost:" + testPort
+	if observedPort != expPort {
+		t.Errorf("GetPort() returned mismatched value: wanted %v, got %v", observedPort, expPort)
 	}
 }
 

--- a/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/process_test.go
+++ b/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/process_test.go
@@ -22,10 +22,23 @@ import (
 	"testing"
 )
 
+func TestFindOpenPort(t *testing.T) {
+	port, err := findOpenPort()
+	if err != nil {
+		t.Fatalf("failed to find open port, got %v", port)
+	}
+	if port < 1 || port > 65535 {
+		t.Errorf("port out of TCP range [1, 66535], got %d", port)
+	}
+}
+
 func TestNewExpansionServiceRunner(t *testing.T) {
 	testPath := "path/to/jar"
 	testPort := "8097"
-	serviceRunner := NewExpansionServiceRunner(testPath, testPort)
+	serviceRunner, err := NewExpansionServiceRunner(testPath, testPort)
+	if err != nil {
+		t.Fatalf("NewExpansionServiceRunner failed, got %v", err)
+	}
 	if serviceRunner.jarPath != testPath {
 		t.Errorf("JAR path mismatch: wanted %v, got %v", testPath, serviceRunner.jarPath)
 	}
@@ -44,19 +57,37 @@ func TestNewExpansionServiceRunner(t *testing.T) {
 	}
 }
 
+func TestGetPort(t *testing.T) {
+	testPort := "8097"
+	serviceRunner, err := NewExpansionServiceRunner("", testPort)
+	if err != nil {
+		t.Fatalf("NewExpansionServiceRunner failed, got %v", err)
+	}
+	observedPort := serviceRunner.GetPort()
+	if observedPort != testPort {
+		t.Errorf("GetPort() returned mismatched value: wanted %v, got %v", observedPort, testPort)
+	}
+}
+
 func TestStartService_badCommand(t *testing.T) {
-	serviceRunner := NewExpansionServiceRunner("", "")
+	serviceRunner, err := NewExpansionServiceRunner("", "")
+	if err != nil {
+		t.Fatalf("NewExpansionServiceRunner failed, got %v", err)
+	}
 	serviceRunner.serviceCommand = exec.Command("jahva", "-jar")
-	err := serviceRunner.StartService()
+	err = serviceRunner.StartService()
 	if err == nil {
 		t.Error("StartService succeeded when it should have failed")
 	}
 }
 
 func TestStartService_good(t *testing.T) {
-	serviceRunner := NewExpansionServiceRunner("", "")
+	serviceRunner, err := NewExpansionServiceRunner("", "")
+	if err != nil {
+		t.Fatalf("NewExpansionServiceRunner failed, got %v", err)
+	}
 	serviceRunner.serviceCommand = exec.Command("which", "go")
-	err := serviceRunner.StartService()
+	err = serviceRunner.StartService()
 	if err != nil {
 		t.Errorf("StartService failed when it should have succeeded, got %v", err)
 	}

--- a/sdks/go/test/integration/xlang/expansion_test.go
+++ b/sdks/go/test/integration/xlang/expansion_test.go
@@ -42,7 +42,10 @@ func TestAutomatedExpansionService(t *testing.T) {
 	}
 	t.Cleanup(func() { os.Remove(jarPath) })
 
-	serviceRunner := expansionx.NewExpansionServiceRunner(jarPath, "")
+	serviceRunner, err := expansionx.NewExpansionServiceRunner(jarPath, "")
+	if err != nil {
+		t.Fatalf("failed to make new expansion service runner, got %v", err)
+	}
 	err = serviceRunner.StartService()
 	if err != nil {
 		t.Errorf("failed to start expansion service JAR, got %v", err)

--- a/sdks/go/test/integration/xlang/expansion_test.go
+++ b/sdks/go/test/integration/xlang/expansion_test.go
@@ -34,7 +34,6 @@ const (
 )
 
 func TestAutomatedExpansionService(t *testing.T) {
-	t.Skip("disabled in google3")
 	integration.CheckFilters(t)
 	jarPath, err := expansionx.GetBeamJar(gradleTarget, beamVersion)
 	if err != nil {
@@ -53,9 +52,9 @@ func TestAutomatedExpansionService(t *testing.T) {
 
 	ctx, canFunc := context.WithTimeout(context.Background(), 15*time.Second)
 	t.Cleanup(func() { canFunc() })
-	conn, err := grpc.DialContext(ctx, serviceRunner.GetPort(), grpc.WithInsecure(), grpc.WithBlock())
+	conn, err := grpc.DialContext(ctx, serviceRunner.Endpoint(), grpc.WithInsecure(), grpc.WithBlock())
 	if err != nil {
-		t.Fatalf("could not connect to port %v, got %v", serviceRunner.GetPort(), err)
+		t.Fatalf("could not connect to endpoint %v, got %v", serviceRunner.Endpoint(), err)
 	}
 	conn.Close()
 

--- a/sdks/go/test/integration/xlang/expansion_test.go
+++ b/sdks/go/test/integration/xlang/expansion_test.go
@@ -27,12 +27,28 @@ import (
 )
 
 const (
-	// TODO(BEAN-13505): Select the most recent Beam release instead of a hard-coded
+	// TODO(BEAM-13505): Select the most recent Beam release instead of a hard-coded
 	// string.
-	beamVersion   = "2.34.0"
-	gradleTarget  = ":sdks:java:io:expansion-service:runExpansionService"
-	expansionPort = "8097"
+	beamVersion  = "2.34.0"
+	gradleTarget = ":sdks:java:io:expansion-service:runExpansionService"
 )
+
+func checkPort(t *testing.T, port string, duration time.Duration) {
+	var outputStr string
+	for i := 0.0; i < duration.Seconds(); i += 0.5 {
+		ping := exec.Command("nc", "-vz", "localhost", port)
+		output, err := ping.CombinedOutput()
+		if err != nil {
+			t.Fatalf("failed to run ping to port, got %v", err)
+		}
+		outputStr = string(output)
+		if !strings.Contains(outputStr, "failed") {
+			return
+		}
+		time.Sleep(500 * time.Millisecond)
+	}
+	t.Errorf("Failed to connect to expansion service after %f seconds", duration.Seconds())
+}
 
 func TestAutomatedExpansionService(t *testing.T) {
 	integration.CheckFilters(t)
@@ -42,19 +58,16 @@ func TestAutomatedExpansionService(t *testing.T) {
 	}
 	t.Cleanup(func() { os.Remove(jarPath) })
 
-	serviceRunner := expansionx.NewExpansionServiceRunner(jarPath, expansionPort)
+	serviceRunner, err := expansionx.NewExpansionServiceRunner(jarPath, "")
+	if err != nil {
+		t.Fatalf("failed to get new expansion service runner, got %v", err)
+	}
 	err = serviceRunner.StartService()
 	if err != nil {
 		t.Errorf("failed to start expansion service JAR, got %v", err)
 	}
 
-	ctx, canFunc := context.WithTimeout(context.Background(), 15*time.Second)
-	t.Cleanup(func() { canFunc() })
-	conn, err := grpc.DialContext(ctx, "localhost:"+expansionPort, grpc.WithInsecure(), grpc.WithBlock())
-	if err != nil {
-		t.Fatalf("could not connect to port %v, got %v", expansionPort, err)
-	}
-	conn.Close()
+	checkPort(t, serviceRunner.GetPort(), 15*time.Second)
 
 	err = serviceRunner.StopService()
 	if err != nil {


### PR DESCRIPTION
Adds automated TCP port selection for the expansion service runner if a port isn't specified rather than defaulting to `localhost:8097`. Also updates relevant unit tests and integration test.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

`ValidatesRunner` compliance status (on master branch)
--------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>Lang</th>
      <th>ULR</th>
      <th>Dataflow</th>
      <th>Flink</th>
      <th>Samza</th>
      <th>Spark</th>
      <th>Twister2</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Go</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon">
        </a>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Samza/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
    </tr>
    <tr>
      <td>Java</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_ULR/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_ULR/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon?subject=V1">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming/lastCompletedBuild/badge/icon?subject=V1+Streaming">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon?subject=V1+Java+11">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/badge/icon?subject=V2">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2_Streaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2_Streaming/lastCompletedBuild/badge/icon?subject=V2+Streaming">
        </a><br>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon?subject=Java+8">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon?subject=Java+11">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon?subject=Portable">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon?subject=Portable+Streaming">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Samza/lastCompletedBuild/badge/icon?subject=Portable">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon?subject=Portable">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon?subject=Structured+Streaming">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon">
        </a>
      </td>
    </tr>
    <tr>
      <td>Python</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon?subject=V1">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon?subject=V2">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon?subject=ValCont">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon?subject=Portable">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Samza/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
    </tr>
    <tr>
      <td>XLang</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Samza/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
    </tr>
  </tbody>
</table>

Examples testing status on various runners
--------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>Lang</th>
      <th>ULR</th>
      <th>Dataflow</th>
      <th>Flink</th>
      <th>Samza</th>
      <th>Spark</th>
      <th>Twister2</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Go</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
    <tr>
      <td>Java</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Cron/lastCompletedBuild/badge/icon?subject=V1">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Java11_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Java11_Cron/lastCompletedBuild/badge/icon?subject=V1+Java11">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_Examples_Dataflow_V2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_Examples_Dataflow_V2/lastCompletedBuild/badge/icon?subject=V2">
        </a><br>
      </td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
    <tr>
      <td>Python</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
    <tr>
      <td>XLang</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
  </tbody>
</table>

Post-Commit SDK/Transform Integration Tests Status (on master branch)
------------------------------------------------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>Go</th>
      <th>Java</th>
      <th>Python</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon?subject=3.6">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon?subject=3.7">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon?subject=3.8">
        </a>
      </td>
    </tr>
  </tbody>
</table>

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>---</th>
      <th>Java</th>
      <th>Python</th>
      <th>Go</th>
      <th>Website</th>
      <th>Whitespace</th>
      <th>Typescript</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Non-portable</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon">
        </a><br>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon?subject=Tests">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon?subject=Lint">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon?subject=Docker">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon?subject=Docs">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
    </tr>
    <tr>
      <td>Portable</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_GoPortable_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_GoPortable_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
  </tbody>
</table>

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
