### PR TITLE
[BEAM-11934] Remove DataflowRunner override for runner-determined sharding

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -525,11 +525,6 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
 
       overridesBuilder.add(
           PTransformOverride.of(
-              PTransformMatchers.writeWithRunnerDeterminedSharding(),
-              new StreamingShardedWriteFactory(options)));
-
-      overridesBuilder.add(
-          PTransformOverride.of(
               PTransformMatchers.groupIntoBatches(),
               new GroupIntoBatchesOverride.StreamingGroupIntoBatchesOverrideFactory(this)));
 
@@ -2188,69 +2183,6 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
     public Map<PCollection<?>, ReplacementOutput> mapOutputs(
         Map<TupleTag<?>, PCollection<?>> outputs, PDone newOutput) {
       return Collections.emptyMap();
-    }
-  }
-
-  @VisibleForTesting
-  static class StreamingShardedWriteFactory<UserT, DestinationT, OutputT>
-      implements PTransformOverrideFactory<
-          PCollection<UserT>,
-          WriteFilesResult<DestinationT>,
-          WriteFiles<UserT, DestinationT, OutputT>> {
-
-    // We pick 10 as a a default, as it works well with the default number of workers started
-    // by Dataflow.
-    static final int DEFAULT_NUM_SHARDS = 10;
-    DataflowPipelineWorkerPoolOptions options;
-
-    StreamingShardedWriteFactory(PipelineOptions options) {
-      this.options = options.as(DataflowPipelineWorkerPoolOptions.class);
-    }
-
-    @Override
-    public PTransformReplacement<PCollection<UserT>, WriteFilesResult<DestinationT>>
-        getReplacementTransform(
-            AppliedPTransform<
-                    PCollection<UserT>,
-                    WriteFilesResult<DestinationT>,
-                    WriteFiles<UserT, DestinationT, OutputT>>
-                transform) {
-      // By default, if numShards is not set WriteFiles will produce one file per bundle. In
-      // streaming, there are large numbers of small bundles, resulting in many tiny files.
-      // Instead we pick max workers * 2 to ensure full parallelism, but prevent too-many files.
-      // (current_num_workers * 2 might be a better choice, but that value is not easily available
-      // today).
-      // If the user does not set either numWorkers or maxNumWorkers, default to 10 shards.
-      int numShards;
-      if (options.getMaxNumWorkers() > 0) {
-        numShards = options.getMaxNumWorkers() * 2;
-      } else if (options.getNumWorkers() > 0) {
-        numShards = options.getNumWorkers() * 2;
-      } else {
-        numShards = DEFAULT_NUM_SHARDS;
-      }
-
-      try {
-        List<PCollectionView<?>> sideInputs =
-            WriteFilesTranslation.getDynamicDestinationSideInputs(transform);
-        FileBasedSink sink = WriteFilesTranslation.getSink(transform);
-        WriteFiles<UserT, DestinationT, OutputT> replacement =
-            WriteFiles.to(sink).withSideInputs(sideInputs);
-        if (WriteFilesTranslation.isWindowedWrites(transform)) {
-          replacement = replacement.withWindowedWrites();
-        }
-        return PTransformReplacement.of(
-            PTransformReplacements.getSingletonMainInput(transform),
-            replacement.withNumShards(numShards));
-      } catch (Exception e) {
-        throw new RuntimeException(e);
-      }
-    }
-
-    @Override
-    public Map<PCollection<?>, ReplacementOutput> mapOutputs(
-        Map<TupleTag<?>, PCollection<?>> outputs, WriteFilesResult<DestinationT> newOutput) {
-      return ReplacementOutputs.tagged(outputs, newOutput);
     }
   }
 


### PR DESCRIPTION
Since https://github.com/apache/beam/pull/14450, this override artificially constrains dataflow's ability to use autosharding.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
