### PR TITLE
[BEAM-9324] Fix incompatibility of direct runner with cython

### DIFF
--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -78,9 +78,7 @@ try:
 except ImportError:
 
   class FakeCython(object):
-    @staticmethod
-    def cast(type, value):
-      return value
+    compiled = False
 
   globals()['cython'] = FakeCython()
 
@@ -91,6 +89,20 @@ _LOGGER = logging.getLogger(__name__)
 
 SdfSplitResultsPrimary = Tuple['DoOperation', 'SplitResultPrimary']
 SdfSplitResultsResidual = Tuple['DoOperation', 'SplitResultResidual']
+
+
+def _cast_to_operation(value):
+  if cython.compiled:
+    return cython.cast(Operation, value)
+  else:
+    return value
+
+
+def _cast_to_receiver(value):
+  if cython.compiled:
+    return cython.cast(Receiver, value)
+  else:
+    return value
 
 
 class ConsumerSet(Receiver):
@@ -307,7 +319,7 @@ class GeneralPurposeConsumerSet(ConsumerSet):
     self.update_counters_start(windowed_value)
 
     for consumer in self.element_consumers:
-      cython.cast(Operation, consumer).process(windowed_value)
+      _cast_to_operation(consumer).process(windowed_value)
 
     # TODO: Do this branching when contstructing ConsumerSet
     if self.has_batch_consumers:
@@ -324,10 +336,10 @@ class GeneralPurposeConsumerSet(ConsumerSet):
       for wv in windowed_batch.as_windowed_values(
           self.producer_batch_converter.explode_batch):
         for consumer in self.element_consumers:
-          cython.cast(Operation, consumer).process(wv)
+          _cast_to_operation(consumer).process(wv)
 
     for consumer in self.passthrough_batch_consumers:
-      cython.cast(Operation, consumer).process_batch(windowed_batch)
+      _cast_to_operation(consumer).process_batch(windowed_batch)
 
     for (consumer_batch_converter,
          consumers) in self.other_batch_consumers.items():
@@ -342,7 +354,7 @@ class GeneralPurposeConsumerSet(ConsumerSet):
             "This is very inefficient, consider re-structuring your pipeline "
             "or adding a DoFn to directly convert between these types.",
             InefficientExecutionWarning)
-        cython.cast(Operation, consumer).process_batch(
+        _cast_to_operation(consumer).process_batch(
             windowed_batch.with_values(
                 consumer_batch_converter.produce_batch(
                     self.producer_batch_converter.explode_batch(
@@ -358,13 +370,13 @@ class GeneralPurposeConsumerSet(ConsumerSet):
       for windowed_batch in WindowedBatch.from_windowed_values(
           self._batched_elements, produce_fn=batch_converter.produce_batch):
         for consumer in consumers:
-          cython.cast(Operation, consumer).process_batch(windowed_batch)
+          _cast_to_operation(consumer).process_batch(windowed_batch)
 
     for consumer in self.passthrough_batch_consumers:
       for windowed_batch in WindowedBatch.from_windowed_values(
           self._batched_elements,
           produce_fn=self.producer_batch_converter.produce_batch):
-        cython.cast(Operation, consumer).process_batch(windowed_batch)
+        _cast_to_operation(consumer).process_batch(windowed_batch)
 
     self._batched_elements = []
 
@@ -495,7 +507,7 @@ class Operation(object):
 
     """Finish operation."""
     for receiver in self.receivers:
-      cython.cast(Receiver, receiver).flush()
+      _cast_to_receiver(receiver).flush()
 
   def teardown(self):
     # type: () -> None
@@ -511,7 +523,7 @@ class Operation(object):
 
   def output(self, windowed_value, output_index=0):
     # type: (WindowedValue, int) -> None
-    cython.cast(Receiver, self.receivers[output_index]).receive(windowed_value)
+    _cast_to_receiver(self.receivers[output_index]).receive(windowed_value)
 
   def add_receiver(self, operation, output_index=0):
     # type: (Operation, int) -> None

--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -91,6 +91,7 @@ SdfSplitResultsPrimary = Tuple['DoOperation', 'SplitResultPrimary']
 SdfSplitResultsResidual = Tuple['DoOperation', 'SplitResultResidual']
 
 
+# TODO(BEAM-9324) Remove these workarounds once upgraded to Cython 3
 def _cast_to_operation(value):
   if cython.compiled:
     return cython.cast(Operation, value)
@@ -98,6 +99,7 @@ def _cast_to_operation(value):
     return value
 
 
+# TODO(BEAM-9324) Remove these workarounds once upgraded to Cython 3
 def _cast_to_receiver(value):
   if cython.compiled:
     return cython.cast(Receiver, value)


### PR DESCRIPTION
This is due to `Cython.Shadow.cast(Receiver, value)` attempting to run Receiver(value) (probably very old code in Python 2 age where "old" class did not have `__call__`)

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
