### PR TITLE
Minor: fix typo

### DIFF
--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -713,7 +713,7 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
       # for declaring input type
       raise TypeError(
           f"{self.__class__.__name__}.process_batch() does not have a type "
-          "annotation on it's first parameter. This is reqired for "
+          "annotation on its first parameter. This is required for "
           "process_batch implementations.")
     return typehints.native_type_compatibility.convert_to_beam_type(input_type)
 


### PR DESCRIPTION
GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
