### PR TITLE
Revert "[BEAM-14064] fix es io windowing (#17112)"

### DIFF
--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-5/build.gradle
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-5/build.gradle
@@ -39,6 +39,10 @@ configurations.all {
   }
 }
 
+test {
+  maxParallelForks = 1
+}
+
 dependencies {
   testImplementation project(path: ":sdks:java:io:elasticsearch-tests:elasticsearch-tests-common", configuration: "testRuntimeMigration")
   testImplementation library.java.testcontainers_elasticsearch

--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-6/build.gradle
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-6/build.gradle
@@ -39,6 +39,10 @@ configurations.all {
   }
 }
 
+test {
+  maxParallelForks = 1
+}
+
 dependencies {
   testImplementation project(path: ":sdks:java:io:elasticsearch-tests:elasticsearch-tests-common", configuration: "testRuntimeMigration")
   testImplementation library.java.testcontainers_elasticsearch

--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-7/build.gradle
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-7/build.gradle
@@ -39,6 +39,10 @@ configurations.all {
   }
 }
 
+test {
+  maxParallelForks = 1
+}
+
 dependencies {
   testImplementation project(path: ":sdks:java:io:elasticsearch-tests:elasticsearch-tests-common", configuration: "testRuntimeMigration")
   testImplementation library.java.testcontainers_elasticsearch

--- a/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
+++ b/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
@@ -46,11 +46,11 @@ import java.util.HashSet;
 import java.util.List;
 import java.util.ListIterator;
 import java.util.Map;
+import java.util.Map.Entry;
 import java.util.NoSuchElementException;
 import java.util.Objects;
 import java.util.Set;
 import java.util.function.Predicate;
-import java.util.stream.Collectors;
 import javax.annotation.Nonnull;
 import javax.net.ssl.SSLContext;
 import org.apache.beam.sdk.annotations.Experimental;
@@ -72,9 +72,7 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.Reshuffle;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.display.DisplayData;
-import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
-import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
-import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.BackOff;
 import org.apache.beam.sdk.util.BackOffUtils;
 import org.apache.beam.sdk.util.FluentBackoff;
@@ -85,10 +83,10 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
-import org.apache.beam.sdk.values.WindowingStrategy;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Strings;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Streams;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ArrayListMultimap;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Multimap;
 import org.apache.http.ConnectionClosedException;
 import org.apache.http.Header;
 import org.apache.http.HttpEntity;
@@ -236,7 +234,7 @@ public class ElasticsearchIO {
         // advised default starting batch size in ES docs
         .setMaxBatchSizeBytes(5L * 1024L * 1024L)
         .setUseStatefulBatches(false)
-        .setMaxParallelRequests(1)
+        .setMaxParallelRequestsPerWindow(1)
         .setThrowWriteErrors(true)
         .build();
   }
@@ -1806,7 +1804,7 @@ public class ElasticsearchIO {
             // advised default starting batch size in ES docs
             .setMaxBatchSizeBytes(5L * 1024L * 1024L)
             .setUseStatefulBatches(false)
-            .setMaxParallelRequests(1)
+            .setMaxParallelRequestsPerWindow(1)
             .setThrowWriteErrors(true)
             .build();
 
@@ -1930,20 +1928,9 @@ public class ElasticsearchIO {
       return this;
     }
 
-    /**
-     * Refer to {@link BulkIO#withMaxParallelRequestsPerWindow}.
-     *
-     * @deprecated use {@link Write#withMaxParallelRequests} instead
-     */
-    @Deprecated
+    /** Refer to {@link BulkIO#withMaxParallelRequestsPerWindow}. */
     public Write withMaxParallelRequestsPerWindow(int maxParallelRequestsPerWindow) {
       bulkIO = bulkIO.withMaxParallelRequestsPerWindow(maxParallelRequestsPerWindow);
-      return this;
-    }
-
-    /** Refer to {@link BulkIO#withMaxParallelRequests}. */
-    public Write withMaxParallelRequests(int maxParallelRequests) {
-      bulkIO = bulkIO.withMaxParallelRequests(maxParallelRequests);
       return this;
     }
 
@@ -1994,9 +1981,7 @@ public class ElasticsearchIO {
 
     abstract boolean getUseStatefulBatches();
 
-    abstract @Nullable Integer getMaxParallelRequestsPerWindow();
-
-    abstract int getMaxParallelRequests();
+    abstract int getMaxParallelRequestsPerWindow();
 
     abstract @Nullable RetryConfiguration getRetryConfiguration();
 
@@ -2022,11 +2007,7 @@ public class ElasticsearchIO {
 
       abstract Builder setUseStatefulBatches(boolean useStatefulBatches);
 
-      /** @deprecated Use {@link #setMaxParallelRequests} instead. */
-      @Deprecated
       abstract Builder setMaxParallelRequestsPerWindow(int maxParallelRequestsPerWindow);
-
-      abstract Builder setMaxParallelRequests(int maxParallelRequests);
 
       abstract Builder setThrowWriteErrors(boolean throwWriteErrors);
 
@@ -2181,45 +2162,22 @@ public class ElasticsearchIO {
     /**
      * When using {@link BulkIO#withUseStatefulBatches} Stateful Processing, states and therefore
      * batches are maintained per-key-per-window. BE AWARE that low values for @param
-     * maxParallelRequests, in particular if the input data has a finite number of windows, can
-     * reduce parallelism greatly. Because data will be temporarily globally windowed as part of
-     * writing data to Elasticsearch, if @param maxParallelRequests is set to 1, there will only
-     * ever be 1 request in flight. Having only a single request in flight can be beneficial for
-     * ensuring an Elasticsearch cluster is not overwhelmed by parallel requests, but may not work
-     * for all use cases. If this number is less than the number of maximum workers in your
-     * pipeline, the IO work will result in a sub-optimal distribution of the write step with most
-     * runners.
+     * maxParallelRequestsPerWindow, in particular if the input data has a finite number of windows,
+     * can reduce parallelism greatly. If data is globally windowed and @param
+     * maxParallelRequestsPerWindow is set to 1,there will only ever be 1 request in flight. Having
+     * only a single request in flight can be beneficial for ensuring an Elasticsearch cluster is
+     * not overwhelmed by parallel requests,but may not work for all use cases. If this number is
+     * less than the number of maximum workers in your pipeline, the IO work will result in a
+     * sub-distribution of the last write step with most of the runners.
      *
-     * @param maxParallelRequests the maximum number of parallel bulk requests for a window of data
+     * @param maxParallelRequestsPerWindow the maximum number of parallel bulk requests for a window
+     *     of data
      * @return the {@link BulkIO} with maximum parallel bulk requests per window set
-     * @deprecated use {@link BulkIO#withMaxParallelRequests} instead.
      */
-    @Deprecated
-    public BulkIO withMaxParallelRequestsPerWindow(int maxParallelRequests) {
+    public BulkIO withMaxParallelRequestsPerWindow(int maxParallelRequestsPerWindow) {
       checkArgument(
-          maxParallelRequests > 0, "maxParallelRequestsPerWindow value must be a positive integer");
-      return builder().setMaxParallelRequests(maxParallelRequests).build();
-    }
-
-    /**
-     * When using {@link BulkIO#withUseStatefulBatches} Stateful Processing, states and therefore
-     * batches are maintained per-key-per-window. BE AWARE that low values for @param
-     * maxParallelRequests, in particular if the input data has a finite number of windows, can
-     * reduce parallelism greatly. Because data will be temporarily globally windowed as part of
-     * writing data to Elasticsearch, if @param maxParallelRequests is set to 1, there will only
-     * ever be 1 request in flight. Having only a single request in flight can be beneficial for
-     * ensuring an Elasticsearch cluster is not overwhelmed by parallel requests, but may not work
-     * for all use cases. If this number is less than the number of maximum workers in your
-     * pipeline, the IO work will result in a sub-optimal distribution of the write step with most
-     * runners.
-     *
-     * @param maxParallelRequests the maximum number of parallel bulk requests
-     * @return the {@link BulkIO} with maximum parallel bulk requests
-     */
-    public BulkIO withMaxParallelRequests(int maxParallelRequests) {
-      checkArgument(
-          maxParallelRequests > 0, "maxParallelRequests value must be a positive integer");
-      return builder().setMaxParallelRequests(maxParallelRequests).build();
+          maxParallelRequestsPerWindow > 0, "parameter value must be positive " + "a integer");
+      return builder().setMaxParallelRequestsPerWindow(maxParallelRequestsPerWindow).build();
     }
 
     /**
@@ -2269,7 +2227,7 @@ public class ElasticsearchIO {
         }
 
         return input
-            .apply(ParDo.of(new Reshuffle.AssignShardFn<>(spec.getMaxParallelRequests())))
+            .apply(ParDo.of(new Reshuffle.AssignShardFn<>(spec.getMaxParallelRequestsPerWindow())))
             .apply(groupIntoBatches);
       }
     }
@@ -2277,42 +2235,19 @@ public class ElasticsearchIO {
     @Override
     public PCollectionTuple expand(PCollection<Document> input) {
       ConnectionConfiguration connectionConfiguration = getConnectionConfiguration();
+
       checkState(connectionConfiguration != null, "withConnectionConfiguration() is required");
 
-      WindowingStrategy<?, ?> originalStrategy = input.getWindowingStrategy();
-
-      PCollection<Document> docResults;
-      PCollection<Document> globalDocs = input.apply(Window.into(new GlobalWindows()));
-
       if (getUseStatefulBatches()) {
-        docResults =
-            globalDocs
-                .apply(StatefulBatching.fromSpec(this))
-                .apply(ParDo.of(new BulkIOStatefulFn(this)));
+        return input
+            .apply(StatefulBatching.fromSpec(this))
+            .apply(
+                ParDo.of(new BulkIOStatefulFn(this))
+                    .withOutputTags(Write.SUCCESSFUL_WRITES, TupleTagList.of(Write.FAILED_WRITES)));
       } else {
-        docResults = globalDocs.apply(ParDo.of(new BulkIOBundleFn(this)));
-      }
-
-      return docResults
-          .setWindowingStrategyInternal(originalStrategy)
-          .apply(
-              ParDo.of(new ResultFilteringFn())
-                  .withOutputTags(Write.SUCCESSFUL_WRITES, TupleTagList.of(Write.FAILED_WRITES)));
-    }
-
-    private static class ResultFilteringFn extends DoFn<Document, Document> {
-      @Override
-      public Duration getAllowedTimestampSkew() {
-        return Duration.millis(Long.MAX_VALUE);
-      }
-
-      @ProcessElement
-      public void processElement(@Element Document doc, MultiOutputReceiver out) {
-        if (doc.getHasError()) {
-          out.get(Write.FAILED_WRITES).outputWithTimestamp(doc, doc.getTimestamp());
-        } else {
-          out.get(Write.SUCCESSFUL_WRITES).outputWithTimestamp(doc, doc.getTimestamp());
-        }
+        return input.apply(
+            ParDo.of(new BulkIOBundleFn(this))
+                .withOutputTags(Write.SUCCESSFUL_WRITES, TupleTagList.of(Write.FAILED_WRITES)));
       }
     }
 
@@ -2323,10 +2258,11 @@ public class ElasticsearchIO {
       }
 
       @ProcessElement
-      public void processElement(ProcessContext context) throws Exception {
+      public void processElement(ProcessContext context, BoundedWindow w) throws Exception {
         // the element KV pair is a pair of raw_doc + resulting Bulk API formatted newline-json
         // based on DocToBulk settings
-        addAndMaybeFlush(context.element(), context);
+        Document summary = context.element();
+        addAndMaybeFlush(summary, context, w);
       }
     }
 
@@ -2340,9 +2276,9 @@ public class ElasticsearchIO {
       }
 
       @ProcessElement
-      public void processElement(ProcessContext context) throws Exception {
-        for (Document timedDoc : context.element().getValue()) {
-          addAndMaybeFlush(timedDoc, context);
+      public void processElement(ProcessContext c, BoundedWindow w) throws Exception {
+        for (Document result : c.element().getValue()) {
+          addAndMaybeFlush(result, c, w);
         }
       }
     }
@@ -2355,7 +2291,7 @@ public class ElasticsearchIO {
 
       private BulkIO spec;
       private transient RestClient restClient;
-      private transient List<Document> batch;
+      private Multimap<BoundedWindow, Document> batch;
       long currentBatchSizeBytes;
 
       protected BulkIOBaseFn(BulkIO bulkSpec) {
@@ -2382,14 +2318,8 @@ public class ElasticsearchIO {
 
       @StartBundle
       public void startBundle(StartBundleContext context) {
-        batch = new ArrayList<>();
+        batch = ArrayListMultimap.create();
         currentBatchSizeBytes = 0;
-      }
-
-      @FinishBundle
-      public void finishBundle(FinishBundleContext context)
-          throws IOException, InterruptedException {
-        flushAndOutputResults(new FinishBundleContextAdapter<>(context));
       }
 
       /**
@@ -2397,7 +2327,8 @@ public class ElasticsearchIO {
        * FinishBundleContext} so that we are able to use a single common invocation to output from.
        */
       interface ContextAdapter {
-        void output(Document timedDoc);
+        void output(
+            TupleTag<Document> tag, Document document, Instant timestamp, BoundedWindow window);
       }
 
       private static final class ProcessContextAdapter<T> implements ContextAdapter {
@@ -2408,8 +2339,11 @@ public class ElasticsearchIO {
         }
 
         @Override
-        public void output(Document timedDoc) {
-          context.outputWithTimestamp(timedDoc, timedDoc.getTimestamp());
+        public void output(
+            TupleTag<Document> tag, Document document, Instant ignored1, BoundedWindow ignored2) {
+          // Note: window and timestamp are intentionally unused, but required as params to fit the
+          // interface
+          context.output(tag, document);
         }
       }
 
@@ -2421,23 +2355,46 @@ public class ElasticsearchIO {
         }
 
         @Override
-        public void output(Document timedDoc) {
-          context.output(timedDoc, timedDoc.getTimestamp(), GlobalWindow.INSTANCE);
+        public void output(
+            TupleTag<Document> tag, Document document, Instant timestamp, BoundedWindow window) {
+          context.output(tag, document, timestamp, window);
         }
+      }
+
+      @FinishBundle
+      public void finishBundle(FinishBundleContext context)
+          throws IOException, InterruptedException {
+        flushAndOutputResults(new FinishBundleContextAdapter<>(context));
       }
 
       private void flushAndOutputResults(ContextAdapter context)
           throws IOException, InterruptedException {
-        for (Document timedDoc : flushBatch()) {
-          context.output(timedDoc);
+        // TODO: remove ContextAdapter and Multimap in favour of MultiOutputReceiver when
+        //  https://issues.apache.org/jira/browse/BEAM-1287 is completed
+        Multimap<BoundedWindow, Document> results = flushBatch();
+        for (Entry<BoundedWindow, Document> result : results.entries()) {
+          BoundedWindow outputWindow = result.getKey();
+          Document outputResult = result.getValue();
+          Instant timestamp = outputResult.getTimestamp();
+          if (timestamp == null) {
+            timestamp = outputWindow.maxTimestamp();
+          }
+
+          if (outputResult.getHasError()) {
+            context.output(Write.FAILED_WRITES, outputResult, timestamp, outputWindow);
+          } else {
+            context.output(Write.SUCCESSFUL_WRITES, outputResult, timestamp, outputWindow);
+          }
         }
       }
 
-      protected void addAndMaybeFlush(Document doc, ProcessContext context)
+      protected void addAndMaybeFlush(
+          Document bulkApiEntity, ProcessContext context, BoundedWindow outputWindow)
           throws IOException, InterruptedException {
 
-        batch.add(doc);
-        currentBatchSizeBytes += doc.getBulkDirective().getBytes(StandardCharsets.UTF_8).length;
+        batch.put(outputWindow, bulkApiEntity);
+        currentBatchSizeBytes +=
+            bulkApiEntity.getBulkDirective().getBytes(StandardCharsets.UTF_8).length;
 
         if (batch.size() >= spec.getMaxBatchSize()
             || currentBatchSizeBytes >= spec.getMaxBatchSizeBytes()) {
@@ -2455,10 +2412,11 @@ public class ElasticsearchIO {
             || t.getCause() instanceof ConnectException;
       }
 
-      private List<Document> flushBatch() throws IOException, InterruptedException {
+      private Multimap<BoundedWindow, Document> flushBatch()
+          throws IOException, InterruptedException {
 
         if (batch.isEmpty()) {
-          return new ArrayList<>();
+          return ArrayListMultimap.create();
         }
 
         LOG.info(
@@ -2468,16 +2426,16 @@ public class ElasticsearchIO {
 
         StringBuilder bulkRequest = new StringBuilder();
         // Create a stable list of input entries, because order is important to keep constant
-        List<Document> inputEntries = new ArrayList<>(batch);
+        List<Entry<BoundedWindow, Document>> inputEntries = new ArrayList<>(batch.entries());
 
         batch.clear();
         currentBatchSizeBytes = 0L;
 
-        for (Document doc : inputEntries) {
+        for (Entry<BoundedWindow, Document> entry : inputEntries) {
           // N.B. we need to ensure that we can iterate in the same order later to match up
           // responses to these bulk directives. ES Bulk response `items` is in the same order
           // as the bulk directives in the request, so order is imperative.
-          bulkRequest.append(doc.getBulkDirective());
+          bulkRequest.append(entry.getValue().getBulkDirective());
         }
 
         Response response = null;
@@ -2519,14 +2477,37 @@ public class ElasticsearchIO {
             createWriteReport(
                 responseEntity, spec.getAllowedResponseErrors(), spec.getThrowWriteErrors());
 
-        return Streams.zip(
-                inputEntries.stream(),
-                responses.stream(),
-                (inputTimedDoc, responseDoc) ->
-                    inputTimedDoc
-                        .withHasError(responseDoc.getHasError())
-                        .withResponseItemJson(responseDoc.getResponseItemJson()))
-            .collect(Collectors.toList());
+        return mergeInputsAndResponses(inputEntries, responses);
+      }
+
+      private static Multimap<BoundedWindow, Document> mergeInputsAndResponses(
+          List<Entry<BoundedWindow, Document>> inputs, List<Document> responses) {
+
+        checkArgument(
+            inputs.size() == responses.size(), "inputs and responses must be of same size");
+
+        Multimap<BoundedWindow, Document> results = ArrayListMultimap.create();
+
+        // N.B. the order of responses must always match the order of inputs
+        for (int i = 0; i < inputs.size(); i++) {
+          BoundedWindow outputWindow = inputs.get(i).getKey();
+
+          // Contains raw input document and Bulk directive counterpart only
+          Document inputDoc = inputs.get(i).getValue();
+
+          // Contains stringified JSON response from Elasticsearch and error status only
+          Document outputDoc = responses.get(i);
+
+          // Create a new Document object with all the input fields from inputDoc (i.e. the raw
+          // input JSON string) and all the response fields from ES bulk API for that input document
+          Document merged =
+              inputDoc
+                  .withHasError(outputDoc.getHasError())
+                  .withResponseItemJson(outputDoc.getResponseItemJson());
+          results.put(outputWindow, merged);
+        }
+
+        return results;
       }
 
       /** retry request based on retry configuration policy. */


### PR DESCRIPTION
This reverts commit 77833b19371a213ef11439b2925fa421af79b641.

As per #21690, this PR is a temporary fix to the window casting error (regression) introduced by #17112.  By reverting,  a potential data-correctness bug is being explicitly added back wherein responses from Elasticsearch could be output to a window which does not correspond to the input.

My assessment is that the data-correctness bug likely has a very low impact to pipeline authors.  It still needs to be addressed, but the potential data-correctness bug is the much lesser evil compared to the state of ElasticsearchIO in 2.39.0

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
