### PR TITLE
[BEAM-14383] Improve "FailedRows" errors returned by beam.io.WriteToBigQuery

### DIFF
--- a/sdks/python/apache_beam/examples/snippets/snippets.py
+++ b/sdks/python/apache_beam/examples/snippets/snippets.py
@@ -1554,8 +1554,12 @@ def bigqueryio_deadletter():
           write_disposition='WRITE_APPEND'))
   result = (
       errors['FailedRows']
-      | 'PrintErrors' >>
-      beam.FlatMap(lambda err: print("Error Found {}".format(err))))
+      | 'PrintErrors' >> beam.FlatMap(
+          lambda err: print({
+              "table": err[0],
+              "reason": json.dumps(err[2]),
+              "row_json": json.dumps(err[1]),
+          })))
   # [END BigQueryIODeadLetter]
 
   return result

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -1748,7 +1748,8 @@ class BigQueryWriteFn(DoFn):
           ignore_unknown_values=self.ignore_unknown_columns)
       self.batch_latency_metric.update((time.time() - start) * 1000)
 
-      failed_rows = [(rows[entry['index']], entry["errors"]) for entry in errors]
+      failed_rows = [(rows[entry['index']], entry["errors"])
+                     for entry in errors]
       should_retry = any(
           RetryStrategy.should_retry(
               self._retry_strategy, entry['errors'][0]['reason'])
@@ -1781,7 +1782,8 @@ class BigQueryWriteFn(DoFn):
         pvalue.TaggedOutput(
             BigQueryWriteFn.FAILED_ROWS,
             GlobalWindows.windowed_value((destination, row, row_errors)))
-        for row, row_errors in failed_rows
+        for row,
+        row_errors in failed_rows
     ]
 
 

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -1748,7 +1748,7 @@ class BigQueryWriteFn(DoFn):
           ignore_unknown_values=self.ignore_unknown_columns)
       self.batch_latency_metric.update((time.time() - start) * 1000)
 
-      failed_rows = [rows[entry['index']] for entry in errors]
+      failed_rows = [(rows[entry['index']], entry["errors"]) for entry in errors]
       should_retry = any(
           RetryStrategy.should_retry(
               self._retry_strategy, entry['errors'][0]['reason'])
@@ -1780,8 +1780,8 @@ class BigQueryWriteFn(DoFn):
     return [
         pvalue.TaggedOutput(
             BigQueryWriteFn.FAILED_ROWS,
-            GlobalWindows.windowed_value((destination, row)))
-        for row in failed_rows
+            GlobalWindows.windowed_value((destination, row, row_errors)))
+        for row, row_errors in failed_rows
     ]
 
 


### PR DESCRIPTION
`WriteToBigQuery` pipeline returns `errors` when trying to insert rows that do not match the BigQuery table schema. `errors` is a dictionary that cointains one `FailedRows` key. `FailedRows` is a list of tuples where each tuple has two elements: BigQuery table name and the row that didn't match the schema.

This can be verified by running the `BigQueryIO deadletter pattern` https://beam.apache.org/documentation/patterns/bigqueryio/

Using the template approach I can print the failed rows in a pipeline. When running the job, logger simultaneously prints out the reason why the rows were invalid. 

The reason (for why the row is invalid) should also be included in the tuple in addition to the BigQuery table and the raw row. This way next pipeline could eg. insert the invalid rows into a different BigQuery table with a schema.
```python
error_schema = (
    {
        'fields': [
            {'name': 'timestamp', 'type': 'TIMESTAMP', 'mode': 'REQUIRED'},
            {'name': 'table', 'type': 'STRING', 'mode': 'REQUIRED'},
            {'name': 'reason', 'type': 'STRING', 'mode': 'NULLABLE'},
            {'name': 'row_json', 'type': 'STRING', 'mode': 'REQUIRED'},
        ]
    }
)
```

The whole pipeline implementation could look something like this
```python
with beam.Pipeline(options=pipeline_options) as p:

    errors = (
        p
        | "Read from Pub/Sub subscription" >> beam.io.gcp.pubsub.ReadFromPubSub(
            subscription=known_args.input_subscription,
            timestamp_attribute=None)
        | "UTF-8 bytes to string" >> beam.Map(lambda msg: msg.decode("utf-8"))
        | "Parse JSON messages" >> beam.Map(json.loads)
        | "WriteToBigQuery" >> beam.io.WriteToBigQuery(
            known_args.output_table,
            schema=schema,
            create_disposition=beam.io.BigQueryDisposition.CREATE_NEVER,
            write_disposition=beam.io.BigQueryDisposition.WRITE_APPEND,
            ignore_unknown_columns=False,
            insert_retry_strategy=RetryStrategy.RETRY_ON_TRANSIENT_ERROR
        )
    )
    
    result = (
        errors["FailedRows"]
        | 'ParseErrors' >> beam.Map(lambda err: {
                "timestamp": time.time_ns() / 1000000000,
                "table": err[0],
                "reason": None, # TODO to be replaced with `err[2]`
                "row_json": json.dumps(err[1]),
            })
        | "WriteErrorsToBigQuery" >> beam.io.WriteToBigQuery(
            known_args.output_table + "_error_records",
            schema=error_schema,
            create_disposition=beam.io.BigQueryDisposition.CREATE_IF_NEEDED,
            write_disposition=beam.io.BigQueryDisposition.WRITE_APPEND,
            ignore_unknown_columns=False,
            insert_retry_strategy=RetryStrategy.RETRY_ON_TRANSIENT_ERROR
        )
    )
```

During my reasearch i found a couple of alternate solutions, but i think they are more complex than they need to be. Thats why I explored the beam source code and found the solution to be an easy and simple change.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
