### PR TITLE
Add @yields_batches and @yields_elements

### DIFF
--- a/sdks/python/apache_beam/runners/common.pxd
+++ b/sdks/python/apache_beam/runners/common.pxd
@@ -71,7 +71,7 @@ cdef class DoFnSignature(object):
 
 cdef class DoFnInvoker(object):
   cdef public DoFnSignature signature
-  cdef OutputProcessor output_processor
+  cdef OutputHandler output_handler
   cdef object user_state_context
   cdef public object bundle_finalizer_param
 
@@ -124,24 +124,47 @@ cdef class DoFnRunner:
   cpdef process(self, WindowedValue windowed_value)
 
 
-cdef class OutputProcessor(object):
+cdef class OutputHandler(object):
   @cython.locals(windowed_value=WindowedValue,
                  output_element_count=int64_t)
-  cpdef process_outputs(self, WindowedValue element, results,
-                        watermark_estimator=*)
+  cpdef handle_process_outputs(self, WindowedValue element, results,
+                               watermark_estimator=*)
+
+  @cython.locals(windowed_batch=WindowedBatch,
+                 output_element_count=int64_t)
+  cpdef handle_process_batch_outputs(self, WindowedBatch input_batch, results,
+                                     watermark_estimator=*)
 
 
-cdef class _OutputProcessor(OutputProcessor):
+cdef class _OutputHandler(OutputHandler):
   cdef object window_fn
   cdef Receiver main_receivers
   cdef object tagged_receivers
   cdef DataflowDistributionCounter per_element_output_counter
   cdef object output_batch_converter
+  cdef bint _process_batch_yields_elements
+  cdef bint _process_yields_batches
 
   @cython.locals(windowed_value=WindowedValue,
+                 windowed_batch=WindowedBatch,
                  output_element_count=int64_t)
-  cpdef process_outputs(self, WindowedValue element, results,
-                        watermark_estimator=*)
+  cpdef handle_process_outputs(self, WindowedValue element, results,
+                               watermark_estimator=*)
+
+  @cython.locals(windowed_value=WindowedValue,
+                 windowed_batch=WindowedBatch,
+                 output_element_count=int64_t)
+  cpdef handle_process_batch_outputs(self, WindowedBatch input_batch, results,
+                                     watermark_estimator=*)
+
+  @cython.locals(windowed_value=WindowedValue)
+  cdef inline WindowedValue _maybe_propagate_windowing_info(self, WindowedValue input_element, result)
+  cdef inline tuple _handle_tagged_output(self, result)
+  cdef inline _write_value_to_tag(self, tag, WindowedValue windowed_value,
+                                  watermark_estimator)
+  cdef inline _write_batch_to_tag(self, tag, WindowedBatch windowed_batch,
+                                  watermark_estimator)
+  cdef inline _verify_batch_output(self, result)
 
 cdef class DoFnContext(object):
   cdef object label

--- a/sdks/python/apache_beam/runners/direct/sdf_direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/sdf_direct_runner.py
@@ -37,7 +37,7 @@ from apache_beam.pipeline import PTransformOverride
 from apache_beam.runners.common import DoFnContext
 from apache_beam.runners.common import DoFnInvoker
 from apache_beam.runners.common import DoFnSignature
-from apache_beam.runners.common import OutputProcessor
+from apache_beam.runners.common import OutputHandler
 from apache_beam.runners.direct.evaluation_context import DirectStepContext
 from apache_beam.runners.direct.util import KeyedWorkItem
 from apache_beam.runners.direct.watermark_manager import WatermarkManager
@@ -121,7 +121,7 @@ class PairWithRestrictionFn(beam.DoFn):
   def start_bundle(self):
     self._invoker = DoFnInvoker.create_invoker(
         self._signature,
-        output_processor=_NoneShallPassOutputProcessor(),
+        output_processor=_NoneShallPassOutputHandler(),
         process_invocation=False)
 
   def process(self, element, window=beam.DoFn.WindowParam, *args, **kwargs):
@@ -142,7 +142,7 @@ class SplitRestrictionFn(beam.DoFn):
     signature = DoFnSignature(self._do_fn)
     self._invoker = DoFnInvoker.create_invoker(
         signature,
-        output_processor=_NoneShallPassOutputProcessor(),
+        output_processor=_NoneShallPassOutputHandler(),
         process_invocation=False)
 
   def process(self, element_and_restriction, *args, **kwargs):
@@ -268,7 +268,7 @@ class ProcessFn(beam.DoFn):
         'watermark_estimator_state')
     self.watermark_hold_tag = _ReadModifyWriteStateTag('watermark_hold')
     self._process_element_invoker = None
-    self._output_processor = _OutputProcessor()
+    self._output_processor = _OutputHandler()
 
     self.sdf_invoker = DoFnInvoker.create_invoker(
         DoFnSignature(self.sdf),
@@ -536,7 +536,7 @@ class SDFProcessElementInvoker(object):
     yield result
 
 
-class _OutputProcessor(OutputProcessor):
+class _OutputHandler(OutputHandler):
   def __init__(self):
     self.output_iter = None
 
@@ -549,7 +549,7 @@ class _OutputProcessor(OutputProcessor):
     self.output_iter = None
 
 
-class _NoneShallPassOutputProcessor(OutputProcessor):
+class _NoneShallPassOutputHandler(OutputHandler):
   def process_outputs(
       self, windowed_input_element, output_iter, watermark_estimator=None):
     # type: (WindowedValue, Iterable[Any], Optional[WatermarkEstimator]) -> None

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
@@ -293,6 +293,51 @@ class FnApiRunnerTest(unittest.TestCase):
                                  9*9                        # [ 9, 14)
                                  ]))
 
+  def test_batch_to_element_pardo(self):
+    class ArraySumDoFn(beam.DoFn):
+      @beam.DoFn.yields_elements
+      def process_batch(self, batch: np.ndarray, *unused_args,
+                        **unused_kwargs) -> Iterator[np.int64]:
+        yield batch.sum()
+
+      def infer_output_type(self, input_type):
+        assert input_type == np.int64
+        return np.int64
+
+    with self.create_pipeline() as p:
+      res = (
+          p
+          | beam.Create(np.array(range(100), dtype=np.int64)).with_output_types(
+              np.int64)
+          | beam.ParDo(ArrayMultiplyDoFn())
+          | beam.ParDo(ArraySumDoFn())
+          | beam.CombineGlobally(sum))
+
+      assert_that(res, equal_to([99 * 50 * 2]))
+
+  def test_element_to_batch_pardo(self):
+    class ArrayProduceDoFn(beam.DoFn):
+      @beam.DoFn.yields_batches
+      def process(self, element: np.int64, *unused_args,
+                  **unused_kwargs) -> Iterator[np.ndarray]:
+        yield np.array([element] * element)
+
+      # infer_output_type must be defined (when there's no process method),
+      # otherwise we don't know the input type is the same as output type.
+      def infer_output_type(self, input_type):
+        return np.int64
+
+    with self.create_pipeline() as p:
+      res = (
+          p
+          | beam.Create(np.array([1, 2, 3], dtype=np.int64)).with_output_types(
+              np.int64)
+          | beam.ParDo(ArrayProduceDoFn())
+          | beam.ParDo(ArrayMultiplyDoFn())
+          | beam.Map(lambda x: x * 3))
+
+      assert_that(res, equal_to([6, 12, 12, 18, 18, 18]))
+
   def test_pardo_large_input(self):
     try:
       utils.check_compiled('apache_beam.coders.coder_impl')

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
@@ -320,7 +320,7 @@ class FnApiRunnerTest(unittest.TestCase):
       @beam.DoFn.yields_batches
       def process(self, element: np.int64, *unused_args,
                   **unused_kwargs) -> Iterator[np.ndarray]:
-        yield np.array([element] * element)
+        yield np.array([element] * int(element))
 
       # infer_output_type must be defined (when there's no process method),
       # otherwise we don't know the input type is the same as output type.

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -786,8 +786,8 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
       if (output_batch_type is not None and
           (not process_batch_type == output_batch_type)):
         raise TypeError(
-            f"DoFn {self!r} yields batches from both process and process_batch, "
-            "but they produce different types:\n"
+            f"DoFn {self!r} yields batches from both process and "
+            "process_batch, but they produce different types:\n"
             f" process: {output_batch_type}\n"
             f" process_batch: {process_batch_type!r}")
 

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -581,6 +581,26 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
 
     return wrapper
 
+  @staticmethod
+  def yields_elements(fn):
+    if not fn.__name__ in ('process', 'process_batch'):
+      raise TypeError(
+          "@yields_elements must be applied to a process or "
+          f"process_batch method, got {fn!r}.")
+
+    fn._beam_yields_elements = True
+    return fn
+
+  @staticmethod
+  def yields_batches(fn):
+    if not fn.__name__ in ('process', 'process_batch'):
+      raise TypeError(
+          "@yields_elements must be applied to a process or "
+          f"process_batch method, got {fn!r}.")
+
+    fn._beam_yields_batches = True
+    return fn
+
   def default_label(self):
     return self.__class__.__name__
 
@@ -703,6 +723,20 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
         if hasattr(self.process_batch, '__self__')
         else self.process_batch) != DoFn.process_batch
 
+  @property
+  def can_yield_batches(self) -> bool:
+    return (
+        (self.process_defined and self.process_yields_batches) or
+        (self.process_batch_defined and not self.process_batch_yields_elements))
+
+  @property
+  def process_yields_batches(self) -> bool:
+    return getattr(self.process, '_beam_yields_batches', False)
+
+  @property
+  def process_batch_yields_elements(self) -> bool:
+    return getattr(self.process_batch, '_beam_yields_elements', False)
+
   def get_input_batch_type(self) -> typing.Optional[TypeConstraint]:
     if not self.process_batch_defined:
       return None
@@ -717,14 +751,12 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
           "process_batch implementations.")
     return typehints.native_type_compatibility.convert_to_beam_type(input_type)
 
-  def get_output_batch_type(self) -> typing.Optional[TypeConstraint]:
-    if not self.process_batch_defined:
-      return None
-    return_type = inspect.signature(self.process_batch).return_annotation
+  @staticmethod
+  def _get_element_type_from_return_annotation(method, input_type):
+    return_type = inspect.signature(method).return_annotation
     if return_type == inspect.Signature.empty:
       # output type not annotated, try to infer it
-      return_type = trivial_inference.infer_return_type(
-          self.process_batch, [self.get_input_batch_type()])
+      return_type = trivial_inference.infer_return_type(method, [input_type])
 
     return_type = typehints.native_type_compatibility.convert_to_beam_type(
         return_type)
@@ -734,8 +766,34 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
       return return_type.yielded_type
     else:
       raise TypeError(
-          "Expected Iterator return type annotation, did you mean "
-          f"Iterator[{return_type}]")
+          "Expected Iterator in return type annotation for "
+          f"{method!r}, did you mean Iterator[{return_type}]?")
+
+  def get_output_batch_type(
+      self, input_element_type) -> typing.Optional[TypeConstraint]:
+    output_batch_type = None
+    if self.process_defined and self.process_yields_batches:
+      # TODO: Use the element_type passed to infer_output_type instead of
+      # typehints.Any
+      output_batch_type = self._get_element_type_from_return_annotation(
+          self.process, input_element_type)
+    if self.process_batch_defined and not self.process_batch_yields_elements:
+      process_batch_type = self._get_element_type_from_return_annotation(
+          self.process_batch, self.get_input_batch_type())
+
+      # TODO: Consider requiring an inheritance relationship rather than
+      # equality
+      if (output_batch_type is not None and
+          (not process_batch_type == output_batch_type)):
+        raise TypeError(
+            f"DoFn {self!r} yields batches from both process and process_batch, "
+            "but they produce different types:\n"
+            f" process: {output_batch_type}\n"
+            f" process_batch: {process_batch_type!r}")
+
+      output_batch_type = process_batch_type
+
+    return output_batch_type
 
   def _strip_output_annotations(self, type_hint):
     annotations = (TimestampedValue, WindowedValue, pvalue.TaggedOutput)
@@ -1355,8 +1413,7 @@ class ParDo(PTransformWithSideInputs):
     return self.fn.infer_output_type(input_type)
 
   def infer_batch_converters(self, input_element_type):
-    # This assumes batch input implies batch output
-    # TODO(BEAM-14293): Define and handle yields_batches and yields_elements
+    # TODO: Test this code (in batch_dofn_test)
     if self.fn.process_batch_defined:
       input_batch_type = self.fn.get_input_batch_type()
 
@@ -1365,30 +1422,28 @@ class ParDo(PTransformWithSideInputs):
             "process_batch method on {self.fn!r} does not have "
             "an input type annoation")
 
-      output_batch_type = self.fn.get_output_batch_type()
-      if output_batch_type is None:
-        raise TypeError(
-            "process_batch method on {self.fn!r} does not have "
-            "a return type annoation")
-
       # Generate a batch converter to convert between the input type and the
       # (batch) input type of process_batch
       self.fn.input_batch_converter = BatchConverter.from_typehints(
           element_type=input_element_type, batch_type=input_batch_type)
+    else:
+      self.fn.input_batch_converter = None
+
+    if self.fn.can_yield_batches:
+      output_batch_type = self.fn.get_output_batch_type(input_element_type)
+      if output_batch_type is None:
+        # TODO: Mention process method in this error
+        raise TypeError(
+            f"process_batch method on {self.fn!r} does not have "
+            "a return type annoation")
 
       # Generate a batch converter to convert between the output type and the
       # (batch) output type of process_batch
       output_element_type = self.infer_output_type(input_element_type)
       self.fn.output_batch_converter = BatchConverter.from_typehints(
           element_type=output_element_type, batch_type=output_batch_type)
-
-  def infer_output_batch_type(self):
-    # TODO(BEAM-14293): Handle process() with @yields_batch
-    if not self.fn.process_batch_defined:
-      return
-
-    batch_type = self.fn.get_output_batch_type()
-    return batch_type
+    else:
+      self.fn.output_batch_converter = None
 
   def make_fn(self, fn, has_side_inputs):
     if isinstance(fn, DoFn):
@@ -1427,8 +1482,7 @@ class ParDo(PTransformWithSideInputs):
             key_coder,
             self)
 
-    if self.dofn.process_batch_defined:
-      self.infer_batch_converters(pcoll.element_type)
+    self.infer_batch_converters(pcoll.element_type)
 
     return pvalue.PCollection.from_(pcoll)
 

--- a/sdks/python/apache_beam/utils/windowed_value.py
+++ b/sdks/python/apache_beam/utils/windowed_value.py
@@ -354,6 +354,12 @@ class HomogeneousWindowedBatch(WindowedBatch):
     for value in explode_fn(self._wv.value):
       yield self._wv.with_value(value)
 
+  def as_empty_windowed_value(self):
+    """Get a single WindowedValue with identical windowing information to this
+    HomogeneousWindowedBatch, but with value=None. Useful for re-using APIs that
+    pull windowing information from a WindowedValue."""
+    return self._wv.with_value(None)
+
   def __eq__(self, other):
     if isinstance(other, HomogeneousWindowedBatch):
       return self._wv == other._wv
@@ -361,6 +367,11 @@ class HomogeneousWindowedBatch(WindowedBatch):
 
   def __hash__(self):
     return hash(self._wv)
+
+  @staticmethod
+  def from_batch_and_windowed_value(
+      *, batch, windowed_value: WindowedValue) -> 'WindowedBatch':
+    return HomogeneousWindowedBatch(windowed_value.with_value(batch))
 
   @staticmethod
   def from_windowed_values(


### PR DESCRIPTION
This PR adds two new decorators, `@yields_batches` and `@yields_elements`, which override the default interpretation for the output of `DoFn.process` and `DoFn.process_batch`. These decorators are handled via changes to `OutputProcessor` (now renamed to `OutputHandler` for clarity), which branches depending on whether batches or elements are expected in the `results` iterable.

Where possible, common logic in `OutputHandler` was extracted into private helper methods that are re-used. The .pxd definition for these methods indicates they should be inlined in cython-generated code so they don't affect performance.

Fixes #21656

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
