### PR TITLE
Followup fix FileIOTest.testMatchWatchForNewFiles flaky

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileIOTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/FileIOTest.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.io;
 
 import static org.apache.beam.sdk.io.fs.ResolveOptions.StandardResolveOptions.RESOLVE_FILE;
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects.firstNonNull;
 import static org.hamcrest.Matchers.isA;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
@@ -33,30 +34,40 @@ import java.io.Writer;
 import java.nio.file.CopyOption;
 import java.nio.file.Files;
 import java.nio.file.Path;
+import java.nio.file.Paths;
 import java.nio.file.StandardCopyOption;
 import java.nio.file.attribute.FileTime;
 import java.util.Arrays;
 import java.util.List;
+import java.util.Objects;
 import java.util.zip.GZIPOutputStream;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.io.fs.EmptyMatchTreatment;
 import org.apache.beam.sdk.io.fs.MatchResult;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.state.StateSpec;
+import org.apache.beam.sdk.state.StateSpecs;
+import org.apache.beam.sdk.state.ValueState;
 import org.apache.beam.sdk.testing.NeedsRunner;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.UsesUnboundedSplittableParDo;
 import org.apache.beam.sdk.transforms.Contextful;
 import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.Requirements;
 import org.apache.beam.sdk.transforms.SerializableFunctions;
 import org.apache.beam.sdk.transforms.View;
 import org.apache.beam.sdk.transforms.Watch;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.PaneInfo;
+import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.sdk.values.TypeDescriptors;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Charsets;
 import org.joda.time.Duration;
@@ -202,6 +213,48 @@ public class FileIOTest implements Serializable {
     p.run();
   }
 
+  /** DoFn that copy test files from source to watch path. */
+  private static class CopyFilesFn
+      extends DoFn<KV<String, MatchResult.Metadata>, MatchResult.Metadata> {
+    public CopyFilesFn(Path sourcePath, Path watchPath) {
+      this.sourcePathStr = sourcePath.toString();
+      this.watchPathStr = watchPath.toString();
+    }
+
+    @StateId("count")
+    @SuppressWarnings("unused")
+    private final StateSpec<ValueState<Integer>> countSpec = StateSpecs.value(VarIntCoder.of());
+
+    @ProcessElement
+    public void processElement(ProcessContext context, @StateId("count") ValueState<Integer> count)
+        throws IOException, InterruptedException {
+      int current = firstNonNull(count.read(), 0);
+      // unpack value as output
+      context.output(Objects.requireNonNull(context.element()).getValue());
+
+      CopyOption[] cpOptions = {StandardCopyOption.COPY_ATTRIBUTES};
+      CopyOption[] updOptions = {StandardCopyOption.REPLACE_EXISTING};
+      final Path sourcePath = Paths.get(sourcePathStr);
+      final Path watchPath = Paths.get(watchPathStr);
+
+      if (0 == current) {
+        Thread.sleep(100);
+        Files.copy(sourcePath.resolve("first"), watchPath.resolve("first"), updOptions);
+        Files.copy(sourcePath.resolve("second"), watchPath.resolve("second"), cpOptions);
+      } else if (1 == current) {
+        Thread.sleep(100);
+        Files.copy(sourcePath.resolve("first"), watchPath.resolve("first"), updOptions);
+        Files.copy(sourcePath.resolve("second"), watchPath.resolve("second"), updOptions);
+        Files.copy(sourcePath.resolve("third"), watchPath.resolve("third"), cpOptions);
+      }
+      count.write(current + 1);
+    }
+
+    // Member variables need to be serializable.
+    private final String sourcePathStr;
+    private final String watchPathStr;
+  }
+
   @Test
   @Category({NeedsRunner.class, UsesUnboundedSplittableParDo.class})
   public void testMatchWatchForNewFiles() throws IOException, InterruptedException {
@@ -222,7 +275,7 @@ public class FileIOTest implements Serializable {
                 .filepattern(watchPath.resolve("*").toString())
                 .continuously(
                     Duration.millis(100),
-                    Watch.Growth.afterTimeSinceNewOutput(Duration.standardSeconds(3))));
+                    Watch.Growth.afterTimeSinceNewOutput(Duration.standardSeconds(1))));
     PCollection<MatchResult.Metadata> matchAllMetadata =
         p.apply("create for matchAll new files", Create.of(watchPath.resolve("*").toString()))
             .apply(
@@ -230,7 +283,7 @@ public class FileIOTest implements Serializable {
                 FileIO.matchAll()
                     .continuously(
                         Duration.millis(100),
-                        Watch.Growth.afterTimeSinceNewOutput(Duration.standardSeconds(3))));
+                        Watch.Growth.afterTimeSinceNewOutput(Duration.standardSeconds(1))));
     PCollection<MatchResult.Metadata> matchUpdatedMetadata =
         p.apply(
             "match updated",
@@ -238,7 +291,7 @@ public class FileIOTest implements Serializable {
                 .filepattern(watchPath.resolve("first").toString())
                 .continuously(
                     Duration.millis(100),
-                    Watch.Growth.afterTimeSinceNewOutput(Duration.standardSeconds(3)),
+                    Watch.Growth.afterTimeSinceNewOutput(Duration.standardSeconds(1)),
                     true));
     PCollection<MatchResult.Metadata> matchAllUpdatedMetadata =
         p.apply("create for matchAll updated files", Create.of(watchPath.resolve("*").toString()))
@@ -247,35 +300,30 @@ public class FileIOTest implements Serializable {
                 FileIO.matchAll()
                     .continuously(
                         Duration.millis(100),
-                        Watch.Growth.afterTimeSinceNewOutput(Duration.standardSeconds(3)),
+                        Watch.Growth.afterTimeSinceNewOutput(Duration.standardSeconds(1)),
                         true));
+
+    // write one file at the beginning. This will trigger the first output for matchAll
+    Files.copy(
+        sourcePath.resolve("first"),
+        watchPath.resolve("first"),
+        new StandardCopyOption[] {StandardCopyOption.COPY_ATTRIBUTES});
+
+    // using matchMetadata outputs to trigger file copy on-the-fly
+    matchMetadata =
+        matchMetadata
+            .apply(
+                MapElements.into(
+                        TypeDescriptors.kvs(
+                            TypeDescriptors.strings(),
+                            TypeDescriptor.of(MatchResult.Metadata.class)))
+                    .via((metadata) -> KV.of("dumb key", metadata)))
+            .apply(ParDo.of(new CopyFilesFn(sourcePath, watchPath)));
+
     assertEquals(PCollection.IsBounded.UNBOUNDED, matchMetadata.isBounded());
     assertEquals(PCollection.IsBounded.UNBOUNDED, matchAllMetadata.isBounded());
     assertEquals(PCollection.IsBounded.UNBOUNDED, matchUpdatedMetadata.isBounded());
     assertEquals(PCollection.IsBounded.UNBOUNDED, matchAllUpdatedMetadata.isBounded());
-
-    // Copy the files to the "watch" directory, preserving the lastModifiedTime;
-    // the COPY_ATTRIBUTES option ensures that we will at a minimum copy lastModifiedTime.
-    CopyOption[] copyOptions = {StandardCopyOption.COPY_ATTRIBUTES};
-    CopyOption[] updateOptions = {StandardCopyOption.REPLACE_EXISTING};
-    Thread writer =
-        new Thread(
-            () -> {
-              try {
-                Thread.sleep(800);
-                Files.copy(sourcePath.resolve("first"), watchPath.resolve("first"), copyOptions);
-                Thread.sleep(400);
-                Files.copy(sourcePath.resolve("first"), watchPath.resolve("first"), updateOptions);
-                Files.copy(sourcePath.resolve("second"), watchPath.resolve("second"), copyOptions);
-                Thread.sleep(400);
-                Files.copy(sourcePath.resolve("first"), watchPath.resolve("first"), updateOptions);
-                Files.copy(
-                    sourcePath.resolve("second"), watchPath.resolve("second"), updateOptions);
-                Files.copy(sourcePath.resolve("third"), watchPath.resolve("third"), copyOptions);
-              } catch (IOException | InterruptedException e) {
-                throw new RuntimeException(e);
-              }
-            });
 
     // We fetch lastModifiedTime from the files in the "source" directory to avoid a race condition
     // with the writer thread.
@@ -309,10 +357,7 @@ public class FileIOTest implements Serializable {
                 .via((metadata) -> metadata.resourceId().getFilename()));
     PAssert.that(matchAllUpdatedCount).containsInAnyOrder(expectedMatchAllUpdated);
 
-    writer.start();
     p.run();
-
-    writer.join();
   }
 
   @Test

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/storage/GcsMatchIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/storage/GcsMatchIT.java
@@ -127,7 +127,9 @@ public class GcsMatchIT {
       }
       // file "first" is expected to appear exactly once
       assertEquals(1, countFirst);
-      // file "second" is expected to appear in growing sizes by one byte
+      // file "second" is expected to appear more than once
+      assertEquals(true, countSecond > 1);
+      // file "second" is expected to appear in growing sizes each time by one byte
       assertEquals((maxSecondSize * 2L - countSecond + 1) * countSecond / 2, sumSecondSize);
 
       return null;

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/storage/GcsMatchIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/storage/GcsMatchIT.java
@@ -74,15 +74,18 @@ public class GcsMatchIT {
       // write a file at the beginning
       writeBytesToFile(writePath.resolve("first").toString(), fileSize);
 
-      while (true) {
+      while (!Thread.interrupted() && fileSize < maxFileSize) {
         try {
           Thread.sleep(interval);
         } catch (InterruptedException e) {
-          return;
+          throw new RuntimeException(e);
         }
         // write another file continuously
         writeBytesToFile(writePath.resolve("second").toString(), fileSize);
         fileSize += 1;
+      }
+      if (fileSize >= maxFileSize) {
+        throw new RuntimeException("Maximum number of write reached.");
       }
     }
 
@@ -100,6 +103,7 @@ public class GcsMatchIT {
 
     private final Path writePath;
     private final long interval;
+    private static final long maxFileSize = 1000;
   }
 
   private static class CheckPathFn implements SerializableFunction<Iterable<Metadata>, Void> {

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/storage/GcsMatchIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/storage/GcsMatchIT.java
@@ -61,7 +61,7 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class GcsMatchIT {
-  /** A thread that write to Gcs continuously */
+  /** A thread that write to Gcs continuously. */
   private static class WriteToPathContinuously extends Thread {
     public WriteToPathContinuously(Path writePath, long interval) {
       this.writePath = writePath;

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/storage/GcsMatchIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/storage/GcsMatchIT.java
@@ -25,11 +25,10 @@ import java.io.IOException;
 import java.nio.channels.Channels;
 import java.nio.channels.ReadableByteChannel;
 import java.nio.channels.WritableByteChannel;
-import java.util.Arrays;
+import java.nio.file.Path;
 import java.util.Collections;
 import java.util.Date;
-import java.util.List;
-import org.apache.beam.runners.direct.DirectRunner;
+import java.util.Objects;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.PipelineResult.State;
@@ -37,81 +36,122 @@ import org.apache.beam.sdk.extensions.gcp.options.GcsOptions;
 import org.apache.beam.sdk.extensions.gcp.util.gcsfs.GcsPath;
 import org.apache.beam.sdk.io.FileIO;
 import org.apache.beam.sdk.io.FileSystems;
+import org.apache.beam.sdk.io.fs.MatchResult;
+import org.apache.beam.sdk.io.fs.MatchResult.Metadata;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.TestPipelineOptions;
 import org.apache.beam.sdk.transforms.Create;
-import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.MapElements;
-import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.Watch;
 import org.apache.beam.sdk.util.MimeTypes;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TypeDescriptors;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.FluentIterable;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.io.ByteStreams;
 import org.joda.time.Duration;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class GcsMatchIT {
-  /** DoFn that writes test files to Gcs System when first time called. */
-  private static class WriteToGcsFn extends DoFn<GcsPath, Void> {
-    public WriteToGcsFn(long waitSec) {
-      this.waitSec = waitSec;
+  /** A thread that write to Gcs continuously */
+  private static class WriteToPathContinuously extends Thread {
+    public WriteToPathContinuously(Path writePath, long interval) {
+      this.writePath = writePath;
+      this.interval = interval;
     }
 
-    @ProcessElement
-    public void processElement(ProcessContext context) {
-      GcsPath writePath = context.element();
-      assert writePath != null;
-      Thread writer =
-          new Thread(
-              () -> {
-                try {
-                  // Write test files to writePath
-                  Thread.sleep(waitSec * 1000);
-                  writeBytesToFile(writePath.resolve("first").toString(), 42);
-                  Thread.sleep(1000);
-                  writeBytesToFile(writePath.resolve("first").toString(), 99);
-                  writeBytesToFile(writePath.resolve("second").toString(), 42);
-                  Thread.sleep(1000);
-                  writeBytesToFile(writePath.resolve("first").toString(), 37);
-                  writeBytesToFile(writePath.resolve("second").toString(), 42);
-                  writeBytesToFile(writePath.resolve("third").toString(), 99);
-                } catch (InterruptedException e) {
-                  throw new RuntimeException(e);
-                }
-              });
-      writer.start();
+    @Override
+    public void run() {
+      int fileSize = 1;
+      // write a file at the beginning
+      writeBytesToFile(writePath.resolve("first").toString(), fileSize);
+
+      while (true) {
+        try {
+          Thread.sleep(interval);
+        } catch (InterruptedException e) {
+          return;
+        }
+        // write another file continuously
+        writeBytesToFile(writePath.resolve("second").toString(), fileSize);
+        fileSize += 1;
+      }
     }
 
-    private final long waitSec;
+    private static void writeBytesToFile(String path, int length) {
+      ResourceId newFileResourceId = FileSystems.matchNewResource(path, false);
+      try (ByteArrayInputStream in = new ByteArrayInputStream(new byte[length]);
+          ReadableByteChannel readerChannel = Channels.newChannel(in);
+          WritableByteChannel writerChannel =
+              FileSystems.create(newFileResourceId, MimeTypes.TEXT)) {
+        ByteStreams.copy(readerChannel, writerChannel);
+      } catch (IOException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    private final Path writePath;
+    private final long interval;
   }
 
-  /** Integration test for TextIO.MatchAll watching for file updates in gcs filesystem. */
-  @Test
-  public void testGcsMatchContinuously() {
-    TestPipelineOptions options =
-        TestPipeline.testingPipelineOptions().as(TestPipelineOptions.class);
+  private static class CheckPathFn implements SerializableFunction<Iterable<Metadata>, Void> {
+
+    @Override
+    public Void apply(Iterable<Metadata> input) {
+      long countFirst = 0; // count the matches of file "first"
+      long countSecond = 0; // count the matches of file "second"
+      long sumSecondSize = 0; // sum the sizes of file "second"
+      long maxSecondSize = 0; // max size observed for file "second"
+      for (MatchResult.Metadata metadata : input) {
+        String filename = Objects.requireNonNull(metadata.resourceId().getFilename());
+        switch (filename) {
+          case "first":
+            countFirst += 1;
+            break;
+          case "second":
+            countSecond += 1;
+            sumSecondSize += metadata.sizeBytes();
+            maxSecondSize = Math.max(maxSecondSize, metadata.sizeBytes());
+            break;
+          default:
+            throw new AssertionError("Get unexpected filename " + filename);
+        }
+      }
+      // file "first" is expected to appear exactly once
+      assertEquals(1, countFirst);
+      // file "second" is expected to appear in growing sizes by one byte
+      assertEquals((maxSecondSize * 2L - countSecond + 1) * countSecond / 2, sumSecondSize);
+
+      return null;
+    }
+  }
+
+  @BeforeClass
+  public static void setUp() throws Exception {
+    options = TestPipeline.testingPipelineOptions().as(TestPipelineOptions.class);
     assertNotNull(options.getTempRoot());
     options.setTempLocation(options.getTempRoot() + "/GcsMatchIT");
     GcsOptions gcsOptions = options.as(GcsOptions.class);
     String dstFolderName =
         gcsOptions.getGcpTempLocation()
             + String.format("/testGcsMatchContinuously.%tF-%<tH-%<tM-%<tS-%<tL/", new Date());
-    final GcsPath watchPath = GcsPath.fromUri(dstFolderName);
-    long waitSec = 7;
-    if (options.getRunner() == DirectRunner.class) {
-      // save some time testing on direct runner
-      waitSec = 1;
-    }
+    watchPath = GcsPath.fromUri(dstFolderName);
+  }
 
+  /** Integration test for TextIO.MatchAll watching for file updates in gcs filesystem. */
+  @Test
+  public void testGcsMatchContinuously() {
     Pipeline p = Pipeline.create(options);
     PCollection<GcsPath> path = p.apply(Create.of(Collections.singletonList(watchPath)));
-    PCollection<String> filenames =
+    PCollection<MatchResult.Metadata> records =
         path.apply(
                 MapElements.into(TypeDescriptors.strings())
                     .via((gcsPath) -> gcsPath.resolve("*").toString()))
@@ -119,34 +159,35 @@ public class GcsMatchIT {
                 "matchAll updated",
                 FileIO.matchAll()
                     .continuously(
-                        Duration.millis(250),
-                        Watch.Growth.afterTimeSinceNewOutput(Duration.standardSeconds(waitSec + 2)),
-                        true))
-            .apply(
-                "pick up file names",
-                MapElements.into(TypeDescriptors.strings())
-                    .via((metadata) -> metadata.resourceId().getFilename()));
+                        Duration.millis(500),
+                        Watch.Growth.afterTotalOf(Duration.standardSeconds(10)),
+                        true));
 
-    path.apply(ParDo.of(new WriteToGcsFn(waitSec)));
+    PAssert.that(records).satisfies(new CheckPathFn());
 
-    List<String> expectedMatchAllUpdated =
-        Arrays.asList("first", "first", "first", "second", "second", "third");
-    PAssert.that(filenames).containsInAnyOrder(expectedMatchAllUpdated);
-
+    Thread writer = new WriteToPathContinuously(watchPath, 2000);
+    writer.start();
     PipelineResult result = p.run();
-
     State state = result.waitUntilFinish();
+
+    writer.interrupt();
     assertEquals(State.DONE, state);
   }
 
-  private static void writeBytesToFile(String gcsPath, int length) {
-    ResourceId newFileResourceId = FileSystems.matchNewResource(gcsPath, false);
-    try (ByteArrayInputStream in = new ByteArrayInputStream(new byte[length]);
-        ReadableByteChannel readerChannel = Channels.newChannel(in);
-        WritableByteChannel writerChannel = FileSystems.create(newFileResourceId, MimeTypes.TEXT)) {
-      ByteStreams.copy(readerChannel, writerChannel);
-    } catch (IOException e) {
-      throw new RuntimeException(e);
-    }
+  @AfterClass
+  public static void tearDown() throws IOException {
+    MatchResult matchResult = FileSystems.match(watchPath.resolve("*").toString());
+    ImmutableList<ResourceId> resourceIdList =
+        FluentIterable.from(matchResult.metadata())
+            .transform(metadata -> (metadata.resourceId()))
+            .toList();
+    // delete temporary files
+    FileSystems.delete(resourceIdList);
+    // delete temporary folder
+    FileSystems.delete(
+        Collections.singletonList(FileSystems.matchNewResource(watchPath.toString(), true)));
   }
+
+  private static TestPipelineOptions options;
+  private static GcsPath watchPath;
 }


### PR DESCRIPTION
Follow up fixes flaky test introduced in #21570

Test been flaky because the pipeline starts indefinite time after p.run() is called. Wrapping the thread that write files into a DoFn which also executes after p.run() is called resolves this timing issue (same test structure for integration test)

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
