### PR TITLE
[BEAM-12164] Convert all static instances to be transient in the connector in order to enable concurrent testing

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/action/ActionFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/action/ActionFactory.java
@@ -29,17 +29,16 @@ import org.joda.time.Duration;
  * Factory class for creating instances that will handle each type of record within a change stream
  * query. The instances created are all singletons.
  */
-// static fields are un-initialized, because we start them during the first fetch call (with the
+// transient fields are un-initialized, because we start them during the first fetch call (with the
 // singleton pattern)
-@SuppressWarnings("initialization.static.fields.uninitialized")
 public class ActionFactory implements Serializable {
 
   private static final long serialVersionUID = -4060958761369602619L;
-  private transient DataChangeRecordAction dataChangeRecordActionInstance;
-  private transient HeartbeatRecordAction heartbeatRecordActionInstance;
-  private transient ChildPartitionsRecordAction childPartitionsRecordActionInstance;
-  private transient QueryChangeStreamAction queryChangeStreamActionInstance;
-  private transient DetectNewPartitionsAction detectNewPartitionsActionInstance;
+  private transient DataChangeRecordAction dataChangeRecordActionInstance = null;
+  private transient HeartbeatRecordAction heartbeatRecordActionInstance = null;
+  private transient ChildPartitionsRecordAction childPartitionsRecordActionInstance = null;
+  private transient QueryChangeStreamAction queryChangeStreamActionInstance = null;
+  private transient DetectNewPartitionsAction detectNewPartitionsActionInstance = null;
 
   /**
    * Creates and returns a singleton instance of an action class capable of processing {@link

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/action/ActionFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/action/ActionFactory.java
@@ -35,11 +35,11 @@ import org.joda.time.Duration;
 public class ActionFactory implements Serializable {
 
   private static final long serialVersionUID = -4060958761369602619L;
-  private static DataChangeRecordAction dataChangeRecordActionInstance;
-  private static HeartbeatRecordAction heartbeatRecordActionInstance;
-  private static ChildPartitionsRecordAction childPartitionsRecordActionInstance;
-  private static QueryChangeStreamAction queryChangeStreamActionInstance;
-  private static DetectNewPartitionsAction detectNewPartitionsActionInstance;
+  private transient DataChangeRecordAction dataChangeRecordActionInstance;
+  private transient HeartbeatRecordAction heartbeatRecordActionInstance;
+  private transient ChildPartitionsRecordAction childPartitionsRecordActionInstance;
+  private transient QueryChangeStreamAction queryChangeStreamActionInstance;
+  private transient DetectNewPartitionsAction detectNewPartitionsActionInstance;
 
   /**
    * Creates and returns a singleton instance of an action class capable of processing {@link

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/action/ActionFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/action/ActionFactory.java
@@ -31,7 +31,7 @@ import org.joda.time.Duration;
  */
 // transient fields are un-initialized, because we start them during the first fetch call (with the
 // singleton pattern).
-@SuppressWarnings("uninitialized")
+@SuppressWarnings("initialization.fields.uninitialized")
 public class ActionFactory implements Serializable {
 
   private static final long serialVersionUID = -4060958761369602619L;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/action/ActionFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/action/ActionFactory.java
@@ -30,15 +30,16 @@ import org.joda.time.Duration;
  * query. The instances created are all singletons.
  */
 // transient fields are un-initialized, because we start them during the first fetch call (with the
-// singleton pattern)
+// singleton pattern).
+@SuppressWarnings("uninitialized")
 public class ActionFactory implements Serializable {
 
   private static final long serialVersionUID = -4060958761369602619L;
-  private transient DataChangeRecordAction dataChangeRecordActionInstance = null;
-  private transient HeartbeatRecordAction heartbeatRecordActionInstance = null;
-  private transient ChildPartitionsRecordAction childPartitionsRecordActionInstance = null;
-  private transient QueryChangeStreamAction queryChangeStreamActionInstance = null;
-  private transient DetectNewPartitionsAction detectNewPartitionsActionInstance = null;
+  private transient DataChangeRecordAction dataChangeRecordActionInstance;
+  private transient HeartbeatRecordAction heartbeatRecordActionInstance;
+  private transient ChildPartitionsRecordAction childPartitionsRecordActionInstance;
+  private transient QueryChangeStreamAction queryChangeStreamActionInstance;
+  private transient DetectNewPartitionsAction detectNewPartitionsActionInstance;
 
   /**
    * Creates and returns a singleton instance of an action class capable of processing {@link

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dao/DaoFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dao/DaoFactory.java
@@ -27,17 +27,16 @@ import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
  * Factory class to create data access objects to perform change stream queries and access the
  * metadata tables. The instances created are all singletons.
  */
-// static fields are un-initialized, because we start them during the first fetch call (with the
+// transient fields are un-initialized, because we start them during the first fetch call (with the
 // singleton pattern)
 // nullness checks for metadata instance and database are handled in the constructor
-@SuppressWarnings({"initialization.static.fields.uninitialized", "nullness"})
 public class DaoFactory implements Serializable {
 
   private static final long serialVersionUID = 7929063669009832487L;
 
-  private transient PartitionMetadataAdminDao partitionMetadataAdminDao;
-  private transient PartitionMetadataDao partitionMetadataDaoInstance;
-  private transient ChangeStreamDao changeStreamDaoInstance;
+  private transient PartitionMetadataAdminDao partitionMetadataAdminDao = null;
+  private transient PartitionMetadataDao partitionMetadataDaoInstance = null;
+  private transient ChangeStreamDao changeStreamDaoInstance = null;
 
   private final SpannerConfig changeStreamSpannerConfig;
   private final SpannerConfig metadataSpannerConfig;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dao/DaoFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dao/DaoFactory.java
@@ -35,9 +35,9 @@ public class DaoFactory implements Serializable {
 
   private static final long serialVersionUID = 7929063669009832487L;
 
-  private static PartitionMetadataAdminDao partitionMetadataAdminDao;
-  private static PartitionMetadataDao partitionMetadataDaoInstance;
-  private static ChangeStreamDao changeStreamDaoInstance;
+  private transient PartitionMetadataAdminDao partitionMetadataAdminDao;
+  private transient PartitionMetadataDao partitionMetadataDaoInstance;
+  private transient ChangeStreamDao changeStreamDaoInstance;
 
   private final SpannerConfig changeStreamSpannerConfig;
   private final SpannerConfig metadataSpannerConfig;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dao/DaoFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dao/DaoFactory.java
@@ -30,13 +30,14 @@ import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
 // transient fields are un-initialized, because we start them during the first fetch call (with the
 // singleton pattern)
 // nullness checks for metadata instance and database are handled in the constructor
+@SuppressWarnings({"uninitialized", "nullness"})
 public class DaoFactory implements Serializable {
 
   private static final long serialVersionUID = 7929063669009832487L;
 
-  private transient PartitionMetadataAdminDao partitionMetadataAdminDao = null;
-  private transient PartitionMetadataDao partitionMetadataDaoInstance = null;
-  private transient ChangeStreamDao changeStreamDaoInstance = null;
+  private transient PartitionMetadataAdminDao partitionMetadataAdminDao;
+  private transient PartitionMetadataDao partitionMetadataDaoInstance;
+  private transient ChangeStreamDao changeStreamDaoInstance;
 
   private final SpannerConfig changeStreamSpannerConfig;
   private final SpannerConfig metadataSpannerConfig;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dao/DaoFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dao/DaoFactory.java
@@ -30,7 +30,7 @@ import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
 // transient fields are un-initialized, because we start them during the first fetch call (with the
 // singleton pattern)
 // nullness checks for metadata instance and database are handled in the constructor
-@SuppressWarnings({"uninitialized", "nullness"})
+@SuppressWarnings({"initialization.fields.uninitialized", "nullness"})
 public class DaoFactory implements Serializable {
 
   private static final long serialVersionUID = 7929063669009832487L;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/mapper/MapperFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/mapper/MapperFactory.java
@@ -23,15 +23,14 @@ import java.io.Serializable;
  * Factory class for creating instances that will map a struct to a connector model. The instances
  * created are all singletons.
  */
-// static fields are un-initialized, because we start them during the first fetch call (with the
+// transient fields are un-initialized, because we start them during the first fetch call (with the
 // singleton pattern)
-@SuppressWarnings("initialization.static.fields.uninitialized")
 public class MapperFactory implements Serializable {
 
   private static final long serialVersionUID = -813434573067800902L;
 
-  private transient ChangeStreamRecordMapper changeStreamRecordMapperInstance;
-  private transient PartitionMetadataMapper partitionMetadataMapperInstance;
+  private transient ChangeStreamRecordMapper changeStreamRecordMapperInstance = null;
+  private transient PartitionMetadataMapper partitionMetadataMapperInstance = null;
 
   /**
    * Creates and returns a singleton instance of a mapper class capable of transforming a {@link

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/mapper/MapperFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/mapper/MapperFactory.java
@@ -25,12 +25,13 @@ import java.io.Serializable;
  */
 // transient fields are un-initialized, because we start them during the first fetch call (with the
 // singleton pattern)
+@SuppressWarnings("nullness")
 public class MapperFactory implements Serializable {
 
   private static final long serialVersionUID = -813434573067800902L;
 
-  private transient ChangeStreamRecordMapper changeStreamRecordMapperInstance = null;
-  private transient PartitionMetadataMapper partitionMetadataMapperInstance = null;
+  private transient ChangeStreamRecordMapper changeStreamRecordMapperInstance;
+  private transient PartitionMetadataMapper partitionMetadataMapperInstance;
 
   /**
    * Creates and returns a singleton instance of a mapper class capable of transforming a {@link

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/mapper/MapperFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/mapper/MapperFactory.java
@@ -25,7 +25,7 @@ import java.io.Serializable;
  */
 // transient fields are un-initialized, because we start them during the first fetch call (with the
 // singleton pattern)
-@SuppressWarnings("nullness")
+@SuppressWarnings("initialization.fields.uninitialized")
 public class MapperFactory implements Serializable {
 
   private static final long serialVersionUID = -813434573067800902L;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/mapper/MapperFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/mapper/MapperFactory.java
@@ -30,8 +30,8 @@ public class MapperFactory implements Serializable {
 
   private static final long serialVersionUID = -813434573067800902L;
 
-  private static ChangeStreamRecordMapper changeStreamRecordMapperInstance;
-  private static PartitionMetadataMapper partitionMetadataMapperInstance;
+  private transient ChangeStreamRecordMapper changeStreamRecordMapperInstance;
+  private transient PartitionMetadataMapper partitionMetadataMapperInstance;
 
   /**
    * Creates and returns a singleton instance of a mapper class capable of transforming a {@link

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/SpannerChangeStreamErrorTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/SpannerChangeStreamErrorTest.java
@@ -101,7 +101,6 @@ public class SpannerChangeStreamErrorTest implements Serializable {
     serviceHelper.reset();
     serviceHelper.stop();
     mockSpannerService.reset();
-    resetDaoFactoryFields();
   }
 
   @Test
@@ -422,21 +421,6 @@ public class SpannerChangeStreamErrorTest implements Serializable {
         .withProjectId(TEST_PROJECT)
         .withInstanceId(TEST_INSTANCE)
         .withDatabaseId(TEST_DATABASE);
-  }
-
-  private static void resetDaoFactoryFields() throws NoSuchFieldException, IllegalAccessException {
-    java.lang.reflect.Field partitionMetadataAdminDaoField =
-        DaoFactory.class.getDeclaredField("partitionMetadataAdminDao");
-    partitionMetadataAdminDaoField.setAccessible(true);
-    partitionMetadataAdminDaoField.set(null, null);
-    java.lang.reflect.Field partitionMetadataDaoInstanceField =
-        DaoFactory.class.getDeclaredField("partitionMetadataDaoInstance");
-    partitionMetadataDaoInstanceField.setAccessible(true);
-    partitionMetadataDaoInstanceField.set(null, null);
-    java.lang.reflect.Field changeStreamDaoInstanceField =
-        DaoFactory.class.getDeclaredField("changeStreamDaoInstance");
-    changeStreamDaoInstanceField.setAccessible(true);
-    changeStreamDaoInstanceField.set(null, null);
   }
 
   private static final ResultSetMetadata PARTITION_METADATA_RESULT_SET_METADATA =

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/SpannerChangeStreamErrorTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/SpannerChangeStreamErrorTest.java
@@ -54,7 +54,6 @@ import java.util.Collections;
 import org.apache.beam.sdk.Pipeline.PipelineExecutionException;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerConfig;
 import org.apache.beam.sdk.io.gcp.spanner.SpannerIO;
-import org.apache.beam.sdk.io.gcp.spanner.changestreams.dao.DaoFactory;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.model.PartitionMetadata.State;
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.testing.TestPipeline;


### PR DESCRIPTION
Convert all static instances to be transient in the connector in order to enable concurrent testing