### PR TITLE
[BEAM-13925] PR-Bot - Dont double assign committers if author or other reviewer is a committer

### DIFF
--- a/scripts/ci/pr-bot/processNewPrs.ts
+++ b/scripts/ci/pr-bot/processNewPrs.ts
@@ -195,6 +195,20 @@ async function processPull(
     for (const approver of approvers) {
       const labelOfReviewer = prState.getLabelForReviewer(approver);
       if (labelOfReviewer) {
+        if (
+          (await github.checkIfCommitter(pull.user.login)) ||
+          (await prState.isAnyAssignedReviewerCommitter()) ||
+          (await github.checkIfCommitter(approver))
+        ) {
+          console.log(
+            "Author or reviewer is committer, not forwarding to another committer"
+          );
+          // Cache this result so we don't need to keep looking it up.
+          prState.committerAssigned = true;
+          await stateClient.writePrState(pull.number, prState);
+          return;
+        }
+
         console.log(`Assigning a committer for label ${labelOfReviewer}`);
         let reviewersState = await stateClient.getReviewersForLabelState(
           labelOfReviewer


### PR DESCRIPTION
Right now, the pr-bot automatically assigns a committer after the first PR review, even if the initial reviewer is a committer. This updates to avoid doing that.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
