### PR TITLE
Update dashboards to use gh issues data instead of jira data

### DIFF
--- a/.test-infra/metrics/grafana/dashboards/post-commit_tests.json
+++ b/.test-infra/metrics/grafana/dashboards/post-commit_tests.json
@@ -36,7 +36,7 @@
       "id": 11,
       "links": [],
       "options": {
-        "content": "This dashboard tracks Post-commit test reliability over-time.\n\n* [Post-commit test policies](https://beam.apache.org/contribute/postcommits-policies/)\n* [Existing test failure issues](https://issues.apache.org/jira/issues/?jql=project%20%3D%20BEAM%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20resolution%20%3D%20Unresolved%20AND%20component%20%3D%20test-failures%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC)\n* [File a new test failure issue](https://s.apache.org/beam-test-failure)",
+        "content": "This dashboard tracks Post-commit test reliability over-time.\n\n* [Post-commit test policies](https://beam.apache.org/contribute/postcommits-policies/)\n* [Existing test failure issues](https://github.com/apache/beam/issues?q=is%3Aopen+is%3Aissue+label%3Atest-failures)\n* [File a new test failure issue](https://github.com/apache/beam/issues/new/choose)",
         "mode": "markdown"
       },
       "pluginVersion": "8.1.2",
@@ -691,14 +691,14 @@
     },
     {
       "datasource": "BeamPSQL",
-      "description": "Tracks the count of test failure JIRA issues currently open.",
+      "description": "Tracks the count of test failure GitHub issues currently open.",
       "fieldConfig": {
         "defaults": {
           "color": {
             "mode": "palette-classic"
           },
           "custom": {
-            "axisLabel": "# of JIRA issues",
+            "axisLabel": "# of GitHub issues",
             "axisPlacement": "auto",
             "barAlignment": 0,
             "drawStyle": "bars",
@@ -786,8 +786,8 @@
       "links": [
         {
           "targetBlank": true,
-          "title": "Jira tickets",
-          "url": "https://issues.apache.org/jira/issues/?jql=project%20%3D%20BEAM%20AND%20resolution%20%3D%20Unresolved%20AND%20component%20%3D%20test-failures%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC"
+          "title": "GitHub issues",
+          "url": "https://github.com/apache/beam/issues?q=is%3Aopen+is%3Aissue+label%3Atest-failures"
         }
       ],
       "options": {
@@ -808,7 +808,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "with days as (select date_trunc('day', dd) as day from generate_series( $__timeFrom()::timestamp, $__timeTo()::timestamp, '1 day'::interval) as dd),\n     knowndays as (SELECT days.day, count(*) as total_open\n                   FROM jira_issues, days\n                   WHERE jira_issues.created < days.day AND (jira_issues.resolutiondate > days.day OR jira_issues.resolutiondate is null)\n                   GROUP BY days.day\n                   ORDER BY days.day)\nselect days.day as time, greatest(knowndays.total_open, 0) as total_open\nfrom days left outer join knowndays\non days.day = knowndays.day",
+          "rawSql": "with days as (select date_trunc('day', dd) as day from generate_series( $__timeFrom()::timestamp, $__timeTo()::timestamp, '1 day'::interval) as dd),\n     knowndays as (SELECT days.day, count(*) as total_open\n                   FROM gh_issues, days\n                   WHERE gh_issues.created_ts < days.day AND (gh_issues.closed_ts > days.day OR gh_issues.closed_ts is null)\n                   GROUP BY days.day\n                   ORDER BY days.day)\nselect days.day as time, greatest(knowndays.total_open, 0) as total_open\nfrom days left outer join knowndays\non days.day = knowndays.day",
           "refId": "A",
           "select": [
             [
@@ -835,7 +835,7 @@
           "hide": false,
           "metricColumn": "none",
           "rawQuery": true,
-          "rawSql": "with days as (select date_trunc('day', dd) as day from generate_series( $__timeFrom()::timestamp, $__timeTo()::timestamp, '1 day'::interval) as dd),\n     knowndays as (SELECT days.day, count(*) as currently_failing\n                   FROM jira_issues, days\n                   WHERE jira_issues.created < days.day AND (jira_issues.resolutiondate > days.day OR jira_issues.resolutiondate is null) AND (jira_issues.labels LIKE '%currently-failing%')\n                   GROUP BY days.day\n                   ORDER BY days.day)\nselect days.day as time, greatest(knowndays.currently_failing, 0) as currently_failing\nfrom days left outer join knowndays\non days.day = knowndays.day",
+          "rawSql": "with days as (select date_trunc('day', dd) as day from generate_series( $__timeFrom()::timestamp, $__timeTo()::timestamp, '1 day'::interval) as dd),\n     knowndays as (SELECT days.day, count(*) as currently_failing\n                   FROM gh_issues, days\n                   WHERE gh_issues.created_ts < days.day AND (gh_issues.closed_ts > days.day OR gh_issues.closed_ts is null) AND (gh_issues.labels LIKE '%test-failures%')\n                   GROUP BY days.day\n                   ORDER BY days.day)\nselect days.day as time, greatest(knowndays.currently_failing, 0) as currently_failing\nfrom days left outer join knowndays\non days.day = knowndays.day",
           "refId": "D",
           "select": [
             [
@@ -859,7 +859,7 @@
       ],
       "timeFrom": null,
       "timeShift": null,
-      "title": "Test Failure JIRA issues",
+      "title": "Test Failure GitHub issues",
       "type": "timeseries"
     }
   ],

--- a/.test-infra/metrics/grafana/dashboards/source_data_freshness.json
+++ b/.test-infra/metrics/grafana/dashboards/source_data_freshness.json
@@ -104,7 +104,7 @@
           "hide": false,
           "metricColumn": "build_result",
           "rawQuery": true,
-          "rawSql": "WITH sources AS (\n  SELECT\n    'Jenkins' as source,\n    MAX(build_timestamp + make_interval(secs:= timing_executingtimemillis / 1000.0)) AS last_sync\n  FROM jenkins_builds\n  UNION SELECT\n    'GitHub Issues ' as source,\n    timestamp AS last_sync\n  FROM gh_sync_metadata\n  WHERE name = 'gh_issue_sync'\n  UNION SELECT\n    'GitHub Pull Requests ' as source,\n    timestamp AS last_sync\n  FROM gh_sync_metadata\n  WHERE name = 'gh_pr_sync')\nSELECT\n  current_timestamp AS time,\n  source,\n  EXTRACT(EPOCH FROM age(current_timestamp, last_sync)) / (60) AS value\nFROM sources",
+          "rawSql": "WITH sources AS (\n  SELECT\n    'Jenkins' as source,\n    MAX(build_timestamp + make_interval(secs:= timing_executingtimemillis / 1000.0)) AS last_sync\n  FROM jenkins_builds\n  UNION SELECT\n    'GitHub Issues' as source,\n    timestamp AS last_sync\n  FROM gh_sync_metadata\n  WHERE name = 'gh_issue_sync'\n  UNION SELECT\n    'GitHub Pull Requests' as source,\n    timestamp AS last_sync\n  FROM gh_sync_metadata\n  WHERE name = 'gh_pr_sync')\nSELECT\n  current_timestamp AS time,\n  source,\n  EXTRACT(EPOCH FROM age(current_timestamp, last_sync)) / (60) AS value\nFROM sources",
           "refId": "A",
           "select": [
             [

--- a/.test-infra/metrics/grafana/dashboards/source_data_freshness.json
+++ b/.test-infra/metrics/grafana/dashboards/source_data_freshness.json
@@ -104,7 +104,7 @@
           "hide": false,
           "metricColumn": "build_result",
           "rawQuery": true,
-          "rawSql": "WITH sources AS (\n  SELECT\n    'Jenkins' as source,\n    MAX(build_timestamp + make_interval(secs:= timing_executingtimemillis / 1000.0)) AS last_sync\n  FROM jenkins_builds\n  UNION SELECT\n    'JIRA' as source,\n    lastsynctime AS last_sync\n  FROM jira_issues_metadata\n  UNION SELECT\n    'GitHub' as source,\n    timestamp AS last_sync\n  FROM gh_sync_metadata\n)\nSELECT\n  current_timestamp AS time,\n  source,\n  EXTRACT(EPOCH FROM age(current_timestamp, last_sync)) / (60) AS value\nFROM sources",
+          "rawSql": "WITH sources AS (\n  SELECT\n    'Jenkins' as source,\n    MAX(build_timestamp + make_interval(secs:= timing_executingtimemillis / 1000.0)) AS last_sync\n  FROM jenkins_builds\n  UNION SELECT\n    'GitHub Issues ' as source,\n    timestamp AS last_sync\n  FROM gh_sync_metadata\n  WHERE name = 'gh_issue_sync'\n  UNION SELECT\n    'GitHub Pull Requests ' as source,\n    timestamp AS last_sync\n  FROM gh_sync_metadata\n  WHERE name = 'gh_pr_sync')\nSELECT\n  current_timestamp AS time,\n  source,\n  EXTRACT(EPOCH FROM age(current_timestamp, last_sync)) / (60) AS value\nFROM sources",
           "refId": "A",
           "select": [
             [

--- a/.test-infra/metrics/grafana/dashboards/stability_critical_jobs_status.json
+++ b/.test-infra/metrics/grafana/dashboards/stability_critical_jobs_status.json
@@ -34,7 +34,7 @@
       "id": 8,
       "links": [],
       "options": {
-        "content": "The graph shows: average greenness of critical post-commit tests jobs per week. This graph show health of our project.\n\nTable shows list of relevant jobs failures during selected time interval (You can change time interval on top-right corner of the dashboard). Please, triage failed jobs and update or create corresponding jira tickets. You can utilized provided links to help with this.",
+        "content": "The graph shows: average greenness of critical post-commit tests jobs per week. This graph show health of our project.\n\nTable shows list of relevant jobs failures during selected time interval (You can change time interval on top-right corner of the dashboard). Please, triage failed jobs and update or create corresponding issues. You can utilized provided links to help with this.",
         "mode": "markdown"
       },
       "pluginVersion": "8.1.2",
@@ -189,7 +189,7 @@
       "id": 6,
       "links": [],
       "options": {
-        "content": "[List existing jira tickets](https://issues.apache.org/jira/issues/?jql=project%20%3D%20BEAM%20AND%20status%20in%20(Open%2C%20%22In%20Progress%22%2C%20Reopened)%20AND%20resolution%20%3D%20Unresolved%20AND%20component%20%3D%20test-failures%20ORDER%20BY%20priority%20DESC%2C%20updated%20DESC)\n\n[Create new Jira ticket](https://issues.apache.org/jira/secure/CreateIssueDetails!init.jspa?pid=12319527&issuetype=1&summary=%5BjobName%5D%5BTestName%5D%5BIsFlake%5D%20Failure%20summary&priority=3&components=12334203&description=%3CFailure%20summary%3E%0AFailing%20job%20url:%0AJob%20history%20url:%0ARelevant%20log:)",
+        "content": "[List existing issues](https://github.com/apache/beam/issues?q=is%3Aopen+is%3Aissue+label%3Atest-failures)\n\n[Create new Issue](https://github.com/apache/beam/issues/new/choose)",
         "mode": "markdown"
       },
       "pluginVersion": "8.1.2",


### PR DESCRIPTION
This is a continuation of #21736 - now that we're using GH Issues, we should start driving our dashboard from issues instead of Jiras.

This relies on the table defined here - https://github.com/damccorm/beam/blob/c2ca26204950899e0324cb07bae613ecc2115a11/.test-infra/metrics/sync/github/sync.py#L53

This is step 2 of #21735

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Add a link to the appropriate issue in your description, if applicable. This will automatically link the pull request to the issue.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
