### PR TITLE
[BEAM-14481] Make ScopedState explicitly not re-entrant

### DIFF
--- a/sdks/python/apache_beam/runners/dataflow/internal/names.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/names.py
@@ -36,10 +36,10 @@ SERIALIZED_SOURCE_KEY = 'serialized_source'
 
 # Update this version to the next version whenever there is a change that will
 # require changes to legacy Dataflow worker execution environment.
-BEAM_CONTAINER_VERSION = 'beam-master-20220512'
+BEAM_CONTAINER_VERSION = 'beam-master-20220526'
 # Update this version to the next version whenever there is a change that
 # requires changes to SDK harness container or SDK harness launcher.
-BEAM_FNAPI_CONTAINER_VERSION = 'beam-master-20220512'
+BEAM_FNAPI_CONTAINER_VERSION = 'beam-master-20220526'
 
 DATAFLOW_CONTAINER_IMAGE_REPOSITORY = 'gcr.io/cloud-dataflow/v1beta3'
 

--- a/sdks/python/apache_beam/runners/dataflow/internal/names.py
+++ b/sdks/python/apache_beam/runners/dataflow/internal/names.py
@@ -36,10 +36,10 @@ SERIALIZED_SOURCE_KEY = 'serialized_source'
 
 # Update this version to the next version whenever there is a change that will
 # require changes to legacy Dataflow worker execution environment.
-BEAM_CONTAINER_VERSION = 'beam-master-20220526'
+BEAM_CONTAINER_VERSION = 'beam-master-20220531'
 # Update this version to the next version whenever there is a change that
 # requires changes to SDK harness container or SDK harness launcher.
-BEAM_FNAPI_CONTAINER_VERSION = 'beam-master-20220526'
+BEAM_FNAPI_CONTAINER_VERSION = 'beam-master-20220531'
 
 DATAFLOW_CONTAINER_IMAGE_REPOSITORY = 'gcr.io/cloud-dataflow/v1beta3'
 

--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -1227,7 +1227,6 @@ class PGBKCVOperation(Operation):
 
   def setup(self):
     # type: () -> None
-    _LOGGER.debug('Setup called for %s', self)
     super(PGBKCVOperation, self).setup()
     with self.scoped_start_state:
       self.combine_fn.setup()

--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -660,8 +660,8 @@ class Operation(object):
 
 class ReadOperation(Operation):
   def start(self):
+    super(ReadOperation, self).start()
     with self.scoped_start_state:
-      super(ReadOperation, self).start()
       range_tracker = self.spec.source.source.get_range_tracker(
           self.spec.source.start_position, self.spec.source.stop_position)
       for value in self.spec.source.source.read(range_tracker):
@@ -830,9 +830,8 @@ class DoOperation(Operation):
 
   def setup(self):
     # type: () -> None
+    super(DoOperation, self).setup()
     with self.scoped_start_state:
-      super(DoOperation, self).setup()
-
       # See fn_data in dataflow_runner.py
       fn, args, kwargs, tags_and_types, window_fn = (
           pickler.loads(self.spec.serialized_fn))
@@ -883,8 +882,8 @@ class DoOperation(Operation):
 
   def start(self):
     # type: () -> None
+    super(DoOperation, self).start()
     with self.scoped_start_state:
-      super(DoOperation, self).start()
       self.dofn_runner.start()
 
   def get_batching_preference(self):
@@ -1109,9 +1108,9 @@ class CombineOperation(Operation):
 
   def setup(self):
     # type: () -> None
+    super(CombineOperation, self).setup()
     with self.scoped_start_state:
       _LOGGER.debug('Setup called for %s', self)
-      super(CombineOperation, self).setup()
       self.phased_combine_fn.combine_fn.setup()
 
   def process(self, o):
@@ -1228,9 +1227,9 @@ class PGBKCVOperation(Operation):
 
   def setup(self):
     # type: () -> None
+    _LOGGER.debug('Setup called for %s', self)
+    super(PGBKCVOperation, self).setup()
     with self.scoped_start_state:
-      _LOGGER.debug('Setup called for %s', self)
-      super(PGBKCVOperation, self).setup()
       self.combine_fn.setup()
 
   def process(self, wkv):

--- a/sdks/python/apache_beam/runners/worker/statesampler_slow.py
+++ b/sdks/python/apache_beam/runners/worker/statesampler_slow.py
@@ -95,6 +95,7 @@ class ScopedState(object):
     self.counter = counter
     self.nsecs = 0
     self.metrics_container = metrics_container
+    self._entered = False
 
   def sampled_seconds(self):
     # type: () -> float
@@ -108,7 +109,12 @@ class ScopedState(object):
     return "ScopedState[%s, %s]" % (self.name, self.nsecs)
 
   def __enter__(self):
+    assert not self._entered, (
+        f"Attempted to re-enter {self!r}",
+        "which is unnecessary and unsupported")
+    self._entered = True
     self.state_sampler._enter_state(self)
 
   def __exit__(self, exc_type, exc_value, traceback):
     self.state_sampler._exit_state()
+    self._entered = False


### PR DESCRIPTION
This PR makes both `ScopedState` implementations raise an `AssertionError` if re-entered. This is necessary because the "fast" implementation ends up with an inconsistent state when re-entered. In practice it should never be necessary to re-enter, so we make this explicitly fail in order to catch future improper usage.

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
