### PR TITLE
[BEAM-14128] Eliminating quadratic behavior of computeCompositeInputOutput

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/pipelinex/replace.go
+++ b/sdks/go/pkg/beam/core/runtime/pipelinex/replace.go
@@ -118,16 +118,25 @@ func makeParentMap(xforms map[string]*pipepb.PTransform) map[string]string {
 func computeCompositeInputOutput(xforms map[string]*pipepb.PTransform) map[string]*pipepb.PTransform {
 	ret := reflectx.ShallowClone(xforms).(map[string]*pipepb.PTransform)
 
+	primitiveXformsForInput := make(map[string][]string)
+	for id, pt := range xforms {
+		if len(pt.GetSubtransforms()) == 0 {
+			for _, col := range pt.GetInputs() {
+				primitiveXformsForInput[col] = append(primitiveXformsForInput[col], id)
+			}
+		}
+	}
+
 	seen := make(map[string]bool)
 	for id := range xforms {
-		walk(id, ret, seen)
+		walk(id, ret, seen, primitiveXformsForInput)
 	}
 	return ret
 }
 
 // walk traverses the structure recursively to compute the input/output
 // maps of composite transforms. Update the transform map.
-func walk(id string, ret map[string]*pipepb.PTransform, seen map[string]bool) {
+func walk(id string, ret map[string]*pipepb.PTransform, seen map[string]bool, primitiveXformsForInput map[string][]string) {
 	t := ret[id]
 	if seen[id] || len(t.Subtransforms) == 0 {
 		return
@@ -142,7 +151,7 @@ func walk(id string, ret map[string]*pipepb.PTransform, seen map[string]bool) {
 	out := make(map[string]bool)
 	local := map[string]bool{id: true}
 	for _, sid := range t.Subtransforms {
-		walk(sid, ret, seen)
+		walk(sid, ret, seen, primitiveXformsForInput)
 		inout(ret[sid], in, out)
 		local[sid] = true
 	}
@@ -152,7 +161,7 @@ func walk(id string, ret map[string]*pipepb.PTransform, seen map[string]bool) {
 	// external to this composite. So we must check the inputs in the rest of
 	// the graph, and ensure they're counted.
 	extIn := make(map[string]bool)
-	externalIns(local, ret, extIn, out)
+	externalIns(local, primitiveXformsForInput, extIn, out)
 
 	upd := ShallowClonePTransform(t)
 	upd.Inputs = diff(in, out)
@@ -201,19 +210,11 @@ func diffAndMerge(out, in, extIn map[string]bool) map[string]string {
 }
 
 // externalIns checks the unseen non-composite graph
-func externalIns(counted map[string]bool, xforms map[string]*pipepb.PTransform, extIn, out map[string]bool) {
-	for id, pt := range xforms {
-		// Ignore other composites or already counted transforms.
-		if counted[id] || len(pt.GetSubtransforms()) != 0 {
-			continue
-		}
-		// Check this PTransform's inputs for anything output by something
-		// the current composite.
-		for col := range out {
-			for _, incol := range pt.GetInputs() {
-				if col == incol {
-					extIn[col] = true
-				}
+func externalIns(counted map[string]bool, primitiveXformsForInput map[string][]string, extIn, out map[string]bool) {
+	for col := range out {
+		for _, id := range primitiveXformsForInput[col] {
+			if !counted[id] {
+				extIn[col] = true
 			}
 		}
 	}

--- a/sdks/go/pkg/beam/core/runtime/pipelinex/replace_test.go
+++ b/sdks/go/pkg/beam/core/runtime/pipelinex/replace_test.go
@@ -16,6 +16,7 @@
 package pipelinex
 
 import (
+	"fmt"
 	"testing"
 
 	pipepb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/pipeline_v1"
@@ -307,6 +308,28 @@ func TestComputeInputOutput(t *testing.T) {
 				t.Errorf("computeInputOutput(%v)\ndiff: %v", test.in, diff)
 			}
 		})
+	}
+}
+
+func BenchmarkComputeInputOutput(b *testing.B) {
+	in := make(map[string]*pipepb.PTransform)
+	for i := 0; i < 3000; i++ {
+		compositeID := fmt.Sprintf("x%d", i)
+		primitiveID := fmt.Sprintf("y%d", i)
+		in[compositeID] = &pipepb.PTransform{
+			UniqueName:    compositeID,
+			Subtransforms: []string{primitiveID},
+		}
+		in[primitiveID] = &pipepb.PTransform{
+			UniqueName: primitiveID,
+			Inputs:     map[string]string{"i0": fmt.Sprintf("p%d", i)},
+			Outputs:    map[string]string{"i0": fmt.Sprintf("p%d", i+1)},
+		}
+	}
+	b.ResetTimer()
+	b.ReportAllocs()
+	for i := 0; i < b.N; i++ {
+		computeCompositeInputOutput(in)
 	}
 }
 

--- a/sdks/go/pkg/beam/core/runtime/pipelinex/replace_test.go
+++ b/sdks/go/pkg/beam/core/runtime/pipelinex/replace_test.go
@@ -313,6 +313,7 @@ func TestComputeInputOutput(t *testing.T) {
 
 func BenchmarkComputeInputOutput(b *testing.B) {
 	in := make(map[string]*pipepb.PTransform)
+	// Build a long chain of composite transforms.
 	for i := 0; i < 3000; i++ {
 		compositeID := fmt.Sprintf("x%d", i)
 		primitiveID := fmt.Sprintf("y%d", i)


### PR DESCRIPTION
Eliminating quadratic behavior of computeCompositeInputOutput  by using a lookup map to find transforms that use a particular collection.

Benchmarking on a graph with 6000 transforms shows a speedup from 1.5s to 15ms, for a memory increase of 8%.

R: @lostluck 