### PR TITLE
[BEAM-14004] fix(mongodb): Ignore error Command not supported because of CosmosDB not support splitKeys command #16972

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -87,6 +87,7 @@
 ## Bugfixes
 
 * Fixed X (Java/Python) ([BEAM-X](https://issues.apache.org/jira/browse/BEAM-X)).
+* Ignore error `Command not supported` because of CosmosDB not support `splitKeys` command in Java SDK ([BEAM-14004](https://issues.apache.org/jira/browse/BEAM-14004)).
 
 ## Known Issues
 

--- a/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbIO.java
+++ b/sdks/java/io/mongodb/src/main/java/org/apache/beam/sdk/io/mongodb/MongoDbIO.java
@@ -26,6 +26,7 @@ import com.mongodb.MongoBulkWriteException;
 import com.mongodb.MongoClient;
 import com.mongodb.MongoClientOptions;
 import com.mongodb.MongoClientURI;
+import com.mongodb.MongoCommandException;
 import com.mongodb.client.AggregateIterable;
 import com.mongodb.client.MongoCollection;
 import com.mongodb.client.MongoCursor;
@@ -489,8 +490,16 @@ public class MongoDbIO {
             // maxChunkSize is the Mongo partition size in MB
             LOG.debug("Splitting in chunk of {} MB", desiredBundleSizeBytes / 1024 / 1024);
             splitVectorCommand.append("maxChunkSize", desiredBundleSizeBytes / 1024 / 1024);
-            Document splitVectorCommandResult = mongoDatabase.runCommand(splitVectorCommand);
-            splitKeys = (List<Document>) splitVectorCommandResult.get("splitKeys");
+            try {
+              Document splitVectorCommandResult = mongoDatabase.runCommand(splitVectorCommand);
+              splitKeys = (List<Document>) splitVectorCommandResult.get("splitKeys");
+            } catch (MongoCommandException e) {
+              if (e.getErrorCode() == 115) {
+                LOG.warn("This command is not supported: " + splitVectorCommand.toString(), e);
+                return Collections.singletonList(this);
+              }
+              throw e;
+            }
           }
 
           if (splitKeys.size() < 1) {


### PR DESCRIPTION
fix(mongodb): Ignore error `Command not supported` because of CosmosDB not support `splitKeys` command

Reviewed-by: @jbonofre
Refs: # (pull request) [BEAM-14004] (jira)

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
