### PR TITLE
Hide internal helpers added to DoFn for batched DoFns

### DIFF
--- a/sdks/python/apache_beam/runners/worker/operations.py
+++ b/sdks/python/apache_beam/runners/worker/operations.py
@@ -888,8 +888,8 @@ class DoOperation(Operation):
       self.dofn_runner.start()
 
   def get_batching_preference(self):
-    if self.fn.process_batch_defined:
-      if self.fn.process_defined:
+    if self.fn._process_batch_defined:
+      if self.fn._process_defined:
         return common.BatchingPreference.DO_NOT_CARE
       else:
         return common.BatchingPreference.BATCH_REQUIRED

--- a/sdks/python/apache_beam/transforms/batch_dofn_test.py
+++ b/sdks/python/apache_beam/transforms/batch_dofn_test.py
@@ -143,7 +143,6 @@ def get_test_class_name(cls, num, params_dict):
 ],
                      class_name_func=get_test_class_name)
 class BatchDoFnParameterizedTest(unittest.TestCase):
-
   def test_process_defined(self):
     self.assertEqual(self.dofn._process_defined, self.expected_process_defined)
 
@@ -167,13 +166,11 @@ class BatchDoFnParameterizedTest(unittest.TestCase):
 
 
 class BatchDoFnNoInputAnnotation(beam.DoFn):
-
   def process_batch(self, batch, *args, **kwargs):
     yield [element * 2 for element in batch]
 
 
 class BatchDoFnTest(unittest.TestCase):
-
   def test_map_pardo(self):
     # verify batch dofn accessors work well with beam.Map generated DoFn
     # checking this in parameterized test causes a circular reference issue

--- a/sdks/python/apache_beam/transforms/batch_dofn_test.py
+++ b/sdks/python/apache_beam/transforms/batch_dofn_test.py
@@ -143,12 +143,13 @@ def get_test_class_name(cls, num, params_dict):
 ],
                      class_name_func=get_test_class_name)
 class BatchDoFnParameterizedTest(unittest.TestCase):
+
   def test_process_defined(self):
-    self.assertEqual(self.dofn.process_defined, self.expected_process_defined)
+    self.assertEqual(self.dofn._process_defined, self.expected_process_defined)
 
   def test_process_batch_defined(self):
     self.assertEqual(
-        self.dofn.process_batch_defined, self.expected_process_batch_defined)
+        self.dofn._process_batch_defined, self.expected_process_batch_defined)
 
   def test_get_input_batch_type(self):
     self.assertEqual(
@@ -162,22 +163,24 @@ class BatchDoFnParameterizedTest(unittest.TestCase):
 
   def test_can_yield_batches(self):
     expected = self.expected_output_batch_type is not None
-    self.assertEqual(self.dofn.can_yield_batches, expected)
+    self.assertEqual(self.dofn._can_yield_batches, expected)
 
 
 class BatchDoFnNoInputAnnotation(beam.DoFn):
+
   def process_batch(self, batch, *args, **kwargs):
     yield [element * 2 for element in batch]
 
 
 class BatchDoFnTest(unittest.TestCase):
+
   def test_map_pardo(self):
     # verify batch dofn accessors work well with beam.Map generated DoFn
     # checking this in parameterized test causes a circular reference issue
     dofn = beam.Map(lambda x: x * 2).dofn
 
-    self.assertTrue(dofn.process_defined)
-    self.assertFalse(dofn.process_batch_defined)
+    self.assertTrue(dofn._process_defined)
+    self.assertFalse(dofn._process_batch_defined)
     self.assertEqual(dofn._get_input_batch_type_normalized(int), None)
     self.assertEqual(dofn._get_output_batch_type_normalized(int), None)
 


### PR DESCRIPTION
#21650

Marks helpers like `process_defined` as protected, we don't want these to show up in documentation, and users shouldn't use them. They are for internal use only.

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
