### PR TITLE
[BEAM-14323] Improve IDE integration of Spark cross version builds

### DIFF
--- a/runners/spark/2/build.gradle
+++ b/runners/spark/2/build.gradle
@@ -22,12 +22,8 @@ project.ext {
   // Set the version of all Spark-related dependencies here.
   spark_version = '2.4.8'
   spark_scala_version = '2.11'
-
-  // Version specific code overrides.
-  main_source_overrides = ['./src/main/java']
-  test_source_overrides = ['./src/test/java']
-  main_resources_overrides = []
-  test_resources_overrides = []
+  // Copy shared sources for Spark 2 to use Spark 3 as primary version in place
+  copySourceBase = true
   archives_base_name = 'beam-runners-spark'
 }
 

--- a/runners/spark/3/build.gradle
+++ b/runners/spark/3/build.gradle
@@ -22,12 +22,7 @@ project.ext {
   // Set the version of all Spark-related dependencies here.
   spark_version = '3.1.2'
   spark_scala_version = '2.12'
-
-  // Version specific code overrides.
-  main_source_overrides = ['./src/main/java']
-  test_source_overrides = ['./src/test/java']
-  main_resources_overrides = []
-  test_resources_overrides = []
+  copySourceBase = false // disabled to use Spark 3 as primary dev version
   archives_base_name = 'beam-runners-spark-3'
 }
 

--- a/runners/spark/spark_runner.gradle
+++ b/runners/spark/spark_runner.gradle
@@ -21,13 +21,13 @@ import java.util.stream.Collectors
 
 apply plugin: 'org.apache.beam.module'
 applyJavaNature(
-  enableStrictDependencies:true,
+  enableStrictDependencies: true,
   automaticModuleName: 'org.apache.beam.runners.spark',
   archivesBaseName: (project.hasProperty('archives_base_name') ? archives_base_name : archivesBaseName),
   classesTriggerCheckerBugs: [
     'SparkAssignWindowFn': 'https://github.com/typetools/checker-framework/issues/3793',
-    'SparkCombineFn': 'https://github.com/typetools/checker-framework/issues/3793',
-    'WindowingHelpers': 'https://github.com/typetools/checker-framework/issues/3793',
+    'SparkCombineFn'     : 'https://github.com/typetools/checker-framework/issues/3793',
+    'WindowingHelpers'   : 'https://github.com/typetools/checker-framework/issues/3793',
   ],
 )
 
@@ -49,67 +49,46 @@ configurations {
 }
 
 def hadoopVersions = [
-    "285": "2.8.5",
-    "292": "2.9.2",
-    "2101": "2.10.1",
-    "321": "3.2.1",
+  "285" : "2.8.5",
+  "292" : "2.9.2",
+  "2101": "2.10.1",
+  "321" : "3.2.1",
 ]
 
-hadoopVersions.each {kv -> configurations.create("hadoopVersion$kv.key")}
+hadoopVersions.each { kv -> configurations.create("hadoopVersion$kv.key") }
 
-/*
- * Copy & merge source overrides into build directory.
- */
-def sourceOverridesBase = "${project.buildDir}/source-overrides/src"
-
-def copySourceOverrides = tasks.register('copySourceOverrides', Copy) {
-  it.from main_source_overrides
-  it.into "${sourceOverridesBase}/main/java"
-  it.duplicatesStrategy DuplicatesStrategy.INCLUDE
-}
-compileJava.dependsOn copySourceOverrides
-
-def copyResourcesOverrides = tasks.register('copyResourcesOverrides', Copy) {
-  it.from main_resources_overrides
-  it.into "${sourceOverridesBase}/main/resources"
-  it.duplicatesStrategy DuplicatesStrategy.INCLUDE
-}
-processResources.dependsOn copyResourcesOverrides
-
-def copyTestSourceOverrides = tasks.register('copyTestSourceOverrides', Copy) {
-  it.from test_source_overrides
-  it.into "${sourceOverridesBase}/test/java"
-  it.duplicatesStrategy DuplicatesStrategy.INCLUDE
-}
-compileTestJava.dependsOn copyTestSourceOverrides
-
-def copyTestResourcesOverrides = tasks.register('copyTestResourcesOverrides', Copy) {
-  it.from test_resources_overrides
-  it.into "${sourceOverridesBase}/test/resources"
-  it.duplicatesStrategy DuplicatesStrategy.INCLUDE
-}
-processTestResources.dependsOn copyTestResourcesOverrides
-
-/*
- * We have to explicitly set all directories here to make sure each
- * version of Spark has the correct overrides set.
- */
 def sourceBase = "${project.projectDir}/../src"
-sourceSets {
-  main {
-    java {
-      srcDirs = ["${sourceBase}/main/java", "${sourceOverridesBase}/main/java"]
-    }
-    resources {
-      srcDirs = ["${sourceBase}/main/resources", "${sourceOverridesBase}/main/resources"]
-    }
+def sourceBaseCopy = "${project.buildDir}/sourcebase/src"
+
+def useCopiedSourceSet = { scope, type, trigger ->
+  def taskName = "copy${scope.capitalize()}${type.capitalize()}"
+  trigger.dependsOn tasks.register(taskName, Copy) {
+    from "$sourceBase/$scope/$type"
+    into "$sourceBaseCopy/$scope/$type"
+    duplicatesStrategy DuplicatesStrategy.INCLUDE
   }
-  test {
-    java {
-      srcDirs = ["${sourceBase}/test/java", "${sourceOverridesBase}/test/java"]
+  // append copied sources to srcDirs
+  sourceSets."$scope"."$type".srcDirs "$sourceBaseCopy/$scope/$type"
+}
+
+if (copySourceBase) {
+  // Copy source base into build directory.
+  // While this is not necessary, having multiple source sets referencing the same shared base will typically confuse an IDE and harm developer experience.
+  // The copySourceBase flag can be swapped without any implications and allows to pick a main version that is actively worked on.
+  useCopiedSourceSet("main", "java", compileJava)
+  useCopiedSourceSet("main", "resources", processResources)
+  useCopiedSourceSet("test", "java", compileTestJava)
+  useCopiedSourceSet("test", "resources", processTestResources)
+} else {
+  // append shared base sources to srcDirs
+  sourceSets {
+    main {
+      java.srcDirs "${sourceBase}/main/java"
+      resources.srcDirs "${sourceBase}/main/resources"
     }
-    resources {
-      srcDirs = ["${sourceBase}/test/resources", "${sourceOverridesBase}/test/resources"]
+    test {
+      java.srcDirs "${sourceBase}/test/java"
+      resources.srcDirs "${sourceBase}/test/resources"
     }
   }
 }
@@ -171,7 +150,7 @@ dependencies {
   provided "org.apache.spark:spark-sql_$spark_scala_version:$spark_version"
   provided "org.apache.spark:spark-streaming_$spark_scala_version:$spark_version"
   provided "org.apache.spark:spark-catalyst_$spark_scala_version:$spark_version"
-  if(project.property("spark_scala_version").equals("2.11")){
+  if (project.property("spark_scala_version").equals("2.11")) {
     compileOnly "org.scala-lang:scala-library:2.11.12"
     runtimeOnly library.java.jackson_module_scala_2_11
   } else {
@@ -208,7 +187,7 @@ dependencies {
   validatesRunner project(":sdks:java:io:hadoop-format").sourceSets.test.output
   validatesRunner project(path: ":examples:java", configuration: "testRuntimeMigration")
   validatesRunner project(path: project.path, configuration: "testRuntimeMigration")
-  hadoopVersions.each {kv ->
+  hadoopVersions.each { kv ->
     "hadoopVersion$kv.key" "org.apache.hadoop:hadoop-common:$kv.value"
   }
 }
@@ -227,7 +206,7 @@ configurations.validatesRunner {
 }
 
 
-hadoopVersions.each {kv ->
+hadoopVersions.each { kv ->
   configurations."hadoopVersion$kv.key" {
     // Testing the Spark runner causes a StackOverflowError if slf4j-jdk14 is on the classpath
     exclude group: "org.slf4j", module: "slf4j-jdk14"
@@ -242,9 +221,9 @@ def validatesRunnerBatch = tasks.register("validatesRunnerBatch", Test) {
   // Disable gradle cache
   outputs.upToDateWhen { false }
   def pipelineOptions = JsonOutput.toJson([
-          "--runner=TestSparkRunner",
-          "--streaming=false",
-          "--enableSparkMetricSinks=false",
+    "--runner=TestSparkRunner",
+    "--streaming=false",
+    "--enableSparkMetricSinks=false",
   ])
   systemProperty "beamTestPipelineOptions", pipelineOptions
   systemProperty "beam.spark.test.reuseSparkContext", "true"
@@ -253,9 +232,9 @@ def validatesRunnerBatch = tasks.register("validatesRunnerBatch", Test) {
 
   classpath = configurations.validatesRunner
   testClassesDirs = files(
-            project(":sdks:java:core").sourceSets.test.output.classesDirs,
-            project(":runners:core-java").sourceSets.test.output.classesDirs,
-        )
+    project(":sdks:java:core").sourceSets.test.output.classesDirs,
+    project(":runners:core-java").sourceSets.test.output.classesDirs,
+  )
   testClassesDirs += files(project.sourceSets.test.output.classesDirs)
 
   // Only one SparkContext may be running in a JVM (SPARK-2243)
@@ -295,9 +274,9 @@ def validatesRunnerStreaming = tasks.register("validatesRunnerStreaming", Test) 
   // Disable gradle cache
   outputs.upToDateWhen { false }
   def pipelineOptions = JsonOutput.toJson([
-          "--runner=TestSparkRunner",
-          "--forceStreaming=true",
-          "--enableSparkMetricSinks=true",
+    "--runner=TestSparkRunner",
+    "--forceStreaming=true",
+    "--enableSparkMetricSinks=true",
   ])
   systemProperty "beamTestPipelineOptions", pipelineOptions
 
@@ -321,9 +300,9 @@ tasks.register("validatesStructuredStreamingRunnerBatch", Test) {
   // Disable gradle cache
   outputs.upToDateWhen { false }
   def pipelineOptions = JsonOutput.toJson([
-          "--runner=SparkStructuredStreamingRunner",
-          "--testMode=true",
-          "--streaming=false",
+    "--runner=SparkStructuredStreamingRunner",
+    "--testMode=true",
+    "--streaming=false",
   ])
   systemProperty "beamTestPipelineOptions", pipelineOptions
   systemProperty "spark.sql.shuffle.partitions", "4"
@@ -332,8 +311,8 @@ tasks.register("validatesStructuredStreamingRunnerBatch", Test) {
 
   classpath = configurations.validatesRunner
   testClassesDirs = files(
-          project(":sdks:java:core").sourceSets.test.output.classesDirs,
-          project(":runners:core-java").sourceSets.test.output.classesDirs,
+    project(":sdks:java:core").sourceSets.test.output.classesDirs,
+    project(":runners:core-java").sourceSets.test.output.classesDirs,
   )
   testClassesDirs += files(project.sourceSets.test.output.classesDirs)
 
@@ -401,8 +380,8 @@ createJavaExamplesArchetypeValidationTask(type: 'Quickstart', runner: 'Spark')
 tasks.register("hadoopVersionsTest") {
   group = "Verification"
   def taskNames = hadoopVersions.keySet().stream()
-      .map{num -> "hadoopVersion${num}Test"}
-      .collect(Collectors.toList())
+    .map { num -> "hadoopVersion${num}Test" }
+    .collect(Collectors.toList())
   dependsOn taskNames
 }
 
@@ -411,11 +390,11 @@ tasks.register("examplesIntegrationTest", Test) {
   // Disable gradle cache
   outputs.upToDateWhen { false }
   def pipelineOptions = JsonOutput.toJson([
-          "--runner=TestSparkRunner",
-          "--enableSparkMetricSinks=true",
-          "--tempLocation=${tempLocation}",
-          "--tempRoot=${tempLocation}",
-          "--project=${gcpProject}",
+    "--runner=TestSparkRunner",
+    "--enableSparkMetricSinks=true",
+    "--tempLocation=${tempLocation}",
+    "--tempRoot=${tempLocation}",
+    "--project=${gcpProject}",
   ])
   systemProperty "beamTestPipelineOptions", pipelineOptions
   systemProperty "beam.spark.test.reuseSparkContext", "true"
@@ -436,7 +415,7 @@ tasks.register("examplesIntegrationTest", Test) {
   jvmArgs '-Xmx3g'
 }
 
-hadoopVersions.each {kv ->
+hadoopVersions.each { kv ->
   tasks.register("hadoopVersion${kv.key}Test", Test) {
     group = "Verification"
     description = "Runs Spark tests with Hadoop version $kv.value"


### PR DESCRIPTION
With the current build setup, developer experience is fairly poor when working with the cross version build for Spark (but also similarly for Flink):

- Sources for version specific overrides are copied to a new location and defined as Gradle sources at that location. 
  1) First of all, this is totally unnecessary. These sources are not shared and should be used in place. 
  2) Much more troublesome, the actual sources won't be resolved / checked by any IDE anymore and can't be properly worked on that way. Sadly for no reason at all ...
- The actual shared resources on the other hand are referenced (added to srcDirs) in place. The IDE will randomly assign them to one Spark version module. Typically, for IntelliJ at least, that's the first (lower) one and not the one developers are actively working on.

The suggested changes in this PR are:
- Don't copy version specific overrides
- Only copy shared sources conditionally based on a flag. This allows developers to disable copying to pick a primary version they intend to work on.

Note: This is primary a cosmetic flag to improve IDE integration and has no impact on builds, even if all modules disable copying.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
