### PR TITLE
Add ability to self-assign issues for non-committers

### DIFF
--- a/.github/workflows/self-assign.yml
+++ b/.github/workflows/self-assign.yml
@@ -1,0 +1,30 @@
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+name: Assign issue to contributor
+on: 
+  issue_comment:
+
+jobs:
+  assign:
+    name: Take an issue
+    runs-on: ubuntu-latest
+    steps:
+    - name: take the issue
+      uses: bdougie/take-action@main
+      env:
+        GITHUB_TOKEN: ${{ github.token }}
+      with:
+        trigger: .take-issue

--- a/.github/workflows/self-assign.yml
+++ b/.github/workflows/self-assign.yml
@@ -13,19 +13,33 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-name: Assign issue to contributor
+name: Assign or close an issue
 on: 
   issue_comment:
 
 jobs:
   assign:
-    name: Take an issue
+    name: Take or close an issue
     runs-on: ubuntu-latest
     steps:
-    - name: take the issue
-      uses: damccorm/take-and-close-action@b37b24519483c490148839a50f74a2e9081b3f3c
+    - run: |
+        BODY="$(jq '.comment.body' $GITHUB_EVENT_PATH)"
+        ISSUE_NUMBER="$(jq '.issue.number' $GITHUB_EVENT_PATH)"
+        LOGIN="$(jq '.comment.user.login' $GITHUB_EVENT_PATH | tr -d \")"
+        REPO="$(jq '.repository.full_name' $GITHUB_EVENT_PATH | tr -d \")"
+        ISSUE_JSON="$(jq '.issue' $GITHUB_EVENT_PATH)"
+        if [[ $BODY == *"$INPUT_TAKE"* ]]; then
+          echo "Assigning issue $ISSUE_NUMBER to $LOGIN"
+          echo "Using the link: https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees"
+          curl -H "Authorization: token $GITHUB_TOKEN" -d '{"assignees":["'"$LOGIN"'"]}' https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees
+        fi
+        if [[ $BODY == *"$INPUT_CLOSE"* ]]; then
+          echo "Closing issue $ISSUE_NUMBER"
+          echo "Using the link: https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER"
+          curl -X PATCH -H "Authorization: token $GITHUB_TOKEN" -d '{"state":"closed"}' https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER
+        fi
+      shell: bash
       env:
+        INPUT_TAKE: ".take-issue"
+        INPUT_CLOSE: ".close-issue"
         GITHUB_TOKEN: ${{ github.token }}
-      with:
-        take: .take-issue
-        close: .close-issue

--- a/.github/workflows/self-assign.yml
+++ b/.github/workflows/self-assign.yml
@@ -23,8 +23,9 @@ jobs:
     runs-on: ubuntu-latest
     steps:
     - name: take the issue
-      uses: bdougie/take-action@main
+      uses: damccorm/take-and-close-action@b37b24519483c490148839a50f74a2e9081b3f3c
       env:
         GITHUB_TOKEN: ${{ github.token }}
       with:
-        trigger: .take-issue
+        take: .take-issue
+        close: .close-issue

--- a/website/www/site/content/en/contribute/get-started-contributing.md
+++ b/website/www/site/content/en/contribute/get-started-contributing.md
@@ -110,6 +110,7 @@ Questions can be asked on the [#beam channel of the ASF Slack](https://beam.apac
    Tracking your work in an issue will avoid duplicated or conflicting work, and provide
    a place for notes. Later, your pull request will be linked to the issue as well.
 2. Comment ".take-issue" on the issue. This will cause the issue to be assigned to you.
+   When you've completed the issue, you can close it by commenting ".close-issue".
 3. If your change is large or it is your first change, it is a good idea to
    [discuss it on the dev@beam.apache.org mailing list](https://beam.apache.org/community/contact-us/).
 4. For large changes create a design doc

--- a/website/www/site/content/en/contribute/get-started-contributing.md
+++ b/website/www/site/content/en/contribute/get-started-contributing.md
@@ -109,7 +109,7 @@ Questions can be asked on the [#beam channel of the ASF Slack](https://beam.apac
 1. Find or create an issue in the [Beam repo](https://github.com/apache/beam/issues/new/choose).
    Tracking your work in an issue will avoid duplicated or conflicting work, and provide
    a place for notes. Later, your pull request will be linked to the issue as well.
-2. Comment on the issue saying that you would like to work on it.
+2. Comment ".take-issue" on the issue. This will cause the issue to be assigned to you.
 3. If your change is large or it is your first change, it is a good idea to
    [discuss it on the dev@beam.apache.org mailing list](https://beam.apache.org/community/contact-us/).
 4. For large changes create a design doc

--- a/website/www/site/content/en/contribute/get-started-contributing.md
+++ b/website/www/site/content/en/contribute/get-started-contributing.md
@@ -111,6 +111,8 @@ Questions can be asked on the [#beam channel of the ASF Slack](https://beam.apac
    a place for notes. Later, your pull request will be linked to the issue as well.
 2. Comment ".take-issue" on the issue. This will cause the issue to be assigned to you.
    When you've completed the issue, you can close it by commenting ".close-issue".
+   If you are a committer and would like to assign an issue to a non-committer, they must comment
+   on the issue first; please tag the user asking them to do so or to comment ".take-issue".
 3. If your change is large or it is your first change, it is a good idea to
    [discuss it on the dev@beam.apache.org mailing list](https://beam.apache.org/community/contact-us/).
 4. For large changes create a design doc


### PR DESCRIPTION
Right now, non-committers can't self assign issues - this allows them to do so by commenting .take-issue.

Example of this working - https://github.com/damccorm/playground/issues/3

Addresses https://github.com/apache/beam/issues/21684

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Add a link to the appropriate issue in your description, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
