### PR TITLE
[BEAM-13925] Add entry files to process new prs and pr updates for PR automation

### DIFF
--- a/scripts/ci/pr-bot/.gitignore
+++ b/scripts/ci/pr-bot/.gitignore
@@ -13,9 +13,6 @@ logs
 results
 tmp
 
-# Build
-public/css/main.css
-
 # Coverage reports
 coverage
 

--- a/scripts/ci/pr-bot/.gitignore
+++ b/scripts/ci/pr-bot/.gitignore
@@ -1,0 +1,41 @@
+lib-cov
+*.seed
+*.log
+*.csv
+*.dat
+*.out
+*.pid
+*.gz
+*.swp
+
+pids
+logs
+results
+tmp
+
+# Build
+public/css/main.css
+
+# Coverage reports
+coverage
+
+# API keys and secrets
+.env
+
+# Dependency directory
+node_modules
+bower_components
+
+# Editors
+.idea
+*.iml
+
+# OS metadata
+.DS_Store
+Thumbs.db
+
+# Ignore built js files
+lib/**/*
+
+# ignore yarn.lock
+yarn.lock

--- a/scripts/ci/pr-bot/Commands.md
+++ b/scripts/ci/pr-bot/Commands.md
@@ -1,0 +1,32 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+# PR Bot Commands
+
+The following commands are available for interaction with the PR Bot
+All commands are case insensitive.
+
+| Command      | Description |
+| ----------- | ----------- |
+| `r: @username` | Ask someone for a review. This will disable the bot for the PR since it assumes you are able to find a reviewer. |
+| `assign to next reviewer` | If someone has been assigned to a PR by the bot, this unassigns them and picks a new reviewer. Useful if you don't have the bandwitdth or context to review. |
+| `stop reviewer notifications` | This will disable the bot for the PR. |
+| `remind me after tests pass` | This will comment after all checks complete and tag the person who commented the command. |
+| `waiting on author` | This shifts the attention set to the author. The author can shift the attention set back to the reviewer by commenting anywhere or pushing. |
+| `assign set of reviewers` | If the bot has not yet assigned a set of reviewers to the PR, this command will trigger that happening. |

--- a/scripts/ci/pr-bot/processNewPrs.ts
+++ b/scripts/ci/pr-bot/processNewPrs.ts
@@ -21,7 +21,9 @@ const { getChecksStatus } = require("./shared/checks");
 const commentStrings = require("./shared/commentStrings");
 const { ReviewerConfig } = require("./shared/reviewerConfig");
 const { PersistentState } = require("./shared/persistentState");
+const { Pr } = require("./shared/pr");
 const { REPO_OWNER, REPO, PATH_TO_CONFIG_FILE } = require("./shared/constants");
+import { CheckStatus } from "./shared/checks";
 
 // Returns true if the pr needs to be processed or false otherwise.
 // We don't need to process PRs that:
@@ -33,7 +35,7 @@ const { REPO_OWNER, REPO, PATH_TO_CONFIG_FILE } = require("./shared/constants");
 // 6) Have notifications stopped
 // unless we're supposed to remind the user after tests pass
 // (in which case that's all we need to do).
-function needsProcessed(pull, prState): boolean {
+function needsProcessed(pull, prState: typeof Pr): boolean {
   if (prState.remindAfterTestsPass && prState.remindAfterTestsPass.length > 0) {
     return true;
   }
@@ -73,7 +75,12 @@ function needsProcessed(pull, prState): boolean {
 }
 
 // If the checks passed in via checkstate have completed, notifies the users who have configured notifications.
-async function remindIfChecksCompleted(pull, stateClient, checkState, prState) {
+async function remindIfChecksCompleted(
+  pull,
+  stateClient: typeof PersistentState,
+  checkState: CheckStatus,
+  prState: typeof Pr
+) {
   console.log(
     `Notifying reviewers if checks for PR ${pull.number} have completed, then returning`
   );
@@ -94,8 +101,12 @@ async function remindIfChecksCompleted(pull, stateClient, checkState, prState) {
   }
 }
 
-// If we haven't already
-async function notifyChecksFailed(pull, stateClient, prState) {
+// If we haven't already, let the author know checks are failing.
+async function notifyChecksFailed(
+  pull,
+  stateClient: typeof PersistentState,
+  prState: typeof Pr
+) {
   console.log(
     `Checks are failing for PR ${pull.number}. Commenting if we haven't already and skipping.`
   );
@@ -115,7 +126,11 @@ async function notifyChecksFailed(pull, stateClient, prState) {
 // 3) Picking/assigning reviewers
 // 4) Adding "Next Action: Reviewers label"
 // 5) Storing the state of the pull request/reviewers in a dedicated branch.
-async function processPull(pull, reviewerConfig, stateClient) {
+async function processPull(
+  pull,
+  reviewerConfig: typeof ReviewerConfig,
+  stateClient: typeof PersistentState
+) {
   let prState = await stateClient.getPrState(pull.number);
   if (!needsProcessed(pull, prState)) {
     return;

--- a/scripts/ci/pr-bot/processNewPrs.ts
+++ b/scripts/ci/pr-bot/processNewPrs.ts
@@ -1,0 +1,198 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const github = require("./shared/githubUtils");
+const { getChecksStatus } = require("./shared/checks");
+const commentStrings = require("./shared/commentStrings");
+const { ReviewerConfig } = require("./shared/reviewerConfig");
+const { PersistentState } = require("./shared/persistentState");
+const { REPO_OWNER, REPO, PATH_TO_CONFIG_FILE } = require("./shared/constants");
+
+// Returns true if the pr needs to be processed or false otherwise.
+// We don't need to process PRs that:
+// 1) Have WIP in their name
+// 2) Are less than 20 minutes old
+// 3) Are draft prs
+// 4) Are closed
+// 5) Have already been processed
+// 6) Have notifications stopped
+// unless we're supposed to remind the user after tests pass
+// (in which case that's all we need to do).
+function needsProcessed(pull, prState): boolean {
+  if (prState.remindAfterTestsPass && prState.remindAfterTestsPass.length > 0) {
+    return true;
+  }
+  if (pull.title.toLowerCase().indexOf("wip") >= 0) {
+    console.log(`Skipping PR ${pull.number} because it is a WIP`);
+    return false;
+  }
+  let timeCutoff = new Date(new Date().getTime() - 20 * 60000);
+  if (new Date(pull.created_at) > timeCutoff) {
+    console.log(
+      `Skipping PR ${pull.number} because it was created less than 20 minutes ago`
+    );
+    return false;
+  }
+  if (pull.state.toLowerCase() != "open") {
+    console.log(`Skipping PR ${pull.number} because it is closed`);
+    return false;
+  }
+  if (pull.draft) {
+    console.log(`Skipping PR ${pull.number} because it is a draft`);
+    return false;
+  }
+  if (Object.keys(prState.reviewersAssignedForLabels).length > 0) {
+    console.log(
+      `Skipping PR ${pull.number} because it already has been assigned`
+    );
+    return false;
+  }
+  if (prState.stopReviewerNotifications) {
+    console.log(
+      `Skipping PR ${pull.number} because reviewer notifications have been stopped`
+    );
+    return false;
+  }
+
+  return true;
+}
+
+// If the checks passed in via checkstate have completed, notifies the users who have configured notifications.
+async function remindIfChecksCompleted(pull, stateClient, checkState, prState) {
+  console.log(
+    `Notifying reviewers if checks for PR ${pull.number} have completed, then returning`
+  );
+  if (checkState.completed) {
+    if (checkState.succeeded) {
+      await github.addPrComment(
+        pull.number,
+        commentStrings.allChecksPassed(prState.remindAfterTestsPass)
+      );
+    } else {
+      await github.addPrComment(
+        pull.number,
+        commentStrings.someChecksFailing(prState.remindAfterTestsPass)
+      );
+    }
+    prState.remindAfterTestsPass = [];
+    await stateClient.writePrState(pull.number, prState);
+  }
+}
+
+// If we haven't already
+async function notifyChecksFailed(pull, stateClient, prState) {
+  console.log(
+    `Checks are failing for PR ${pull.number}. Commenting if we haven't already and skipping.`
+  );
+  if (!prState.commentedAboutFailingChecks) {
+    await github.addPrComment(
+      pull.number,
+      commentStrings.failingChecksCantAssign()
+    );
+  }
+  prState.commentedAboutFailingChecks = true;
+  await stateClient.writePrState(pull.number, prState);
+}
+
+// Performs all the business logic of processing a new pull request, including:
+// 1) Checking if it needs processed
+// 2) Reminding reviewers if checks have completed (if they've subscribed to that)
+// 3) Picking/assigning reviewers
+// 4) Adding "Next Action: Reviewers label"
+// 5) Storing the state of the pull request/reviewers in a dedicated branch.
+async function processPull(pull, reviewerConfig, stateClient) {
+  let prState = await stateClient.getPrState(pull.number);
+  if (!needsProcessed(pull, prState)) {
+    return;
+  }
+
+  let checkState = await getChecksStatus(REPO_OWNER, REPO, pull.head.sha);
+
+  if (prState.remindAfterTestsPass && prState.remindAfterTestsPass.length > 0) {
+    return await remindIfChecksCompleted(
+      pull,
+      stateClient,
+      checkState,
+      prState
+    );
+  }
+
+  if (!checkState.succeeded) {
+    return await notifyChecksFailed(pull, stateClient, prState);
+  }
+  prState.commentedAboutFailingChecks = false;
+
+  // Pick reviewers to assign. Store them in reviewerStateToUpdate and update the prState object with those reviewers (and their associated labels)
+  let reviewerStateToUpdate = {};
+  const reviewersForLabels: { [key: string]: string[] } =
+    reviewerConfig.getReviewersForLabels(pull.labels, [pull.user.login]);
+  var labels = Object.keys(reviewersForLabels);
+  if (!labels || labels.length === 0) {
+    return;
+  }
+  for (let i = 0; i < labels.length; i++) {
+    let label = labels[i];
+    let availableReviewers = reviewersForLabels[label];
+    let reviewersState = await stateClient.getReviewersForLabelState(label);
+    let chosenReviewer = reviewersState.assignNextReviewer(availableReviewers);
+    reviewerStateToUpdate[label] = reviewersState;
+    prState.reviewersAssignedForLabels[label] = chosenReviewer;
+  }
+
+  console.log(`Assigning reviewers for PR ${pull.number}`);
+  await github.addPrComment(
+    pull.number,
+    commentStrings.assignReviewer(prState.reviewersAssignedForLabels)
+  );
+
+  github.nextActionReviewers(pull.number, pull.labels);
+  prState.nextAction = "Reviewers";
+
+  await stateClient.writePrState(pull.number, prState);
+  let labelsToUpdate = Object.keys(reviewerStateToUpdate);
+  for (let i = 0; i < labelsToUpdate.length; i++) {
+    let label = labelsToUpdate[i];
+    await stateClient.writeReviewersForLabelState(
+      label,
+      reviewerStateToUpdate[label]
+    );
+  }
+}
+
+async function processNewPrs() {
+  const githubClient = github.getGitHubClient();
+  let reviewerConfig = new ReviewerConfig(PATH_TO_CONFIG_FILE);
+  let stateClient = new PersistentState();
+
+  let openPulls = await githubClient.paginate(
+    "GET /repos/{owner}/{repo}/pulls",
+    {
+      owner: REPO_OWNER,
+      repo: REPO,
+    }
+  );
+
+  for (let i = 0; i < openPulls.length; i++) {
+    let pull = openPulls[i];
+    await processPull(pull, reviewerConfig, stateClient);
+  }
+}
+
+processNewPrs();
+
+export {};

--- a/scripts/ci/pr-bot/processNewPrs.ts
+++ b/scripts/ci/pr-bot/processNewPrs.ts
@@ -33,9 +33,16 @@ import { CheckStatus } from "./shared/checks";
 // 4) Are closed
 // 5) Have already been processed
 // 6) Have notifications stopped
+// 7) The pr doesn't contain the go label (temporary). TODO(damccorm) - remove this when we're ready to roll this out to everyone.
 // unless we're supposed to remind the user after tests pass
 // (in which case that's all we need to do).
 function needsProcessed(pull, prState: typeof Pr): boolean {
+  if (!pull.labels.find((label) => label.name.toLowerCase() == "go")) {
+    console.log(
+      `Skipping PR ${pull.number} because it doesn't contain the go label`
+    );
+    return false;
+  }
   if (prState.remindAfterTestsPass && prState.remindAfterTestsPass.length > 0) {
     return true;
   }

--- a/scripts/ci/pr-bot/processPrUpdate.ts
+++ b/scripts/ci/pr-bot/processPrUpdate.ts
@@ -26,16 +26,16 @@ const { PATH_TO_CONFIG_FILE } = require("./shared/constants");
 
 async function areReviewersAssigned(
   pullNumber: number,
-  stateClient: any
+  stateClient: typeof PersistentState
 ): Promise<boolean> {
   const prState = await stateClient.getPrState(pullNumber);
   return Object.values(prState.reviewersAssignedForLabels).length > 0;
 }
 
 async function processPrComment(
-  payload: any,
-  stateClient: any,
-  reviewerConfig: any
+  payload,
+  stateClient: typeof PersistentState,
+  reviewerConfig: typeof ReviewerConfig
 ) {
   const commentContents = payload.comment.body;
   const commentAuthor = payload.sender.login;
@@ -72,9 +72,9 @@ async function processPrComment(
 
 // On approval from a reviewer we have assigned, assign committer if one not already assigned
 async function processPrReview(
-  payload: any,
-  stateClient: any,
-  reviewerConfig: any
+  payload,
+  stateClient: typeof PersistentState,
+  reviewerConfig: typeof ReviewerConfig
 ) {
   if (payload.review.state != "approved") {
     return;
@@ -123,7 +123,10 @@ async function processPrReview(
 }
 
 // On pr push or author comment, we should put the attention set back on the reviewers
-async function setNextActionReviewers(payload: any, stateClient: any) {
+async function setNextActionReviewers(
+  payload,
+  stateClient: typeof PersistentState
+) {
   const pullNumber = payload.issue?.number || payload.pull_request?.number;
   if (!(await areReviewersAssigned(pullNumber, stateClient))) {
     console.log("No reviewers assigned, dont need to manipulate attention set");

--- a/scripts/ci/pr-bot/processPrUpdate.ts
+++ b/scripts/ci/pr-bot/processPrUpdate.ts
@@ -1,0 +1,201 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+const github = require("@actions/github");
+const commentStrings = require("./shared/commentStrings");
+const { processCommand } = require("./shared/userCommand");
+const { addPrComment, nextActionReviewers } = require("./shared/githubUtils");
+const { PersistentState } = require("./shared/persistentState");
+const { ReviewerConfig } = require("./shared/reviewerConfig");
+const { PATH_TO_CONFIG_FILE } = require("./shared/constants");
+
+async function areReviewersAssigned(
+  pullNumber: number,
+  stateClient: any
+): Promise<boolean> {
+  const prState = await stateClient.getPrState(pullNumber);
+  return Object.values(prState.reviewersAssignedForLabels).length > 0;
+}
+
+async function processPrComment(
+  payload: any,
+  stateClient: any,
+  reviewerConfig: any
+) {
+  const commentContents = payload.comment.body;
+  const commentAuthor = payload.sender.login;
+  console.log(commentContents);
+  if (
+    await processCommand(
+      payload,
+      commentAuthor,
+      commentContents,
+      stateClient,
+      reviewerConfig
+    )
+  ) {
+    // If we've processed a command, don't worry about trying to change the attention set.
+    // This is not a meaningful push or comment from the author.
+    console.log("Processed command");
+    return;
+  }
+
+  // If comment was from the author, we should shift attention back to the reviewers.
+  console.log(
+    "No command to be processed, checking if we should shift attention to reviewers"
+  );
+  const pullAuthor =
+    payload.issue?.user?.login || payload.pull_request?.user?.login;
+  if (pullAuthor == commentAuthor) {
+    await setNextActionReviewers(payload, stateClient);
+  } else {
+    console.log(
+      `Comment was from ${commentAuthor}, not author: ${pullAuthor}. No action to take.`
+    );
+  }
+}
+
+// On approval from a reviewer we have assigned, assign committer if one not already assigned
+async function processPrReview(
+  payload: any,
+  stateClient: any,
+  reviewerConfig: any
+) {
+  if (payload.review.state != "approved") {
+    return;
+  }
+
+  const pullNumber = payload.issue?.number || payload.pull_request?.number;
+  if (!(await areReviewersAssigned(pullNumber, stateClient))) {
+    return;
+  }
+
+  let prState = await stateClient.getPrState(pullNumber);
+  // TODO(damccorm) - also check if the author is a committer, if they are don't auto-assign a committer
+  if (await prState.isAnyAssignedReviewerCommitter()) {
+    return;
+  }
+
+  let labelOfReviewer = prState.getLabelForReviewer(payload.sender.login);
+  if (labelOfReviewer) {
+    let reviewersState = await stateClient.getReviewersForLabelState(
+      labelOfReviewer
+    );
+    let availableReviewers =
+      reviewerConfig.getReviewersForLabel(labelOfReviewer);
+    let chosenCommitter = await reviewersState.assignNextCommitter(
+      availableReviewers
+    );
+    prState.reviewersAssignedForLabels[labelOfReviewer] = chosenCommitter;
+
+    // Set next action to committer
+    await addPrComment(
+      pullNumber,
+      commentStrings.assignCommitter(chosenCommitter)
+    );
+    const existingLabels =
+      payload.issue?.labels || payload.pull_request?.labels;
+    await nextActionReviewers(pullNumber, existingLabels);
+    prState.nextAction = "Reviewers";
+
+    // Persist state
+    await stateClient.writePrState(pullNumber, prState);
+    await stateClient.writeReviewersForLabelState(
+      labelOfReviewer,
+      reviewersState
+    );
+  }
+}
+
+// On pr push or author comment, we should put the attention set back on the reviewers
+async function setNextActionReviewers(payload: any, stateClient: any) {
+  const pullNumber = payload.issue?.number || payload.pull_request?.number;
+  if (!(await areReviewersAssigned(pullNumber, stateClient))) {
+    console.log("No reviewers assigned, dont need to manipulate attention set");
+    return;
+  }
+  const existingLabels = payload.issue?.labels || payload.pull_request?.labels;
+  await nextActionReviewers(pullNumber, existingLabels);
+  let prState = await stateClient.getPrState(pullNumber);
+  prState.nextAction = "Reviewers";
+  await stateClient.writePrState(pullNumber, prState);
+}
+
+async function processPrUpdate() {
+  const reviewerConfig = new ReviewerConfig(PATH_TO_CONFIG_FILE);
+  const context = github.context;
+  console.log("Event context:");
+  console.log(context);
+  const payload = context.payload;
+
+  // TODO(damccorm) - remove this when we roll out to more than go
+  const existingLabels = payload.issue?.labels || payload.pull_request?.labels;
+  let containsGoLabel = false;
+  existingLabels.forEach((label) => {
+    if (label.name.toLowerCase() == "go") {
+      containsGoLabel = true;
+    }
+  });
+  if (!containsGoLabel) {
+    console.log("Does not contain the go label - skipping");
+    return;
+  }
+
+  if (!payload.issue?.pull_request && !payload.pull_request) {
+    console.log("Issue, not pull request - returning");
+    return;
+  }
+  const pullNumber = payload.issue?.number || payload.pull_request?.number;
+
+  let stateClient = new PersistentState();
+  let prState = await stateClient.getPrState(pullNumber);
+  if (prState.stopReviewerNotifications) {
+    console.log("Notifications have been paused for this pull - skipping");
+    return;
+  }
+
+  switch (github.context.eventName) {
+    case "pull_request_review_comment":
+    case "issue_comment":
+      console.log("Processing comment event");
+      if (payload.action != "created") {
+        console.log("Comment wasnt just created, skipping");
+        return;
+      }
+      await processPrComment(payload, stateClient, reviewerConfig);
+      break;
+    case "pull_request_review":
+      console.log("Processing PR review event");
+      await processPrReview(payload, stateClient, reviewerConfig);
+      break;
+    case "pull_request_target":
+      if (payload.action == "synchronize") {
+        console.log("Processing synchronize action");
+        await setNextActionReviewers(payload, stateClient);
+      }
+      // TODO(damccorm) - it would be good to eventually handle the following events here, even though they're not part of the normal workflow
+      // review requested, assigned, label added, label removed
+      break;
+    default:
+      console.log("Not a PR comment, push, or review, doing nothing");
+  }
+}
+
+processPrUpdate();
+
+export {};

--- a/scripts/ci/pr-bot/processPrUpdate.ts
+++ b/scripts/ci/pr-bot/processPrUpdate.ts
@@ -148,13 +148,7 @@ async function processPrUpdate() {
 
   // TODO(damccorm) - remove this when we roll out to more than go
   const existingLabels = payload.issue?.labels || payload.pull_request?.labels;
-  let containsGoLabel = false;
-  existingLabels.forEach((label) => {
-    if (label.name.toLowerCase() == "go") {
-      containsGoLabel = true;
-    }
-  });
-  if (!containsGoLabel) {
+  if (!existingLabels.find((label) => label.name.toLowerCase() == "go")) {
     console.log("Does not contain the go label - skipping");
     return;
   }

--- a/scripts/ci/pr-bot/shared/githubUtils.ts
+++ b/scripts/ci/pr-bot/shared/githubUtils.ts
@@ -85,6 +85,14 @@ export async function checkIfCommitter(username: string): Promise<boolean> {
   );
 }
 
+export function getPullAuthorFromPayload(payload: any) {
+  return payload.issue?.user?.login || payload.pull_request?.user?.login;
+}
+
+export function getPullNumberFromPayload(payload: any) {
+  return payload.issue?.number || payload.pull_request?.number;
+}
+
 function removeNextActionLabel(existingLabels: Label[]): string[] {
   return existingLabels
     .filter(

--- a/scripts/ci/pr-bot/shared/userCommand.ts
+++ b/scripts/ci/pr-bot/shared/userCommand.ts
@@ -81,8 +81,7 @@ async function assignToNextReviewer(
     let reviewersState = await stateClient.getReviewersForLabelState(
       labelOfReviewer
     );
-    const pullAuthor =
-      payload.issue?.user?.login || payload.pull_request?.user?.login;
+    const pullAuthor = github.getPullAuthorFromPayload(payload);
     let availableReviewers = reviewerConfig.getReviewersForLabel(
       labelOfReviewer,
       [commentAuthor, pullAuthor]
@@ -187,8 +186,7 @@ async function assignReviewerSet(
   }
 
   const existingLabels = payload.issue?.labels || payload.pull_request?.labels;
-  const pullAuthor =
-    payload.issue?.user?.login || payload.pull_request?.user?.login;
+  const pullAuthor = github.getPullAuthorFromPayload(payload);
   const reviewersForLabels = reviewerConfig.getReviewersForLabels(
     existingLabels,
     [pullAuthor]


### PR DESCRIPTION
Right now, we don't have a well defined automated system for staying on top of pull request reviews - we rely on contributors being able to find the correct OWNERS file and committers manually triaging/calling attention to old pull requests. This is the continuation of an effort to improve our automation around this. [Design doc for the full effort here](https://docs.google.com/document/d/1FhRPRD6VXkYlLAPhNfZB7y2Yese2FCWBzjx67d3TjBo/edit#) Part 1 was https://github.com/apache/beam/pull/16898

I have the code to handle new prs and pr updates in a repo here - https://github.com/damccorm/beam-pr-bot-demo - this is a subset of the https://github.com/damccorm/beam-pr-bot-demo/pull/1 split up to try to keep reviews manageable. This PR introduces the files used to process new prs and pr updates and it builds on the shared files introduced in the last PR. This contains most of the business logic of the tool. It also contains a .gitignore and Commands.md file I missed in the last PR.

Initially, I am filtering all bot activity prs with the Go label. This is to minimize the blast radius of the automation in case it doesn't work perfectly out the gate or we find it unhelpful. Eventually, I plan on expanding to the rest of the repo.

You can see see the completed portions of the bot in action in https://github.com/damccorm/beam-pr-bot-demo/pull/3 and https://github.com/damccorm/beam-pr-bot-demo/pull/4 (they show different use cases and exercise almost all of the behavior of the bot).

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
