### PR TITLE
[BEAM-12753] and [BEAM-12815] Fix Flink Integration Tests

### DIFF
--- a/sdks/go/test/integration/integration.go
+++ b/sdks/go/test/integration/integration.go
@@ -91,11 +91,7 @@ var portableFilters = []string{
 var flinkFilters = []string{
 	// TODO(BEAM-11500): Flink tests timing out on reads.
 	"TestXLang_Combine.*",
-	// TODO(BEAM-12815): Test fails: "Insufficient number of network buffers".
-	"TestXLang_Multi",
 	"TestDebeziumIO_BasicRead",
-	// TODO(BEAM-12753): Flink test stream fails for non-string/byte slice inputs
-	"TestTestStream.*Sequence.*",
 	// Triggers are not yet supported
 	"TestTrigger.*",
 }

--- a/sdks/go/test/resources/flink-conf.yaml
+++ b/sdks/go/test/resources/flink-conf.yaml
@@ -1,0 +1,20 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#  http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+taskmanager.memory.network.fraction: 0.2
+taskmanager.memory.network.max: 2gb

--- a/sdks/go/test/run_validatesrunner_tests.sh
+++ b/sdks/go/test/run_validatesrunner_tests.sh
@@ -73,6 +73,9 @@ set -e
 trap '! [[ "$BASH_COMMAND" =~ ^(echo|read|if|ARGS|shift|SOCKET_SCRIPT|\[\[) ]] && \
 cmd=`eval echo "$BASH_COMMAND" 2>/dev/null` && echo "\$ $cmd"' DEBUG
 
+# Resolve current directory
+CURRENT_DIRECTORY=$( cd -- "$( dirname -- "${BASH_SOURCE[0]}" )" &> /dev/null && pwd )
+
 # Default test targets.
 TESTS="./test/integration/... ./test/regression"
 
@@ -271,6 +274,7 @@ elif [[ "$RUNNER" == "flink" || "$RUNNER" == "spark" || "$RUNNER" == "samza" || 
       java \
           -jar $FLINK_JOB_SERVER_JAR \
           --flink-master [local] \
+          --flink-conf-dir $CURRENT_DIRECTORY/resources \
           --job-port $JOB_PORT \
           --expansion-port 0 \
           --artifact-port 0 &


### PR DESCRIPTION
Right now, multiple go integration tests are excluded on Flink because they run into the following Flink error:

```
java.io.IOException: Insufficient number of network buffers: required 17, but only 14 available. The total number of network buffers is currently set to 2048 of 32768 bytes each. You can increase this number by setting the configuration keys 'taskmanager.memory.network.fraction', 'taskmanager.memory.network.min', and 'taskmanager.memory.network.max'.
```

(the number of available/required network buffers is variable from run to run).

The underlying cause of this error is that we allow a greater parallelism than we have network memory to support for these tests (specifically, parallelism = # available cores[1]), and we run into issues when performing shuffle operations. This is expected to happen sometimes[1] depending on the workload, with the expectation that users will do the appropriate tuning. This PR fixes this problem by doubling the fraction of flink memory to be used as network memory from 10% to 20% and upping the max network memory for task executors from 1 gb to 2 gb (see more on these config options here - https://nightlies.apache.org/flink/flink-docs-master/docs/deployment/config/#taskmanager-memory-network-fraction). This will help us avoid this issue while still staying within the bounds of a reasonable flink config.

[1] https://lists.apache.org/thread/p04qpcxxfvpqzowgy7lpos1gzdns4cnm

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
