### PR TITLE
[BEAM-13870] [Playground] Increase test coverage for the cache package

### DIFF
--- a/playground/backend/internal/cache/local/local_cache_test.go
+++ b/playground/backend/internal/cache/local/local_cache_test.go
@@ -236,8 +236,6 @@ func TestLocalCache_SetExpTime(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			// Test case with calling SetExpTime method with pipelineId and his expiration time.
-			// As a result, want to set expiration time for this pipelineId.
 			name: "Set expiration time",
 			fields: fields{
 				cleanupInterval:     cleanupInterval,

--- a/playground/backend/internal/cache/local/local_cache_test.go
+++ b/playground/backend/internal/cache/local/local_cache_test.go
@@ -78,7 +78,7 @@ func TestLocalCache_GetValue(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "Get exist value",
+			name: "get existing value",
 			fields: fields{
 				cleanupInterval:     cleanupInterval,
 				items:               preparedItemsMap,
@@ -93,7 +93,7 @@ func TestLocalCache_GetValue(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "Get not exist value",
+			name: "get not existing value",
 			fields: fields{
 				cleanupInterval: cleanupInterval,
 				items:           make(map[uuid.UUID]map[cache.SubKey]interface{}),
@@ -106,9 +106,9 @@ func TestLocalCache_GetValue(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			// Test case with calling GetValue method with exist value the expiration time of which has ended.
+			// Test case with calling GetValue method with existing value that is expiring.
 			// As a result, want to receive an error.
-			name: "Get exist value the expiration time of which has ended",
+			name: "get an existing value that is expiring",
 			fields: fields{
 				cleanupInterval:     cleanupInterval,
 				items:               preparedItemsMap,
@@ -181,7 +181,7 @@ func TestLocalCache_SetValue(t *testing.T) {
 		{
 			// Test case with calling SetValue method with RunOutputIndex subKey.
 			// As a result, want to save value to cache.
-			name: "Set value for some index subKey",
+			name: "Set value for RunOutputIndex subKey",
 			fields: fields{
 				cleanupInterval:     cleanupInterval,
 				items:               make(map[uuid.UUID]map[cache.SubKey]interface{}),
@@ -254,7 +254,7 @@ func TestLocalCache_SetExpTime(t *testing.T) {
 		{
 			// Test case with calling SetExpTime method with pipelineId which not set in cache and expiration time.
 			// As a result, want to receive an error.
-			name: "Set expiration time for not exist value",
+			name: "Set expiration time for not existing value in cache items",
 			fields: fields{
 				cleanupInterval:     cleanupInterval,
 				items:               make(map[uuid.UUID]map[cache.SubKey]interface{}),
@@ -488,9 +488,9 @@ func TestLocalCache_startGC(t *testing.T) {
 			},
 		},
 		{
-			// Test case with calling startGC method with nil items.
+			// Test case with calling startGC method with nil cache items.
 			// As a result, items stay the same.
-			name: "Checking for deleting expired pipelines with nil items",
+			name: "Checking for deleting expired pipelines with nil cache items",
 			fields: fields{
 				cleanupInterval:     time.Microsecond,
 				items:               nil,
@@ -621,9 +621,7 @@ func TestNew(t *testing.T) {
 		want *Cache
 	}{
 		{
-			// Test case with calling New method.
-			// As a result, want to receive an expected Cache.
-			name: "initialize local cache",
+			name: "Initialize local cache",
 			args: args{ctx: context.Background()},
 			want: &Cache{
 				cleanupInterval:     cleanupInterval,

--- a/playground/backend/internal/cache/local/local_cache_test.go
+++ b/playground/backend/internal/cache/local/local_cache_test.go
@@ -106,6 +106,8 @@ func TestLocalCache_GetValue(t *testing.T) {
 			wantErr: true,
 		},
 		{
+			// Test case with calling GetValue method with exist value the expiration time of which has ended.
+			// As a result, want to receive an error.
 			name: "Get exist value the expiration time of which has ended",
 			fields: fields{
 				cleanupInterval:     cleanupInterval,
@@ -234,6 +236,8 @@ func TestLocalCache_SetExpTime(t *testing.T) {
 		wantErr bool
 	}{
 		{
+			// Test case with calling SetExpTime method with pipelineId and his expiration time.
+			// As a result, want to set expiration time for this pipelineId.
 			name: "Set expiration time",
 			fields: fields{
 				cleanupInterval:     cleanupInterval,
@@ -248,6 +252,8 @@ func TestLocalCache_SetExpTime(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			// Test case with calling SetExpTime method with pipelineId which not set in cache and expiration time.
+			// As a result, want to receive an error.
 			name: "Set expiration time for not exist value",
 			fields: fields{
 				cleanupInterval:     cleanupInterval,
@@ -482,6 +488,8 @@ func TestLocalCache_startGC(t *testing.T) {
 			},
 		},
 		{
+			// Test case with calling startGC method with nil items.
+			// As a result, items stay the same.
 			name: "Checking for deleting expired pipelines with nil items",
 			fields: fields{
 				cleanupInterval:     time.Microsecond,

--- a/playground/backend/internal/cache/local/local_cache_test.go
+++ b/playground/backend/internal/cache/local/local_cache_test.go
@@ -58,6 +58,8 @@ func TestLocalCache_GetValue(t *testing.T) {
 	preparedItemsMap[preparedId][preparedSubKey] = value
 	preparedExpMap := make(map[uuid.UUID]time.Time)
 	preparedExpMap[preparedId] = time.Now().Add(time.Millisecond)
+	endedExpMap := make(map[uuid.UUID]time.Time)
+	endedExpMap[preparedId] = time.Now().Add(-time.Millisecond)
 	type fields struct {
 		cleanupInterval     time.Duration
 		items               map[uuid.UUID]map[cache.SubKey]interface{}
@@ -97,6 +99,21 @@ func TestLocalCache_GetValue(t *testing.T) {
 				items:           make(map[uuid.UUID]map[cache.SubKey]interface{}),
 			},
 			args: args{
+				pipelineId: preparedId,
+				subKey:     preparedSubKey,
+			},
+			want:    nil,
+			wantErr: true,
+		},
+		{
+			name: "Get exist value the expiration time of which has ended",
+			fields: fields{
+				cleanupInterval:     cleanupInterval,
+				items:               preparedItemsMap,
+				pipelinesExpiration: endedExpMap,
+			},
+			args: args{
+				ctx:        context.Background(),
 				pipelineId: preparedId,
 				subKey:     preparedSubKey,
 			},
@@ -159,6 +176,23 @@ func TestLocalCache_SetValue(t *testing.T) {
 			},
 			wantErr: false,
 		},
+		{
+			// Test case with calling SetValue method with RunOutputIndex subKey.
+			// As a result, want to save value to cache.
+			name: "Set value for some index subKey",
+			fields: fields{
+				cleanupInterval:     cleanupInterval,
+				items:               make(map[uuid.UUID]map[cache.SubKey]interface{}),
+				pipelinesExpiration: preparedExpMap,
+			},
+			args: args{
+				ctx:        context.Background(),
+				pipelineId: preparedId,
+				subKey:     cache.RunOutputIndex,
+				value:      5,
+			},
+			wantErr: false,
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -180,6 +214,9 @@ func TestLocalCache_SetValue(t *testing.T) {
 
 func TestLocalCache_SetExpTime(t *testing.T) {
 	preparedId, _ := uuid.NewUUID()
+	preparedItems := make(map[uuid.UUID]map[cache.SubKey]interface{})
+	preparedItems[preparedId] = make(map[cache.SubKey]interface{})
+	preparedItems[preparedId][cache.Status] = 1
 	type fields struct {
 		cleanupInterval     time.Duration
 		items               map[uuid.UUID]map[cache.SubKey]interface{}
@@ -191,12 +228,27 @@ func TestLocalCache_SetExpTime(t *testing.T) {
 		expTime    time.Duration
 	}
 	tests := []struct {
-		name   string
-		fields fields
-		args   args
+		name    string
+		fields  fields
+		args    args
+		wantErr bool
 	}{
 		{
 			name: "Set expiration time",
+			fields: fields{
+				cleanupInterval:     cleanupInterval,
+				items:               preparedItems,
+				pipelinesExpiration: make(map[uuid.UUID]time.Time),
+			},
+			args: args{
+				ctx:        context.Background(),
+				pipelineId: preparedId,
+				expTime:    time.Minute,
+			},
+			wantErr: false,
+		},
+		{
+			name: "Set expiration time for not exist value",
 			fields: fields{
 				cleanupInterval:     cleanupInterval,
 				items:               make(map[uuid.UUID]map[cache.SubKey]interface{}),
@@ -207,6 +259,7 @@ func TestLocalCache_SetExpTime(t *testing.T) {
 				pipelineId: preparedId,
 				expTime:    time.Minute,
 			},
+			wantErr: true,
 		},
 	}
 	for _, tt := range tests {
@@ -216,14 +269,13 @@ func TestLocalCache_SetExpTime(t *testing.T) {
 				items:               tt.fields.items,
 				pipelinesExpiration: tt.fields.pipelinesExpiration,
 			}
-			_ = lc.SetValue(tt.args.ctx, preparedId, cache.Status, 1)
 			err := lc.SetExpTime(tt.args.ctx, tt.args.pipelineId, tt.args.expTime)
-			if err != nil {
-				t.Error(err)
-			}
-			expTime, found := lc.pipelinesExpiration[tt.args.pipelineId]
-			if expTime.Round(time.Second) != time.Now().Add(tt.args.expTime).Round(time.Second) || !found {
-				t.Errorf("Expiration time of the pipeline: %s not set in cache.", tt.args.pipelineId)
+			if (err != nil) != tt.wantErr {
+				t.Errorf("SetExpTime() error = %v, wantErr %v", err, tt.wantErr)
+				expTime, found := lc.pipelinesExpiration[tt.args.pipelineId]
+				if expTime.Round(time.Second) != time.Now().Add(tt.args.expTime).Round(time.Second) || !found {
+					t.Errorf("Expiration time of the pipeline: %s not set in cache.", tt.args.pipelineId)
+				}
 			}
 		})
 	}
@@ -429,6 +481,14 @@ func TestLocalCache_startGC(t *testing.T) {
 				pipelinesExpiration: preparedExpMap,
 			},
 		},
+		{
+			name: "Checking for deleting expired pipelines with nil items",
+			fields: fields{
+				cleanupInterval:     time.Microsecond,
+				items:               nil,
+				pipelinesExpiration: preparedExpMap,
+			},
+		},
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
@@ -536,6 +596,39 @@ func TestLocalCache_clearItems(t *testing.T) {
 			lc.clearItems(tt.args.pipelines)
 			if _, found := tt.fields.items[preparedId1]; found {
 				t.Errorf("Pipeline: %s has not been deleted.", preparedId1)
+			}
+		})
+	}
+}
+
+func TestNew(t *testing.T) {
+	items := make(map[uuid.UUID]map[cache.SubKey]interface{})
+	pipelinesExpiration := make(map[uuid.UUID]time.Time)
+	type args struct {
+		ctx context.Context
+	}
+	tests := []struct {
+		name string
+		args args
+		want *Cache
+	}{
+		{
+			// Test case with calling New method.
+			// As a result, want to receive an expected Cache.
+			name: "initialize local cache",
+			args: args{ctx: context.Background()},
+			want: &Cache{
+				cleanupInterval:     cleanupInterval,
+				items:               items,
+				pipelinesExpiration: pipelinesExpiration,
+				catalog:             nil,
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := New(tt.args.ctx); !reflect.DeepEqual(got, tt.want) {
+				t.Errorf("New() = %v, want %v", got, tt.want)
 			}
 		})
 	}

--- a/playground/backend/internal/cache/local/local_cache_test.go
+++ b/playground/backend/internal/cache/local/local_cache_test.go
@@ -78,7 +78,7 @@ func TestLocalCache_GetValue(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "get existing value",
+			name: "Get existing value",
 			fields: fields{
 				cleanupInterval:     cleanupInterval,
 				items:               preparedItemsMap,
@@ -93,7 +93,7 @@ func TestLocalCache_GetValue(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "get not existing value",
+			name: "Get not existing value",
 			fields: fields{
 				cleanupInterval: cleanupInterval,
 				items:           make(map[uuid.UUID]map[cache.SubKey]interface{}),
@@ -106,9 +106,7 @@ func TestLocalCache_GetValue(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			// Test case with calling GetValue method with existing value that is expiring.
-			// As a result, want to receive an error.
-			name: "get an existing value that is expiring",
+			name: "Get an existing value that is expiring",
 			fields: fields{
 				cleanupInterval:     cleanupInterval,
 				items:               preparedItemsMap,
@@ -179,8 +177,6 @@ func TestLocalCache_SetValue(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			// Test case with calling SetValue method with RunOutputIndex subKey.
-			// As a result, want to save value to cache.
 			name: "Set value for RunOutputIndex subKey",
 			fields: fields{
 				cleanupInterval:     cleanupInterval,
@@ -250,8 +246,6 @@ func TestLocalCache_SetExpTime(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			// Test case with calling SetExpTime method with pipelineId which not set in cache and expiration time.
-			// As a result, want to receive an error.
 			name: "Set expiration time for not existing value in cache items",
 			fields: fields{
 				cleanupInterval:     cleanupInterval,

--- a/playground/backend/internal/cache/redis/redis_cache_test.go
+++ b/playground/backend/internal/cache/redis/redis_cache_test.go
@@ -54,7 +54,7 @@ func TestRedisCache_GetValue(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "error during HGet operation",
+			name: "Error during HGet operation",
 			mocks: func() {
 				mock.ExpectHGet(pipelineId.String(), string(marshSubKey)).SetErr(fmt.Errorf("MOCK_ERROR"))
 			},
@@ -68,7 +68,7 @@ func TestRedisCache_GetValue(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "get existing value",
+			name: "Get existing value",
 			mocks: func() {
 				mock.ExpectHGet(pipelineId.String(), string(marshSubKey)).SetVal(string(marshValue))
 			},
@@ -122,7 +122,7 @@ func TestRedisCache_SetExpTime(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "error during Exists operation",
+			name: "Error during Exists operation",
 			mocks: func() {
 				mock.ExpectExists(pipelineId.String()).SetErr(fmt.Errorf("MOCK_ERROR"))
 			},
@@ -215,7 +215,7 @@ func TestRedisCache_SetValue(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "error during HSet operation",
+			name: "Error during HSet operation",
 			mocks: func() {
 				mock.ExpectHSet(pipelineId.String(), marshSubKey, marshValue).SetErr(fmt.Errorf("MOCK_ERROR"))
 			},
@@ -229,7 +229,7 @@ func TestRedisCache_SetValue(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "set correct value",
+			name: "Set correct value",
 			mocks: func() {
 				mock.ExpectHSet(pipelineId.String(), marshSubKey, marshValue).SetVal(1)
 				mock.ExpectExpire(pipelineId.String(), time.Minute*15).SetVal(true)
@@ -244,7 +244,7 @@ func TestRedisCache_SetValue(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "set incorrect value",
+			name: "Set incorrect value",
 			mocks: func() {
 				mock.ExpectHSet(pipelineId.String(), marshSubKey, marshValue).SetVal(1)
 				mock.ExpectExpire(pipelineId.String(), time.Minute*15).SetVal(true)
@@ -480,7 +480,7 @@ func Test_newRedisCache(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "error during Ping operation",
+			name: "Error during Ping operation",
 			args: args{
 				ctx:  context.Background(),
 				addr: address,
@@ -517,7 +517,7 @@ func Test_unmarshalBySubKey(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "status subKey",
+			name: "Status subKey",
 			args: args{
 				ctx:    context.Background(),
 				subKey: cache.Status,
@@ -527,7 +527,7 @@ func Test_unmarshalBySubKey(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "runOutput subKey",
+			name: "RunOutput subKey",
 			args: args{
 				subKey: cache.RunOutput,
 				value:  string(outputValue),
@@ -536,7 +536,7 @@ func Test_unmarshalBySubKey(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "compileOutput subKey",
+			name: "CompileOutput subKey",
 			args: args{
 				subKey: cache.CompileOutput,
 				value:  string(outputValue),
@@ -545,7 +545,7 @@ func Test_unmarshalBySubKey(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			name: "graph subKey",
+			name: "Graph subKey",
 			args: args{
 				subKey: cache.Graph,
 				value:  string(outputValue),

--- a/playground/backend/internal/cache/redis/redis_cache_test.go
+++ b/playground/backend/internal/cache/redis/redis_cache_test.go
@@ -556,6 +556,8 @@ func Test_unmarshalBySubKey(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			// Test case with calling unmarshalBySubKey method with Canceled subKey.
+			// As a result, want to receive false.
 			name: "Canceled subKey",
 			args: args{
 				subKey: cache.Canceled,
@@ -565,6 +567,8 @@ func Test_unmarshalBySubKey(t *testing.T) {
 			wantErr: false,
 		},
 		{
+			// Test case with calling unmarshalBySubKey method with RunOutputIndex subKey.
+			// As a result, want to receive expected runOutputIndexValue.
 			name: "RunOutputIndex subKey",
 			args: args{
 				subKey: cache.RunOutputIndex,

--- a/playground/backend/internal/cache/redis/redis_cache_test.go
+++ b/playground/backend/internal/cache/redis/redis_cache_test.go
@@ -68,7 +68,7 @@ func TestRedisCache_GetValue(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "all success",
+			name: "get existing value",
 			mocks: func() {
 				mock.ExpectHGet(pipelineId.String(), string(marshSubKey)).SetVal(string(marshValue))
 			},
@@ -148,7 +148,7 @@ func TestRedisCache_SetExpTime(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "error during Expire operation",
+			name: "Set expiration time with error during Expire operation",
 			mocks: func() {
 				mock.ExpectExists(pipelineId.String()).SetVal(1)
 				mock.ExpectExpire(pipelineId.String(), expTime).SetErr(fmt.Errorf("MOCK_ERROR"))
@@ -162,7 +162,7 @@ func TestRedisCache_SetExpTime(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "all success",
+			name: "Set expiration time",
 			mocks: func() {
 				mock.ExpectExists(pipelineId.String()).SetVal(1)
 				mock.ExpectExpire(pipelineId.String(), expTime).SetVal(true)
@@ -229,7 +229,7 @@ func TestRedisCache_SetValue(t *testing.T) {
 			wantErr: true,
 		},
 		{
-			name: "all success",
+			name: "set correct value",
 			mocks: func() {
 				mock.ExpectHSet(pipelineId.String(), marshSubKey, marshValue).SetVal(1)
 				mock.ExpectExpire(pipelineId.String(), time.Minute*15).SetVal(true)
@@ -244,8 +244,6 @@ func TestRedisCache_SetValue(t *testing.T) {
 			wantErr: false,
 		},
 		{
-			// Test case with calling SetValue method with incorrect value.
-			// As a result, want to receive an error during marshal value.
 			name: "set incorrect value",
 			mocks: func() {
 				mock.ExpectHSet(pipelineId.String(), marshSubKey, marshValue).SetVal(1)
@@ -335,7 +333,7 @@ func TestCache_GetCatalog(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "Success",
+			name: "Get existing catalog",
 			mocks: func() {
 				mock.ExpectGet(cache.ExamplesCatalog).SetVal(string(catalogMarsh))
 			},
@@ -433,7 +431,7 @@ func TestCache_SetCatalog(t *testing.T) {
 		wantErr bool
 	}{
 		{
-			name: "Success",
+			name: "Set catalog",
 			mocks: func() {
 				mock.ExpectSet(cache.ExamplesCatalog, catalogMarsh, 0).SetVal("")
 			},
@@ -568,7 +566,7 @@ func Test_unmarshalBySubKey(t *testing.T) {
 		},
 		{
 			// Test case with calling unmarshalBySubKey method with RunOutputIndex subKey.
-			// As a result, want to receive expected runOutputIndexValue.
+			// As a result, want to receive expected runOutputIndex.
 			name: "RunOutputIndex subKey",
 			args: args{
 				subKey: cache.RunOutputIndex,


### PR DESCRIPTION
[[BEAM-13870]](https://issues.apache.org/jira/browse/BEAM-13870)
Add unit tests to increase test coverage for the cache package

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

`ValidatesRunner` compliance status (on master branch)
--------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>Lang</th>
      <th>ULR</th>
      <th>Dataflow</th>
      <th>Flink</th>
      <th>Samza</th>
      <th>Spark</th>
      <th>Twister2</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Go</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon">
        </a>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Flink/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Samza/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go_VR_Spark/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
    </tr>
    <tr>
      <td>Java</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_ULR/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_ULR/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow/lastCompletedBuild/badge/icon?subject=V1">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Streaming/lastCompletedBuild/badge/icon?subject=V1+Streaming">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Dataflow_Java11/lastCompletedBuild/badge/icon?subject=V1+Java+11">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2/lastCompletedBuild/badge/icon?subject=V2">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2_Streaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_VR_Dataflow_V2_Streaming/lastCompletedBuild/badge/icon?subject=V2+Streaming">
        </a><br>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink/lastCompletedBuild/badge/icon?subject=Java+8">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Flink_Java11/lastCompletedBuild/badge/icon?subject=Java+11">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Batch/lastCompletedBuild/badge/icon?subject=Portable">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Flink_Streaming/lastCompletedBuild/badge/icon?subject=Portable+Streaming">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Samza/lastCompletedBuild/badge/icon">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Samza/lastCompletedBuild/badge/icon?subject=Portable">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Spark/lastCompletedBuild/badge/icon">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_PVR_Spark_Batch/lastCompletedBuild/badge/icon?subject=Portable">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_SparkStructuredStreaming/lastCompletedBuild/badge/icon?subject=Structured+Streaming">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_ValidatesRunner_Twister2/lastCompletedBuild/badge/icon">
        </a>
      </td>
    </tr>
    <tr>
      <td>Python</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow/lastCompletedBuild/badge/icon?subject=V1">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Py_VR_Dataflow_V2/lastCompletedBuild/badge/icon?subject=V2">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont/lastCompletedBuild/badge/icon?subject=ValCont">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Python_PVR_Flink_Cron/lastCompletedBuild/badge/icon?subject=Portable">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Flink/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Samza/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python_VR_Spark/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
    </tr>
    <tr>
      <td>XLang</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Direct/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_PythonUsingJava_Dataflow/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_PythonUsingJava_Dataflow/lastCompletedBuild/badge/icon">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_PythonUsingJavaSQL_Dataflow/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_PythonUsingJavaSQL_Dataflow/lastCompletedBuild/badge/icon">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_JavaUsingPython_Dataflow/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_JavaUsingPython_Dataflow/lastCompletedBuild/badge/icon">
        </a><br>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Flink/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Samza/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Samza/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_XVR_Spark/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
    </tr>
  </tbody>
</table>

Examples testing status on various runners
--------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>Lang</th>
      <th>ULR</th>
      <th>Dataflow</th>
      <th>Flink</th>
      <th>Samza</th>
      <th>Spark</th>
      <th>Twister2</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Go</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
    <tr>
      <td>Java</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Cron/lastCompletedBuild/badge/icon?subject=V1">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Java11_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Java_Examples_Dataflow_Java11_Cron/lastCompletedBuild/badge/icon?subject=V1+Java11">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java_Examples_Dataflow_V2/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java_Examples_Dataflow_V2/lastCompletedBuild/badge/icon?subject=V2">
        </a><br>
      </td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
    <tr>
      <td>Python</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
    <tr>
      <td>XLang</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
  </tbody>
</table>

Post-Commit SDK/Transform Integration Tests Status (on master branch)
------------------------------------------------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>Go</th>
      <th>Java</th>
      <th>Python</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Go/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Java/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python36/lastCompletedBuild/badge/icon?subject=3.6">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python37/lastCompletedBuild/badge/icon?subject=3.7">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PostCommit_Python38/lastCompletedBuild/badge/icon?subject=3.8">
        </a>
      </td>
    </tr>
  </tbody>
</table>

Pre-Commit Tests Status (on master branch)
------------------------------------------------------------------------------------------------

<table>
  <thead>
    <tr>
      <th>---</th>
      <th>Java</th>
      <th>Python</th>
      <th>Go</th>
      <th>Website</th>
      <th>Whitespace</th>
      <th>Typescript</th>
    </tr>
  </thead>
  <tbody>
    <tr>
      <td>Non-portable</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Java_Cron/lastCompletedBuild/badge/icon">
        </a><br>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Python_Cron/lastCompletedBuild/badge/icon?subject=Tests">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_PythonLint_Cron/lastCompletedBuild/badge/icon?subject=Lint">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocker_Cron/badge/icon?subject=Docker">
        </a><br>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/badge/icon?subject=Docs">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Go_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Website_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Whitespace_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Typescript_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
    </tr>
    <tr>
      <td>Portable</td>
      <td>---</td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_Portable_Python_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>
        <a href="https://ci-beam.apache.org/job/beam_PreCommit_GoPortable_Cron/lastCompletedBuild/">
          <img alt="Build Status" src="https://ci-beam.apache.org/job/beam_PreCommit_GoPortable_Cron/lastCompletedBuild/badge/icon">
        </a>
      </td>
      <td>---</td>
      <td>---</td>
      <td>---</td>
    </tr>
  </tbody>
</table>

See [.test-infra/jenkins/README](https://github.com/apache/beam/blob/master/.test-infra/jenkins/README.md) for trigger phrase, status and link of all Jenkins jobs.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
