### PR TITLE
[release-2.37.0] Fix BoundedQueueExecutor and StreamingDataflowWorker to actually limit memory from windmill

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -178,6 +178,30 @@ public interface DataflowPipelineDebugOptions extends ExperimentalOptions, Pipel
   void setNumberOfWorkerHarnessThreads(int value);
 
   /**
+   * Maximum number of bundles outstanding from windmill before the worker stops requesting.
+   *
+   * <p>If <= 0, use the default value of 100 + getNumberOfWorkerHarnessThreads()
+   */
+  @Description(
+      "Maximum number of bundles outstanding from windmill before the worker stops requesting.")
+  @Default.Integer(0)
+  int getMaxBundlesFromWindmillOutstanding();
+
+  void setMaxBundlesFromWindmillOutstanding(int value);
+
+  /**
+   * Maximum number of bytes outstanding from windmill before the worker stops requesting.
+   *
+   * <p>If <= 0, use the default value of 50% of jvm memory.
+   */
+  @Description(
+      "Maximum number of bytes outstanding from windmill before the worker stops requesting. If <= 0, use the default value of 50% of jvm memory.")
+  @Default.Long(0)
+  long getMaxBytesFromWindmillOutstanding();
+
+  void setMaxBytesFromWindmillOutstanding(long value);
+
+  /**
    * If {@literal true}, save a heap dump before killing a thread or process which is GC thrashing
    * or out of memory. The location of the heap file will either be echoed back to the user, or the
    * user will be given the opportunity to download the heap file.

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -191,10 +191,6 @@ public class StreamingDataflowWorker {
   // Maximum number of threads for processing.  Currently each thread processes one key at a time.
   static final int MAX_PROCESSING_THREADS = 300;
   static final long THREAD_EXPIRATION_TIME_SEC = 60;
-  // Maximum work units retrieved from Windmill and queued before processing. Limiting this delays
-  // retrieving extra work from Windmill without working on it, leading to better
-  // prioritization / utilization.
-  static final int MAX_WORK_UNITS_QUEUED = 100;
   static final long TARGET_COMMIT_BUNDLE_BYTES = 32 << 20;
   static final int MAX_COMMIT_QUEUE_BYTES = 500 << 20; // 500MB
   static final int NUM_COMMIT_STREAMS = 1;
@@ -209,9 +205,6 @@ public class StreamingDataflowWorker {
   // Reserved ID for counter updates.
   // Matches kWindmillCounterUpdate in workflow_worker_service_multi_hubs.cc.
   private static final String WINDMILL_COUNTER_UPDATE_WORK_ID = "3";
-
-  /** Maximum number of items to return in a GetWork request. */
-  private static final long MAX_GET_WORK_ITEMS = MAX_WORK_UNITS_QUEUED + MAX_PROCESSING_THREADS;
 
   /** Maximum number of failure stacktraces to report in each update sent to backend. */
   private static final int MAX_FAILURES_TO_REPORT_IN_UPDATE = 1000;
@@ -666,7 +659,8 @@ public class StreamingDataflowWorker {
             chooseMaximumNumberOfThreads(),
             THREAD_EXPIRATION_TIME_SEC,
             TimeUnit.SECONDS,
-            MAX_WORK_UNITS_QUEUED,
+            chooseMaximumBundlesOutstanding(),
+            chooseMaximumBytesOutstanding(),
             threadFactory);
 
     maxSinkBytes =
@@ -785,6 +779,22 @@ public class StreamingDataflowWorker {
     return MAX_PROCESSING_THREADS;
   }
 
+  private int chooseMaximumBundlesOutstanding() {
+    int maxBundles = options.getMaxBundlesFromWindmillOutstanding();
+    if (maxBundles > 0) {
+      return maxBundles;
+    }
+    return chooseMaximumNumberOfThreads() + 100;
+  }
+
+  private long chooseMaximumBytesOutstanding() {
+    long maxMem = options.getMaxBytesFromWindmillOutstanding();
+    if (maxMem > 0) {
+      return maxMem;
+    }
+    return Runtime.getRuntime().maxMemory() / 2;
+  }
+
   void addStateNameMappings(Map<String, String> nameMap) {
     stateNameMap.putAll(nameMap);
   }
@@ -804,7 +814,7 @@ public class StreamingDataflowWorker {
 
   @VisibleForTesting
   public boolean workExecutorIsEmpty() {
-    return workUnitExecutor.getQueue().isEmpty();
+    return workUnitExecutor.executorQueueIsEmpty();
   }
 
   public void start() {
@@ -949,9 +959,6 @@ public class StreamingDataflowWorker {
       memoryMonitor.stop();
       memoryMonitorThread.join();
       workUnitExecutor.shutdown();
-      if (!workUnitExecutor.awaitTermination(5, TimeUnit.MINUTES)) {
-        throw new RuntimeException("Work executor did not terminate within 5 minutes");
-      }
       for (ComputationState state : computationMap.values()) {
         state.close();
       }
@@ -1065,7 +1072,7 @@ public class StreamingDataflowWorker {
           windmillServer.getWorkStream(
               Windmill.GetWorkRequest.newBuilder()
                   .setClientId(clientId)
-                  .setMaxItems(MAX_GET_WORK_ITEMS)
+                  .setMaxItems(chooseMaximumBundlesOutstanding())
                   .setMaxBytes(MAX_GET_WORK_FETCH_BYTES)
                   .build(),
               (String computation,
@@ -1236,7 +1243,8 @@ public class StreamingDataflowWorker {
               } catch (Throwable t) {
                 LOG.error("Source checkpoint finalization failed:", t);
               }
-            });
+            },
+            0);
       }
     }
   }
@@ -1548,7 +1556,7 @@ public class StreamingDataflowWorker {
       if (retryLocally) {
         // Try again after some delay and at the end of the queue to avoid a tight loop.
         sleep(retryLocallyDelayMs);
-        workUnitExecutor.forceExecute(work);
+        workUnitExecutor.forceExecute(work, work.getWorkItem().getSerializedSize());
       } else {
         // Consider the item invalid. It will eventually be retried by Windmill if it still needs to
         // be processed.
@@ -1726,7 +1734,7 @@ public class StreamingDataflowWorker {
     return windmillServer.getWork(
         Windmill.GetWorkRequest.newBuilder()
             .setClientId(clientId)
-            .setMaxItems(MAX_GET_WORK_ITEMS)
+            .setMaxItems(chooseMaximumBundlesOutstanding())
             .setMaxBytes(MAX_GET_WORK_FETCH_BYTES)
             .build());
   }
@@ -2285,7 +2293,7 @@ public class StreamingDataflowWorker {
           // Fall through to execute without the lock held.
         }
       }
-      executor.execute(work);
+      executor.execute(work, work.getWorkItem().getSerializedSize());
       return true;
     }
 
@@ -2327,7 +2335,7 @@ public class StreamingDataflowWorker {
         }
       }
       if (nextWork != null) {
-        executor.forceExecute(nextWork);
+        executor.forceExecute(nextWork, nextWork.getWorkItem().getSerializedSize());
       }
     }
 
@@ -2511,27 +2519,9 @@ public class StreamingDataflowWorker {
   }
 
   private class MetricsDataProvider implements StatusDataProvider {
-
     @Override
     public void appendSummaryHtml(PrintWriter writer) {
-      writer.println(
-          "Worker Threads: "
-              + workUnitExecutor.getPoolSize()
-              + "/"
-              + workUnitExecutor.getMaximumPoolSize()
-              + "<br>");
-      writer.println("Active Threads: " + workUnitExecutor.getActiveCount() + "<br>");
-      writer.println(
-          "Work Queue Size: "
-              + workUnitExecutor.getQueue().size()
-              + "/"
-              + MAX_WORK_UNITS_QUEUED
-              + "<br>");
-      writer.print("Commit Queue: ");
-      appendHumanizedBytes(commitQueue.weight(), writer);
-      writer.print(", ");
-      writer.print(commitQueue.size());
-      writer.println(" elements<br>");
+      writer.println(workUnitExecutor.summaryHtml());
 
       writer.print("Active commit: ");
       appendHumanizedBytes(activeCommitBytes.get(), writer);

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/BoundedQueueExecutor.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/BoundedQueueExecutor.java
@@ -18,62 +18,138 @@
 package org.apache.beam.runners.dataflow.worker.util;
 
 import java.util.concurrent.LinkedBlockingQueue;
-import java.util.concurrent.Semaphore;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.ThreadPoolExecutor;
 import java.util.concurrent.TimeUnit;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.util.concurrent.Monitor;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.util.concurrent.Monitor.Guard;
 
-/** Executor that blocks on execute() if its queue is full. */
+/** An executor for executing work on windmill items. */
 @SuppressWarnings({
   "nullness" // TODO(https://issues.apache.org/jira/browse/BEAM-10402)
 })
-public class BoundedQueueExecutor extends ThreadPoolExecutor {
-  private static class ReducableSemaphore extends Semaphore {
-    ReducableSemaphore(int permits) {
-      super(permits);
-    }
+public class BoundedQueueExecutor {
+  private final ThreadPoolExecutor executor;
+  private final int maximumElementsOutstanding;
+  private final long maximumBytesOutstanding;
 
-    @Override
-    public void reducePermits(int permits) {
-      super.reducePermits(permits);
-    }
-  }
-
-  private ReducableSemaphore semaphore;
+  private final Monitor monitor = new Monitor();
+  private int elementsOutstanding = 0;
+  private long bytesOutstanding = 0;
 
   public BoundedQueueExecutor(
       int maximumPoolSize,
       long keepAliveTime,
       TimeUnit unit,
-      int maximumQueueSize,
+      int maximumElementsOutstanding,
+      long maximumBytesOutstanding,
       ThreadFactory threadFactory) {
-    super(
-        maximumPoolSize,
-        maximumPoolSize,
-        keepAliveTime,
-        unit,
-        new LinkedBlockingQueue<Runnable>(),
-        threadFactory);
-    this.semaphore = new ReducableSemaphore(maximumQueueSize);
-    allowCoreThreadTimeOut(true);
+    executor =
+        new ThreadPoolExecutor(
+            maximumPoolSize,
+            maximumPoolSize,
+            keepAliveTime,
+            unit,
+            new LinkedBlockingQueue<>(),
+            threadFactory);
+    executor.allowCoreThreadTimeOut(true);
+    this.maximumElementsOutstanding = maximumElementsOutstanding;
+    this.maximumBytesOutstanding = maximumBytesOutstanding;
   }
 
-  // Before adding a Runnable to the queue, acquire the semaphore.
-  @Override
-  public void execute(Runnable r) {
-    semaphore.acquireUninterruptibly();
-    super.execute(r);
+  // Before adding a Work to the queue, check that there are enough bytes of space or no other
+  // outstanding elements of work.
+  public void execute(Runnable work, long workBytes) {
+    monitor.enterWhenUninterruptibly(
+        new Guard(monitor) {
+          @Override
+          public boolean isSatisfied() {
+            return elementsOutstanding == 0
+                || (bytesAvailable() >= workBytes
+                    && elementsOutstanding < maximumElementsOutstanding);
+          }
+        });
+    executeLockHeld(work, workBytes);
   }
 
   // Forcibly add something to the queue, ignoring the length limit.
-  public void forceExecute(Runnable r) {
-    semaphore.reducePermits(1);
-    super.execute(r);
+  public void forceExecute(Runnable work, long workBytes) {
+    monitor.enter();
+    executeLockHeld(work, workBytes);
   }
 
-  // Release the semaphore after taking a Runnable off the queue.
-  @Override
-  public void beforeExecute(Thread t, Runnable r) {
-    semaphore.release();
+  public void shutdown() throws InterruptedException {
+    executor.shutdown();
+    if (!executor.awaitTermination(5, TimeUnit.MINUTES)) {
+      throw new RuntimeException("Work executor did not terminate within 5 minutes");
+    }
+  }
+
+  public boolean executorQueueIsEmpty() {
+    return executor.getQueue().isEmpty();
+  }
+
+  public String summaryHtml() {
+    monitor.enter();
+    try {
+      StringBuilder builder = new StringBuilder();
+      builder.append("Worker Threads: ");
+      builder.append(executor.getPoolSize());
+      builder.append("/");
+      builder.append(executor.getMaximumPoolSize());
+      builder.append("<br>/n");
+
+      builder.append("Active Threads: ");
+      builder.append(executor.getActiveCount());
+      builder.append("<br>/n");
+
+      builder.append("Work Queue Size: ");
+      builder.append(elementsOutstanding);
+      builder.append("/");
+      builder.append(maximumElementsOutstanding);
+      builder.append("<br>/n");
+
+      builder.append("Work Queue Bytes: ");
+      builder.append(bytesOutstanding);
+      builder.append("/");
+      builder.append(maximumBytesOutstanding);
+      builder.append("<br>/n");
+
+      return builder.toString();
+    } finally {
+      monitor.leave();
+    }
+  }
+
+  private void executeLockHeld(Runnable work, long workBytes) {
+    bytesOutstanding += workBytes;
+    ++elementsOutstanding;
+    monitor.leave();
+
+    try {
+      executor.execute(
+          () -> {
+            try {
+              work.run();
+            } finally {
+              decrementCounters(workBytes);
+            }
+          });
+    } catch (RuntimeException e) {
+      // If the execute() call threw an exception, decrement counters here.
+      decrementCounters(workBytes);
+      throw e;
+    }
+  }
+
+  private void decrementCounters(long workBytes) {
+    monitor.enter();
+    --elementsOutstanding;
+    bytesOutstanding -= workBytes;
+    monitor.leave();
+  }
+
+  private long bytesAvailable() {
+    return maximumBytesOutstanding - bytesOutstanding;
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
@@ -2693,14 +2693,14 @@ public class StreamingDataflowWorkerTest {
 
     MockWork m1 = new MockWork(1);
     assertTrue(computationState.activateWork(key1, m1));
-    Mockito.verify(mockExecutor).execute(m1);
+    Mockito.verify(mockExecutor).execute(m1, m1.getWorkItem().getSerializedSize());
     computationState.completeWork(key1, 1);
     Mockito.verifyNoMoreInteractions(mockExecutor);
 
     // Verify work queues.
     MockWork m2 = new MockWork(2);
     assertTrue(computationState.activateWork(key1, m2));
-    Mockito.verify(mockExecutor).execute(m2);
+    Mockito.verify(mockExecutor).execute(m2, m2.getWorkItem().getSerializedSize());
     MockWork m3 = new MockWork(3);
     assertTrue(computationState.activateWork(key1, m3));
     Mockito.verifyNoMoreInteractions(mockExecutor);
@@ -2708,19 +2708,19 @@ public class StreamingDataflowWorkerTest {
     // Verify another key is a separate queue.
     MockWork m4 = new MockWork(4);
     assertTrue(computationState.activateWork(key2, m4));
-    Mockito.verify(mockExecutor).execute(m4);
+    Mockito.verify(mockExecutor).execute(m4, m4.getWorkItem().getSerializedSize());
     computationState.completeWork(key2, 4);
     Mockito.verifyNoMoreInteractions(mockExecutor);
 
     computationState.completeWork(key1, 2);
-    Mockito.verify(mockExecutor).forceExecute(m3);
+    Mockito.verify(mockExecutor).forceExecute(m3, m3.getWorkItem().getSerializedSize());
     computationState.completeWork(key1, 3);
     Mockito.verifyNoMoreInteractions(mockExecutor);
 
     // Verify duplicate work dropped.
     MockWork m5 = new MockWork(5);
     computationState.activateWork(key1, m5);
-    Mockito.verify(mockExecutor).execute(m5);
+    Mockito.verify(mockExecutor).execute(m5, m5.getWorkItem().getSerializedSize());
     assertFalse(computationState.activateWork(key1, m5));
     Mockito.verifyNoMoreInteractions(mockExecutor);
     computationState.completeWork(key1, 5);
@@ -2743,14 +2743,14 @@ public class StreamingDataflowWorkerTest {
 
     MockWork m1 = new MockWork(1);
     assertTrue(computationState.activateWork(key1Shard1, m1));
-    Mockito.verify(mockExecutor).execute(m1);
+    Mockito.verify(mockExecutor).execute(m1, m1.getWorkItem().getSerializedSize());
     computationState.completeWork(key1Shard1, 1);
     Mockito.verifyNoMoreInteractions(mockExecutor);
 
     // Verify work queues.
     MockWork m2 = new MockWork(2);
     assertTrue(computationState.activateWork(key1Shard1, m2));
-    Mockito.verify(mockExecutor).execute(m2);
+    Mockito.verify(mockExecutor).execute(m2, m2.getWorkItem().getSerializedSize());
     MockWork m3 = new MockWork(3);
     assertTrue(computationState.activateWork(key1Shard1, m3));
     Mockito.verifyNoMoreInteractions(mockExecutor);
@@ -2760,7 +2760,7 @@ public class StreamingDataflowWorkerTest {
     assertFalse(computationState.activateWork(key1Shard1, m4));
     Mockito.verifyNoMoreInteractions(mockExecutor);
     assertTrue(computationState.activateWork(key1Shard2, m4));
-    Mockito.verify(mockExecutor).execute(m4);
+    Mockito.verify(mockExecutor).execute(m4, m4.getWorkItem().getSerializedSize());
 
     // Verify duplicate work dropped
     assertFalse(computationState.activateWork(key1Shard2, m4));


### PR DESCRIPTION
Cherrypick #16901 into 2.37.0 release branch

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
