### PR TITLE
[BEAM-13204] Fix website bug where code tabs do not appear if the default language is not available

### DIFF
--- a/website/www/site/assets/js/language-switch-v2.js
+++ b/website/www/site/assets/js/language-switch-v2.js
@@ -13,7 +13,8 @@
 $(document).ready(function() {
     function Switcher(conf) {
         var id = conf["class-prefix"],
-            def = conf["default"];
+            def = conf["default"],
+            langs = [];
         var prefix = id + "-";
         return {
             "id": id,
@@ -31,7 +32,6 @@ $(document).ready(function() {
             "navHtml": function(types) {
                 var lists = "";
                 var selectors = "";
-
                 types.forEach(function(type) {
                     var name = type.replace(prefix, "");
                     name = (name === "py")? "python": name;
@@ -76,6 +76,7 @@ $(document).ready(function() {
             */
             "lookup": function(el, lang) {
                 if (!el.is("div"+this.selector)) {
+                    langs = lang;
                     return lang;
                 }
 
@@ -102,8 +103,14 @@ $(document).ready(function() {
                     }
                 });
 
-                if(!isPrefSelected) {
-                  pref = this.default;
+                if (!isPrefSelected) {
+                  // if there's no code block for the default language, set the
+                  // preferred language to the first available language
+                  if (!langs.includes(this.default)) {
+                    pref = langs[0]
+                  } else {
+                    pref = this.default;
+                  }
 
                   $("." + this.wrapper + " li").each(function() {
                       if ($(this).data("type") === pref) {
@@ -111,7 +118,6 @@ $(document).ready(function() {
                       }
                   });
                }
-
                 // Swapping visibility of code blocks.
                 $(this.selector).hide();
                 $("nav"+this.selector).show();

--- a/website/www/site/assets/js/language-switch-v2.js
+++ b/website/www/site/assets/js/language-switch-v2.js
@@ -32,6 +32,7 @@ $(document).ready(function() {
             "navHtml": function(types) {
                 var lists = "";
                 var selectors = "";
+
                 types.forEach(function(type) {
                     var name = type.replace(prefix, "");
                     name = (name === "py")? "python": name;
@@ -104,12 +105,14 @@ $(document).ready(function() {
                 });
 
                 if (!isPrefSelected) {
-                  // if there's no code block for the default language, set the
-                  // preferred language to the first available language
-                  if (!langs.includes(this.default)) {
-                    pref = langs[0]
-                  } else {
+                  // if there's a code block for the default language,
+                  // set the preferred language to the default language
+                  if (langs.includes(this.default)) {
                     pref = this.default;
+                  // otherwise set the preferred language to the first available
+                  // language, so we don't have a page with no code blocks
+                  } else {
+                    pref = langs[0];
                   }
 
                   $("." + this.wrapper + " li").each(function() {


### PR DESCRIPTION
**Please** add a meaningful description for your change here

This fixes a bug where no code tabs display if the code tab language doesn't match the last selected language.

@TheNeuralBit 

Testing:

- [Ensuring Python Type Safety](http://apache-beam-website-pull-requests.storage.googleapis.com/17379/documentation/sdks/python-type-safety/index.html)
  - Set `language-go` in local storage and reload page. Python code tabs display.
  - Go to a different page and select Java, which sets `language-java`. Return to this page. Python code tabs display.
- [Resource hints](http://apache-beam-website-pull-requests.storage.googleapis.com/17379/documentation/runtime/resource-hints/index.html)
  - Set `language-go` in local storage and reload page. Java and Python code tabs display.
  - Go to a different page and select Python, which sets `language-py`. Return to this page. Java and Python code tabs display, and Python tabs are active, as expected.
- [Java Quickstart](http://apache-beam-website-pull-requests.storage.googleapis.com/17379/get-started/quickstart-java/index.html)
  - In local storage, change `shell-unix` to `shell-unicorn`, which is not an available shell tab. Refresh page. Unix and Powershell tabs display as expected, with Unix active.
  - Ensure that switching between Unix and Powershell works as expected.
  - In local storage, set runner to `runner-dataflower`, which is not an available runner. Refresh page. Runner tabs display as expected, with Direct runner active.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
