### PR TITLE
BEAM-14419: Remove invalid mod type

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/model/ModType.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/model/ModType.java
@@ -22,12 +22,11 @@ import org.apache.beam.sdk.coders.DefaultCoder;
 
 /**
  * Represents the type of modification applied in the {@link DataChangeRecord}. It can be one of the
- * following: INSERT, UPDATE, INSERT_OR_UPDATE or DELETE.
+ * following: INSERT, UPDATE or DELETE.
  */
 @DefaultCoder(AvroCoder.class)
 public enum ModType {
   INSERT,
   UPDATE,
-  INSERT_OR_UPDATE,
   DELETE
 }


### PR DESCRIPTION
Removes invalid mod type from the DataChangeRecord. This is not returned from the Change Streams API and can be removed safely.