### PR TITLE
Updates ml/inference ModelLoader to allow defining arguments to BatchElements

### DIFF
--- a/sdks/python/apache_beam/ml/inference/base.py
+++ b/sdks/python/apache_beam/ml/inference/base.py
@@ -80,6 +80,10 @@ class ModelLoader(Generic[T]):
   def get_inference_runner(self) -> InferenceRunner:
     """Returns an implementation of InferenceRunner for this model."""
     raise NotImplementedError(type(self))
+    
+  def batch_elements_kwargs(self) -> Mapping[str, Any]:
+    """Returns kwargs suitable for beam.BatchElements."""
+    return {}
 
 
 class RunInference(beam.PTransform):
@@ -94,7 +98,7 @@ class RunInference(beam.PTransform):
     return (
         pcoll
         # TODO(BEAM-14044): Hook into the batching DoFn APIs.
-        | beam.BatchElements()
+        | beam.BatchElements(**self._model_loader.batch_elements_kwargs())
         | beam.ParDo(_RunInferenceDoFn(self._model_loader, self._clock)))
 
 


### PR DESCRIPTION
Adds a method to ModelLoader to allow overriding of arguments to beam.BatchElements. The main goal here is to set a max batch size (e.g., 1) when the caller has particular requirements.
