### PR TITLE
[BEAM-13945] (FIX) Update Java BQ connector to support new JSON type 

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -3012,7 +3012,10 @@ public class BigQueryIO {
         checkArgument(
             !field.getString("type").equals("JSON"),
             "Found JSON type in TableSchema. JSON data insertion is currently "
-                + "not supported with 'FILE_LOADS' write method.");
+                + "not supported with 'FILE_LOADS' write method. This is supported with the "
+                + "other write methods, however. For more information, visit: "
+                + "https://cloud.google.com/bigquery/docs/reference/standard-sql/"
+                + "json-data#ingest_json_data");
 
         if (field.getString("type").equals("STRUCT")) {
           validateNoJsonTypeInSchema(field);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -2919,7 +2919,9 @@ public class BigQueryIO {
         // Batch load jobs currently support JSON data insertion only with CSV files
         if (getJsonSchema() != null && getJsonSchema().isAccessible()) {
           JSONObject schema = new JSONObject(getJsonSchema().get());
-          validateNoJsonTypeInSchema(schema);
+          if (!schema.isEmpty()) {
+            validateNoJsonTypeInSchema(schema);
+          }
         }
 
         BatchLoads<DestinationT, T> batchLoads =

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -2917,7 +2917,7 @@ public class BigQueryIO {
         if (getJsonSchema() != null && getJsonSchema().isAccessible()) {
           // Batch load jobs currently support JSON data insertion only with CSV files
           checkArgument(
-              !getJsonSchema().get().contains("JSON"),
+              !getJsonSchema().get().contains("\"type\":\"JSON\""),
               "Found JSON type in TableSchema. JSON data insertion is currently "
                   + "not supported with batch loads.");
         }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -3002,17 +3002,17 @@ public class BigQueryIO {
       }
     }
 
-    private void validateNoJsonTypeInSchema(JSONObject schema){
+    private void validateNoJsonTypeInSchema(JSONObject schema) {
       JSONArray fields = schema.getJSONArray("fields");
 
-      for(int i = 0; i < fields.length(); i++){
+      for (int i = 0; i < fields.length(); i++) {
         JSONObject field = fields.getJSONObject(i);
         checkArgument(
             !field.getString("type").equals("JSON"),
             "Found JSON type in TableSchema. JSON data insertion is currently "
                 + "not supported with 'FILE_LOADS' write method.");
 
-        if(field.getString("type").equals("STRUCT")){
+        if (field.getString("type").equals("STRUCT")) {
           validateNoJsonTypeInSchema(field);
         }
       }


### PR DESCRIPTION
Follow up to https://github.com/apache/beam/pull/17209. 
More thorough way to look for JSON column type in schema and throw an error when the user is writing to BigQuery with the FILE_LOADS write method. The error is thrown because JSON insertion is currently not supported with batch loads.