### PR TITLE
Allow users to comment `.take-issue` without taking

### DIFF
--- a/.github/workflows/self-assign.yml
+++ b/.github/workflows/self-assign.yml
@@ -28,12 +28,12 @@ jobs:
         LOGIN="$(jq '.comment.user.login' $GITHUB_EVENT_PATH | tr -d \")"
         REPO="$(jq '.repository.full_name' $GITHUB_EVENT_PATH | tr -d \")"
         ISSUE_JSON="$(jq '.issue' $GITHUB_EVENT_PATH)"
-        if [[ $BODY == *"$INPUT_TAKE"* ]]; then
+        if [[ $BODY == *"$INPUT_TAKE"* && $BODY != *"\`$INPUT_TAKE\`"* ]]; then
           echo "Assigning issue $ISSUE_NUMBER to $LOGIN"
           echo "Using the link: https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees"
           curl -H "Authorization: token $GITHUB_TOKEN" -d '{"assignees":["'"$LOGIN"'"]}' https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER/assignees
         fi
-        if [[ $BODY == *"$INPUT_CLOSE"* ]]; then
+        if [[ $BODY == *"$INPUT_CLOSE"* && $BODY != *"\`$INPUT_CLOSE\`"* ]]; then
           echo "Closing issue $ISSUE_NUMBER"
           echo "Using the link: https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER"
           curl -X PATCH -H "Authorization: token $GITHUB_TOKEN" -d '{"state":"closed"}' https://api.github.com/repos/$REPO/issues/$ISSUE_NUMBER

--- a/website/www/site/content/en/contribute/get-started-contributing.md
+++ b/website/www/site/content/en/contribute/get-started-contributing.md
@@ -113,7 +113,7 @@ Questions can be asked on the [#beam channel of the ASF Slack](https://beam.apac
    When you've completed the issue, you can close it by commenting ".close-issue".
    If you are a committer and would like to assign an issue to a non-committer, they must comment
    on the issue first; please tag the user asking them to do so or to comment "\`.take-issue\`".
-   The command will be ignored if it is surrounded by \` markdown characters.
+   The command will be ignored if it is surrounded by `\`` markdown characters.
 3. If your change is large or it is your first change, it is a good idea to
    [discuss it on the dev@beam.apache.org mailing list](https://beam.apache.org/community/contact-us/).
 4. For large changes create a design doc

--- a/website/www/site/content/en/contribute/get-started-contributing.md
+++ b/website/www/site/content/en/contribute/get-started-contributing.md
@@ -112,7 +112,8 @@ Questions can be asked on the [#beam channel of the ASF Slack](https://beam.apac
 2. Comment ".take-issue" on the issue. This will cause the issue to be assigned to you.
    When you've completed the issue, you can close it by commenting ".close-issue".
    If you are a committer and would like to assign an issue to a non-committer, they must comment
-   on the issue first; please tag the user asking them to do so or to comment ".take-issue".
+   on the issue first; please tag the user asking them to do so or to comment "\`.take-issue\`".
+   The command will be ignored if it is surrounded by \` markdown characters.
 3. If your change is large or it is your first change, it is a good idea to
    [discuss it on the dev@beam.apache.org mailing list](https://beam.apache.org/community/contact-us/).
 4. For large changes create a design doc


### PR DESCRIPTION
Right now, there's no way for committers (or other users) to tell non-committers about the `.take-issue` command without taking the issue. This updates the command to ignore usages that are bracketed by \` markdown characters.

Part of #21684

✨ [Rendered doc changes](http://apache-beam-website-pull-requests.storage.googleapis.com/21755/contribute/get-started-contributing/index.html#share-your-intent) ✨ 

Example of this working - https://github.com/damccorm/playground/issues/8

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Add a link to the appropriate issue in your description, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
