### PR TITLE
[BEAM-12920] Assume that bare generator types define simple generators

### DIFF
--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -258,11 +258,11 @@ def convert_to_beam_type(typ):
     elif _match_is_union(typ):
       raise ValueError('Unsupported Union with no arguments.')
     elif _match_issubclass(typing.Generator)(typ):
-      raise ValueError('Unsupported Generator with no arguments.')
+      # Assume a simple generator.
+      args = (typehints.TypeVariable('T_co'), type(None), type(None))
     elif _match_issubclass(typing.Dict)(typ):
       args = (typehints.TypeVariable('KT'), typehints.TypeVariable('VT'))
     elif (_match_issubclass(typing.Iterator)(typ) or
-          _match_issubclass(typing.Generator)(typ) or
           _match_is_exactly_iterable(typ)):
       args = (typehints.TypeVariable('T_co'), )
     else:

--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -196,10 +196,6 @@ class NativeTypeCompatibilityTest(unittest.TestCase):
     test_cases = [
         ('bare union', typing.Union),
     ]
-    if sys.version_info < (3, 7):
-      test_cases += [
-          ('bare generator', typing.Generator),
-      ]
     for test_case in test_cases:
       description = test_case[0]
       typing_type = test_case[1]


### PR DESCRIPTION
Assume that bare generator types define simple generators.
The only type of generators that Beam type inference currently handles are simple generators: https://github.com/apache/beam/blob/d7ee6b8c8b4fedb05d31d6554ab55a6d4bca0356/sdks/python/apache_beam/typehints/typehints.py#L1120

This test started to fail on Python 3.9 because bare Generator instances on Python <3.9 were not truly 'bare' and still had `__args__` defined:
 ```
> python3.7
>>> import typing
>>> typing.Generator.__args__
(+T_co, -T_contra, +V_co)
```
, so we inferred a type for bare generators as Generator[T_co, T_contra,  V_co] and didn't fail. Preserving this behavior for Python 3.9+ as well, but setting the last two type variables to `None`, since we are ignoring them later, otherwise they add an extra warning.