### PR TITLE
Standardizing output of WriteToBigQuery

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -322,6 +322,7 @@ from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.options.value_provider import StaticValueProvider
 from apache_beam.options.value_provider import ValueProvider
 from apache_beam.options.value_provider import check_accessible
+from apache_beam.pvalue import PCollection
 from apache_beam.runners.dataflow.native_io import iobase as dataflow_io
 from apache_beam.transforms import DoFn
 from apache_beam.transforms import ParDo
@@ -1509,11 +1510,11 @@ class WriteResult:
     self.method = method
     self.destination = destination
     self.schema = schema
-    self.destination_load_jobid_pairs = destination_load_jobid_pairs
-    self.destination_file_pairs = destination_file_pairs
-    self.destination_copy_jobid_pairs = destination_copy_jobid_pairs
-    self.failed_rows = failed_rows
-    self.failed_rows_with_errors = failed_rows_with_errors
+    self._destination_load_jobid_pairs: PCollection = destination_load_jobid_pairs
+    self._destination_file_pairs: PCollection = destination_file_pairs
+    self._destination_copy_jobid_pairs: PCollection = destination_copy_jobid_pairs
+    self._failed_rows: PCollection = failed_rows
+    self._failed_rows_with_errors: PCollection = failed_rows_with_errors
 
     self.config = {
         'method': method,
@@ -1548,27 +1549,33 @@ class WriteResult:
   def get_destination_load_jobid_pairs(self):
     self.validate('FILE_LOADS', 'DESTINATION_JOBID_PAIRS')
 
-    return self.destination_load_jobid_pairs
+    return self._destination_load_jobid_pairs
 
   def get_destination_file_pairs(self):
     self.validate('FILE_LOADS', 'DESTINATION_FILE_PAIRS')
 
-    return self.destination_file_pairs
+    return self._destination_file_pairs
 
   def get_destination_copy_jobid_pairs(self):
     self.validate('FILE_LOADS', 'DESTINATION_COPY_JOBID_PAIRS')
 
-    return self.destination_copy_jobid_pairs
+    return self._destination_copy_jobid_pairs
 
   def get_failed_rows(self):
     self.validate('STREAMING_INSERTS', 'FAILED_ROWS')
 
-    return self.failed_rows
+    return self._failed_rows
 
   def get_failed_rows_with_errors(self):
     self.validate('STREAMING_INSERTS', 'FAILED_ROWS_WITH_ERRORS')
 
-    return self.failed_rows_with_errors
+    return self._failed_rows_with_errors
+
+  destination_load_jobid_pairs = property(get_destination_load_jobid_pairs)
+  destination_file_pairs = property(get_destination_file_pairs)
+  destination_copy_jobid_pairs = property(get_destination_copy_jobid_pairs)
+  failed_rows = property(get_failed_rows)
+  failed_rows_with_errors = property(get_failed_rows_with_errors)
 
   def __getitem__(self, key):
     if key not in self.attributes:

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -1497,7 +1497,33 @@ bigquery_v2_messages.TableSchema` object.
 
 
 class WriteResult:
-  """The result of a WriteToBigQuery transform."""
+  """The result of a WriteToBigQuery transform.
+
+  Attributes can be accessed using dot notation or bracket notation:
+    with Pipeline() as p:
+      result = (p
+      | 'Create Columns' >> beam.Create([
+                {'column': 'value'},
+                {'bad_column': 'bad_value'}
+              ])
+      | 'Write Data' >> WriteToBigQuery(
+                method=WriteToBigQuery.Method.STREAMING_INSERTS,
+                table=my_table,
+                schema=my_schema,
+                insert_retry_strategy=RetryStrategy.RETRY_NEVER))
+
+      _ = (result.failed_rows_with_errors
+      | 'Get Errors' >> beam.Map(lambda e: {
+                "destination": e[0],
+                "row": e[1],
+                "error_message": e[2][0]['message']
+              })
+      | 'Write Errors' >> WriteToBigQuery(
+                method=WriteToBigQuery.Method.STREAMING_INSERTS,
+                table=error_log_table,
+                schema=error_schema,
+              )
+  """
   def __init__(
       self,
       method=None,
@@ -1506,6 +1532,7 @@ class WriteResult:
       destination_copy_jobid_pairs=None,
       failed_rows=None,
       failed_rows_with_errors=None):
+
     self.method: str = method
     self._destination_load_jobid_pairs: PCollection = destination_load_jobid_pairs
     self._destination_file_pairs: PCollection = destination_file_pairs

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -1521,19 +1521,19 @@ class WriteResult:
         'destination': destination,
         'schema': schema,
     }
-
+    
     from apache_beam.io.gcp.bigquery_file_loads import BigQueryBatchFileLoads
     self.attributes = {
-        BigQueryWriteFn.FAILED_ROWS: self.get_failed_rows,
-        BigQueryWriteFn.FAILED_ROWS_WITH_ERRORS: self.
-        get_failed_rows_with_errors,
-        BigQueryBatchFileLoads.DESTINATION_JOBID_PAIRS: self.
-        get_destination_load_jobid_pairs,
-        BigQueryBatchFileLoads.DESTINATION_FILE_PAIRS: self.
-        get_destination_file_pairs,
-        BigQueryBatchFileLoads.DESTINATION_COPY_JOBID_PAIRS: self.
-        get_destination_copy_jobid_pairs,
-        'write_configuration': self.get_write_configuration
+        BigQueryWriteFn.FAILED_ROWS: WriteResult.failed_rows,
+        BigQueryWriteFn.FAILED_ROWS_WITH_ERRORS: WriteResult.
+        failed_rows_with_errors,
+        BigQueryBatchFileLoads.DESTINATION_JOBID_PAIRS: WriteResult.
+        destination_load_jobid_pairs,
+        BigQueryBatchFileLoads.DESTINATION_FILE_PAIRS: WriteResult.
+        destination_file_pairs,
+        BigQueryBatchFileLoads.DESTINATION_COPY_JOBID_PAIRS: WriteResult.
+        destination_copy_jobid_pairs,
+        'write_configuration': WriteResult.get_write_configuration
     }
 
   def get_write_configuration(self):
@@ -1541,49 +1541,48 @@ class WriteResult:
 
   def validate(self, method, attribute):
     if self.method != method:
-      raise ValueError(
+      raise AttributeError(
           f'Cannot get {attribute} because it is not produced '
           f'by {self.method} write method. Note: only {method} '
           'produces this attribute.')
 
-  def get_destination_load_jobid_pairs(self):
+  @property
+  def destination_load_jobid_pairs(self):
     self.validate('FILE_LOADS', 'DESTINATION_JOBID_PAIRS')
 
     return self._destination_load_jobid_pairs
 
-  def get_destination_file_pairs(self):
+  @property
+  def destination_file_pairs(self):
     self.validate('FILE_LOADS', 'DESTINATION_FILE_PAIRS')
 
     return self._destination_file_pairs
 
-  def get_destination_copy_jobid_pairs(self):
+  @property
+  def destination_copy_jobid_pairs(self):
     self.validate('FILE_LOADS', 'DESTINATION_COPY_JOBID_PAIRS')
 
     return self._destination_copy_jobid_pairs
 
-  def get_failed_rows(self):
+  @property
+  def failed_rows(self):
     self.validate('STREAMING_INSERTS', 'FAILED_ROWS')
 
     return self._failed_rows
 
-  def get_failed_rows_with_errors(self):
+  @property
+  def failed_rows_with_errors(self):
     self.validate('STREAMING_INSERTS', 'FAILED_ROWS_WITH_ERRORS')
 
     return self._failed_rows_with_errors
 
-  destination_load_jobid_pairs = property(get_destination_load_jobid_pairs)
-  destination_file_pairs = property(get_destination_file_pairs)
-  destination_copy_jobid_pairs = property(get_destination_copy_jobid_pairs)
-  failed_rows = property(get_failed_rows)
-  failed_rows_with_errors = property(get_failed_rows_with_errors)
-
   def __getitem__(self, key):
     if key not in self.attributes:
-      raise ValueError(
+      raise AttributeError(
           f'Error trying to access nonexistent attribute `{key}` in write '
           'result. Please see __documentation__ for available attributes.')
 
-    return self.attributes[key].__call__()
+    return self.attributes[key].__get__(self, WriteResult)
 
 
 _KNOWN_TABLES = set()

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -1499,8 +1499,6 @@ class WriteResult:
   def __init__(
       self,
       method=None,
-      destination=None,
-      schema=None,
       destination_load_jobid_pairs=None,
       destination_file_pairs=None,
       destination_copy_jobid_pairs=None,
@@ -1508,20 +1506,12 @@ class WriteResult:
       failed_rows_with_errors=None):
 
     self.method = method
-    self.destination = destination
-    self.schema = schema
     self._destination_load_jobid_pairs: PCollection = destination_load_jobid_pairs
     self._destination_file_pairs: PCollection = destination_file_pairs
     self._destination_copy_jobid_pairs: PCollection = destination_copy_jobid_pairs
     self._failed_rows: PCollection = failed_rows
     self._failed_rows_with_errors: PCollection = failed_rows_with_errors
 
-    self.config = {
-        'method': method,
-        'destination': destination,
-        'schema': schema,
-    }
-    
     from apache_beam.io.gcp.bigquery_file_loads import BigQueryBatchFileLoads
     self.attributes = {
         BigQueryWriteFn.FAILED_ROWS: WriteResult.failed_rows,
@@ -1533,11 +1523,7 @@ class WriteResult:
         destination_file_pairs,
         BigQueryBatchFileLoads.DESTINATION_COPY_JOBID_PAIRS: WriteResult.
         destination_copy_jobid_pairs,
-        'write_configuration': WriteResult.get_write_configuration
     }
-
-  def get_write_configuration(self):
-    return self.config
 
   def validate(self, method, attribute):
     if self.method != method:
@@ -2328,8 +2314,6 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
 
       return WriteResult(
           method=WriteToBigQuery.Method.STREAMING_INSERTS,
-          destination=self.table_reference,
-          schema=self.schema,
           failed_rows=outputs[BigQueryWriteFn.FAILED_ROWS],
           failed_rows_with_errors=outputs[
               BigQueryWriteFn.FAILED_ROWS_WITH_ERRORS])
@@ -2390,8 +2374,6 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
 
       return WriteResult(
           method=WriteToBigQuery.Method.FILE_LOADS,
-          destination=self.table_reference,
-          schema=self.schema,
           destination_load_jobid_pairs=output[
               BigQueryBatchFileLoads.DESTINATION_JOBID_PAIRS],
           destination_file_pairs=output[

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -235,53 +235,39 @@ also take a callable that receives a table reference.
 [2] https://cloud.google.com/bigquery/docs/reference/rest/v2/tables/insert
 [3] https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#resource
 
-Output of the WriteToBigQuery transform
+Chaining of operations after WriteToBigQuery
 ---------------------------------------
+WritToBigQuery returns an object with several PCollections that consist of
+metadata about the write operations. These are useful to inspect the write
+operation and follow up on the results. Often, the simplest use case is to
+chain an operation after writing data to BigQuery.
 
-Writing to BigQuery returns a WriteResult object that includes metadata
-relating to the write you configured. This data can be used in later steps
-in your pipeline:::
+To do this, one can chain the operation after one of the output PCollections.
+A generic way in which this operation (independent of write method) could look
+like::
 
-  schema = {'fields': [
-      {'name': 'column', 'type': 'STRING', 'mode': 'NULLABLE'}]}
+  def chain_after(result):
+    try:
+      # This works for FILE_LOADS, where we run load and possibly copy jobs.
+      return (result.load_jobid_pairs, result.copy_jobid_pairs) | beam.Flatten()
+    except AttributeError:
+      # This works for STREAMING_INSERTS, where we return the rows BigQuery rejected
+      return result.failed_rows
 
-  error_schema = {'fields': [
-      {'name': 'destination', 'type': 'STRING', 'mode': 'NULLABLE'},
-      {'name': 'row', 'type': 'STRING', 'mode': 'NULLABLE'},
-      {'name': 'error_message', 'type': 'STRING', 'mode': 'NULLABLE'}]}
+  result = (pcoll | WriteToBigQuery(...))
 
-  with Pipeline() as p:
-    result = (p
-      | 'Create Columns' >> beam.Create([
-              {'column': 'value'},
-              {'bad_column': 'bad_value'}
-            ])
-      | 'Write Data' >> WriteToBigQuery(
-              method=WriteToBigQuery.Method.STREAMING_INSERTS,
-              table=my_table,
-              schema=schema,
-              insert_retry_strategy=RetryStrategy.RETRY_NEVER
-            ))
-
-    _ = (result.failed_rows_with_errors
-      | 'Get Errors' >> beam.Map(lambda e: {
-              "destination": e[0],
-              "row": json.dumps(e[1]),
-              "error_message": e[2][0]['message']
-            })
-      | 'Write Errors' >> WriteToBigQuery(
-              method=WriteToBigQuery.Method.STREAMING_INSERTS,
-              table=error_log_table,
-              schema=error_schema,
-            ))
+  _ = (chain_after(result)
+       | beam.Reshuffle() # Force a 'commit' of the intermediate date
+       | MyOperationAfterWriteToBQ())
 
 Attributes can be accessed using dot notation or bracket notation:
-
+```
 result.failed_rows                  <--> result['FailedRows']
 result.failed_rows_with_errors      <--> result['FailedRowsWithErrors']
 result.destination_load_jobid_pairs <--> result['destination_load_jobid_pairs']
 result.destination_file_pairs       <--> result['destination_file_pairs']
 result.destination_copy_jobid_pairs <--> result['destination_copy_jobid_pairs']
+```
 
 
 *** Short introduction to BigQuery concepts ***

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -236,7 +236,7 @@ also take a callable that receives a table reference.
 [3] https://cloud.google.com/bigquery/docs/reference/rest/v2/tables#resource
 
 Chaining of operations after WriteToBigQuery
----------------------------------------
+--------------------------------------------
 WritToBigQuery returns an object with several PCollections that consist of
 metadata about the write operations. These are useful to inspect the write
 operation and follow with the results::
@@ -407,9 +407,11 @@ from apache_beam.utils.annotations import experimental
 try:
   from apache_beam.io.gcp.internal.clients.bigquery import DatasetReference
   from apache_beam.io.gcp.internal.clients.bigquery import TableReference
+  from apache_beam.io.gcp.internal.clients.bigquery import JobReference
 except ImportError:
   DatasetReference = None
   TableReference = None
+  JobReference = None
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -2461,11 +2463,11 @@ class WriteResult:
   def __init__(
       self,
       method: WriteToBigQuery.Method = None,
-      destination_load_jobid_pairs: PCollection[Tuple[
-          str, bigquery.JobReference]] = None,
+      destination_load_jobid_pairs: PCollection[Tuple[str,
+                                                      JobReference]] = None,
       destination_file_pairs: PCollection[Tuple[str, Tuple[str, int]]] = None,
-      destination_copy_jobid_pairs: PCollection[Tuple[
-          str, bigquery.JobReference]] = None,
+      destination_copy_jobid_pairs: PCollection[Tuple[str,
+                                                      JobReference]] = None,
       failed_rows: PCollection[Tuple[str, dict]] = None,
       failed_rows_with_errors: PCollection[Tuple[str, dict, list]] = None):
 
@@ -2498,7 +2500,7 @@ class WriteResult:
 
   @property
   def destination_load_jobid_pairs(
-      self) -> PCollection[Tuple[str, bigquery.JobReference]]:
+      self) -> PCollection[Tuple[str, JobReference]]:
     """A ``FILE_LOADS`` method attribute
 
     Returns: A PCollection of the table destinations that were successfully
@@ -2525,7 +2527,7 @@ class WriteResult:
 
   @property
   def destination_copy_jobid_pairs(
-      self) -> PCollection[Tuple[str, bigquery.JobReference]]:
+      self) -> PCollection[Tuple[str, JobReference]]:
     """A ``FILE_LOADS`` method attribute
 
     Returns: A PCollection of the table destinations that were successfully

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -239,12 +239,16 @@ Chaining of operations after WriteToBigQuery
 ---------------------------------------
 WritToBigQuery returns an object with several PCollections that consist of
 metadata about the write operations. These are useful to inspect the write
-operation and follow up on the results. Often, the simplest use case is to
-chain an operation after writing data to BigQuery.
+operation and follow with the results::
 
-To do this, one can chain the operation after one of the output PCollections.
-A generic way in which this operation (independent of write method) could look
-like::
+  
+
+
+
+Often, the simplest use case is to chain an operation after writing data to
+BigQuery.To do this, one can chain the operation after one of the output
+PCollections. A generic way in which this operation (independent of write
+method) could look like::
 
   def chain_after(result):
     try:

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -1541,32 +1541,32 @@ class WriteResult:
   def validate(self, method, attribute):
     if self.method != method:
       raise ValueError(
-          f'Cannot get {attribute} because they are not produced '
+          f'Cannot get {attribute} because it is not produced '
           f'by {self.method} write method. Note: only {method} '
           'produces this attribute.')
 
   def get_destination_load_jobid_pairs(self):
-    self.validate('FILE_LOADS', 'destination-load job ID pairs')
+    self.validate('FILE_LOADS', 'DESTINATION_JOBID_PAIRS')
 
     return self.destination_load_jobid_pairs
 
   def get_destination_file_pairs(self):
-    self.validate('FILE_LOADS', 'destination-file pairs')
+    self.validate('FILE_LOADS', 'DESTINATION_FILE_PAIRS')
 
     return self.destination_file_pairs
 
   def get_destination_copy_jobid_pairs(self):
-    self.validate('FILE_LOADS', 'destination-copy job ID pairs')
+    self.validate('FILE_LOADS', 'DESTINATION_COPY_JOBID_PAIRS')
 
     return self.destination_copy_jobid_pairs
 
   def get_failed_rows(self):
-    self.validate('STREAMING_INSERTS', 'failed rows')
+    self.validate('STREAMING_INSERTS', 'FAILED_ROWS')
 
     return self.failed_rows
 
   def get_failed_rows_with_errors(self):
-    self.validate('STREAMING_INSERTS', 'failed rows with errors')
+    self.validate('STREAMING_INSERTS', 'FAILED_ROWS_WITH_ERRORS')
 
     return self.failed_rows_with_errors
 

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -360,6 +360,7 @@ __all__ = [
     'BigQuerySink',
     'BigQueryQueryPriority',
     'WriteToBigQuery',
+    'WriteResult',
     'ReadFromBigQuery',
     'ReadFromBigQueryRequest',
     'ReadAllFromBigQuery',
@@ -1496,6 +1497,7 @@ bigquery_v2_messages.TableSchema` object.
 
 
 class WriteResult:
+  """The result of a WriteToBigQuery transform."""
   def __init__(
       self,
       method=None,
@@ -1504,8 +1506,7 @@ class WriteResult:
       destination_copy_jobid_pairs=None,
       failed_rows=None,
       failed_rows_with_errors=None):
-
-    self.method = method
+    self.method: str = method
     self._destination_load_jobid_pairs: PCollection = destination_load_jobid_pairs
     self._destination_file_pairs: PCollection = destination_file_pairs
     self._destination_copy_jobid_pairs: PCollection = destination_copy_jobid_pairs
@@ -1534,30 +1535,58 @@ class WriteResult:
 
   @property
   def destination_load_jobid_pairs(self):
+    """A ``FILE_LOADS`` method attribute
+
+    Returns: A PCollection of the table destinations that were successfully
+      loaded to using the batch load API, along with the load job IDs.
+
+    Raises: AttributeError: if accessed with a write method besides ``FILE_LOADS``."""
     self.validate('FILE_LOADS', 'DESTINATION_JOBID_PAIRS')
 
     return self._destination_load_jobid_pairs
 
   @property
   def destination_file_pairs(self):
+    """A ``FILE_LOADS`` method attribute
+
+    Returns: A PCollection of the table destinations along with the
+      temp files used as sources to load from.
+
+    Raises: AttributeError: if accessed with a write method besides ``FILE_LOADS``."""
     self.validate('FILE_LOADS', 'DESTINATION_FILE_PAIRS')
 
     return self._destination_file_pairs
 
   @property
   def destination_copy_jobid_pairs(self):
+    """A ``FILE_LOADS`` method attribute
+
+    Returns: A PCollection of the table destinations that were successfully
+      copied to, along with the copy job ID.
+
+    Raises: AttributeError: if accessed with a write method besides ``FILE_LOADS``."""
     self.validate('FILE_LOADS', 'DESTINATION_COPY_JOBID_PAIRS')
 
     return self._destination_copy_jobid_pairs
 
   @property
   def failed_rows(self):
+    """A ``STREAMING_INSERTS`` method attribute
+
+    Returns: A PCollection of rows that failed when inserting to BigQuery.
+
+    Raises: AttributeError: if accessed with a write method besides ``STREAMING_INSERTS``."""
     self.validate('STREAMING_INSERTS', 'FAILED_ROWS')
 
     return self._failed_rows
 
   @property
   def failed_rows_with_errors(self):
+    """A ``STREAMING_INSERTS`` method attribute
+
+    Returns: A PCollection of rows that failed when inserting to BigQuery, along with their errors.
+
+    Raises: AttributeError: if accessed with a write method besides ``STREAMING_INSERTS``."""
     self.validate('STREAMING_INSERTS', 'FAILED_ROWS_WITH_ERRORS')
 
     return self._failed_rows_with_errors


### PR DESCRIPTION
Standardizing WriteToBigQuery's output to adhere to the [[Beam I/O Standards] API Syntax and Semantics](https://docs.google.com/document/d/1V2FkGGunVgvLwi1dKHr-7mtDuwYjTuvuESV_oPzVnfQ/edit?resourcekey=0-KvfQq-5iCcMlu3f3MFJ-GQ#heading=h.k9bqspolh594) document (specifically, T2).

This solution creates a joint `WriteResult` object (similar to the [WriteResult class](https://github.com/apache/beam/blob/master/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteResult.java) in the Java SDK) that would be returned by both `STREAMING_INSERTS` and `FILE_LOADS` write methods.