### PR TITLE
Fixing a small bug in TypedSchemaTransformTest that caused it to flake.

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/TypedSchemaTransformProviderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/transforms/TypedSchemaTransformProviderTest.java
@@ -86,7 +86,7 @@ public class TypedSchemaTransformProviderTest {
     public Optional<List<String>> dependencies(
         Configuration configuration, PipelineOptions options) {
       return Optional.of(
-          Arrays.asList(configuration.getField1(), configuration.getField2().toString()));
+          Arrays.asList(configuration.getField1(), String.valueOf(configuration.getField2())));
     }
   }
 
@@ -108,7 +108,10 @@ public class TypedSchemaTransformProviderTest {
   public void testFrom() {
     SchemaTransformProvider provider = new FakeTypedSchemaIOProvider();
     Row inputConfig =
-        Row.withSchema(provider.configurationSchema()).addValues("field1", 13).build();
+        Row.withSchema(provider.configurationSchema())
+            .withFieldValue("field1", "field1")
+            .withFieldValue("field2", Integer.valueOf(13))
+            .build();
 
     Configuration outputConfig = ((FakeSchemaTransform) provider.from(inputConfig)).config;
     assertEquals("field1", outputConfig.getField1());
@@ -119,7 +122,10 @@ public class TypedSchemaTransformProviderTest {
   public void testDependencies() {
     SchemaTransformProvider provider = new FakeTypedSchemaIOProvider();
     Row inputConfig =
-        Row.withSchema(provider.configurationSchema()).addValues("field1", 13).build();
+        Row.withSchema(provider.configurationSchema())
+            .withFieldValue("field1", "field1")
+            .withFieldValue("field2", Integer.valueOf(13))
+            .build();
 
     assertEquals(Arrays.asList("field1", "13"), provider.dependencies(inputConfig, null).get());
   }


### PR DESCRIPTION
The configuration schema is based on interference and reflection and is non-deterministic. Therefore we can't use addValues and instead need to add by field name.

Stack trace from failures: 
java.lang.ClassCastException: java.lang.String cannot be cast to java.lang.Integer
at org.apache.beam.sdk.values.RowUtils$CapturingRowCases.processInt32(RowUtils.java:569)
at org.apache.beam.sdk.values.RowUtils$RowFieldMatcher.match(RowUtils.java:182)

@TheNeuralBit 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
