### PR TITLE
[BEAM-14175] Log read loop abort at debug rather than error

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/ReadOperation.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/ReadOperation.java
@@ -47,6 +47,12 @@ import org.slf4j.LoggerFactory;
   "nullness" // TODO(https://issues.apache.org/jira/browse/BEAM-10402)
 })
 public class ReadOperation extends Operation {
+  public static class ReadLoopAbortedException extends InterruptedException {
+    public ReadLoopAbortedException() {
+      super("Read loop was aborted.");
+    }
+  }
+
   private static final Logger LOG = LoggerFactory.getLogger(ReadOperation.class);
 
   // This is the rate at which the local, threadsafe progress variable is updated from the iterator,
@@ -178,7 +184,7 @@ public class ReadOperation extends Operation {
       }
 
       if (abortRead.get()) {
-        throw new InterruptedException("Read loop was aborted.");
+        throw new ReadLoopAbortedException();
       }
 
       // Call reader.iterator() outside the lock, because it can take an
@@ -204,7 +210,7 @@ public class ReadOperation extends Operation {
         readerIterator.setProgressFromIterator();
         for (boolean more = readerIterator.start(); more; more = readerIterator.advance()) {
           if (abortRead.get()) {
-            throw new InterruptedException("Read loop was aborted.");
+            throw new ReadLoopAbortedException();
           }
           if (progressUpdatePeriodMs == UPDATE_ON_EACH_ITERATION) {
             readerIterator.setProgressFromIterator();


### PR DESCRIPTION
When dataflow shuts down a large job unexpectedly (cancelled, error) it can potentially log 1000s of "Read loop aborted" errors as read loops are shut down.  This changes them to be logged at DEBUG level rather than ERROR.

R: @lukecwik 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
