### PR TITLE
[BEAM-14449] Support cluster provisioning when using Flink on Dataproc

### DIFF
--- a/runners/flink/flink_runner.gradle
+++ b/runners/flink/flink_runner.gradle
@@ -185,6 +185,7 @@ dependencies {
   implementation project(path: ":model:job-management", configuration: "shadow")
   implementation project(":sdks:java:fn-execution")
   implementation library.java.jackson_databind
+  runtimeOnly library.java.jackson_jaxb_annotations
   implementation "org.apache.flink:flink-annotations:$flink_version"
   examplesJavaIntegrationTest project(project.path)
   examplesJavaIntegrationTest project(":examples:java")

--- a/sdks/python/apache_beam/runners/interactive/dataproc/dataproc_cluster_manager.py
+++ b/sdks/python/apache_beam/runners/interactive/dataproc/dataproc_cluster_manager.py
@@ -136,6 +136,11 @@ class DataprocClusterManager:
                     'https://www.googleapis.com/auth/cloud-platform'
                 ]
             },
+            'master_config': {
+                # There must be 1 and only 1 instance of master.
+                'num_instances': 1
+            },
+            'worker_config': {},
             'endpoint_config': {
                 'enable_http_port_access': True
             }
@@ -145,6 +150,21 @@ class DataprocClusterManager:
                 '.', '_')
         }
     }
+
+    # Additional gce_cluster_config.
+    gce_cluster_config = cluster['config']['gce_cluster_config']
+    if self.cluster_metadata.subnetwork:
+      gce_cluster_config['subnetwork_uri'] = self.cluster_metadata.subnetwork
+
+    # Additional InstanceGroupConfig for master and workers.
+    master_config = cluster['config']['master_config']
+    worker_config = cluster['config']['worker_config']
+    if self.cluster_metadata.num_workers:
+      worker_config['num_instances'] = self.cluster_metadata.num_workers
+    if self.cluster_metadata.machine_type:
+      master_config['machine_type_uri'] = self.cluster_metadata.machine_type
+      worker_config['machine_type_uri'] = self.cluster_metadata.machine_type
+
     self.create_cluster(cluster)
 
   def cleanup(self) -> None:

--- a/sdks/python/apache_beam/runners/interactive/dataproc/types.py
+++ b/sdks/python/apache_beam/runners/interactive/dataproc/types.py
@@ -32,15 +32,44 @@ def _default_cluster_name():
 
 @dataclass
 class ClusterMetadata:
+  """Metadata of a provisioned worker cluster that executes Beam pipelines.
+
+  Apache Beam supports running Beam pipelines on different runners provisioned
+  in different setups based on the runner and pipeline options associated with
+  each pipeline. To provide similar portability features, Interactive Beam
+  automatically extracts such ClusterMetadata information from pipeline options
+  of a pipeline in the REPL context and provision suitable clusters to execute
+  the pipeline. The lifecyle of the clusters is managed by Interactive Beam
+  and the user doesn not need to interact with it.
+
+  It's not recommended to build this ClusterMetadata from raw values nor use it
+  to interact with the cluster management logic directly.
+
+  Interactive Beam now supports::
+
+    1. Runner: FlinkRunner; Setup: on Google Cloud with Flink on Dataproc.
+
+  """
   project_id: Optional[str] = None
   region: Optional[str] = None
   cluster_name: Optional[str] = field(default_factory=_default_cluster_name)
+  # From WorkerOptions.
+  subnetwork: Optional[str] = None
+  num_workers: Optional[int] = None
+  machine_type: Optional[int] = None
+
   # Derivative fields do not affect hash or comparison.
   master_url: Optional[str] = None
   dashboard: Optional[str] = None
 
   def __key(self):
-    return (self.project_id, self.region, self.cluster_name)
+    return (
+        self.project_id,
+        self.region,
+        self.cluster_name,
+        self.subnetwork,
+        self.num_workers,
+        self.machine_type)
 
   def __hash__(self):
     return hash(self.__key())
@@ -49,6 +78,9 @@ class ClusterMetadata:
     if isinstance(other, ClusterMetadata):
       return self.__key() == other.__key()
     return False
+
+  def rename(self):
+    self.cluster_name = _default_cluster_name()
 
 
 ClusterIdentifier = Union[str, Pipeline, ClusterMetadata]

--- a/sdks/python/apache_beam/runners/interactive/dataproc/types.py
+++ b/sdks/python/apache_beam/runners/interactive/dataproc/types.py
@@ -26,7 +26,7 @@ from typing import Union
 from apache_beam.pipeline import Pipeline
 
 
-def _default_cluster_name():
+def _generate_unique_cluster_name():
   return f'interactive-beam-{uuid.uuid4().hex}'
 
 
@@ -52,7 +52,8 @@ class ClusterMetadata:
   """
   project_id: Optional[str] = None
   region: Optional[str] = None
-  cluster_name: Optional[str] = field(default_factory=_default_cluster_name)
+  cluster_name: Optional[str] = field(
+      default_factory=_generate_unique_cluster_name)
   # From WorkerOptions.
   subnetwork: Optional[str] = None
   num_workers: Optional[int] = None
@@ -79,8 +80,8 @@ class ClusterMetadata:
       return self.__key() == other.__key()
     return False
 
-  def rename(self):
-    self.cluster_name = _default_cluster_name()
+  def reset_name(self):
+    self.cluster_name = _generate_unique_cluster_name()
 
 
 ClusterIdentifier = Union[str, Pipeline, ClusterMetadata]

--- a/sdks/python/apache_beam/runners/interactive/interactive_beam.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_beam.py
@@ -379,6 +379,12 @@ class Clusters:
       # manager without creating a new one.
       dcm = ib.clusters.create(pipeline)
 
+  To provision the cluster, use WorkerOptions. Supported configurations are::
+
+    1. subnetwork
+    2. num_workers
+    3. machine_type
+
   To configure a pipeline to run on an existing FlinkRunner deployed elsewhere,
   set the flink_master explicitly so no cluster will be created/reused.
 
@@ -418,15 +424,19 @@ class Clusters:
       raise ValueError(
           'Unknown cluster identifier: %s. Cannot create or reuse'
           'a Dataproc cluster.')
-    elif cluster_metadata.region == 'global':
-      # The global region is unsupported as it will be eventually deprecated.
-      raise ValueError('Clusters in the global region are not supported.')
-    elif not cluster_metadata.region:
+    if not cluster_metadata.region:
       _LOGGER.info(
           'No region information was detected, defaulting Dataproc cluster '
           'region to: us-central1.')
       cluster_metadata.region = 'us-central1'
+    elif cluster_metadata.region == 'global':
+      # The global region is unsupported as it will be eventually deprecated.
+      raise ValueError('Clusters in the global region are not supported.')
     # else use the provided region.
+    if cluster_metadata.num_workers and cluster_metadata.num_workers < 2:
+      _LOGGER.info(
+          'At least 2 workers are required for a cluster, defaulting to 2.')
+      cluster_metadata.num_workers = 2
     known_dcm = self.dataproc_cluster_managers.get(cluster_metadata, None)
     if known_dcm:
       return known_dcm
@@ -475,7 +485,9 @@ class Clusters:
             'options is deprecated since First stable release. References to '
             '<pipeline>.options will not be supported',
             category=DeprecationWarning)
-        p.options.view_as(FlinkRunnerOptions).flink_master = '[auto]'
+        p_flink_options = p.options.view_as(FlinkRunnerOptions)
+        p_flink_options.flink_master = '[auto]'
+        p_flink_options.flink_version = None
         # Only cleans up when there is no pipeline using the cluster.
         if not dcm.pipelines:
           self._cleanup(dcm)
@@ -558,6 +570,19 @@ class Clusters:
         meta = cluster_identifier
         if meta in self.dataproc_cluster_managers:
           meta = self.dataproc_cluster_managers[meta].cluster_metadata
+        elif (meta and self.default_cluster_metadata and
+              meta.cluster_name == self.default_cluster_metadata.cluster_name):
+          _LOGGER.warning(
+              'Cannot change the configuration of the running cluster %s. '
+              'Existing is %s, desired is %s.',
+              self.default_cluster_metadata.cluster_name,
+              self.default_cluster_metadata,
+              meta)
+          meta.rename()
+          _LOGGER.warning(
+              'To avoid conflict, issuing a new cluster name %s '
+              'for a new cluster.',
+              meta.cluster_name)
       else:
         raise TypeError(
             'A cluster_identifier should be Optional[Union[str, '

--- a/sdks/python/apache_beam/runners/interactive/interactive_beam.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_beam.py
@@ -402,6 +402,9 @@ class Clusters:
   # https://cloud.google.com/dataproc/docs/concepts/versioning/dataproc-release-2.0
   DATAPROC_FLINK_VERSION = '1.12'
 
+  # The minimum worker number to create a Dataproc cluster.
+  DATAPROC_MINIMUM_WORKER_NUM = 2
+
   # TODO(BEAM-14142): Fix the Dataproc image version after a released image
   # contains all missing dependencies for Flink to run.
   # DATAPROC_IMAGE_VERSION = '2.0.XX-debian10'
@@ -433,10 +436,13 @@ class Clusters:
       # The global region is unsupported as it will be eventually deprecated.
       raise ValueError('Clusters in the global region are not supported.')
     # else use the provided region.
-    if cluster_metadata.num_workers and cluster_metadata.num_workers < 2:
+    if (cluster_metadata.num_workers and
+        cluster_metadata.num_workers < self.DATAPROC_MINIMUM_WORKER_NUM):
       _LOGGER.info(
-          'At least 2 workers are required for a cluster, defaulting to 2.')
-      cluster_metadata.num_workers = 2
+          'At least %s workers are required for a cluster, defaulting to %s.',
+          self.DATAPROC_MINIMUM_WORKER_NUM,
+          self.DATAPROC_MINIMUM_WORKER_NUM)
+      cluster_metadata.num_workers = self.DATAPROC_MINIMUM_WORKER_NUM
     known_dcm = self.dataproc_cluster_managers.get(cluster_metadata, None)
     if known_dcm:
       return known_dcm
@@ -578,7 +584,7 @@ class Clusters:
               self.default_cluster_metadata.cluster_name,
               self.default_cluster_metadata,
               meta)
-          meta.rename()
+          meta.reset_name()
           _LOGGER.warning(
               'To avoid conflict, issuing a new cluster name %s '
               'for a new cluster.',

--- a/sdks/python/apache_beam/runners/interactive/interactive_beam_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_beam_test.py
@@ -563,6 +563,12 @@ class InteractiveBeamClustersTest(unittest.TestCase):
     meta_list = self.clusters.describe(cid_meta)
     self.assertEqual([known_meta, known_meta2], meta_list)
 
+  def test_default_value_for_invalid_worker_number(self):
+    meta = ClusterMetadata(project_id='test-project', num_workers=1)
+    self.clusters.create(meta)
+
+    self.assertEqual(meta.num_workers, 2)
+
 
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
- Added support of provisioning cluster for Flink on Dataproc.
- Fixed the jackson Module provider not a subtype issue when
running Beam pipelines on EMRs by explicitly declaring the jaxb dependency
in flink_runner build file as a runtimeOnly dependency.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
