### PR TITLE
Add default classpath when not present

### DIFF
--- a/sdks/go/pkg/beam/io/xlang/jdbcio/jdbc.go
+++ b/sdks/go/pkg/beam/io/xlang/jdbcio/jdbc.go
@@ -255,7 +255,7 @@ func WriteToPostgres(s beam.Scope, tableName, jdbcUrl, username, password string
 //   outT := reflect.TypeOf((*JdbcTestRow)(nil)).Elem()
 //   jdbcio.Read(s, tableName, driverClassName, jdbcurl, username, password, outT, jdbcio.ExpansionAddrRead("localhost:9000"))
 //
-// With Classpath paramater:
+// With Classpath parameter:
 //   jdbcio.Read(s, tableName, driverClassName, jdbcurl, username, password, outT, jdbcio.ExpansionAddrRead("localhost:9000"), jdbcio.ReadClasspaths([]string{"org.postgresql:postgresql:42.3.3"})))
 func Read(s beam.Scope, tableName, driverClassName, jdbcUrl, username, password string, outT reflect.Type, opts ...readOption) beam.PCollection {
 	s = s.Scope("jdbcio.Read")

--- a/sdks/go/pkg/beam/io/xlang/jdbcio/jdbc.go
+++ b/sdks/go/pkg/beam/io/xlang/jdbcio/jdbc.go
@@ -64,6 +64,11 @@ const (
 	serviceGradleTarget = ":sdks:java:extensions:schemaio-expansion-service:runExpansionService"
 )
 
+var defaultClasspaths = map[string][]string{
+	"org.postgresql.Driver": []string{"org.postgresql:postgresql:42.3.3"},
+	"com.mysql.jdbc.Driver": []string{"mysql:mysql-connector-java:8.0.28"},
+}
+
 var autoStartupAddress string = xlangx.UseAutomatedJavaExpansionService(serviceGradleTarget)
 
 // jdbcConfigSchema is the config schema as per the expected corss language payload
@@ -118,6 +123,9 @@ func toRow(pl interface{}) []byte {
 // an appropriate expansion service will be automatically started; however
 // this is slower than having a persistent expansion service running.
 //
+// If no additional classpaths are provided using jdbcio.WriteClasspaths() then the default classpath
+// for that driver would be used. As of now, the default classpaths are present only for PostgreSQL and MySQL.
+//
 // The default write statement is: "INSERT INTO tableName(column1, ...) INTO VALUES(value1, ...)"
 // Example:
 //   tableName := "roles"
@@ -126,6 +134,9 @@ func toRow(pl interface{}) []byte {
 // 	 password := "root123"
 // 	 jdbcUrl := "jdbc:postgresql://localhost:5432/dbname"
 //	 jdbcio.Write(s, tableName, driverClassName, jdbcurl, username, password, jdbcio.ExpansionAddrWrite("localhost:9000"))
+//
+// With Classpath paramater:
+//   jdbcio.Write(s, tableName, driverClassName, jdbcurl, username, password, jdbcio.ExpansionAddrWrite("localhost:9000"), jdbcio.WriteClasspaths([]string{"org.postgresql:postgresql:42.3.3"}))
 func Write(s beam.Scope, tableName, driverClassName, jdbcUrl, username, password string, col beam.PCollection, opts ...writeOption) {
 	s = s.Scope("jdbcio.Write")
 
@@ -138,6 +149,10 @@ func Write(s beam.Scope, tableName, driverClassName, jdbcUrl, username, password
 	cfg := jdbcConfig{config: &wpl}
 	for _, opt := range opts {
 		opt(&cfg)
+	}
+
+	if len(cfg.classpaths) == 0 {
+		cfg.classpaths = defaultClasspaths[driverClassName]
 	}
 
 	expansionAddr := cfg.expansionAddr
@@ -222,6 +237,9 @@ func WriteToPostgres(s beam.Scope, tableName, jdbcUrl, username, password string
 // address is not provided, an appropriate expansion service will be automatically started;
 // however this is slower than having a persistent expansion service running.
 //
+// If no additional classpaths are provided using jdbcio.ReadClasspaths() then the default classpath
+// for that driver would be used. As of now, the default classpaths are present only for PostgreSQL and MySQL.
+//
 // The default read query is "SELECT * FROM tableName;"
 //
 // Read also accepts optional parameters as readOptions. All optional parameters
@@ -236,6 +254,9 @@ func WriteToPostgres(s beam.Scope, tableName, jdbcUrl, username, password string
 //   jdbcUrl := "jdbc:postgresql://localhost:5432/dbname"
 //   outT := reflect.TypeOf((*JdbcTestRow)(nil)).Elem()
 //   jdbcio.Read(s, tableName, driverClassName, jdbcurl, username, password, outT, jdbcio.ExpansionAddrRead("localhost:9000"))
+//
+// With Classpath paramater:
+//   jdbcio.Read(s, tableName, driverClassName, jdbcurl, username, password, outT, jdbcio.ExpansionAddrRead("localhost:9000"), jdbcio.ReadClasspaths([]string{"org.postgresql:postgresql:42.3.3"})))
 func Read(s beam.Scope, tableName, driverClassName, jdbcUrl, username, password string, outT reflect.Type, opts ...readOption) beam.PCollection {
 	s = s.Scope("jdbcio.Read")
 
@@ -248,6 +269,10 @@ func Read(s beam.Scope, tableName, driverClassName, jdbcUrl, username, password 
 	cfg := jdbcConfig{config: &rpl}
 	for _, opt := range opts {
 		opt(&cfg)
+	}
+
+	if len(cfg.classpaths) == 0 {
+		cfg.classpaths = defaultClasspaths[driverClassName]
 	}
 
 	expansionAddr := cfg.expansionAddr


### PR DESCRIPTION
This PR adds a small enhancement to specifying additional dependency jars to JDBC IO. As discussed in #17216, we don't want users to specify both driver class name and the classpath when using a default driver jar. Integration tested by modifying [expand.go](https://github.com/apache/beam/blob/b0e6b561683425fe865720970ce60d45ecec11e4/sdks/go/pkg/beam/core/runtime/xlangx/expand.go#L148) to use version `2.38.0` instead of `core.SdkVersion`.
change 
`jarPath, err := expansionx.GetBeamJar(gradleTarget, core.SdkVersion)` 
to
`jarPath, err := expansionx.GetBeamJar(gradleTarget, "2.38.0")`

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
