### PR TITLE
[BEAM-12164]: use the end timestamp for progress estimation in batch jobs

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/action/QueryChangeStreamAction.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/action/QueryChangeStreamAction.java
@@ -223,8 +223,7 @@ public class QueryChangeStreamAction {
             // string representation of the record. Here, we only try to achieve an estimate
             // instead of an accurate throughput.
             this.throughputEstimator.update(
-                record.getRecordTimestamp(),
-                record.toString().getBytes(StandardCharsets.UTF_8).length);
+                Timestamp.now(), record.toString().getBytes(StandardCharsets.UTF_8).length);
 
             if (maybeContinuation.isPresent()) {
               LOG.debug("[" + token + "] Continuation present, returning " + maybeContinuation);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/restriction/TimestampRangeTracker.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/restriction/TimestampRangeTracker.java
@@ -18,7 +18,6 @@
 package org.apache.beam.sdk.io.gcp.spanner.changestreams.restriction;
 
 import static java.math.MathContext.DECIMAL128;
-import static org.apache.beam.sdk.io.gcp.spanner.changestreams.ChangeStreamsConstants.MAX_INCLUSIVE_END_AT;
 import static org.apache.beam.sdk.io.gcp.spanner.changestreams.restriction.TimestampUtils.next;
 import static org.apache.beam.sdk.io.gcp.spanner.changestreams.restriction.TimestampUtils.toNanos;
 import static org.apache.beam.sdk.io.gcp.spanner.changestreams.restriction.TimestampUtils.toTimestamp;
@@ -206,8 +205,10 @@ public class TimestampRangeTracker extends RestrictionTracker<TimestampRange, Ti
   @Override
   public Progress getProgress() {
     BigDecimal end;
-    if (range.getTo().compareTo(MAX_INCLUSIVE_END_AT) == 0) {
-      // Use now() as the end timestamp.
+    if (range.getTo().compareTo(Timestamp.MAX_VALUE) == 0) {
+      // When the given end timestamp equals to Timestamp.MAX_VALUE, this means that
+      // the end timestamp is not specified which should be a streaming job. So we
+      // use now() as the end timestamp.
       end = BigDecimal.valueOf(timeSupplier.get().getSeconds());
     } else {
       end = BigDecimal.valueOf(range.getTo().getSeconds());

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/restriction/TimestampRangeTrackerTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/restriction/TimestampRangeTrackerTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.io.gcp.spanner.changestreams.restriction;
 
+import static org.apache.beam.sdk.io.gcp.spanner.changestreams.ChangeStreamsConstants.MAX_INCLUSIVE_END_AT;
 import static org.apache.beam.sdk.io.gcp.spanner.changestreams.restriction.TimestampUtils.next;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -232,13 +233,12 @@ public class TimestampRangeTrackerTest {
 
     final TimestampRange range = TimestampRange.of(from, to);
     final TimestampRangeTracker tracker = new TimestampRangeTracker(range);
-    tracker.setTimeSupplier(() -> Timestamp.ofTimeSecondsAndNanos(position.getSeconds() + 10, 0));
 
     tracker.tryClaim(position);
     final Progress progress = tracker.getProgress();
 
     assertEquals(position.getSeconds(), progress.getWorkCompleted(), DELTA);
-    assertEquals(10D, progress.getWorkRemaining(), DELTA);
+    assertEquals(to.getSeconds() - position.getSeconds(), progress.getWorkRemaining(), DELTA);
   }
 
   @Test
@@ -247,8 +247,6 @@ public class TimestampRangeTrackerTest {
     final Timestamp to = Timestamp.now();
     final TimestampRange range = TimestampRange.of(from, to);
     final TimestampRangeTracker tracker = new TimestampRangeTracker(range);
-
-    tracker.setTimeSupplier(() -> Timestamp.ofTimeSecondsAndNanos(to.getSeconds(), 0));
 
     final Progress progress = tracker.getProgress();
     assertEquals(0D, progress.getWorkCompleted(), DELTA);
@@ -263,8 +261,6 @@ public class TimestampRangeTrackerTest {
     final TimestampRange range = TimestampRange.of(from, to);
     final TimestampRangeTracker tracker = new TimestampRangeTracker(range);
 
-    tracker.setTimeSupplier(() -> Timestamp.ofTimeSecondsAndNanos(to.getSeconds(), 0));
-
     tracker.tryClaim(position);
     final Progress progress = tracker.getProgress();
 
@@ -275,13 +271,12 @@ public class TimestampRangeTrackerTest {
   }
 
   @Test
-  public void testGetProgressReturnsWorkCompletedAsOneWhenRangeEndHasBeenAttempted() {
+  public void testGetProgressReturnsWorkCompletedWhenRangeEndHasBeenAttempted() {
     final Timestamp from = Timestamp.ofTimeSecondsAndNanos(0, 0);
     final Timestamp to = Timestamp.ofTimeSecondsAndNanos(101, 0);
     final TimestampRange range = TimestampRange.of(from, to);
     final TimestampRangeTracker tracker = new TimestampRangeTracker(range);
 
-    tracker.setTimeSupplier(() -> Timestamp.ofTimeSecondsAndNanos(to.getSeconds(), 0));
     tracker.tryClaim(Timestamp.ofTimeSecondsAndNanos(100, 0));
     tracker.tryClaim(Timestamp.ofTimeSecondsAndNanos(101, 0));
     final Progress progress = tracker.getProgress();
@@ -293,14 +288,13 @@ public class TimestampRangeTrackerTest {
   }
 
   @Test
-  public void testGetProgressReturnsWorkCompletedAsOneWhenPastRangeEndHasBeenAttempted() {
+  public void testGetProgressReturnsWorkCompletedWhenPastRangeEndHasBeenAttempted() {
     final Timestamp from = Timestamp.ofTimeSecondsAndNanos(0, 0);
     final Timestamp to = Timestamp.ofTimeSecondsAndNanos(101, 0);
     final Timestamp position = Timestamp.ofTimeSecondsAndNanos(101, 0);
     final TimestampRange range = TimestampRange.of(from, to);
     final TimestampRangeTracker tracker = new TimestampRangeTracker(range);
 
-    tracker.setTimeSupplier(() -> Timestamp.ofTimeSecondsAndNanos(position.getSeconds(), 0));
     tracker.tryClaim(position);
     final Progress progress = tracker.getProgress();
 
@@ -308,5 +302,22 @@ public class TimestampRangeTrackerTest {
     assertEquals(0D, progress.getWorkCompleted(), DELTA);
     assertTrue(progress.getWorkRemaining() >= 0);
     assertEquals(101D, progress.getWorkRemaining(), DELTA);
+  }
+
+  @Test
+  public void testGetProgressForStreaming() {
+    final Timestamp from = Timestamp.ofTimeSecondsAndNanos(0, 0);
+    final Timestamp position = Timestamp.ofTimeSecondsAndNanos(101, 0);
+    final TimestampRange range = TimestampRange.of(from, MAX_INCLUSIVE_END_AT);
+    final TimestampRangeTracker tracker = new TimestampRangeTracker(range);
+
+    tracker.setTimeSupplier(() -> Timestamp.ofTimeSecondsAndNanos(position.getSeconds() + 10, 0));
+    tracker.tryClaim(position);
+    final Progress progress = tracker.getProgress();
+
+    assertTrue(progress.getWorkCompleted() >= 0);
+    assertEquals(101D, progress.getWorkCompleted(), DELTA);
+    assertTrue(progress.getWorkRemaining() >= 0);
+    assertEquals(10D, progress.getWorkRemaining(), DELTA);
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/restriction/TimestampRangeTrackerTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/restriction/TimestampRangeTrackerTest.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.sdk.io.gcp.spanner.changestreams.restriction;
 
-import static org.apache.beam.sdk.io.gcp.spanner.changestreams.ChangeStreamsConstants.MAX_INCLUSIVE_END_AT;
 import static org.apache.beam.sdk.io.gcp.spanner.changestreams.restriction.TimestampUtils.next;
 import static org.hamcrest.Matchers.greaterThan;
 import static org.hamcrest.Matchers.greaterThanOrEqualTo;
@@ -308,7 +307,7 @@ public class TimestampRangeTrackerTest {
   public void testGetProgressForStreaming() {
     final Timestamp from = Timestamp.ofTimeSecondsAndNanos(0, 0);
     final Timestamp position = Timestamp.ofTimeSecondsAndNanos(101, 0);
-    final TimestampRange range = TimestampRange.of(from, MAX_INCLUSIVE_END_AT);
+    final TimestampRange range = TimestampRange.of(from, Timestamp.MAX_VALUE);
     final TimestampRangeTracker tracker = new TimestampRangeTracker(range);
 
     tracker.setTimeSupplier(() -> Timestamp.ofTimeSecondsAndNanos(position.getSeconds() + 10, 0));


### PR DESCRIPTION
The logic of the progress calculation is: 

* If the end timestamp is specified, then use it to estimate the remaining work via `endTimestamp - lastClaimedPosition`. 
* Otherwise, use `now() - lastClaimedPosition` as the remaining work. 

This PR also includes a change to use Timestamp.now() for the throughput updates instead of using the event timestamp. 