### PR TITLE
[BEAM-5878] Add (failing) kwonly-argument test

### DIFF
--- a/sdks/python/apache_beam/runners/common_test.py
+++ b/sdks/python/apache_beam/runners/common_test.py
@@ -50,6 +50,25 @@ class DoFnSignatureTest(unittest.TestCase):
     with self.assertRaises(ValueError):
       DoFnSignature(MyDoFn())
 
+  def test_dofn_get_defaults(self):
+    class MyDoFn(DoFn):
+      def process(self, element, w=DoFn.WindowParam):
+        pass
+
+    signature = DoFnSignature(MyDoFn())
+
+    self.assertEqual(signature.process_method.defaults, [DoFn.WindowParam])
+
+  @unittest.skip('BEAM-5878')
+  def test_dofn_get_defaults_kwonly(self):
+    class MyDoFn(DoFn):
+      def process(self, element, *, w=DoFn.WindowParam):
+        pass
+
+    signature = DoFnSignature(MyDoFn())
+
+    self.assertEqual(signature.process_method.defaults, [DoFn.WindowParam])
+
   def test_dofn_validate_start_bundle_error(self):
     class MyDoFn(DoFn):
       def process(self, element):


### PR DESCRIPTION
`DoFnSignature` and `MethodWrapper` don't properly handle kwonly arguments (some `TODO(BEAM-5878)` references in the codebase point to the paths that need to be updated).

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
