### PR TITLE
[BEAM-14111] Increase timeout for data handover in KafkaReader's internal queue

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java
@@ -331,7 +331,12 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
    */
   private static final Duration KAFKA_POLL_TIMEOUT = Duration.millis(1000);
 
-  private static final Duration RECORDS_DEQUEUE_POLL_TIMEOUT = Duration.millis(10);
+  // This timeout should be longer than any reasonable expected Kafka poll latency, see BEAM-14111.
+  // The reason to not set it too high is that it defines how long the message processing thread
+  // remains blocked after we polled all available data from Kafka.
+  private static final Duration RECORDS_DEQUEUE_POLL_TIMEOUT = Duration.standardSeconds(1);
+  // This timeout is the lower bound of the offset checkpointing interval, other than that the
+  // reader performance shouldn't be sensitive to it.
   private static final Duration RECORDS_ENQUEUE_POLL_TIMEOUT = Duration.millis(100);
 
   // Use a separate thread to read Kafka messages. Kafka Consumer does all its work including


### PR DESCRIPTION
Beam has two KafkaIO source implementations now:
 * a modern one implemented as a Splittable DoFn (SDF), and
 * a (deprecated) legacy one implemented as an SDF wrapper over an UnboundedSource and KafkaUnboundedReader classes.

O found that the legacy KafkaIO source can not provide good throughput when the latency of calls to Kafka [Consumer.poll|https://github.com/apache/beam/blob/master/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java#L523] becomes high. The degradation is very sharp: a pipeline that drops elements immediately after reading them from source was only able to read about 100-1000 qps per Kafka partition. The Kafka cluster was overprovisioned but was in a remote network and had poll latency about 30ms.

The cause of throughput degradation is poor choice of the [RECORDS_DEQUEUE_POLL_TIMEOUTT|https://github.com/apache/beam/blob/master/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java#L334-L335] set too low, it should be longer than any reasonable expected Kafka poll latency. This is what's happening otherwise:

* consumerPollLoop fetches data bundle from Kafka via poll() and offers it to the avaliableRecordsQueue
* message processing loop fetches bundle from avaliableRecordsQueue and unblocks the consumerPollLoop
* consumerPollLoop calls poll() again
* message processing loop completes processing the bundle BEFORE the poll() call above completes, and tries to fetch next bundle from avaliableRecordsQueue.
* fetch from avaliableRecordsQueue has a very short timeout (10ms) and if it expires before the pending poll() in the consumerPollLoop completes the message processing loop will believe there's no fresh data in Kafka and exit. All the time until the message processing loop is rescheduled is wasted.

R: @lukecwik 
------------------------

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
