### PR TITLE
Minor: Drop dataclasses requirement, we only support python 3.7+

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -205,10 +205,6 @@ if __name__ == '__main__':
         # Avro 1.9.2 for python3 was broken.
         # The issue was fixed in version 1.9.2.1
         'crcmod>=1.7,<2.0',
-        # dataclasses backport for python_version<3.7. No version bound because
-        # this is Python standard since Python 3.7 and each Python version is
-        # compatible with a specific dataclasses version.
-        'dataclasses;python_version<"3.7"',
         'orjson<4.0',
         # Dill doesn't have forwards-compatibility guarantees within minor
         # version. Pickles created with a new version of dill may not unpickle


### PR DESCRIPTION
GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
