### PR TITLE
[BEAM-14273] typo fix for BigQueryIO JSON test (python)

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery_json_it_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_json_it_test.py
@@ -149,7 +149,7 @@ class BigQueryJsonIT(unittest.TestCase):
             method=method,
         ) | 'Validate rows' >> beam.ParDo(CompareJson())
 
-  @pytest.mark.it_postcomit
+  @pytest.mark.it_postcommit
   def test_direct_read(self):
     extra_opts = {
         'read_method': "DIRECT_READ",
@@ -159,7 +159,7 @@ class BigQueryJsonIT(unittest.TestCase):
 
     self.read_and_validate_rows(options)
 
-  @pytest.mark.it_postcomit
+  @pytest.mark.it_postcommit
   def test_export_read(self):
     extra_opts = {
         'read_method': "EXPORT",
@@ -169,7 +169,7 @@ class BigQueryJsonIT(unittest.TestCase):
 
     self.read_and_validate_rows(options)
 
-  @pytest.mark.it_postcomit
+  @pytest.mark.it_postcommit
   def test_query_read(self):
     extra_opts = {
         'query': "SELECT "
@@ -184,7 +184,7 @@ class BigQueryJsonIT(unittest.TestCase):
 
     self.read_and_validate_rows(options)
 
-  @pytest.mark.it_postcomit
+  @pytest.mark.it_postcommit
   def test_streaming_inserts(self):
     extra_opts = {
         'output': f"{PROJECT}:{DATASET_ID}.{STREAMING_TEST_TABLE}",
@@ -194,7 +194,7 @@ class BigQueryJsonIT(unittest.TestCase):
 
     self.run_test_write(options)
 
-  @pytest.mark.it_postcomit
+  @pytest.mark.it_postcommit
   def test_file_loads_write(self):
     extra_opts = {
         'output': f"{PROJECT}:{DATASET_ID}.{STREAMING_TEST_TABLE}",


### PR DESCRIPTION
Follow up to https://github.com/apache/beam/pull/17431.

Typo in test decorators prevented tests from running.