### PR TITLE
[BEAM-14363] Fixes WatermarkParameters builder for Kinesis

### DIFF
--- a/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/kinesis/WatermarkParameters.java
+++ b/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/kinesis/WatermarkParameters.java
@@ -84,7 +84,7 @@ public abstract class WatermarkParameters implements Serializable {
   public WatermarkParameters withTimestampFn(
       SerializableFunction<KinesisRecord, Instant> timestampFn) {
     checkArgument(timestampFn != null, "timestampFn function is null");
-    return builder().setTimestampFn(timestampFn).build();
+    return toBuilder().setTimestampFn(timestampFn).build();
   }
 
   /**
@@ -93,6 +93,6 @@ public abstract class WatermarkParameters implements Serializable {
    */
   public WatermarkParameters withWatermarkIdleDurationThreshold(Duration idleDurationThreshold) {
     checkArgument(idleDurationThreshold != null, "watermark idle duration threshold is null");
-    return builder().setWatermarkIdleDurationThreshold(idleDurationThreshold).build();
+    return toBuilder().setWatermarkIdleDurationThreshold(idleDurationThreshold).build();
   }
 }

--- a/sdks/java/io/amazon-web-services2/src/test/java/org/apache/beam/sdk/io/aws2/kinesis/WatermarkPolicyTest.java
+++ b/sdks/java/io/amazon-web-services2/src/test/java/org/apache/beam/sdk/io/aws2/kinesis/WatermarkPolicyTest.java
@@ -147,4 +147,18 @@ public class WatermarkPolicyTest {
     policy.update(b);
     assertThat(policy.getWatermark()).isEqualTo(time2.plus(Duration.standardMinutes(1)));
   }
+
+  @Test
+  public void shouldUpdateWatermarkParameters() {
+    SerializableFunction<KinesisRecord, Instant> fn = input -> Instant.now();
+    Duration idleDurationThreshold = Duration.standardSeconds(30);
+
+    WatermarkParameters parameters =
+        WatermarkParameters.create()
+            .withTimestampFn(fn)
+            .withWatermarkIdleDurationThreshold(idleDurationThreshold);
+
+    assertThat(parameters.getTimestampFn()).isEqualTo(fn);
+    assertThat(parameters.getWatermarkIdleDurationThreshold()).isEqualTo(idleDurationThreshold);
+  }
 }

--- a/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/WatermarkParameters.java
+++ b/sdks/java/io/kinesis/src/main/java/org/apache/beam/sdk/io/kinesis/WatermarkParameters.java
@@ -84,7 +84,7 @@ public abstract class WatermarkParameters implements Serializable {
   public WatermarkParameters withTimestampFn(
       SerializableFunction<KinesisRecord, Instant> timestampFn) {
     checkArgument(timestampFn != null, "timestampFn function is null");
-    return builder().setTimestampFn(timestampFn).build();
+    return toBuilder().setTimestampFn(timestampFn).build();
   }
 
   /**
@@ -93,6 +93,6 @@ public abstract class WatermarkParameters implements Serializable {
    */
   public WatermarkParameters withWatermarkIdleDurationThreshold(Duration idleDurationThreshold) {
     checkArgument(idleDurationThreshold != null, "watermark idle duration threshold is null");
-    return builder().setWatermarkIdleDurationThreshold(idleDurationThreshold).build();
+    return toBuilder().setWatermarkIdleDurationThreshold(idleDurationThreshold).build();
   }
 }

--- a/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/WatermarkPolicyTest.java
+++ b/sdks/java/io/kinesis/src/test/java/org/apache/beam/sdk/io/kinesis/WatermarkPolicyTest.java
@@ -149,4 +149,18 @@ public class WatermarkPolicyTest {
     policy.update(b);
     assertThat(policy.getWatermark()).isEqualTo(time2.plus(Duration.standardMinutes(1)));
   }
+
+  @Test
+  public void shouldUpdateWatermarkParameters() {
+    SerializableFunction<KinesisRecord, Instant> fn = input -> Instant.now();
+    Duration idleDurationThreshold = Duration.standardSeconds(30);
+
+    WatermarkParameters parameters =
+        WatermarkParameters.create()
+            .withTimestampFn(fn)
+            .withWatermarkIdleDurationThreshold(idleDurationThreshold);
+
+    assertThat(parameters.getTimestampFn()).isEqualTo(fn);
+    assertThat(parameters.getWatermarkIdleDurationThreshold()).isEqualTo(idleDurationThreshold);
+  }
 }


### PR DESCRIPTION
This fixes the `WatermarkParameters` to use `toBuilder()` instead of `builder()`.

------------------------

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
