### PR TITLE
feat: add experimental spanner readChangeStreams

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.io.gcp.spanner;
 
 import static java.util.stream.Collectors.toList;
 import static org.apache.beam.sdk.io.gcp.spanner.MutationUtils.isPointDelete;
+import static org.apache.beam.sdk.io.gcp.spanner.changestreams.NameGenerator.generatePartitionMetadataTableName;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
 
@@ -26,6 +27,7 @@ import com.google.auto.value.AutoValue;
 import com.google.cloud.ServiceFactory;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.AbortedException;
+import com.google.cloud.spanner.DatabaseId;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.KeySet;
 import com.google.cloud.spanner.Mutation;
@@ -39,6 +41,12 @@ import com.google.cloud.spanner.SpannerOptions;
 import com.google.cloud.spanner.Statement;
 import com.google.cloud.spanner.Struct;
 import com.google.cloud.spanner.TimestampBound;
+import io.opencensus.common.Scope;
+import io.opencensus.trace.Sampler;
+import io.opencensus.trace.Tracer;
+import io.opencensus.trace.Tracing;
+import io.opencensus.trace.config.TraceConfig;
+import io.opencensus.trace.config.TraceParams;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
@@ -47,6 +55,7 @@ import java.util.Arrays;
 import java.util.Comparator;
 import java.util.HashMap;
 import java.util.List;
+import java.util.Optional;
 import java.util.OptionalInt;
 import java.util.concurrent.TimeUnit;
 import org.apache.beam.runners.core.metrics.GcpResourceIdentifiers;
@@ -55,14 +64,26 @@ import org.apache.beam.runners.core.metrics.ServiceCallMetric;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.coders.SerializableCoder;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.ChangeStreamMetrics;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.TimestampConverter;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.action.ActionFactory;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.dao.DaoFactory;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.dofn.DetectNewPartitionsDoFn;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.dofn.InitializeDoFn;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.dofn.PostProcessingMetricsDoFn;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.dofn.ReadChangeStreamPartitionDoFn;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.mapper.MapperFactory;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.DataChangeRecord;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Distribution;
 import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.options.ValueProvider;
+import org.apache.beam.sdk.options.ValueProvider.Deserializer;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.Flatten;
+import org.apache.beam.sdk.transforms.Impulse;
 import org.apache.beam.sdk.transforms.MapElements;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
@@ -91,6 +112,7 @@ import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Stopwatch;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
@@ -107,13 +129,13 @@ import org.slf4j.LoggerFactory;
  *
  * <h3>Reading from Cloud Spanner</h3>
  *
- * <p>To read from Cloud Spanner, apply {@link SpannerIO.Read} transformation. It will return a
- * {@link PCollection} of {@link Struct Structs}, where each element represents an individual row
- * returned from the read operation. Both Query and Read APIs are supported. See more information
- * about <a href="https://cloud.google.com/spanner/docs/reads">reading from Cloud Spanner</a>
+ * <p>To read from Cloud Spanner, apply {@link Read} transformation. It will return a {@link
+ * PCollection} of {@link Struct Structs}, where each element represents an individual row returned
+ * from the read operation. Both Query and Read APIs are supported. See more information about <a
+ * href="https://cloud.google.com/spanner/docs/reads">reading from Cloud Spanner</a>
  *
- * <p>To execute a <strong>query</strong>, specify a {@link SpannerIO.Read#withQuery(Statement)} or
- * {@link SpannerIO.Read#withQuery(String)} during the construction of the transform.
+ * <p>To execute a <strong>query</strong>, specify a {@link Read#withQuery(Statement)} or {@link
+ * Read#withQuery(String)} during the construction of the transform.
  *
  * <pre>{@code
  * PCollection<Struct> rows = p.apply(
@@ -123,8 +145,8 @@ import org.slf4j.LoggerFactory;
  *         .withQuery("SELECT id, name, email FROM users"));
  * }</pre>
  *
- * <p>To use the Read API, specify a {@link SpannerIO.Read#withTable(String) table name} and a
- * {@link SpannerIO.Read#withColumns(List) list of columns}.
+ * <p>To use the Read API, specify a {@link Read#withTable(String) table name} and a {@link
+ * Read#withColumns(List) list of columns}.
  *
  * <pre>{@code
  * PCollection<Struct> rows = p.apply(
@@ -135,18 +157,18 @@ import org.slf4j.LoggerFactory;
  *        .withColumns("id", "name", "email"));
  * }</pre>
  *
- * <p>To optimally read using index, specify the index name using {@link SpannerIO.Read#withIndex}.
+ * <p>To optimally read using index, specify the index name using {@link Read#withIndex}.
  *
  * <p>The transform is guaranteed to be executed on a consistent snapshot of data, utilizing the
  * power of read only transactions. Staleness of data can be controlled using {@link
- * SpannerIO.Read#withTimestampBound} or {@link SpannerIO.Read#withTimestamp(Timestamp)} methods. <a
+ * Read#withTimestampBound} or {@link Read#withTimestamp(Timestamp)} methods. <a
  * href="https://cloud.google.com/spanner/docs/transactions">Read more</a> about transactions in
  * Cloud Spanner.
  *
  * <p>It is possible to read several {@link PCollection PCollections} within a single transaction.
  * Apply {@link SpannerIO#createTransaction()} transform, that lazily creates a transaction. The
  * result of this transformation can be passed to read operation using {@link
- * SpannerIO.Read#withTransaction(PCollectionView)}.
+ * Read#withTransaction(PCollectionView)}.
  *
  * <pre>{@code
  * SpannerConfig spannerConfig = ...
@@ -171,9 +193,8 @@ import org.slf4j.LoggerFactory;
  *
  * <h3>Writing to Cloud Spanner</h3>
  *
- * <p>The Cloud Spanner {@link SpannerIO.Write} transform writes to Cloud Spanner by executing a
- * collection of input row {@link Mutation Mutations}. The mutations are grouped into batches for
- * efficiency.
+ * <p>The Cloud Spanner {@link Write} transform writes to Cloud Spanner by executing a collection of
+ * input row {@link Mutation Mutations}. The mutations are grouped into batches for efficiency.
  *
  * <p>To configure the write transform, create an instance using {@link #write()} and then specify
  * the destination Cloud Spanner instance ({@link Write#withInstanceId(String)} and destination
@@ -191,10 +212,10 @@ import org.slf4j.LoggerFactory;
  *
  * <p>The {@link SpannerWriteResult SpannerWriteResult} object contains the results of the
  * transform, including a {@link PCollection} of MutationGroups that failed to write, and a {@link
- * PCollection} that can be used in batch pipelines as a completion signal to {@link
- * org.apache.beam.sdk.transforms.Wait Wait.OnSignal} to indicate when all input has been written.
- * Note that in streaming pipelines, this signal will never be triggered as the input is unbounded
- * and this {@link PCollection} is using the {@link GlobalWindow}.
+ * PCollection} that can be used in batch pipelines as a completion signal to {@link Wait
+ * Wait.OnSignal} to indicate when all input has been written. Note that in streaming pipelines,
+ * this signal will never be triggered as the input is unbounded and this {@link PCollection} is
+ * using the {@link GlobalWindow}.
  *
  * <h3>Batching and Grouping</h3>
  *
@@ -325,8 +346,8 @@ import org.slf4j.LoggerFactory;
  *
  * <h3>Streaming Support</h3>
  *
- * <p>{@link SpannerIO.Write} can be used as a streaming sink, however as with batch mode note that
- * the write order of individual {@link Mutation}/{@link MutationGroup} objects is not guaranteed.
+ * <p>{@link Write} can be used as a streaming sink, however as with batch mode note that the write
+ * order of individual {@link Mutation}/{@link MutationGroup} objects is not guaranteed.
  */
 @Experimental(Kind.SOURCE_SINK)
 @SuppressWarnings({
@@ -395,6 +416,28 @@ public class SpannerIO {
         .setMaxNumMutations(DEFAULT_MAX_NUM_MUTATIONS)
         .setMaxNumRows(DEFAULT_MAX_NUM_ROWS)
         .setFailureMode(FailureMode.FAIL_FAST)
+        .build();
+  }
+
+  /**
+   * Creates an uninitialized instance of {@link ReadChangeStream}. Before use, the {@link
+   * ReadChangeStream} must be configured with a {@link ReadChangeStream#withProjectId}, {@link
+   * ReadChangeStream#withInstanceId}, and {@link ReadChangeStream#withDatabaseId} that identify the
+   * Cloud Spanner database being written. It must also be configured with the start time and the
+   * change stream name.
+   */
+  @Experimental
+  public static ReadChangeStream readChangeStream() {
+    return new AutoValue_SpannerIO_ReadChangeStream.Builder()
+        .setSpannerConfig(SpannerConfig.create())
+        .setChangeStreamName("")
+        .setInclusiveStartAt(Timestamp.MIN_VALUE)
+        // Sets the default change stream request priority as high
+        .setRpcPriority(RpcPriority.HIGH)
+        // Set a default value to the end timestamp. Do not delete this.
+        // Otherwise, we will get a null pointer exception when we try to access
+        // it later.
+        .setInclusiveEndAt(Timestamp.MAX_VALUE)
         .build();
   }
 
@@ -1131,16 +1174,16 @@ public class SpannerIO {
 
   static class WriteRows extends PTransform<PCollection<Row>, PDone> {
     private final Write write;
-    private final Mutation.Op operation;
+    private final Op operation;
     private final String table;
 
-    private WriteRows(Write write, Mutation.Op operation, String table) {
+    private WriteRows(Write write, Op operation, String table) {
       this.write = write;
       this.operation = operation;
       this.table = table;
     }
 
-    public static WriteRows of(Write write, Mutation.Op operation, String table) {
+    public static WriteRows of(Write write, Op operation, String table) {
       return new WriteRows(write, operation, table);
     }
 
@@ -1291,6 +1334,241 @@ public class SpannerIO {
         throw new RuntimeException(e);
       }
       return bos.toByteArray();
+    }
+  }
+
+  @AutoValue
+  public abstract static class ReadChangeStream
+      extends PTransform<PBegin, PCollection<DataChangeRecord>> {
+
+    abstract SpannerConfig getSpannerConfig();
+
+    abstract String getChangeStreamName();
+
+    abstract @Nullable String getMetadataInstance();
+
+    abstract @Nullable String getMetadataDatabase();
+
+    abstract Timestamp getInclusiveStartAt();
+
+    abstract @Nullable Timestamp getInclusiveEndAt();
+
+    abstract @Nullable Deserializer getDeserializer();
+
+    abstract @Nullable RpcPriority getRpcPriority();
+
+    abstract @Nullable Sampler getTraceSampler();
+
+    abstract Builder toBuilder();
+
+    @AutoValue.Builder
+    abstract static class Builder {
+
+      abstract Builder setSpannerConfig(SpannerConfig spannerConfig);
+
+      abstract Builder setChangeStreamName(String changeStreamName);
+
+      abstract Builder setMetadataInstance(String metadataInstance);
+
+      abstract Builder setMetadataDatabase(String metadataDatabase);
+
+      abstract Builder setInclusiveStartAt(Timestamp inclusiveStartAt);
+
+      abstract Builder setInclusiveEndAt(Timestamp inclusiveEndAt);
+
+      abstract Builder setDeserializer(Deserializer deserializer);
+
+      abstract Builder setRpcPriority(RpcPriority rpcPriority);
+
+      abstract Builder setTraceSampler(Sampler traceSampler);
+
+      abstract ReadChangeStream build();
+    }
+
+    /** Specifies the Cloud Spanner configuration. */
+    public ReadChangeStream withSpannerConfig(SpannerConfig spannerConfig) {
+      return toBuilder().setSpannerConfig(spannerConfig).build();
+    }
+
+    /** Specifies the Cloud Spanner project. */
+    public ReadChangeStream withProjectId(String projectId) {
+      return withProjectId(ValueProvider.StaticValueProvider.of(projectId));
+    }
+
+    /** Specifies the Cloud Spanner project. */
+    public ReadChangeStream withProjectId(ValueProvider<String> projectId) {
+      SpannerConfig config = getSpannerConfig();
+      return withSpannerConfig(config.withProjectId(projectId));
+    }
+
+    /** Specifies the Cloud Spanner instance. */
+    public ReadChangeStream withInstanceId(String instanceId) {
+      return withInstanceId(ValueProvider.StaticValueProvider.of(instanceId));
+    }
+
+    /** Specifies the Cloud Spanner instance. */
+    public ReadChangeStream withInstanceId(ValueProvider<String> instanceId) {
+      SpannerConfig config = getSpannerConfig();
+      return withSpannerConfig(config.withInstanceId(instanceId));
+    }
+
+    /** Specifies the Cloud Spanner database. */
+    public ReadChangeStream withDatabaseId(String databaseId) {
+      return withDatabaseId(ValueProvider.StaticValueProvider.of(databaseId));
+    }
+
+    /** Specifies the Cloud Spanner database. */
+    public ReadChangeStream withDatabaseId(ValueProvider<String> databaseId) {
+      SpannerConfig config = getSpannerConfig();
+      return withSpannerConfig(config.withDatabaseId(databaseId));
+    }
+
+    /** Specifies the change stream name. */
+    public ReadChangeStream withChangeStreamName(String changeStreamName) {
+      return toBuilder().setChangeStreamName(changeStreamName).build();
+    }
+
+    /** Specifies the metadata database. */
+    public ReadChangeStream withMetadataInstance(String metadataInstance) {
+      return toBuilder().setMetadataInstance(metadataInstance).build();
+    }
+
+    /** Specifies the metadata database. */
+    public ReadChangeStream withMetadataDatabase(String metadataDatabase) {
+      return toBuilder().setMetadataDatabase(metadataDatabase).build();
+    }
+
+    /** Specifies the time that the change stream should be read from. */
+    public ReadChangeStream withInclusiveStartAt(Timestamp timestamp) {
+      return toBuilder().setInclusiveStartAt(timestamp).build();
+    }
+
+    /** Specifies the end time of the change stream. */
+    public ReadChangeStream withInclusiveEndAt(Timestamp timestamp) {
+      return toBuilder().setInclusiveEndAt(timestamp).build();
+    }
+
+    /**
+     * Specifies the class to be used to transform the data records read from the change stream into
+     * Java objects or other serial formats.
+     */
+    public ReadChangeStream withDeserializer(Deserializer deserializer) {
+      return toBuilder().setDeserializer(deserializer).build();
+    }
+
+    public ReadChangeStream withRpcPriority(RpcPriority rpcPriority) {
+      return toBuilder().setRpcPriority(rpcPriority).build();
+    }
+
+    public ReadChangeStream withTraceSampler(Sampler traceSampler) {
+      return toBuilder().setTraceSampler(traceSampler).build();
+    }
+
+    @Override
+    public PCollection<DataChangeRecord> expand(PBegin input) {
+      checkArgument(
+          getSpannerConfig() != null,
+          "SpannerIO.readChangeStream() requires the spanner config to be set.");
+      checkArgument(
+          getSpannerConfig().getProjectId() != null,
+          "SpannerIO.readChangeStream() requires the project ID to be set.");
+      checkArgument(
+          getSpannerConfig().getInstanceId() != null,
+          "SpannerIO.readChangeStream() requires the instance ID to be set.");
+      checkArgument(
+          getSpannerConfig().getDatabaseId() != null,
+          "SpannerIO.readChangeStream() requires the database ID to be set.");
+      checkArgument(
+          getChangeStreamName() != null,
+          "SpannerIO.readChangeStream() requires the name of the change stream to be set.");
+      checkArgument(
+          getInclusiveStartAt() != null,
+          "SpannerIO.readChangeStream() requires the start time to be set.");
+      if (getMetadataInstance() != null) {
+        checkArgument(
+            getMetadataDatabase() != null,
+            "SpannerIO.readChangeStream() requires the metadata database to be set if metadata instance is set.");
+      }
+
+      // Start time must be before end time
+      if (getInclusiveEndAt() != null
+          && getInclusiveStartAt().toSqlTimestamp().after(getInclusiveEndAt().toSqlTimestamp())) {
+        throw new IllegalArgumentException("Start time cannot be after end time.");
+      }
+
+      final DatabaseId changeStreamDatabaseId =
+          DatabaseId.of(
+              getSpannerConfig().getProjectId().get(),
+              getSpannerConfig().getInstanceId().get(),
+              getSpannerConfig().getDatabaseId().get());
+      final String partitionMetadataInstanceId =
+          MoreObjects.firstNonNull(
+              getMetadataInstance(), changeStreamDatabaseId.getInstanceId().getInstance());
+      final String partitionMetadataDatabaseId =
+          MoreObjects.firstNonNull(getMetadataDatabase(), changeStreamDatabaseId.getDatabase());
+      final String partitionMetadataTableName =
+          generatePartitionMetadataTableName(partitionMetadataDatabaseId);
+
+      if (getTraceSampler() != null) {
+        TraceConfig globalTraceConfig = Tracing.getTraceConfig();
+        globalTraceConfig.updateActiveTraceParams(
+            TraceParams.DEFAULT.toBuilder().setSampler(getTraceSampler()).build());
+      }
+      Tracer tracer = Tracing.getTracer();
+      try (Scope scope =
+          tracer
+              .spanBuilder("SpannerIO.ReadChangeStream.expand")
+              .setRecordEvents(true)
+              .startScopedSpan()) {
+        final SpannerConfig changeStreamSpannerConfig = getSpannerConfig();
+        final SpannerConfig partitionMetadataSpannerConfig =
+            SpannerConfig.create()
+                .withProjectId(changeStreamSpannerConfig.getProjectId())
+                .withHost(changeStreamSpannerConfig.getHost())
+                .withInstanceId(partitionMetadataInstanceId)
+                .withDatabaseId(partitionMetadataDatabaseId)
+                .withCommitDeadline(changeStreamSpannerConfig.getCommitDeadline())
+                .withEmulatorHost(changeStreamSpannerConfig.getEmulatorHost())
+                .withMaxCumulativeBackoff(changeStreamSpannerConfig.getMaxCumulativeBackoff());
+        final String changeStreamName = getChangeStreamName();
+        // FIXME: The backend only supports microsecond granularity. Remove when fixed.
+        final Timestamp startTimestamp = TimestampConverter.truncateNanos(getInclusiveStartAt());
+        final Timestamp endTimestamp =
+            Optional.ofNullable(getInclusiveEndAt())
+                .map(TimestampConverter::truncateNanos)
+                .orElse(null);
+        final MapperFactory mapperFactory = new MapperFactory();
+        final ChangeStreamMetrics metrics = new ChangeStreamMetrics();
+        final RpcPriority rpcPriority =
+            MoreObjects.firstNonNull(getRpcPriority(), RpcPriority.HIGH);
+        final DaoFactory daoFactory =
+            new DaoFactory(
+                changeStreamSpannerConfig,
+                changeStreamName,
+                partitionMetadataSpannerConfig,
+                partitionMetadataTableName,
+                rpcPriority,
+                input.getPipeline().getOptions().getJobName());
+        final ActionFactory actionFactory = new ActionFactory();
+
+        final InitializeDoFn initializeDoFn =
+            new InitializeDoFn(daoFactory, mapperFactory, startTimestamp, endTimestamp);
+        final DetectNewPartitionsDoFn detectNewPartitionsDoFn =
+            new DetectNewPartitionsDoFn(daoFactory, mapperFactory, metrics);
+        final ReadChangeStreamPartitionDoFn readChangeStreamPartitionDoFn =
+            new ReadChangeStreamPartitionDoFn(daoFactory, mapperFactory, actionFactory, metrics);
+        final PostProcessingMetricsDoFn postProcessingMetricsDoFn =
+            new PostProcessingMetricsDoFn(metrics);
+
+        LOG.info("Partition metadata table that will be used is " + partitionMetadataTableName);
+
+        return input
+            .apply(Impulse.create())
+            .apply("Initialize the connector", ParDo.of(initializeDoFn))
+            .apply("Detect new partitions", ParDo.of(detectNewPartitionsDoFn))
+            .apply("Read change stream partition", ParDo.of(readChangeStreamPartitionDoFn))
+            .apply("Gather metrics", ParDo.of(postProcessingMetricsDoFn));
+      }
     }
   }
 
@@ -1538,7 +1816,7 @@ public class SpannerIO {
       this.maxNumRows = maxNumRows;
     }
 
-    @DoFn.ProcessElement
+    @ProcessElement
     public void processElement(ProcessContext c) {
       MutationGroup mg = c.element();
       if (mg.primary().getOperation() == Op.DELETE && !isPointDelete(mg.primary())) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/NameGenerator.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/NameGenerator.java
@@ -1,0 +1,47 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.spanner.changestreams;
+
+import java.util.UUID;
+
+/**
+ * This class generates a unique name for the partition metadata table, which is created when the
+ * Connector is initialized.
+ */
+public class NameGenerator {
+
+  private static final String PARTITION_METADATA_TABLE_NAME_FORMAT =
+      "CDC_Partitions_Metadata_%s_%s";
+
+  /**
+   * Generates an unique name for the partition metadata table in the form of {@code
+   * "CDC_Partitions_Metadata_<databaseId>_<uuid>"}.
+   *
+   * @param databaseId The database id where the table will be created
+   * @return the unique generated name of the partition metadata table
+   */
+  public static String generatePartitionMetadataTableName(String databaseId) {
+    // Maximum Spanner table name length is 128 characters.
+    // There are 25 characters in the name format.
+    // Maximum Spanner database ID length is 30 characters.
+    // UUID always generates a String with 36 characters.
+    // 128 - (25 + 30 + 36) = 37 characters short of the limit
+    return String.format(PARTITION_METADATA_TABLE_NAME_FORMAT, databaseId, UUID.randomUUID())
+        .replaceAll("-", "_");
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dao/PartitionMetadataDao.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dao/PartitionMetadataDao.java
@@ -70,6 +70,27 @@ public class PartitionMetadataDao {
   }
 
   /**
+   * Checks whether the metadata table already exists in the database.
+   *
+   * @return true if the table exists, false if the table does not exist.
+   */
+  public boolean tableExists() {
+    final String checkTableExistsStmt =
+        "SELECT t.table_name FROM information_schema.tables AS t "
+            + "WHERE t.table_catalog = '' AND "
+            + "t.table_schema = '' AND "
+            + "t.table_name = '"
+            + metadataTableName
+            + "'";
+    try (ResultSet queryResultSet =
+        databaseClient
+            .singleUseReadOnlyTransaction()
+            .executeQuery(Statement.of(checkTableExistsStmt))) {
+      return queryResultSet.next();
+    }
+  }
+
+  /**
    * Fetches the partition metadata row data for the given partition token.
    *
    * @param partitionToken the partition unique identifier

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/DetectNewPartitionsDoFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/DetectNewPartitionsDoFn.java
@@ -54,7 +54,7 @@ import org.slf4j.LoggerFactory;
   "rawtypes", // TODO(https://issues.apache.org/jira/browse/BEAM-10556)
   "nullness" // TODO(https://issues.apache.org/jira/browse/BEAM-10402)
 })
-public class DetectNewPartitionsDoFn extends DoFn<byte[], PartitionMetadata> {
+public class DetectNewPartitionsDoFn extends DoFn<PartitionMetadata, PartitionMetadata> {
 
   private static final long serialVersionUID = 1523712495885011374L;
   private static final Duration DEFAULT_RESUME_DURATION = Duration.millis(100L);
@@ -108,8 +108,8 @@ public class DetectNewPartitionsDoFn extends DoFn<byte[], PartitionMetadata> {
   }
 
   @GetInitialWatermarkEstimatorState
-  public Instant getInitialWatermarkEstimatorState(@Timestamp Instant currentElementTimestamp) {
-    return currentElementTimestamp;
+  public Instant getInitialWatermarkEstimatorState(@Element PartitionMetadata partition) {
+    return new Instant(partition.getStartTimestamp().toSqlTimestamp());
   }
 
   @NewWatermarkEstimator

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/InitializeDoFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/InitializeDoFn.java
@@ -1,0 +1,98 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.spanner.changestreams.dofn;
+
+import java.io.Serializable;
+import java.util.Optional;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.dao.DaoFactory;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.dao.PartitionMetadataDao;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.mapper.MapperFactory;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.InitialPartition;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.PartitionMetadata;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.PartitionMetadata.State;
+import org.apache.beam.sdk.transforms.DoFn;
+
+/**
+ * A SplittableDoFn (SDF) that is responsible for initializing the change stream Connector. It
+ * handles the creation of the partition metadata table and the insertion of a fake partition (see
+ * {@link InitialPartition#PARTITION_TOKEN}), which will be used to dispatch the change streams
+ * query.
+ */
+public class InitializeDoFn extends DoFn<byte[], PartitionMetadata> implements Serializable {
+
+  private static final long serialVersionUID = -8921188388649003102L;
+
+  /** Heartbeat interval for all change stream queries will be of 2 seconds. */
+  // Be careful when changing this interval, as it needs to be less than the checkpointing interval
+  // in Dataflow. Otherwise, if there are no records within checkpoint intervals, the consuming of
+  // a change stream query might get stuck.
+  private static final long DEFAULT_HEARTBEAT_MILLIS = 2000;
+
+  private final DaoFactory daoFactory;
+  private final MapperFactory mapperFactory;
+  // The change streams query start time
+  private final com.google.cloud.Timestamp startTimestamp;
+  // The change streams query end time
+  private final com.google.cloud.Timestamp endTimestamp;
+
+  public InitializeDoFn(
+      DaoFactory daoFactory,
+      MapperFactory mapperFactory,
+      com.google.cloud.Timestamp startTimestamp,
+      com.google.cloud.Timestamp endTimestamp) {
+    this.daoFactory = daoFactory;
+    this.mapperFactory = mapperFactory;
+    this.startTimestamp = startTimestamp;
+    this.endTimestamp = endTimestamp;
+  }
+
+  @ProcessElement
+  public void processElement(OutputReceiver<PartitionMetadata> receiver) {
+    PartitionMetadataDao partitionMetadataDao = daoFactory.getPartitionMetadataDao();
+    if (!partitionMetadataDao.tableExists()) {
+      daoFactory.getPartitionMetadataAdminDao().createPartitionMetadataTable();
+      createFakeParentPartition();
+    }
+    final PartitionMetadata initialPartition =
+        Optional.ofNullable(partitionMetadataDao.getPartition(InitialPartition.PARTITION_TOKEN))
+            .map(mapperFactory.partitionMetadataMapper()::from)
+            .orElseThrow(
+                () -> new IllegalStateException("Initial partition not found in metadata table."));
+    receiver.output(initialPartition);
+  }
+
+  /**
+   * Creates an initial partition in the partition metadata table to serve as the parent of all the
+   * partitions in the change stream query. This initial partition will be used to dispatch the
+   * first change streams query in the job. The heartbeat interval to be used will be the one
+   * specified in {@link InitializeDoFn#DEFAULT_HEARTBEAT_MILLIS}.
+   */
+  private void createFakeParentPartition() {
+    PartitionMetadata parentPartition =
+        PartitionMetadata.newBuilder()
+            .setPartitionToken(InitialPartition.PARTITION_TOKEN)
+            .setParentTokens(InitialPartition.PARENT_TOKENS)
+            .setStartTimestamp(startTimestamp)
+            .setEndTimestamp(endTimestamp)
+            .setHeartbeatMillis(DEFAULT_HEARTBEAT_MILLIS)
+            .setState(State.CREATED)
+            .setWatermark(startTimestamp)
+            .build();
+    daoFactory.getPartitionMetadataDao().insert(parentPartition);
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/PostProcessingMetricsDoFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/PostProcessingMetricsDoFn.java
@@ -1,0 +1,115 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.spanner.changestreams.dofn;
+
+import java.io.Serializable;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.ChangeStreamMetrics;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.ChangeStreamRecordMetadata;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.DataChangeRecord;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A DoFn class to gather metrics about the emitted {@link DataChangeRecord}s. It will simply
+ * delegate the metrics gathering to the {@link ChangeStreamMetrics}. The metrics measured in this
+ * component are:
+ *
+ * <ol>
+ *   <li>The number of data records emitted.
+ *   <li>The latency between a record's Cloud Spanner commit timestamp and the time it reached this
+ *       component (referred as emit timestamp).
+ *   <li>The streaming latency of a record from the change stream query.
+ * </ol>
+ */
+public class PostProcessingMetricsDoFn extends DoFn<DataChangeRecord, DataChangeRecord>
+    implements Serializable {
+
+  private static final long serialVersionUID = -1515578871387565606L;
+  private static final Logger LOG = LoggerFactory.getLogger(PostProcessingMetricsDoFn.class);
+  private static final long COMMITTED_TO_EMITTED_THRESHOLD_MS = 100_000;
+  private static final long STREAM_THRESHOLD_MS = 5_000;
+
+  private final ChangeStreamMetrics metrics;
+
+  public PostProcessingMetricsDoFn(ChangeStreamMetrics metrics) {
+    this.metrics = metrics;
+  }
+
+  /**
+   * Stage to measure a data records latencies and metrics. The metrics gathered are:
+   *
+   * <ol>
+   *   <li>The number of data records emitted.
+   *   <li>The latency between a record's Cloud Spanner commit timestamp and the time it reached
+   *       this component (referred as emit timestamp).
+   *   <li>The streaming latency of a record from the change stream query.
+   * </ol>
+   *
+   * After measurement the record is re-emitted to the next stage.
+   *
+   * @param dataChangeRecord the record to gather metrics for
+   * @param receiver the output receiver of the {@link PostProcessingMetricsDoFn} SDF
+   */
+  @ProcessElement
+  public void processElement(
+      @Element DataChangeRecord dataChangeRecord, OutputReceiver<DataChangeRecord> receiver) {
+    final Instant commitInstant =
+        new Instant(dataChangeRecord.getCommitTimestamp().toSqlTimestamp().getTime());
+
+    metrics.incDataRecordCounter();
+    measureCommitTimestampToEmittedMillis(dataChangeRecord);
+    measureStreamMillis(dataChangeRecord);
+
+    receiver.outputWithTimestamp(dataChangeRecord, commitInstant);
+  }
+
+  private void measureCommitTimestampToEmittedMillis(DataChangeRecord dataChangeRecord) {
+    final com.google.cloud.Timestamp emittedTimestamp = com.google.cloud.Timestamp.now();
+    final com.google.cloud.Timestamp commitTimestamp = dataChangeRecord.getCommitTimestamp();
+    final Duration committedToEmitted =
+        new Duration(
+            commitTimestamp.toSqlTimestamp().getTime(),
+            emittedTimestamp.toSqlTimestamp().getTime());
+    final long commitedToEmittedMillis = committedToEmitted.getMillis();
+
+    if (commitedToEmittedMillis > COMMITTED_TO_EMITTED_THRESHOLD_MS) {
+      LOG.debug(
+          "Data record took "
+              + commitedToEmittedMillis
+              + "ms to be emitted: "
+              + dataChangeRecord.getMetadata());
+    }
+  }
+
+  private void measureStreamMillis(DataChangeRecord dataChangeRecord) {
+    final ChangeStreamRecordMetadata metadata = dataChangeRecord.getMetadata();
+    final com.google.cloud.Timestamp streamStartedAt = metadata.getRecordStreamStartedAt();
+    final com.google.cloud.Timestamp streamEndedAt = metadata.getRecordStreamEndedAt();
+    final Duration streamDuration =
+        new Duration(
+            streamStartedAt.toSqlTimestamp().getTime(), streamEndedAt.toSqlTimestamp().getTime());
+    final long streamMillis = streamDuration.getMillis();
+
+    if (streamMillis > STREAM_THRESHOLD_MS) {
+      LOG.debug("Data record took " + streamMillis + "ms to be streamed: " + metadata);
+    }
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/ReadChangeStreamPartitionDoFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/ReadChangeStreamPartitionDoFn.java
@@ -102,8 +102,8 @@ public class ReadChangeStreamPartitionDoFn extends DoFn<PartitionMetadata, DataC
   }
 
   @GetInitialWatermarkEstimatorState
-  public Instant getInitialWatermarkEstimatorState(@Timestamp Instant currentElementTimestamp) {
-    return currentElementTimestamp;
+  public Instant getInitialWatermarkEstimatorState(@Element PartitionMetadata partition) {
+    return new Instant(partition.getStartTimestamp().toSqlTimestamp());
   }
 
   @NewWatermarkEstimator

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/mapper/ChangeStreamRecordMapper.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/mapper/ChangeStreamRecordMapper.java
@@ -42,6 +42,9 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Sets;
 /**
  * This class is responsible for transforming a {@link Struct} to a {@link List} of {@link
  * ChangeStreamRecord} models.
+ *
+ * <p>The change stream full specification can be seen in the internal documentation
+ * https://docs.google.com/document/d/1nLlMGvQLIeUSDNmtoLT9vaQo0hVGl4CIf6iCSOkdIbA/edit#bookmark=id.fxgtygh8eony
  */
 public class ChangeStreamRecordMapper {
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/NameGeneratorTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/NameGeneratorTest.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.spanner.changestreams;
+
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertTrue;
+
+import org.junit.Test;
+
+public class NameGeneratorTest {
+
+  private static final int MAXIMUM_TABLE_NAME_LENGTH = 128;
+
+  @Test
+  public void testGenerateMetadataTableNameRemovesHyphens() {
+    final String tableName =
+        NameGenerator.generatePartitionMetadataTableName("my-database-id-12345");
+    assertFalse(tableName.contains("-"));
+  }
+
+  @Test
+  public void testGenerateMetadataTableNameIsShorterThan128Characters() {
+    final String tableName =
+        NameGenerator.generatePartitionMetadataTableName("my-database-id1-maximum-length");
+    assertTrue(tableName.length() < MAXIMUM_TABLE_NAME_LENGTH);
+  }
+}


### PR DESCRIPTION
Adds the SpannerIO.readChangeStreams feature that will enable users to consume a change stream from Cloud Spanner.
This feature is under preview now, and can only be used for allowlisted customers.

When reading a change stream the users will be able to operate on a PCollection of DataChangeRecords, containing the modifications made to the database as well as the type of operation.

This PR contains the following modifications:

1. It exposes the `SpannerIO.readChangeStream(...)` functionality. Here we construct the internal pipeline composed of `Impulse -> Initialize -> DetectNewPartitions -> ReadChangeStreamPartition -> PostProcessingMetrics`.
2. It adds a DoFn to create the metadata table when the pipeline is deployed. This will be used to maintain internal state for the Connector. It can be seen in the `InitializeDoFn` class.
3. The `InitializeDoFn` uses a new class called `NameGenerator` that creates a random metadata table name to be used within the Connector.
4. It adds a DoFn to collect metrics as a final step in the Connector, the `PostProcessingMetricsDoFn`. This class will count the number of DataRecords produced, the stream time of a record from Cloud Spanner to the worker, and the total time that a record took from commit time in Spanner until it is emitted into the output PCollection.
5. Small bug fixes that changes the initial watermark timestamp from the current timestamp to the partition's start at timestamp.