### PR TITLE
[BEAM-12777] Removed current docs version redirect

### DIFF
--- a/website/www/site/static/.htaccess
+++ b/website/www/site/static/.htaccess
@@ -20,7 +20,5 @@ RewriteRule ^(.*)$ https://beam.apache.org/$1 [L,R=301]
 # path /documentation/sdks/(javadoc|pydoc)/..
 # The following redirect maintains the previously supported URLs.
 RedirectMatch permanent "/documentation/sdks/(javadoc|pydoc)(.*)" "https://beam.apache.org/releases/$1$2"
-# Keep this updated to point to the current release.
-RedirectMatch "/releases/([^/]+)/current(.*)" "https://beam.apache.org/releases/$1/2.36.0$2"
 
 RedirectMatch "/contribute/design-documents" "https://cwiki.apache.org/confluence/display/BEAM/Design+Documents"


### PR DESCRIPTION
Removed the ```.htaccess``` redirect to a hardcoded URL with the current version of docs.
- ```beam.apache.org/releases/javadoc/current/``` stays as it is instead of redirecting to ```beam.apache.org/releases/javadoc/2.36.0/```

------------------------

------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
