### PR TITLE
[BEAM-14006] Update Python katas to 2.38 and fix issue with one test

### DIFF
--- a/learning/katas/python/Examples/section-remote-info.yaml
+++ b/learning/katas/python/Examples/section-remote-info.yaml
@@ -1,2 +1,2 @@
 id: 85647
-update_date: Mon, 09 Mar 2020 14:34:14 UTC
+update_date: Thu, 12 May 2022 13:06:24 UTC

--- a/learning/katas/python/Introduction/Hello Beam/Hello Beam/tests.py
+++ b/learning/katas/python/Introduction/Hello Beam/Hello Beam/tests.py
@@ -20,6 +20,9 @@ from test_helper import failed, passed, get_file_output, test_is_not_empty
 def test_output():
     output = get_file_output()
 
+    # Remove warning line about docker and Python versions
+    output = [x for x in output if not x.startswith("WARNING")]
+
     if len(output) == 1 and 'Hello Beam' in output:
         passed()
     else:

--- a/learning/katas/python/Triggers/Early Triggers/Early Triggers/task-remote-info.yaml
+++ b/learning/katas/python/Triggers/Early Triggers/Early Triggers/task-remote-info.yaml
@@ -1,0 +1,2 @@
+id: 1315717712
+update_date: Thu, 01 Jan 1970 00:00:00 UTC

--- a/learning/katas/python/Triggers/Early Triggers/lesson-remote-info.yaml
+++ b/learning/katas/python/Triggers/Early Triggers/lesson-remote-info.yaml
@@ -1,0 +1,3 @@
+id: 415852098
+update_date: Thu, 01 Jan 1970 00:00:00 UTC
+unit: 0

--- a/learning/katas/python/Triggers/Event Time Triggers/Event Time Triggers/task-remote-info.yaml
+++ b/learning/katas/python/Triggers/Event Time Triggers/Event Time Triggers/task-remote-info.yaml
@@ -1,0 +1,2 @@
+id: 825593025
+update_date: Thu, 01 Jan 1970 00:00:00 UTC

--- a/learning/katas/python/Triggers/Event Time Triggers/lesson-remote-info.yaml
+++ b/learning/katas/python/Triggers/Event Time Triggers/lesson-remote-info.yaml
@@ -1,0 +1,3 @@
+id: 1858884960
+update_date: Thu, 01 Jan 1970 00:00:00 UTC
+unit: 0

--- a/learning/katas/python/Triggers/Window Accumulation Mode/Window Accumulation Mode/task-remote-info.yaml
+++ b/learning/katas/python/Triggers/Window Accumulation Mode/Window Accumulation Mode/task-remote-info.yaml
@@ -1,0 +1,2 @@
+id: 84386334
+update_date: Thu, 01 Jan 1970 00:00:00 UTC

--- a/learning/katas/python/Triggers/Window Accumulation Mode/lesson-remote-info.yaml
+++ b/learning/katas/python/Triggers/Window Accumulation Mode/lesson-remote-info.yaml
@@ -1,0 +1,3 @@
+id: 158109835
+update_date: Thu, 01 Jan 1970 00:00:00 UTC
+unit: 0

--- a/learning/katas/python/Triggers/section-remote-info.yaml
+++ b/learning/katas/python/Triggers/section-remote-info.yaml
@@ -1,0 +1,2 @@
+id: 334072318
+update_date: Thu, 01 Jan 1970 00:00:00 UTC

--- a/learning/katas/python/course-info.yaml
+++ b/learning/katas/python/course-info.yaml
@@ -29,5 +29,5 @@ content:
 - Common Transforms
 - IO
 - Windowing
-- Triggers
 - Examples
+- Triggers

--- a/learning/katas/python/requirements.txt
+++ b/learning/katas/python/requirements.txt
@@ -14,7 +14,7 @@
 #   See the License for the specific language governing permissions and
 #   limitations under the License.
 
-apache-beam==2.36.0
-apache-beam[test]==2.36.0
+apache-beam==2.38.0
+apache-beam[test]==2.38.0
 
-pytz~=2021.3
+pytz~=2022.1


### PR DESCRIPTION
This updates the Python katas to 2.38, and fixes a minor issue with warnings with different Python versions in one of the katas.

This version has already been published to Stepik.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
