### PR TITLE
Alias worker_harness_container_image to sdk_container_image

### DIFF
--- a/sdks/go/pkg/beam/runners/dataflow/dataflow.go
+++ b/sdks/go/pkg/beam/runners/dataflow/dataflow.go
@@ -53,7 +53,8 @@ import (
 var (
 	endpoint               = flag.String("dataflow_endpoint", "", "Dataflow endpoint (optional).")
 	stagingLocation        = flag.String("staging_location", "", "GCS staging location (required).")
-	image                  = flag.String("worker_harness_container_image", "", "Worker harness container image (optional).")
+	workerHarnessImage     = flag.String("worker_harness_container_image", "", "Worker harness container image (optional). Deprecated in favor of the sdk_container_image flag.")
+	image                  = flag.String("sdk_container_image", "", "Worker harness container image (optional).")
 	labels                 = flag.String("labels", "", "JSON-formatted map[string]string of job labels (optional).")
 	serviceAccountEmail    = flag.String("service_account_email", "", "Service account email (optional).")
 	numWorkers             = flag.Int64("num_workers", 0, "Number of workers (optional).")
@@ -103,6 +104,7 @@ var flagFilter = map[string]bool{
 	"dataflow_endpoint":              true,
 	"staging_location":               true,
 	"worker_harness_container_image": true,
+	"sdk_container_image":            true,
 	"labels":                         true,
 	"service_account_email":          true,
 	"num_workers":                    true,
@@ -360,6 +362,12 @@ func gcsRecorderHook(opts []string) perf.CaptureHook {
 func getContainerImage(ctx context.Context) string {
 	urn := jobopts.GetEnvironmentUrn(ctx)
 	if urn == "" || urn == "beam:env:docker:v1" {
+		if *workerHarnessImage != "" {
+			if *image != "" {
+				panic("Both worker_harness_container_image and sdk_container_image cannot both be set. Prefer sdk_container_image, worker_harness_container_image is deprecated.")
+			}
+			return *workerHarnessImage
+		}
 		if *image != "" {
 			return *image
 		}

--- a/sdks/go/pkg/beam/runners/dataflow/dataflow_test.go
+++ b/sdks/go/pkg/beam/runners/dataflow/dataflow_test.go
@@ -182,6 +182,18 @@ func TestGetJobOptions_DockerWithImage(t *testing.T) {
 	*jobopts.EnvironmentType = "docker"
 	*jobopts.EnvironmentConfig = "testContainerImage"
 	*image = "testContainerImageOverride"
+	*workerHarnessImage = ""
+
+	if got, want := getContainerImage(context.Background()), "testContainerImageOverride"; got != want {
+		t.Fatalf("getContainerImage() = %q, want %q", got, want)
+	}
+}
+
+func TestGetJobOptions_DockerWithOldImage(t *testing.T) {
+	*jobopts.EnvironmentType = "docker"
+	*jobopts.EnvironmentConfig = "testContainerImage"
+	*image = ""
+	*workerHarnessImage = "testContainerImageOverride"
 
 	if got, want := getContainerImage(context.Background()), "testContainerImageOverride"; got != want {
 		t.Fatalf("getContainerImage() = %q, want %q", got, want)
@@ -192,6 +204,7 @@ func TestGetJobOptions_DockerNoImage(t *testing.T) {
 	*jobopts.EnvironmentType = "docker"
 	*jobopts.EnvironmentConfig = "testContainerImage"
 	*image = ""
+	*workerHarnessImage = ""
 
 	if got, want := getContainerImage(context.Background()), "testContainerImage"; got != want {
 		t.Fatalf("getContainerImage() = %q, want %q", got, want)


### PR DESCRIPTION
Right now, the Go SDK is inconsistent with Java/Python because it uses `worker_harness_container_image` instead of `sdk_container_image` while the other 2 have deprecated this flag. This deprecates the old flag and aliases it to the new flag.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Format the pull request title like `[BEAM-XXX] Fixes bug in ApproximateQuantiles`, where you replace `BEAM-XXX` with the appropriate JIRA issue, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
