### PR TITLE
[BEAM-14534] Allow users to compress values being shuffled in dataflow

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/ShuffleCompressor.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/ShuffleCompressor.java
@@ -1,0 +1,48 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow;
+
+import java.nio.ByteBuffer;
+import org.apache.beam.runners.dataflow.util.RandomAccessData;
+
+public interface ShuffleCompressor {
+  interface Factory {
+    ShuffleCompressor create();
+  }
+
+  /**
+   * Compress data "in-place". `data` contains the bytes to compress starting at `start` and `len`
+   * bytes long. After compression, the compressed data should be in `data` starting at `start`.
+   *
+   * <p>When compress returns `data` MUST be set to the position 1 byte after the last byte written.
+   *
+   * @param data The buffer to read data from and compress into.
+   * @param start The starting position of the data to compress.
+   * @param len The number of bytes to compress.
+   */
+  void compress(RandomAccessData data, int start, int len);
+
+  /**
+   * Decompress `input`.
+   *
+   * @param input The data to decompress. This buffer is guaranteed to always be a heap-backed
+   *     buffer.
+   * @return A ByteBuffer containing the decompressed data.
+   */
+  ByteBuffer decompress(ByteBuffer input);
+}

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/ShuffleCompressor.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/ShuffleCompressor.java
@@ -22,7 +22,7 @@ import org.apache.beam.runners.dataflow.util.RandomAccessData;
 
 public interface ShuffleCompressor {
   interface Factory {
-    ShuffleCompressor create();
+    ShuffleCompressor create(String datasetId);
   }
 
   /**

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/ShuffleCompressor.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/ShuffleCompressor.java
@@ -20,10 +20,11 @@ package org.apache.beam.runners.dataflow;
 import java.io.Closeable;
 import java.nio.ByteBuffer;
 import org.apache.beam.runners.dataflow.util.RandomAccessData;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 public interface ShuffleCompressor extends Closeable {
   interface Factory {
-    ShuffleCompressor create(String datasetId);
+    @Nullable ShuffleCompressor create(String datasetId);
   }
 
   /**

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/ShuffleCompressor.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/ShuffleCompressor.java
@@ -17,10 +17,11 @@
  */
 package org.apache.beam.runners.dataflow;
 
+import java.io.Closeable;
 import java.nio.ByteBuffer;
 import org.apache.beam.runners.dataflow.util.RandomAccessData;
 
-public interface ShuffleCompressor {
+public interface ShuffleCompressor extends Closeable {
   interface Factory {
     ShuffleCompressor create(String datasetId);
   }

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -332,7 +332,7 @@ public interface DataflowPipelineDebugOptions extends ExperimentalOptions, Pipel
     private static ShuffleCompressor.Factory NOOP =
         new ShuffleCompressor.Factory() {
           @Override
-          public ShuffleCompressor create() {
+          public ShuffleCompressor create(String datasetId) {
             return null;
           }
         };

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -32,6 +32,7 @@ import org.apache.beam.sdk.options.ExperimentalOptions;
 import org.apache.beam.sdk.options.Hidden;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.util.InstanceBuilder;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * Internal. Options used to control execution of the Dataflow SDK for debugging and testing
@@ -332,7 +333,7 @@ public interface DataflowPipelineDebugOptions extends ExperimentalOptions, Pipel
     private static ShuffleCompressor.Factory NOOP =
         new ShuffleCompressor.Factory() {
           @Override
-          public ShuffleCompressor create(String datasetId) {
+          public @Nullable ShuffleCompressor create(String datasetId) {
             return null;
           }
         };

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ApplianceShuffleEntryReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ApplianceShuffleEntryReader.java
@@ -41,7 +41,7 @@ public class ApplianceShuffleEntryReader implements ShuffleEntryReader {
     applianceShuffleReader = new ApplianceShuffleReader(shuffleReaderConfig, operationContext);
 
     ShuffleBatchReader batchReader =
-        new ChunkingShuffleBatchReader(executionContext, operationContext, applianceShuffleReader);
+        new ChunkingShuffleBatchReader(executionContext, operationContext, applianceShuffleReader, executionContext.getShuffleCompressor(applianceShuffleReader.getDatasetId()));
 
     if (cache) {
       // Limit the size of the cache.

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ApplianceShuffleReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ApplianceShuffleReader.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.runners.dataflow.worker;
 
-import java.io.Closeable;
 import java.io.IOException;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.beam.runners.dataflow.worker.util.common.worker.OperationContext;
@@ -31,7 +30,7 @@ import org.apache.beam.runners.dataflow.worker.util.common.worker.OperationConte
 @SuppressWarnings({
   "nullness" // TODO(https://issues.apache.org/jira/browse/BEAM-10402)
 })
-public final class ApplianceShuffleReader implements ShuffleReader, Closeable {
+public final class ApplianceShuffleReader implements ShuffleReader {
   static {
     ShuffleLibrary.load();
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/BatchModeExecutionContext.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/BatchModeExecutionContext.java
@@ -316,8 +316,8 @@ public class BatchModeExecutionContext
             + "for each side input, and a SideInputReader provided via getSideInputReader");
   }
 
-  public ShuffleCompressor getShuffleCompressor(String datasetId) {
-    return shuffleCompressorFactory.create(datasetId);
+  public ShuffleCompressor.Factory getShuffleCompressorFactory() {
+    return shuffleCompressorFactory;
   }
 
   // TODO: Expose a keyed sub-cache which allows one to store all cached values in their

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/BatchModeExecutionContext.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/BatchModeExecutionContext.java
@@ -32,6 +32,8 @@ import org.apache.beam.runners.core.metrics.CounterCell;
 import org.apache.beam.runners.core.metrics.ExecutionStateSampler;
 import org.apache.beam.runners.core.metrics.MetricUpdates;
 import org.apache.beam.runners.core.metrics.MetricsContainerImpl;
+import org.apache.beam.runners.dataflow.ShuffleCompressor;
+import org.apache.beam.runners.dataflow.options.DataflowPipelineDebugOptions;
 import org.apache.beam.runners.dataflow.options.DataflowPipelineOptions;
 import org.apache.beam.runners.dataflow.worker.counters.CounterFactory;
 import org.apache.beam.runners.dataflow.worker.counters.NameContext;
@@ -66,6 +68,8 @@ public class BatchModeExecutionContext
   protected final ReaderFactory readerFactory;
   private Object key;
 
+  private final ShuffleCompressor.Factory shuffleCompressorFactory;
+
   private final MetricsContainerRegistry<MetricsContainerImpl> containerRegistry;
 
   // TODO(BEAM-7863): Move throttle time Metric to a dedicated namespace.
@@ -99,6 +103,8 @@ public class BatchModeExecutionContext
     this.dataCache = dataCache;
     this.containerRegistry =
         (MetricsContainerRegistry<MetricsContainerImpl>) getMetricsContainerRegistry();
+    this.shuffleCompressorFactory =
+        options.as(DataflowPipelineDebugOptions.class).getShuffleCompressorFactory();
   }
 
   private static MetricsContainerRegistry<MetricsContainerImpl> createMetricsContainerRegistry() {
@@ -308,6 +314,10 @@ public class BatchModeExecutionContext
         "Cannot call getSideInputReaderForViews for batch DataflowWorker: "
             + "the MapTask specification should have had SideInputInfo descriptors "
             + "for each side input, and a SideInputReader provided via getSideInputReader");
+  }
+
+  public ShuffleCompressor getShuffleCompressor() {
+    return shuffleCompressorFactory.create();
   }
 
   // TODO: Expose a keyed sub-cache which allows one to store all cached values in their

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/BatchModeExecutionContext.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/BatchModeExecutionContext.java
@@ -316,8 +316,8 @@ public class BatchModeExecutionContext
             + "for each side input, and a SideInputReader provided via getSideInputReader");
   }
 
-  public ShuffleCompressor getShuffleCompressor() {
-    return shuffleCompressorFactory.create();
+  public ShuffleCompressor getShuffleCompressor(String datasetId) {
+    return shuffleCompressorFactory.create(datasetId);
   }
 
   // TODO: Expose a keyed sub-cache which allows one to store all cached values in their

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ByteArrayReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ByteArrayReader.java
@@ -15,21 +15,38 @@
  * See the License for the specific language governing permissions and
  * limitations under the License.
  */
-package org.apache.beam.runners.dataflow.worker.util.common.worker;
+package org.apache.beam.runners.dataflow.worker;
 
 import com.google.protobuf.ByteString;
-import org.apache.beam.sdk.util.common.Reiterable;
+import com.google.protobuf.UnsafeByteOperations;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.primitives.Ints;
 
-/** A collection of ShuffleEntries, all with the same key. */
-public class KeyGroupedShuffleEntries {
-  public final ShufflePosition position;
-  public final ByteString key;
-  public final Reiterable<ShuffleEntry> values;
+class ByteArrayReader {
+  private final byte[] arr;
+  private int pos;
 
-  public KeyGroupedShuffleEntries(
-      ShufflePosition position, ByteString key, Reiterable<ShuffleEntry> values) {
-    this.position = position;
-    this.key = key;
-    this.values = values;
+  public ByteArrayReader(byte[] arr) {
+    this.arr = arr;
+    this.pos = 0;
+  }
+
+  public int available() {
+    return arr.length - pos;
+  }
+
+  public int readInt() {
+    int ret = Ints.fromBytes(arr[pos], arr[pos + 1], arr[pos + 2], arr[pos + 3]);
+    pos += 4;
+    return ret;
+  }
+
+  public ByteString read(int size) {
+    if (size == 0) {
+      return ByteString.EMPTY;
+    }
+
+    ByteString ret = UnsafeByteOperations.unsafeWrap(arr, pos, size);
+    pos += size;
+    return ret;
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ByteArrayReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ByteArrayReader.java
@@ -17,11 +17,12 @@
  */
 package org.apache.beam.runners.dataflow.worker;
 
-import com.google.protobuf.ByteString;
-import com.google.protobuf.UnsafeByteOperations;
+import java.nio.ByteBuffer;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.primitives.Ints;
 
 class ByteArrayReader {
+  private static final ByteBuffer EMPTY = ByteBuffer.allocate(0).asReadOnlyBuffer();
+
   private final byte[] arr;
   private int pos;
 
@@ -40,12 +41,12 @@ class ByteArrayReader {
     return ret;
   }
 
-  public ByteString read(int size) {
+  public ByteBuffer read(int size) {
     if (size == 0) {
-      return ByteString.EMPTY;
+      return EMPTY;
     }
 
-    ByteString ret = UnsafeByteOperations.unsafeWrap(arr, pos, size);
+    ByteBuffer ret = ByteBuffer.wrap(arr, pos, size);
     pos += size;
     return ret;
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ChunkingShuffleBatchReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ChunkingShuffleBatchReader.java
@@ -38,7 +38,7 @@ final class ChunkingShuffleBatchReader implements ShuffleBatchReader {
   private ExecutionStateTracker tracker;
   private ExecutionState readState;
 
-  private final ShuffleCompressor shuffleCompressor;
+  private final @Nullable ShuffleCompressor shuffleCompressor;
 
   public ChunkingShuffleBatchReader(
       BatchModeExecutionContext executionContext,

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ChunkingShuffleBatchReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ChunkingShuffleBatchReader.java
@@ -44,8 +44,7 @@ final class ChunkingShuffleBatchReader implements ShuffleBatchReader {
       BatchModeExecutionContext executionContext,
       DataflowOperationContext operationContext,
       ShuffleReader reader,
-      @Nullable ShuffleCompressor shuffleCompressor
-      ) {
+      @Nullable ShuffleCompressor shuffleCompressor) {
     this.reader = reader;
     this.readState = operationContext.newExecutionState("read-shuffle");
     this.tracker = executionContext.getExecutionStateTracker();
@@ -124,6 +123,14 @@ final class ChunkingShuffleBatchReader implements ShuffleBatchReader {
       return ByteString.EMPTY;
     } else {
       return UnsafeByteOperations.unsafeWrap(slice);
+    }
+  }
+
+  @Override
+  public void close() throws IOException {
+    reader.close();
+    if (shuffleCompressor != null) {
+      shuffleCompressor.close();
     }
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ChunkingShuffleBatchReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ChunkingShuffleBatchReader.java
@@ -43,11 +43,13 @@ final class ChunkingShuffleBatchReader implements ShuffleBatchReader {
   public ChunkingShuffleBatchReader(
       BatchModeExecutionContext executionContext,
       DataflowOperationContext operationContext,
-      ShuffleReader reader) {
+      ShuffleReader reader,
+      @Nullable ShuffleCompressor shuffleCompressor
+      ) {
     this.reader = reader;
     this.readState = operationContext.newExecutionState("read-shuffle");
     this.tracker = executionContext.getExecutionStateTracker();
-    this.shuffleCompressor = executionContext.getShuffleCompressor();
+    this.shuffleCompressor = shuffleCompressor;
   }
 
   @Override

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ChunkingShuffleBatchReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ChunkingShuffleBatchReader.java
@@ -17,9 +17,8 @@
  */
 package org.apache.beam.runners.dataflow.worker;
 
-import java.io.ByteArrayInputStream;
+import com.google.protobuf.ByteString;
 import java.io.Closeable;
-import java.io.DataInputStream;
 import java.io.IOException;
 import java.util.ArrayList;
 import org.apache.beam.runners.core.metrics.ExecutionStateTracker;
@@ -28,7 +27,6 @@ import org.apache.beam.runners.dataflow.worker.util.common.worker.ByteArrayShuff
 import org.apache.beam.runners.dataflow.worker.util.common.worker.ShuffleBatchReader;
 import org.apache.beam.runners.dataflow.worker.util.common.worker.ShuffleEntry;
 import org.apache.beam.runners.dataflow.worker.util.common.worker.ShufflePosition;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.io.ByteStreams;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** ChunkingShuffleBatchReader reads data from a shuffle dataset using a ShuffleReader. */
@@ -57,11 +55,13 @@ final class ChunkingShuffleBatchReader implements ShuffleBatchReader {
     try (Closeable trackedReadState = tracker.enterState(readState)) {
       result = reader.readIncludingPosition(startPosition, endPosition);
     }
-    DataInputStream input = new DataInputStream(new ByteArrayInputStream(result.chunk));
+    ByteArrayReader input = new ByteArrayReader(result.chunk);
     ArrayList<ShuffleEntry> entries = new ArrayList<>();
+
     while (input.available() > 0) {
       entries.add(getShuffleEntry(input));
     }
+
     return new Batch(
         entries,
         result.nextStartPosition == null
@@ -72,31 +72,28 @@ final class ChunkingShuffleBatchReader implements ShuffleBatchReader {
   /**
    * Extracts a ShuffleEntry by parsing bytes from a given InputStream.
    *
-   * @param input stream to read from
+   * @param chunk chunk to read from
    * @return parsed ShuffleEntry
    */
-  static ShuffleEntry getShuffleEntry(DataInputStream input) throws IOException {
-    byte[] position = getFixedLengthPrefixedByteArray(input);
-    byte[] key = getFixedLengthPrefixedByteArray(input);
-    byte[] skey = getFixedLengthPrefixedByteArray(input);
-    byte[] value = getFixedLengthPrefixedByteArray(input);
+  static ShuffleEntry getShuffleEntry(ByteArrayReader chunk) throws IOException {
+    ByteString position = getFixedLengthPrefixedByteArray(chunk);
+    ByteString key = getFixedLengthPrefixedByteArray(chunk);
+    ByteString skey = getFixedLengthPrefixedByteArray(chunk);
+    ByteString value = getFixedLengthPrefixedByteArray(chunk);
     return new ShuffleEntry(ByteArrayShufflePosition.of(position), key, skey, value);
   }
 
   /**
    * Extracts a length-prefix-encoded byte array from a given InputStream.
    *
-   * @param dataInputStream stream to read from
+   * @param chunk chunk to read from
    * @return parsed byte array
    */
-  static byte[] getFixedLengthPrefixedByteArray(DataInputStream dataInputStream)
-      throws IOException {
-    int length = dataInputStream.readInt();
+  static ByteString getFixedLengthPrefixedByteArray(ByteArrayReader chunk) throws IOException {
+    int length = chunk.readInt();
     if (length < 0) {
       throw new IOException("invalid length: " + length);
     }
-    byte[] data = new byte[length];
-    ByteStreams.readFully(dataInputStream, data);
-    return data;
+    return chunk.read(length);
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/PartitioningShuffleReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/PartitioningShuffleReader.java
@@ -27,7 +27,6 @@ import org.apache.beam.runners.dataflow.worker.util.common.worker.ShuffleEntryRe
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.options.PipelineOptions;
-import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.util.WindowedValue.WindowedValueCoder;
 import org.apache.beam.sdk.values.KV;
@@ -144,9 +143,10 @@ public class PartitioningShuffleReader<K, V> extends NativeReader<WindowedValue<
         return false;
       }
       ShuffleEntry record = iterator.next();
-      K key = CoderUtils.decodeFromByteArray(shuffleReader.keyCoder, record.getKey());
+      K key = shuffleReader.keyCoder.decode(record.getKey().newInput(), Coder.Context.OUTER);
       WindowedValue<V> windowedValue =
-          CoderUtils.decodeFromByteArray(shuffleReader.windowedValueCoder, record.getValue());
+          shuffleReader.windowedValueCoder.decode(
+              record.getValue().newInput(), Coder.Context.OUTER);
       shuffleReader.notifyElementRead(record.length());
       current = windowedValue.withValue(KV.of(key, windowedValue.getValue()));
       return true;

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ShuffleReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ShuffleReader.java
@@ -17,12 +17,13 @@
  */
 package org.apache.beam.runners.dataflow.worker;
 
+import java.io.Closeable;
 import java.io.IOException;
 
 /** ShuffleReader reads chunks of data from a shuffle dataset for a given position range. */
-interface ShuffleReader {
+interface ShuffleReader extends Closeable {
   /** Represents a chunk of data read from a shuffle dataset. */
-  public static class ReadChunkResult {
+  class ReadChunkResult {
     public final byte[] chunk;
     public final byte[] nextStartPosition;
 
@@ -41,6 +42,6 @@ interface ShuffleReader {
    * @param startPosition the start of the requested range (inclusive)
    * @param endPosition the end of the requested range (exclusive)
    */
-  public ReadChunkResult readIncludingPosition(byte[] startPosition, byte[] endPosition)
+  ReadChunkResult readIncludingPosition(byte[] startPosition, byte[] endPosition)
       throws IOException;
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ShuffleSink.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ShuffleSink.java
@@ -42,8 +42,6 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.primitives.Ints;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /**
  * A sink that writes to a shuffle dataset.
@@ -55,7 +53,6 @@ import org.slf4j.LoggerFactory;
   "nullness" // TODO(https://issues.apache.org/jira/browse/BEAM-10402)
 })
 public class ShuffleSink<T> extends Sink<WindowedValue<T>> {
-  private static final Logger LOG = LoggerFactory.getLogger(ShuffleSink.class);
 
   enum ShuffleKind {
     UNGROUPED,
@@ -185,17 +182,6 @@ public class ShuffleSink<T> extends Sink<WindowedValue<T>> {
       this.sortValueCoder = null;
       this.windowedValueCoder = null;
     }
-
-    LOG.info(
-        "Starting ShuffleSink for {} with kind {}, keyCoder = {}, valueCoder = {}, sortKeyCoder = {}, sortValueCoder = {}, windowedValueCoder = {}, elemCoder = {}",
-        operationContext.nameContext(),
-        shuffleKind,
-        keyCoder,
-        valueCoder,
-        sortKeyCoder,
-        sortValueCoder,
-        windowedValueCoder,
-        windowedElemCoder);
   }
 
   /**
@@ -209,7 +195,7 @@ public class ShuffleSink<T> extends Sink<WindowedValue<T>> {
         options,
         operationContext.counterFactory(),
         datasetId,
-        shuffleCompressorFactory.create());
+        shuffleCompressorFactory.create(datasetId));
   }
 
   /** The SinkWriter for a ShuffleSink. */

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -134,7 +134,6 @@ import org.apache.beam.sdk.util.FluentBackoff;
 import org.apache.beam.sdk.util.Sleeper;
 import org.apache.beam.sdk.util.UserCodeException;
 import org.apache.beam.sdk.util.WindowedValue.WindowedValueCoder;
-import org.apache.beam.sdk.util.common.ReflectHelpers;
 import org.apache.beam.vendor.grpc.v1p43p2.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.grpc.v1p43p2.com.google.protobuf.TextFormat;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -134,6 +134,7 @@ import org.apache.beam.sdk.util.FluentBackoff;
 import org.apache.beam.sdk.util.Sleeper;
 import org.apache.beam.sdk.util.UserCodeException;
 import org.apache.beam.sdk.util.WindowedValue.WindowedValueCoder;
+import org.apache.beam.sdk.util.common.ReflectHelpers;
 import org.apache.beam.vendor.grpc.v1p43p2.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.grpc.v1p43p2.com.google.protobuf.TextFormat;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/UngroupedShuffleReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/UngroupedShuffleReader.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.dataflow.worker;
 
+import com.google.protobuf.ByteString;
 import java.io.IOException;
 import java.util.Iterator;
 import java.util.NoSuchElementException;
@@ -26,7 +27,6 @@ import org.apache.beam.runners.dataflow.worker.util.common.worker.ShuffleEntry;
 import org.apache.beam.runners.dataflow.worker.util.common.worker.ShuffleEntryReader;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.options.PipelineOptions;
-import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -114,9 +114,9 @@ public class UngroupedShuffleReader<T> extends NativeReader<T> {
       }
       ShuffleEntry record = iterator.next();
       // Throw away the primary and the secondary keys.
-      byte[] value = record.getValue();
+      ByteString value = record.getValue();
       shuffleReader.notifyElementRead(record.length());
-      current = CoderUtils.decodeFromByteArray(shuffleReader.coder, value);
+      current = shuffleReader.coder.decode(value.newInput(), Coder.Context.OUTER);
       return true;
     }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/BatchingShuffleEntryReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/BatchingShuffleEntryReader.java
@@ -20,6 +20,7 @@ package org.apache.beam.runners.dataflow.worker.util.common.worker;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkState;
 
+import java.io.IOException;
 import java.util.ListIterator;
 import java.util.NoSuchElementException;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -140,5 +141,7 @@ public final class BatchingShuffleEntryReader implements ShuffleEntryReader {
   }
 
   @Override
-  public void close() {}
+  public void close() throws IOException {
+    batchReader.close();
+  }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/ByteArrayShufflePosition.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/ByteArrayShufflePosition.java
@@ -20,10 +20,9 @@ package org.apache.beam.runners.dataflow.worker.util.common.worker;
 import static com.google.api.client.util.Base64.decodeBase64;
 import static com.google.api.client.util.Base64.encodeBase64URLSafeString;
 
-import java.util.Arrays;
+import com.google.protobuf.ByteString;
+import com.google.protobuf.UnsafeByteOperations;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.primitives.Bytes;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.primitives.UnsignedBytes;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -35,9 +34,10 @@ import org.checkerframework.checker.nullness.qual.Nullable;
   "nullness" // TODO(https://issues.apache.org/jira/browse/BEAM-10402)
 })
 public class ByteArrayShufflePosition implements Comparable<ShufflePosition>, ShufflePosition {
-  private final byte[] position;
+  private static final ByteString ZERO = ByteString.copyFrom(new byte[] {0});
+  private final ByteString position;
 
-  public ByteArrayShufflePosition(byte[] position) {
+  public ByteArrayShufflePosition(ByteString position) {
     this.position = position;
   }
 
@@ -46,6 +46,13 @@ public class ByteArrayShufflePosition implements Comparable<ShufflePosition>, Sh
   }
 
   public static ByteArrayShufflePosition of(byte[] position) {
+    if (position == null) {
+      return null;
+    }
+    return new ByteArrayShufflePosition(UnsafeByteOperations.unsafeWrap(position));
+  }
+
+  public static ByteArrayShufflePosition of(ByteString position) {
     if (position == null) {
       return null;
     }
@@ -58,15 +65,15 @@ public class ByteArrayShufflePosition implements Comparable<ShufflePosition>, Sh
     }
     Preconditions.checkArgument(shufflePosition instanceof ByteArrayShufflePosition);
     ByteArrayShufflePosition adapter = (ByteArrayShufflePosition) shufflePosition;
-    return adapter.getPosition();
+    return adapter.getPosition().toByteArray();
   }
 
-  public byte[] getPosition() {
+  public ByteString getPosition() {
     return position;
   }
 
   public String encodeBase64() {
-    return encodeBase64URLSafeString(position);
+    return encodeBase64URLSafeString(position.toByteArray());
   }
 
   /**
@@ -75,7 +82,7 @@ public class ByteArrayShufflePosition implements Comparable<ShufflePosition>, Sh
    * successor.
    */
   public ByteArrayShufflePosition immediateSuccessor() {
-    return new ByteArrayShufflePosition(Bytes.concat(position, new byte[] {0}));
+    return new ByteArrayShufflePosition(position.concat(ZERO));
   }
 
   @Override
@@ -85,14 +92,14 @@ public class ByteArrayShufflePosition implements Comparable<ShufflePosition>, Sh
     }
     if (o instanceof ByteArrayShufflePosition) {
       ByteArrayShufflePosition that = (ByteArrayShufflePosition) o;
-      return Arrays.equals(this.position, that.position);
+      return this.position.equals(that.position);
     }
     return false;
   }
 
   @Override
   public int hashCode() {
-    return Arrays.hashCode(position);
+    return position.hashCode();
   }
 
   @Override
@@ -107,6 +114,6 @@ public class ByteArrayShufflePosition implements Comparable<ShufflePosition>, Sh
       return 0;
     }
     ByteArrayShufflePosition other = (ByteArrayShufflePosition) o;
-    return UnsignedBytes.lexicographicalComparator().compare(position, other.position);
+    return ByteString.unsignedLexicographicalComparator().compare(position, other.position);
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/CachingShuffleBatchReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/CachingShuffleBatchReader.java
@@ -81,6 +81,11 @@ public class CachingShuffleBatchReader implements ShuffleBatchReader {
     }
   }
 
+  @Override
+  public void close() throws IOException {
+    reader.close();
+  }
+
   /** The key for the entries stored in the batch cache. */
   static final class BatchRange {
     protected final @Nullable ShufflePosition startPosition;

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/GroupingShuffleEntryIterator.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/GroupingShuffleEntryIterator.java
@@ -20,7 +20,7 @@ package org.apache.beam.runners.dataflow.worker.util.common.worker;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkState;
 
-import java.util.Arrays;
+import com.google.protobuf.ByteString;
 import java.util.NoSuchElementException;
 import org.apache.beam.sdk.util.common.ElementByteSizeObservableIterable;
 import org.apache.beam.sdk.util.common.ElementByteSizeObservableIterator;
@@ -59,7 +59,7 @@ public abstract class GroupingShuffleEntryIterator {
    * shuffleIterator.next() is the key of the next KeyGroupedShuffleEntries to return via {@link
    * #advance}/{@link #getCurrent}.
    */
-  private byte @Nullable [] currentKeyBytes = null;
+  private @Nullable ByteString currentKeyBytes = null;
 
   private ShufflePosition lastGroupStart;
 
@@ -118,7 +118,7 @@ public abstract class GroupingShuffleEntryIterator {
       // start ValuesIterable below from this entry.
       atCurrentEntry = shuffleIterator.copy();
       entry = shuffleIterator.next();
-      if (!Arrays.equals(entry.getKey(), currentKeyBytes)) {
+      if (!entry.getKey().equals(currentKeyBytes)) {
         break;
       }
       // Note: we can get here only if the ValuesIterable of the preceding key has NOT been
@@ -190,12 +190,12 @@ public abstract class GroupingShuffleEntryIterator {
       extends ElementByteSizeObservableIterable<ShuffleEntry, ValuesIterator>
       implements Reiterable<ShuffleEntry> {
     private final GroupingShuffleEntryIterator parent;
-    private final byte[] currentKeyBytes;
+    private final ByteString currentKeyBytes;
     private Reiterator<ShuffleEntry> baseValuesIterator;
 
     public ValuesIterable(
         GroupingShuffleEntryIterator parent,
-        byte[] keyBytes,
+        ByteString keyBytes,
         Reiterator<ShuffleEntry> baseValuesIterator) {
       this.parent = parent;
       this.currentKeyBytes = keyBytes;
@@ -217,7 +217,7 @@ public abstract class GroupingShuffleEntryIterator {
     private final GroupingShuffleEntryIterator parent;
     private final Reiterator<ShuffleEntry> valuesIterator;
     private final ProgressTracker<ShuffleEntry> tracker;
-    private final byte[] expectedKeyBytes;
+    private final ByteString expectedKeyBytes;
 
     private Boolean cachedHasNext;
     private long byteSizeRead = 0L;
@@ -226,7 +226,7 @@ public abstract class GroupingShuffleEntryIterator {
     public ValuesIterator(
         GroupingShuffleEntryIterator parent,
         Reiterator<ShuffleEntry> valuesIterator,
-        byte[] expectedKeyBytes) {
+        ByteString expectedKeyBytes) {
       this.parent = parent;
       this.valuesIterator = valuesIterator;
       this.expectedKeyBytes = checkNotNull(expectedKeyBytes);
@@ -267,13 +267,14 @@ public abstract class GroupingShuffleEntryIterator {
       return cachedHasNext;
     }
 
+    @SuppressWarnings("ReferenceEquality")
     private boolean advance() {
       // Save a copy of the iterator pointing at the next entry, to use below in case we're right
       // before a key boundary (or end of stream).
       Reiterator<ShuffleEntry> possibleStartOfNextKey = valuesIterator.copy();
       if (valuesIterator.hasNext()) {
         ShuffleEntry entry = valuesIterator.next();
-        if (Arrays.equals(entry.getKey(), expectedKeyBytes)) {
+        if (entry.getKey().equals(expectedKeyBytes)) {
           byteSizeRead += entry.length();
           tracker.saw(entry);
           current = entry;

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/ShuffleBatchReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/ShuffleBatchReader.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.dataflow.worker.util.common.worker;
 
+import java.io.Closeable;
 import java.io.IOException;
 import java.util.List;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -25,9 +26,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * ShuffleBatchReader provides an interface for reading a batch of key/value entries from a shuffle
  * dataset.
  */
-public interface ShuffleBatchReader {
+public interface ShuffleBatchReader extends Closeable {
   /** The result returned by #read. */
-  public static class Batch {
+  class Batch {
     public final List<ShuffleEntry> entries;
     public final @Nullable ShufflePosition nextStartPosition;
 
@@ -49,6 +50,6 @@ public interface ShuffleBatchReader {
    *     key is greater than or equal to startPosition).
    * @return the first {@link Batch} of entries
    */
-  public Batch read(@Nullable ShufflePosition startPosition, @Nullable ShufflePosition endPosition)
+  Batch read(@Nullable ShufflePosition startPosition, @Nullable ShufflePosition endPosition)
       throws IOException;
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/ShuffleEntry.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/ShuffleEntry.java
@@ -17,7 +17,9 @@
  */
 package org.apache.beam.runners.dataflow.worker.util.common.worker;
 
+import com.google.protobuf.ByteString;
 import java.util.Arrays;
+import java.util.Objects;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** Entry written to/read from a shuffle dataset. */
@@ -26,18 +28,34 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 })
 public class ShuffleEntry {
   final ShufflePosition position;
-  final byte[] key;
-  final byte[] secondaryKey;
-  final byte[] value;
+  final ByteString key;
+  final ByteString secondaryKey;
+  final ByteString value;
 
-  public ShuffleEntry(byte[] key, byte[] secondaryKey, byte[] value) {
+  public ShuffleEntry(ByteString key, ByteString secondaryKey, ByteString value) {
     this.position = null;
     this.key = key;
     this.secondaryKey = secondaryKey;
     this.value = value;
   }
 
+  public ShuffleEntry(byte[] key, byte[] secondaryKey, byte[] value) {
+    this(
+        key == null ? null : ByteString.copyFrom(key),
+        secondaryKey == null ? null : ByteString.copyFrom(secondaryKey),
+        value == null ? null : ByteString.copyFrom(value));
+  }
+
   public ShuffleEntry(ShufflePosition position, byte[] key, byte[] secondaryKey, byte[] value) {
+    this(
+        position,
+        ByteString.copyFrom(key),
+        ByteString.copyFrom(secondaryKey),
+        ByteString.copyFrom(value));
+  }
+
+  public ShuffleEntry(
+      ShufflePosition position, ByteString key, ByteString secondaryKey, ByteString value) {
     this.position = position;
     this.key = key;
     this.secondaryKey = secondaryKey;
@@ -48,23 +66,23 @@ public class ShuffleEntry {
     return position;
   }
 
-  public byte[] getKey() {
+  public ByteString getKey() {
     return key;
   }
 
-  public byte[] getSecondaryKey() {
+  public ByteString getSecondaryKey() {
     return secondaryKey;
   }
 
-  public byte[] getValue() {
+  public ByteString getValue() {
     return value;
   }
 
   /** Returns the size of this entry in bytes, excluding {@code position}. */
   public int length() {
-    return (key == null ? 0 : key.length)
-        + (secondaryKey == null ? 0 : secondaryKey.length)
-        + (value == null ? 0 : value.length);
+    return (key == null ? 0 : key.size())
+        + (secondaryKey == null ? 0 : secondaryKey.size())
+        + (value == null ? 0 : value.size());
   }
 
   @Override
@@ -72,11 +90,11 @@ public class ShuffleEntry {
     return "ShuffleEntry("
         + position.toString()
         + ","
-        + byteArrayToString(key)
+        + byteArrayToString(key.toByteArray())
         + ","
-        + byteArrayToString(secondaryKey)
+        + byteArrayToString(secondaryKey.toByteArray())
         + ","
-        + byteArrayToString(value)
+        + byteArrayToString(value.toByteArray())
         + ")";
   }
 
@@ -93,12 +111,10 @@ public class ShuffleEntry {
     }
     if (o instanceof ShuffleEntry) {
       ShuffleEntry that = (ShuffleEntry) o;
-      return (this.position == null ? that.position == null : this.position.equals(that.position))
-          && (this.key == null ? that.key == null : Arrays.equals(this.key, that.key))
-          && (this.secondaryKey == null
-              ? that.secondaryKey == null
-              : Arrays.equals(this.secondaryKey, that.secondaryKey))
-          && (this.value == null ? that.value == null : Arrays.equals(this.value, that.value));
+      return (Objects.equals(this.position, that.position))
+          && (Objects.equals(this.key, that.key))
+          && (Objects.equals(this.secondaryKey, that.secondaryKey))
+          && (Objects.equals(this.value, that.value));
     }
     return false;
   }
@@ -107,8 +123,8 @@ public class ShuffleEntry {
   public int hashCode() {
     return getClass().hashCode()
         + (position == null ? 0 : position.hashCode())
-        + (key == null ? 0 : Arrays.hashCode(key))
-        + (secondaryKey == null ? 0 : Arrays.hashCode(secondaryKey))
-        + (value == null ? 0 : Arrays.hashCode(value));
+        + (key == null ? 0 : key.hashCode())
+        + (secondaryKey == null ? 0 : secondaryKey.hashCode())
+        + (value == null ? 0 : value.hashCode());
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/ShuffleEntryReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/common/worker/ShuffleEntryReader.java
@@ -39,6 +39,6 @@ public interface ShuffleEntryReader extends Closeable {
    *     key is greater than or equal to startPosition).
    * @return a {@link Reiterator} over the requested range of entries.
    */
-  public Reiterator<ShuffleEntry> read(
+  Reiterator<ShuffleEntry> read(
       @Nullable ShufflePosition startPosition, @Nullable ShufflePosition endPosition);
 }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/GroupingShuffleReaderTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/GroupingShuffleReaderTest.java
@@ -33,6 +33,7 @@ import static org.junit.Assert.fail;
 
 import com.google.api.services.dataflow.model.ApproximateReportedProgress;
 import com.google.api.services.dataflow.model.Position;
+import com.google.protobuf.ByteString;
 import java.io.ByteArrayOutputStream;
 import java.io.Closeable;
 import java.io.DataOutputStream;
@@ -617,7 +618,8 @@ public class GroupingShuffleReaderTest {
     // Note that TestShuffleReader start/end positions are in the
     // space of keys not the positions (TODO: should probably always
     // use positions instead).
-    String stop = encodeBase64URLSafeString(fabricatePosition(kNumRecords).getPosition());
+    String stop =
+        encodeBase64URLSafeString(fabricatePosition(kNumRecords).getPosition().toByteArray());
     TestOperationContext operationContext = TestOperationContext.create();
     GroupingShuffleReader<Integer, Integer> groupingShuffleReader =
         new GroupingShuffleReader<>(
@@ -742,11 +744,12 @@ public class GroupingShuffleReaderTest {
 
   private Position makeShufflePosition(int shard, byte[] key) throws Exception {
     return new Position()
-        .setShufflePosition(encodeBase64URLSafeString(fabricatePosition(shard, key).getPosition()));
+        .setShufflePosition(
+            encodeBase64URLSafeString(fabricatePosition(shard, key).getPosition().toByteArray()));
   }
 
-  private Position makeShufflePosition(byte[] position) throws Exception {
-    return new Position().setShufflePosition(encodeBase64URLSafeString(position));
+  private Position makeShufflePosition(ByteString position) throws Exception {
+    return new Position().setShufflePosition(encodeBase64URLSafeString(position.toByteArray()));
   }
 
   @Test
@@ -813,7 +816,7 @@ public class GroupingShuffleReaderTest {
           iter.requestDynamicSplit(splitRequestAtPosition(makeShufflePosition(kSecondShard, null)));
       assertNotNull(dynamicSplitResult);
       assertEquals(
-          encodeBase64URLSafeString(fabricatePosition(kSecondShard).getPosition()),
+          encodeBase64URLSafeString(fabricatePosition(kSecondShard).getPosition().toByteArray()),
           positionFromSplitResult(dynamicSplitResult).getShufflePosition());
 
       for (; iter.advance(); ++i) {
@@ -906,7 +909,7 @@ public class GroupingShuffleReaderTest {
 
       // Cannot split since all input was consumed.
       Position proposedSplitPosition = new Position();
-      String stop = encodeBase64URLSafeString(fabricatePosition(0).getPosition());
+      String stop = encodeBase64URLSafeString(fabricatePosition(0).getPosition().toByteArray());
       proposedSplitPosition.setShufflePosition(stop);
       assertNull(
           iter.requestDynamicSplit(
@@ -936,7 +939,8 @@ public class GroupingShuffleReaderTest {
     // Note that TestShuffleReader start/end positions are in the
     // space of keys not the positions (TODO: should probably always
     // use positions instead).
-    String stop = encodeBase64URLSafeString(fabricatePosition(kNumRecords).getPosition());
+    String stop =
+        encodeBase64URLSafeString(fabricatePosition(kNumRecords).getPosition().toByteArray());
     TestOperationContext operationContext = TestOperationContext.create();
     GroupingShuffleReader<Integer, Integer> groupingShuffleReader =
         new GroupingShuffleReader<>(

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/TestShuffleReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/TestShuffleReader.java
@@ -17,7 +17,7 @@
  */
 package org.apache.beam.runners.dataflow.worker;
 
-import java.nio.charset.StandardCharsets;
+import com.google.protobuf.ByteString;
 import java.util.ArrayList;
 import java.util.Comparator;
 import java.util.Iterator;
@@ -36,7 +36,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 /** A fake implementation of a ShuffleEntryReader, for testing. */
 public class TestShuffleReader implements ShuffleEntryReader {
   // Sorts by secondary key where an empty secondary key sorts before all other secondary keys.
-  static final Comparator<byte[]> SHUFFLE_KEY_COMPARATOR =
+  static final Comparator<ByteString> SHUFFLE_KEY_COMPARATOR =
       (o1, o2) -> {
         if (o1 == o2) {
           return 0;
@@ -47,10 +47,11 @@ public class TestShuffleReader implements ShuffleEntryReader {
         if (o2 == null) {
           return 1;
         }
-        return UnsignedBytes.lexicographicalComparator().compare(o1, o2);
+        return UnsignedBytes.lexicographicalComparator()
+            .compare(o1.toByteArray(), o2.toByteArray());
       };
 
-  final TreeMap<byte[], TreeMap<byte[], List<ShuffleEntry>>> records =
+  final TreeMap<ByteString, TreeMap<ByteString, List<ShuffleEntry>>> records =
       new TreeMap<>(SHUFFLE_KEY_COMPARATOR);
   boolean closed = false;
 
@@ -59,13 +60,13 @@ public class TestShuffleReader implements ShuffleEntryReader {
   public void addEntry(String key, String secondaryKey, String value) {
     addEntry(
         new ShuffleEntry(
-            key.getBytes(StandardCharsets.UTF_8),
-            secondaryKey.getBytes(StandardCharsets.UTF_8),
-            value.getBytes(StandardCharsets.UTF_8)));
+            ByteString.copyFromUtf8(key),
+            ByteString.copyFromUtf8(secondaryKey),
+            ByteString.copyFromUtf8(value)));
   }
 
   public void addEntry(ShuffleEntry entry) {
-    TreeMap<byte[], List<ShuffleEntry>> valuesBySecondaryKey = records.get(entry.getKey());
+    TreeMap<ByteString, List<ShuffleEntry>> valuesBySecondaryKey = records.get(entry.getKey());
     if (valuesBySecondaryKey == null) {
       valuesBySecondaryKey = new TreeMap<>(SHUFFLE_KEY_COMPARATOR);
       records.put(entry.getKey(), valuesBySecondaryKey);
@@ -79,7 +80,15 @@ public class TestShuffleReader implements ShuffleEntryReader {
   }
 
   public Iterator<ShuffleEntry> read() {
-    return read((byte[]) null, (byte[]) null);
+    return read((ByteString) null, (ByteString) null);
+  }
+
+  private ByteString toByteString(ShufflePosition pos) {
+    byte[] posBytes = ByteArrayShufflePosition.getPosition(pos);
+    if (posBytes == null) {
+      return null;
+    }
+    return ByteString.copyFrom(posBytes);
   }
 
   @Override
@@ -88,24 +97,22 @@ public class TestShuffleReader implements ShuffleEntryReader {
     if (closed) {
       throw new RuntimeException("Cannot read from a closed reader.");
     }
-    return read(
-        ByteArrayShufflePosition.getPosition(startPosition),
-        ByteArrayShufflePosition.getPosition(endPosition));
+    return read(toByteString(startPosition), toByteString(endPosition));
   }
 
   public Reiterator<ShuffleEntry> read(@Nullable String startKey, @Nullable String endKey) {
     return read(
-        startKey == null ? null : startKey.getBytes(StandardCharsets.UTF_8),
-        endKey == null ? null : endKey.getBytes(StandardCharsets.UTF_8));
+        startKey == null ? null : ByteString.copyFromUtf8(startKey),
+        endKey == null ? null : ByteString.copyFromUtf8(endKey));
   }
 
-  public Reiterator<ShuffleEntry> read(byte @Nullable [] startKey, byte @Nullable [] endKey) {
+  public Reiterator<ShuffleEntry> read(@Nullable ByteString startKey, @Nullable ByteString endKey) {
     List<ShuffleEntry> res = new ArrayList<>();
-    for (byte[] key : records.keySet()) {
+    for (ByteString key : records.keySet()) {
       if ((startKey == null || SHUFFLE_KEY_COMPARATOR.compare(startKey, key) <= 0)
           && (endKey == null || SHUFFLE_KEY_COMPARATOR.compare(key, endKey) < 0)) {
-        TreeMap<byte[], List<ShuffleEntry>> entriesBySecondaryKey = records.get(key);
-        for (Map.Entry<byte[], List<ShuffleEntry>> entries : entriesBySecondaryKey.entrySet()) {
+        TreeMap<ByteString, List<ShuffleEntry>> entriesBySecondaryKey = records.get(key);
+        for (Map.Entry<ByteString, List<ShuffleEntry>> entries : entriesBySecondaryKey.entrySet()) {
           res.addAll(entries.getValue());
         }
       }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/TestShuffleReaderTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/TestShuffleReaderTest.java
@@ -20,7 +20,6 @@ package org.apache.beam.runners.dataflow.worker;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.fail;
 
-import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -116,10 +115,8 @@ public class TestShuffleReaderTest {
       ShuffleEntry entry = iter.next();
       actual.add(
           KV.of(
-              new String(entry.getKey(), StandardCharsets.UTF_8),
-              KV.of(
-                  new String(entry.getSecondaryKey(), StandardCharsets.UTF_8),
-                  new String(entry.getValue(), StandardCharsets.UTF_8))));
+              (entry.getKey().toStringUtf8()),
+              KV.of((entry.getSecondaryKey().toStringUtf8()), (entry.getValue().toStringUtf8()))));
     }
     return actual;
   }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/util/common/worker/ShuffleEntryTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/util/common/worker/ShuffleEntryTest.java
@@ -23,6 +23,7 @@ import static org.hamcrest.Matchers.not;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 
+import com.google.protobuf.ByteString;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -30,9 +31,9 @@ import org.junit.runners.JUnit4;
 /** Unit tests for {@link ShuffleEntry}. */
 @RunWith(JUnit4.class)
 public class ShuffleEntryTest {
-  private static final byte[] KEY = {0xA};
-  private static final byte[] SKEY = {0xB};
-  private static final byte[] VALUE = {0xC};
+  private static final ByteString KEY = ByteString.copyFrom(new byte[] {0xA});
+  private static final ByteString SKEY = ByteString.copyFrom(new byte[] {0xB});
+  private static final ByteString VALUE = ByteString.copyFrom(new byte[] {0xC});
 
   @Test
   public void accessors() {
@@ -52,7 +53,7 @@ public class ShuffleEntryTest {
   @Test
   public void equalsForEqualEntries() {
     ShuffleEntry entry0 = new ShuffleEntry(KEY, SKEY, VALUE);
-    ShuffleEntry entry1 = new ShuffleEntry(KEY.clone(), SKEY.clone(), VALUE.clone());
+    ShuffleEntry entry1 = new ShuffleEntry(KEY.concat(ByteString.EMPTY), SKEY, VALUE);
 
     assertEquals(entry0, entry1);
     assertEquals(entry1, entry0);
@@ -61,8 +62,8 @@ public class ShuffleEntryTest {
 
   @Test
   public void equalsForEqualNullEntries() {
-    ShuffleEntry entry0 = new ShuffleEntry(null, null, null);
-    ShuffleEntry entry1 = new ShuffleEntry(null, null, null);
+    ShuffleEntry entry0 = new ShuffleEntry((byte[]) null, null, null);
+    ShuffleEntry entry1 = new ShuffleEntry((byte[]) null, null, null);
 
     assertEquals(entry0, entry1);
     assertEquals(entry1, entry0);
@@ -71,7 +72,7 @@ public class ShuffleEntryTest {
 
   @Test
   public void notEqualsWhenKeysDiffer() {
-    final byte[] otherKey = {0x1};
+    final ByteString otherKey = ByteString.copyFrom(new byte[] {0x1});
     ShuffleEntry entry0 = new ShuffleEntry(KEY, SKEY, VALUE);
     ShuffleEntry entry1 = new ShuffleEntry(otherKey, SKEY, VALUE);
 
@@ -92,7 +93,7 @@ public class ShuffleEntryTest {
 
   @Test
   public void notEqualsWhenSecondaryKeysDiffer() {
-    final byte[] otherSKey = {0x2};
+    final ByteString otherSKey = ByteString.copyFrom(new byte[] {0x2});
     ShuffleEntry entry0 = new ShuffleEntry(KEY, SKEY, VALUE);
     ShuffleEntry entry1 = new ShuffleEntry(KEY, otherSKey, VALUE);
 
@@ -113,7 +114,7 @@ public class ShuffleEntryTest {
 
   @Test
   public void notEqualsWhenValuesDiffer() {
-    final byte[] otherValue = {0x2};
+    final ByteString otherValue = ByteString.copyFrom(new byte[] {0x2});
     ShuffleEntry entry0 = new ShuffleEntry(KEY, SKEY, VALUE);
     ShuffleEntry entry1 = new ShuffleEntry(KEY, SKEY, otherValue);
 
@@ -135,7 +136,7 @@ public class ShuffleEntryTest {
   @Test
   public void emptyNotTheSameAsNull() {
     final byte[] empty = {};
-    ShuffleEntry entry0 = new ShuffleEntry(null, null, null);
+    ShuffleEntry entry0 = new ShuffleEntry((byte[]) null, null, null);
     ShuffleEntry entry1 = new ShuffleEntry(empty, empty, empty);
 
     assertFalse(entry0.equals(entry1));


### PR DESCRIPTION
This PR adds a new interface, `ShuffleCompressor`, which allows users to plug in compression for values just before they're written to shuffle.

The interface is a little odd, we originally had exposed it as simply wrapping Input/Output streams.  However, this interface is much more efficient:
- In the compression path, the implementor can use the RandomAccessData as both a buffer pool (using scratch space at the end for example) and also compress the data "in place" if possible.  Additionally, many compression algorithms can operate more efficiently on a fixed-sized buffer rather than having to deal with an unknown amount of input data.
- In the decompression path, using ByteBuffer allows efficiently slicing the input and output buffers as well.  Ideally I think this interface would use ByteString as well, but didn't want to expose the shaded protobuf library in the public API.

Additionally this also changes most places in the shuffle IO path to use ByteString rather than byte[].  This allows efficiently "slicing" the buffer received from the shuffle reader, removing a significant number of byte[] copies.

Internally we have an implementation of ShuffleCompressor that uses zstd, and we see a significant benefit from using it.  For example, at level 3 (the default), a simple `read -> reshuffle -> do something` pipeline sees a 50% reduction in data shuffled for our representative test datasets.

R: @lukecwik 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
