### PR TITLE
[BEAM-14486] Document pubsubio & fix its behavior.

### DIFF
--- a/sdks/go/pkg/beam/io/pubsubio/pubsubio.go
+++ b/sdks/go/pkg/beam/io/pubsubio/pubsubio.go
@@ -13,11 +13,16 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-// Package pubsubio provides access to PubSub on Dataflow streaming.
-// Experimental.
+// Package pubsubio provides access to Pub/Sub on Dataflow streaming.
+//
+// This implementation only functions on the Dataflow runner.
+//
+// See https://cloud.google.com/dataflow/docs/concepts/streaming-with-cloud-pubsub
+// for details on using Pub/Sub with Dataflow.
 package pubsubio
 
 import (
+	"fmt"
 	"reflect"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam"
@@ -25,6 +30,7 @@ import (
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/util/protox"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/util/reflectx"
 	pipepb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/pipeline_v1"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/register"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/util/pubsubx"
 	pb "google.golang.org/genproto/googleapis/pubsub/v1"
 	"google.golang.org/protobuf/proto"
@@ -36,8 +42,9 @@ var (
 )
 
 func init() {
-	beam.RegisterType(reflect.TypeOf((*pb.PubsubMessage)(nil)).Elem())
-	beam.RegisterFunction(unmarshalMessageFn)
+	register.Function2x1(unmarshalMessageFn)
+	register.Function2x1(marshalMessageFn)
+	register.Function2x0(wrapInMessage)
 }
 
 // ReadOptions represents options for reading from PubSub.
@@ -73,15 +80,38 @@ func Read(s beam.Scope, project, topic string, opts *ReadOptions) beam.PCollecti
 	return out[0]
 }
 
-func unmarshalMessageFn(raw []byte) (*pb.PubsubMessage, error) {
+func unmarshalMessageFn(raw []byte, emit func(*pb.PubsubMessage)) error {
 	var msg pb.PubsubMessage
 	if err := proto.Unmarshal(raw, &msg); err != nil {
-		return nil, err
+		return err
 	}
-	return &msg, nil
+	emit(&msg)
+	return nil
 }
 
-// Write writes PubSubMessages or bytes to the given pubsub topic.
+func wrapInMessage(raw []byte, emit func(*pb.PubsubMessage)) {
+	emit(&pb.PubsubMessage{
+		Data: raw,
+	})
+}
+
+func marshalMessageFn(in *pb.PubsubMessage, emit func([]byte)) error {
+	out, err := proto.Marshal(in)
+	if err != nil {
+		return err
+	}
+	emit(out)
+	return nil
+}
+
+var pubSubMessageT = reflect.TypeOf((*pb.PubsubMessage)(nil))
+
+// Write writes PubSubMessages or []bytes to the given pubsub topic.
+// Panics if the input pcollection type is not one of those two types.
+//
+// When given []bytes, they are first wrapped in PubSubMessages.
+//
+// Note: Doesn't function in batch pipelines.
 func Write(s beam.Scope, project, topic string, col beam.PCollection) {
 	s = s.Scope("pubsubio.Write")
 
@@ -90,8 +120,12 @@ func Write(s beam.Scope, project, topic string, col beam.PCollection) {
 	}
 
 	out := col
-	if col.Type().Type() != reflectx.ByteSlice {
-		out = beam.ParDo(s, proto.Marshal, col)
+	if col.Type().Type() == reflectx.ByteSlice {
+		out = beam.ParDo(s, wrapInMessage, col)
 	}
-	beam.External(s, writeURN, protox.MustEncode(payload), []beam.PCollection{out}, nil, false)
+	if out.Type().Type() != pubSubMessageT {
+		panic(fmt.Sprintf("pubsubio.Write only accepts PCollections of %v and %v, received %v", pubSubMessageT, reflectx.ByteSlice, col.Type().Type()))
+	}
+	marshaled := beam.ParDo(s, marshalMessageFn, out)
+	beam.External(s, writeURN, protox.MustEncode(payload), []beam.PCollection{marshaled}, nil, false)
 }

--- a/sdks/go/pkg/beam/io/pubsubio/pubsubio.go
+++ b/sdks/go/pkg/beam/io/pubsubio/pubsubio.go
@@ -45,6 +45,9 @@ func init() {
 	register.Function2x1(unmarshalMessageFn)
 	register.Function2x1(marshalMessageFn)
 	register.Function2x0(wrapInMessage)
+	register.Function2x0(wrapInMessage)
+	register.Emitter1[[]byte]()
+	register.Emitter1[*pb.PubsubMessage]()
 }
 
 // ReadOptions represents options for reading from PubSub.


### PR DESCRIPTION
Removes experimental note from the Go SDK's PubSubio and make it clear that it only works with Dataflow as currently implemented. If that changes, so too can the documentation.

Fix a behavioral difference with the python implementation, where raw bytes messages weren't wrapped in messages before writing. They are now wrapped. Explicitly panic for other PCollection inputs.

Since this only works on dataflow as implemented, these changes have been manually tested with a modified wordcap that sends data through a PubSub loop (publishing to the same topic being read from). Each pipeline was then successfully drained.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
