### PR TITLE
[BEAM-14406] Drain test for SDF truncation in Go SDK

### DIFF
--- a/sdks/go/test/integration/integration.go
+++ b/sdks/go/test/integration/integration.go
@@ -79,6 +79,8 @@ var directFilters = []string{
 	"TestLargeWordcount_Loopback",
 	// The direct runner does not support self-checkpointing
 	"TestCheckpointing",
+	// The direct runner does not support pipeline drain for SDF.
+	"TestDrain",
 }
 
 var portableFilters = []string{
@@ -91,6 +93,8 @@ var portableFilters = []string{
 	"TestKafkaIO.*",
 	// The portable runner does not support self-checkpointing
 	"TestCheckpointing",
+	// The portable runner does not support pipeline drain for SDF.
+	"TestDrain",
 }
 
 var flinkFilters = []string{
@@ -101,6 +105,8 @@ var flinkFilters = []string{
 	"TestDebeziumIO_BasicRead",
 	// Triggers are not yet supported
 	"TestTrigger.*",
+	// The flink runner does not support pipeline drain for SDF.
+	"TestDrain",
 }
 
 var samzaFilters = []string{
@@ -116,6 +122,8 @@ var samzaFilters = []string{
 	"TestWordCount.*",
 	// The Samza runner does not support self-checkpointing
 	"TestCheckpointing",
+	// The samza runner does not support pipeline drain for SDF.
+	"TestDrain",
 }
 
 var sparkFilters = []string{
@@ -132,6 +140,8 @@ var sparkFilters = []string{
 	"TestDebeziumIO_BasicRead",
 	// The spark runner does not support self-checkpointing
 	"TestCheckpointing",
+	// The spark runner does not support pipeline drain for SDF.
+	"TestDrain",
 }
 
 var dataflowFilters = []string{
@@ -154,6 +164,8 @@ var dataflowFilters = []string{
 	// Dataflow does not automatically terminate the TestCheckpointing pipeline when
 	// complete.
 	"TestCheckpointing",
+	// Dataflow does not drain jobs by itself.
+	"TestDrain",
 }
 
 // CheckFilters checks if an integration test is filtered to be skipped, either

--- a/sdks/go/test/integration/primitives/drain_test.go
+++ b/sdks/go/test/integration/primitives/drain_test.go
@@ -25,7 +25,6 @@ import (
 
 func TestDrain(t *testing.T) {
 	integration.CheckFilters(t)
-
 	p, s := beam.NewPipelineWithRoot()
 	Drain(s)
 	_, err := ptest.RunWithMetrics(p)


### PR DESCRIPTION
Adds a drain test for SDF truncation during drain added in #17432 . It runs only on Dataflow as of now but it is filtered from it because drain has to be triggered manually from the UI. 

Screenshots of truncation in action:
![image](https://user-images.githubusercontent.com/25881114/171657986-f781bee2-d2bd-4da3-a3ba-1d5a971157fd.png)
![image](https://user-images.githubusercontent.com/25881114/171658252-3d73a500-fdc1-4f93-ad89-097946646f97.png)


closes #21681

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
