### PR TITLE
[BEAM-14251] add output_coder_override to ExpansionRequest

### DIFF
--- a/model/job-management/src/main/proto/org/apache/beam/model/job_management/v1/beam_expansion_api.proto
+++ b/model/job-management/src/main/proto/org/apache/beam/model/job_management/v1/beam_expansion_api.proto
@@ -46,6 +46,12 @@ message ExpansionRequest {
   // A namespace (prefix) to use for the id of any newly created
   // components.
   string namespace = 3;
+
+  // (Optional) Map from a local output tag to a coder id.
+  // If it is set, asks the expansion service to use the given
+  // coders for the output PCollections. Note that the request
+  // may not be fulfilled.
+  map<string, string> output_coder_override = 4;
 }
 
 message ExpansionResponse {

--- a/model/job-management/src/main/proto/org/apache/beam/model/job_management/v1/beam_expansion_api.proto
+++ b/model/job-management/src/main/proto/org/apache/beam/model/job_management/v1/beam_expansion_api.proto
@@ -51,7 +51,7 @@ message ExpansionRequest {
   // If it is set, asks the expansion service to use the given
   // coders for the output PCollections. Note that the request
   // may not be fulfilled.
-  map<string, string> output_coder_override = 4;
+  map<string, string> output_coder_requests = 4;
 }
 
 message ExpansionResponse {

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/External.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/External.java
@@ -94,7 +94,7 @@ public class External {
     Endpoints.ApiServiceDescriptor apiDesc =
         Endpoints.ApiServiceDescriptor.newBuilder().setUrl(endpoint).build();
     return new SingleOutputExpandableTransform<>(
-        urn, payload, apiDesc, DEFAULT, getFreshNamespaceIndex());
+        urn, payload, apiDesc, DEFAULT, getFreshNamespaceIndex(), null);
   }
 
   @VisibleForTesting
@@ -103,7 +103,7 @@ public class External {
     Endpoints.ApiServiceDescriptor apiDesc =
         Endpoints.ApiServiceDescriptor.newBuilder().setUrl(endpoint).build();
     return new SingleOutputExpandableTransform<>(
-        urn, payload, apiDesc, clientFactory, getFreshNamespaceIndex());
+        urn, payload, apiDesc, clientFactory, getFreshNamespaceIndex(), null);
   }
 
   /** Expandable transform for output type of PCollection. */
@@ -114,8 +114,9 @@ public class External {
         byte[] payload,
         Endpoints.ApiServiceDescriptor endpoint,
         ExpansionServiceClientFactory clientFactory,
-        Integer namespaceIndex) {
-      super(urn, payload, endpoint, clientFactory, namespaceIndex);
+        Integer namespaceIndex,
+        Map<String, Coder> outputCoders) {
+      super(urn, payload, endpoint, clientFactory, namespaceIndex, outputCoders);
     }
 
     @Override
@@ -126,12 +127,33 @@ public class External {
 
     public MultiOutputExpandableTransform<InputT> withMultiOutputs() {
       return new MultiOutputExpandableTransform<>(
-          getUrn(), getPayload(), getEndpoint(), getClientFactory(), getNamespaceIndex());
+          getUrn(),
+          getPayload(),
+          getEndpoint(),
+          getClientFactory(),
+          getNamespaceIndex(),
+          getOutputCoders());
     }
 
-    public <T> SingleOutputExpandableTransform<InputT, T> withOutputType() {
+    public SingleOutputExpandableTransform<InputT, OutputT> withOutputCoder(Coder outputCoder) {
       return new SingleOutputExpandableTransform<>(
-          getUrn(), getPayload(), getEndpoint(), getClientFactory(), getNamespaceIndex());
+          getUrn(),
+          getPayload(),
+          getEndpoint(),
+          getClientFactory(),
+          getNamespaceIndex(),
+          ImmutableMap.of("0", outputCoder));
+    }
+
+    public SingleOutputExpandableTransform<InputT, OutputT> withOutputCoder(
+        Map<String, Coder> outputCoders) {
+      return new SingleOutputExpandableTransform<>(
+          getUrn(),
+          getPayload(),
+          getEndpoint(),
+          getClientFactory(),
+          getNamespaceIndex(),
+          outputCoders);
     }
   }
 
@@ -143,8 +165,9 @@ public class External {
         byte[] payload,
         Endpoints.ApiServiceDescriptor endpoint,
         ExpansionServiceClientFactory clientFactory,
-        Integer namespaceIndex) {
-      super(urn, payload, endpoint, clientFactory, namespaceIndex);
+        Integer namespaceIndex,
+        Map<String, Coder> outputCoders) {
+      super(urn, payload, endpoint, clientFactory, namespaceIndex, outputCoders);
     }
 
     @Override
@@ -167,6 +190,7 @@ public class External {
     private final Endpoints.ApiServiceDescriptor endpoint;
     private final ExpansionServiceClientFactory clientFactory;
     private final Integer namespaceIndex;
+    private final Map<String, Coder> outputCoders;
 
     private transient RunnerApi.@Nullable Components expandedComponents;
     private transient RunnerApi.@Nullable PTransform expandedTransform;
@@ -179,12 +203,14 @@ public class External {
         byte[] payload,
         Endpoints.ApiServiceDescriptor endpoint,
         ExpansionServiceClientFactory clientFactory,
-        Integer namespaceIndex) {
+        Integer namespaceIndex,
+        Map<String, Coder> outputCoders) {
       this.urn = urn;
       this.payload = payload;
       this.endpoint = endpoint;
       this.clientFactory = clientFactory;
       this.namespaceIndex = namespaceIndex;
+      this.outputCoders = outputCoders;
     }
 
     @Override
@@ -225,9 +251,25 @@ public class External {
         }
       }
 
+      ExpansionApi.ExpansionRequest.Builder requestBuilder =
+          ExpansionApi.ExpansionRequest.newBuilder();
+      if (!outputCoders.isEmpty()) {
+        requestBuilder.putAllOutputCoderOverride(
+            outputCoders.entrySet().stream()
+                .collect(
+                    Collectors.toMap(
+                        Map.Entry::getKey,
+                        v -> {
+                          try {
+                            return components.registerCoder(v.getValue());
+                          } catch (IOException e) {
+                            throw new RuntimeException(e);
+                          }
+                        })));
+      }
       RunnerApi.Components originalComponents = components.toComponents();
       ExpansionApi.ExpansionRequest request =
-          ExpansionApi.ExpansionRequest.newBuilder()
+          requestBuilder
               .setComponents(originalComponents)
               .setTransform(ptransformBuilder.build())
               .setNamespace(getNamespace())
@@ -433,6 +475,10 @@ public class External {
 
     Integer getNamespaceIndex() {
       return namespaceIndex;
+    }
+
+    Map<String, Coder> getOutputCoders() {
+      return outputCoders;
     }
   }
 }

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/External.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/External.java
@@ -94,7 +94,7 @@ public class External {
     Endpoints.ApiServiceDescriptor apiDesc =
         Endpoints.ApiServiceDescriptor.newBuilder().setUrl(endpoint).build();
     return new SingleOutputExpandableTransform<>(
-        urn, payload, apiDesc, DEFAULT, getFreshNamespaceIndex(), null);
+        urn, payload, apiDesc, DEFAULT, getFreshNamespaceIndex(), ImmutableMap.of());
   }
 
   @VisibleForTesting
@@ -103,7 +103,7 @@ public class External {
     Endpoints.ApiServiceDescriptor apiDesc =
         Endpoints.ApiServiceDescriptor.newBuilder().setUrl(endpoint).build();
     return new SingleOutputExpandableTransform<>(
-        urn, payload, apiDesc, clientFactory, getFreshNamespaceIndex(), null);
+        urn, payload, apiDesc, clientFactory, getFreshNamespaceIndex(), ImmutableMap.of());
   }
 
   /** Expandable transform for output type of PCollection. */

--- a/sdks/python/apache_beam/runners/portability/expansion_service.py
+++ b/sdks/python/apache_beam/runners/portability/expansion_service.py
@@ -63,6 +63,13 @@ class ExpansionServiceServicer(
       }
       transform = with_pipeline(
           ptransform.PTransform.from_runner_api(request.transform, context))
+      if len(request.output_coder_override) == 1:
+        output_coder = {
+            k: context.element_type_from_coder_id(v)
+            for k,
+            v in request.output_coder_override.items()
+        }
+        transform = transform.with_output_types(list(output_coder.values())[0])
       inputs = transform._pvaluish_from_dict({
           tag:
           with_pipeline(context.pcollections.get_by_id(pcoll_id), pcoll_id)

--- a/sdks/python/apache_beam/runners/portability/expansion_service.py
+++ b/sdks/python/apache_beam/runners/portability/expansion_service.py
@@ -70,6 +70,10 @@ class ExpansionServiceServicer(
             v in request.output_coder_override.items()
         }
         transform = transform.with_output_types(list(output_coder.values())[0])
+      elif len(request.output_coder_override) > 1:
+        raise ValueError(
+            'type annotation for multiple outputs is not allowed yet: %s' %
+            request.output_coder_override)
       inputs = transform._pvaluish_from_dict({
           tag:
           with_pipeline(context.pcollections.get_by_id(pcoll_id), pcoll_id)

--- a/sdks/python/apache_beam/runners/portability/expansion_service.py
+++ b/sdks/python/apache_beam/runners/portability/expansion_service.py
@@ -63,17 +63,17 @@ class ExpansionServiceServicer(
       }
       transform = with_pipeline(
           ptransform.PTransform.from_runner_api(request.transform, context))
-      if len(request.output_coder_override) == 1:
+      if len(request.output_coder_requests) == 1:
         output_coder = {
             k: context.element_type_from_coder_id(v)
             for k,
-            v in request.output_coder_override.items()
+            v in request.output_coder_requests.items()
         }
         transform = transform.with_output_types(list(output_coder.values())[0])
-      elif len(request.output_coder_override) > 1:
+      elif len(request.output_coder_requests) > 1:
         raise ValueError(
             'type annotation for multiple outputs is not allowed yet: %s' %
-            request.output_coder_override)
+            request.output_coder_requests)
       inputs = transform._pvaluish_from_dict({
           tag:
           with_pipeline(context.pcollections.get_by_id(pcoll_id), pcoll_id)

--- a/sdks/python/apache_beam/runners/portability/expansion_service_test.py
+++ b/sdks/python/apache_beam/runners/portability/expansion_service_test.py
@@ -270,6 +270,29 @@ class PayloadTransform(ptransform.PTransform):
     return PayloadTransform(payload.decode('ascii'))
 
 
+@ptransform.PTransform.register_urn('map_to_union_types', None)
+class MapToUnionTypesTransform(ptransform.PTransform):
+  class CustomDoFn(beam.DoFn):
+    def process(self, element):
+      if element == 1:
+        return ['1']
+      elif element == 2:
+        return [2]
+      else:
+        return [3.0]
+
+  def expand(self, pcoll):
+    return pcoll | beam.ParDo(self.CustomDoFn())
+
+  def to_runner_api_parameter(self, unused_context):
+    return b'map_to_union_types', None
+
+  @staticmethod
+  def from_runner_api_parameter(
+      unused_ptransform, unused_payload, unused_context):
+    return MapToUnionTypesTransform()
+
+
 @ptransform.PTransform.register_urn('fib', bytes)
 class FibTransform(ptransform.PTransform):
   def __init__(self, level):

--- a/sdks/python/apache_beam/transforms/external.py
+++ b/sdks/python/apache_beam/transforms/external.py
@@ -43,6 +43,7 @@ from apache_beam.portability.api import external_transforms_pb2
 from apache_beam.runners import pipeline_context
 from apache_beam.runners.portability import artifact_service
 from apache_beam.transforms import ptransform
+from apache_beam.typehints import WithTypeHints
 from apache_beam.typehints import native_type_compatibility
 from apache_beam.typehints import row_type
 from apache_beam.typehints.schemas import named_fields_to_schema
@@ -433,6 +434,9 @@ class ExternalTransform(ptransform.PTransform):
     self._inputs = {}  # type: Dict[str, pvalue.PCollection]
     self._outputs = {}  # type: Dict[str, pvalue.PCollection]
 
+  def with_output_types(self, *args, **kwargs):
+    return WithTypeHints.with_output_types(self, *args, **kwargs)
+
   def replace_named_inputs(self, named_inputs):
     self._inputs = named_inputs
 
@@ -498,11 +502,24 @@ class ExternalTransform(ptransform.PTransform):
               spec=beam_runner_api_pb2.FunctionSpec(
                   urn=common_urns.primitives.IMPULSE.urn),
               outputs={'out': transform_proto.inputs[tag]}))
+    output_coder = None
+    if self._type_hints.output_types:
+      if self._type_hints.output_types[0]:
+        output_coder = dict((str(k), context.coder_id_from_element_type(v))
+                            for k,
+                            v in enumerate(self._type_hints.output_types[0]))
+      elif self._type_hints.output_types[1]:
+        output_coder = {
+            k: context.coder_id_from_element_type(v)
+            for k,
+            v in self._type_hints.output_types[1].items()
+        }
     components = context.to_runner_api()
     request = beam_expansion_api_pb2.ExpansionRequest(
         components=components,
         namespace=self._external_namespace,  # type: ignore  # mypy thinks self._namespace is threading.local
-        transform=transform_proto)
+        transform=transform_proto,
+        output_coder_override=output_coder)
 
     with self._service() as service:
       response = service.Expand(request)

--- a/sdks/python/apache_beam/transforms/external.py
+++ b/sdks/python/apache_beam/transforms/external.py
@@ -502,24 +502,23 @@ class ExternalTransform(ptransform.PTransform):
               spec=beam_runner_api_pb2.FunctionSpec(
                   urn=common_urns.primitives.IMPULSE.urn),
               outputs={'out': transform_proto.inputs[tag]}))
-    output_coder = None
+    output_coders = None
     if self._type_hints.output_types:
       if self._type_hints.output_types[0]:
-        output_coder = dict((str(k), context.coder_id_from_element_type(v))
-                            for k,
-                            v in enumerate(self._type_hints.output_types[0]))
+        output_coders = dict(
+            (str(k), context.coder_id_from_element_type(v))
+            for (k, v) in enumerate(self._type_hints.output_types[0]))
       elif self._type_hints.output_types[1]:
-        output_coder = {
+        output_coders = {
             k: context.coder_id_from_element_type(v)
-            for k,
-            v in self._type_hints.output_types[1].items()
+            for (k, v) in self._type_hints.output_types[1].items()
         }
     components = context.to_runner_api()
     request = beam_expansion_api_pb2.ExpansionRequest(
         components=components,
         namespace=self._external_namespace,  # type: ignore  # mypy thinks self._namespace is threading.local
         transform=transform_proto,
-        output_coder_override=output_coder)
+        output_coder_requests=output_coders)
 
     with self._service() as service:
       response = service.Expand(request)


### PR DESCRIPTION
Oftentimes expansion services set sdk-native coders (e.g. `FastPrimitivesCoder` for Python or `SerializableCoder` for Java) for the output of expanded transforms that can be encoded with the standard coders . This PR allows to explicitly override the implicitly inferred output coder of the expanded transform. See https://github.com/apache/beam/blob/93338f9b38d97de6537d3731f69510b0c89d45de/sdks/python/apache_beam/transforms/external_test.py#L285 and https://github.com/apache/beam/blob/93338f9b38d97de6537d3731f69510b0c89d45de/sdks/python/apache_beam/transforms/external_test.py#L272 for the concrete example. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
