### PR TITLE
Add a type hint to nexmark query 3 joinFn

### DIFF
--- a/sdks/python/apache_beam/testing/benchmarks/nexmark/queries/query3.py
+++ b/sdks/python/apache_beam/testing/benchmarks/nexmark/queries/query3.py
@@ -108,7 +108,7 @@ class JoinFn(beam.DoFn):
   def __init__(self, max_auction_wait_time):
     self.max_auction_wait_time = max_auction_wait_time
 
-  def process(
+  def process(  # type: ignore
       self,
       element: typing.Tuple[
           str,

--- a/sdks/python/apache_beam/testing/benchmarks/nexmark/queries/query3.py
+++ b/sdks/python/apache_beam/testing/benchmarks/nexmark/queries/query3.py
@@ -32,6 +32,7 @@ the stored person record.
 """
 
 import logging
+import typing
 
 import apache_beam as beam
 from apache_beam.testing.benchmarks.nexmark.models import nexmark_model
@@ -109,7 +110,11 @@ class JoinFn(beam.DoFn):
 
   def process(
       self,
-      element,
+      element: typing.Tuple[
+          typing.AnyStr,
+          typing.Dict[typing.AnyStr,
+                      typing.Union[typing.List[nexmark_model.Auction],
+                                   typing.List[nexmark_model.Person]]]],
       auction_state=beam.DoFn.StateParam(auction_spec),
       person_state=beam.DoFn.StateParam(person_spec),
       person_timer=beam.DoFn.TimerParam(person_timer_spec)):

--- a/sdks/python/apache_beam/testing/benchmarks/nexmark/queries/query3.py
+++ b/sdks/python/apache_beam/testing/benchmarks/nexmark/queries/query3.py
@@ -111,8 +111,8 @@ class JoinFn(beam.DoFn):
   def process(
       self,
       element: typing.Tuple[
-          typing.AnyStr,
-          typing.Dict[typing.AnyStr,
+          str,
+          typing.Dict[str,
                       typing.Union[typing.List[nexmark_model.Auction],
                                    typing.List[nexmark_model.Person]]]],
       auction_state=beam.DoFn.StateParam(auction_spec),


### PR DESCRIPTION
This resolves a exception when running on dataflow:

```
Error message from worker: generic::unknown: Traceback (most recent call last):
  File "apache_beam/runners/common.py", line 1404, in apache_beam.runners.common.DoFnRunner.process
  File "apache_beam/runners/common.py", line 837, in apache_beam.runners.common.PerWindowInvoker.invoke_process
  File "apache_beam/runners/common.py", line 981, in apache_beam.runners.common.PerWindowInvoker._invoke_process_per_window
  File "apache_beam/runners/common.py", line 1585, in apache_beam.runners.common._OutputProcessor.process_outputs
  File "apache_beam/runners/worker/operations.py", line 239, in apache_beam.runners.worker.operations.SingletonElementConsumerSet.receive
  File "apache_beam/runners/worker/operations.py", line 198, in apache_beam.runners.worker.operations.ConsumerSet.update_counters_start
  File "apache_beam/runners/worker/opcounters.py", line 215, in apache_beam.runners.worker.opcounters.OperationCounters.update_from
  File "apache_beam/runners/worker/opcounters.py", line 263, in apache_beam.runners.worker.opcounters.OperationCounters.do_sample
  File "apache_beam/coders/coder_impl.py", line 1453, in apache_beam.coders.coder_impl.WindowedValueCoderImpl.get_estimated_size_and_observables
  File "apache_beam/coders/coder_impl.py", line 1464, in apache_beam.coders.coder_impl.WindowedValueCoderImpl.get_estimated_size_and_observables
  File "apache_beam/coders/coder_impl.py", line 1015, in apache_beam.coders.coder_impl.AbstractComponentCoderImpl.get_estimated_size_and_observables
  File "apache_beam/coders/coder_impl.py", line 377, in apache_beam.coders.coder_impl.FastPrimitivesCoderImpl.get_estimated_size_and_observables
  File "apache_beam/coders/coder_impl.py", line 457, in apache_beam.coders.coder_impl.FastPrimitivesCoderImpl.encode_to_stream
  File "apache_beam/coders/coder_impl.py", line 518, in apache_beam.coders.coder_impl.FastPrimitivesCoderImpl.encode_special_deterministic
TypeError: Unable to deterministically encode '{"id":597730,"item_name":"u jfsctnpmqpzxyl","description":"czvqtvsmzak xykvni ysgajsrlqvgmezcshts nugvqnxjhstlfcissod","initial_bid":591608,"reserve":592301,"date_time":1436918855010,"expires":1436918881023,"seller":199900,"category":10,"extra":"rxyqgeldtkcy^O[PYSzitmedJPa[SNQR[S`Hobaarugezbvmcjexwhvyvhvx__V_]LVQLXVNndeaohZXTSHUM\\XYQPN^YPUKtzbirdbuspinUSH_T_tslilylwmpamifsbxc`TaMaWa^SQZ]xunwavcmmzqx^]ZUMOH\\WMQZQaZ\\UaXPOMWZwcrxijophybxsrkqpwdjccoqvthmzbesvvwdpoccqghbsmlhRU\\J\\YszbvvoOaTL\\IhuqknpaliyqhZJ]LMT_OTN^UTY[XPWkxdvylKSKOSXowpbfkfgeifvPaM]HHZQY_YOjntoonkvnzukMZK]M^tucqgnX]WXLZI[X\\LHW[aT`YmvaxzwtwolkdWKXP\\QqoafmqR`R]NNZQRIQUkqzbywR[THTYgcoiluHZaJ`Rvixsn"}' of type '<class 'apache_beam.testing.benchmarks.nexmark.models.nexmark_model.Auction'>', please provide a type hint for the input of 'query3_join'
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
