### PR TITLE
[BEAM-14365]: fix the negative throughput issue

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/restriction/ThroughputEstimator.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/restriction/ThroughputEstimator.java
@@ -91,6 +91,7 @@ public class ThroughputEstimator implements Serializable {
     }
     return bytesInQueue
         .divide(BigDecimal.valueOf(queue.size()), MathContext.DECIMAL128)
+        .max(BigDecimal.ZERO)
         .doubleValue();
   }
 
@@ -103,7 +104,7 @@ public class ThroughputEstimator implements Serializable {
       // Remove the element if the timestamp of the first element is beyond
       // the time range to look backward.
       ImmutablePair<Timestamp, BigDecimal> pair = queue.remove();
-      bytesInQueue = bytesInQueue.subtract(pair.getRight());
+      bytesInQueue = bytesInQueue.subtract(pair.getRight()).max(BigDecimal.ZERO);
     }
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/restriction/ThroughputEstimatorTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/restriction/ThroughputEstimatorTest.java
@@ -110,6 +110,14 @@ public class ThroughputEstimatorTest {
     assertEquals(want.doubleValue(), actual, DELTA);
   }
 
+  @Test
+  public void testThroughputShouldNotBeNegative() {
+    estimator.update(Timestamp.ofTimeSecondsAndNanos(0, 0), -10);
+    estimator.update(Timestamp.ofTimeSecondsAndNanos(1, 0), 10);
+    double actual = estimator.getFrom(Timestamp.ofTimeSecondsAndNanos(0, 0));
+    assertEquals(0D, actual, DELTA);
+  }
+
   private List<ImmutablePair<Timestamp, Long>> generateTestData(
       int size, int startSeconds, int endSeconds, long maxBytes) {
     Random random = new Random();


### PR DESCRIPTION
Somehow, the getSize() can be a negative number which must come from the local throughput estimator as the fields in Progress cannot be negative. Therefore, we set the lower bound of the throughput to 0. 