### PR TITLE
[BEAM-14470] Use lifecycle method names directly.

### DIFF
--- a/sdks/go/pkg/beam/core/graph/fn.go
+++ b/sdks/go/pkg/beam/core/graph/fn.go
@@ -441,9 +441,6 @@ func AsDoFn(fn *Fn, numMainIn mainInputs) (*DoFn, error) {
 	if fn.Fn != nil {
 		fn.methods[processElementName] = fn.Fn
 	}
-	if err := verifyValidNames("graph.AsDoFn", fn, doFnNames...); err != nil {
-		return nil, err
-	}
 
 	if _, ok := fn.methods[processElementName]; !ok {
 		err := errors.Errorf("failed to find %v method", processElementName)
@@ -1286,9 +1283,6 @@ func AsCombineFn(fn *Fn) (*CombineFn, error) {
 	if fn.Fn != nil {
 		fn.methods[mergeAccumulatorsName] = fn.Fn
 	}
-	if err := verifyValidNames(fnKind, fn, setupName, createAccumulatorName, addInputName, mergeAccumulatorsName, extractOutputName, compactName, teardownName); err != nil {
-		return nil, err
-	}
 
 	mergeFn, ok := fn.methods[mergeAccumulatorsName]
 	if !ok {
@@ -1342,20 +1336,6 @@ func validateSignature(fnKind, methodName string, fn *Fn, accumType reflect.Type
 		sig := sigFunc(fx, accumType)
 		if err := funcx.Satisfy(fx, sig); err != nil {
 			return &verifyMethodError{fnKind, methodName, err, fn, accumType, sig}
-		}
-	}
-	return nil
-}
-
-func verifyValidNames(fnKind string, fn *Fn, names ...string) error {
-	m := make(map[string]bool)
-	for _, name := range names {
-		m[name] = true
-	}
-
-	for key := range fn.methods {
-		if !m[key] {
-			return errors.Errorf("%s: unexpected exported method %v present on %v. Valid methods are: %v", fnKind, key, fn.Name(), names)
 		}
 	}
 	return nil

--- a/sdks/go/pkg/beam/core/graph/fn_test.go
+++ b/sdks/go/pkg/beam/core/graph/fn_test.go
@@ -503,6 +503,43 @@ func TestNewFn_SplittableDoFn(t *testing.T) {
 	}
 }
 
+func TestNewFn_CombineFn(t *testing.T) {
+	userFn := &GoodCombineFn{}
+	fn, err := NewFn(userFn)
+	if err != nil {
+		t.Errorf("NewFn(%T) failed:\n%v", userFn, err)
+	}
+	cfn, err := AsCombineFn(fn)
+	if err != nil {
+		t.Errorf("AsCombineFn(%v) failed:\n%v", fn.Name(), err)
+	}
+	// Check that we get expected values for all the methods.
+	if got, want := cfn.Name(), "GoodCombineFn"; !strings.HasSuffix(got, want) {
+		t.Errorf("(%v).Name() = %q, want suffix %q", cfn.Name(), got, want)
+	}
+	if cfn.SetupFn() == nil {
+		t.Errorf("(%v).SetupFn() == nil, want value", cfn.Name())
+	}
+	if cfn.CreateAccumulatorFn() == nil {
+		t.Errorf("(%v).CreateAccumulatorFn() == nil, want value", cfn.Name())
+	}
+	if cfn.AddInputFn() == nil {
+		t.Errorf("(%v).AddInputFn() == nil, want value", cfn.Name())
+	}
+	if cfn.MergeAccumulatorsFn() == nil {
+		t.Errorf("(%v).MergeAccumulatorsFn() == nil, want value", cfn.Name())
+	}
+	if cfn.ExtractOutputFn() == nil {
+		t.Errorf("(%v).ExtractOutputFn() == nil, want value", cfn.Name())
+	}
+	if cfn.CompactFn() == nil {
+		t.Errorf("(%v).CompactFn() == nil, want value", cfn.Name())
+	}
+	if cfn.TeardownFn() == nil {
+		t.Errorf("(%v).TeardownFn() == nil, want value", cfn.Name())
+	}
+}
+
 // Do not copy. The following types are for testing signatures only.
 // They are not working examples.
 // Keep all test functions Above this point.
@@ -1391,6 +1428,8 @@ type MyAccum struct{}
 
 type GoodCombineFn struct{}
 
+func (fn *GoodCombineFn) Setup() {}
+
 func (fn *GoodCombineFn) MergeAccumulators(MyAccum, MyAccum) MyAccum {
 	return MyAccum{}
 }
@@ -1406,6 +1445,12 @@ func (fn *GoodCombineFn) AddInput(MyAccum, int) MyAccum {
 func (fn *GoodCombineFn) ExtractOutput(MyAccum) int64 {
 	return 0
 }
+
+func (fn *GoodCombineFn) Compact(MyAccum) MyAccum {
+	return MyAccum{}
+}
+
+func (fn *GoodCombineFn) Teardown() {}
 
 type GoodWErrorCombineFn struct{}
 

--- a/sdks/go/pkg/beam/core/graph/fn_test.go
+++ b/sdks/go/pkg/beam/core/graph/fn_test.go
@@ -20,11 +20,13 @@ package graph
 import (
 	"context"
 	"reflect"
+	"strings"
 	"testing"
 	"time"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/sdf"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/typex"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/util/reflectx"
 )
 
 func TestNewDoFn(t *testing.T) {
@@ -376,6 +378,129 @@ func TestNewCombineFn(t *testing.T) {
 			})
 		}
 	})
+}
+
+func TestNewFn_DoFn(t *testing.T) {
+	// Validate wrap fallthrough
+	reflectx.RegisterStructWrapper(reflect.TypeOf((*GoodDoFn)(nil)).Elem(), func(fn interface{}) map[string]reflectx.Func {
+		gdf := fn.(*GoodDoFn)
+		return map[string]reflectx.Func{
+			processElementName: reflectx.MakeFunc1x1(func(v int) int {
+				return gdf.ProcessElement(v)
+			}),
+		}
+	})
+
+	userFn := &GoodDoFn{}
+	fn, err := NewFn(userFn)
+	if err != nil {
+		t.Errorf("NewFn(%T) failed:\n%v", userFn, err)
+	}
+	dofn, err := AsDoFn(fn, MainSingle)
+	if err != nil {
+		t.Errorf("AsDoFn(%v, MainSingle) failed:\n%v", fn.Name(), err)
+	}
+	// Check that we get expected values for all the methods.
+	if got, want := dofn.Name(), "GoodDoFn"; !strings.HasSuffix(got, want) {
+		t.Errorf("(%v).Name() = %q, want suffix %q", dofn.Name(), got, want)
+	}
+	if dofn.SetupFn() == nil {
+		t.Errorf("(%v).SetupFn() == nil, want value", dofn.Name())
+	}
+	if dofn.StartBundleFn() == nil {
+		t.Errorf("(%v).StartBundleFn() == nil, want value", dofn.Name())
+	}
+	if dofn.ProcessElementFn() == nil {
+		t.Errorf("(%v).ProcessElementFn() == nil, want value", dofn.Name())
+	}
+	if dofn.FinishBundleFn() == nil {
+		t.Errorf("(%v).FinishBundleFn() == nil, want value", dofn.Name())
+	}
+	if dofn.TeardownFn() == nil {
+		t.Errorf("(%v).TeardownFn() == nil, want value", dofn.Name())
+	}
+	if dofn.IsSplittable() {
+		t.Errorf("(%v).IsSplittable() = true, want false", dofn.Name())
+	}
+}
+
+func TestNewFn_SplittableDoFn(t *testing.T) {
+	userFn := &GoodStatefulWatermarkEstimating{}
+	fn, err := NewFn(userFn)
+	if err != nil {
+		t.Errorf("NewFn(%T) failed:\n%v", userFn, err)
+	}
+	dofn, err := AsDoFn(fn, MainSingle)
+	if err != nil {
+		t.Errorf("AsDoFn(%v, MainKv) failed:\n%v", fn.Name(), err)
+	}
+	// Check that we get expected values for all the methods.
+	if dofn.SetupFn() == nil {
+		t.Errorf("(%v).SetupFn() == nil, want value", dofn.Name())
+	}
+	if dofn.StartBundleFn() == nil {
+		t.Errorf("(%v).StartBundleFn() == nil, want value", dofn.Name())
+	}
+	if dofn.ProcessElementFn() == nil {
+		t.Errorf("(%v).ProcessElementFn() == nil, want value", dofn.Name())
+	}
+	if dofn.FinishBundleFn() == nil {
+		t.Errorf("(%v).FinishBundleFn() == nil, want value", dofn.Name())
+	}
+	if dofn.TeardownFn() == nil {
+		t.Errorf("(%v).TeardownFn() == nil, want value", dofn.Name())
+	}
+
+	if !dofn.IsSplittable() {
+		t.Fatalf("(%v).IsSplittable() = false, want true", dofn.Name())
+	}
+	sdofn := (*SplittableDoFn)(dofn)
+
+	if got, want := sdofn.Name(), "GoodStatefulWatermarkEstimating"; !strings.HasSuffix(got, want) {
+		t.Errorf("(%v).Name() = %q, want suffix %q", sdofn.Name(), got, want)
+	}
+	if sdofn.CreateInitialRestrictionFn() == nil {
+		t.Errorf("(%v).CreateInitialRestrictionFn() == nil, want value", sdofn.Name())
+	}
+	if sdofn.CreateTrackerFn() == nil {
+		t.Errorf("(%v).CreateTrackerFn() == nil, want value", sdofn.Name())
+	}
+	if sdofn.RestrictionSizeFn() == nil {
+		t.Errorf("(%v).RestrictionSizeFn() == nil, want value", sdofn.Name())
+	}
+	if got, want := sdofn.RestrictionT(), reflect.TypeOf(RestT{}); got != want {
+		t.Errorf("(%v).RestrictionT() == %v, want %v", sdofn.Name(), got, want)
+	}
+	if sdofn.SplitRestrictionFn() == nil {
+		t.Errorf("(%v).SplitRestrictionFn() == nil, want value", sdofn.Name())
+	}
+	if !sdofn.HasTruncateRestriction() {
+		t.Fatalf("(%v).HasTruncateRestriction() = false, want true", dofn.Name())
+	}
+	if sdofn.TruncateRestrictionFn() == nil {
+		t.Errorf("(%v).TruncateRestrictionFn() == nil, want value", sdofn.Name())
+	}
+	if !sdofn.IsWatermarkEstimating() {
+		t.Fatalf("(%v).IsWatermarkEstimating() = false, want true", dofn.Name())
+	}
+	if sdofn.CreateWatermarkEstimatorFn() == nil {
+		t.Errorf("(%v).CreateWatermarkEstimatorFn() == nil, want value", sdofn.Name())
+	}
+	if !sdofn.IsStatefulWatermarkEstimating() {
+		t.Fatalf("(%v).IsStatefulWatermarkEstimating() = false, want true", dofn.Name())
+	}
+	if sdofn.InitialWatermarkEstimatorStateFn() == nil {
+		t.Errorf("(%v).InitialWatermarkEstimatorStateFn() == nil, want value", sdofn.Name())
+	}
+	if sdofn.WatermarkEstimatorStateFn() == nil {
+		t.Errorf("(%v).WatermarkEstimatorStateFn() == nil, want value", sdofn.Name())
+	}
+	if got, want := sdofn.WatermarkEstimatorT(), reflect.TypeOf(&WatermarkEstimatorT{}); got != want {
+		t.Errorf("(%v).WatermarkEstimatorT() == %v, want %v", sdofn.Name(), got, want)
+	}
+	if got, want := sdofn.WatermarkEstimatorStateT(), reflectx.Int; got != want {
+		t.Errorf("(%v).WatermarkEstimatorT() == %v, want %v", sdofn.Name(), got, want)
+	}
 }
 
 // Do not copy. The following types are for testing signatures only.


### PR DESCRIPTION
Use lifecycle method names directly, rather than excluding all exported methods on DoFns. 

Breaks certain usecases with extreme number (10+) of emitter parameters, when the method doesn't have a generic representation. The static code generator works in those cases, but it isn't recommended.

The ideal work around would be to have a tagged API instead of the positional one, but that's significantly more work.

Using lifecycle names directly neutered the previous verification check anyway, so we've opted to remove that entirely. Additional tests were also added to ensure the fallthrough behavior occurs.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
