### PR TITLE
[BEAM-14536] Handle 0.0 splits in offsetrange restriction

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/sdf.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf.go
@@ -678,10 +678,6 @@ func (n *ProcessSizedElementsAndRestrictions) Checkpoint() ([]*FullValue, error)
 		return nil, addContext(err)
 	}
 
-	if !n.rt.IsDone() {
-		return nil, addContext(errors.Errorf("Primary restriction %#v is not done. Check that the RTracker's TrySplit() at fraction 0.0 returns a completed primary restriction", n.rt))
-	}
-
 	return r, nil
 }
 

--- a/sdks/go/pkg/beam/core/runtime/exec/sdf.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf.go
@@ -678,6 +678,10 @@ func (n *ProcessSizedElementsAndRestrictions) Checkpoint() ([]*FullValue, error)
 		return nil, addContext(err)
 	}
 
+	if !n.rt.IsDone() {
+		return nil, addContext(errors.Errorf("Primary restriction %#v is not done. Check that the RTracker's TrySplit() at fraction 0.0 returns a completed primary restriction", n.rt))
+	}
+
 	return r, nil
 }
 

--- a/sdks/go/pkg/beam/core/runtime/exec/sdf_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf_test.go
@@ -1204,7 +1204,6 @@ func TestAsSplittableUnit(t *testing.T) {
 			fn            *graph.DoFn
 			in            FullValue
 			finishPrimary bool
-			expErr        bool
 			wantResiduals []*FullValue
 		}{
 			{
@@ -1223,7 +1222,6 @@ func TestAsSplittableUnit(t *testing.T) {
 					Windows:   testWindows,
 				},
 				finishPrimary: true,
-				expErr:        false,
 				wantResiduals: []*FullValue{{
 					Elm: &FullValue{
 						Elm: 1,
@@ -1236,25 +1234,6 @@ func TestAsSplittableUnit(t *testing.T) {
 					Timestamp: testTimestamp,
 					Windows:   testWindows,
 				}},
-			},
-			{
-				name: "unfinished primary",
-				fn:   dfn,
-				in: FullValue{
-					Elm: &FullValue{
-						Elm: 1,
-						Elm2: &FullValue{
-							Elm:  &VetRestriction{ID: "Sdf"},
-							Elm2: false,
-						},
-					},
-					Elm2:      1.0,
-					Timestamp: testTimestamp,
-					Windows:   testWindows,
-				},
-				finishPrimary: false,
-				expErr:        true,
-				wantResiduals: []*FullValue{},
 			},
 		}
 		for _, test := range tests {
@@ -1276,20 +1255,12 @@ func TestAsSplittableUnit(t *testing.T) {
 					t.Fatalf("ProcessSizedElementsAndRestrictions.Up() failed: %v", err)
 				}
 				gotResiduals, err := su.Checkpoint()
-				if test.expErr {
-					if err == nil {
-						t.Errorf("SplittableUnit.Checkpoint() succeeded when it should have failed")
-					}
-					if len(gotResiduals) != 0 {
-						t.Errorf("SplittableUnit.Checkpoint() got residuals %v, want none", gotResiduals)
-					}
-				} else {
-					if err != nil {
-						t.Fatalf("SplittableUnit.Checkpoint() returned error, got %v", err)
-					}
-					if diff := cmp.Diff(gotResiduals, test.wantResiduals); diff != "" {
-						t.Errorf("SplittableUnit.Checkpoint() has incorrect residual (-got, +want)\n%v", diff)
-					}
+
+				if err != nil {
+					t.Fatalf("SplittableUnit.Checkpoint() returned error, got %v", err)
+				}
+				if diff := cmp.Diff(gotResiduals, test.wantResiduals); diff != "" {
+					t.Errorf("SplittableUnit.Checkpoint() has incorrect residual (-got, +want)\n%v", diff)
 				}
 			})
 		}

--- a/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange.go
+++ b/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange.go
@@ -196,6 +196,9 @@ func (tracker *Tracker) TrySplit(fraction float64) (primary, residual interface{
 	if splitPt >= tracker.rest.End {
 		return tracker.rest, nil, nil
 	}
+	if splitPt < tracker.rest.Start {
+		splitPt = tracker.rest.Start
+	}
 	residual = Restriction{splitPt, tracker.rest.End}
 	tracker.rest.End = splitPt
 	return tracker.rest, residual, nil
@@ -208,9 +211,11 @@ func (tracker *Tracker) GetProgress() (done, remaining float64) {
 	return
 }
 
-// IsDone returns true if the most recent claimed element is past the end of the restriction.
+// IsDone returns true if the most recent claimed element is past the end of the restriction
+// or if the restriction represents no work to be done (aka the start of the restriction is
+// greater than or equal to the end).
 func (tracker *Tracker) IsDone() bool {
-	return tracker.err == nil && tracker.claimed >= tracker.rest.End
+	return tracker.err == nil && (tracker.claimed >= tracker.rest.End || tracker.rest.Start >= tracker.rest.End)
 }
 
 // GetRestriction returns a copy of the tracker's underlying offsetrange.Restriction.

--- a/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange.go
+++ b/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange.go
@@ -210,11 +210,9 @@ func (tracker *Tracker) GetProgress() (done, remaining float64) {
 	return
 }
 
-// IsDone returns true if the most recent claimed element is past the end of the restriction
-// or if the restriction represents no work to be done (aka the start of the restriction is
-// greater than or equal to the end).
+// IsDone returns true if the most recent claimed element is at or past the end of the restriction
 func (tracker *Tracker) IsDone() bool {
-	return tracker.err == nil && (tracker.claimed >= tracker.rest.End || tracker.rest.Start >= tracker.rest.End)
+	return tracker.err == nil && (tracker.claimed+1) >= tracker.rest.End
 }
 
 // GetRestriction returns a copy of the tracker's underlying offsetrange.Restriction.

--- a/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange.go
+++ b/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange.go
@@ -192,12 +192,9 @@ func (tracker *Tracker) TrySplit(fraction float64) (primary, residual interface{
 	}
 
 	// Use Ceil to always round up from float split point.
-	splitPt := tracker.claimed + int64(math.Ceil(fraction*float64(tracker.rest.End-tracker.claimed)))
+	splitPt := tracker.claimed + int64(math.Max(math.Ceil(fraction*float64(tracker.rest.End-tracker.claimed)), 1))
 	if splitPt >= tracker.rest.End {
 		return tracker.rest, nil, nil
-	}
-	if splitPt < tracker.rest.Start {
-		splitPt = tracker.rest.Start
 	}
 	residual = Restriction{splitPt, tracker.rest.End}
 	tracker.rest.End = splitPt

--- a/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange.go
+++ b/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange.go
@@ -192,6 +192,8 @@ func (tracker *Tracker) TrySplit(fraction float64) (primary, residual interface{
 	}
 
 	// Use Ceil to always round up from float split point.
+	// Use Max to make sure the split point is greater than the current claimed work since
+	// claimed work belongs to the primary.
 	splitPt := tracker.claimed + int64(math.Max(math.Ceil(fraction*float64(tracker.rest.End-tracker.claimed)), 1))
 	if splitPt >= tracker.rest.End {
 		return tracker.rest, nil, nil

--- a/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange_test.go
+++ b/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange_test.go
@@ -299,3 +299,72 @@ func TestTracker_TrySplit(t *testing.T) {
 		})
 	}
 }
+
+// TestTracker_TrySplit_WithoutClaiming tests that TrySplit follows its contract
+// when no TryClaim calls have been made, meaning that
+// splits don't lose any elements, split fractions are clamped to 0 or 1, and
+// that TrySplit always splits at the nearest integer greater than the given
+// fraction.
+func TestTracker_TrySplit_WithoutClaiming(t *testing.T) {
+	tests := []struct {
+		rest     Restriction
+		claimed  int64
+		fraction float64
+		// Index where we want the split to happen. This will be the end
+		// (exclusive) of the primary and first element of the residual.
+		splitPt int64
+	}{
+		{
+			rest:     Restriction{Start: 0, End: 1},
+			fraction: 0.5,
+			splitPt:  0,
+		},
+		{
+			rest:     Restriction{Start: 0, End: 1},
+			fraction: 0.0,
+			splitPt:  0,
+		},
+		{
+			rest:     Restriction{Start: 0, End: 5},
+			fraction: 0.5,
+			splitPt:  2,
+		},
+		{
+			rest:     Restriction{Start: 5, End: 10},
+			fraction: 0.5,
+			splitPt:  7,
+		},
+		{
+			rest:     Restriction{Start: 5, End: 10},
+			fraction: -0.5,
+			splitPt:  5,
+		},
+		{
+			rest:     Restriction{Start: 5, End: 10},
+			fraction: 1.5,
+			splitPt:  10,
+		},
+	}
+	for _, test := range tests {
+		test := test
+		t.Run(fmt.Sprintf("(split at %v of [%v, %v])",
+			test.fraction, test.rest.Start, test.rest.End), func(t *testing.T) {
+			rt := NewTracker(test.rest)
+			gotP, gotR, err := rt.TrySplit(test.fraction)
+			if err != nil {
+				t.Fatalf("tracker failed on split: %v", err)
+			}
+			var wantP interface{} = Restriction{Start: test.rest.Start, End: test.splitPt}
+			var wantR interface{} = Restriction{Start: test.splitPt, End: test.rest.End}
+			if test.splitPt == test.rest.End {
+				wantR = nil // When residuals are empty we should get nil.
+			}
+			if !cmp.Equal(gotP, wantP) {
+				t.Errorf("split got incorrect primary: got: %v, want: %v", gotP, wantP)
+			}
+			if !cmp.Equal(gotR, wantR) {
+				t.Errorf("split got incorrect residual: got: %v, want: %v", gotR, wantR)
+			}
+		})
+	}
+}

--- a/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange_test.go
+++ b/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange_test.go
@@ -263,7 +263,7 @@ func TestTracker_TrySplit(t *testing.T) {
 			rest:     Restriction{Start: 0, End: 10},
 			claimed:  5,
 			fraction: -0.5,
-			splitPt:  5,
+			splitPt:  6,
 		},
 		{
 			rest:     Restriction{Start: 0, End: 10},


### PR DESCRIPTION
Right now, if you try to call TrySplit on an offsetrange restriction with a fraction of 0.0 and without first claiming work, it sets the primary restriction to {Start, Start-1}. This causes newSplitResult to panic - https://github.com/apache/beam/blob/ff39fcb5229b15140e41a61bd09f7d590730e93a/sdks/go/pkg/beam/core/runtime/exec/sdf.go#L859

This fixes the issue by never allowing End to be set less than Start. That in turn creates a possible issue with the IsDone function (since the restriction should be considered done, but it won't be until claimed reaches End), which this PR handles as well.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
