### PR TITLE
[BEAM-12645] Fix code-cov flakes due to monorepo.

### DIFF
--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -64,6 +64,7 @@ ignore:
   - "**/*_test_py3*.py"
   - "**/*_microbenchmark.py"
 
+# See https://docs.codecov.com/docs/flags for options.
 flag_management:
   default_rules: # the rules that will be followed for any flag added, generally
-    carryforward: true
+    carryforward: true # recommended for multi-lang mono-repos.

--- a/.github/codecov.yml
+++ b/.github/codecov.yml
@@ -29,12 +29,16 @@ coverage:
   status:
     project:
       python:
+        flags: 
+          - python
         target: auto
         threshold: 5%
         base: auto
         paths:
           - "sdks/python"
       go:
+        flags: 
+          - go
         target: auto
         threshold: 5%
         base: auto
@@ -59,3 +63,7 @@ ignore:
   - "**/*_test.py"
   - "**/*_test_py3*.py"
   - "**/*_microbenchmark.py"
+
+flag_management:
+  default_rules: # the rules that will be followed for any flag added, generally
+    carryforward: true

--- a/.github/workflows/go_tests.yml
+++ b/.github/workflows/go_tests.yml
@@ -44,7 +44,10 @@ jobs:
         run: "cd sdks/go/pkg && rm -rf .coverage || :"
       - name: Run coverage
         run: cd sdks/go/pkg && go test -coverprofile=coverage.txt -covermode=atomic ./...
-      - name: Upload to codecov
-        run: bash <(curl -s https://codecov.io/bash)
+      - uses: codecov/codecov-action@v2
+        with:
+          flags: go 
+          files: ./sdks/go/pkg/coverage.txt
+          name: go-unittests
       - name: Run vet
         run: cd sdks/go/pkg/beam && go vet --copylocks=false --unsafeptr=false ./...

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -102,7 +102,7 @@ extras = test,gcp,interactive,dataframe,aws
 commands =
   -rm .coverage
   {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}" "--cov-report=xml --cov=. --cov-append"
-  codecov
+  codecov -F python
 
 [testenv:py37-lint]
 # Don't set TMPDIR to avoid "AF_UNIX path too long" errors in pylint.


### PR DESCRIPTION
Use features of codecov to avoid overwriting codecov.
- Flag the different uploads (go and python) so they are merged, and not clobbered.
- Update the Go SDK upload to use the github action, rather than the decommissioned bash script.

In particular, Go SDK coverage is presently lower than python, and Go uploads would overwrite a previous python upload entirely. Codecov has a [flags](https://docs.codecov.com/docs/flags) mechnaism for this that segments uploads into their own groups, and merges everything at the top level.

Further, we likely want to have carryforward enabled, since not all tests are run on every run, avoiding weird "0%" coverage messages, when very little was changed.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
