### PR TITLE
[BEAM-14134] Optimize memory allocations for various core coders

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/BigEndianIntegerCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/BigEndianIntegerCoder.java
@@ -17,8 +17,6 @@
  */
 package org.apache.beam.sdk.coders;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -45,13 +43,13 @@ public class BigEndianIntegerCoder extends AtomicCoder<Integer> {
     if (value == null) {
       throw new CoderException("cannot encode a null Integer");
     }
-    new DataOutputStream(outStream).writeInt(value);
+    BitConverters.writeBigEndianInt(value, outStream);
   }
 
   @Override
   public Integer decode(InputStream inStream) throws IOException, CoderException {
     try {
-      return new DataInputStream(inStream).readInt();
+      return BitConverters.readBigEndianInt(inStream);
     } catch (EOFException | UTFDataFormatException exn) {
       // These exceptions correspond to decoding problems, so change
       // what kind of exception they're branded as.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/BigEndianLongCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/BigEndianLongCoder.java
@@ -17,8 +17,6 @@
  */
 package org.apache.beam.sdk.coders;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -45,13 +43,13 @@ public class BigEndianLongCoder extends AtomicCoder<Long> {
     if (value == null) {
       throw new CoderException("cannot encode a null Long");
     }
-    new DataOutputStream(outStream).writeLong(value);
+    BitConverters.writeBigEndianLong(value, outStream);
   }
 
   @Override
   public Long decode(InputStream inStream) throws IOException, CoderException {
     try {
-      return new DataInputStream(inStream).readLong();
+      return BitConverters.readBigEndianLong(inStream);
     } catch (EOFException | UTFDataFormatException exn) {
       // These exceptions correspond to decoding problems, so change
       // what kind of exception they're branded as.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/BigEndianShortCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/BigEndianShortCoder.java
@@ -17,8 +17,6 @@
  */
 package org.apache.beam.sdk.coders;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -45,13 +43,13 @@ public class BigEndianShortCoder extends AtomicCoder<Short> {
     if (value == null) {
       throw new CoderException("cannot encode a null Short");
     }
-    new DataOutputStream(outStream).writeShort(value);
+    BitConverters.writeBigEndianShort(value, outStream);
   }
 
   @Override
   public Short decode(InputStream inStream) throws IOException, CoderException {
     try {
-      return new DataInputStream(inStream).readShort();
+      return BitConverters.readBigEndianShort(inStream);
     } catch (EOFException | UTFDataFormatException exn) {
       // These exceptions correspond to decoding problems, so change
       // what kind of exception they're branded as.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/BitConverters.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/BitConverters.java
@@ -1,0 +1,77 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.coders;
+
+import java.io.EOFException;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.io.ByteStreams;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.primitives.Longs;
+
+class BitConverters {
+  private BitConverters() {}
+
+  static long readBigEndianLong(InputStream in) throws IOException {
+    byte[] buf = new byte[8];
+    ByteStreams.readFully(in, buf);
+
+    return Longs.fromByteArray(buf);
+  }
+
+  static int readBigEndianInt(InputStream in) throws IOException {
+    int b1 = in.read();
+    int b2 = in.read();
+    int b3 = in.read();
+    int b4 = in.read();
+
+    if ((b1 | b2 | b3 | b4) < 0) {
+      throw new EOFException();
+    }
+
+    return (b1 & 255) << 24 | (b2 & 255) << 16 | (b3 & 255) << 8 | (b4 & 255);
+  }
+
+  static short readBigEndianShort(InputStream in) throws IOException {
+    int b1 = in.read();
+    int b2 = in.read();
+
+    if ((b1 | b2) < 0) {
+      throw new EOFException();
+    }
+
+    return (short) ((b1 & 255) << 8 | (b2 & 255));
+  }
+
+  static void writeBigEndianLong(long value, OutputStream out) throws IOException {
+    byte[] buf = Longs.toByteArray(value);
+    out.write(buf);
+  }
+
+  static void writeBigEndianInt(int value, OutputStream out) throws IOException {
+    out.write((byte) (value >>> 24) & 0xFF);
+    out.write((byte) (value >>> 16) & 0xFF);
+    out.write((byte) (value >>> 8) & 0xFF);
+    out.write((byte) value);
+  }
+
+  static void writeBigEndianShort(short value, OutputStream out) throws IOException {
+    out.write((byte) (value >> 8));
+    out.write((byte) value);
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/DoubleCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/DoubleCoder.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.sdk.coders;
 
-import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
@@ -51,7 +50,7 @@ public class DoubleCoder extends AtomicCoder<Double> {
   @Override
   public Double decode(InputStream inStream) throws IOException, CoderException {
     try {
-      return new DataInputStream(inStream).readDouble();
+      return Double.longBitsToDouble(BitConverters.readBigEndianLong(inStream));
     } catch (EOFException | UTFDataFormatException exn) {
       // These exceptions correspond to decoding problems, so change
       // what kind of exception they're branded as.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/FloatCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/FloatCoder.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.sdk.coders;
 
-import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
@@ -51,7 +50,7 @@ public class FloatCoder extends AtomicCoder<Float> {
   @Override
   public Float decode(InputStream inStream) throws IOException, CoderException {
     try {
-      return new DataInputStream(inStream).readFloat();
+      return Float.intBitsToFloat(BitConverters.readBigEndianInt(inStream));
     } catch (EOFException | UTFDataFormatException exn) {
       // These exceptions correspond to decoding problems, so change
       // what kind of exception they're branded as.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/InstantCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/InstantCoder.java
@@ -17,8 +17,6 @@
  */
 package org.apache.beam.sdk.coders;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.EOFException;
 import java.io.IOException;
 import java.io.InputStream;
@@ -56,14 +54,14 @@ public class InstantCoder extends AtomicCoder<Instant> {
     // This deliberately utilizes the well-defined underflow for {@code long} values.
     // See http://docs.oracle.com/javase/specs/jls/se7/html/jls-15.html#jls-15.18.2
     long shiftedMillis = value.getMillis() - Long.MIN_VALUE;
-    new DataOutputStream(outStream).writeLong(shiftedMillis);
+    BitConverters.writeBigEndianLong(shiftedMillis, outStream);
   }
 
   @Override
   public Instant decode(InputStream inStream) throws CoderException, IOException {
     long shiftedMillis;
     try {
-      shiftedMillis = new DataInputStream(inStream).readLong();
+      shiftedMillis = BitConverters.readBigEndianLong(inStream);
     } catch (EOFException | UTFDataFormatException exn) {
       // These exceptions correspond to decoding problems, so change
       // what kind of exception they're branded as.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/IterableLikeCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/IterableLikeCoder.java
@@ -19,7 +19,6 @@ package org.apache.beam.sdk.coders;
 
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
 
-import java.io.DataInputStream;
 import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
@@ -132,24 +131,23 @@ public abstract class IterableLikeCoder<T, IterableT extends Iterable<T>>
 
   @Override
   public IterableT decode(InputStream inStream) throws IOException, CoderException {
-    DataInputStream dataInStream = new DataInputStream(inStream);
-    int size = dataInStream.readInt();
+    int size = BitConverters.readBigEndianInt(inStream);
     if (size >= 0) {
       List<T> elements = new ArrayList<>(size);
       for (int i = 0; i < size; i++) {
-        elements.add(elementCoder.decode(dataInStream));
+        elements.add(elementCoder.decode(inStream));
       }
       return decodeToIterable(elements);
     }
     List<T> elements = new ArrayList<>();
     // We don't know the size a priori.  Check if we're done with
     // each block of elements.
-    long count = VarInt.decodeLong(dataInStream);
+    long count = VarInt.decodeLong(inStream);
     while (count > 0L) {
-      elements.add(elementCoder.decode(dataInStream));
+      elements.add(elementCoder.decode(inStream));
       --count;
       if (count == 0L) {
-        count = VarInt.decodeLong(dataInStream);
+        count = VarInt.decodeLong(inStream);
       }
     }
     if (count == 0) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/MapCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/MapCoder.java
@@ -17,8 +17,6 @@
  */
 package org.apache.beam.sdk.coders;
 
-import java.io.DataInputStream;
-import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
@@ -75,10 +73,9 @@ public class MapCoder<K, V> extends StructuredCoder<Map<K, V>> {
     if (map == null) {
       throw new CoderException("cannot encode a null Map");
     }
-    DataOutputStream dataOutStream = new DataOutputStream(outStream);
 
     int size = map.size();
-    dataOutStream.writeInt(size);
+    BitConverters.writeBigEndianInt(size, outStream);
     if (size == 0) {
       return;
     }
@@ -94,7 +91,6 @@ public class MapCoder<K, V> extends StructuredCoder<Map<K, V>> {
 
     keyCoder.encode(entry.getKey(), outStream);
     valueCoder.encode(entry.getValue(), outStream, context);
-    // no flush needed as DataOutputStream does not buffer
   }
 
   @Override
@@ -105,8 +101,7 @@ public class MapCoder<K, V> extends StructuredCoder<Map<K, V>> {
   @Override
   public Map<K, V> decode(InputStream inStream, Context context)
       throws IOException, CoderException {
-    DataInputStream dataInStream = new DataInputStream(inStream);
-    int size = dataInStream.readInt();
+    int size = BitConverters.readBigEndianInt(inStream);
     if (size == 0) {
       return Collections.emptyMap();
     }


### PR DESCRIPTION
Many coders have significant overhead due to the usage of `DataInputStream`.  DataInputStream allocates a significant amount of internal buffers when instantiated, which adds unnecessary overhead for very simple operations like decoding a big-endian long.

This changes most coders that use DataInputStream internally to use a more optimized big-endian decoder.  I actually benchmarked three different options here, the solution I arrived at was the best mix of performance and allocations.

```
Benchmark                Mode  Cnt          Score         Error  Units
readLongViaLocalBuffer  thrpt   10  204364633.343 ± 7412002.528  ops/s
readLongViaTLBuffer     thrpt   10  108663164.381 ±  229471.991  ops/s
readLongViaReadCalls    thrpt   10  160694853.195 ± 5272248.704  ops/s
```

readLongViaLocalBuffer allocates an 8 byte buffer per call and reads it using a single read() call.
readLongViaTLBuffer does the same, but uses a thread-local buffer rather than allocating a new one each call.
readLongViaReadCalls simply calls read 8 times, storing the results in temporary variables.

R: @lukecwik  maybe?  Not really sure who's the best to look at this.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
