### PR TITLE
[BEAM-14143] Renames ExternalPythonTransform to PythonExternalTransform

### DIFF
--- a/sdks/java/extensions/python/src/main/java/org/apache/beam/sdk/extensions/python/PythonExternalTransform.java
+++ b/sdks/java/extensions/python/src/main/java/org/apache/beam/sdk/extensions/python/PythonExternalTransform.java
@@ -54,7 +54,7 @@ import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** Wrapper for invoking external Python transforms. */
-public class ExternalPythonTransform<InputT extends PInput, OutputT extends POutput>
+public class PythonExternalTransform<InputT extends PInput, OutputT extends POutput>
     extends PTransform<InputT, OutputT> {
 
   private static final SchemaRegistry SCHEMA_REGISTRY = SchemaRegistry.createDefault();
@@ -68,7 +68,7 @@ public class ExternalPythonTransform<InputT extends PInput, OutputT extends POut
   private @Nullable Object @NonNull [] argsArray;
   private @Nullable Row providedKwargsRow;
 
-  private ExternalPythonTransform(String fullyQualifiedName, String expansionService) {
+  private PythonExternalTransform(String fullyQualifiedName, String expansionService) {
     this.fullyQualifiedName = fullyQualifiedName;
     this.expansionService = expansionService;
     this.kwargsMap = new TreeMap<>();
@@ -81,11 +81,11 @@ public class ExternalPythonTransform<InputT extends PInput, OutputT extends POut
    * @param tranformName fully qualified transform name.
    * @param <InputT> Input {@link PCollection} type
    * @param <OutputT> Output {@link PCollection} type
-   * @return A {@link ExternalPythonTransform} for the given transform name.
+   * @return A {@link PythonExternalTransform} for the given transform name.
    */
   public static <InputT extends PInput, OutputT extends POutput>
-      ExternalPythonTransform<InputT, OutputT> from(String tranformName) {
-    return new ExternalPythonTransform<>(tranformName, "");
+      PythonExternalTransform<InputT, OutputT> from(String tranformName) {
+    return new PythonExternalTransform<>(tranformName, "");
   }
 
   /**
@@ -95,11 +95,11 @@ public class ExternalPythonTransform<InputT extends PInput, OutputT extends POut
    * @param expansionService address and port number for externally launched expansion service
    * @param <InputT> Input {@link PCollection} type
    * @param <OutputT> Output {@link PCollection} type
-   * @return A {@link ExternalPythonTransform} for the given transform name.
+   * @return A {@link PythonExternalTransform} for the given transform name.
    */
   public static <InputT extends PInput, OutputT extends POutput>
-      ExternalPythonTransform<InputT, OutputT> from(String tranformName, String expansionService) {
-    return new ExternalPythonTransform<>(tranformName, expansionService);
+      PythonExternalTransform<InputT, OutputT> from(String tranformName, String expansionService) {
+    return new PythonExternalTransform<>(tranformName, expansionService);
   }
 
   /**
@@ -109,7 +109,7 @@ public class ExternalPythonTransform<InputT extends PInput, OutputT extends POut
    * @param args list of arguments.
    * @return updated wrapper for the cross-language transform.
    */
-  public ExternalPythonTransform<InputT, OutputT> withArgs(@NonNull Object... args) {
+  public PythonExternalTransform<InputT, OutputT> withArgs(@NonNull Object... args) {
     @Nullable
     Object @NonNull [] result = Arrays.copyOf(this.argsArray, this.argsArray.length + args.length);
     System.arraycopy(args, 0, result, this.argsArray.length, args.length);
@@ -125,7 +125,7 @@ public class ExternalPythonTransform<InputT extends PInput, OutputT extends POut
    * @param value argument value
    * @return updated wrapper for the cross-language transform.
    */
-  public ExternalPythonTransform<InputT, OutputT> withKwarg(String name, Object value) {
+  public PythonExternalTransform<InputT, OutputT> withKwarg(String name, Object value) {
     if (providedKwargsRow != null) {
       throw new IllegalArgumentException("Kwargs were specified both directly and as a Row object");
     }
@@ -139,7 +139,7 @@ public class ExternalPythonTransform<InputT extends PInput, OutputT extends POut
    *
    * @return updated wrapper for the cross-language transform.
    */
-  public ExternalPythonTransform<InputT, OutputT> withKwargs(Map<String, Object> kwargs) {
+  public PythonExternalTransform<InputT, OutputT> withKwargs(Map<String, Object> kwargs) {
     if (providedKwargsRow != null) {
       throw new IllegalArgumentException("Kwargs were specified both directly and as a Row object");
     }
@@ -154,7 +154,7 @@ public class ExternalPythonTransform<InputT extends PInput, OutputT extends POut
    *     arguments.
    * @return updated wrapper for the cross-language transform.
    */
-  public ExternalPythonTransform<InputT, OutputT> withKwargs(Row kwargs) {
+  public PythonExternalTransform<InputT, OutputT> withKwargs(Row kwargs) {
     if (this.kwargsMap.size() > 0) {
       throw new IllegalArgumentException("Kwargs were specified both directly and as a Row object");
     }

--- a/sdks/java/extensions/python/src/test/java/org/apache/beam/sdk/extensions/python/ExternalPythonTransformTest.java
+++ b/sdks/java/extensions/python/src/test/java/org/apache/beam/sdk/extensions/python/ExternalPythonTransformTest.java
@@ -49,7 +49,7 @@ public class ExternalPythonTransformTest implements Serializable {
     PCollection<String> output =
         p.apply(Create.of(KV.of("A", "x"), KV.of("A", "y"), KV.of("B", "z")))
             .apply(
-                ExternalPythonTransform
+                PythonExternalTransform
                     .<PCollection<KV<String, String>>, PCollection<KV<String, Iterable<String>>>>
                         from("apache_beam.GroupByKey"))
             .apply(MapElements.into(TypeDescriptors.strings()).via(kv -> kv.getKey()));
@@ -59,8 +59,8 @@ public class ExternalPythonTransformTest implements Serializable {
 
   @Test
   public void generateArgsEmpty() {
-    ExternalPythonTransform<?, ?> transform =
-        ExternalPythonTransform
+    PythonExternalTransform<?, ?> transform =
+        PythonExternalTransform
             .<PCollection<KV<String, String>>, PCollection<KV<String, Iterable<String>>>>from(
                 "DummyTransform");
 
@@ -70,8 +70,8 @@ public class ExternalPythonTransformTest implements Serializable {
 
   @Test
   public void generateArgsWithPrimitives() {
-    ExternalPythonTransform<?, ?> transform =
-        ExternalPythonTransform
+    PythonExternalTransform<?, ?> transform =
+        PythonExternalTransform
             .<PCollection<KV<String, String>>, PCollection<KV<String, Iterable<String>>>>from(
                 "DummyTransform")
             .withArgs("aaa", "bbb", 11, 12L, 15.6, true);
@@ -105,8 +105,8 @@ public class ExternalPythonTransformTest implements Serializable {
             .build();
     Row rowField2 = Row.withSchema(subRowSchema2).addValues(12.5, true, "yyy").build();
 
-    ExternalPythonTransform<?, ?> transform =
-        ExternalPythonTransform
+    PythonExternalTransform<?, ?> transform =
+        PythonExternalTransform
             .<PCollection<KV<String, String>>, PCollection<KV<String, Iterable<String>>>>from(
                 "DummyTransform")
             .withArgs(rowField1, rowField2);
@@ -124,8 +124,8 @@ public class ExternalPythonTransformTest implements Serializable {
 
   @Test
   public void generatePayloadWithoutKwargs() throws Exception {
-    ExternalPythonTransform<?, ?> transform =
-        ExternalPythonTransform
+    PythonExternalTransform<?, ?> transform =
+        PythonExternalTransform
             .<PCollection<KV<String, String>>, PCollection<KV<String, Iterable<String>>>>from(
                 "DummyTransform")
             .withArgs("aaa", "bbb", 11, 12L, 15.6, true);
@@ -138,8 +138,8 @@ public class ExternalPythonTransformTest implements Serializable {
 
   @Test
   public void generatePayloadWithoutArgs() {
-    ExternalPythonTransform<?, ?> transform =
-        ExternalPythonTransform
+    PythonExternalTransform<?, ?> transform =
+        PythonExternalTransform
             .<PCollection<KV<String, String>>, PCollection<KV<String, Iterable<String>>>>from(
                 "DummyTransform")
             .withKwarg("stringField1", "aaa")
@@ -169,8 +169,8 @@ public class ExternalPythonTransformTest implements Serializable {
     customType2.strField = "yyy";
     customType2.intField = 456;
 
-    ExternalPythonTransform<?, ?> transform =
-        ExternalPythonTransform
+    PythonExternalTransform<?, ?> transform =
+        PythonExternalTransform
             .<PCollection<KV<String, String>>, PCollection<KV<String, Iterable<String>>>>from(
                 "DummyTransform")
             .withArgs(customType1, customType2);
@@ -186,8 +186,8 @@ public class ExternalPythonTransformTest implements Serializable {
 
   @Test
   public void generateKwargsEmpty() {
-    ExternalPythonTransform<?, ?> transform =
-        ExternalPythonTransform
+    PythonExternalTransform<?, ?> transform =
+        PythonExternalTransform
             .<PCollection<KV<String, String>>, PCollection<KV<String, Iterable<String>>>>from(
                 "DummyTransform");
 
@@ -197,8 +197,8 @@ public class ExternalPythonTransformTest implements Serializable {
 
   @Test
   public void generateKwargsWithPrimitives() {
-    ExternalPythonTransform<?, ?> transform =
-        ExternalPythonTransform
+    PythonExternalTransform<?, ?> transform =
+        PythonExternalTransform
             .<PCollection<KV<String, String>>, PCollection<KV<String, Iterable<String>>>>from(
                 "DummyTransform")
             .withKwarg("stringField1", "aaa")
@@ -230,8 +230,8 @@ public class ExternalPythonTransformTest implements Serializable {
             .build();
     Row rowField2 = Row.withSchema(subRowSchema2).addValues(12.5, true, "yyy").build();
 
-    ExternalPythonTransform<?, ?> transform =
-        ExternalPythonTransform
+    PythonExternalTransform<?, ?> transform =
+        PythonExternalTransform
             .<PCollection<KV<String, String>>, PCollection<KV<String, Iterable<String>>>>from(
                 "DummyTransform")
             .withKwarg("customField0", rowField1)
@@ -258,8 +258,8 @@ public class ExternalPythonTransformTest implements Serializable {
     customType2.strField = "yyy";
     customType2.intField = 456;
 
-    ExternalPythonTransform<?, ?> transform =
-        ExternalPythonTransform
+    PythonExternalTransform<?, ?> transform =
+        PythonExternalTransform
             .<PCollection<KV<String, String>>, PCollection<KV<String, Iterable<String>>>>from(
                 "DummyTransform")
             .withKwarg("customField0", customType1)
@@ -289,8 +289,8 @@ public class ExternalPythonTransformTest implements Serializable {
             "doubleField",
             Double.valueOf(15.6));
 
-    ExternalPythonTransform<?, ?> transform =
-        ExternalPythonTransform
+    PythonExternalTransform<?, ?> transform =
+        PythonExternalTransform
             .<PCollection<KV<String, String>>, PCollection<KV<String, Iterable<String>>>>from(
                 "DummyTransform")
             .withKwargs(kwargsMap);


### PR DESCRIPTION
This makes the Java API more consistent with the naming of the corresponding Python API 'JavaExternalTransform':
https://github.com/apache/beam/blob/adfa113a6402b76571d746f8357879bd66fff4d7/sdks/python/apache_beam/transforms/external.py#L292


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
