### PR TITLE
[BEAM-14377] Revert "Improvement to Seed job configuration so we can launch seed jobs against PRs"

### DIFF
--- a/.test-infra/jenkins/job_00_seed.groovy
+++ b/.test-infra/jenkins/job_00_seed.groovy
@@ -63,10 +63,6 @@ job('beam_SeedJob') {
         'sha1',
         'master',
         'Commit id or refname (eg: origin/pr/4001/head) you want to build against.')
-    stringParam(
-        'ghprbPullId',
-        '',
-        'Pull Request ID (eg: 4001) that you want to build against.')
   }
 
   wrappers {

--- a/.test-infra/jenkins/job_seed_standalone.groovy
+++ b/.test-infra/jenkins/job_seed_standalone.groovy
@@ -63,10 +63,6 @@ job('beam_SeedJob_Standalone') {
         'sha1',
         'master',
         'Commit id or refname (eg: origin/pr/4001/head) you want to build against.')
-    stringParam(
-        'ghprbPullId',
-        '',
-        'Pull Request ID (eg: 4001) that you want to build against.')
   }
 
   wrappers {


### PR DESCRIPTION
Reverts apache/beam#17468

Reason: suspecting that this change broke the seed job: https://github.com/apache/beam/pull/17468#issuecomment-1112069701