### PR TITLE
[BEAM-13948] Add unstack(), a non-deferred column operation on categorical columns

### DIFF
--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -960,6 +960,49 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
   @frame_base.with_docs_from(pd.DataFrame)
   @frame_base.args_to_kwargs(pd.DataFrame)
   @frame_base.populate_defaults(pd.DataFrame)
+  def unstack(self, **kwargs):
+    return self._unstack_helper(**kwargs)
+
+  def _unstack_helper(self, **kwargs):
+    level = kwargs.get('level', -1)
+
+    if self._expr.proxy().index.nlevels == 1:
+      return frame_base.DeferredFrame.wrap(
+          expressions.ComputedExpression(
+              'unstack',
+              lambda s: s.unstack(level, **kwargs), [self._expr],
+              requires_partition_by=partitionings.Index()))
+    else:
+      # Unstacking MultiIndex objects
+      idx = self._expr.proxy().index
+
+      # Converting level (int, str, or combination) to a list of number levels
+      level_list = level if isinstance(level, list) else [level]
+      level_number_list = [idx._get_level_number(l) for l in level_list]
+
+      # Checking if levels provided are of CategoricalDtype
+      if not all(isinstance(idx.levels[l].dtype, (pd.CategoricalDtype,
+                                                  pd.BooleanDtype))
+                 for l in level_number_list):
+        raise frame_base.WontImplementError(
+            "unstack() is only supported on DataFrames if unstacked level "
+            "is a categorical or boolean column",
+            reason="non-deferred-columns")
+      else:
+        proxy = pd.DataFrame(columns=self._expr.proxy().unstack().columns)
+
+        with expressions.allow_non_parallel_operations(True):
+          return frame_base.DeferredFrame.wrap(
+              expressions.ComputedExpression(
+                  'unstack',
+                  lambda s: pd.concat([proxy, s.unstack(**kwargs)]),
+                  [self._expr],
+                  proxy=proxy,
+                  requires_partition_by=partitionings.Singleton()))
+
+  @frame_base.with_docs_from(pd.DataFrame)
+  @frame_base.args_to_kwargs(pd.DataFrame)
+  @frame_base.populate_defaults(pd.DataFrame)
   def xs(self, key, axis, level, **kwargs):
     """Note that ``xs(axis='index')`` will raise a ``KeyError`` at execution
     time if the key does not exist in the index."""
@@ -2185,9 +2228,6 @@ class DeferredSeries(DeferredDataFrameOrSeries):
         other: df.update(other) or df, [self._expr, other._expr],
         preserves_partition_by=partitionings.Arbitrary(),
         requires_partition_by=partitionings.Index())
-
-  unstack = frame_base.wont_implement_method(
-      pd.Series, 'unstack', reason='non-deferred-columns')
 
   @frame_base.with_docs_from(pd.Series)
   def value_counts(
@@ -3687,25 +3727,6 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
       pd.DataFrame, 'transpose', reason='non-deferred-columns')
   T = property(frame_base.wont_implement_method(
       pd.DataFrame, 'T', reason='non-deferred-columns'))
-
-
-  @frame_base.with_docs_from(pd.DataFrame)
-  def unstack(self, *args, **kwargs):
-    """unstack cannot be used on :class:`DeferredDataFrame` instances with
-    multiple index levels, because the columns in the output depend on the
-    data."""
-    if self._expr.proxy().index.nlevels == 1:
-      return frame_base.DeferredFrame.wrap(
-        expressions.ComputedExpression(
-            'unstack',
-            lambda df: df.unstack(*args, **kwargs),
-            [self._expr],
-            requires_partition_by=partitionings.Index()))
-    else:
-      raise frame_base.WontImplementError(
-          "unstack() is not supported on DataFrames with a multiple indexes, "
-          "because the columns in the output depend on the input data.",
-          reason="non-deferred-columns")
 
   update = frame_base._proxy_method(
       'update',


### PR DESCRIPTION
Adding `unstack`, a non-deferred operation. i.e. operations that produce a variable set of columns based on the intrinsic nature of the data.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
