### PR TITLE
Remove obsolete commands from Inventory job.

### DIFF
--- a/.test-infra/jenkins/job_Inventory.groovy
+++ b/.test-infra/jenkins/job_Inventory.groovy
@@ -64,8 +64,6 @@ nums.each {
       ALL_SUPPORTED_VERSIONS.each { version ->
         shell("python${version} --version || echo \"python${version} not found\"")
       }
-      shell('/home/jenkins/tools/maven/latest/mvn -v || echo "mvn not found"')
-      shell('/home/jenkins/tools/gradle4.3/gradle -v || echo "gradle not found"')
       shell('gcloud -v || echo "gcloud not found"')
       shell('kubectl version || echo "kubectl not found"')
       ALL_SUPPORTED_VERSIONS.each { version ->


### PR DESCRIPTION
These currently failing and not required for our Jenkins infra.

```
11:10:21 [beam_Inventory_apache-beam-jenkins-1] $ /bin/bash -xe /tmp/jenkins1167683408123032334.sh
11:10:21 + /home/jenkins/tools/maven/latest/mvn -v
11:10:21 /tmp/jenkins1167683408123032334.sh: line 2: /home/jenkins/tools/maven/latest/mvn: No such file or directory
11:10:21 + echo 'mvn not found'
11:10:21 mvn not found
11:10:22 [beam_Inventory_apache-beam-jenkins-1] $ /bin/bash -xe /tmp/jenkins8237644259935897101.sh
11:10:22 + /home/jenkins/tools/gradle4.3/gradle -v
11:10:22 /tmp/jenkins8237644259935897101.sh: line 2: /home/jenkins/tools/gradle4.3/gradle: No such file or directory
```