### PR TITLE
[BEAM-14244] Use the supplied output timestamp for processing time timers rather than the input watermark

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/SimpleDoFnRunner.java
@@ -209,7 +209,12 @@ public class SimpleDoFnRunner<InputT, OutputT> implements DoFnRunner<InputT, Out
         break;
       case PROCESSING_TIME:
       case SYNCHRONIZED_PROCESSING_TIME:
-        effectiveTimestamp = stepContext.timerInternals().currentInputWatermarkTime();
+        Instant outputWatermark = stepContext.timerInternals().currentOutputWatermarkTime();
+        Instant inputWatermark = stepContext.timerInternals().currentInputWatermarkTime();
+        effectiveTimestamp =
+            outputTimestamp != null
+                ? outputTimestamp
+                : outputWatermark != null ? outputWatermark : inputWatermark;
         break;
 
       default:


### PR DESCRIPTION
Using the input watermark as the output timestamp for processing time timers causes many issues, rooted in the fact that the input watermark can advance past the end of the window that the timer is set in.

This causes:
- Errors outputting valid elements, since the user's supplied output timestamp is now validated to be after the (incorrect) timestamp of the timer (https://github.com/apache/beam/pull/15540)
- Incorrect timestamps on elements output by `OnTimerContext.output`, elements may be emitted with a timestamp after the end of their window.  One of the most noticeable cases here is that elements are emitted with `BoundedWindow.MAX_TIMESTAMP` in some cases when dataflow jobs are drained.

For more context: https://lists.apache.org/thread/gmqr5d4jm3sb308rmm8t6wc45pm97h26

R: @reuvenlax @lukecwik 

PS: I'm not sure if there's an existing JIRA capturing this, if not I'll make a new one.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
