### PR TITLE
Vortex performance improvement: Enable multiple stream clients per worker

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryOptions.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryOptions.java
@@ -93,7 +93,10 @@ public interface BigQueryOptions
   void setUseStorageWriteApiAtLeastOnce(Boolean value);
 
   @Description(
-      "If set, then BigQueryIO.Write will default to using this number of Storage Write API streams.")
+      "If set, then BigQueryIO.Write will default to using this number of Storage Write API streams. "
+              + "The number of streams indicated will be allocated at a per worker and destination basis, "
+              + "a high number can cause a large pipeline to go over the BigQuery connection quota quickly. "
+              + "With low-mid volume pipelines using the default configuration should be enough.")
   @Default.Integer(0)
   Integer getNumStorageWriteApiStreams();
 
@@ -129,4 +132,10 @@ public interface BigQueryOptions
   Integer getStorageApiAppendThresholdBytes();
 
   void setStorageApiAppendThresholdBytes(Integer value);
+  
+  @Description("Maximum (best effort) record count of a single append to the storage API.")
+  @Default.Integer(150000)
+  Integer getStorageApiAppendThresholdRecordCount();
+
+  void setStorageApiAppendThresholdRecordCount(Integer value);
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryOptions.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryOptions.java
@@ -100,9 +100,10 @@ public interface BigQueryOptions
   void setNumStorageWriteApiStreams(Integer value);
 
   @Description(
-      "The number of stream append clients indicated will be allocated at a per worker and destination "
-          + "basis. A large value can cause a large pipeline to go over the BigQuery connection quota quickly. "
-          + "With low-mid volume pipelines using the default configuration should be enough.")
+      "When using the \"_default\" table stream, this option sets the number of stream append clients that will be allocated "
+          + "at a per worker and destination basis. A large value can cause a large pipeline to go over the BigQuery "
+          + "connection quota quickly on a job with large number of workers. On the case of low-mid volume pipelines "
+          + "using the default configuration should be enough.")
   @Default.Integer(1)
   Integer getNumStorageWriteApiStreamAppendClients();
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryOptions.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryOptions.java
@@ -93,14 +93,20 @@ public interface BigQueryOptions
   void setUseStorageWriteApiAtLeastOnce(Boolean value);
 
   @Description(
-      "If set, then BigQueryIO.Write will default to using this number of Storage Write API streams. "
-          + "The number of streams indicated will be allocated at a per worker and destination basis, "
-          + "a high number can cause a large pipeline to go over the BigQuery connection quota quickly. "
-          + "With low-mid volume pipelines using the default configuration should be enough.")
+      "If set, then BigQueryIO.Write will default to using this number of Storage Write API streams. ")
   @Default.Integer(0)
   Integer getNumStorageWriteApiStreams();
 
   void setNumStorageWriteApiStreams(Integer value);
+
+  @Description(
+      "The number of stream append clients indicated will be allocated at a per worker and destination "
+          + "basis. A large value can cause a large pipeline to go over the BigQuery connection quota quickly. "
+          + "With low-mid volume pipelines using the default configuration should be enough.")
+  @Default.Integer(1)
+  Integer getNumStorageWriteApiStreamAppendClients();
+
+  void setNumStorageWriteApiStreamAppendClients(Integer value);
 
   @Description(
       "If set, then BigQueryIO.Write will default to triggering the Storage Write API writes this often.")

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryOptions.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryOptions.java
@@ -100,10 +100,10 @@ public interface BigQueryOptions
   void setNumStorageWriteApiStreams(Integer value);
 
   @Description(
-      "When using the \"_default\" table stream, this option sets the number of stream append clients that will be allocated "
-          + "at a per worker and destination basis. A large value can cause a large pipeline to go over the BigQuery "
-          + "connection quota quickly on a job with large number of workers. On the case of low-mid volume pipelines "
-          + "using the default configuration should be enough.")
+      "When using the {@link org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.Method#STORAGE_API_AT_LEAST_ONCE} write method, "
+          + "this option sets the number of stream append clients that will be allocated at a per worker and destination basis. "
+          + "A large value can cause a large pipeline to go over the BigQuery connection quota quickly on a job with "
+          + "enough number of workers. On the case of low-mid volume pipelines using the default configuration should be sufficient.")
   @Default.Integer(1)
   Integer getNumStorageWriteApiStreamAppendClients();
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryOptions.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryOptions.java
@@ -94,9 +94,9 @@ public interface BigQueryOptions
 
   @Description(
       "If set, then BigQueryIO.Write will default to using this number of Storage Write API streams. "
-              + "The number of streams indicated will be allocated at a per worker and destination basis, "
-              + "a high number can cause a large pipeline to go over the BigQuery connection quota quickly. "
-              + "With low-mid volume pipelines using the default configuration should be enough.")
+          + "The number of streams indicated will be allocated at a per worker and destination basis, "
+          + "a high number can cause a large pipeline to go over the BigQuery connection quota quickly. "
+          + "With low-mid volume pipelines using the default configuration should be enough.")
   @Default.Integer(0)
   Integer getNumStorageWriteApiStreams();
 
@@ -132,7 +132,7 @@ public interface BigQueryOptions
   Integer getStorageApiAppendThresholdBytes();
 
   void setStorageApiAppendThresholdBytes(Integer value);
-  
+
   @Description("Maximum (best effort) record count of a single append to the storage API.")
   @Default.Integer(150000)
   Integer getStorageApiAppendThresholdRecordCount();

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteRecordsInconsistent.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteRecordsInconsistent.java
@@ -47,11 +47,6 @@ public class StorageApiWriteRecordsInconsistent<DestinationT, ElementT>
   public PCollection<Void> expand(PCollection<KV<DestinationT, StorageApiWritePayload>> input) {
     String operationName = input.getName() + "/" + getName();
     BigQueryOptions bigQueryOptions = input.getPipeline().getOptions().as(BigQueryOptions.class);
-    // default value from options is 0, so we set at least one client
-    Integer numStreams =
-        bigQueryOptions.getNumStorageWriteApiStreams() == 0
-            ? 1
-            : bigQueryOptions.getNumStorageWriteApiStreams();
     // Append records to the Storage API streams.
     input.apply(
         "Write Records",
@@ -63,7 +58,7 @@ public class StorageApiWriteRecordsInconsistent<DestinationT, ElementT>
                     true,
                     bigQueryOptions.getStorageApiAppendThresholdBytes(),
                     bigQueryOptions.getStorageApiAppendThresholdRecordCount(),
-                    numStreams))
+                    bigQueryOptions.getNumStorageWriteApiStreamAppendClients()))
             .withSideInputs(dynamicDestinations.getSideInputs()));
     return input.getPipeline().apply("voids", Create.empty(VoidCoder.of()));
   }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteRecordsInconsistent.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteRecordsInconsistent.java
@@ -47,9 +47,10 @@ public class StorageApiWriteRecordsInconsistent<DestinationT, ElementT>
   public PCollection<Void> expand(PCollection<KV<DestinationT, StorageApiWritePayload>> input) {
     String operationName = input.getName() + "/" + getName();
     BigQueryOptions bigQueryOptions = input.getPipeline().getOptions().as(BigQueryOptions.class);
-    // default value from options is 0, so we set at least one client 
-    Integer numStreams = bigQueryOptions.getNumStorageWriteApiStreams() == 0 
-            ? 1 
+    // default value from options is 0, so we set at least one client
+    Integer numStreams =
+        bigQueryOptions.getNumStorageWriteApiStreams() == 0
+            ? 1
             : bigQueryOptions.getNumStorageWriteApiStreams();
     // Append records to the Storage API streams.
     input.apply(

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteRecordsInconsistent.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteRecordsInconsistent.java
@@ -49,7 +49,7 @@ public class StorageApiWriteRecordsInconsistent<DestinationT, ElementT>
     BigQueryOptions bigQueryOptions = input.getPipeline().getOptions().as(BigQueryOptions.class);
     // Append records to the Storage API streams.
     input.apply(
-        "WriteRecordsAtLeastOnce",
+        "Write Records",
         ParDo.of(
                 new StorageApiWriteUnshardedRecords.WriteRecordsDoFn<>(
                     operationName,

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteRecordsInconsistent.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteRecordsInconsistent.java
@@ -49,7 +49,7 @@ public class StorageApiWriteRecordsInconsistent<DestinationT, ElementT>
     BigQueryOptions bigQueryOptions = input.getPipeline().getOptions().as(BigQueryOptions.class);
     // Append records to the Storage API streams.
     input.apply(
-        "Write Records",
+        "WriteRecordsAtLeastOnce",
         ParDo.of(
                 new StorageApiWriteUnshardedRecords.WriteRecordsDoFn<>(
                     operationName,


### PR DESCRIPTION
Changing the StorageWrite stream append client cache to use a list of entries instead of just one entry per stream.

In the majority of the cases the default configuration would be sufficient to address the ingestion volume, but there are cases were the ingestion will need a higher level of parallelism. Setting `--numStorageWriteApiStreams=X` to a value > 1 will help to increase the ingestion parallelism level, users should be mindful of changing this number to a high one since the number of open connections will rapidly scale with the number of workers potentially reaching BigQuery quota/limits (see: https://cloud.google.com/bigquery/quotas#write-api-limits).   

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
