### PR TITLE
[BEAM-14481] Remove unnecessary context

### DIFF
--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -191,19 +191,18 @@ class DataInputOperation(RunnerIOOperation):
     self.started = False
 
   def setup(self):
-    with self.scoped_start_state:
-      super().setup()
-      # We must do this manually as we don't have a spec or spec.output_coders.
-      self.receivers = [
-          operations.ConsumerSet.create(
-              self.counter_factory,
-              self.name_context.step_name,
-              0,
-              self.consumer,
-              self.windowed_coder,
-              self.get_output_batch_converter(),
-              self._get_runtime_performance_hints())
-      ]
+    super().setup()
+    # We must do this manually as we don't have a spec or spec.output_coders.
+    self.receivers = [
+        operations.ConsumerSet.create(
+            self.counter_factory,
+            self.name_context.step_name,
+            0,
+            self.consumer,
+            self.windowed_coder,
+            self.get_output_batch_converter(),
+            self._get_runtime_performance_hints())
+    ]
 
   def start(self):
     # type: () -> None


### PR DESCRIPTION
This `self.scoped_start_state` context is unecessary. The previous logic did not create the `ConsumerSet` in the context, and the `super().setup()` call already applies the context itself: https://github.com/apache/beam/blob/d9436c41b3235a08bf8da693a562599b08039bf8/sdks/python/apache_beam/runners/worker/operations.py#L421-L429

Unfortunately I don't quite understand the failure mode, so I'm not sure how to add a test that verifies the fix. For now I have just tested this change internally and found that it fixed the affected pipeline.

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
