### PR TITLE
[BEAM-11745] Fix author list rendering

### DIFF
--- a/website/www/site/layouts/blog/single.html
+++ b/website/www/site/layouts/blog/single.html
@@ -25,13 +25,13 @@ limitations under the License. See accompanying LICENSE file.
         <h2 itemprop="name headline">{{ .Title }}</h1>
         <div class="post-info">
           <span>
-          {{ with $authors }}
+            {{ with $authors }}
                 {{ $count := len . }}
                 {{ range $index, $authorId := . }}
-                    {{ if and (ne $index 0) (gt $count 2) }},{{ end }}
+                    {{ if and (ne $index 0) (gt $count 2) (lt $index (sub $count 1))}},{{ end }}
                     {{ if and (eq $index (sub $count 1)) (gt $count 1) }} &amp;{{ end }}
                     {{ with index $.Site.Data.authors $authorId }}
-                      {{ .name }} {{ with .twitter }}[<a href="https://twitter.com/{{ . }}">@{{ . }}</a>]{{ end }}
+                      {{ .name }}{{ with .twitter }} [<a href="https://twitter.com/{{ . }}">@{{ . }}</a>]{{ end }}
                     {{ else }}
                       {{ $authorId }}
                     {{ end }}


### PR DESCRIPTION

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
