### PR TITLE
Minor: Fix release script for `current` symlinks

### DIFF
--- a/release/src/main/scripts/build_release_candidate.sh
+++ b/release/src/main/scripts/build_release_candidate.sh
@@ -386,13 +386,13 @@ if [[ $confirmation = "y" ]]; then
   cp -r ${GENERATE_JAVADOC} javadoc/${RELEASE}
   # Update current symlink to point to the latest release
   unlink javadoc/current
-  ln -s javadoc/${RELEASE} javadoc/current
+  ln -s ${RELEASE} javadoc/current
 
   echo "............Copying generated pydoc into beam-site.........."
   cp -r ${GENERATED_PYDOC} pydoc/${RELEASE}
   # Update current symlink to point to the latest release
   unlink pydoc/current
-  ln -s pydoc/${RELEASE} pydoc/current
+  ln -s ${RELEASE} pydoc/current
 
   git add -A
   git commit -m "Update beam-site for release ${RELEASE}." -m "Content generated from commit ${RELEASE_COMMIT}."


### PR DESCRIPTION
synlinks should be defined with a target path relative to the link, not the current working directory.

Context: https://lists.apache.org/thread/158mg25sfdgltzsjx7sr5ks4q6zhkyhq
See also: https://github.com/apache/beam-site/pull/626

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
