### PR TITLE
Fix BoundedQueueExecutor and StreamingDataflowWorker to actually limit memory from windmill

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -177,10 +177,14 @@ public interface DataflowPipelineDebugOptions extends ExperimentalOptions, Pipel
 
   void setNumberOfWorkerHarnessThreads(int value);
 
-  /** Maximum number of bundles outstanding from windmill before the worker stops requesting. */
+  /**
+   * Maximum number of bundles outstanding from windmill before the worker stops requesting.
+   *
+   * <p>If <= 0, use the default value of 100 + getNumberOfWorkerHarnessThreads()
+   */
   @Description(
       "Maximum number of bundles outstanding from windmill before the worker stops requesting.")
-  @Default.Integer(400)
+  @Default.Integer(0)
   int getMaxBundlesFromWindmillOutstanding();
 
   void setMaxBundlesFromWindmillOutstanding(int value);

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -178,6 +178,24 @@ public interface DataflowPipelineDebugOptions extends ExperimentalOptions, Pipel
   void setNumberOfWorkerHarnessThreads(int value);
 
   /**
+   * Maximum number of bundles outstanding from windmill before the worker stops requesting.
+   */
+  @Description(
+      "Maximum number of bundles outstanding from windmill before the worker stops requesting.")
+  @Default.Integer(400)
+  int getMaxBundlesFromWindmillOutstanding();
+  void setMaxBundlesFromWindmillOutstanding(int value);
+
+  /**
+   * Maximum number of bytes outstanding from windmill before the worker stops requesting.
+   */
+  @Description(
+      "Maximum number of bytes outstanding from windmill before the worker stops requesting.")
+  @Default.Long(500L << 20L) // 500MB
+  long getMaxBytesFromWindmillOutstanding();
+  void setMaxBytesFromWindmillOutstanding(long value);
+
+  /**
    * If {@literal true}, save a heap dump before killing a thread or process which is GC thrashing
    * or out of memory. The location of the heap file will either be echoed back to the user, or the
    * user will be given the opportunity to download the heap file.

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -177,22 +177,24 @@ public interface DataflowPipelineDebugOptions extends ExperimentalOptions, Pipel
 
   void setNumberOfWorkerHarnessThreads(int value);
 
-  /**
-   * Maximum number of bundles outstanding from windmill before the worker stops requesting.
-   */
+  /** Maximum number of bundles outstanding from windmill before the worker stops requesting. */
   @Description(
       "Maximum number of bundles outstanding from windmill before the worker stops requesting.")
   @Default.Integer(400)
   int getMaxBundlesFromWindmillOutstanding();
+
   void setMaxBundlesFromWindmillOutstanding(int value);
 
   /**
    * Maximum number of bytes outstanding from windmill before the worker stops requesting.
+   *
+   * <p>If <= 0, use the default value of 50% of jvm memory.
    */
   @Description(
-      "Maximum number of bytes outstanding from windmill before the worker stops requesting.")
-  @Default.Long(500L << 20L) // 500MB
+      "Maximum number of bytes outstanding from windmill before the worker stops requesting. If <= 0, use the default value of 50% of jvm memory.")
+  @Default.Long(0)
   long getMaxBytesFromWindmillOutstanding();
+
   void setMaxBytesFromWindmillOutstanding(long value);
 
   /**

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -660,7 +660,7 @@ public class StreamingDataflowWorker {
             THREAD_EXPIRATION_TIME_SEC,
             TimeUnit.SECONDS,
             chooseMaximumBundlesOutstanding(),
-            options.getMaxBytesFromWindmillOutstanding(),
+            chooseMaximumBytesOutstanding(),
             threadFactory);
 
     maxSinkBytes =
@@ -781,6 +781,14 @@ public class StreamingDataflowWorker {
 
   private int chooseMaximumBundlesOutstanding() {
     return Math.max(options.getMaxBundlesFromWindmillOutstanding(), chooseMaximumNumberOfThreads());
+  }
+
+  private long chooseMaximumBytesOutstanding() {
+    long maxMem = options.getMaxBytesFromWindmillOutstanding();
+    if (maxMem > 0) {
+      return maxMem;
+    }
+    return Runtime.getRuntime().maxMemory() / 2;
   }
 
   void addStateNameMappings(Map<String, String> nameMap) {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -1243,7 +1243,8 @@ public class StreamingDataflowWorker {
               } catch (Throwable t) {
                 LOG.error("Source checkpoint finalization failed:", t);
               }
-            });
+            },
+            0);
       }
     }
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -780,7 +780,11 @@ public class StreamingDataflowWorker {
   }
 
   private int chooseMaximumBundlesOutstanding() {
-    return Math.max(options.getMaxBundlesFromWindmillOutstanding(), chooseMaximumNumberOfThreads());
+    int maxBundles = options.getMaxBundlesFromWindmillOutstanding();
+    if (maxBundles > 0) {
+      return maxBundles;
+    }
+    return chooseMaximumNumberOfThreads() + 100;
   }
 
   private long chooseMaximumBytesOutstanding() {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -1551,7 +1551,7 @@ public class StreamingDataflowWorker {
       if (retryLocally) {
         // Try again after some delay and at the end of the queue to avoid a tight loop.
         sleep(retryLocallyDelayMs);
-        workUnitExecutor.forceExecute(work);
+        workUnitExecutor.forceExecute(work, work.getWorkItem().getSerializedSize());
       } else {
         // Consider the item invalid. It will eventually be retried by Windmill if it still needs to
         // be processed.
@@ -2330,7 +2330,7 @@ public class StreamingDataflowWorker {
         }
       }
       if (nextWork != null) {
-        executor.forceExecute(nextWork);
+        executor.forceExecute(nextWork, nextWork.getWorkItem().getSerializedSize());
       }
     }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/BoundedQueueExecutor.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/BoundedQueueExecutor.java
@@ -18,62 +18,126 @@
 package org.apache.beam.runners.dataflow.worker.util;
 
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.util.concurrent.Monitor;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.util.concurrent.Monitor.Guard;
 
-/** Executor that blocks on execute() if its queue is full. */
+/** An executor for executing work on windmill items. */
 @SuppressWarnings({
   "nullness" // TODO(https://issues.apache.org/jira/browse/BEAM-10402)
 })
-public class BoundedQueueExecutor extends ThreadPoolExecutor {
-  private static class ReducableSemaphore extends Semaphore {
-    ReducableSemaphore(int permits) {
-      super(permits);
-    }
+public class BoundedQueueExecutor {
+  private final ThreadPoolExecutor executor;
+  private final int maximumElementsOutstanding;
+  private final long maximumBytesOutstanding;
 
-    @Override
-    public void reducePermits(int permits) {
-      super.reducePermits(permits);
-    }
-  }
-
-  private ReducableSemaphore semaphore;
+  private final Monitor monitor = new Monitor();
+  private int elementsOutstanding = 0;
+  private long bytesOutstanding = 0;
 
   public BoundedQueueExecutor(
       int maximumPoolSize,
       long keepAliveTime,
       TimeUnit unit,
-      int maximumQueueSize,
+      int maximumElementsOutstanding,
+      long maximumBytesOutstanding,
       ThreadFactory threadFactory) {
-    super(
-        maximumPoolSize,
-        maximumPoolSize,
-        keepAliveTime,
-        unit,
-        new LinkedBlockingQueue<Runnable>(),
-        threadFactory);
-    this.semaphore = new ReducableSemaphore(maximumQueueSize);
-    allowCoreThreadTimeOut(true);
+    executor =
+        new ThreadPoolExecutor(
+            maximumPoolSize,
+            maximumPoolSize,
+            keepAliveTime,
+            unit,
+            new LinkedBlockingQueue<>(),
+            threadFactory);
+    executor.allowCoreThreadTimeOut(true);
+    this.maximumElementsOutstanding = maximumElementsOutstanding;
+    this.maximumBytesOutstanding = maximumBytesOutstanding;
   }
 
-  // Before adding a Runnable to the queue, acquire the semaphore.
-  @Override
-  public void execute(Runnable r) {
-    semaphore.acquireUninterruptibly();
-    super.execute(r);
+  // Before adding a Work to the queue, check that there are enough bytes of space or no other
+  // outstanding elements of work.
+  public void execute(Runnable work, long workBytes) {
+    monitor.enterWhenUninterruptibly(
+        new Guard(monitor) {
+          @Override
+          public boolean isSatisfied() {
+            return elementsOutstanding == 0
+                || (bytesAvailable() >= workBytes
+                    && elementsOutstanding < maximumElementsOutstanding);
+          }
+        });
+    Runnable workRunnable =
+        () -> {
+          try {
+            work.run();
+          } finally {
+            monitor.enter();
+            --elementsOutstanding;
+            bytesOutstanding -= workBytes;
+            monitor.leave();
+          }
+        };
+    try {
+      bytesOutstanding += workBytes;
+      ++elementsOutstanding;
+      executor.execute(workRunnable);
+    } finally {
+      monitor.leave();
+    }
   }
 
   // Forcibly add something to the queue, ignoring the length limit.
   public void forceExecute(Runnable r) {
-    semaphore.reducePermits(1);
-    super.execute(r);
+    executor.execute(r);
   }
 
-  // Release the semaphore after taking a Runnable off the queue.
-  @Override
-  public void beforeExecute(Thread t, Runnable r) {
-    semaphore.release();
+  public void shutdown() throws InterruptedException {
+    executor.shutdown();
+    if (!executor.awaitTermination(5, TimeUnit.MINUTES)) {
+      throw new RuntimeException("Work executor did not terminate within 5 minutes");
+    }
+  }
+
+  public boolean executorQueueIsEmpty() {
+    return executor.getQueue().isEmpty();
+  }
+
+  public String summaryHtml() {
+    monitor.enter();
+    try {
+      StringBuilder builder = new StringBuilder();
+      builder.append("Worker Threads: ");
+      builder.append(executor.getPoolSize());
+      builder.append("/");
+      builder.append(executor.getMaximumPoolSize());
+      builder.append("<br>/n");
+
+      builder.append("Active Threads: ");
+      builder.append(executor.getActiveCount());
+      builder.append("<br>/n");
+
+      builder.append("Work Queue Size: ");
+      builder.append(elementsOutstanding);
+      builder.append("/");
+      builder.append(maximumElementsOutstanding);
+      builder.append("<br>/n");
+
+      builder.append("Work Queue Bytes: ");
+      builder.append(bytesOutstanding);
+      builder.append("/");
+      builder.append(maximumBytesOutstanding);
+      builder.append("<br>/n");
+
+      return builder.toString();
+    } finally {
+      monitor.leave();
+    }
+  }
+
+  private long bytesAvailable() {
+    return maximumBytesOutstanding - bytesOutstanding;
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
@@ -2713,7 +2713,7 @@ public class StreamingDataflowWorkerTest {
     Mockito.verifyNoMoreInteractions(mockExecutor);
 
     computationState.completeWork(key1, 2);
-    Mockito.verify(mockExecutor).forceExecute(m3);
+    Mockito.verify(mockExecutor).forceExecute(m3, m3.getWorkItem().getSerializedSize());
     computationState.completeWork(key1, 3);
     Mockito.verifyNoMoreInteractions(mockExecutor);
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
@@ -2693,14 +2693,14 @@ public class StreamingDataflowWorkerTest {
 
     MockWork m1 = new MockWork(1);
     assertTrue(computationState.activateWork(key1, m1));
-    Mockito.verify(mockExecutor).execute(m1);
+    Mockito.verify(mockExecutor).execute(m1, m1.getWorkItem().getSerializedSize());
     computationState.completeWork(key1, 1);
     Mockito.verifyNoMoreInteractions(mockExecutor);
 
     // Verify work queues.
     MockWork m2 = new MockWork(2);
     assertTrue(computationState.activateWork(key1, m2));
-    Mockito.verify(mockExecutor).execute(m2);
+    Mockito.verify(mockExecutor).execute(m2, m2.getWorkItem().getSerializedSize());
     MockWork m3 = new MockWork(3);
     assertTrue(computationState.activateWork(key1, m3));
     Mockito.verifyNoMoreInteractions(mockExecutor);
@@ -2708,7 +2708,7 @@ public class StreamingDataflowWorkerTest {
     // Verify another key is a separate queue.
     MockWork m4 = new MockWork(4);
     assertTrue(computationState.activateWork(key2, m4));
-    Mockito.verify(mockExecutor).execute(m4);
+    Mockito.verify(mockExecutor).execute(m4, m4.getWorkItem().getSerializedSize());
     computationState.completeWork(key2, 4);
     Mockito.verifyNoMoreInteractions(mockExecutor);
 
@@ -2720,7 +2720,7 @@ public class StreamingDataflowWorkerTest {
     // Verify duplicate work dropped.
     MockWork m5 = new MockWork(5);
     computationState.activateWork(key1, m5);
-    Mockito.verify(mockExecutor).execute(m5);
+    Mockito.verify(mockExecutor).execute(m5, m5.getWorkItem().getSerializedSize());
     assertFalse(computationState.activateWork(key1, m5));
     Mockito.verifyNoMoreInteractions(mockExecutor);
     computationState.completeWork(key1, 5);
@@ -2743,14 +2743,14 @@ public class StreamingDataflowWorkerTest {
 
     MockWork m1 = new MockWork(1);
     assertTrue(computationState.activateWork(key1Shard1, m1));
-    Mockito.verify(mockExecutor).execute(m1);
+    Mockito.verify(mockExecutor).execute(m1, m1.getWorkItem().getSerializedSize());
     computationState.completeWork(key1Shard1, 1);
     Mockito.verifyNoMoreInteractions(mockExecutor);
 
     // Verify work queues.
     MockWork m2 = new MockWork(2);
     assertTrue(computationState.activateWork(key1Shard1, m2));
-    Mockito.verify(mockExecutor).execute(m2);
+    Mockito.verify(mockExecutor).execute(m2, m2.getWorkItem().getSerializedSize());
     MockWork m3 = new MockWork(3);
     assertTrue(computationState.activateWork(key1Shard1, m3));
     Mockito.verifyNoMoreInteractions(mockExecutor);
@@ -2760,7 +2760,7 @@ public class StreamingDataflowWorkerTest {
     assertFalse(computationState.activateWork(key1Shard1, m4));
     Mockito.verifyNoMoreInteractions(mockExecutor);
     assertTrue(computationState.activateWork(key1Shard2, m4));
-    Mockito.verify(mockExecutor).execute(m4);
+    Mockito.verify(mockExecutor).execute(m4, m4.getWorkItem().getSerializedSize());
 
     // Verify duplicate work dropped
     assertFalse(computationState.activateWork(key1Shard2, m4));


### PR DESCRIPTION
Currently, because the queue is only limited by number of elements, there can be up to (num threads + queue size) elements outstanding at a time, which for large work items will almost certainly OOM the worker.

This change both makes this limit explicit and adds a 50% JVM max memory limit on outstanding WorkItems to push back on windmill before workers run out of memory.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/validate-runner/README.md)


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
