### PR TITLE
[BEAM-14469] Allow nil primary returns from TrySplit() in a single-windowed context

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/sdf.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf.go
@@ -665,15 +665,20 @@ func (n *ProcessSizedElementsAndRestrictions) singleWindowSplit(f float64, pWeSt
 		return []*FullValue{}, []*FullValue{}, nil
 	}
 
-	pfv, err := n.newSplitResult(p, n.elm.Windows, pWeState)
-	if err != nil {
-		return nil, nil, err
+	var primaryResult []*FullValue
+	if p != nil {
+		pfv, err := n.newSplitResult(p, n.elm.Windows, pWeState)
+		if err != nil {
+			return nil, nil, err
+		}
+		primaryResult = append(primaryResult, pfv)
 	}
+
 	rfv, err := n.newSplitResult(r, n.elm.Windows, rWeState)
 	if err != nil {
 		return nil, nil, err
 	}
-	return []*FullValue{pfv}, []*FullValue{rfv}, nil
+	return primaryResult, []*FullValue{rfv}, nil
 }
 
 // multiWindowSplit is intended for splitting multi-window elements in


### PR DESCRIPTION
Allow explicit returns of nil primaries from TrySplit() RTracker calls in single-windowed contexts. This allows native streaming IOs to simplify returns in a self-checkpointing contexts to just residuals, removing any extra checks on returned primaries beyond existence. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
