### PR TITLE
[#21252] Enforce pubsub message publishing limits in the python SDK

### DIFF
--- a/sdks/python/apache_beam/io/gcp/pubsub.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub.py
@@ -135,6 +135,9 @@ class PubsubMessage(object):
   def _to_proto_str(self, for_publish=False):
     """Get serialized form of ``PubsubMessage``.
 
+    The serialized message is validated against pubsub message limits specified
+    at https://cloud.google.com/pubsub/quotas#resource_limits
+
     Args:
       proto_msg: str containing a serialized protobuf.
       for_publish: bool, if True strip out message fields which cannot be
@@ -147,15 +150,39 @@ class PubsubMessage(object):
       containing the payload of this object.
     """
     msg = pubsub.types.PubsubMessage()
+    if len(self.data) > (10 << 20):
+      raise ValueError('A pubsub message data field must not exceed 10MB')
     msg.data = self.data
-    for key, value in self.attributes.items():
-      msg.attributes[key] = value
-    if self.message_id and not for_publish:
-      msg.message_id = self.message_id
-    if self.publish_time and not for_publish:
-      msg.publish_time = self.publish_time
+
+    if self.attributes:
+      if len(self.attributes) > 100:
+        raise ValueError(
+            'A pubsub message must not have more than 100 attributes.')
+      for key, value in self.attributes.items():
+        if len(key) > 256:
+          raise ValueError(
+              'A pubsub message attribute key must not exceed 256 bytes.')
+        if len(value) > 1024:
+          raise ValueError(
+              'A pubsub message attribute value must not exceed 1024 bytes')
+        msg.attributes[key] = value
+
+    if not for_publish:
+      if self.message_id:
+        msg.message_id = self.message_id
+        if self.publish_time:
+          msg.publish_time = self.publish_time
+
+    if len(self.ordering_key) > 1024:
+      raise ValueError(
+          'A pubsub message ordering key must not exceed 1024 bytes.')
     msg.ordering_key = self.ordering_key
-    return pubsub.types.PubsubMessage.serialize(msg)
+
+    serialized = pubsub.types.PubsubMessage.serialize(msg)
+    if len(serialized) > (10 << 20):
+      raise ValueError(
+          'Serialized pubsub message exceeds the publish request limit of 10MB')
+    return serialized
 
   @staticmethod
   def _from_message(msg):
@@ -340,9 +367,8 @@ class WriteToPubSub(PTransform):
   @staticmethod
   def bytes_to_proto_str(element):
     # type: (bytes) -> bytes
-    msg = pubsub.types.PubsubMessage()
-    msg.data = element
-    return pubsub.types.PubsubMessage.serialize(msg)
+    msg = PubsubMessage(element, {})
+    return msg._to_proto_str(for_publish=True)
 
   def expand(self, pcoll):
     if self.with_attributes:

--- a/sdks/python/apache_beam/io/gcp/pubsub_test.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub_test.py
@@ -105,7 +105,7 @@ class TestPubsubMessage(unittest.TestCase):
       msg = PubsubMessage(b'0', attributes)
       msg._to_proto_str(for_publish=True)
     with self.assertRaisesRegex(ValueError, 'ordering key'):
-      msg = PubsubMessage(b'0', None, ordering_key='0' * 1001)
+      msg = PubsubMessage(b'0', None, ordering_key='0' * 1301)
       msg._to_proto_str(for_publish=True)
 
   def test_eq(self):

--- a/sdks/python/apache_beam/io/gcp/pubsub_test.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub_test.py
@@ -87,6 +87,27 @@ class TestPubsubMessage(unittest.TestCase):
     self.assertEqual(m_converted.data, data)
     self.assertEqual(m_converted.attributes, attributes)
 
+  @unittest.skipIf(pubsub is None, 'GCP dependencies are not installed')
+  def test_payload_publish_invalid(self):
+    with self.assertRaisesRegex(ValueError, r'data field.*10MB'):
+      msg = PubsubMessage(b'0' * 1024 * 1024 * 11, None)
+      msg._to_proto_str(for_publish=True)
+    with self.assertRaisesRegex(ValueError, 'attribute key'):
+      msg = PubsubMessage(b'0', {'0' * 257: '0'})
+      msg._to_proto_str(for_publish=True)
+    with self.assertRaisesRegex(ValueError, 'attribute value'):
+      msg = PubsubMessage(b'0', {'0' * 100: '0' * 1025})
+      msg._to_proto_str(for_publish=True)
+    with self.assertRaisesRegex(ValueError, '100 attributes'):
+      attributes = {}
+      for i in range(0, 101):
+        attributes[str(i)] = str(i)
+      msg = PubsubMessage(b'0', attributes)
+      msg._to_proto_str(for_publish=True)
+    with self.assertRaisesRegex(ValueError, 'ordering key'):
+      msg = PubsubMessage(b'0', None, ordering_key='0' * 1001)
+      msg._to_proto_str(for_publish=True)
+
   def test_eq(self):
     a = PubsubMessage(b'abc', {1: 2, 3: 4})
     b = PubsubMessage(b'abc', {1: 2, 3: 4})


### PR DESCRIPTION
This improves visiblity as otherwise messages can become stuck publishing
inside runners such as dataflow that specialize pubsub publishing. This also allows users to handle errors by
catching them.

Fixes issue #21252

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
