### PR TITLE
[BEAM-13996] Removing 'No cluster_manager is associated with the provided pipeline!' logger error

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/interactive_beam.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_beam.py
@@ -420,10 +420,6 @@ class Clusters:
           self.master_urls.pop(master_url, None)
           self.master_urls_to_pipelines.pop(master_url, None)
           self.dataproc_cluster_managers.pop(str(id(pipeline)), None)
-      else:
-        _LOGGER.error(
-            'No cluster_manager is associated with the provided '
-            'pipeline!')
     else:
       cluster_manager_identifiers = set()
       for cluster_manager in self.dataproc_cluster_managers.values():

--- a/sdks/python/apache_beam/runners/interactive/interactive_beam_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_beam_test.py
@@ -311,19 +311,6 @@ class InteractiveBeamClustersTest(unittest.TestCase):
     self.assertEqual('test-project', clusters.describe()[None] \
     ['cluster_metadata'].project_id)
 
-  def test_clusters_cleanup_cluster_manager_not_found(self):
-    clusters = ib.Clusters()
-    p = beam.Pipeline(
-        options=PipelineOptions(
-            project='test-project',
-            region='test-region',
-        ))
-    from apache_beam.runners.interactive.interactive_beam import _LOGGER
-    with self.assertLogs(_LOGGER, level='ERROR') as context_manager:
-      clusters.cleanup(p)
-      self.assertTrue(
-          'No cluster_manager is associated' in context_manager.output[0])
-
   @patch(
       'apache_beam.runners.interactive.dataproc.dataproc_cluster_manager.'
       'DataprocClusterManager.get_master_url',


### PR DESCRIPTION
Bug fix: removing the 'No cluster_manager is associated with the provided pipeline!' logger error message when a pipeline is present, but has no cluster manager. The bug in this scenario is that this case can be triggered when the user uses Interactive Beam in a way that automatically cleans up an individual pipeline (e.g. running InteractiveRunner() using a `with` clause).

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
