### PR TITLE
Avoid pr-bot state desync

### DIFF
--- a/scripts/ci/pr-bot/processNewPrs.ts
+++ b/scripts/ci/pr-bot/processNewPrs.ts
@@ -225,6 +225,8 @@ async function processPull(
         return;
       }
     }
+    // If none of the approvers were assigned to the pr, no-op.
+    return;
   }
 
   let checkState = await getChecksStatus(REPO_OWNER, REPO, pull.head.sha);

--- a/scripts/ci/pr-bot/shared/persistentState.ts
+++ b/scripts/ci/pr-bot/shared/persistentState.ts
@@ -117,7 +117,7 @@ export class PersistentState {
       );
       await exec.exec("git checkout -b pr-bot-state");
       // Ensure that if we've created or just checked out the branch that we can also push to it
-      await exec.exec("git push origin pr-bot-state")
+      await exec.exec("git push origin pr-bot-state");
     }
     this.switchedBranch = true;
   }

--- a/scripts/ci/pr-bot/shared/persistentState.ts
+++ b/scripts/ci/pr-bot/shared/persistentState.ts
@@ -115,12 +115,9 @@ export class PersistentState {
       console.log(
         "Couldnt find branch pr-bot-state in origin, trying to create it"
       );
-      try {
-        await exec.exec("git checkout -b pr-bot-state");
-      } catch {
-        console.log("Creating branch failed, trying a simple checkout.");
-        await exec.exec("git checkout pr-bot-state");
-      }
+      await exec.exec("git checkout -b pr-bot-state");
+      // Ensure that if we've created or just checked out the branch that we can also push to it
+      await exec.exec("git push origin pr-bot-state")
     }
     this.switchedBranch = true;
   }


### PR DESCRIPTION
In https://github.com/apache/beam/pull/17285 the PR bot exhibited 2 pieces of broken behavior:

1) It requested a second review from me after having already requested one from `@riteshghorse`
2) Once I approved, it requested an extra review from me again.

These were caused by 2 underlying issues:
1) Git failed to correctly checkout the pr-bot-state branch causing the first issue. This led the bot to believe nobody had been assigned, and it tried to assign me, but it wasn't able to persist that state back to the state branch (See this [broken run](https://github.com/apache/beam/runs/5852769678?check_suite_focus=true)). To fix this, I added an extra git push step to make sure we're actually able to push to the pr-bot-state branch before we try to do any state manipulation.
2) Because the state got out of sync, the bot didn't realize I had been assigned and thought Ritesh was still assigned. When I approved, it revealed a bug that will cause a new reviewer to get assigned when a non-reviewer approves. To fix this, I added an early return in those cases.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
