### PR TITLE
Fix test ordering issue

### DIFF
--- a/sdks/go/pkg/beam/runners/dataflow/dataflow_test.go
+++ b/sdks/go/pkg/beam/runners/dataflow/dataflow_test.go
@@ -143,21 +143,22 @@ func TestGetJobOptions_InvalidAutoscaling(t *testing.T) {
 	}
 }
 
-func TestGetJobOptions_DockerNoImage(t *testing.T) {
-	*jobopts.EnvironmentType = "docker"
-	*jobopts.EnvironmentConfig = "testContainerImage"
-
-	if got, want := getContainerImage(context.Background()), "testContainerImage"; got != want {
-		t.Fatalf("getContainerImage() = %q, want %q", got, want)
-	}
-}
-
 func TestGetJobOptions_DockerWithImage(t *testing.T) {
 	*jobopts.EnvironmentType = "docker"
 	*jobopts.EnvironmentConfig = "testContainerImage"
 	*image = "testContainerImageOverride"
 
 	if got, want := getContainerImage(context.Background()), "testContainerImageOverride"; got != want {
+		t.Fatalf("getContainerImage() = %q, want %q", got, want)
+	}
+}
+
+func TestGetJobOptions_DockerNoImage(t *testing.T) {
+	*jobopts.EnvironmentType = "docker"
+	*jobopts.EnvironmentConfig = "testContainerImage"
+	*image = ""
+
+	if got, want := getContainerImage(context.Background()), "testContainerImage"; got != want {
 		t.Fatalf("getContainerImage() = %q, want %q", got, want)
 	}
 }


### PR DESCRIPTION
Right now, if these 2 tests are run in the opposite order that they are composed in the file, `TestGetJobOptions_DockerNoImage` fails because it relies on *image not being set. This forces *image to be unset and reorders the tests to prove that its working.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
