### PR TITLE
[BEAM-14187] Fix NPE

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/IsmReaderImpl.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/IsmReaderImpl.java
@@ -551,7 +551,8 @@ public class IsmReaderImpl<V> extends IsmReader<V> {
               resourceId);
 
           try {
-            SeekableByteChannel rawChannel = openIfNeeded(Optional.of(rawChannelReference.get()));
+            SeekableByteChannel rawChannel =
+                openIfNeeded(Optional.fromNullable(rawChannelReference.get()));
             rawChannelReference.set(rawChannel);
             return readIndexBlockForShard(resourceId, shardWithIndex, startOfNextBlock, rawChannel);
           } catch (IOException e) {


### PR DESCRIPTION
Fix NPE when `rawChannelReference` has a `null` reference.