### PR TITLE
[BEAM-14411] Re-enable TypecodersTest, fix most issues

### DIFF
--- a/sdks/python/apache_beam/coders/typecoders_test.py
+++ b/sdks/python/apache_beam/coders/typecoders_test.py
@@ -23,7 +23,6 @@ import unittest
 from apache_beam.coders import coders
 from apache_beam.coders import typecoders
 from apache_beam.internal import pickler
-from apache_beam.tools import utils
 from apache_beam.typehints import typehints
 
 

--- a/sdks/python/apache_beam/coders/typecoders_test.py
+++ b/sdks/python/apache_beam/coders/typecoders_test.py
@@ -40,7 +40,7 @@ class CustomClass(object):
 
 class CustomCoder(coders.Coder):
   def encode(self, value):
-    return str(value.number)
+    return str(value.number).encode('ASCII')
 
   def decode(self, encoded):
     return CustomClass(int(encoded))
@@ -53,21 +53,14 @@ class CustomCoder(coders.Coder):
 
 
 class TypeCodersTest(unittest.TestCase):
-  def setUp(self):
-    try:
-      utils.check_compiled('apache_beam.coders')
-    except RuntimeError:
-      self.skipTest('Cython is not installed')
-
   def test_register_non_type_coder(self):
     coder = CustomCoder()
-    with self.assertRaises(TypeError) as e:
+    with self.assertRaisesRegex(TypeError, (
+        'Coder registration requires a coder class object. '
+        'Received %r instead.' % coder)):
+
       # When registering a coder the coder class must be specified.
       typecoders.registry.register_coder(CustomClass, coder)
-    self.assertEqual(
-        e.exception.message,
-        'Coder registration requires a coder class object. '
-        'Received %r instead.' % coder)
 
   def test_get_coder_with_custom_coder(self):
     typecoders.registry.register_coder(CustomClass, CustomCoder)
@@ -128,6 +121,7 @@ class TypeCodersTest(unittest.TestCase):
     self.assertEqual(expected_coder, real_coder)
     self.assertEqual(real_coder.encode(values), expected_coder.encode(values))
 
+  @unittest.skip('BEAM-14411')
   def test_list_coder(self):
     real_coder = typecoders.registry.get_coder(typehints.List[bytes])
     expected_coder = coders.IterableCoder(coders.BytesCoder())
@@ -142,7 +136,7 @@ class TypeCodersTest(unittest.TestCase):
 
   def test_nullable_coder(self):
     expected_coder = coders.NullableCoder(coders.BytesCoder())
-    real_coder = typecoders.registry.get_coder(typehints.Optional(bytes))
+    real_coder = typecoders.registry.get_coder(typehints.Optional[bytes])
     self.assertEqual(expected_coder, real_coder)
     self.assertEqual(expected_coder.encode(None), real_coder.encode(None))
     self.assertEqual(expected_coder.encode(b'abc'), real_coder.encode(b'abc'))

--- a/sdks/python/apache_beam/coders/typecoders_test.py
+++ b/sdks/python/apache_beam/coders/typecoders_test.py
@@ -55,9 +55,10 @@ class CustomCoder(coders.Coder):
 class TypeCodersTest(unittest.TestCase):
   def test_register_non_type_coder(self):
     coder = CustomCoder()
-    with self.assertRaisesRegex(TypeError, (
-        'Coder registration requires a coder class object. '
-        'Received %r instead.' % coder)):
+    with self.assertRaisesRegex(
+        TypeError,
+        ('Coder registration requires a coder class object. '
+         'Received %r instead.' % coder)):
 
       # When registering a coder the coder class must be specified.
       typecoders.registry.register_coder(CustomClass, coder)


### PR DESCRIPTION
TypecodersTest has been inadvertently disabled as it branches on `utils.check_compiled('apache_beam.coders')` which is always false (coders is not compiled, coders_impl is). It turns out the test should now test under cython and non-cython, so this PR removes the branch, and fixes a few test issues that were masked.

There's one more test issue that I'm not sure how to fix so I left the test skipped for now.

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
