### PR TITLE
BEAM-14235 parquetio module does not parse PEP-440 compliant Pyarrow version

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -124,6 +124,7 @@
 * Fix S3 copy for large objects (Java) ([BEAM-14011](https://issues.apache.org/jira/browse/BEAM-14011))
 * Fix quadratic behavior of pipeline canonicalization (Go) ([BEAM-14128](https://issues.apache.org/jira/browse/BEAM-14128))
   * This caused unnecessarily long pre-processing times before job submission for large complex pipelines.
+* Fix `pyarrow` version parsing (Python)([BEAM-14235](https://issues.apache.org/jira/browse/BEAM-14235))
 
 ## Known Issues
 

--- a/sdks/python/apache_beam/io/parquetio.py
+++ b/sdks/python/apache_beam/io/parquetio.py
@@ -31,6 +31,7 @@ Parquet file.
 # pytype: skip-file
 
 from functools import partial
+from pkg_resources import parse_version
 
 from apache_beam.io import filebasedsink
 from apache_beam.io import filebasedsource
@@ -50,7 +51,8 @@ except ImportError:
   pq = None
   ARROW_MAJOR_VERSION = None
 else:
-  ARROW_MAJOR_VERSION, _, _ = map(int, pa.__version__.split('.'))
+  base_pa_version = parse_version(pa.__version__).base_version
+  ARROW_MAJOR_VERSION, _, _ = map(int, base_pa_version.split('.'))
 
 __all__ = [
     'ReadFromParquet',

--- a/sdks/python/apache_beam/io/parquetio.py
+++ b/sdks/python/apache_beam/io/parquetio.py
@@ -31,6 +31,7 @@ Parquet file.
 # pytype: skip-file
 
 from functools import partial
+
 from pkg_resources import parse_version
 
 from apache_beam.io import filebasedsink


### PR DESCRIPTION
**Description**

parquetio module does not parse [PEP-440](https://peps.python.org/pep-0440/) compliant pyarrow version. For example, if the `pyarrow` version was `1.0.0+abc.7`, it would fail with the following:

```
Traceback (most recent call last):
  File "/usr/local/lib/python3.7/runpy.py", line 183, in _run_module_as_main
    mod_name, mod_spec, code = _get_module_details(mod_name, _Error)
  File "/usr/local/lib/python3.7/runpy.py", line 109, in _get_module_details
    __import__(pkg_name)
  File "/usr/local/lib/python3.7/site-packages/apache_beam/__init__.py", line 93, in <module>
    from apache_beam import io
  File "/usr/local/lib/python3.7/site-packages/apache_beam/io/__init__.py", line 28, in <module>
    from apache_beam.io.parquetio import *
  File "/usr/local/lib/python3.7/site-packages/apache_beam/io/parquetio.py", line 53, in <module>
    ARROW_MAJOR_VERSION, _, _ = map(int, pa.__version__.split('.'))
ValueError: invalid literal for int() with base 10: '0+abc.7'
```

In practice, this would fail when somebody uses their own fork of `pyarrow` (like me). This change uses setuptools' `pkg_resources.parse_version`, which is PEP-440 compliant after setuptools > 6.0.

https://peps.python.org/pep-0440/#summary-of-differences-from-pkg-resources-parse-version

> Note: this comparison is to pkg_resources.parse_version as it existed at the time the PEP was written. After the PEP was accepted, setuptools 6.0 and later versions adopted the behaviour described in this PEP.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
