### PR TITLE
[BEAM-14470] Use Generic Registrations in loadtests.

### DIFF
--- a/.test-infra/jenkins/job_LoadTests_SideInput_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_SideInput_Go.groovy
@@ -29,7 +29,7 @@ String now = new Date().format('MMddHHmmss', TimeZone.getTimeZone('UTC'))
 def batchScenarios = {
   [
     [
-      title          : 'SideInput Go Load test: 400mb-1kb-10workers-1window-first-iterable',
+      title          : 'SideInput Go Load test: 10gb-1kb-10workers-1window-first-iterable',
       test           : 'sideinput',
       runner         : CommonTestProperties.Runner.DATAFLOW,
       pipelineOptions: [
@@ -41,7 +41,7 @@ def batchScenarios = {
         influx_namespace     : 'dataflow',
         influx_measurement   : 'go_batch_sideinput_3',
         input_options        : '\'{' +
-        '"num_records": 400000,' +
+        '"num_records": 10000000,' +
         '"key_size": 100,' +
         '"value_size": 900}\'',
         access_percentage: 1,
@@ -52,7 +52,7 @@ def batchScenarios = {
       ]
     ],
     [
-      title          : 'SideInput Go Load test: 400mb-1kb-10workers-1window-iterable',
+      title          : 'SideInput Go Load test: 10gb-1kb-10workers-1window-iterable',
       test           : 'sideinput',
       runner         : CommonTestProperties.Runner.DATAFLOW,
       pipelineOptions: [
@@ -64,7 +64,7 @@ def batchScenarios = {
         influx_namespace     : 'dataflow',
         influx_measurement   : 'go_batch_sideinput_4',
         input_options        : '\'{' +
-        '"num_records": 400000,' +
+        '"num_records": 10000000,' +
         '"key_size": 100,' +
         '"value_size": 900}\'',
         num_workers          : 10,

--- a/.test-infra/metrics/grafana/dashboards/perftests_metrics/SideInput_Load_Tests.json
+++ b/.test-infra/metrics/grafana/dashboards/perftests_metrics/SideInput_Load_Tests.json
@@ -21,7 +21,7 @@
   "links": [],
   "panels": [
     {
-      "content": "The following options should be used by default:\n* key size: 100B\n* value size: 900B\n* number of workers: 10\n* size of the window (if fixed windows are used): 1 second\n\n[Jenkins job definition (Python, Dataflow)](https://github.com/apache/beam/blob/master/.test-infra/jenkins/job_LoadTests_SideInput_Python.groovy) [Jenkins job definition (Go, Flink)](https://github.com/apache/beam/tree/master/.test-infra/jenkins/job_LoadTests_SideInput_Flink_Go.groovy) [Jenkins job definition (Go, Dataflow)](https://github.com/apache/beam/blob/master/.test-infra/jenkins/job_LoadTests_SideInput_Go.groovy)\n\nUntil the issue [BEAM-11427](https://issues.apache.org/jira/browse/BEAM-11427) in Go SDK is resolved, sideinput iteration test have 400MB, instead of 10GB.",
+      "content": "Jenkins job definition (Python, Dataflow)](https://github.com/apache/beam/blob/master/.test-infra/jenkins/job_LoadTests_SideInput_Python.groovy) [Jenkins job definition (Go, Flink)](https://github.com/apache/beam/tree/master/.test-infra/jenkins/job_LoadTests_SideInput_Flink_Go.groovy) [Jenkins job definition (Go, Dataflow)](https://github.com/apache/beam/blob/master/.test-infra/jenkins/job_LoadTests_SideInput_Go.groovy)",
       "datasource": null,
       "gridPos": {
         "h": 8,

--- a/sdks/go/pkg/beam/core/graph/fn.go
+++ b/sdks/go/pkg/beam/core/graph/fn.go
@@ -122,7 +122,6 @@ func NewFn(fn interface{}) (*Fn, error) {
 				}
 				methods[name] = f
 			}
-			return &Fn{Recv: fn, methods: methods, annotations: annotations}, nil
 		}
 		// TODO(lostluck): Consider moving this into the reflectx package.
 		for i := 0; i < val.Type().NumMethod(); i++ {
@@ -132,6 +131,9 @@ func NewFn(fn interface{}) (*Fn, error) {
 			}
 			if m.Name == "String" {
 				continue // skip: harmless
+			}
+			if _, ok := methods[m.Name]; ok {
+				continue // skip : already wrapped
 			}
 
 			// CAVEAT(herohde) 5/22/2017: The type val.Type.Method.Type is not

--- a/sdks/go/pkg/beam/io/synthetic/source.go
+++ b/sdks/go/pkg/beam/io/synthetic/source.go
@@ -27,17 +27,19 @@ import (
 	"encoding/json"
 	"fmt"
 	"math/rand"
-	"reflect"
 	"time"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/sdf"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/io/rtrackers/offsetrange"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/register"
 )
 
 func init() {
-	beam.RegisterType(reflect.TypeOf((*sourceFn)(nil)).Elem())
-	beam.RegisterType(reflect.TypeOf((*SourceConfig)(nil)).Elem())
+	// beam.RegisterType(reflect.TypeOf((*sourceFn)(nil)).Elem())
+	// beam.RegisterType(reflect.TypeOf((*SourceConfig)(nil)).Elem())
+	register.DoFn3x1[*sdf.LockRTracker, SourceConfig, func([]byte, []byte), error]((*sourceFn)(nil))
+	register.Emitter2[[]byte, []byte]()
 }
 
 // Source creates a synthetic source transform that emits randomly

--- a/sdks/go/pkg/beam/io/synthetic/source.go
+++ b/sdks/go/pkg/beam/io/synthetic/source.go
@@ -36,8 +36,6 @@ import (
 )
 
 func init() {
-	// beam.RegisterType(reflect.TypeOf((*sourceFn)(nil)).Elem())
-	// beam.RegisterType(reflect.TypeOf((*SourceConfig)(nil)).Elem())
 	register.DoFn3x1[*sdf.LockRTracker, SourceConfig, func([]byte, []byte), error]((*sourceFn)(nil))
 	register.Emitter2[[]byte, []byte]()
 }

--- a/sdks/go/pkg/beam/io/synthetic/step.go
+++ b/sdks/go/pkg/beam/io/synthetic/step.go
@@ -18,18 +18,19 @@ package synthetic
 import (
 	"fmt"
 	"math/rand"
-	"reflect"
 	"time"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/sdf"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/register"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/io/rtrackers/offsetrange"
 )
 
 func init() {
-	beam.RegisterType(reflect.TypeOf((*stepFn)(nil)).Elem())
-	beam.RegisterType(reflect.TypeOf((*sdfStepFn)(nil)).Elem())
+	register.DoFn3x0[[]byte, []byte, func([]byte, []byte)]((*stepFn)(nil))
+	register.DoFn4x0[*sdf.LockRTracker, []byte, []byte, func([]byte, []byte)]((*sdfStepFn)(nil))
+	register.Emitter2[[]byte, []byte]()
 }
 
 // Step creates a synthetic step transform that receives KV<[]byte, []byte>

--- a/sdks/go/test/load/cogbk/cogbk.go
+++ b/sdks/go/test/load/cogbk/cogbk.go
@@ -18,11 +18,11 @@ package main
 import (
 	"context"
 	"flag"
-	"reflect"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/io/synthetic"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/log"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/register"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/x/beamx"
 	"github.com/apache/beam/sdks/v2/go/test/load"
 )
@@ -43,13 +43,17 @@ var (
 )
 
 func init() {
-	beam.RegisterType(reflect.TypeOf((*ungroupAndReiterateFn)(nil)).Elem())
+	register.DoFn4x0[[]byte, func(*[]byte) bool, func(*[]byte) bool, func([]byte, []byte)]((*ungroupAndReiterateFn)(nil))
+	register.Emitter2[[]byte, []byte]()
+	register.Iter1[[]byte]()
 }
 
 // ungroupAndReiterateFn reiterates given number of times over CoGBK's output.
 type ungroupAndReiterateFn struct {
 	Iterations int
 }
+
+// TODO use re-iterators once supported.
 
 func (fn *ungroupAndReiterateFn) ProcessElement(key []byte, p1values, p2values func(*[]byte) bool, emit func([]byte, []byte)) {
 	var value []byte

--- a/sdks/go/test/load/combine/combine.go
+++ b/sdks/go/test/load/combine/combine.go
@@ -23,6 +23,7 @@ import (
 	"github.com/apache/beam/sdks/v2/go/pkg/beam"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/io/synthetic"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/log"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/register"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/transforms/top"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/x/beamx"
 	"github.com/apache/beam/sdks/v2/go/test/load"
@@ -52,6 +53,12 @@ func parseSyntheticConfig() synthetic.SourceConfig {
 	}
 }
 
+func init() {
+	register.Function2x1(compareLess)
+	register.Function3x0(getElement)
+	register.Emitter2[[]byte, []byte]()
+}
+
 func compareLess(key []byte, value []byte) bool {
 	return bytes.Compare(key, value) < 0
 }
@@ -73,6 +80,7 @@ func main() {
 		pcoll := top.LargestPerKey(s, src, *topCount, compareLess)
 		pcoll = beam.ParDo(s, getElement, pcoll)
 		pcoll = beam.ParDo(s, &load.RuntimeMonitor{}, pcoll)
+		_ = pcoll
 	}
 
 	presult, err := beamx.RunWithMetrics(ctx, p)

--- a/sdks/go/test/load/pardo/pardo.go
+++ b/sdks/go/test/load/pardo/pardo.go
@@ -19,11 +19,11 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"reflect"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/io/synthetic"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/log"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/register"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/x/beamx"
 	"github.com/apache/beam/sdks/v2/go/test/load"
 )
@@ -48,7 +48,8 @@ var (
 )
 
 func init() {
-	beam.RegisterType(reflect.TypeOf((*counterOperationFn)(nil)).Elem())
+	register.DoFn4x0[context.Context, []byte, []byte, func([]byte, []byte)]((*counterOperationFn)(nil))
+	register.Emitter2[[]byte, []byte]()
 }
 
 type counterOperationFn struct {
@@ -57,7 +58,10 @@ type counterOperationFn struct {
 }
 
 func newCounterOperationFn(operations, numCounters int) *counterOperationFn {
-	return &counterOperationFn{operations, numCounters, nil}
+	return &counterOperationFn{
+		Operations:  operations,
+		NumCounters: numCounters,
+	}
 }
 
 func (fn *counterOperationFn) Setup() {

--- a/sdks/go/test/load/sideinput/sideinput.go
+++ b/sdks/go/test/load/sideinput/sideinput.go
@@ -28,7 +28,7 @@ import (
 )
 
 func init() {
-	register.DoFn4x0[[]byte, []byte, func(*[]byte, *[]byte) bool, func([]byte, []byte)]((*doFn)(nil))
+	register.DoFn4x0[[]byte, []byte, func(*[]byte, *[]byte) bool, func([]byte, []byte)]((*iterSideInputFn)(nil))
 	register.Emitter2[[]byte, []byte]()
 	register.Iter2[[]byte, []byte]()
 	register.Function2x0(impToKV)
@@ -60,11 +60,11 @@ func impToKV(imp []byte, emit func([]byte, []byte)) {
 	emit(imp, imp)
 }
 
-type doFn struct {
+type iterSideInputFn struct {
 	ElementsToAccess int64
 }
 
-func (fn *doFn) ProcessElement(_, _ []byte, values func(*[]byte, *[]byte) bool, emit func([]byte, []byte)) {
+func (fn *iterSideInputFn) ProcessElement(_, _ []byte, values func(*[]byte, *[]byte) bool, emit func([]byte, []byte)) {
 	var key, value []byte
 	var i int64
 	for values(&key, &value) {
@@ -93,7 +93,7 @@ func main() {
 
 	useSide := beam.ParDo(
 		s,
-		&doFn{ElementsToAccess: elementsToAccess},
+		&iterSideInputFn{ElementsToAccess: elementsToAccess},
 		monitored,
 		beam.SideInput{Input: src})
 

--- a/sdks/go/test/load/sideinput/sideinput.go
+++ b/sdks/go/test/load/sideinput/sideinput.go
@@ -18,17 +18,20 @@ package main
 import (
 	"context"
 	"flag"
-	"reflect"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/io/synthetic"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/log"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/register"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/x/beamx"
 	"github.com/apache/beam/sdks/v2/go/test/load"
 )
 
 func init() {
-	beam.RegisterDoFn(reflect.TypeOf((*doFn)(nil)))
+	register.DoFn4x0[[]byte, []byte, func(*[]byte, *[]byte) bool, func([]byte, []byte)]((*doFn)(nil))
+	register.Emitter2[[]byte, []byte]()
+	register.Iter2[[]byte, []byte]()
+	register.Function2x0(impToKV)
 }
 
 var (
@@ -51,11 +54,17 @@ func parseSyntheticConfig() synthetic.SourceConfig {
 	}
 }
 
+// impToKV just turns an impulse signal into a KV instead of
+// adding a single value input version of RuntimeMonitor
+func impToKV(imp []byte, emit func([]byte, []byte)) {
+	emit(imp, imp)
+}
+
 type doFn struct {
 	ElementsToAccess int64
 }
 
-func (fn *doFn) ProcessElement(_ []byte, values func(*[]byte, *[]byte) bool, emit func([]byte, []byte)) {
+func (fn *doFn) ProcessElement(_, _ []byte, values func(*[]byte, *[]byte) bool, emit func([]byte, []byte)) {
 	var key, value []byte
 	var i int64
 	for values(&key, &value) {
@@ -74,18 +83,21 @@ func main() {
 	p, s := beam.NewPipelineWithRoot()
 
 	syntheticConfig := parseSyntheticConfig()
-	elementsToAccess := syntheticConfig.NumElements * int64(*accessPercentage/100)
+	elementsToAccess := syntheticConfig.NumElements * int64(float64(*accessPercentage)/float64(100))
 
 	src := synthetic.SourceSingle(s, syntheticConfig)
-	src = beam.ParDo(s, &load.RuntimeMonitor{}, src)
 
-	src = beam.ParDo(
+	imp := beam.Impulse(s)
+	impKV := beam.ParDo(s, impToKV, imp)
+	monitored := beam.ParDo(s, &load.RuntimeMonitor{}, impKV)
+
+	useSide := beam.ParDo(
 		s,
 		&doFn{ElementsToAccess: elementsToAccess},
-		beam.Impulse(s),
+		monitored,
 		beam.SideInput{Input: src})
 
-	beam.ParDo(s, &load.RuntimeMonitor{}, src)
+	beam.ParDo(s, &load.RuntimeMonitor{}, useSide)
 
 	presult, err := beamx.RunWithMetrics(ctx, p)
 	if err != nil {

--- a/sdks/go/test/load/util.go
+++ b/sdks/go/test/load/util.go
@@ -141,7 +141,7 @@ func PublishMetrics(results metrics.QueryResults) {
 		log.Print("No metrics returned.")
 		return
 	}
-	if options.validate() && len(ress) > 0 {
+	if options.validate() {
 		publishMetricstoInfluxDB(options, ress)
 	} else {
 		log.Print("Missing InfluxDB options. Metrics will not be published to InfluxDB")

--- a/sdks/go/test/load/util.go
+++ b/sdks/go/test/load/util.go
@@ -24,12 +24,12 @@ import (
 	"log"
 	"net/http"
 	"os"
-	"reflect"
 	"strings"
 	"time"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/metrics"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/register"
 )
 
 const (
@@ -60,7 +60,8 @@ var (
 )
 
 func init() {
-	beam.RegisterType(reflect.TypeOf((*RuntimeMonitor)(nil)).Elem())
+	register.DoFn3x0[[]byte, []byte, func([]byte, []byte)]((*RuntimeMonitor)(nil))
+	register.Emitter2[[]byte, []byte]()
 }
 
 // RuntimeMonitor is a DoFn to record processing time in the pipeline.
@@ -132,10 +133,16 @@ func newLoadTestResult(value float64) loadTestResult {
 // PublishMetrics calculates the runtime and sends the result to InfluxDB database.
 func PublishMetrics(results metrics.QueryResults) {
 	options := newInfluxDBOptions()
-	if options.validate() {
-		if res := toLoadTestResults(results); len(res) > 0 {
-			publishMetricstoInfluxDB(options, toLoadTestResults(results))
-		}
+	ress := toLoadTestResults(results)
+	for _, res := range ress {
+		log.Printf("%s %v", res.metric, time.Duration(float64(time.Second)*res.value))
+	}
+	if len(ress) == 0 {
+		log.Print("No metrics returned.")
+		return
+	}
+	if options.validate() && len(ress) > 0 {
+		publishMetricstoInfluxDB(options, ress)
 	} else {
 		log.Print("Missing InfluxDB options. Metrics will not be published to InfluxDB")
 	}
@@ -212,8 +219,8 @@ func publishMetricstoInfluxDB(options *influxDBOptions, results []loadTestResult
 	if resp.StatusCode != 204 {
 		jsonData := make(map[string]string)
 		json.Unmarshal(body, &jsonData)
-		log.Print(fmt.Errorf("Failed to publish metrics to InfluxDB. Received status code %v "+
-			"with an error message: %v", resp.StatusCode, jsonData["error"]))
+		log.Printf("Failed to publish metrics to InfluxDB. Received status code %v "+
+			"with an error message: %v", resp.StatusCode, jsonData["error"])
 	}
 }
 


### PR DESCRIPTION
This PR uses the new generic registrations to optimize the performance of the load tests WRT reflective invocation. This includes DoFns, Functions, Iterators, and Emitters.

This required adding registrations for the synthetic SDF source, the RuntimeMonitor, and any test specific DoFns or functions.

In many cases, performance has improved! But not quite to Java levels. That JIT is black magic, though Go might be able to get closer with some effort.

In addition:
* Always processes the metrics, and print out the measurement in human readable formats, even if we aren't uploading.
* Allows for a "mixed mode" method approach for the generic method invocation wrappers.
  * Previous behavior would cause a break for SDFs and similar, since the methods were unavailable. This allows for a fallback using standard reflective wrappers for the additional low frequency methods.
* Fixes the SideInput load tests: they weren't using the same load as the python tests, nor were they measuring from the correct point (after initializing the side input data).

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
