### PR TITLE
[BEAM-14007] Update Java katas to Beam 2.38

### DIFF
--- a/learning/katas/java/Common Transforms/Aggregation/Count/task-remote-info.yaml
+++ b/learning/katas/java/Common Transforms/Aggregation/Count/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076163
-update_date: Fri, 12 Jun 2020 08:08:04 UTC
+update_date: Thu, 21 Apr 2022 14:23:22 UTC

--- a/learning/katas/java/Common Transforms/Aggregation/Max/task-remote-info.yaml
+++ b/learning/katas/java/Common Transforms/Aggregation/Max/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076167
-update_date: Fri, 12 Jun 2020 08:08:18 UTC
+update_date: Thu, 21 Apr 2022 14:23:27 UTC

--- a/learning/katas/java/Common Transforms/Aggregation/Mean/task-remote-info.yaml
+++ b/learning/katas/java/Common Transforms/Aggregation/Mean/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076165
-update_date: Fri, 12 Jun 2020 08:08:10 UTC
+update_date: Thu, 21 Apr 2022 14:23:24 UTC

--- a/learning/katas/java/Common Transforms/Aggregation/Min/task-remote-info.yaml
+++ b/learning/katas/java/Common Transforms/Aggregation/Min/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076166
-update_date: Fri, 12 Jun 2020 08:08:13 UTC
+update_date: Thu, 21 Apr 2022 14:23:25 UTC

--- a/learning/katas/java/Common Transforms/Aggregation/Sum/task-remote-info.yaml
+++ b/learning/katas/java/Common Transforms/Aggregation/Sum/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076164
-update_date: Fri, 12 Jun 2020 08:08:07 UTC
+update_date: Thu, 21 Apr 2022 14:23:23 UTC

--- a/learning/katas/java/Common Transforms/Filter/Filter/task-remote-info.yaml
+++ b/learning/katas/java/Common Transforms/Filter/Filter/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076162
-update_date: Fri, 12 Jun 2020 08:08:01 UTC
+update_date: Thu, 21 Apr 2022 14:23:21 UTC

--- a/learning/katas/java/Common Transforms/Filter/ParDo/task-remote-info.yaml
+++ b/learning/katas/java/Common Transforms/Filter/ParDo/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076161
-update_date: Fri, 12 Jun 2020 08:07:58 UTC
+update_date: Thu, 21 Apr 2022 14:23:20 UTC

--- a/learning/katas/java/Common Transforms/WithKeys/WithKeys/task-remote-info.yaml
+++ b/learning/katas/java/Common Transforms/WithKeys/WithKeys/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076168
-update_date: Fri, 12 Jun 2020 08:08:21 UTC
+update_date: Thu, 21 Apr 2022 14:23:28 UTC

--- a/learning/katas/java/Core Transforms/Branching/Branching/task-remote-info.yaml
+++ b/learning/katas/java/Core Transforms/Branching/Branching/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076188
-update_date: Fri, 12 Jun 2020 08:07:49 UTC
+update_date: Thu, 21 Apr 2022 14:23:17 UTC

--- a/learning/katas/java/Core Transforms/CoGroupByKey/CoGroupByKey/task-remote-info.yaml
+++ b/learning/katas/java/Core Transforms/CoGroupByKey/CoGroupByKey/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076151
-update_date: Fri, 12 Jun 2020 08:07:18 UTC
+update_date: Thu, 21 Apr 2022 14:23:04 UTC

--- a/learning/katas/java/Core Transforms/Combine/BinaryCombineFn Lambda/task-remote-info.yaml
+++ b/learning/katas/java/Core Transforms/Combine/BinaryCombineFn Lambda/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076154
-update_date: Fri, 12 Jun 2020 08:07:32 UTC
+update_date: Thu, 21 Apr 2022 14:23:10 UTC

--- a/learning/katas/java/Core Transforms/Combine/BinaryCombineFn/task-remote-info.yaml
+++ b/learning/katas/java/Core Transforms/Combine/BinaryCombineFn/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076153
-update_date: Fri, 12 Jun 2020 08:07:29 UTC
+update_date: Thu, 21 Apr 2022 14:23:08 UTC

--- a/learning/katas/java/Core Transforms/Combine/Combine PerKey/task-remote-info.yaml
+++ b/learning/katas/java/Core Transforms/Combine/Combine PerKey/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076155
-update_date: Fri, 12 Jun 2020 08:07:34 UTC
+update_date: Thu, 21 Apr 2022 14:23:11 UTC

--- a/learning/katas/java/Core Transforms/Combine/CombineFn/task-remote-info.yaml
+++ b/learning/katas/java/Core Transforms/Combine/CombineFn/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076152
-update_date: Fri, 12 Jun 2020 08:07:25 UTC
+update_date: Thu, 21 Apr 2022 14:23:07 UTC

--- a/learning/katas/java/Core Transforms/Combine/Simple Function/task-remote-info.yaml
+++ b/learning/katas/java/Core Transforms/Combine/Simple Function/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076194
-update_date: Fri, 12 Jun 2020 08:07:21 UTC
+update_date: Thu, 21 Apr 2022 14:23:06 UTC

--- a/learning/katas/java/Core Transforms/Composite Transform/Composite Transform/task-remote-info.yaml
+++ b/learning/katas/java/Core Transforms/Composite Transform/Composite Transform/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076159
-update_date: Fri, 12 Jun 2020 08:07:52 UTC
+update_date: Thu, 21 Apr 2022 14:23:18 UTC

--- a/learning/katas/java/Core Transforms/DoFn Additional Parameters/DoFn Additional Parameters/task-remote-info.yaml
+++ b/learning/katas/java/Core Transforms/DoFn Additional Parameters/DoFn Additional Parameters/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076160
-update_date: Fri, 12 Jun 2020 08:07:55 UTC
+update_date: Thu, 21 Apr 2022 14:23:19 UTC

--- a/learning/katas/java/Core Transforms/Flatten/Flatten/task-remote-info.yaml
+++ b/learning/katas/java/Core Transforms/Flatten/Flatten/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076187
-update_date: Fri, 12 Jun 2020 08:12:23 UTC
+update_date: Thu, 21 Apr 2022 14:23:12 UTC

--- a/learning/katas/java/Core Transforms/GroupByKey/GroupByKey/task-remote-info.yaml
+++ b/learning/katas/java/Core Transforms/GroupByKey/GroupByKey/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076186
-update_date: Fri, 12 Jun 2020 08:09:35 UTC
+update_date: Thu, 21 Apr 2022 14:23:03 UTC

--- a/learning/katas/java/Core Transforms/Map/FlatMapElements/task-remote-info.yaml
+++ b/learning/katas/java/Core Transforms/Map/FlatMapElements/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076150
-update_date: Fri, 12 Jun 2020 08:09:32 UTC
+update_date: Thu, 21 Apr 2022 14:23:01 UTC

--- a/learning/katas/java/Core Transforms/Map/MapElements/task-remote-info.yaml
+++ b/learning/katas/java/Core Transforms/Map/MapElements/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076149
-update_date: Fri, 12 Jun 2020 08:07:12 UTC
+update_date: Thu, 21 Apr 2022 14:23:00 UTC

--- a/learning/katas/java/Core Transforms/Map/ParDo OneToMany/task-remote-info.yaml
+++ b/learning/katas/java/Core Transforms/Map/ParDo OneToMany/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076148
-update_date: Fri, 12 Jun 2020 08:07:08 UTC
+update_date: Thu, 21 Apr 2022 14:22:59 UTC

--- a/learning/katas/java/Core Transforms/Map/ParDo/task-remote-info.yaml
+++ b/learning/katas/java/Core Transforms/Map/ParDo/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076185
-update_date: Fri, 12 Jun 2020 08:07:05 UTC
+update_date: Thu, 21 Apr 2022 14:22:58 UTC

--- a/learning/katas/java/Core Transforms/Partition/Partition/task-remote-info.yaml
+++ b/learning/katas/java/Core Transforms/Partition/Partition/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076156
-update_date: Fri, 12 Jun 2020 08:07:39 UTC
+update_date: Thu, 21 Apr 2022 14:23:14 UTC

--- a/learning/katas/java/Core Transforms/Side Input/Side Input/task-remote-info.yaml
+++ b/learning/katas/java/Core Transforms/Side Input/Side Input/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076157
-update_date: Fri, 12 Jun 2020 08:07:43 UTC
+update_date: Thu, 21 Apr 2022 14:23:15 UTC

--- a/learning/katas/java/Core Transforms/Side Output/Side Output/task-remote-info.yaml
+++ b/learning/katas/java/Core Transforms/Side Output/Side Output/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076158
-update_date: Fri, 12 Jun 2020 08:07:46 UTC
+update_date: Thu, 21 Apr 2022 14:23:16 UTC

--- a/learning/katas/java/Examples/Word Count/Word Count/task-remote-info.yaml
+++ b/learning/katas/java/Examples/Word Count/Word Count/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076176
-update_date: Fri, 12 Jun 2020 08:08:50 UTC
+update_date: Thu, 21 Apr 2022 14:23:40 UTC

--- a/learning/katas/java/IO/Built-in IOs/Built-in IOs/task-remote-info.yaml
+++ b/learning/katas/java/IO/Built-in IOs/Built-in IOs/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076208
-update_date: Fri, 12 Jun 2020 08:08:27 UTC
+update_date: Thu, 21 Apr 2022 14:23:32 UTC

--- a/learning/katas/java/IO/TextIO/TextIO Read/task-remote-info.yaml
+++ b/learning/katas/java/IO/TextIO/TextIO Read/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076189
-update_date: Fri, 12 Jun 2020 08:08:24 UTC
+update_date: Thu, 21 Apr 2022 14:23:29 UTC

--- a/learning/katas/java/Introduction/Hello Beam/Hello Beam/task-remote-info.yaml
+++ b/learning/katas/java/Introduction/Hello Beam/Hello Beam/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076147
-update_date: Fri, 12 Jun 2020 08:07:02 UTC
+update_date: Thu, 21 Apr 2022 14:22:56 UTC

--- a/learning/katas/java/Triggers/Early Triggers/Early Triggers/task-remote-info.yaml
+++ b/learning/katas/java/Triggers/Early Triggers/Early Triggers/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076174
-update_date: Fri, 12 Jun 2020 08:08:43 UTC
+update_date: Thu, 21 Apr 2022 14:23:38 UTC

--- a/learning/katas/java/Triggers/Event Time Triggers/Event Time Triggers/task-remote-info.yaml
+++ b/learning/katas/java/Triggers/Event Time Triggers/Event Time Triggers/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076173
-update_date: Fri, 12 Jun 2020 08:08:40 UTC
+update_date: Thu, 21 Apr 2022 14:23:37 UTC

--- a/learning/katas/java/Triggers/Window Accumulation Mode/Window Accumulation Mode/task-remote-info.yaml
+++ b/learning/katas/java/Triggers/Window Accumulation Mode/Window Accumulation Mode/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076175
-update_date: Fri, 12 Jun 2020 08:08:47 UTC
+update_date: Thu, 21 Apr 2022 14:23:39 UTC

--- a/learning/katas/java/Windowing/Adding Timestamp/ParDo/task-remote-info.yaml
+++ b/learning/katas/java/Windowing/Adding Timestamp/ParDo/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076170
-update_date: Fri, 12 Jun 2020 08:08:30 UTC
+update_date: Thu, 21 Apr 2022 14:23:33 UTC

--- a/learning/katas/java/Windowing/Adding Timestamp/WithTimestamps/task-remote-info.yaml
+++ b/learning/katas/java/Windowing/Adding Timestamp/WithTimestamps/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076190
-update_date: Fri, 12 Jun 2020 08:11:12 UTC
+update_date: Thu, 21 Apr 2022 14:23:34 UTC

--- a/learning/katas/java/Windowing/Fixed Time Window/Fixed Time Window/task-remote-info.yaml
+++ b/learning/katas/java/Windowing/Fixed Time Window/Fixed Time Window/task-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 1076172
-update_date: Fri, 12 Jun 2020 08:08:37 UTC
+update_date: Thu, 21 Apr 2022 14:23:35 UTC

--- a/learning/katas/java/build.gradle
+++ b/learning/katas/java/build.gradle
@@ -18,7 +18,7 @@
 
 buildscript {
   ext {
-    beamVersion = '2.36.0'
+    beamVersion = '2.38.0'
     guavaVersion = '31.0.1-jre'
     jodaTimeVersion = '2.10.10'
     slf4jVersion = '1.7.30'

--- a/learning/katas/java/course-remote-info.yaml
+++ b/learning/katas/java/course-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 54530
-update_date: Fri, 12 Jun 2020 07:48:33 UTC
+update_date: Thu, 21 Apr 2022 14:22:55 UTC


### PR DESCRIPTION
This is a trivial pull request that updates the Java katas to Beam 2.38. This is the version that is already published in Stepik.

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
