### PR TITLE
[BEAM-14029] Add getter, setter for target maven repo

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/download.go
+++ b/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/download.go
@@ -53,7 +53,7 @@ func newJarGetter() *jarGetter {
 // GetRepositoryURL returns the current target URL for the defaultJarGetter,
 // indicating what repository will be connected to when getting a Beam JAR.
 func GetDefaultRepositoryURL() string {
-	return defaultJarGetter.GetRepositoryURL()
+	return defaultJarGetter.getRepositoryURL()
 }
 
 // SetRepositoryURL updates the target URL for the defaultJarGetter, changing
@@ -65,7 +65,7 @@ func GetDefaultRepositoryURL() string {
 // that of the default from that point on to ensure that the conversion of the
 // Gradle target to the JAR name is correct.
 func SetDefaultRepositoryURL(repoURL string) error {
-	return defaultJarGetter.SetRepositoryURL(repoURL)
+	return defaultJarGetter.setRepositoryURL(repoURL)
 }
 
 // GetBeamJar checks a temporary directory for the desired Beam JAR, downloads the
@@ -75,17 +75,11 @@ func GetBeamJar(gradleTarget, version string) (string, error) {
 	return defaultJarGetter.getJar(gradleTarget, version)
 }
 
-// GetRepositoryURL returns the current target URL for the jarGetter,
-// indicating what repository will be connected to when getting a Beam JAR.
-func (j *jarGetter) GetRepositoryURL() string {
+func (j *jarGetter) getRepositoryURL() string {
 	return string(j.repository)
 }
 
-// SetRepositoryURL updates the target URL for the jarGetter, changing
-// which Maven repository will be connected to when getting a Beam JAR. Also
-// does some minor validation that it has been passed a URL and returns an
-// error if not.
-func (j *jarGetter) SetRepositoryURL(repoURL string) error {
+func (j *jarGetter) setRepositoryURL(repoURL string) error {
 	if !strings.HasPrefix(repoURL, "http") {
 		return fmt.Errorf("repo URL %v does not have an http or https prefix", repoURL)
 	}

--- a/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/download_test.go
+++ b/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/download_test.go
@@ -53,12 +53,12 @@ func TestGetAndSetRepositoryURL(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			j := newJarGetter()
-			err := j.SetRepositoryURL(test.newRepo)
+			err := j.setRepositoryURL(test.newRepo)
 			if err != nil {
 				t.Errorf("failed to set repository URL, got %v", err)
 			}
-			if got, want := j.GetRepositoryURL(), test.expRepo; got != want {
-				t.Errorf("GetRepositoryURL() got %v, want %v", got, want)
+			if got, want := j.getRepositoryURL(), test.expRepo; got != want {
+				t.Errorf("getRepositoryURL() got %v, want %v", got, want)
 			}
 		})
 	}
@@ -77,13 +77,13 @@ func TestGetAndSetRepositoryURL_bad(t *testing.T) {
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
 			j := newJarGetter()
-			err := j.SetRepositoryURL(test.newRepo)
+			err := j.setRepositoryURL(test.newRepo)
 			if err == nil {
-				t.Errorf("SetRepositoryURL(%v) succeeded when it should have failed", test.newRepo)
+				t.Errorf("setRepositoryURL(%v) succeeded when it should have failed", test.newRepo)
 			}
 			// Check that the failed Set call did not change the URL.
-			if got, want := j.GetRepositoryURL(), string(apacheRepository); got != want {
-				t.Errorf("GetRepositoryURL() got %v, want %v", got, want)
+			if got, want := j.getRepositoryURL(), string(apacheRepository); got != want {
+				t.Errorf("getRepositoryURL() got %v, want %v", got, want)
 			}
 		})
 	}

--- a/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/download_test.go
+++ b/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/download_test.go
@@ -23,6 +23,72 @@ import (
 	"testing"
 )
 
+func TestGetAndSetRepositoryURL(t *testing.T) {
+	tests := []struct {
+		name    string
+		newRepo string
+		expRepo string
+	}{
+		{
+			"correct URL",
+			"http://new.repo.org",
+			"http://new.repo.org",
+		},
+		{
+			"correct URL https",
+			"https://new.repo.org",
+			"https://new.repo.org",
+		},
+		{
+			"correct URL with trailing backslash",
+			"http://new.repo.org/",
+			"http://new.repo.org",
+		},
+		{
+			"correct URL https with trailing backslash",
+			"https://new.repo.org/",
+			"https://new.repo.org",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			j := newJarGetter()
+			err := j.SetRepositoryURL(test.newRepo)
+			if err != nil {
+				t.Errorf("failed to set repository URL, got %v", err)
+			}
+			if got, want := j.GetRepositoryURL(), test.expRepo; got != want {
+				t.Errorf("GetRepositoryURL() got %v, want %v", got, want)
+			}
+		})
+	}
+}
+
+func TestGetAndSetRepositoryURL_bad(t *testing.T) {
+	tests := []struct {
+		name    string
+		newRepo string
+	}{
+		{
+			"no http",
+			"new.maven.repo.com",
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			j := newJarGetter()
+			err := j.SetRepositoryURL(test.newRepo)
+			if err == nil {
+				t.Errorf("SetRepositoryURL(%v) succeeded when it should have failed", test.newRepo)
+			}
+			// Check that the failed Set call did not change the URL.
+			if got, want := j.GetRepositoryURL(), string(apacheRepository); got != want {
+				t.Errorf("GetRepositoryURL() got %v, want %v", got, want)
+			}
+		})
+	}
+}
+
 func TestGetURLForBeamJar(t *testing.T) {
 	tests := []struct {
 		name        string


### PR DESCRIPTION
Adds a mechanism through which a user could change the automated expansion service Maven repo to target a different repository. Current target audience is developers performing Beam release validation who want to target the RC JARs for cross-language valdiation.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
