### PR TITLE
[BEAM-14157] GrpcWindmillServer: Use stream specific boolean to do client closed check

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServer.java
@@ -632,7 +632,7 @@ public class GrpcWindmillServer extends WindmillServerStub {
     // The following should be protected by synchronizing on this, except for
     // the atomics which may be read atomically for status pages.
     private StreamObserver<RequestT> requestObserver;
-    // Indicates if the current stream in requestObserver is client closed
+    // Indicates if the current stream in requestObserver is closed by calling close() method
     private final AtomicBoolean streamClosed = new AtomicBoolean();
     private final AtomicLong startTimeMs = new AtomicLong();
     private final AtomicLong lastSendTimeMs = new AtomicLong();
@@ -749,7 +749,7 @@ public class GrpcWindmillServer extends WindmillServerStub {
           debugDuration(nowMs, startTimeMs.get()),
           debugDuration(nowMs, lastSendTimeMs.get()),
           debugDuration(nowMs, lastResponseTimeMs.get()),
-          streamClosed.get() ? "true" : "false");
+          streamClosed.get());
     }
 
     // Don't require synchronization on stream, see the appendSummaryHtml comment.

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServer.java
@@ -632,6 +632,8 @@ public class GrpcWindmillServer extends WindmillServerStub {
     // The following should be protected by synchronizing on this, except for
     // the atomics which may be read atomically for status pages.
     private StreamObserver<RequestT> requestObserver;
+    // Indicates if the current stream in requestObserver is client closed
+    private final AtomicBoolean streamClosed = new AtomicBoolean();
     private final AtomicLong startTimeMs = new AtomicLong();
     private final AtomicLong lastSendTimeMs = new AtomicLong();
     private final AtomicLong lastResponseTimeMs = new AtomicLong();
@@ -663,7 +665,7 @@ public class GrpcWindmillServer extends WindmillServerStub {
     protected final void send(RequestT request) {
       lastSendTimeMs.set(Instant.now().getMillis());
       synchronized (this) {
-        if (clientClosed.get()) {
+        if (streamClosed.get()) {
           throw new IllegalStateException("Send called on a client closed stream.");
         }
         requestObserver.onNext(request);
@@ -681,6 +683,7 @@ public class GrpcWindmillServer extends WindmillServerStub {
             startTimeMs.set(Instant.now().getMillis());
             lastResponseTimeMs.set(0);
             requestObserver = streamObserverFactory.from(clientFactory, new ResponseObserver());
+            streamClosed.set(false);
             onNewStream();
             if (clientClosed.get()) {
               close();
@@ -742,10 +745,11 @@ public class GrpcWindmillServer extends WindmillServerStub {
         writer.format(", %dms backoff remaining", sleepLeft);
       }
       writer.format(
-          ", current stream is %dms old, last send %dms, last response %dms",
+          ", current stream is %dms old, last send %dms, last response %dms, closed: %s",
           debugDuration(nowMs, startTimeMs.get()),
           debugDuration(nowMs, lastSendTimeMs.get()),
-          debugDuration(nowMs, lastResponseTimeMs.get()));
+          debugDuration(nowMs, lastResponseTimeMs.get()),
+          streamClosed.get() ? "true" : "false");
     }
 
     // Don't require synchronization on stream, see the appendSummaryHtml comment.
@@ -838,6 +842,7 @@ public class GrpcWindmillServer extends WindmillServerStub {
       // Synchronization of close and onCompleted necessary for correct retry logic in onNewStream.
       clientClosed.set(true);
       requestObserver.onCompleted();
+      streamClosed.set(true);
     }
 
     @Override

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServerTest.java
@@ -712,8 +712,8 @@ public class GrpcWindmillServerTest {
       Thread.sleep(100);
       int tmpErrorsAfterClose = errorsAfterClose.get();
       int tmpErrorsBeforeClose = errorsBeforeClose.get();
-      // wait for at least 2 errors before and after
-      if (tmpErrorsAfterClose > 1 && tmpErrorsBeforeClose > 1) {
+      // wait for at least 1 errors before and after
+      if (tmpErrorsAfterClose > 0 && tmpErrorsBeforeClose > 0) {
         break;
       }
       if (System.currentTimeMillis() > deadline) {

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/GrpcWindmillServerTest.java
@@ -717,9 +717,11 @@ public class GrpcWindmillServerTest {
         break;
       }
       if (System.currentTimeMillis() > deadline) {
+        // Control should not reach here if the test is working as expected
         fail(
             String.format(
-                "Expected errors not sent by server errorsAfterClose: %s errorsBeforeClose: %s",
+                "Expected errors not sent by server errorsAfterClose: %s errorsBeforeClose: %s"
+                    + " \n Should not reach here if the test is working as expected.",
                 tmpErrorsAfterClose, tmpErrorsBeforeClose));
       }
     }


### PR DESCRIPTION
This is a follow up to #17162. An `AbstractWindmillStream` can create more than one grpc stream during its lifetime, new streams can be created after client closed for sending pending requests. So it is not correct to check `if(clientClosed)` in `send()`, this PR adds a new grpc stream level boolean to do the closed check in `send()`.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
