### PR TITLE
[BEAM-14273] Add integration tests for BQ JSON type for Python BigQueryIO connector

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -2201,8 +2201,7 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
                   'FILE_LOADS write method. This is supported with '
                   'STREAMING_INSERTS. For more information: '
                   'https://cloud.google.com/bigquery/docs/reference/'
-                  'standard-sql/json-data#ingest_json_data'
-              )
+                  'standard-sql/json-data#ingest_json_data')
             elif field['type'] == 'STRUCT':
               find_in_nested_dict(field)
 

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -2190,6 +2190,12 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
               'A schema must be provided when writing to BigQuery using '
               'Avro based file loads')
 
+      if self.schema and 'JSON' in str(self.schema):
+        raise ValueError(
+            'Found JSON type in table schema. JSON data '
+            'insertion is currently not supported with '
+            'FILE_LOADS write method.')
+
       from apache_beam.io.gcp import bigquery_file_loads
       # Only cast to int when a value is given.
       # We only use an int for BigQueryBatchFileLoads

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -2190,11 +2190,19 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
               'A schema must be provided when writing to BigQuery using '
               'Avro based file loads')
 
-      if self.schema and 'JSON' in str(self.schema):
-        raise ValueError(
-            'Found JSON type in table schema. JSON data '
-            'insertion is currently not supported with '
-            'FILE_LOADS write method.')
+      if self.schema and type(self.schema) is dict:
+
+        def find_in_nested_dict(schema):
+          for field in schema['fields']:
+            if field['type'] == 'JSON':
+              raise ValueError(
+                  'Found JSON type in table schema. JSON data '
+                  'insertion is currently not supported with '
+                  'FILE_LOADS write method.')
+            elif field['type'] == 'STRUCT':
+              find_in_nested_dict(field)
+
+        find_in_nested_dict(self.schema)
 
       from apache_beam.io.gcp import bigquery_file_loads
       # Only cast to int when a value is given.

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -2198,7 +2198,11 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
               raise ValueError(
                   'Found JSON type in table schema. JSON data '
                   'insertion is currently not supported with '
-                  'FILE_LOADS write method.')
+                  'FILE_LOADS write method. This is supported with '
+                  'STREAMING_INSERTS. For more information: '
+                  'https://cloud.google.com/bigquery/docs/reference/'
+                  'standard-sql/json-data#ingest_json_data'
+              )
             elif field['type'] == 'STRUCT':
               find_in_nested_dict(field)
 

--- a/sdks/python/apache_beam/io/gcp/bigquery_json_it_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_json_it_test.py
@@ -107,19 +107,33 @@ class BigQueryJsonIT(unittest.TestCase):
           method=method,
         ) | 'Validate rows' >> beam.ParDo(CompareJson())
 
-  def test_direct_read(self):
-    extra_opts = {
-      'read_method': "DIRECT_READ",
-      'input': JSON_TABLE_DESTINATION,
-    }
-    options = self.test_pipeline.get_full_options_as_args(**extra_opts)
+  # def test_direct_read(self):
+  #   extra_opts = {
+  #     'read_method': "DIRECT_READ",
+  #     'input': JSON_TABLE_DESTINATION,
+  #   }
+  #   options = self.test_pipeline.get_full_options_as_args(**extra_opts)
+  #
+  #   self.read_and_validate_rows(options)
+  #
+  # def test_export_read(self):
+  #   extra_opts = {
+  #     'read_method': "EXPORT",
+  #     'input': JSON_TABLE_DESTINATION,
+  #   }
+  #   options = self.test_pipeline.get_full_options_as_args(**extra_opts)
+  #
+  #   self.read_and_validate_rows(options)
 
-    self.read_and_validate_rows(options)
-
-  def test_export_read(self):
+  def test_query_read(self):
     extra_opts = {
-      'read_method': "EXPORT",
-      'input': JSON_TABLE_DESTINATION,
+      'query': "SELECT "
+               "country_code, "
+               "country.past_leaders[2] AS past_leader, "
+               "stats.gdp_per_capita[\"gdp_per_capita\"] AS gdp, "
+               "cities[OFFSET(1)].city.name AS city_name, "
+               "landmarks[OFFSET(1)][\"name\"] AS landmark_name "
+               f"FROM `{PROJECT}.{DATASET_ID}.{JSON_TABLE_NAME}`",
     }
     options = self.test_pipeline.get_full_options_as_args(**extra_opts)
 

--- a/sdks/python/apache_beam/io/gcp/bigquery_json_it_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_json_it_test.py
@@ -20,6 +20,7 @@ Integration tests for BigQuery's JSON data type
 
 import logging
 import unittest
+import json
 
 from apache_beam.testing.test_pipeline import TestPipeline
 
@@ -31,6 +32,226 @@ class BigQueryJsonIT(unittest.TestCase):
   def setUpClass(cls):
     cls.test_pipeline = TestPipeline(is_integration_test=True)
     cls.args = cls.test_pipeline.get_full_options_as_args()
+
+  # Expected data for query test
+  def generate_query_data(self):
+    JSON_QUERY_DATA = [
+      {'country_code': 'usa',
+       'past_leader': '\"George W. Bush\"',
+       'gdp': '58559.675',
+       'city_name': '\"Los Angeles\"',
+       'landmark_name': '\"Golden Gate Bridge\"'},
+      {'country_code': 'aus',
+       'past_leader': '\"Kevin Rudd\"',
+       'gdp': '58043.581',
+       'city_name': '\"Melbourne\"',
+       'landmark_name': '\"Great Barrier Reef\"'},
+      {'country_code': 'special',
+       'past_leader': '\"!@#$%^&*()_+\"',
+       'gdp': '421.7',
+       'city_name': '\"Bikini Bottom\"',
+       'landmark_name': "\"Willy Wonka's Factory\""}
+    ]
+    return JSON_QUERY_DATA
+
+  def generate_data(self):
+    # Raw country data
+    usa = {
+      "name": "United States of America",
+      "population": 329484123,
+      "cities": {
+        "nyc": {
+          "name": "New York City",
+          "state": "NY",
+          "population": 8622357
+        },
+        "la": {
+          "name": "Los Angeles",
+          "state": "CA",
+          "population": 4085014
+        },
+        "chicago": {
+          "name": "Chicago",
+          "state": "IL",
+          "population": 2670406
+        },
+      },
+      "past_leaders": [
+        "Donald Trump",
+        "Barack Obama",
+        "George W. Bush",
+        "Bill Clinton"
+      ],
+      "in_northern_hemisphere": True
+    }
+
+    aus = {
+      "name": "Australia",
+      "population": 25687041,
+      "cities": {
+        "sydney": {
+          "name": "Sydney",
+          "state": "New South Wales",
+          "population": 5367206
+        },
+        "melbourne": {
+          "name": "Melbourne",
+          "state": "Victoria",
+          "population": 5159211
+        },
+        "brisbane": {
+          "name": "Brisbane",
+          "state": "Queensland",
+          "population": 2560720
+        }
+      },
+      "past_leaders": [
+        "Malcolm Turnbull",
+        "Tony Abbot",
+        "Kevin Rudd",
+      ],
+      "in_northern_hemisphere": False
+    }
+
+    special = {
+      "name": "newline\n, form\f, tab\t, \"quotes\", \\backslash\\, backspace\b, \u0000_hex_\u0f0f",
+      "population": -123456789,
+      "cities": {
+        "basingse": {
+          "name": "Ba Sing Se",
+          "state": "The Earth Kingdom",
+          "population": 200000
+        },
+        "bikinibottom": {
+          "name": "Bikini Bottom",
+          "state": "The Pacific Ocean",
+          "population": 50000
+        }
+      },
+      "past_leaders": [
+        "1",
+        "2",
+        "!@#$%^&*()_+",
+      ],
+      "in_northern_hemisphere": True
+    }
+
+    landmarks = {
+      "usa_0": {
+        "name": "Statue of Liberty",
+        "cool rating": None
+      },
+      "usa_1": {
+        "name": "Golden Gate Bridge",
+        "cool rating": "very cool"
+      },
+      "usa_2": {
+        "name": "Grand Canyon",
+        "cool rating": "very very cool"
+      },
+      "aus_0": {
+        "name": "Sydney Opera House",
+        "cool rating": "amazing"
+      },
+      "aus_1": {
+        "name": "Great Barrier Reef",
+        "cool rating": None
+      },
+      "special_0": {
+        "name": "Hogwarts School of WitchCraft and Wizardry",
+        "cool rating": "magical"
+      },
+      "special_1": {
+        "name": "Willy Wonka's Factory",
+        "cool rating": None
+      },
+      "special_2": {
+        "name": "Rivendell",
+        "cool rating": "precious"
+      },
+    }
+    stats = {
+      "usa_gdp_per_capita": {
+        "gdp_per_capita": 58559.675,
+        "currency": "constant 2015 US$"
+      },
+      "usa_co2_emissions": {
+        "co2 emissions": 15.241,
+        "measurement": "metric tons per capita",
+        "year": 2018
+      },
+      "aus_gdp_per_capita": {
+        "gdp_per_capita": 58043.581,
+        "currency": "constant 2015 US$"
+      },
+      "aus_co2_emissions": {
+        "co2 emissions": 15.476,
+        "measurement": "metric tons per capita",
+        "year": 2018
+      },
+      "special_gdp_per_capita": {
+        "gdp_per_capita": 421.70,
+        "currency": "constant 200 BC gold"
+      },
+      "special_co2_emissions": {
+        "co2 emissions": -10.79,
+        "measurement": "metric tons per capita",
+        "year": 2018
+      }
+    }
+
+    JSON_DATA = {
+      "usa": {
+        "country": json.dumps(usa),
+        "cities": {
+          "nyc": json.dumps(usa["cities"]["nyc"]),
+          "la": json.dumps(usa["cities"]["la"]),
+          "chicago": json.dumps(usa["cities"]["chicago"])
+        },
+        "landmarks": [
+          json.dumps(landmarks["usa_0"]),
+          json.dumps(landmarks["usa_1"]),
+          json.dumps(landmarks["usa_2"])
+        ],
+        "stats": {
+          "gdp_per_capita": json.dumps(stats["usa_gdp_per_capita"]),
+          "co2_emissions": json.dumps(stats["usa_co2_emissions"])
+        }
+      },
+      "aus": {
+        "country": json.dumps(aus),
+        "cities": {
+          "sydney": json.dumps(aus["cities"]["sydney"]),
+          "melbourne": json.dumps(aus["cities"]["melbourne"]),
+          "brisbane": json.dumps(aus["cities"]["brisbane"])
+        },
+        "landmarks": [
+          json.dumps(landmarks["aus_0"]),
+          json.dumps(landmarks["aus_1"])
+        ],
+        "stats": {
+          "gdp_per_capita": json.dumps(stats["aus_gdp_per_capita"]),
+          "co2_emissions": json.dumps(stats["aus_co2_emissions"])
+        }
+      },
+      "special": {
+        "country": json.dumps(special),
+        "cities": {
+          "basingse": json.dumps(special["cities"]["basingse"]),
+          "bikinibottom": json.dumps(special["cities"]["bikinibottom"])
+        },
+        "landmarks": [
+          json.dumps(landmarks["special_0"]),
+          json.dumps(landmarks["special_1"]),
+          json.dumps(landmarks["special_2"])
+        ],
+        "stats": {
+          "gdp_per_capita": json.dumps(stats["special_gdp_per_capita"]),
+          "co2_emissions": json.dumps(stats["special_co2_emissions"])
+        }
+      }
+    }
+    return JSON_DATA
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)

--- a/sdks/python/apache_beam/io/gcp/bigquery_json_it_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_json_it_test.py
@@ -1,0 +1,37 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+"""
+Integration tests for BigQuery's JSON data type
+"""
+
+import logging
+import unittest
+
+from apache_beam.testing.test_pipeline import TestPipeline
+
+_LOGGER = logging.getLogger(__name__)
+
+
+class BigQueryJsonIT(unittest.TestCase):
+  @classmethod
+  def setUpClass(cls):
+    cls.test_pipeline = TestPipeline(is_integration_test=True)
+    cls.args = cls.test_pipeline.get_full_options_as_args()
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/sdks/python/apache_beam/io/gcp/bigquery_json_it_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_json_it_test.py
@@ -194,6 +194,16 @@ class BigQueryJsonIT(unittest.TestCase):
 
     self.run_test_write(options)
 
+  @pytest.mark.it_postcomit
+  def test_file_loads_write(self):
+    extra_opts = {
+        'output': f"{PROJECT}:{DATASET_ID}.{STREAMING_TEST_TABLE}",
+        'write_method': "FILE_LOADS"
+    }
+    options = self.test_pipeline.get_full_options_as_args(**extra_opts)
+    with self.assertRaises(ValueError):
+      self.run_test_write(options)
+
   # Schema for writing to BigQuery
   def generate_schema(self):
     from apache_beam.io.gcp.internal.clients.bigquery import TableFieldSchema


### PR DESCRIPTION
BigQuery now natively supports JSON data type [1]. This PR adds integration tests for using the JSON data type with Python BigQueryIO read and write methods.

Batch loads currently only support CSV loads, so FILE_LOADS write method is not included.

[1] https://cloud.google.com/bigquery/docs/reference/standard-sql/json-data#query_json_data