### PR TITLE
[BEAM-14374] Fix module import error in FullyQualifiedNamedTransform

### DIFF
--- a/sdks/python/apache_beam/transforms/fully_qualified_named_transform.py
+++ b/sdks/python/apache_beam/transforms/fully_qualified_named_transform.py
@@ -65,11 +65,11 @@ class FullyQualifiedNamedTransform(ptransform.PTransform):
     o = None
     path = ''
     for segment in fully_qualified_name.split('.'):
+      path = '.'.join([path, segment]) if path else segment
       if o is not None and hasattr(o, segment):
         o = getattr(o, segment)
       else:
-        o = importlib.import_module(segment, path)
-      path = '.'.join([path, segment])
+        o = importlib.import_module(path)
     return o
 
   def to_runner_api_parameter(self, unused_context):

--- a/sdks/python/apache_beam/transforms/fully_qualified_named_transform_test.py
+++ b/sdks/python/apache_beam/transforms/fully_qualified_named_transform_test.py
@@ -18,6 +18,9 @@
 
 import unittest
 
+from mock import call
+from mock import patch
+
 import apache_beam as beam
 from apache_beam.runners.portability import expansion_service
 from apache_beam.testing.util import assert_that
@@ -115,6 +118,14 @@ class FullyQualifiedNamedTransformTest(unittest.TestCase):
     with FullyQualifiedNamedTransform.with_filter('apache_beam.foo.*'):
       with self.assertRaises(ValueError):
         FullyQualifiedNamedTransform._resolve('apache_beam.Row')
+
+  @patch('importlib.import_module')
+  def test_resolve(self, mock_import_module):
+    mock_import_module.return_value = None
+    with FullyQualifiedNamedTransform.with_filter('*'):
+      FullyQualifiedNamedTransform._resolve('a.b.c.d')
+    mock_import_module.assert_has_calls(
+        [call('a'), call('a.b'), call('a.b.c'), call('a.b.c.d')])
 
 
 class _TestTransform(beam.PTransform):


### PR DESCRIPTION
The second argument of `import_module` is ignored when the first argument is not a relative name. For example, the current implementation works for `io` module since `import_module('io')` also works however it doesn't work for `apache_beam.dataframe` since `import_module('dataframe')` also doesn't work.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
