### PR TITLE
[BEAM-14429] Force java load test on dataflow runner v2 forceNumIniti…

### DIFF
--- a/.test-infra/jenkins/job_LoadTests_CoGBK_Dataflow_V2_Java11.groovy
+++ b/.test-infra/jenkins/job_LoadTests_CoGBK_Dataflow_V2_Java11.groovy
@@ -23,6 +23,8 @@ import PhraseTriggeringPostCommitBuilder
 import CronJobBuilder
 import InfluxDBCredentialsHelper
 
+// TODO(BEAM-14229): remove forceNumInitialBundles once source issue resolved.
+
 def loadTestConfigurations = { mode, isStreaming ->
   [
     [
@@ -47,6 +49,7 @@ def loadTestConfigurations = { mode, isStreaming ->
             "numRecords": 20000000,
             "keySizeBytes": 10,
             "valueSizeBytes": 90,
+            "forceNumInitialBundles": 1,
             "numHotKeys": 1
           }
         """.trim().replaceAll("\\s", ""),
@@ -55,6 +58,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                 "numRecords": 2000000,
                 "keySizeBytes": 10,
                 "valueSizeBytes": 90,
+                "forceNumInitialBundles": 1,
                 "numHotKeys": 1000
               }
             """.trim().replaceAll("\\s", ""),
@@ -86,6 +90,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                     "numRecords": 20000000,
                     "keySizeBytes": 10,
                     "valueSizeBytes": 90,
+                    "forceNumInitialBundles": 1,
                     "numHotKeys": 5
                   }
                 """.trim().replaceAll("\\s", ""),
@@ -94,6 +99,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                             "numRecords": 2000000,
                             "keySizeBytes": 10,
                             "valueSizeBytes": 90,
+                            "forceNumInitialBundles": 1,
                             "numHotKeys": 1000
                           }
                         """.trim().replaceAll("\\s", ""),
@@ -126,6 +132,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                                 "numRecords": 2000000,
                                 "keySizeBytes": 10,
                                 "valueSizeBytes": 90,
+                                "forceNumInitialBundles": 1,
                                 "numHotKeys": 200000
                               }
                             """.trim().replaceAll("\\s", ""),
@@ -134,6 +141,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                                 "numRecords": 2000000,
                                 "keySizeBytes": 10,
                                 "valueSizeBytes": 90,
+                                "forceNumInitialBundles": 1,
                                 "numHotKeys": 1000
                               }
                             """.trim().replaceAll("\\s", ""),
@@ -166,6 +174,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                                 "numRecords": 2000000,
                                 "keySizeBytes": 10,
                                 "valueSizeBytes": 90,
+                                "forceNumInitialBundles": 1,
                                 "numHotKeys": 1000
                               }
                             """.trim().replaceAll("\\s", ""),
@@ -174,6 +183,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                                 "numRecords": 2000000,
                                 "keySizeBytes": 10,
                                 "valueSizeBytes": 90,
+                                "forceNumInitialBundles": 1,
                                 "numHotKeys": 1000
                               }
                             """.trim().replaceAll("\\s", ""),

--- a/.test-infra/jenkins/job_LoadTests_CoGBK_Dataflow_V2_Java17.groovy
+++ b/.test-infra/jenkins/job_LoadTests_CoGBK_Dataflow_V2_Java17.groovy
@@ -23,6 +23,8 @@ import PhraseTriggeringPostCommitBuilder
 import CronJobBuilder
 import InfluxDBCredentialsHelper
 
+// TODO(BEAM-14229): remove forceNumInitialBundles once source issue resolved.
+
 def loadTestConfigurations = { mode, isStreaming ->
   [
     [
@@ -47,6 +49,7 @@ def loadTestConfigurations = { mode, isStreaming ->
             "numRecords": 20000000,
             "keySizeBytes": 10,
             "valueSizeBytes": 90,
+            "forceNumInitialBundles": 1,
             "numHotKeys": 1
           }
         """.trim().replaceAll("\\s", ""),
@@ -55,6 +58,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                 "numRecords": 2000000,
                 "keySizeBytes": 10,
                 "valueSizeBytes": 90,
+                "forceNumInitialBundles": 1,
                 "numHotKeys": 1000
               }
             """.trim().replaceAll("\\s", ""),
@@ -86,6 +90,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                     "numRecords": 20000000,
                     "keySizeBytes": 10,
                     "valueSizeBytes": 90,
+                    "forceNumInitialBundles": 1,
                     "numHotKeys": 5
                   }
                 """.trim().replaceAll("\\s", ""),
@@ -94,6 +99,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                             "numRecords": 2000000,
                             "keySizeBytes": 10,
                             "valueSizeBytes": 90,
+                            "forceNumInitialBundles": 1,
                             "numHotKeys": 1000
                           }
                         """.trim().replaceAll("\\s", ""),
@@ -126,6 +132,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                                 "numRecords": 2000000,
                                 "keySizeBytes": 10,
                                 "valueSizeBytes": 90,
+                                "forceNumInitialBundles": 1,
                                 "numHotKeys": 200000
                               }
                             """.trim().replaceAll("\\s", ""),
@@ -134,6 +141,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                                 "numRecords": 2000000,
                                 "keySizeBytes": 10,
                                 "valueSizeBytes": 90,
+                                "forceNumInitialBundles": 1,
                                 "numHotKeys": 1000
                               }
                             """.trim().replaceAll("\\s", ""),
@@ -166,6 +174,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                                 "numRecords": 2000000,
                                 "keySizeBytes": 10,
                                 "valueSizeBytes": 90,
+                                "forceNumInitialBundles": 1,
                                 "numHotKeys": 1000
                               }
                             """.trim().replaceAll("\\s", ""),
@@ -174,6 +183,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                                 "numRecords": 2000000,
                                 "keySizeBytes": 10,
                                 "valueSizeBytes": 90,
+                                "forceNumInitialBundles": 1,
                                 "numHotKeys": 1000
                               }
                             """.trim().replaceAll("\\s", ""),

--- a/.test-infra/jenkins/job_LoadTests_GBK_Dataflow_V2_Java11.groovy
+++ b/.test-infra/jenkins/job_LoadTests_GBK_Dataflow_V2_Java11.groovy
@@ -23,6 +23,8 @@ import PhraseTriggeringPostCommitBuilder
 import CronJobBuilder
 import InfluxDBCredentialsHelper
 
+// TODO(BEAM-14229): remove forceNumInitialBundles once source issue resolved.
+
 def loadTestConfigurations = { mode, isStreaming ->
   [
     [
@@ -46,7 +48,8 @@ def loadTestConfigurations = { mode, isStreaming ->
                                   {
                                     "numRecords": 200000000,
                                     "keySizeBytes": 1,
-                                    "valueSizeBytes": 9
+                                    "valueSizeBytes": 9,
+                                    "forceNumInitialBundles": 1
                                   }
                                 """.trim().replaceAll("\\s", ""),
         fanout                : 1,
@@ -77,7 +80,8 @@ def loadTestConfigurations = { mode, isStreaming ->
                                   {
                                     "numRecords": 20000000,
                                     "keySizeBytes": 10,
-                                    "valueSizeBytes": 90
+                                    "valueSizeBytes": 90,
+                                    "forceNumInitialBundles": 1
                                   }
                                 """.trim().replaceAll("\\s", ""),
         fanout                : 1,
@@ -109,7 +113,8 @@ def loadTestConfigurations = { mode, isStreaming ->
                                   {
                                     "numRecords": 20000,
                                     "keySizeBytes": 10000,
-                                    "valueSizeBytes": 90000
+                                    "valueSizeBytes": 90000,
+                                    "forceNumInitialBundles": 1
                                   }
                                 """.trim().replaceAll("\\s", ""),
         fanout                : 1,
@@ -141,7 +146,8 @@ def loadTestConfigurations = { mode, isStreaming ->
                                   {
                                     "numRecords": 5000000,
                                     "keySizeBytes": 10,
-                                    "valueSizeBytes": 90
+                                    "valueSizeBytes": 90,
+                                    "forceNumInitialBundles": 1
                                   }
                                 """.trim().replaceAll("\\s", ""),
         fanout                : 4,
@@ -172,7 +178,8 @@ def loadTestConfigurations = { mode, isStreaming ->
                                   {
                                     "numRecords": 2500000,
                                     "keySizeBytes": 10,
-                                    "valueSizeBytes": 90
+                                    "valueSizeBytes": 90,
+                                    "forceNumInitialBundles": 1
                                   }
                                 """.trim().replaceAll("\\s", ""),
         fanout                : 8,
@@ -204,6 +211,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                                     "numRecords": 20000000,
                                     "keySizeBytes": 10,
                                     "valueSizeBytes": 90,
+                                    "forceNumInitialBundles": 1,
                                     "numHotKeys": 200,
                                     "hotKeyFraction": 1
                                   }
@@ -237,6 +245,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                                     "numRecords": 20000000,
                                     "keySizeBytes": 10,
                                     "valueSizeBytes": 90,
+                                    "forceNumInitialBundles": 1,
                                     "numHotKeys": 10,
                                     "hotKeyFraction": 1
                                   }

--- a/.test-infra/jenkins/job_LoadTests_GBK_Dataflow_V2_Java17.groovy
+++ b/.test-infra/jenkins/job_LoadTests_GBK_Dataflow_V2_Java17.groovy
@@ -23,6 +23,8 @@ import PhraseTriggeringPostCommitBuilder
 import CronJobBuilder
 import InfluxDBCredentialsHelper
 
+// TODO(BEAM-14229): remove forceNumInitialBundles once source issue resolved.
+
 def loadTestConfigurations = { mode, isStreaming ->
   [
     [
@@ -46,7 +48,8 @@ def loadTestConfigurations = { mode, isStreaming ->
                                   {
                                     "numRecords": 200000000,
                                     "keySizeBytes": 1,
-                                    "valueSizeBytes": 9
+                                    "valueSizeBytes": 9,
+                                    "forceNumInitialBundles": 1
                                   }
                                 """.trim().replaceAll("\\s", ""),
         fanout                : 1,
@@ -77,7 +80,8 @@ def loadTestConfigurations = { mode, isStreaming ->
                                   {
                                     "numRecords": 20000000,
                                     "keySizeBytes": 10,
-                                    "valueSizeBytes": 90
+                                    "valueSizeBytes": 90,
+                                    "forceNumInitialBundles": 1
                                   }
                                 """.trim().replaceAll("\\s", ""),
         fanout                : 1,
@@ -109,7 +113,8 @@ def loadTestConfigurations = { mode, isStreaming ->
                                   {
                                     "numRecords": 20000,
                                     "keySizeBytes": 10000,
-                                    "valueSizeBytes": 90000
+                                    "valueSizeBytes": 90000,
+                                    "forceNumInitialBundles": 1
                                   }
                                 """.trim().replaceAll("\\s", ""),
         fanout                : 1,
@@ -141,7 +146,8 @@ def loadTestConfigurations = { mode, isStreaming ->
                                   {
                                     "numRecords": 5000000,
                                     "keySizeBytes": 10,
-                                    "valueSizeBytes": 90
+                                    "valueSizeBytes": 90,
+                                    "forceNumInitialBundles": 1
                                   }
                                 """.trim().replaceAll("\\s", ""),
         fanout                : 4,
@@ -172,7 +178,8 @@ def loadTestConfigurations = { mode, isStreaming ->
                                   {
                                     "numRecords": 2500000,
                                     "keySizeBytes": 10,
-                                    "valueSizeBytes": 90
+                                    "valueSizeBytes": 90,
+                                    "forceNumInitialBundles": 1
                                   }
                                 """.trim().replaceAll("\\s", ""),
         fanout                : 8,
@@ -204,6 +211,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                                     "numRecords": 20000000,
                                     "keySizeBytes": 10,
                                     "valueSizeBytes": 90,
+                                    "forceNumInitialBundles": 1,
                                     "numHotKeys": 200,
                                     "hotKeyFraction": 1
                                   }
@@ -237,6 +245,7 @@ def loadTestConfigurations = { mode, isStreaming ->
                                     "numRecords": 20000000,
                                     "keySizeBytes": 10,
                                     "valueSizeBytes": 90,
+                                    "forceNumInitialBundles": 1,
                                     "numHotKeys": 10,
                                     "hotKeyFraction": 1
                                   }

--- a/.test-infra/jenkins/job_LoadTests_ParDo_Dataflow_V2_Java11.groovy
+++ b/.test-infra/jenkins/job_LoadTests_ParDo_Dataflow_V2_Java11.groovy
@@ -23,6 +23,8 @@ import PhraseTriggeringPostCommitBuilder
 import CronJobBuilder
 import InfluxDBCredentialsHelper
 
+// TODO(BEAM-14229): remove forceNumInitialBundles once source issue resolved.
+
 def commonLoadTestConfig = { jobType, isStreaming ->
   [
     [
@@ -46,7 +48,8 @@ def commonLoadTestConfig = { jobType, isStreaming ->
                                 {
                                   "numRecords": 20000000,
                                   "keySizeBytes": 10,
-                                  "valueSizeBytes": 90
+                                  "valueSizeBytes": 90,
+                                  "forceNumInitialBundles": 1
                                 }
                               """.trim().replaceAll("\\s", ""),
         iterations          : 10,
@@ -78,7 +81,8 @@ def commonLoadTestConfig = { jobType, isStreaming ->
                                 {
                                   "numRecords": 20000000,
                                   "keySizeBytes": 10,
-                                  "valueSizeBytes": 90
+                                  "valueSizeBytes": 90,
+                                  "forceNumInitialBundles": 1
                                 }
                               """.trim().replaceAll("\\s", ""),
         iterations          : 200,
@@ -111,7 +115,8 @@ def commonLoadTestConfig = { jobType, isStreaming ->
                                 {
                                   "numRecords": 20000000,
                                   "keySizeBytes": 10,
-                                  "valueSizeBytes": 90
+                                  "valueSizeBytes": 90,
+                                  "forceNumInitialBundles": 1
                                 }
                               """.trim().replaceAll("\\s", ""),
         iterations          : 1,
@@ -144,7 +149,8 @@ def commonLoadTestConfig = { jobType, isStreaming ->
                                 {
                                   "numRecords": 20000000,
                                   "keySizeBytes": 10,
-                                  "valueSizeBytes": 90
+                                  "valueSizeBytes": 90,
+                                  "forceNumInitialBundles": 1
                                 }
                               """.trim().replaceAll("\\s", ""),
         iterations          : 1,

--- a/.test-infra/jenkins/job_LoadTests_ParDo_Dataflow_V2_Java17.groovy
+++ b/.test-infra/jenkins/job_LoadTests_ParDo_Dataflow_V2_Java17.groovy
@@ -23,6 +23,8 @@ import PhraseTriggeringPostCommitBuilder
 import CronJobBuilder
 import InfluxDBCredentialsHelper
 
+// TODO(BEAM-14229): remove forceNumInitialBundles once source issue resolved.
+
 def commonLoadTestConfig = { jobType, isStreaming ->
   [
     [
@@ -46,7 +48,8 @@ def commonLoadTestConfig = { jobType, isStreaming ->
                                 {
                                   "numRecords": 20000000,
                                   "keySizeBytes": 10,
-                                  "valueSizeBytes": 90
+                                  "valueSizeBytes": 90,
+                                  "forceNumInitialBundles": 1
                                 }
                               """.trim().replaceAll("\\s", ""),
         iterations          : 10,
@@ -78,7 +81,8 @@ def commonLoadTestConfig = { jobType, isStreaming ->
                                 {
                                   "numRecords": 20000000,
                                   "keySizeBytes": 10,
-                                  "valueSizeBytes": 90
+                                  "valueSizeBytes": 90,
+                                  "forceNumInitialBundles": 1
                                 }
                               """.trim().replaceAll("\\s", ""),
         iterations          : 200,
@@ -111,7 +115,8 @@ def commonLoadTestConfig = { jobType, isStreaming ->
                                 {
                                   "numRecords": 20000000,
                                   "keySizeBytes": 10,
-                                  "valueSizeBytes": 90
+                                  "valueSizeBytes": 90,
+                                  "forceNumInitialBundles": 1
                                 }
                               """.trim().replaceAll("\\s", ""),
         iterations          : 1,
@@ -144,7 +149,8 @@ def commonLoadTestConfig = { jobType, isStreaming ->
                                 {
                                   "numRecords": 20000000,
                                   "keySizeBytes": 10,
-                                  "valueSizeBytes": 90
+                                  "valueSizeBytes": 90,
+                                  "forceNumInitialBundles": 1
                                 }
                               """.trim().replaceAll("\\s", ""),
         iterations          : 1,


### PR DESCRIPTION
…alBundles to 1

This ensures that the number of records being produced by SyntheticUnboundedSource is consistent with what has been specified with numRecords option.

This PR can be reverted when BEAM-14429 is resolved.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
