### PR TITLE
[BEAM-14259, BEAM-14266] Remove unused function, replace use of ptypes package in exec/translate.go

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/translate.go
@@ -33,7 +33,6 @@ import (
 	fnpb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/fnexecution_v1"
 	pipepb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/pipeline_v1"
 	"github.com/golang/protobuf/proto"
-	"github.com/golang/protobuf/ptypes"
 )
 
 // TODO(lostluck): 2018/05/28 Extract these from the canonical enums in beam_runner_api.proto
@@ -164,24 +163,6 @@ func (b *builder) build() (*Plan, error) {
 	return NewPlan(b.desc.GetId(), b.units)
 }
 
-func (b *builder) makeWindowingStrategy(id string) (*window.WindowingStrategy, error) {
-	if w, exists := b.windowing[id]; exists {
-		return w, nil
-	}
-
-	ws, ok := b.desc.GetWindowingStrategies()[id]
-	if !ok {
-		return nil, errors.Errorf("windowing strategy %v not found", id)
-	}
-	wfn, err := unmarshalWindowFn(ws.GetWindowFn())
-	if err != nil {
-		return nil, err
-	}
-	w := &window.WindowingStrategy{Fn: wfn}
-	b.windowing[id] = w
-	return w, nil
-}
-
 func unmarshalWindowFn(wfn *pipepb.FunctionSpec) (*window.Fn, error) {
 	switch urn := wfn.GetUrn(); urn {
 	case graphx.URNGlobalWindowsWindowFn:
@@ -192,10 +173,11 @@ func unmarshalWindowFn(wfn *pipepb.FunctionSpec) (*window.Fn, error) {
 		if err := proto.Unmarshal(wfn.GetPayload(), &payload); err != nil {
 			return nil, err
 		}
-		size, err := ptypes.Duration(payload.GetSize())
-		if err != nil {
+		sizePB := payload.GetSize()
+		if err := sizePB.CheckValid(); err != nil {
 			return nil, err
 		}
+		size := sizePB.AsDuration()
 		return window.NewFixedWindows(size), nil
 
 	case graphx.URNSlidingWindowsWindowFn:
@@ -203,14 +185,18 @@ func unmarshalWindowFn(wfn *pipepb.FunctionSpec) (*window.Fn, error) {
 		if err := proto.Unmarshal(wfn.GetPayload(), &payload); err != nil {
 			return nil, err
 		}
-		period, err := ptypes.Duration(payload.GetPeriod())
-		if err != nil {
+		periodPB := payload.GetPeriod()
+		if err := periodPB.CheckValid(); err != nil {
 			return nil, err
 		}
-		size, err := ptypes.Duration(payload.GetSize())
-		if err != nil {
+		period := periodPB.AsDuration()
+
+		sizePB := payload.GetSize()
+		if err := sizePB.CheckValid(); err != nil {
 			return nil, err
 		}
+		size := sizePB.AsDuration()
+
 		return window.NewSlidingWindows(period, size), nil
 
 	case graphx.URNSessionsWindowFn:
@@ -218,10 +204,11 @@ func unmarshalWindowFn(wfn *pipepb.FunctionSpec) (*window.Fn, error) {
 		if err := proto.Unmarshal(wfn.GetPayload(), &payload); err != nil {
 			return nil, err
 		}
-		gap, err := ptypes.Duration(payload.GetGapSize())
-		if err != nil {
+		gapPB := payload.GetGapSize()
+		if err := gapPB.CheckValid(); err != nil {
 			return nil, err
 		}
+		gap := gapPB.AsDuration()
 		return window.NewSessions(gap), nil
 
 	default:
@@ -238,24 +225,28 @@ func unmarshalAndMakeWindowMapping(wmfn *pipepb.FunctionSpec) (WindowMapper, err
 		if err := proto.Unmarshal(wmfn.GetPayload(), &payload); err != nil {
 			return nil, err
 		}
-		size, err := ptypes.Duration(payload.GetSize())
-		if err != nil {
+		sizePB := payload.GetSize()
+		if err := sizePB.CheckValid(); err != nil {
 			return nil, err
 		}
+		size := sizePB.AsDuration()
 		return &windowMapper{wfn: window.NewFixedWindows(size)}, nil
 	case graphx.URNWindowMappingSliding:
 		var payload pipepb.SlidingWindowsPayload
 		if err := proto.Unmarshal(wmfn.GetPayload(), &payload); err != nil {
 			return nil, err
 		}
-		period, err := ptypes.Duration(payload.GetPeriod())
-		if err != nil {
+		periodPB := payload.GetPeriod()
+		if err := periodPB.CheckValid(); err != nil {
 			return nil, err
 		}
-		size, err := ptypes.Duration(payload.GetSize())
-		if err != nil {
+		period := periodPB.AsDuration()
+
+		sizePB := payload.GetSize()
+		if err := sizePB.CheckValid(); err != nil {
 			return nil, err
 		}
+		size := sizePB.AsDuration()
 		return &windowMapper{wfn: window.NewSlidingWindows(period, size)}, nil
 	default:
 		return nil, fmt.Errorf("unsupported window mapping fn URN %v", urn)


### PR DESCRIPTION
Removes the unused (*builder).makeWindowingStrategy() function and replaces use of ptypes.Duration with functionality found in the durationpb types being handled.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
