### PR TITLE
[BEAM-14290] Address staticcheck warnings in the reflectx package

### DIFF
--- a/sdks/go/pkg/beam/core/util/reflectx/call.go
+++ b/sdks/go/pkg/beam/core/util/reflectx/call.go
@@ -99,7 +99,7 @@ func CallNoPanic(fn Func, args []interface{}) (ret []interface{}, err error) {
 
 // ValueOf performs a per-element reflect.ValueOf.
 func ValueOf(list []interface{}) []reflect.Value {
-	ret := make([]reflect.Value, len(list), len(list))
+	ret := make([]reflect.Value, len(list))
 	for i := 0; i < len(list); i++ {
 		ret[i] = reflect.ValueOf(list[i])
 	}
@@ -108,7 +108,7 @@ func ValueOf(list []interface{}) []reflect.Value {
 
 // Interface performs a per-element Interface call.
 func Interface(list []reflect.Value) []interface{} {
-	ret := make([]interface{}, len(list), len(list))
+	ret := make([]interface{}, len(list))
 	for i := 0; i < len(list); i++ {
 		ret[i] = list[i].Interface()
 	}

--- a/sdks/go/pkg/beam/core/util/reflectx/call_test.go
+++ b/sdks/go/pkg/beam/core/util/reflectx/call_test.go
@@ -102,7 +102,7 @@ func TestValue(t *testing.T) {
 	if len(got) != len(want) {
 		t.Fatalf("ValueOf(interfaces) got slice %v, expected slice of length %v", got, len(want))
 	}
-	for idx, _ := range got {
+	for idx := range got {
 		if got[idx].Kind() != want[idx] {
 			t.Errorf("ValueOf(interfaces)[%v], got %v of kind %v, want %v", idx, got[idx], got[idx].Kind(), want[idx])
 		}
@@ -117,7 +117,7 @@ func TestInterface(t *testing.T) {
 	if len(got) != len(interfaces) {
 		t.Fatalf("Interface(values) got slice %v, expected slice of length %v", got, len(interfaces))
 	}
-	for idx, _ := range got {
+	for idx := range got {
 		if got[idx] != interfaces[idx] {
 			t.Errorf("Interface(values)[%v]=%v, want %v", idx, got[idx], interfaces[idx])
 		}

--- a/sdks/go/pkg/beam/core/util/reflectx/calls.go
+++ b/sdks/go/pkg/beam/core/util/reflectx/calls.go
@@ -15,6 +15,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//lint:file-ignore S1023 redundant return statements are generated
+
 package reflectx
 
 import (

--- a/sdks/go/pkg/beam/core/util/reflectx/calls.tmpl
+++ b/sdks/go/pkg/beam/core/util/reflectx/calls.tmpl
@@ -13,6 +13,8 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
+//lint:file-ignore S1023 redundant return statements are generated
+
 package reflectx
 
 import (

--- a/sdks/go/pkg/beam/core/util/reflectx/types.go
+++ b/sdks/go/pkg/beam/core/util/reflectx/types.go
@@ -105,7 +105,6 @@ func MakeSlice(t reflect.Type, values ...reflect.Value) reflect.Value {
 
 // UnderlyingType drops value's type by converting it to an interface and then returning ValueOf() the untyped value.
 func UnderlyingType(value reflect.Value) reflect.Value {
-	var untyped interface{}
-	untyped = value.Interface()
+	untyped := value.Interface()
 	return reflect.ValueOf(untyped)
 }

--- a/sdks/go/pkg/beam/core/util/reflectx/types_test.go
+++ b/sdks/go/pkg/beam/core/util/reflectx/types_test.go
@@ -398,8 +398,7 @@ func TestMakeSlice(t *testing.T) {
 type typeWrapper interface{}
 
 func TestUnderlyingType(t *testing.T) {
-	var wrapper typeWrapper
-	wrapper = "test"
+	wrapper := typeWrapper("test")
 	underlying := UnderlyingType(reflect.ValueOf(wrapper))
 	if got, want := underlying.Type(), reflect.TypeOf((*string)(nil)).Elem(); got != want {
 		t.Fatalf("UnderlyingType(reflect.ValueOf(wrapper)) returned type of %v, want %v", got, want)


### PR DESCRIPTION
Adds a lint:file-ignore to the calls.tmpl file and has it added to a regenerated calls.go file, cleans up unnecessary blank identifiers and variable declarations, and shortens make() calls.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
