### PR TITLE
Fix NonType error when importing google.api_core fails

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_test.py
@@ -858,19 +858,19 @@ class BigQueryStreamingInsertsErrorHandling(unittest.TestCase):
   # to determine error types and messages to try for retriables.
   @parameterized.expand([
       param(
-          exception_type=exceptions.Forbidden,
+          exception_type=exceptions.Forbidden if exceptions else None,
           error_reason='rateLimitExceeded'),
       param(
-          exception_type=exceptions.DeadlineExceeded,
+          exception_type=exceptions.DeadlineExceeded if exceptions else None,
           error_reason='somereason'),
       param(
-          exception_type=exceptions.ServiceUnavailable,
+          exception_type=exceptions.ServiceUnavailable if exceptions else None,
           error_reason='backendError'),
       param(
-          exception_type=exceptions.InternalServerError,
+          exception_type=exceptions.InternalServerError if exceptions else None,
           error_reason='internalError'),
       param(
-          exception_type=exceptions.InternalServerError,
+          exception_type=exceptions.InternalServerError if exceptions else None,
           error_reason='backendError'),
   ])
   @mock.patch('time.sleep')
@@ -934,7 +934,7 @@ class BigQueryStreamingInsertsErrorHandling(unittest.TestCase):
           exception_type=ConnectionError,
           error_message='some py connection error'),
       param(
-          exception_type=exceptions.BadGateway,
+          exception_type=exceptions.BadGateway if exceptions else None,
           error_message='some badgateway error'),
   ])
   @mock.patch('time.sleep')
@@ -980,28 +980,31 @@ class BigQueryStreamingInsertsErrorHandling(unittest.TestCase):
           exception_type=retry.PermanentException,
           error_args=('nonretriable', )),
       param(
-          exception_type=exceptions.BadRequest,
+          exception_type=exceptions.BadRequest if exceptions else None,
           error_args=(
               'forbidden morbidden', [{
                   'reason': 'nonretriablereason'
               }])),
       param(
-          exception_type=exceptions.BadRequest,
+          exception_type=exceptions.BadRequest if exceptions else None,
           error_args=('BAD REQUEST!', [{
               'reason': 'nonretriablereason'
           }])),
       param(
-          exception_type=exceptions.MethodNotAllowed,
+          exception_type=exceptions.MethodNotAllowed if exceptions else None,
           error_args=(
               'method not allowed!', [{
                   'reason': 'nonretriablereason'
               }])),
       param(
-          exception_type=exceptions.MethodNotAllowed,
+          exception_type=exceptions.MethodNotAllowed if exceptions else None,
           error_args=('method not allowed!', 'args')),
-      param(exception_type=exceptions.Unknown, error_args=('unknown!', 'args')),
       param(
-          exception_type=exceptions.Aborted, error_args=('abortet!', 'abort')),
+          exception_type=exceptions.Unknown if exceptions else None,
+          error_args=('unknown!', 'args')),
+      param(
+          exception_type=exceptions.Aborted if exceptions else None,
+          error_args=('abortet!', 'abort')),
   ])
   @mock.patch('time.sleep')
   @mock.patch('google.cloud.bigquery.Client.insert_rows_json')
@@ -1041,28 +1044,31 @@ class BigQueryStreamingInsertsErrorHandling(unittest.TestCase):
           exception_type=retry.PermanentException,
           error_args=('nonretriable', )),
       param(
-          exception_type=exceptions.BadRequest,
+          exception_type=exceptions.BadRequest if exceptions else None,
           error_args=(
               'forbidden morbidden', [{
                   'reason': 'nonretriablereason'
               }])),
       param(
-          exception_type=exceptions.BadRequest,
+          exception_type=exceptions.BadRequest if exceptions else None,
           error_args=('BAD REQUEST!', [{
               'reason': 'nonretriablereason'
           }])),
       param(
-          exception_type=exceptions.MethodNotAllowed,
+          exception_type=exceptions.MethodNotAllowed if exceptions else None,
           error_args=(
               'method not allowed!', [{
                   'reason': 'nonretriablereason'
               }])),
       param(
-          exception_type=exceptions.MethodNotAllowed,
+          exception_type=exceptions.MethodNotAllowed if exceptions else None,
           error_args=('method not allowed!', 'args')),
-      param(exception_type=exceptions.Unknown, error_args=('unknown!', 'args')),
       param(
-          exception_type=exceptions.Aborted, error_args=('abortet!', 'abort')),
+          exception_type=exceptions.Unknown if exceptions else None,
+          error_args=('unknown!', 'args')),
+      param(
+          exception_type=exceptions.Aborted if exceptions else None,
+          error_args=('abortet!', 'abort')),
       param(
           exception_type=requests.exceptions.ConnectionError,
           error_args=('some connection error', )),
@@ -1073,7 +1079,7 @@ class BigQueryStreamingInsertsErrorHandling(unittest.TestCase):
           exception_type=ConnectionError,
           error_args=('some py connection error', )),
       param(
-          exception_type=exceptions.BadGateway,
+          exception_type=exceptions.BadGateway if exceptions else None,
           error_args=('some badgateway error', )),
   ])
   @mock.patch('time.sleep')


### PR DESCRIPTION
skipIf doesn't work for parameterized arguments since it's executed first.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
