### PR TITLE
[BEAM-11106] small nits to truncate sdf exec unit

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/sdf.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf.go
@@ -310,6 +310,11 @@ func (n *TruncateSizedRestriction) StartBundle(ctx context.Context, id string, d
 func (n *TruncateSizedRestriction) ProcessElement(ctx context.Context, elm *FullValue, values ...ReStream) error {
 	mainElm := elm.Elm.(*FullValue)
 	inp := mainElm.Elm
+	// For the main element, the way we fill it out depends on whether the input element
+	// is a KV or single-element. Single-elements might have been lifted out of
+	// their FullValue if they were decoded, so we need to have a case for that.
+	// TODO(BEAM-9798): Optimize this so it's decided in exec/translate.go
+	// instead of checking per-element.
 	if e, ok := mainElm.Elm.(*FullValue); ok {
 		mainElm = e
 		inp = e

--- a/sdks/go/pkg/beam/core/runtime/exec/sdf.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf.go
@@ -316,7 +316,7 @@ func (n *TruncateSizedRestriction) ProcessElement(ctx context.Context, elm *Full
 		// do not propagate discarded restrictions.
 		return nil
 	}
-	size := n.sizeInv.Invoke(elm.Elm.(*FullValue), newRest)
+	size := n.sizeInv.Invoke(mainElm, newRest)
 
 	output := &FullValue{}
 	output.Timestamp = elm.Timestamp

--- a/sdks/go/pkg/beam/core/runtime/exec/sdf.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf.go
@@ -309,6 +309,11 @@ func (n *TruncateSizedRestriction) StartBundle(ctx context.Context, id string, d
 //    }
 func (n *TruncateSizedRestriction) ProcessElement(ctx context.Context, elm *FullValue, values ...ReStream) error {
 	mainElm := elm.Elm.(*FullValue)
+	inp := mainElm.Elm
+	if e, ok := mainElm.Elm.(*FullValue); ok {
+		mainElm = e
+		inp = e
+	}
 	rest := elm.Elm.(*FullValue).Elm2.(*FullValue).Elm
 	rt := n.ctInv.Invoke(rest)
 	newRest := n.truncateInv.Invoke(rt, mainElm)
@@ -321,7 +326,7 @@ func (n *TruncateSizedRestriction) ProcessElement(ctx context.Context, elm *Full
 	output := &FullValue{}
 	output.Timestamp = elm.Timestamp
 	output.Windows = elm.Windows
-	output.Elm = &FullValue{Elm: mainElm.Elm, Elm2: &FullValue{Elm: newRest, Elm2: elm.Elm.(*FullValue).Elm2.(*FullValue).Elm2}}
+	output.Elm = &FullValue{Elm: inp, Elm2: &FullValue{Elm: newRest, Elm2: elm.Elm.(*FullValue).Elm2.(*FullValue).Elm2}}
 	output.Elm2 = size
 
 	if err := n.Out.ProcessElement(ctx, output, values...); err != nil {

--- a/sdks/go/pkg/beam/core/runtime/exec/sdf.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf.go
@@ -308,7 +308,7 @@ func (n *TruncateSizedRestriction) StartBundle(ctx context.Context, id string, d
 //     Timestamps
 //    }
 func (n *TruncateSizedRestriction) ProcessElement(ctx context.Context, elm *FullValue, values ...ReStream) error {
-	mainElm := elm.Elm.(*FullValue).Elm.(*FullValue)
+	mainElm := elm.Elm.(*FullValue)
 	rest := elm.Elm.(*FullValue).Elm2.(*FullValue).Elm
 	rt := n.ctInv.Invoke(rest)
 	newRest := n.truncateInv.Invoke(rt, mainElm)
@@ -316,11 +316,12 @@ func (n *TruncateSizedRestriction) ProcessElement(ctx context.Context, elm *Full
 		// do not propagate discarded restrictions.
 		return nil
 	}
-	size := n.sizeInv.Invoke(mainElm, newRest)
+	size := n.sizeInv.Invoke(elm.Elm.(*FullValue), newRest)
+
 	output := &FullValue{}
 	output.Timestamp = elm.Timestamp
 	output.Windows = elm.Windows
-	output.Elm = &FullValue{Elm: mainElm, Elm2: &FullValue{Elm: newRest, Elm2: elm.Elm.(*FullValue).Elm2.(*FullValue).Elm2}}
+	output.Elm = &FullValue{Elm: mainElm.Elm, Elm2: &FullValue{Elm: newRest, Elm2: elm.Elm.(*FullValue).Elm2.(*FullValue).Elm2}}
 	output.Elm2 = size
 
 	if err := n.Out.ProcessElement(ctx, output, values...); err != nil {

--- a/sdks/go/pkg/beam/core/runtime/exec/sdf_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf_test.go
@@ -575,7 +575,10 @@ func TestSdfNodes(t *testing.T) {
 				fn:   dfn,
 				in: FullValue{
 					Elm: &FullValue{
-						Elm: 1,
+						Elm: &FullValue{
+							Elm:  1,
+							Elm2: nil,
+						},
 						Elm2: &FullValue{
 							Elm:  &VetRestriction{ID: "Sdf"},
 							Elm2: nil,
@@ -588,7 +591,10 @@ func TestSdfNodes(t *testing.T) {
 				want: []FullValue{
 					{
 						Elm: &FullValue{
-							Elm: 1,
+							Elm: &FullValue{
+								Elm:  1,
+								Elm2: nil,
+							},
 							Elm2: &FullValue{
 								Elm:  &VetRestriction{ID: "Sdf", CreateTracker: true, TruncateRest: true, RestSize: true, Val: 1},
 								Elm2: nil,

--- a/sdks/go/pkg/beam/core/runtime/exec/sdf_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf_test.go
@@ -575,10 +575,7 @@ func TestSdfNodes(t *testing.T) {
 				fn:   dfn,
 				in: FullValue{
 					Elm: &FullValue{
-						Elm: &FullValue{
-							Elm:  1,
-							Elm2: nil,
-						},
+						Elm: 1,
 						Elm2: &FullValue{
 							Elm:  &VetRestriction{ID: "Sdf"},
 							Elm2: nil,
@@ -591,10 +588,7 @@ func TestSdfNodes(t *testing.T) {
 				want: []FullValue{
 					{
 						Elm: &FullValue{
-							Elm: &FullValue{
-								Elm:  1,
-								Elm2: nil,
-							},
+							Elm: 1,
 							Elm2: &FullValue{
 								Elm:  &VetRestriction{ID: "Sdf", CreateTracker: true, TruncateRest: true, RestSize: true, Val: 1},
 								Elm2: nil,

--- a/sdks/go/pkg/beam/core/runtime/graphx/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate.go
@@ -68,7 +68,7 @@ const (
 
 	URNRequiresSplittableDoFn     = "beam:requirement:pardo:splittable_dofn:v1"
 	URNRequiresBundleFinalization = "beam:requirement:pardo:finalization:v1"
-	URNTruncate                   = "beam:transform:sdf_truncate_sized_restrictions_v1"
+	URNTruncate                   = "beam:transform:sdf_truncate_sized_restrictions:v1"
 
 	// Deprecated: Determine worker binary based on GoWorkerBinary Role instead.
 	URNArtifactGoWorker = "beam:artifact:type:go_worker_binary:v1"
@@ -87,6 +87,7 @@ func goCapabilities() []string {
 	capabilities := []string{
 		URNLegacyProgressReporting,
 		URNMultiCore,
+		URNTruncate,
 		// TOOD(BEAM-9614): Make this versioned.
 		"beam:version:sdk_base:go",
 	}


### PR DESCRIPTION
Small nits to truncate exec unit. Earlier we were extracting the main input from FullValue. This extraction is not required because the element can be of any type and not FullValue. Having a `[]byte` in process element gave me the error that the extracting value is []uint8 and not FullValue. This PR fixes that.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
