### PR TITLE
README update for the Docker Error 255 during Website launch on Apple Silicon

### DIFF
--- a/website/README.md
+++ b/website/README.md
@@ -75,6 +75,8 @@ If you're developing the site, you should know a little bit about Hugo and Docsy
 
 ## Troubleshooting
 
+Apple Silicon:
+
 ### Hugo server does not reload static files
 
 The Hugo dev server waits for changes in site content, static files, configuration, and other resources. On change, the server rebuilds and reloads the site in your browser. If you're making changes to static files, and those changes are detected by the server but don't appear in the browser, you may have a caching issue.

--- a/website/README.md
+++ b/website/README.md
@@ -75,6 +75,8 @@ If you're developing the site, you should know a little bit about Hugo and Docsy
 
 ## Troubleshooting
 
+### Docker Error 255 on Apple Silicon
+
 To fix the Docker Error 255 during the Website launch on Apple Silicon:
 - Open website/Dockerfile
 - Replace "FROM debian:stretch-slim" with "FROM --platform=linux/amd64 debian:stretch-slim"

--- a/website/README.md
+++ b/website/README.md
@@ -75,7 +75,9 @@ If you're developing the site, you should know a little bit about Hugo and Docsy
 
 ## Troubleshooting
 
-Apple Silicon:
+To fix the Docker Error 255 during the Website launch on Apple Silicon:
+- Open website/Dockerfile
+- Replace "FROM debian:stretch-slim" with "FROM --platform=linux/amd64 debian:stretch-slim"
 
 ### Hugo server does not reload static files
 


### PR DESCRIPTION
I've updated the README.md file to describe a workaround for the Docker Error 255 during Website launch on Apple Silicon.