### PR TITLE
[BEAM-14484] Step back unexpected primary handling to warnings

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/datasource_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasource_test.go
@@ -611,6 +611,12 @@ func (n *TestSplittableUnit) Split(f float64) ([]*FullValue, []*FullValue, error
 	return []*FullValue{{Elm: n.elm}}, []*FullValue{{Elm: n.elm}}, nil
 }
 
+// Checkpoint routes through the Split() function to satisfy the interface.
+func (n *TestSplittableUnit) Checkpoint() ([]*FullValue, error) {
+	_, r, err := n.Split(0.0)
+	return r, err
+}
+
 // GetProgress always returns 0, to keep tests consistent.
 func (n *TestSplittableUnit) GetProgress() float64 {
 	return 0

--- a/sdks/go/pkg/beam/core/runtime/exec/sdf.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf.go
@@ -658,10 +658,17 @@ func (n *ProcessSizedElementsAndRestrictions) Split(f float64) ([]*FullValue, []
 // ProcessContinuation. If the split occurs and the primary restriction is marked as done
 // my the RTracker, the Checkpoint fails as this is a potential data-loss case.
 func (n *ProcessSizedElementsAndRestrictions) Checkpoint() ([]*FullValue, error) {
+	addContext := func(err error) error {
+		return errors.WithContext(err, "Attempting checkpoint in ProcessSizedElementsAndRestrictions")
+	}
 	_, r, err := n.Split(0.0)
 
+	if err != nil {
+		return nil, addContext(err)
+	}
+
 	if !n.rt.IsDone() {
-		return nil, addContext(errors.New("Primary restriction is not done, data may be lost as a result"))
+		return nil, addContext(errors.Errorf("Primary restriction %#v is not done. Check that the RTracker's TrySplit() at fraction 0.0 returns a completed primary restriction", n.rt))
 	}
 
 	return r, nil

--- a/sdks/go/pkg/beam/core/sdf/sdf.go
+++ b/sdks/go/pkg/beam/core/sdf/sdf.go
@@ -73,9 +73,11 @@ type RTracker interface {
 	// reason), then this function returns nil as the residual.
 	//
 	// If the split fraction is 0 (e.g. a self-checkpointing split) TrySplit() should return
-	// a restriction that represents no remaining work. The remaining RTracker should be marked as done
-	// (and return true when IsDone() is called) after that split. This will ensure that there
-	// is not data loss, which would result in the pipeline failing during the checkpoint.
+	// a primary restriction that represents no remaining work, and the residual should
+	// contain all remaining work. The RTracker should be marked as done
+	// (and return true when IsDone() is called) after that split.
+	// This will ensure that there is no data loss, which would result in 
+	// the pipeline failing during the checkpoint.
 	//
 	// If an error is returned, some catastrophic failure occurred and the entire bundle will fail.
 	TrySplit(fraction float64) (primary, residual interface{}, err error)

--- a/sdks/go/pkg/beam/core/sdf/sdf.go
+++ b/sdks/go/pkg/beam/core/sdf/sdf.go
@@ -72,7 +72,7 @@ type RTracker interface {
 	// the only split point is the end of the restriction, or the split failed for some recoverable
 	// reason), then this function returns nil as the residual.
 	//
-	// If the split fraction is 0 (e.g. a self-checkpointing split) TrySplit() should return either
+	// If the split fraction is 0 (e.g. a self-checkpointing split) TrySplit() should return
 	// a restriction that represents no remaining work. The remaining RTracker should be marked as done
 	// (and return true when IsDone() is called) after that split. This will ensure that there
 	// is not data loss, which would result in the pipeline failing during the checkpoint.
@@ -90,7 +90,8 @@ type RTracker interface {
 	// correctly processed all work in a restriction before finishing. If this method still returns
 	// false after processing, then GetError is expected to return a non-nil error.
 	//
-	// When called immediately following a checkpointing TrySplit() call, this should return true.
+	// When called immediately following a checkpointing TrySplit() call (with value 0.0), this
+	// should return true.
 	IsDone() bool
 
 	// GetRestriction returns the restriction this tracker is tracking, or nil if the restriction

--- a/sdks/go/pkg/beam/core/sdf/sdf.go
+++ b/sdks/go/pkg/beam/core/sdf/sdf.go
@@ -73,8 +73,9 @@ type RTracker interface {
 	// reason), then this function returns nil as the residual.
 	//
 	// If the split fraction is 0 (e.g. a self-checkpointing split) TrySplit() should return either
-	// a nil primary or a restriction that represents no remaining work. This will ensure that there
-	// is not data loss.
+	// a restriction that represents no remaining work. The remaining RTracker should be marked as done
+	// (and return true when IsDone() is called) after that split. This will ensure that there
+	// is not data loss, which would result in the pipeline failing during the checkpoint.
 	//
 	// If an error is returned, some catastrophic failure occurred and the entire bundle will fail.
 	TrySplit(fraction float64) (primary, residual interface{}, err error)
@@ -88,6 +89,8 @@ type RTracker interface {
 	// claimed. This method is called by the SDK Harness to validate that a splittable DoFn has
 	// correctly processed all work in a restriction before finishing. If this method still returns
 	// false after processing, then GetError is expected to return a non-nil error.
+	//
+	// When called immediately following a checkpointing TrySplit() call, this should return true.
 	IsDone() bool
 
 	// GetRestriction returns the restriction this tracker is tracking, or nil if the restriction

--- a/sdks/go/pkg/beam/core/sdf/sdf.go
+++ b/sdks/go/pkg/beam/core/sdf/sdf.go
@@ -73,8 +73,8 @@ type RTracker interface {
 	// reason), then this function returns nil as the residual.
 	//
 	// If the split fraction is 0 (e.g. a self-checkpointing split) TrySplit() should return either
-	// a nil primary or an RTracker that is both bounded and has size 0. This ensures that there is
-	// no data that is lost by not being rescheduled for execution later.
+	// a nil primary or a restriction that represents no remaining work. This will ensure that there
+	// is not data loss.
 	//
 	// If an error is returned, some catastrophic failure occurred and the entire bundle will fail.
 	TrySplit(fraction float64) (primary, residual interface{}, err error)

--- a/sdks/go/pkg/beam/core/sdf/sdf.go
+++ b/sdks/go/pkg/beam/core/sdf/sdf.go
@@ -76,7 +76,7 @@ type RTracker interface {
 	// a primary restriction that represents no remaining work, and the residual should
 	// contain all remaining work. The RTracker should be marked as done
 	// (and return true when IsDone() is called) after that split.
-	// This will ensure that there is no data loss, which would result in 
+	// This will ensure that there is no data loss, which would result in
 	// the pipeline failing during the checkpoint.
 	//
 	// If an error is returned, some catastrophic failure occurred and the entire bundle will fail.


### PR DESCRIPTION
Nested type in primary root was the pure restriction and not the restriction tracker, leading to recurring type assertion failures that were consistently throwing warnings. Change set-up to warn when primaries are returned and continue instead, as restrictions have no guarantees as far as being able to check size or boundedness.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
