### PR TITLE
[BEAM-14129] Clean up PubsubLiteIO by removing options that no longer apply

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsublite/SubscriberOptions.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsublite/SubscriberOptions.java
@@ -19,45 +19,18 @@ package org.apache.beam.sdk.io.gcp.pubsublite;
 
 import com.google.auto.value.AutoValue;
 import com.google.cloud.pubsublite.SubscriptionPath;
-import com.google.cloud.pubsublite.cloudpubsub.FlowControlSettings;
 import com.google.errorprone.annotations.CanIgnoreReturnValue;
 import java.io.Serializable;
-import org.joda.time.Duration;
 
 @AutoValue
 public abstract class SubscriberOptions implements Serializable {
   private static final long serialVersionUID = 269598118L;
 
-  private static final long MEBIBYTE = 1L << 20;
-
-  private static final Duration MIN_BUNDLE_TIMEOUT = Duration.standardMinutes(1);
-
-  public static final FlowControlSettings DEFAULT_FLOW_CONTROL =
-      FlowControlSettings.builder()
-          .setMessagesOutstanding(Long.MAX_VALUE)
-          .setBytesOutstanding(100 * MEBIBYTE)
-          .build();
-
   // Required parameters.
   public abstract SubscriptionPath subscriptionPath();
 
-  // Optional parameters.
-  /** Per-partition flow control parameters for this subscription. */
-  public abstract FlowControlSettings flowControlSettings();
-
-  /**
-   * The minimum wall time to pass before allowing bundle closure.
-   *
-   * <p>Setting this to too small of a value will result in increased compute costs and lower
-   * throughput per byte. Immediate timeouts (Duration.ZERO) may be useful for testing.
-   */
-  public abstract Duration minBundleTimeout();
-
   public static Builder newBuilder() {
-    Builder builder = new AutoValue_SubscriberOptions.Builder();
-    return builder
-        .setFlowControlSettings(DEFAULT_FLOW_CONTROL)
-        .setMinBundleTimeout(MIN_BUNDLE_TIMEOUT);
+    return new AutoValue_SubscriberOptions.Builder();
   }
 
   public abstract Builder toBuilder();
@@ -67,11 +40,6 @@ public abstract class SubscriberOptions implements Serializable {
   public abstract static class Builder {
     // Required parameters.
     public abstract Builder setSubscriptionPath(SubscriptionPath path);
-
-    // Optional parameters
-    public abstract Builder setFlowControlSettings(FlowControlSettings flowControlSettings);
-
-    public abstract Builder setMinBundleTimeout(Duration minBundleTimeout);
 
     public abstract SubscriberOptions build();
   }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsublite/internal/ExternalTransformConfig.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsublite/internal/ExternalTransformConfig.java
@@ -30,7 +30,6 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PDone;
-import org.joda.time.Duration;
 
 class ExternalTransformConfig {
   private ExternalTransformConfig() {}
@@ -74,10 +73,6 @@ class ExternalTransformConfig {
 
     public void setSubscriptionPath(String path) {
       builder.setSubscriptionPath(SubscriptionPath.parse(path));
-    }
-
-    public void setMinBundleTimeout(Long durationMillis) {
-      builder.setMinBundleTimeout(Duration.millis(durationMillis));
     }
 
     public void setDeduplicate(Boolean deduplicate) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsublite/internal/MemoryBufferedSubscriber.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsublite/internal/MemoryBufferedSubscriber.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.sdk.io.gcp.pubsublite.internal;
 
-import com.google.api.core.ApiFuture;
 import com.google.api.core.ApiService;
 import com.google.api.gax.rpc.ApiException;
 import com.google.cloud.pubsublite.Offset;
@@ -46,10 +45,4 @@ interface MemoryBufferedSubscriber extends ApiService {
 
   /** Remove the head message from the buffer. Throws if no messages exist in the buffer. */
   void pop();
-
-  /**
-   * Return a future which will be satisfied when data is likely available or the subscriber has
-   * failed.
-   */
-  ApiFuture<Void> onData();
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsublite/internal/SubscribeTransform.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsublite/internal/SubscribeTransform.java
@@ -39,7 +39,6 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
-import org.joda.time.Duration;
 
 public class SubscribeTransform extends PTransform<PBegin, PCollection<SequencedMessage>> {
   private static final long MEBIBYTE = 1L << 20;
@@ -144,8 +143,6 @@ public class SubscribeTransform extends PTransform<PBegin, PCollection<Sequenced
     return subscriptionPartitions.apply(
         ParDo.of(
             new PerSubscriptionPartitionSdf(
-                // Ensure we read for at least 5 seconds more than the bundle timeout.
-                options.minBundleTimeout().plus(Duration.standardSeconds(5)),
                 new ManagedBacklogReaderFactoryImpl(this::newBacklogReader),
                 this::newInitialOffsetReader,
                 this::newRestrictionTracker,

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsublite/internal/SubscriptionPartitionProcessor.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsublite/internal/SubscriptionPartitionProcessor.java
@@ -20,10 +20,9 @@ package org.apache.beam.sdk.io.gcp.pubsublite.internal;
 import com.google.cloud.pubsublite.Offset;
 import java.util.Optional;
 import org.apache.beam.sdk.transforms.DoFn.ProcessContinuation;
-import org.joda.time.Duration;
 
 interface SubscriptionPartitionProcessor {
-  ProcessContinuation runFor(Duration duration);
+  ProcessContinuation run();
 
   Optional<Offset> lastClaimed();
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsublite/internal/SubscriptionPartitionProcessorImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsublite/internal/SubscriptionPartitionProcessorImpl.java
@@ -69,8 +69,7 @@ class SubscriptionPartitionProcessorImpl implements SubscriptionPartitionProcess
         return ProcessContinuation.stop();
       }
     }
-    // There is no more data available. If we received any messages, tell the runtime reschedule us
-    // as soon as possible. If not, tell it to reschedule us 5 seconds from now.
+    // There is no more data available, yield to the runtime.
     return ProcessContinuation.resume();
   }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsublite/internal/SubscriptionPartitionProcessorImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsublite/internal/SubscriptionPartitionProcessorImpl.java
@@ -25,7 +25,6 @@ import java.util.function.Supplier;
 import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
 import org.apache.beam.sdk.transforms.DoFn.ProcessContinuation;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
-import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -72,9 +71,7 @@ class SubscriptionPartitionProcessorImpl implements SubscriptionPartitionProcess
     }
     // There is no more data available. If we received any messages, tell the runtime reschedule us
     // as soon as possible. If not, tell it to reschedule us 5 seconds from now.
-    return ProcessContinuation.resume()
-        .withResumeDelay(
-            lastClaimedOffset.isPresent() ? Duration.ZERO : Duration.standardSeconds(5));
+    return ProcessContinuation.resume();
   }
 
   @Override

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsublite/ReadWriteIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsublite/ReadWriteIT.java
@@ -194,13 +194,7 @@ public class ReadWriteIT {
         pipeline.apply(
             "readMessages",
             PubsubLiteIO.read(
-                SubscriberOptions.newBuilder()
-                    .setSubscriptionPath(subscriptionPath)
-                    // setMinBundleTimeout INTENDED FOR TESTING ONLY
-                    // This sacrifices efficiency to make tests run faster. Do not use this in a
-                    // real pipeline!
-                    .setMinBundleTimeout(Duration.standardSeconds(5))
-                    .build()));
+                SubscriberOptions.newBuilder().setSubscriptionPath(subscriptionPath).build()));
     return messages;
     // TODO(BEAM-13230): Fix and re-enable
     // Deduplicate messages based on the uuids added in PubsubLiteIO.addUuids() when writing.

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsublite/internal/SubscriptionPartitionProcessorImplTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsublite/internal/SubscriptionPartitionProcessorImplTest.java
@@ -47,7 +47,6 @@ import org.apache.beam.sdk.io.range.OffsetRange;
 import org.apache.beam.sdk.transforms.DoFn.OutputReceiver;
 import org.apache.beam.sdk.transforms.DoFn.ProcessContinuation;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
-import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.junit.Before;
 import org.junit.Rule;
@@ -149,7 +148,7 @@ public class SubscriptionPartitionProcessorImplTest {
   }
 
   @Test
-  public void successfulClaimThenTimeout() {
+  public void successfulClaimsThenNoMoreMessagesFromSubscriber() {
     doReturn(true).when(tracker).tryClaim(any());
 
     SequencedMessage message1 = messageWithOffset(1);

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsublite/internal/SubscriptionPartitionProcessorImplTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsublite/internal/SubscriptionPartitionProcessorImplTest.java
@@ -64,7 +64,6 @@ import org.mockito.Spy;
 public class SubscriptionPartitionProcessorImplTest {
   private static final SubscriptionPartition PARTITION =
       SubscriptionPartition.of(example(SubscriptionPath.class), example(Partition.class));
-  private static final Duration NO_DATA_RESUME_DELAY = Duration.standardSeconds(5);
 
   @Spy RestrictionTracker<OffsetByteRange, OffsetByteProgress> tracker;
   @Mock OutputReceiver<SequencedMessage> receiver;
@@ -104,8 +103,7 @@ public class SubscriptionPartitionProcessorImplTest {
   @Test
   public void lifecycle() {
     SubscriptionPartitionProcessor processor = newProcessor();
-    assertEquals(
-        ProcessContinuation.resume().withResumeDelay(NO_DATA_RESUME_DELAY), processor.run());
+    assertEquals(ProcessContinuation.resume(), processor.run());
     InOrder order = inOrder(subscriberFactory, subscriber);
     order.verify(subscriberFactory).get();
     order.verify(subscriber).fetchOffset();
@@ -119,8 +117,7 @@ public class SubscriptionPartitionProcessorImplTest {
     doThrow(new RuntimeException("Ignored")).when(badSubscriber).awaitTerminated();
     doReturn(badSubscriber, subscriber).when(subscriberFactory).get();
     SubscriptionPartitionProcessor processor = newProcessor();
-    assertEquals(
-        ProcessContinuation.resume().withResumeDelay(NO_DATA_RESUME_DELAY), processor.run());
+    assertEquals(ProcessContinuation.resume(), processor.run());
     InOrder order = inOrder(subscriberFactory, badSubscriber, subscriber);
     order.verify(subscriberFactory).get();
     order.verify(badSubscriber).fetchOffset();

--- a/sdks/python/apache_beam/io/gcp/pubsublite/external.py
+++ b/sdks/python/apache_beam/io/gcp/pubsublite/external.py
@@ -29,8 +29,7 @@ from apache_beam.transforms.external import ExternalTransform
 from apache_beam.transforms.external import NamedTupleBasedPayloadBuilder
 
 _ReadSchema = typing.NamedTuple(
-    '_ReadSchema',
-    [('subscription_path', str), ('deduplicate', bool)])
+    '_ReadSchema', [('subscription_path', str), ('deduplicate', bool)])
 
 
 def _default_io_expansion_service():
@@ -70,8 +69,7 @@ class _ReadExternal(ExternalTransform):
         'beam:transform:org.apache.beam:pubsublite_read:v1',
         NamedTupleBasedPayloadBuilder(
             _ReadSchema(
-                subscription_path=subscription_path,
-                deduplicate=deduplicate)),
+                subscription_path=subscription_path, deduplicate=deduplicate)),
         expansion_service)
 
 

--- a/sdks/python/apache_beam/io/gcp/pubsublite/external.py
+++ b/sdks/python/apache_beam/io/gcp/pubsublite/external.py
@@ -30,8 +30,7 @@ from apache_beam.transforms.external import NamedTupleBasedPayloadBuilder
 
 _ReadSchema = typing.NamedTuple(
     '_ReadSchema',
-    [('subscription_path', str), ('min_bundle_timeout', int),
-     ('deduplicate', bool)])
+    [('subscription_path', str), ('deduplicate', bool)])
 
 
 def _default_io_expansion_service():
@@ -51,7 +50,6 @@ class _ReadExternal(ExternalTransform):
   def __init__(
       self,
       subscription_path,
-      min_bundle_timeout=None,
       deduplicate=None,
       expansion_service=None,
   ):
@@ -61,15 +59,9 @@ class _ReadExternal(ExternalTransform):
 
     Args:
       subscription_path: A Pub/Sub Lite Subscription path.
-      min_bundle_timeout: The minimum wall time to pass before allowing
-          bundle closure. Setting this to too small of a value will result in
-          increased compute costs and lower throughput per byte. Immediate
-          timeouts (0) may be useful for testing.
       deduplicate: Whether to deduplicate messages based on the value of
           the 'x-goog-pubsublite-dataflow-uuid' attribute.
     """
-    if min_bundle_timeout is None:
-      min_bundle_timeout = 60 * 1000
     if deduplicate is None:
       deduplicate = False
     if expansion_service is None:
@@ -79,7 +71,6 @@ class _ReadExternal(ExternalTransform):
         NamedTupleBasedPayloadBuilder(
             _ReadSchema(
                 subscription_path=subscription_path,
-                min_bundle_timeout=min_bundle_timeout,
                 deduplicate=deduplicate)),
         expansion_service)
 

--- a/sdks/python/apache_beam/io/gcp/pubsublite/proto_api.py
+++ b/sdks/python/apache_beam/io/gcp/pubsublite/proto_api.py
@@ -37,7 +37,6 @@ class ReadFromPubSubLite(PTransform):
   def __init__(
       self,
       subscription_path,
-      min_bundle_timeout=None,
       deduplicate=None,
       expansion_service=None,
   ):
@@ -46,17 +45,12 @@ class ReadFromPubSubLite(PTransform):
     Args:
       subscription_path: Pub/Sub Lite Subscription in the form
           projects/<project>/locations/<location>/subscriptions/<subscription>
-      min_bundle_timeout: The minimum wall time to pass before allowing
-          bundle closure. Setting this to too small of a value will result in
-          increased compute costs and lower throughput per byte. Immediate
-          timeouts (0) may be useful for testing.
       deduplicate: Whether to deduplicate messages based on the value of
           the 'x-goog-pubsublite-dataflow-uuid' attribute. Defaults to False.
     """
     super().__init__()
     self._source = _ReadExternal(
         subscription_path=subscription_path,
-        min_bundle_timeout=min_bundle_timeout,
         deduplicate=deduplicate,
         expansion_service=expansion_service,
     )


### PR DESCRIPTION
Also remove explicit blocking on data delivery- yield to the runtime instead if no data is available since reading from Pub/Sub Lite is now performed in the background
