### PR TITLE
[BEAM-14467] Fix bug where run_pytest.sh does not elevate errors raised in no_xdist tests

### DIFF
--- a/sdks/python/scripts/run_pytest.sh
+++ b/sdks/python/scripts/run_pytest.sh
@@ -43,15 +43,15 @@ pytest -o junit_suite_name=${envname}_no_xdist \
   --junitxml=pytest_${envname}_no_xdist.xml -m 'no_xdist' ${pytest_args} --pyargs ${posargs}
 status2=$?
 
-# Exit with error if no tests were run (status code 5).
+# Exit with error if no tests were run in either suite (status code 5).
 if [[ $status1 == 5 && $status2 == 5 ]]; then
   exit $status1
 fi
 
 # Exit with error if one of the statuses has an error that's not 5.
-if [[ $status1 && $status1 != 5 ]]; then
+if [[ $status1 != 0 && $status1 != 5 ]]; then
   exit $status1
 fi
-if [[ $status2 && $status2 != 5 ]]; then
+if [[ $status2 != 0 && $status2 != 5 ]]; then
   exit $status2
 fi


### PR DESCRIPTION
Verified this in https://github.com/apache/beam/pull/17685

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
