### PR TITLE
[BEAM-14357] Fix BigqueryFullResultStreamingMatcher unit test

### DIFF
--- a/sdks/python/apache_beam/io/gcp/tests/bigquery_matcher_test.py
+++ b/sdks/python/apache_beam/io/gcp/tests/bigquery_matcher_test.py
@@ -158,16 +158,16 @@ class BigqueryTableMatcherTest(unittest.TestCase):
     self.assertEqual(bq_verifier.MAX_RETRIES + 1, mock_query.call_count)
 
 
-@pytest.mark.no_xdist  # xdist somehow makes the test do real requests.
 @unittest.skipIf(bigquery is None, 'Bigquery dependencies are not installed.')
-@mock.patch.object(
-    bq_verifier.BigqueryFullResultStreamingMatcher, '_query_with_retry')
-class BigqueryFullResultStreamingMatcher(unittest.TestCase):
+@mock.patch.object(bigquery, 'Client')
+class BigqueryFullResultStreamingMatcherTest(unittest.TestCase):
   def setUp(self):
     self.timeout = 0.01
 
-  def test__get_query_result_timeout(self, mock__query_with_retry):
-    mock__query_with_retry.side_effect = lambda: []
+  def test__get_query_result_timeout(self, mock_bigquery):
+    mock_query = mock_bigquery.return_value.query
+    mock_query.return_value.result.return_value = []
+
     matcher = bq_verifier.BigqueryFullResultStreamingMatcher(
         'some-project', 'some-query', [1, 2, 3], timeout=self.timeout)
     with self.assertRaises(TimeoutError):  # noqa: F821

--- a/sdks/python/apache_beam/io/gcp/tests/bigquery_matcher_test.py
+++ b/sdks/python/apache_beam/io/gcp/tests/bigquery_matcher_test.py
@@ -23,7 +23,6 @@ import logging
 import unittest
 
 import mock
-import pytest
 from hamcrest import assert_that as hc_assert_that
 
 from apache_beam.io.gcp import bigquery_tools


### PR DESCRIPTION
* patch bigquery.Client in test class

**Please** add a meaningful description for your change here

The original patch for '_query_with_retry' actually did not work. BigqueryMatcher._query_with_retry still get called. The test passed because timeout checking passed before the first call of this method. In local machine that runs fast enough, it may still make actual bigquery request and fail.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
