### PR TITLE
Handling invalid WriteToBigQuery use case

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -2064,7 +2064,7 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
         DEFAULT will use STREAMING_INSERTS on Streaming pipelines and
         FILE_LOADS on Batch pipelines.
         Note: FILE_LOADS currently does not support BigQuery's JSON data type:
-        https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#json_type">
+        https://cloud.google.com/bigquery/docs/reference/standard-sql/data-types#json_type
       insert_retry_strategy: The strategy to use when retrying streaming inserts
         into BigQuery. Options are shown in bigquery_tools.RetryStrategy attrs.
         Default is to retry always. This means that whenever there are rows
@@ -2089,6 +2089,8 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
         These can be 'timePartitioning', 'clustering', etc. They are passed
         directly to the job load configuration. See
         https://cloud.google.com/bigquery/docs/reference/rest/v2/Job#jobconfigurationload
+        Note: FILE_LOAD writes that are large enough to invoke BigQuery
+        copy jobs will fail when writing to a table partition.
       table_side_inputs (tuple): A tuple with ``AsSideInput`` PCollections to be
         passed to the table callable (if one is provided).
       schema_side_inputs: A tuple with ``AsSideInput`` PCollections to be

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -729,7 +729,7 @@ class PartitionFiles(beam.DoFn):
       # a table partition as the destination
       if '$' in destination:
         raise ValueError(
-            "This write will utilize BigQuery copy jobs via API, "
+            "This write will invoke BigQuery copy jobs via API, "
             "which don't support copying to a table partition")
 
       output_tag = PartitionFiles.MULTIPLE_PARTITIONS_TAG

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -725,6 +725,13 @@ class PartitionFiles(beam.DoFn):
     partitions.append(latest_partition.files)
 
     if len(partitions) > 1:
+      # Copy jobs with BigQuery API do not support having
+      # a table partition as the destination
+      if '$' in destination:
+        raise ValueError(
+            "This write will utilize BigQuery copy jobs via API, "
+            "which don't support copying to a table partition")
+
       output_tag = PartitionFiles.MULTIPLE_PARTITIONS_TAG
     else:
       output_tag = PartitionFiles.SINGLE_PARTITION_TAG

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -729,8 +729,9 @@ class PartitionFiles(beam.DoFn):
       # a table partition as the destination
       if '$' in destination:
         raise ValueError(
-            "This write will invoke BigQuery copy jobs via API, "
-            "which don't support copying to a table partition")
+            f"The write to {destination} is too big for a single "
+            "load job and BigQuery copy jobs don't support having"
+            " a table partition as the destination.")
 
       output_tag = PartitionFiles.MULTIPLE_PARTITIONS_TAG
     else:

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
@@ -402,18 +402,15 @@ class TestPartitionFiles(unittest.TestCase):
 
   def test_fail_when_write_to_table_partition_requires_copy_jobs(self):
     TABLE_PARTITION_ELEMENTS = [
-      ('destination0', [('file0', 50), ('file1', 50), ('file2', 50)]),
-      ('table$partition', [('file0', 50), ('file1', 50), ('file2', 50)])
+        ('destination0', [('file0', 50), ('file1', 50), ('file2', 50)]),
+        ('table$partition', [('file0', 50), ('file1', 50), ('file2', 50)])
     ]
 
     with self.assertRaises(ValueError):
       with TestPipeline() as p:
-        destination_file_pairs = p | beam.Create(TABLE_PARTITION_ELEMENTS, reshuffle=False)
-        partitioned_files = (
-          destination_file_pairs
-          | beam.ParDo(bqfl.PartitionFiles(100, 10)))
-
-
+        destination_file_pairs = p | beam.Create(
+            TABLE_PARTITION_ELEMENTS, reshuffle=False)
+        _ = (destination_file_pairs | beam.ParDo(bqfl.PartitionFiles(100, 10)))
 
 
 class TestBigQueryFileLoads(_TestCaseWithTempDirCleanUp):

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
@@ -400,6 +400,21 @@ class TestPartitionFiles(unittest.TestCase):
         equal_to(single_partition_result),
         label='CheckSinglePartition')
 
+  def test_fail_when_write_to_table_partition_requires_copy_jobs(self):
+    TABLE_PARTITION_ELEMENTS = [
+      ('destination0', [('file0', 50), ('file1', 50), ('file2', 50)]),
+      ('table$partition', [('file0', 50), ('file1', 50), ('file2', 50)])
+    ]
+
+    with self.assertRaises(ValueError):
+      with TestPipeline() as p:
+        destination_file_pairs = p | beam.Create(TABLE_PARTITION_ELEMENTS, reshuffle=False)
+        partitioned_files = (
+          destination_file_pairs
+          | beam.ParDo(bqfl.PartitionFiles(100, 10)))
+
+
+
 
 class TestBigQueryFileLoads(_TestCaseWithTempDirCleanUp):
   def test_records_traverse_transform_with_mocks(self):


### PR DESCRIPTION
WriteToBigQuery with copy jobs doesn't support writing to a single table partition.
This PR is to throw an early error before beam starts writing anything (temp files/temp tables). Error is thrown only when it's determined that copy jobs are needed.
Also adding some documentation.