### PR TITLE
[BEAM-21811 adding more info to the sdk_worker_parallelism description

### DIFF
--- a/website/www/site/content/en/documentation/runtime/sdk-harness-config.md
+++ b/website/www/site/content/en/documentation/runtime/sdk-harness-config.md
@@ -51,4 +51,4 @@ as well.)
     option is useful for local testing. However, it is not suitable for a production environment,
     as it performs work on the machine the job originated from.
     - `environment_config` is not used for the `LOOPBACK` environment.
-- `sdk_worker_parallelism` sets the number of SDK workers that will run on each worker node.
+- `sdk_worker_parallelism` sets the number of SDK workers that run on each worker node. The default is 1. If 0, the value is automatically set by the runner by looking at different parameters, such as the number of CPU cores on the worker machine.


### PR DESCRIPTION
Documentation update: adding more information to the sdk_worker_parallelism description. The additions are based on the information found here: 

https://github.com/apache/beam/blob/fdccad20f2af4f4af84b55529acae4b9d0004a01/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PortablePipelineOptions.java#L69

------------------------

R: @tvalentyn 
R: @kennknowles 

fixes #21811
