### PR TITLE
[BEAM-13699] Replace fnv with maphash.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/hash.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/hash.go
@@ -35,7 +35,6 @@ type elementHasher interface {
 }
 
 func makeElementHasher(c *coder.Coder, wc *coder.WindowCoder) elementHasher {
-	// TODO(lostluck): move to a faster hashing library once we can take dependencies easily.
 	hasher := &maphash.Hash{}
 	we := MakeWindowEncoder(wc)
 	switch c.Kind {

--- a/sdks/go/pkg/beam/core/runtime/exec/hash.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/hash.go
@@ -19,7 +19,7 @@ import (
 	"encoding/binary"
 	"fmt"
 	"hash"
-	"hash/fnv"
+	"hash/maphash"
 	"math"
 	"reflect"
 
@@ -36,7 +36,7 @@ type elementHasher interface {
 
 func makeElementHasher(c *coder.Coder, wc *coder.WindowCoder) elementHasher {
 	// TODO(lostluck): move to a faster hashing library once we can take dependencies easily.
-	hasher := fnv.New64a()
+	hasher := &maphash.Hash{}
 	we := MakeWindowEncoder(wc)
 	switch c.Kind {
 	case coder.Bytes:

--- a/sdks/go/pkg/beam/core/runtime/exec/hash_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/hash_test.go
@@ -18,7 +18,7 @@ package exec
 import (
 	"encoding/json"
 	"fmt"
-	"hash/fnv"
+	"hash/maphash"
 	"reflect"
 	"strings"
 	"testing"
@@ -32,7 +32,7 @@ import (
 
 func BenchmarkPrimitives(b *testing.B) {
 	var value FullValue
-	myHash := fnv.New64a()
+	myHash := &maphash.Hash{}
 	wfn := window.NewGlobalWindows()
 	we := MakeWindowEncoder(wfn.Coder())
 	b.Run("int", func(b *testing.B) {


### PR DESCRIPTION
Simple enough change. Internal to google, we finally ran into a user observable collision with fnv, and this should significantly reduce the odds.

Generally an improvement, especially over strings, but some changes, no change to allocations or bytes allocated.

My overladen chromebook ran the benchmarks before and after 10 times each with the following results.

```
benchstat fnv.txt maphash.txt                                                                  
name                                                                         old time/op    new time/op    delta
Primitives/int/native-8                                                        15.0ns ± 5%    14.7ns ± 4%     ~     (p=0.072 n=10+10)
Primitives/int/interface-8                                                     39.3ns ± 9%    38.9ns ± 2%     ~     (p=0.796 n=9+9)
Primitives/int/encodedHash-8                                                    110ns ± 2%     114ns ± 2%   +3.19%  (p=0.000 n=9+10)
Primitives/int/dedicatedHash-8                                                 35.5ns ± 2%    36.6ns ± 3%   +3.02%  (p=0.000 n=9+9)
Primitives/float32/native-8                                                    39.5ns ± 2%    39.4ns ± 1%     ~     (p=0.956 n=10+10)
Primitives/float32/interface-8                                                 45.0ns ± 2%    45.4ns ± 6%     ~     (p=1.000 n=9+10)
Primitives/float32/encodedHash-8                                                132ns ± 6%     150ns ±37%  +13.75%  (p=0.007 n=9+10)
Primitives/float32/dedicatedHash-8                                             36.0ns ± 6%    37.1ns ± 3%   +2.95%  (p=0.022 n=10+9)
Primitives/string/45/native-8                                                  20.2ns ± 4%    20.1ns ± 4%     ~     (p=0.590 n=10+9)
Primitives/string/45/interface-8                                               48.9ns ± 3%    49.8ns ± 5%     ~     (p=0.118 n=10+10)
Primitives/string/45/encodedHash-8                                              158ns ± 3%     140ns ± 7%  -11.34%  (p=0.000 n=9+9)
Primitives/string/45/dedicatedHash-8                                            108ns ± 4%      82ns ± 4%  -24.72%  (p=0.000 n=10+10)
Primitives/string/10/native-8                                                  20.0ns ±10%    19.6ns ± 8%     ~     (p=0.182 n=9+10)
Primitives/string/10/interface-8                                               47.9ns ± 3%    49.7ns ± 2%   +3.80%  (p=0.001 n=10+10)
Primitives/string/10/encodedHash-8                                              116ns ± 2%     122ns ± 6%   +5.54%  (p=0.000 n=9+10)
Primitives/string/10/dedicatedHash-8                                           73.1ns ± 4%    79.4ns ± 4%   +8.48%  (p=0.000 n=9+10)
Primitives/string/100/native-8                                                 24.0ns ± 5%    24.1ns ± 2%     ~     (p=0.965 n=10+8)
Primitives/string/100/interface-8                                              53.2ns ± 4%    56.4ns ± 6%   +5.87%  (p=0.000 n=10+9)
Primitives/string/100/encodedHash-8                                             229ns ± 1%     158ns ± 5%  -31.28%  (p=0.000 n=10+9)
Primitives/string/100/dedicatedHash-8                                           169ns ± 7%     101ns ± 3%  -40.08%  (p=0.000 n=9+9)
Primitives/string/1000/native-8                                                51.1ns ± 1%    53.1ns ± 7%   +3.98%  (p=0.013 n=9+10)
Primitives/string/1000/interface-8                                              109ns ± 3%     110ns ± 2%     ~     (p=0.484 n=9+10)
Primitives/string/1000/encodedHash-8                                           1.48µs ± 6%    0.48µs ± 5%  -67.50%  (p=0.000 n=10+10)
Primitives/string/1000/dedicatedHash-8                                         1.14µs ± 1%    0.34µs ± 5%  -69.93%  (p=0.000 n=10+10)
Primitives/string/10000/native-8                                                345ns ± 1%     349ns ± 3%     ~     (p=0.094 n=9+9)
Primitives/string/10000/interface-8                                             716ns ± 5%     713ns ± 5%     ~     (p=0.863 n=9+9)
Primitives/string/10000/encodedHash-8                                          13.1µs ± 1%     3.3µs ± 9%  -74.75%  (p=0.000 n=10+10)
Primitives/string/10000/dedicatedHash-8                                        10.9µs ± 2%     2.8µs ± 9%  -74.28%  (p=0.000 n=10+10)
Primitives/struct/struct_{_A_int;_B_string;_Foobar_[4]int_}/interface-8        99.4ns ± 5%   113.7ns ±12%  +14.37%  (p=0.000 n=9+10)
Primitives/struct/struct_{_A_int;_B_string;_Foobar_[4]int_}/encodedHash-8       391ns ±12%     364ns ± 4%   -6.96%  (p=0.000 n=9+8)
Primitives/struct/struct_{_A_int;_B_string;_Foobar_[4]int_}/dedicatedHash-8     226ns ±11%     246ns ± 2%   +8.68%  (p=0.003 n=9+10)

name                                                                         old alloc/op   new alloc/op   delta
Primitives/int/native-8                                                         0.00B          0.00B          ~     (all equal)
Primitives/int/interface-8                                                      0.00B          0.00B          ~     (all equal)
Primitives/int/encodedHash-8                                                    40.0B ± 0%     40.0B ± 0%     ~     (all equal)
Primitives/int/dedicatedHash-8                                                  0.00B          0.00B          ~     (all equal)
Primitives/float32/native-8                                                     0.00B          0.00B          ~     (all equal)
Primitives/float32/interface-8                                                  0.00B          0.00B          ~     (all equal)
Primitives/float32/encodedHash-8                                                48.0B ± 0%     48.0B ± 0%     ~     (all equal)
Primitives/float32/dedicatedHash-8                                              0.00B          0.00B          ~     (all equal)
Primitives/string/45/native-8                                                   0.00B          0.00B          ~     (all equal)
Primitives/string/45/interface-8                                                0.00B          0.00B          ~     (all equal)
Primitives/string/45/encodedHash-8                                              72.0B ± 0%     72.0B ± 0%     ~     (all equal)
Primitives/string/45/dedicatedHash-8                                            64.0B ± 0%     64.0B ± 0%     ~     (all equal)
Primitives/string/10/native-8                                                   0.00B          0.00B          ~     (all equal)
Primitives/string/10/interface-8                                                0.00B          0.00B          ~     (all equal)
Primitives/string/10/encodedHash-8                                              40.0B ± 0%     40.0B ± 0%     ~     (all equal)
Primitives/string/10/dedicatedHash-8                                            64.0B ± 0%     64.0B ± 0%     ~     (all equal)
Primitives/string/100/native-8                                                  0.00B          0.00B          ~     (all equal)
Primitives/string/100/interface-8                                               0.00B          0.00B          ~     (all equal)
Primitives/string/100/encodedHash-8                                              136B ± 0%      136B ± 0%     ~     (all equal)
Primitives/string/100/dedicatedHash-8                                           64.0B ± 0%     64.0B ± 0%     ~     (all equal)
Primitives/string/1000/native-8                                                 0.00B          0.00B          ~     (all equal)
Primitives/string/1000/interface-8                                              0.00B          0.00B          ~     (all equal)
Primitives/string/1000/encodedHash-8                                           1.05kB ± 0%    1.05kB ± 0%     ~     (all equal)
Primitives/string/1000/dedicatedHash-8                                          64.0B ± 0%     64.0B ± 0%     ~     (all equal)
Primitives/string/10000/native-8                                                0.00B          0.00B          ~     (all equal)
Primitives/string/10000/interface-8                                             0.00B          0.00B          ~     (all equal)
Primitives/string/10000/encodedHash-8                                          10.3kB ± 0%    10.3kB ± 0%     ~     (all equal)
Primitives/string/10000/dedicatedHash-8                                         64.0B ± 0%     64.0B ± 0%     ~     (all equal)
Primitives/struct/struct_{_A_int;_B_string;_Foobar_[4]int_}/interface-8         0.00B          0.00B          ~     (all equal)
Primitives/struct/struct_{_A_int;_B_string;_Foobar_[4]int_}/encodedHash-8       48.0B ± 0%     48.0B ± 0%     ~     (all equal)
Primitives/struct/struct_{_A_int;_B_string;_Foobar_[4]int_}/dedicatedHash-8     1.00B ± 0%     1.00B ± 0%     ~     (all equal)

name                                                                         old allocs/op  new allocs/op  delta
Primitives/int/native-8                                                          0.00           0.00          ~     (all equal)
Primitives/int/interface-8                                                       0.00           0.00          ~     (all equal)
Primitives/int/encodedHash-8                                                     2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Primitives/int/dedicatedHash-8                                                   0.00           0.00          ~     (all equal)
Primitives/float32/native-8                                                      0.00           0.00          ~     (all equal)
Primitives/float32/interface-8                                                   0.00           0.00          ~     (all equal)
Primitives/float32/encodedHash-8                                                 3.00 ± 0%      3.00 ± 0%     ~     (all equal)
Primitives/float32/dedicatedHash-8                                               0.00           0.00          ~     (all equal)
Primitives/string/45/native-8                                                    0.00           0.00          ~     (all equal)
Primitives/string/45/interface-8                                                 0.00           0.00          ~     (all equal)
Primitives/string/45/encodedHash-8                                               2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Primitives/string/45/dedicatedHash-8                                             1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Primitives/string/10/native-8                                                    0.00           0.00          ~     (all equal)
Primitives/string/10/interface-8                                                 0.00           0.00          ~     (all equal)
Primitives/string/10/encodedHash-8                                               2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Primitives/string/10/dedicatedHash-8                                             1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Primitives/string/100/native-8                                                   0.00           0.00          ~     (all equal)
Primitives/string/100/interface-8                                                0.00           0.00          ~     (all equal)
Primitives/string/100/encodedHash-8                                              2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Primitives/string/100/dedicatedHash-8                                            1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Primitives/string/1000/native-8                                                  0.00           0.00          ~     (all equal)
Primitives/string/1000/interface-8                                               0.00           0.00          ~     (all equal)
Primitives/string/1000/encodedHash-8                                             2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Primitives/string/1000/dedicatedHash-8                                           1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Primitives/string/10000/native-8                                                 0.00           0.00          ~     (all equal)
Primitives/string/10000/interface-8                                              0.00           0.00          ~     (all equal)
Primitives/string/10000/encodedHash-8                                            2.00 ± 0%      2.00 ± 0%     ~     (all equal)
Primitives/string/10000/dedicatedHash-8                                          1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Primitives/struct/struct_{_A_int;_B_string;_Foobar_[4]int_}/interface-8          0.00           0.00          ~     (all equal)
Primitives/struct/struct_{_A_int;_B_string;_Foobar_[4]int_}/encodedHash-8        1.00 ± 0%      1.00 ± 0%     ~     (all equal)
Primitives/struct/struct_{_A_int;_B_string;_Foobar_[4]int_}/dedicatedHash-8      1.00 ± 0%      1.00 ± 0%     ~     (all equal)
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

`ValidatesRunner` compliance status (on master branch)
--------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>Lang</th>
      <th>ULR</th>
      <th>Dataflow</th>
      <th>Flink</th>
      <th>Samza</th>
      <th>Spark</th>
      <th>Twister2</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Go</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon">
        </a>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Samza/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
    </tr>
    <tr>
      <td>Java</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_ULR/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_ULR/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon?subject=V1">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming/lastCompletedBuild/badge/icon?subject=V1+Streaming">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon?subject=V1+Java+11">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/badge/icon?subject=V2">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2_Streaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2_Streaming/lastCompletedBuild/badge/icon?subject=V2+Streaming">
        </a><br>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon?subject=Java+8">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon?subject=Java+11">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon?subject=Portable">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon?subject=Portable+Streaming">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Samza/lastCompletedBuild/badge/icon?subject=Portable">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon?subject=Portable">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon?subject=Structured+Streaming">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon">
        </a>
      </td>
    </tr>
    <tr>
      <td>Python</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon?subject=V1">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon?subject=V2">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon?subject=ValCont">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon?subject=Portable">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Samza/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
    </tr>
    <tr>
      <td>XLang</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Dataflow/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Samza/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
    </tr>
  </tbody>
</table>

Examples testing status on various runners
--------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>Lang</th>
      <th>ULR</th>
      <th>Dataflow</th>
      <th>Flink</th>
      <th>Samza</th>
      <th>Spark</th>
      <th>Twister2</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Go</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
    <tr>
      <td>Java</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Cron/lastCompletedBuild/badge/icon?subject=V1">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Java11_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Java11_Cron/lastCompletedBuild/badge/icon?subject=V1+Java11">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_Examples_Dataflow_V2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_Examples_Dataflow_V2/lastCompletedBuild/badge/icon?subject=V2">
        </a><br>
      </td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
    <tr>
      <td>Python</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
    <tr>
      <td>XLang</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
  </tbody>
</table>

Post-Commit SDK/Transform Integration Tests Status (on master branch)
------------------------------------------------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>Go</th>
      <th>Java</th>
      <th>Python</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon?subject=3.6">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon?subject=3.7">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon?subject=3.8">
        </a>
      </td>
    </tr>
  </tbody>
</table>

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>---</th>
      <th>Java</th>
      <th>Python</th>
      <th>Go</th>
      <th>Website</th>
      <th>Whitespace</th>
      <th>Typescript</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Non-portable</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon">
        </a><br>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon?subject=Tests">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon?subject=Lint">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon?subject=Docker">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon?subject=Docs">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
    </tr>
    <tr>
      <td>Portable</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_GoPortable_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_GoPortable_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
  </tbody>
</table>

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
