### PR TITLE
[BEAM-12164]: add metrics for partition reads, queries, and latencies for Spanner Change Streams Connector

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/ChangeStreamMetrics.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/ChangeStreamMetrics.java
@@ -75,6 +75,10 @@ public class ChangeStreamMetrics implements Serializable {
   public static final Distribution PARTITION_SCHEDULED_TO_RUNNING_MS =
       Metrics.distribution(ChangeStreamMetrics.class, "partition_scheduled_to_running_ms");
 
+  /** Counter for the active partition reads during the execution of the Connector. */
+  public static final Counter ACTIVE_PARTITION_READ_COUNT =
+      Metrics.counter(ChangeStreamMetrics.class, "active_partition_read_count");
+
   // -------------------
   // Data record metrics
 
@@ -83,6 +87,25 @@ public class ChangeStreamMetrics implements Serializable {
    */
   public static final Counter DATA_RECORD_COUNT =
       Metrics.counter(ChangeStreamMetrics.class, "data_record_count");
+
+  /** Counter for the total number of queries issued during the execution of the Connector. */
+  public static final Counter QUERY_COUNT =
+      Metrics.counter(ChangeStreamMetrics.class, "query_count");
+
+  /** Counter for record latencies [0, 1000) ms during the execution of the Connector. */
+  public static final Counter DATA_RECORD_COMMITTED_TO_EMITTED_0MS_TO_1000MS_COUNT =
+      Metrics.counter(
+          ChangeStreamMetrics.class, "data_record_committed_to_emitted_0ms_to_1000ms_count");
+
+  /** Counter for record latencies [1000, 3000) ms during the execution of the Connector. */
+  public static final Counter DATA_RECORD_COMMITTED_TO_EMITTED_1000MS_TO_3000MS_COUNT =
+      Metrics.counter(
+          ChangeStreamMetrics.class, "data_record_committed_to_emitted_1000ms_to_3000ms_count");
+
+  /** Counter for record latencies equal or above 3000ms during the execution of the Connector. */
+  public static final Counter DATA_RECORD_COMMITTED_TO_EMITTED_3000MS_TO_INF_COUNT =
+      Metrics.counter(
+          ChangeStreamMetrics.class, "data_record_committed_to_emitted_3000ms_to_inf_count");
 
   // -------------------
   // Hearbeat record metrics
@@ -106,8 +129,12 @@ public class ChangeStreamMetrics implements Serializable {
    */
   public ChangeStreamMetrics() {
     enabledMetrics = new HashSet<>();
-    enabledMetrics.add(PARTITION_RECORD_COUNT.getName());
     enabledMetrics.add(DATA_RECORD_COUNT.getName());
+    enabledMetrics.add(ACTIVE_PARTITION_READ_COUNT.getName());
+    enabledMetrics.add(QUERY_COUNT.getName());
+    enabledMetrics.add(DATA_RECORD_COMMITTED_TO_EMITTED_0MS_TO_1000MS_COUNT.getName());
+    enabledMetrics.add(DATA_RECORD_COMMITTED_TO_EMITTED_1000MS_TO_3000MS_COUNT.getName());
+    enabledMetrics.add(DATA_RECORD_COMMITTED_TO_EMITTED_3000MS_TO_INF_COUNT.getName());
   }
 
   /**
@@ -159,9 +186,30 @@ public class ChangeStreamMetrics implements Serializable {
     update(PARTITION_SCHEDULED_TO_RUNNING_MS, duration.getMillis());
   }
 
+  /**
+   * Increments the {@link ChangeStreamMetrics#ACTIVE_PARTITION_READ_COUNT} by 1 if the metric is
+   * enabled.
+   */
+  public void incActivePartitionReadCounter() {
+    inc(ACTIVE_PARTITION_READ_COUNT);
+  }
+
+  /**
+   * Decrements the {@link ChangeStreamMetrics#ACTIVE_PARTITION_READ_COUNT} by 1 if the metric is
+   * enabled.
+   */
+  public void decActivePartitionReadCounter() {
+    dec(ACTIVE_PARTITION_READ_COUNT);
+  }
+
   /** Increments the {@link ChangeStreamMetrics#DATA_RECORD_COUNT} by 1 if the metric is enabled. */
   public void incDataRecordCounter() {
     inc(DATA_RECORD_COUNT);
+  }
+
+  /** Increments the {@link ChangeStreamMetrics#QUERY_COUNT} by 1 if the metric is enabled. */
+  public void incQueryCounter() {
+    inc(QUERY_COUNT);
   }
 
   /**
@@ -178,9 +226,26 @@ public class ChangeStreamMetrics implements Serializable {
     }
   }
 
+  private void dec(Counter counter) {
+    if (enabledMetrics.contains(counter.getName())) {
+      counter.dec();
+    }
+  }
+
   private void update(Distribution distribution, long value) {
     if (enabledMetrics.contains(distribution.getName())) {
       distribution.update(value);
+    }
+  }
+
+  public void updateDataRecordCommittedToEmitted(Duration duration) {
+    final long millis = duration.getMillis();
+    if (millis < 1000) {
+      inc(DATA_RECORD_COMMITTED_TO_EMITTED_0MS_TO_1000MS_COUNT);
+    } else if (millis < 3000) {
+      inc(DATA_RECORD_COMMITTED_TO_EMITTED_1000MS_TO_3000MS_COUNT);
+    } else {
+      inc(DATA_RECORD_COMMITTED_TO_EMITTED_3000MS_TO_INF_COUNT);
     }
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/action/ActionFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/action/ActionFactory.java
@@ -107,6 +107,7 @@ public class ActionFactory implements Serializable {
    *     org.apache.beam.sdk.io.gcp.spanner.changestreams.model.HeartbeatRecord}s
    * @param childPartitionsRecordAction action class to process {@link
    *     org.apache.beam.sdk.io.gcp.spanner.changestreams.model.ChildPartitionsRecord}s
+   * @param metrics metrics gathering class
    * @return single instance of the {@link QueryChangeStreamAction}
    */
   public synchronized QueryChangeStreamAction queryChangeStreamAction(
@@ -116,7 +117,8 @@ public class ActionFactory implements Serializable {
       PartitionMetadataMapper partitionMetadataMapper,
       DataChangeRecordAction dataChangeRecordAction,
       HeartbeatRecordAction heartbeatRecordAction,
-      ChildPartitionsRecordAction childPartitionsRecordAction) {
+      ChildPartitionsRecordAction childPartitionsRecordAction,
+      ChangeStreamMetrics metrics) {
     if (queryChangeStreamActionInstance == null) {
       queryChangeStreamActionInstance =
           new QueryChangeStreamAction(
@@ -126,7 +128,8 @@ public class ActionFactory implements Serializable {
               partitionMetadataMapper,
               dataChangeRecordAction,
               heartbeatRecordAction,
-              childPartitionsRecordAction);
+              childPartitionsRecordAction,
+              metrics);
     }
     return queryChangeStreamActionInstance;
   }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/PostProcessingMetricsDoFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/PostProcessingMetricsDoFn.java
@@ -90,6 +90,8 @@ public class PostProcessingMetricsDoFn extends DoFn<DataChangeRecord, DataChange
             emittedTimestamp.toSqlTimestamp().getTime());
     final long commitedToEmittedMillis = committedToEmitted.getMillis();
 
+    metrics.updateDataRecordCommittedToEmitted(committedToEmitted);
+
     if (commitedToEmittedMillis > COMMITTED_TO_EMITTED_THRESHOLD_MS) {
       LOG.debug(
           "Data record took "

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/ReadChangeStreamPartitionDoFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/ReadChangeStreamPartitionDoFn.java
@@ -143,6 +143,7 @@ public class ReadChangeStreamPartitionDoFn extends DoFn<PartitionMetadata, DataC
               partitionRunningAt.toSqlTimestamp().getTime()));
     }
 
+    metrics.incActivePartitionReadCounter();
     return TimestampRange.of(startTimestamp, endTimestamp);
   }
 
@@ -179,7 +180,8 @@ public class ReadChangeStreamPartitionDoFn extends DoFn<PartitionMetadata, DataC
             partitionMetadataMapper,
             dataChangeRecordAction,
             heartbeatRecordAction,
-            childPartitionsRecordAction);
+            childPartitionsRecordAction,
+            metrics);
   }
 
   /**

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/action/QueryChangeStreamActionTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/action/QueryChangeStreamActionTest.java
@@ -29,6 +29,7 @@ import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.Struct;
 import java.util.Arrays;
 import java.util.Optional;
+import org.apache.beam.sdk.io.gcp.spanner.changestreams.ChangeStreamMetrics;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.dao.ChangeStreamDao;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.dao.ChangeStreamResultSet;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.dao.ChangeStreamResultSetMetadata;
@@ -62,6 +63,7 @@ public class QueryChangeStreamActionTest {
   private ChangeStreamDao changeStreamDao;
   private PartitionMetadataDao partitionMetadataDao;
   private PartitionMetadata partition;
+  private ChangeStreamMetrics metrics;
   private TimestampRange restriction;
   private RestrictionTracker<TimestampRange, Timestamp> restrictionTracker;
   private OutputReceiver<DataChangeRecord> outputReceiver;
@@ -83,6 +85,7 @@ public class QueryChangeStreamActionTest {
     dataChangeRecordAction = mock(DataChangeRecordAction.class);
     heartbeatRecordAction = mock(HeartbeatRecordAction.class);
     childPartitionsRecordAction = mock(ChildPartitionsRecordAction.class);
+    metrics = mock(ChangeStreamMetrics.class);
 
     action =
         new QueryChangeStreamAction(
@@ -92,7 +95,8 @@ public class QueryChangeStreamActionTest {
             partitionMetadataMapper,
             dataChangeRecordAction,
             heartbeatRecordAction,
-            childPartitionsRecordAction);
+            childPartitionsRecordAction,
+            metrics);
     final Struct row = mock(Struct.class);
     partition =
         PartitionMetadata.newBuilder()

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/ReadChangeStreamPartitionDoFnTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/ReadChangeStreamPartitionDoFnTest.java
@@ -125,7 +125,8 @@ public class ReadChangeStreamPartitionDoFnTest {
             partitionMetadataMapper,
             dataChangeRecordAction,
             heartbeatRecordAction,
-            childPartitionsRecordAction))
+            childPartitionsRecordAction,
+            metrics))
         .thenReturn(queryChangeStreamAction);
 
     doFn.setup();


### PR DESCRIPTION
This change adds the following Dataflow custom metrics: 

- ACTIVE_PARTITION_READ_COUNT
- QUERY_COUNT
- DATA_RECORD_COMMITTED_TO_EMITTED_0MS_TO_1000MS_COUNT
- DATA_RECORD_COMMITTED_TO_EMITTED_1000MS_TO_3000MS_COUNT
- DATA_RECORD_COMMITTED_TO_EMITTED_3000MS_TO_INF_COUNT
