### PR TITLE
[BEAM-14337] Support batched key examples and non-batchable kwargs params for RunInference models

### DIFF
--- a/sdks/python/apache_beam/ml/inference/base_test.py
+++ b/sdks/python/apache_beam/ml/inference/base_test.py
@@ -19,7 +19,6 @@
 
 import pickle
 import unittest
-from typing import Any
 from typing import Iterable
 from typing import List
 
@@ -40,7 +39,8 @@ class FakeInferenceRunner(base.InferenceRunner[int, int, FakeModel]):
   def __init__(self, clock=None):
     self._fake_clock = clock
 
-  def run_inference(self, batch: List[int], model: FakeModel) -> Iterable[int]:
+  def run_inference(self, batch: List[int], model: FakeModel,
+                    **kwargs) -> Iterable[int]:
     if self._fake_clock:
       self._fake_clock.current_time_ns += 3_000_000  # 3 milliseconds
     for example in batch:
@@ -89,6 +89,18 @@ class FakeLoaderWithBatchArgForwarding(FakeModelLoader):
     return {'min_batch_size': 9999}
 
 
+class FakeInferenceRunnerKwargs(FakeInferenceRunner):
+  def run_inference(self, batch, unused_model, **kwargs):
+    if not kwargs.get('key'):
+      raise ValueError('key should be True')
+    return batch
+
+
+class FakeLoaderWithKwargs(FakeModelLoader):
+  def get_inference_runner(self):
+    return FakeInferenceRunnerKwargs()
+
+
 class RunInferenceBaseTest(unittest.TestCase):
   def test_run_inference_impl_simple_examples(self):
     with TestPipeline() as pipeline:
@@ -106,6 +118,14 @@ class RunInferenceBaseTest(unittest.TestCase):
       pcoll = pipeline | 'start' >> beam.Create(keyed_examples)
       actual = pcoll | base.RunInference(FakeModelLoader())
       assert_that(actual, equal_to(expected), label='assert:inferences')
+
+  def test_run_inference_impl_kwargs(self):
+    with TestPipeline() as pipeline:
+      examples = [1, 5, 3, 10]
+      pcoll = pipeline | 'start' >> beam.Create(examples)
+      kwargs = {'key': True}
+      actual = pcoll | base.RunInference(FakeLoaderWithKwargs(), **kwargs)
+      assert_that(actual, equal_to(examples), label='assert:inferences')
 
   def test_counted_metrics(self):
     pipeline = TestPipeline()

--- a/sdks/python/apache_beam/ml/inference/pytorch_inference.py
+++ b/sdks/python/apache_beam/ml/inference/pytorch_inference.py
@@ -57,7 +57,8 @@ class PytorchInferenceRunner(InferenceRunner[torch.Tensor,
   def run_inference(
       self,
       batch: List[Union[torch.Tensor, Dict[str, torch.Tensor]]],
-      model: torch.nn.Module) -> Iterable[PredictionResult]:
+      model: torch.nn.Module,
+      **kwargs) -> Iterable[PredictionResult]:
     """
     Runs inferences on a batch of Tensors and returns an Iterable of
     Tensor Predictions.
@@ -65,6 +66,7 @@ class PytorchInferenceRunner(InferenceRunner[torch.Tensor,
     This method stacks the list of Tensors in a vectorized format to optimize
     the inference call.
     """
+    prediction_params = kwargs.get('prediction_params', {})
 
     # If elements in `batch` are provided as a dictionaries from key to Tensors,
     # then iterate through the batch list, and group Tensors to the same key
@@ -78,12 +80,12 @@ class PytorchInferenceRunner(InferenceRunner[torch.Tensor,
         batched_tensors = torch.stack(key_to_tensor_list[key])
         batched_tensors = self._convert_to_device(batched_tensors)
         key_to_batched_tensors[key] = batched_tensors
-      predictions = model(**key_to_batched_tensors)
+      predictions = model(**key_to_batched_tensors, **prediction_params)
     else:
       # If elements in `batch` are provided as Tensors, then do a regular stack
       batched_tensors = torch.stack(batch)
       batched_tensors = self._convert_to_device(batched_tensors)
-      predictions = model(batched_tensors)
+      predictions = model(batched_tensors, **prediction_params)
     return [PredictionResult(x, y) for x, y in zip(batch, predictions)]
 
   def get_num_bytes(self, batch: List[torch.Tensor]) -> int:

--- a/sdks/python/apache_beam/ml/inference/pytorch_inference.py
+++ b/sdks/python/apache_beam/ml/inference/pytorch_inference.py
@@ -17,11 +17,13 @@
 
 # pytype: skip-file
 
+from collections import defaultdict
 from typing import Any
 from typing import Callable
 from typing import Dict
 from typing import Iterable
 from typing import List
+from typing import Union
 
 import torch
 from apache_beam.io.filesystems import FileSystems
@@ -41,8 +43,21 @@ class PytorchInferenceRunner(InferenceRunner[torch.Tensor,
   def __init__(self, device: torch.device):
     self._device = device
 
-  def run_inference(self, batch: List[torch.Tensor],
-                    model: torch.nn.Module) -> Iterable[PredictionResult]:
+  def _convert_to_device(self, examples: torch.Tensor) -> torch.Tensor:
+    """
+    Converts samples to a style matching given device.
+
+    Note: A user may pass in device='GPU' but if GPU is not detected in the
+    environment it must be converted back to CPU.
+    """
+    if examples.device != self._device:
+      examples = examples.to(self._device)
+    return examples
+
+  def run_inference(
+      self,
+      batch: List[Union[torch.Tensor, Dict[str, torch.Tensor]]],
+      model: torch.nn.Module) -> Iterable[PredictionResult]:
     """
     Runs inferences on a batch of Tensors and returns an Iterable of
     Tensor Predictions.
@@ -51,15 +66,35 @@ class PytorchInferenceRunner(InferenceRunner[torch.Tensor,
     the inference call.
     """
 
-    torch_batch = torch.stack(batch)
-    if torch_batch.device != self._device:
-      torch_batch = torch_batch.to(self._device)
-    predictions = model(torch_batch)
+    # If elements in `batch` are provided as a dictionaries from key to Tensors,
+    # then iterate through the batch list, and group Tensors to the same key
+    if isinstance(batch[0], dict):
+      key_to_tensor_list = defaultdict(list)
+      for example in batch:
+        for key, tensor in example.items():
+          key_to_tensor_list[key].append(tensor)
+      key_to_batched_tensors = {}
+      for key in key_to_tensor_list:
+        batched_tensors = torch.stack(key_to_tensor_list[key])
+        batched_tensors = self._convert_to_device(batched_tensors)
+        key_to_batched_tensors[key] = batched_tensors
+      predictions = model(**key_to_batched_tensors)
+    else:
+      # If elements in `batch` are provided as Tensors, then do a regular stack
+      batched_tensors = torch.stack(batch)
+      batched_tensors = self._convert_to_device(batched_tensors)
+      predictions = model(batched_tensors)
     return [PredictionResult(x, y) for x, y in zip(batch, predictions)]
 
   def get_num_bytes(self, batch: List[torch.Tensor]) -> int:
     """Returns the number of bytes of data for a batch of Tensors."""
-    return sum((el.element_size() for tensor in batch for el in tensor))
+    # If elements in `batch` are provided as a dictionaries from key to Tensors
+    if isinstance(batch[0], dict):
+      return sum(
+          (el.element_size() for tensor in batch for el in tensor.values()))
+    else:
+      # If elements in `batch` are provided as Tensors
+      return sum((el.element_size() for tensor in batch for el in tensor))
 
   def get_metrics_namespace(self) -> str:
     """

--- a/sdks/python/apache_beam/ml/inference/pytorch_inference_test.py
+++ b/sdks/python/apache_beam/ml/inference/pytorch_inference_test.py
@@ -47,11 +47,58 @@ try:
 except ImportError:
   GCSFileSystem = None  # type: ignore
 
+TWO_FEATURES_EXAMPLES = [
+    torch.from_numpy(np.array([1, 5], dtype="float32")),
+    torch.from_numpy(np.array([3, 10], dtype="float32")),
+    torch.from_numpy(np.array([-14, 0], dtype="float32")),
+    torch.from_numpy(np.array([0.5, 0.5], dtype="float32")),
+]
 
-def _compare_prediction_result(a, b):
-  return (
-      torch.equal(a.inference, b.inference) and
-      torch.equal(a.example, b.example))
+TWO_FEATURES_PREDICTIONS = [
+    PredictionResult(ex, pred) for ex,
+    pred in zip(
+        TWO_FEATURES_EXAMPLES,
+        torch.Tensor(
+            [f1 * 2.0 + f2 * 3 + 0.5
+             for f1, f2 in TWO_FEATURES_EXAMPLES]).reshape(-1, 1))
+]
+
+KWARGS_TORCH_EXAMPLES = [
+    {
+        'k1': torch.from_numpy(np.array([1], dtype="float32")),
+        'k2': torch.from_numpy(np.array([1.5], dtype="float32"))
+    },
+    {
+        'k1': torch.from_numpy(np.array([5], dtype="float32")),
+        'k2': torch.from_numpy(np.array([5.5], dtype="float32"))
+    },
+    {
+        'k1': torch.from_numpy(np.array([-3], dtype="float32")),
+        'k2': torch.from_numpy(np.array([-3.5], dtype="float32"))
+    },
+    {
+        'k1': torch.from_numpy(np.array([10.0], dtype="float32")),
+        'k2': torch.from_numpy(np.array([10.5], dtype="float32"))
+    },
+]
+
+KWARGS_TORCH_PREDICTIONS = [
+    PredictionResult(ex, pred) for ex,
+    pred in zip(
+        KWARGS_TORCH_EXAMPLES,
+        torch.Tensor([(example['k1'] * 2.0 + 0.5) + (example['k2'] * 2.0 + 0.5)
+                      for example in KWARGS_TORCH_EXAMPLES]).reshape(-1, 1))
+]
+
+
+def _compare_prediction_result(x, y):
+  if isinstance(x.example, dict):
+    example_equals = all(
+        torch.equal(x, y) for x,
+        y in zip(x.example.values(), y.example.values()))
+  else:
+    example_equals = torch.equal(x.example, y.example)
+  return torch.equal(x.inference, y.inference) and example_equals
 
 
 class PytorchLinearRegression(torch.nn.Module):
@@ -66,12 +113,6 @@ class PytorchLinearRegression(torch.nn.Module):
 
 @pytest.mark.uses_pytorch
 class PytorchRunInferenceTest(unittest.TestCase):
-  def setUp(self):
-    self.tmpdir = tempfile.mkdtemp()
-
-  def tearDown(self):
-    shutil.rmtree(self.tmpdir)
-
   def test_inference_runner_single_tensor_feature(self):
     examples = [
         torch.from_numpy(np.array([1], dtype="float32")),
@@ -96,26 +137,9 @@ class PytorchRunInferenceTest(unittest.TestCase):
     inference_runner = PytorchInferenceRunner(torch.device('cpu'))
     predictions = inference_runner.run_inference(examples, model)
     for actual, expected in zip(predictions, expected_predictions):
-      self.assertTrue(_compare_prediction_result(actual, expected))
+      self.assertEqual(actual, expected)
 
   def test_inference_runner_multiple_tensor_features(self):
-    examples = torch.from_numpy(
-        np.array([1, 5, 3, 10, -14, 0, 0.5, 0.5],
-                 dtype="float32")).reshape(-1, 2)
-    examples = [
-        torch.from_numpy(np.array([1, 5], dtype="float32")),
-        torch.from_numpy(np.array([3, 10], dtype="float32")),
-        torch.from_numpy(np.array([-14, 0], dtype="float32")),
-        torch.from_numpy(np.array([0.5, 0.5], dtype="float32")),
-    ]
-    expected_predictions = [
-        PredictionResult(ex, pred) for ex,
-        pred in zip(
-            examples,
-            torch.Tensor([f1 * 2.0 + f2 * 3 + 0.5
-                          for f1, f2 in examples]).reshape(-1, 1))
-    ]
-
     model = PytorchLinearRegression(input_dim=2, output_dim=1)
     model.load_state_dict(
         OrderedDict([('linear.weight', torch.Tensor([[2.0, 3]])),
@@ -123,8 +147,43 @@ class PytorchRunInferenceTest(unittest.TestCase):
     model.eval()
 
     inference_runner = PytorchInferenceRunner(torch.device('cpu'))
-    predictions = inference_runner.run_inference(examples, model)
-    for actual, expected in zip(predictions, expected_predictions):
+    predictions = inference_runner.run_inference(TWO_FEATURES_EXAMPLES, model)
+    for actual, expected in zip(predictions, TWO_FEATURES_PREDICTIONS):
+      self.assertEqual(actual, expected)
+
+  def test_inference_runner_kwargs(self):
+    """
+    This tests for inputs that are passed as a dictionary from key to tensor
+    instead of a standard non-kwarg input.
+
+    Example:
+    Typical input format is
+    input = torch.tensor([1, 2, 3])
+
+    But Pytorch syntax allows inputs to have the form
+    input = {
+      'k1' : torch.tensor([1, 2, 3]),
+      'k2' : torch.tensor([4, 5, 6])
+    }
+    """
+    class PytorchLinearRegressionMultipleArgs(torch.nn.Module):
+      def __init__(self, input_dim, output_dim):
+        super().__init__()
+        self.linear = torch.nn.Linear(input_dim, output_dim)
+
+      def forward(self, k1, k2):
+        out = self.linear(k1) + self.linear(k2)
+        return out
+
+    model = PytorchLinearRegressionMultipleArgs(input_dim=1, output_dim=1)
+    model.load_state_dict(
+        OrderedDict([('linear.weight', torch.Tensor([[2.0]])),
+                     ('linear.bias', torch.Tensor([0.5]))]))
+    model.eval()
+
+    inference_runner = PytorchInferenceRunner(torch.device('cpu'))
+    predictions = inference_runner.run_inference(KWARGS_TORCH_EXAMPLES, model)
+    for actual, expected in zip(predictions, KWARGS_TORCH_PREDICTIONS):
       self.assertTrue(_compare_prediction_result(actual, expected))
 
   def test_num_bytes(self):
@@ -140,19 +199,17 @@ class PytorchRunInferenceTest(unittest.TestCase):
     self.assertEqual(
         'RunInferencePytorch', inference_runner.get_metrics_namespace())
 
-  def test_pipeline_local_model(self):
-    with TestPipeline() as pipeline:
-      examples = torch.from_numpy(
-          np.array([1, 5, 3, 10, -14, 0, 0.5, 0.5],
-                   dtype="float32")).reshape(-1, 2)
-      expected_predictions = [
-          PredictionResult(ex, pred) for ex,
-          pred in zip(
-              examples,
-              torch.Tensor([f1 * 2.0 + f2 * 3 + 0.5
-                            for f1, f2 in examples]).reshape(-1, 1))
-      ]
 
+@pytest.mark.uses_pytorch
+class PytorchRunInferencePipelineTest(unittest.TestCase):
+  def setUp(self):
+    self.tmpdir = tempfile.mkdtemp()
+
+  def tearDown(self):
+    shutil.rmtree(self.tmpdir)
+
+  def test_pipeline_local_model_simple(self):
+    with TestPipeline() as pipeline:
       state_dict = OrderedDict([('linear.weight', torch.Tensor([[2.0, 3]])),
                                 ('linear.bias', torch.Tensor([0.5]))])
       path = os.path.join(self.tmpdir, 'my_state_dict_path')
@@ -165,11 +222,12 @@ class PytorchRunInferenceTest(unittest.TestCase):
               'input_dim': 2, 'output_dim': 1
           })
 
-      pcoll = pipeline | 'start' >> beam.Create(examples)
+      pcoll = pipeline | 'start' >> beam.Create(TWO_FEATURES_EXAMPLES)
       predictions = pcoll | RunInference(model_loader)
       assert_that(
           predictions,
-          equal_to(expected_predictions, equals_fn=_compare_prediction_result))
+          equal_to(
+              TWO_FEATURES_PREDICTIONS, equals_fn=_compare_prediction_result))
 
   @unittest.skipIf(GCSFileSystem is None, 'GCP dependencies are not installed')
   def test_pipeline_gcs_model(self):

--- a/sdks/python/apache_beam/ml/inference/sklearn_inference.py
+++ b/sdks/python/apache_beam/ml/inference/sklearn_inference.py
@@ -18,7 +18,6 @@
 import enum
 import pickle
 import sys
-from typing import Any
 from typing import Iterable
 from typing import List
 
@@ -45,8 +44,9 @@ class ModelFileType(enum.Enum):
 class SklearnInferenceRunner(InferenceRunner[numpy.ndarray,
                                              PredictionResult,
                                              BaseEstimator]):
-  def run_inference(self, batch: List[numpy.ndarray],
-                    model: BaseEstimator) -> Iterable[PredictionResult]:
+  def run_inference(
+      self, batch: List[numpy.ndarray], model: BaseEstimator,
+      **kwargs) -> Iterable[PredictionResult]:
     # vectorize data for better performance
     vectorized_batch = numpy.stack(batch, axis=0)
     predictions = model.predict(vectorized_batch)


### PR DESCRIPTION
This PR has two related, but technically independent efforts. 

**1. Support for batched keyed examples.**
We currently only support ability to pass in a single Tensor that does not have any keys attached to it: `model(batched_input)`. We want to support passing in key-batched values to pytorch model via kwargs in model() call. like so: `model(**batched_inputs)`.

Implementation: Because of the way Beam returns BatchElements(), we will convert a list of (key to Tensor) dicts into a dict of Tensor lists.

**2. Support for non-batchable kwargs params.**
We want to support the ability to pass in non-batchable kwargs params to RunInference models, particularly for Pytorch.

This adds the `**kwargs` as an argument to `RunInference`. Since the original motivation was for Pytorch models, we added an interpreted parameter `prediction_params` to the PytorchInferenceRunner.

------------------------

Note: This is a squash of https://github.com/apache/beam/pull/17470/ so that we can make a distinction in the commit history.