### PR TITLE
[BEAM-13988] Update mtime to use time.UnixMilli() calls

### DIFF
--- a/sdks/go/pkg/beam/core/graph/mtime/time.go
+++ b/sdks/go/pkg/beam/core/graph/mtime/time.go
@@ -65,8 +65,7 @@ func FromDuration(d time.Duration) Time {
 
 // FromTime returns a milli-second precision timestamp from a time.Time.
 func FromTime(t time.Time) Time {
-	// TODO(BEAM-13988): Replace t.UnixNano() with t.UnixMilli() for Go 1.17 or higher.
-	return Normalize(Time(t.UnixNano() / 1e6))
+	return Normalize(Time(t.UnixMilli()))
 }
 
 // Milliseconds returns the number of milli-seconds since the Unix epoch.
@@ -76,8 +75,7 @@ func (t Time) Milliseconds() int64 {
 
 // ToTime returns the Time represented as a time.Time
 func (t Time) ToTime() time.Time {
-	// TODO(BEAM-13988): Replace with time.UnixMilli(int64(t)).UTC() for Go 1.17 or higher.
-	return time.Unix(0, int64(t)*1e6).UTC()
+	return time.UnixMilli(int64(t)).UTC()
 }
 
 // Add returns the time plus the duration. Input Durations of less than one

--- a/sdks/go/pkg/beam/core/graph/mtime/time_test.go
+++ b/sdks/go/pkg/beam/core/graph/mtime/time_test.go
@@ -244,3 +244,57 @@ func TestToTime(t *testing.T) {
 		})
 	}
 }
+
+func TestMilliseconds(t *testing.T) {
+	tests := []struct {
+		name        string
+		inputMillis int64
+	}{
+		{
+			"Zero",
+			int64(0),
+		},
+		{
+			"End of Global Window",
+			EndOfGlobalWindowTime.Milliseconds(),
+		},
+		{
+			"some number",
+			int64(1000),
+		},
+	}
+	for _, test := range tests {
+		milliTime := FromMilliseconds(test.inputMillis)
+		outputMillis := milliTime.Milliseconds()
+		if got, want := outputMillis, test.inputMillis; got != want {
+			t.Errorf("got %v milliseconds, want %v milliseconds", got, want)
+		}
+	}
+}
+
+func TestFromDuration(t *testing.T) {
+	tests := []struct {
+		name string
+		dur  time.Duration
+	}{
+		{
+			"zero",
+			0 * time.Millisecond,
+		},
+		{
+			"End of Global Window",
+			time.Duration(EndOfGlobalWindowTime),
+		},
+		{
+			"day",
+			24 * time.Hour,
+		},
+	}
+	for _, test := range tests {
+		durTime := FromDuration(test.dur)
+		timeMillis := durTime.Milliseconds()
+		if got, want := timeMillis, test.dur.Milliseconds(); got != want {
+			t.Errorf("got %v milliseconds, want %v milliseconds", got, want)
+		}
+	}
+}


### PR DESCRIPTION
Removes the last manual calculations for millisecond time, routes calls through time.UnixMilli() instead now that the Go SDK is using Go 1.18

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
