### PR TITLE
Minor: Update Go API doc links

### DIFF
--- a/website/www/site/data/io_matrix.yaml
+++ b/website/www/site/data/io_matrix.yaml
@@ -34,7 +34,7 @@ categories:
             url: https://beam.apache.org/releases/pydoc/current/apache_beam.io.avroio.html
           - language: go
             name: github.com/apache/beam/sdks/go/pkg/beam/io/avroio
-            url: https://godoc.org/github.com/apache/beam/sdks/go/pkg/beam/io/avroio
+            url: https://pkg.go.dev/github.com/apache/beam/sdks/v2/go/pkg/beam/io/avroio
       - transform: TextIO
         description: PTransforms for reading and writing text files.
         implementations:
@@ -46,7 +46,7 @@ categories:
             url: https://beam.apache.org/releases/pydoc/current/apache_beam.io.textio.html
           - language: go
             name: github.com/apache/beam/sdks/go/pkg/beam/io/textio
-            url: https://godoc.org/github.com/apache/beam/sdks/go/pkg/beam/io/textio
+            url: https://pkg.go.dev/github.com/apache/beam/sdks/v2/go/pkg/beam/io/textio
       - transform: TFRecordIO
         description: PTransforms for reading and writing [TensorFlow TFRecord](https://www.tensorflow.org/tutorials/load_data/tfrecord) files.
         implementations:
@@ -119,7 +119,7 @@ categories:
             url: https://beam.apache.org/releases/pydoc/current/apache_beam.io.gcp.gcsfilesystem.html
           - language: go
             name: github.com/apache/beam/sdks/go/pkg/beam/io/filesystem/gcs
-            url: https://godoc.org/github.com/apache/beam/sdks/go/pkg/beam/io/filesystem/gcs
+            url: https://pkg.go.dev/github.com/apache/beam/sdks/v2/go/pkg/beam/io/filesystem/gcs
       - transform: LocalFileSystem
         description: "`FileSystem` implementation for accessing files on disk."
         implementations:
@@ -131,7 +131,7 @@ categories:
             url: https://beam.apache.org/releases/pydoc/current/apache_beam.io.localfilesystem.html
           - language: go
             name: github.com/apache/beam/sdks/go/pkg/beam/io/filesystem/local
-            url: https://godoc.org/github.com/apache/beam/sdks/go/pkg/beam/io/filesystem/local
+            url: https://pkg.go.dev/github.com/apache/beam/sdks/v2/go/pkg/beam/io/filesystem/local
       - transform: S3FileSystem
         description: "`FileSystem` implementation for [Amazon S3](https://aws.amazon.com/s3/)."
         implementations:
@@ -143,7 +143,7 @@ categories:
         implementations:
           - language: go
             name: github.com/apache/beam/sdks/go/pkg/beam/io/filesystem/memfs
-            url: https://godoc.org/github.com/apache/beam/sdks/go/pkg/beam/io/filesystem/memfs
+            url: https://pkg.go.dev/github.com/apache/beam/sdks/v2/go/pkg/beam/io/filesystem/memfs
   - name: Messaging
     description: These I/O connectors typically involve working with unbounded sources that come from messaging sources.
     rows:
@@ -182,7 +182,7 @@ categories:
             url: https://beam.apache.org/releases/pydoc/current/apache_beam.io.external.gcp.pubsub.html
           - language: go
             name: github.com/apache/beam/sdks/go/pkg/beam/io/pubsubio
-            url: https://godoc.org/github.com/apache/beam/sdks/go/pkg/beam/io/pubsubio
+            url: https://pkg.go.dev/github.com/apache/beam/sdks/v2/go/pkg/beam/io/pubsubio
       - transform: JmsIO
         description: An unbounded source for [JMS](https://www.oracle.com/java/technologies/java-message-service.html) destinations (queues or topics).
         implementations:
@@ -278,7 +278,7 @@ categories:
             url: https://beam.apache.org/releases/pydoc/current/apache_beam.io.gcp.bigquery.html
           - language: go
             name: github.com/apache/beam/sdks/go/pkg/beam/io/bigqueryio
-            url: https://godoc.org/github.com/apache/beam/sdks/go/pkg/beam/io/bigqueryio
+            url: https://pkg.go.dev/github.com/apache/beam/sdks/v2/go/pkg/beam/io/bigqueryio
       - transform: BigTableIO
         description: Read from (only for Java SDK) and write to [Google Cloud Bigtable](https://cloud.google.com/bigtable/).
         implementations:
@@ -360,7 +360,7 @@ categories:
         implementations:
           - language: go
             name: github.com/apache/beam/sdks/go/pkg/beam/io/databaseio
-            url: https://godoc.org/github.com/apache/beam/sdks/go/pkg/beam/io/databaseio
+            url: https://pkg.go.dev/github.com/apache/beam/sdks/v2/go/pkg/beam/io/databaseio
   - name: Miscellaneous
     description: Miscellaneous I/O sources.
     rows:

--- a/website/www/site/layouts/partials/section-menu/en/sdks.html
+++ b/website/www/site/layouts/partials/section-menu/en/sdks.html
@@ -48,7 +48,7 @@
   <span class="section-nav-list-title">Go</span>
   <ul class="section-nav-list">
     <li><a href="/documentation/sdks/go/">Go SDK overview</a></li>
-    <li><a href="https://godoc.org/github.com/apache/beam/sdks/go/pkg/beam" target="_blank">Go SDK API reference <img src="/images/external-link-icon.png"
+    <li><a href="https://pkg.go.dev/github.com/apache/beam/sdks/v2/go/pkg/beam" target="_blank">Go SDK API reference <img src="/images/external-link-icon.png"
                                                                                                                                    width="14" height="14"
                                                                                                                                    alt="External link."></a>
     </li>


### PR DESCRIPTION
I noticed that these links are still pointing to the old documentation

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
