### PR TITLE
[BEAM-13015] Avoid repeated weighing of StateKey in StateFetchingIterator cache usage.

### DIFF
--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/StateFetchingIteratorsTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/StateFetchingIteratorsTest.java
@@ -211,14 +211,15 @@ public class StateFetchingIteratorsTest {
               ImmutableMap.of(requestForFirstChunk.getStateKey(), Ints.asList(expected)),
               4);
 
-      Cache<StateKey, Blocks<Integer>> cache = Caches.eternal();
+      Cache<Object, Blocks<Integer>> cache = Caches.eternal();
       CachingStateIterable<Integer> iterable =
           new CachingStateIterable<>(
               cache, fakeStateClient, requestForFirstChunk, BigEndianIntegerCoder.of());
+      Cache<Object, Blocks<Integer>> subcache =
+          Caches.subCache(cache, requestForFirstChunk.getStateKey());
       // Loads the entire iterable into memory
       verifyFetch(iterable.iterator(), expected);
-      assertThat(
-          cache.peek(requestForFirstChunk.getStateKey()), is(instanceOf(BlocksPrefix.class)));
+      assertThat(subcache.peek(null), is(instanceOf(BlocksPrefix.class)));
 
       int stateRequestCount = fakeStateClient.getCallCount();
       // Start an iterator that is reading fully from cache.
@@ -228,21 +229,20 @@ public class StateFetchingIteratorsTest {
 
       // Remove from the cache when it is partially done and show that state is required
       stateRequestCount = fakeStateClient.getCallCount();
-      cache.remove(requestForFirstChunk.getStateKey());
+      cache.remove(null);
       assertEquals(1, (int) iterator.next());
       stateRequestCount += 2; // The first to get 1 and the second to start the prefetch of 2
       assertEquals(stateRequestCount, fakeStateClient.getCallCount());
       stateRequestCount += 1; // Start the prefetch for 3
       assertEquals(2, (int) iterator.next());
       assertEquals(stateRequestCount, fakeStateClient.getCallCount());
-      assertNull(cache.peek(requestForFirstChunk.getStateKey()));
+      assertNull(cache.peek(null));
 
       // Start another iterator and ensure that the cache is populated and state is interacted with
       stateRequestCount = fakeStateClient.getCallCount();
       PrefetchableIterator<Integer> iterator2 = iterable.iterator();
       assertEquals(0, (int) iterator2.next());
-      assertThat(
-          cache.peek(requestForFirstChunk.getStateKey()), is(instanceOf(BlocksPrefix.class)));
+      assertThat(cache.peek(null), is(instanceOf(BlocksPrefix.class)));
       assertTrue(stateRequestCount < fakeStateClient.getCallCount());
 
       // Have the second iterator surpass the first and show that the first iterator starts to


### PR DESCRIPTION
The cache provided to the StateFetchingIterator is already a subcache
based upon the StateKey so we can just us a singleton key within
the subcache. See FnApiStateAccessor.getCacheFor.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
