### PR TITLE
[BEAM-14160] Parse filesToStage in Java expansion service

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -44,6 +44,7 @@
 ## Bugfixes
 
 * Fixed X (Java/Python) ([BEAM-X](https://issues.apache.org/jira/browse/BEAM-X)).
+* Fixed Java expansion service to allow specific files to stage ([BEAM-14160](https://issues.apache.org/jira/browse/BEAM-14160)).
 
 ## Known Issues
 

--- a/sdks/java/expansion-service/src/main/java/org/apache/beam/sdk/expansion/service/ExpansionService.java
+++ b/sdks/java/expansion-service/src/main/java/org/apache/beam/sdk/expansion/service/ExpansionService.java
@@ -576,6 +576,10 @@ public class ExpansionService extends ExpansionServiceGrpc.ExpansionServiceImplB
         .ifPresent(portableOptions::setDefaultEnvironmentType);
     Optional.ofNullable(specifiedOptions.getDefaultEnvironmentConfig())
         .ifPresent(portableOptions::setDefaultEnvironmentConfig);
+    List<String> filesToStage = specifiedOptions.getFilesToStage();
+    if (filesToStage != null) {
+      effectiveOpts.as(PortablePipelineOptions.class).setFilesToStage(filesToStage);
+    }
     effectiveOpts
         .as(ExperimentalOptions.class)
         .setExperiments(pipelineOptions.as(ExperimentalOptions.class).getExperiments());

--- a/sdks/java/expansion-service/src/test/java/org/apache/beam/sdk/expansion/service/ExpansionServerTest.java
+++ b/sdks/java/expansion-service/src/test/java/org/apache/beam/sdk/expansion/service/ExpansionServerTest.java
@@ -25,6 +25,8 @@ import static org.hamcrest.core.Is.is;
 import org.apache.beam.sdk.options.PortablePipelineOptions;
 import org.junit.Test;
 
+import java.util.Arrays;
+
 /** Tests for {@link ExpansionServer}. */
 public class ExpansionServerTest {
 
@@ -62,5 +64,35 @@ public class ExpansionServerTest {
             .as(PortablePipelineOptions.class)
             .getDefaultEnvironmentType(),
         equalTo("PROCESS"));
+  }
+
+  @Test
+  public void testNonEmptyFilesToStage() {
+    String[] args = {
+            "--filesToStage=nonExistent1.jar,nonExistent2.jar"
+    };
+    ExpansionService service = new ExpansionService(args);
+    assertThat(
+            service
+                    .createPipeline()
+                    .getOptions()
+                    .as(PortablePipelineOptions.class)
+                    .getFilesToStage(),
+            equalTo(Arrays.asList("nonExistent1.jar", "nonExistent2.jar")));
+  }
+
+  @Test
+  public void testEmptyFilesToStageIsOK() {
+    String[] args = {
+            "--filesToStage="
+    };
+    ExpansionService service = new ExpansionService(args);
+    assertThat(
+            service
+                    .createPipeline()
+                    .getOptions()
+                    .as(PortablePipelineOptions.class)
+                    .getFilesToStage(),
+            equalTo(Arrays.asList("")));
   }
 }

--- a/sdks/java/expansion-service/src/test/java/org/apache/beam/sdk/expansion/service/ExpansionServerTest.java
+++ b/sdks/java/expansion-service/src/test/java/org/apache/beam/sdk/expansion/service/ExpansionServerTest.java
@@ -22,10 +22,9 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.core.Is.is;
 
+import java.util.Arrays;
 import org.apache.beam.sdk.options.PortablePipelineOptions;
 import org.junit.Test;
-
-import java.util.Arrays;
 
 /** Tests for {@link ExpansionServer}. */
 public class ExpansionServerTest {
@@ -68,31 +67,19 @@ public class ExpansionServerTest {
 
   @Test
   public void testNonEmptyFilesToStage() {
-    String[] args = {
-            "--filesToStage=nonExistent1.jar,nonExistent2.jar"
-    };
+    String[] args = {"--filesToStage=nonExistent1.jar,nonExistent2.jar"};
     ExpansionService service = new ExpansionService(args);
     assertThat(
-            service
-                    .createPipeline()
-                    .getOptions()
-                    .as(PortablePipelineOptions.class)
-                    .getFilesToStage(),
-            equalTo(Arrays.asList("nonExistent1.jar", "nonExistent2.jar")));
+        service.createPipeline().getOptions().as(PortablePipelineOptions.class).getFilesToStage(),
+        equalTo(Arrays.asList("nonExistent1.jar", "nonExistent2.jar")));
   }
 
   @Test
   public void testEmptyFilesToStageIsOK() {
-    String[] args = {
-            "--filesToStage="
-    };
+    String[] args = {"--filesToStage="};
     ExpansionService service = new ExpansionService(args);
     assertThat(
-            service
-                    .createPipeline()
-                    .getOptions()
-                    .as(PortablePipelineOptions.class)
-                    .getFilesToStage(),
-            equalTo(Arrays.asList("")));
+        service.createPipeline().getOptions().as(PortablePipelineOptions.class).getFilesToStage(),
+        equalTo(Arrays.asList("")));
   }
 }


### PR DESCRIPTION
### Summary

A filesToStage arg when starting expansion service will let us customize and/or control what files can be staged. This speeds up pipeline execution in environments where we can pre-stage jars in the Java harness SDK.

This is based on guidance by @chamikaramj in a [mailing list thread](https://lists.apache.org/thread/knkf6yn52z1fxzbcgkt22dv48o8055bh).

### Testing

Added two unit tests.

Also ran expansion service separately and a portable Python pipeline that uses Kafka I/O (hence Java expansion service). Pipeline ran successfully.

```
$ java -cp ./runners/flink/1.13/job-server/build/libs/beam-runners-flink-1.13-job-server-2.35.0-SNAPSHOT.jar org.apache.beam.sdk.expansion.service.ExpansionService 8096 --filesToStage="foo.jar"
...
Mar 22, 2022 7:04:30 PM org.apache.beam.sdk.expansion.service.ExpansionService$TransformProvider getDependencies
INFO: Staging to files from the classpath: 1, [foo.jar]
```

One can also prevent staging (useful when we have already pre-staged relevant jars in the Java harness SDK):

```
$ java -cp ./runners/flink/1.13/job-server/build/libs/beam-runners-flink-1.13-job-server-2.35.0-SNAPSHOT.jar org.apache.beam.sdk.expansion.service.ExpansionService 8096 --filesToStage=
...
Mar 22, 2022 7:03:59 PM org.apache.beam.sdk.expansion.service.ExpansionService$TransformProvider getDependencies
INFO: Staging to files from the classpath: 1, []