### PR TITLE
[BEAM-13925] Find and address prs that havent been reviewed in a week

### DIFF
--- a/.github/workflows/pr-bot-prs-needing-attention.yml
+++ b/.github/workflows/pr-bot-prs-needing-attention.yml
@@ -13,12 +13,12 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: pr-bot-new-prs
+name: pr-bot-prs-needing-attention
 
-# Run every 30 minutes
+# Run every day at 12:07 UTC
 on:
   schedule:
-  - cron: '0,30 * * * *'
+  - cron: '7 12 * * *'
   workflow_dispatch:
 
 jobs:
@@ -33,7 +33,7 @@ jobs:
         working-directory: 'scripts/ci/pr-bot'
 
       # Runs a set of commands using the runners shell
-      - run: npm run processNewPrs
+      - run: npm run findPrsNeedingAttention
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
         working-directory: 'scripts/ci/pr-bot'

--- a/scripts/ci/pr-bot/findPrsNeedingAttention.ts
+++ b/scripts/ci/pr-bot/findPrsNeedingAttention.ts
@@ -1,3 +1,21 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
 const github = require("./shared/githubUtils");
 const commentStrings = require("./shared/commentStrings");
 const { ReviewerConfig } = require("./shared/reviewerConfig");

--- a/scripts/ci/pr-bot/findPrsNeedingAttention.ts
+++ b/scripts/ci/pr-bot/findPrsNeedingAttention.ts
@@ -1,0 +1,210 @@
+const github = require("./shared/githubUtils");
+const commentStrings = require("./shared/commentStrings");
+const { ReviewerConfig } = require("./shared/reviewerConfig");
+const { PersistentState } = require("./shared/persistentState");
+const {
+  BOT_NAME,
+  REPO_OWNER,
+  REPO,
+  PATH_TO_CONFIG_FILE,
+  SLOW_REVIEW_LABEL,
+} = require("./shared/constants");
+
+function hasLabel(pull: any, labelName: string): boolean {
+  const labels = pull.labels;
+  for (const label of labels) {
+    if (label.name.toLowerCase() === labelName.toLowerCase()) {
+      return true;
+    }
+  }
+  return false;
+}
+
+function getTwoWeekdaysAgo(): Date {
+  let twoWeekDaysAgo = new Date(Date.now() - 2 * 24 * 60 * 60 * 1000);
+  const currentDay = new Date(Date.now()).getDay();
+  // If Saturday, sunday, monday, or tuesday, add extra time to account for weekend.
+  if (currentDay === 6) {
+    twoWeekDaysAgo.setDate(twoWeekDaysAgo.getDate() - 1);
+  }
+  if (currentDay <= 2) {
+    twoWeekDaysAgo.setDate(twoWeekDaysAgo.getDate() - 2);
+  }
+
+  return twoWeekDaysAgo;
+}
+
+async function isSlowReview(pull: any): Promise<boolean> {
+  if (!hasLabel(pull, "Next Action: Reviewers")) {
+    return false;
+  }
+  const lastModified = new Date(pull.updated_at);
+  const sevenDaysAgo = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000);
+  if (lastModified.getTime() < sevenDaysAgo.getTime()) {
+    return true;
+  }
+
+  // If it has no comments from a non-bot/author in the last 2 weekdays, return true
+  const twoWeekDaysAgo = getTwoWeekdaysAgo();
+  if (lastModified.getTime() < twoWeekDaysAgo.getTime()) {
+    const pullAuthor = pull.user.login;
+    const githubClient = github.getGitHubClient();
+    const comments = (
+      await githubClient.rest.issues.listComments({
+        owner: REPO_OWNER,
+        repo: REPO,
+        issue_number: pull.number,
+      })
+    ).data;
+    for (let i = 0; i < comments.length; i++) {
+      const comment = comments[i];
+      if (
+        comment.user.login !== pullAuthor &&
+        comment.user.login !== BOT_NAME
+      ) {
+        return false;
+      }
+    }
+
+    const reviewComments = (
+      await githubClient.rest.pulls.listReviewComments({
+        owner: REPO_OWNER,
+        repo: REPO,
+        pull_number: pull.number,
+      })
+    ).data;
+    for (let i = 0; i < reviewComments.length; i++) {
+      const comment = reviewComments[i];
+      if (
+        comment.user.login !== pullAuthor &&
+        comment.user.login !== BOT_NAME
+      ) {
+        return false;
+      }
+    }
+
+    return true;
+  }
+
+  return false;
+}
+
+async function assignToNewReviewers(
+  pull: any,
+  reviewerConfig: typeof ReviewerConfig,
+  stateClient: typeof PersistentState
+) {
+  let prState = await stateClient.getPrState(pull.number);
+  let reviewerStateToUpdate = {};
+  const labelObjects = pull.labels;
+  let reviewersToExclude = Object.values(prState.reviewersAssignedForLabels);
+  reviewersToExclude.push(pull.user.login);
+  const reviewersForLabels: { [key: string]: string[] } =
+    reviewerConfig.getReviewersForLabels(labelObjects, reviewersToExclude);
+  for (const labelObject of labelObjects) {
+    const label = labelObject.name;
+    let availableReviewers = reviewersForLabels[label];
+    if (availableReviewers && availableReviewers.length > 0) {
+      let reviewersState = await stateClient.getReviewersForLabelState(label);
+      let chosenReviewer = await reviewersState.assignNextCommitter(
+        availableReviewers
+      );
+      reviewerStateToUpdate[label] = reviewersState;
+      prState.reviewersAssignedForLabels[label] = chosenReviewer;
+    }
+  }
+
+  console.log(`Assigning new reviewers for pr ${pull.number}`);
+  await github.addPrComment(
+    pull.number,
+    commentStrings.assignNewReviewer(prState.reviewersAssignedForLabels)
+  );
+
+  await stateClient.writePrState(pull.number, prState);
+  let labelsToUpdate = Object.keys(reviewerStateToUpdate);
+  for (const label of labelsToUpdate) {
+    await stateClient.writeReviewersForLabelState(
+      label,
+      reviewerStateToUpdate[label]
+    );
+  }
+}
+
+// Flag any prs that have been awaiting reviewer action at least 7 days,
+// or have been awaiting initial review for at least 2 days and ping the reviewers
+// If there's still no action after 2 more days, assign a new set of committers.
+async function processPull(
+  pull: any,
+  reviewerConfig: typeof ReviewerConfig,
+  stateClient: typeof PersistentState
+) {
+  const prState = await stateClient.getPrState(pull.number);
+  if (prState.stopReviewerNotifications) {
+    console.log(`Skipping PR ${pull.number} - notifications silenced`);
+    return;
+  }
+  if (hasLabel(pull, SLOW_REVIEW_LABEL)) {
+    const lastModified = new Date(pull.updated_at);
+    const twoWeekDaysAgo = getTwoWeekdaysAgo();
+    console.log(
+      `PR ${pull.number} has the slow review label. Last modified ${lastModified}`
+    );
+    if (lastModified.getTime() < twoWeekDaysAgo.getTime()) {
+      console.log(
+        `PR ${pull.number} still awaiting action - assigning new reviewers`
+      );
+      await assignToNewReviewers(pull, reviewerConfig, stateClient);
+      await github.getGitHubClient().rest.issues.removeLabel({
+        owner: REPO_OWNER,
+        repo: REPO,
+        issue_number: pull.number,
+        name: SLOW_REVIEW_LABEL,
+      });
+    }
+
+    return;
+  }
+
+  if (await isSlowReview(pull)) {
+    const client = github.getGitHubClient();
+    const currentReviewers = prState.reviewersAssignedForLabels;
+    if (currentReviewers && Object.values(currentReviewers).length > 0) {
+      console.log(
+        `Flagging pr ${pull.number} as slow. Tagging reviewers ${currentReviewers}`
+      );
+      await github.addPrComment(
+        pull.number,
+        commentStrings.slowReview(Object.values(currentReviewers))
+      );
+      await client.rest.issues.addLabels({
+        owner: REPO_OWNER,
+        repo: REPO,
+        issue_number: pull.number,
+        labels: [SLOW_REVIEW_LABEL],
+      });
+    }
+  }
+}
+
+async function processOldPrs() {
+  const githubClient = github.getGitHubClient();
+  let reviewerConfig = new ReviewerConfig(PATH_TO_CONFIG_FILE);
+  let stateClient = new PersistentState();
+
+  let openPulls = await githubClient.paginate(
+    "GET /repos/{owner}/{repo}/pulls",
+    {
+      owner: REPO_OWNER,
+      repo: REPO,
+    }
+  );
+
+  for (let i = 0; i < openPulls.length; i++) {
+    let pull = openPulls[i];
+    await processPull(pull, reviewerConfig, stateClient);
+  }
+}
+
+processOldPrs();
+
+export {};

--- a/scripts/ci/pr-bot/package-lock.json
+++ b/scripts/ci/pr-bot/package-lock.json
@@ -11,13 +11,13 @@
         "@actions/exec": "^1.1.0",
         "@actions/github": "^5.0.0",
         "@octokit/rest": "^18.12.0",
-        "js-yaml": "^4.1.0",
-        "prettier": "^2.5.1"
+        "js-yaml": "^4.1.0"
       },
       "devDependencies": {
         "@types/mocha": "^9.1.0",
         "@types/node": "^16.11.7",
         "mocha": "^9.1.3",
+        "prettier": "^2.5.1",
         "typescript": "4.2.4"
       }
     },
@@ -910,6 +910,7 @@
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
       "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "dev": true,
       "bin": {
         "prettier": "bin-prettier.js"
       },
@@ -1862,7 +1863,8 @@
     "prettier": {
       "version": "2.5.1",
       "resolved": "https://registry.npmjs.org/prettier/-/prettier-2.5.1.tgz",
-      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg=="
+      "integrity": "sha512-vBZcPRUR5MZJwoyi3ZoyQlc1rXeEck8KgeC9AwwOn+exuxLxq5toTRDTSaVrXHxelDMHy9zlicw8u66yxoSUFg==",
+      "dev": true
     },
     "randombytes": {
       "version": "2.1.0",

--- a/scripts/ci/pr-bot/package.json
+++ b/scripts/ci/pr-bot/package.json
@@ -9,19 +9,20 @@
     "test": "mocha lib/test",
     "processNewPrs": "npm run build && node lib/processNewPrs.js",
     "processPrUpdate": "npm run build && node lib/processPrUpdate.js",
-    "gatherMetrics": "npm run build && node lib/gatherMetrics.js"
+    "gatherMetrics": "npm run build && node lib/gatherMetrics.js",
+    "findPrsNeedingAttention": "npm run build && node lib/findPrsNeedingAttention.js"
   },
   "dependencies": {
     "@actions/exec": "^1.1.0",
     "@actions/github": "^5.0.0",
     "@octokit/rest": "^18.12.0",
-    "js-yaml": "^4.1.0",
-    "prettier": "^2.5.1"
+    "js-yaml": "^4.1.0"
   },
   "devDependencies": {
     "@types/mocha": "^9.1.0",
     "@types/node": "^16.11.7",
     "mocha": "^9.1.3",
-    "typescript": "4.2.4"
+    "typescript": "4.2.4",
+    "prettier": "^2.5.1"
   }
 }

--- a/scripts/ci/pr-bot/processPrUpdate.ts
+++ b/scripts/ci/pr-bot/processPrUpdate.ts
@@ -39,7 +39,7 @@ const {
 const reviewerAction = "Reviewers";
 
 // Removes the slow label if the pr has been reviewed and returns an updated payload.
-async function removeSlowReviewLabel(payload: any): Promise<any> {
+async function removeSlowReviewLabel(payload: any) {
   let labels = payload.issue?.labels || payload.pull_request?.labels;
   if (labels.some((label) => label.name.toLowerCase() == SLOW_REVIEW_LABEL)) {
     const pullNumber = payload.issue?.number || payload.pull_request?.number;
@@ -58,7 +58,6 @@ async function removeSlowReviewLabel(payload: any): Promise<any> {
       payload.pull_request.labels = labels;
     }
   }
-  return payload;
 }
 
 async function areReviewersAssigned(
@@ -79,7 +78,7 @@ async function processPrComment(
   const pullAuthor = getPullAuthorFromPayload(payload);
   // If there's been a comment by a non-author, we can remove the slow review label
   if (commentAuthor !== pullAuthor && commentAuthor !== BOT_NAME) {
-    payload = await removeSlowReviewLabel(payload);
+    await removeSlowReviewLabel(payload);
   }
   console.log(commentContents);
   if (
@@ -122,7 +121,7 @@ async function processPrReview(
   const pullAuthor = getPullAuthorFromPayload(payload);
   // If there's been a review by a non-author, we can remove the slow review label
   if (reviewer !== pullAuthor) {
-    payload = await removeSlowReviewLabel(payload);
+    await removeSlowReviewLabel(payload);
   }
   if (payload.review.state !== "approved") {
     return;

--- a/scripts/ci/pr-bot/processPrUpdate.ts
+++ b/scripts/ci/pr-bot/processPrUpdate.ts
@@ -21,15 +21,45 @@ const commentStrings = require("./shared/commentStrings");
 const { processCommand } = require("./shared/userCommand");
 const {
   addPrComment,
+  getGitHubClient,
   nextActionReviewers,
   getPullAuthorFromPayload,
   getPullNumberFromPayload,
 } = require("./shared/githubUtils");
 const { PersistentState } = require("./shared/persistentState");
 const { ReviewerConfig } = require("./shared/reviewerConfig");
-const { PATH_TO_CONFIG_FILE } = require("./shared/constants");
+const {
+  BOT_NAME,
+  PATH_TO_CONFIG_FILE,
+  REPO_OWNER,
+  REPO,
+  SLOW_REVIEW_LABEL,
+} = require("./shared/constants");
 
 const reviewerAction = "Reviewers";
+
+// Removes the slow label if the pr has been reviewed and returns an updated payload.
+async function removeSlowReviewLabel(payload: any): Promise<any> {
+  let labels = payload.issue?.labels || payload.pull_request?.labels;
+  if (labels.some((label) => label.name.toLowerCase() == SLOW_REVIEW_LABEL)) {
+    const pullNumber = payload.issue?.number || payload.pull_request?.number;
+    labels = (
+      await getGitHubClient().rest.issues.removeLabel({
+        owner: REPO_OWNER,
+        repo: REPO,
+        issue_number: pullNumber,
+        name: "slow-review",
+      })
+    ).data;
+    if (payload.issues) {
+      payload.issues.labels = labels;
+    }
+    if (payload.pull_request) {
+      payload.pull_request.labels = labels;
+    }
+  }
+  return payload;
+}
 
 async function areReviewersAssigned(
   pullNumber: number,
@@ -46,6 +76,11 @@ async function processPrComment(
 ) {
   const commentContents = payload.comment.body;
   const commentAuthor = payload.sender.login;
+  const pullAuthor = getPullAuthorFromPayload(payload);
+  // If there's been a comment by a non-author, we can remove the slow review label
+  if (commentAuthor !== pullAuthor && commentAuthor !== BOT_NAME) {
+    payload = await removeSlowReviewLabel(payload);
+  }
   console.log(commentContents);
   if (
     await processCommand(
@@ -66,7 +101,6 @@ async function processPrComment(
   console.log(
     "No command to be processed, checking if we should shift attention to reviewers"
   );
-  const pullAuthor = getPullAuthorFromPayload(payload);
   if (pullAuthor === commentAuthor) {
     await setNextActionReviewers(payload, stateClient);
   } else {
@@ -84,6 +118,12 @@ async function processPrReview(
   stateClient: typeof PersistentState,
   reviewerConfig: typeof ReviewerConfig
 ) {
+  const reviewer = payload.sender.login;
+  const pullAuthor = getPullAuthorFromPayload(payload);
+  // If there's been a review by a non-author, we can remove the slow review label
+  if (reviewer !== pullAuthor) {
+    payload = await removeSlowReviewLabel(payload);
+  }
   if (payload.review.state !== "approved") {
     return;
   }
@@ -99,7 +139,7 @@ async function processPrReview(
     return;
   }
 
-  const labelOfReviewer = prState.getLabelForReviewer(payload.sender.login);
+  const labelOfReviewer = prState.getLabelForReviewer(reviewer);
   if (labelOfReviewer) {
     let reviewersState = await stateClient.getReviewersForLabelState(
       labelOfReviewer

--- a/scripts/ci/pr-bot/shared/commentStrings.ts
+++ b/scripts/ci/pr-bot/shared/commentStrings.ts
@@ -70,3 +70,33 @@ export function reviewersAlreadyAssigned(reviewers: string[]): string {
 export function noLegalReviewers(): string {
   return "No reviewers could be found from any of the labels on the PR or in the fallback reviewers list. Check the config file to make sure reviewers are configured";
 }
+
+export function assignNewReviewer(labelToReviewerMapping: any): string {
+  let commentString =
+    "Assigning new set of reviewers because Pr has gone too long without review. If you would like to opt out of this review, comment `assign to next reviewer`:\n\n";
+
+  for (let label in labelToReviewerMapping) {
+    let reviewer = labelToReviewerMapping[label];
+    if (label == "no-matching-label") {
+      commentString += `R: @${reviewer} added as fallback since no labels match configuration\n`;
+    } else {
+      commentString += `R: @${reviewer} for label ${label}.\n`;
+    }
+  }
+
+  commentString += `
+Available commands:
+- \`stop reviewer notifications\` - opt out of the automated review tooling
+- \`remind me after tests pass\` - tag the comment author after tests pass
+- \`waiting on author\` - shift the attention set back to the author (any comment or push by the author will return the attention set to the reviewers)`;
+  return commentString;
+}
+
+export function slowReview(reviewers: string[]): string {
+  let commentString = `Reminder, please take a look at this pr: `;
+  reviewers.forEach((reviewer) => {
+    commentString += `@${reviewer} `;
+  });
+
+  return commentString;
+}

--- a/scripts/ci/pr-bot/shared/commentStrings.ts
+++ b/scripts/ci/pr-bot/shared/commentStrings.ts
@@ -16,6 +16,8 @@
  * limitations under the License.
  */
 
+const { NO_MATCHING_LABEL } = require("./shared/constants");
+
 export function allChecksPassed(reviewersToNotify: string[]): string {
   return `All checks have passed: @${reviewersToNotify.join(" ")}`;
 }
@@ -30,7 +32,7 @@ export function assignReviewer(labelToReviewerMapping: any): string {
 
   for (let label in labelToReviewerMapping) {
     let reviewer = labelToReviewerMapping[label];
-    if (label === "no-matching-label") {
+    if (label === NO_MATCHING_LABEL) {
       commentString += `R: @${reviewer} added as fallback since no labels match configuration\n`;
     } else {
       commentString += `R: @${reviewer} for label ${label}.\n`;
@@ -71,13 +73,15 @@ export function noLegalReviewers(): string {
   return "No reviewers could be found from any of the labels on the PR or in the fallback reviewers list. Check the config file to make sure reviewers are configured";
 }
 
-export function assignNewReviewer(labelToReviewerMapping: any): string {
+export function assignNewReviewer(labelToReviewerMapping: {
+  [label: string]: string;
+}): string {
   let commentString =
     "Assigning new set of reviewers because Pr has gone too long without review. If you would like to opt out of this review, comment `assign to next reviewer`:\n\n";
 
-  for (let label in labelToReviewerMapping) {
-    let reviewer = labelToReviewerMapping[label];
-    if (label == "no-matching-label") {
+  for (const label in labelToReviewerMapping) {
+    const reviewer = labelToReviewerMapping[label];
+    if (label === NO_MATCHING_LABEL) {
       commentString += `R: @${reviewer} added as fallback since no labels match configuration\n`;
     } else {
       commentString += `R: @${reviewer} for label ${label}.\n`;
@@ -94,9 +98,9 @@ Available commands:
 
 export function slowReview(reviewers: string[]): string {
   let commentString = `Reminder, please take a look at this pr: `;
-  reviewers.forEach((reviewer) => {
+  for (const reviewer of reviewers) {
     commentString += `@${reviewer} `;
-  });
+  }
 
   return commentString;
 }

--- a/scripts/ci/pr-bot/shared/constants.ts
+++ b/scripts/ci/pr-bot/shared/constants.ts
@@ -28,3 +28,4 @@ export const PATH_TO_METRICS_CSV = path.resolve(
   path.join(__dirname, "../../metrics.csv")
 );
 export const BOT_NAME = "github-actions";
+export const SLOW_REVIEW_LABEL = "slow-review";

--- a/scripts/ci/pr-bot/shared/constants.ts
+++ b/scripts/ci/pr-bot/shared/constants.ts
@@ -29,3 +29,4 @@ export const PATH_TO_METRICS_CSV = path.resolve(
 );
 export const BOT_NAME = "github-actions";
 export const SLOW_REVIEW_LABEL = "slow-review";
+export const NO_MATCHING_LABEL = "no-matching";

--- a/scripts/ci/pr-bot/shared/constants.ts
+++ b/scripts/ci/pr-bot/shared/constants.ts
@@ -29,4 +29,4 @@ export const PATH_TO_METRICS_CSV = path.resolve(
 );
 export const BOT_NAME = "github-actions";
 export const SLOW_REVIEW_LABEL = "slow-review";
-export const NO_MATCHING_LABEL = "no-matching";
+export const NO_MATCHING_LABEL = "no-matching-label";

--- a/scripts/ci/pr-bot/shared/reviewerConfig.ts
+++ b/scripts/ci/pr-bot/shared/reviewerConfig.ts
@@ -19,6 +19,7 @@
 const yaml = require("js-yaml");
 const fs = require("fs");
 import { Label } from "./githubUtils";
+const { NO_MATCHING_LABEL } = require("./shared/constants");
 
 export class ReviewerConfig {
   private config: any;
@@ -46,7 +47,7 @@ export class ReviewerConfig {
     if (!reviewersFound) {
       const fallbackReviewers = this.getFallbackReviewers(exclusionList);
       if (fallbackReviewers.length > 0) {
-        labelToReviewerMapping["no-matching-label"] =
+        labelToReviewerMapping[NO_MATCHING_LABEL] =
           this.getFallbackReviewers(exclusionList);
       }
     }


### PR DESCRIPTION
Right now, we don't have a well defined automated system for staying on top of pull request reviews - we rely on contributors being able to find the correct OWNERS file and committers manually triaging/calling attention to old pull requests. This is the continuation of an effort to improve our automation around this. [Design doc for the full effort here](https://docs.google.com/document/d/1FhRPRD6VXkYlLAPhNfZB7y2Yese2FCWBzjx67d3TjBo/edit#).

This specific change adds automation to flag prs that should be receiving attention but aren't. There are basically 3 parts:

1) Find prs that are assigned to a reviewer and haven't had action in 7 days - tag the reviewers and add a slow-review label.
2) Find prs with the slow-review label that haven't had action in 2 additional business days - assign a new set of **committers**
3) Remove the slow-review label any time a reviewer performs a review or comments on the pr.

This was tested in my test repo here - https://github.com/damccorm/beam-pr-bot-demo. I lowered the time thresholds so I didn't have to wait for a PR to sit for days to test it. The only eligible PR for the automation was initially https://github.com/damccorm/beam-pr-bot-demo/pull/4, so that's where most of the testing happened. There's a lot of junk in between the start and finish as I was getting things working, but the last couple comments show it working. The other prs show that they get excluded correctly (either because they've had notifications silenced or they have not had reviewers assigned by the bot for other reasons.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
