### PR TITLE
Go SDK: Update memory file system to return an io.ReadSeekCloser.

### DIFF
--- a/sdks/go/pkg/beam/io/filesystem/memfs/memory.go
+++ b/sdks/go/pkg/beam/io/filesystem/memfs/memory.go
@@ -19,6 +19,7 @@ package memfs
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"os"
 	"regexp"
@@ -72,10 +73,11 @@ func (f *fs) OpenRead(_ context.Context, filename string) (io.ReadCloser, error)
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	if v, ok := f.m[normalize(filename)]; ok {
-		return &bytesReader{bytes.NewReader(v)}, nil
+	normalizedKey := normalize(filename)
+	if _, ok := f.m[normalizedKey]; !ok {
+		return nil, os.ErrNotExist
 	}
-	return nil, os.ErrNotExist
+	return &bytesReader{fs: f, normalizedKey: normalizedKey}, nil
 }
 
 func (f *fs) OpenWrite(_ context.Context, filename string) (io.WriteCloser, error) {
@@ -164,13 +166,67 @@ func (w *commitWriter) Close() error {
 
 // bytesReader is like a bytes.Reader that implements io.Closer as well.
 type bytesReader struct {
-	impl *bytes.Reader
+	mu            sync.Mutex
+	fs            *fs
+	normalizedKey string
+	pos           int64
 }
 
 var _ io.ReadSeekCloser = (*bytesReader)(nil)
 
-func (r *bytesReader) Read(p []byte) (n int, err error) { return r.impl.Read(p) }
-func (r *bytesReader) Close() error                     { return nil }
+func (r *bytesReader) Read(p []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.fs.mu.Lock()
+	defer r.fs.mu.Unlock()
+
+	currentValue, exists := r.fs.m[r.normalizedKey]
+	if !exists {
+		return 0, os.ErrNotExist
+	}
+	if int(r.pos) >= len(currentValue) {
+		return 0, io.EOF
+	}
+	wantEnd := int(r.pos) + len(p)
+	if wantEnd > len(currentValue) {
+		wantEnd = len(currentValue)
+	}
+	n := wantEnd - int(r.pos)
+	copy(p, currentValue[r.pos:])
+	r.pos = int64(wantEnd)
+	return n, nil
+}
+
+func (r *bytesReader) Close() error { return nil }
 func (r *bytesReader) Seek(offset int64, whence int) (int64, error) {
-	return r.impl.Seek(offset, whence)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.fs.mu.Lock()
+	defer r.fs.mu.Unlock()
+
+	currentValue, exists := r.fs.m[r.normalizedKey]
+	if !exists {
+		return 0, os.ErrNotExist
+	}
+	currentLen := len(currentValue)
+
+	wantPos := r.pos
+	switch whence {
+	case io.SeekCurrent:
+		wantPos = r.pos + offset
+	case io.SeekStart:
+		wantPos = offset
+	case io.SeekEnd:
+		wantPos = int64(currentLen) + offset
+	}
+	if wantPos < 0 {
+		return 0, fmt.Errorf("invalid seek position %d is before start of file", wantPos)
+	}
+	if int(wantPos) > currentLen {
+		return 0, fmt.Errorf("invalid seek position %d is after end of file", wantPos)
+	}
+	r.pos = wantPos
+	return r.pos, nil
 }

--- a/sdks/go/pkg/beam/io/filesystem/memfs/memory.go
+++ b/sdks/go/pkg/beam/io/filesystem/memfs/memory.go
@@ -72,10 +72,11 @@ func (f *fs) OpenRead(_ context.Context, filename string) (io.ReadCloser, error)
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	if v, ok := f.m[normalize(filename)]; ok {
-		return &bytesReader{bytes.NewReader(v)}, nil
+	normalizedKey := normalize(filename)
+	if _, ok := f.m[normalizedKey]; !ok {
+		return nil, os.ErrNotExist
 	}
-	return nil, os.ErrNotExist
+	return &bytesReader{fs: f, normalizedKey: normalizedKey}, nil
 }
 
 func (f *fs) OpenWrite(_ context.Context, filename string) (io.WriteCloser, error) {
@@ -164,13 +165,67 @@ func (w *commitWriter) Close() error {
 
 // bytesReader is like a bytes.Reader that implements io.Closer as well.
 type bytesReader struct {
-	impl *bytes.Reader
+	mu            sync.Mutex
+	fs            *fs
+	normalizedKey string
+	pos           int64
 }
 
 var _ io.ReadSeekCloser = (*bytesReader)(nil)
 
-func (r *bytesReader) Read(p []byte) (n int, err error) { return r.impl.Read(p) }
-func (r *bytesReader) Close() error                     { return nil }
+func (r *bytesReader) Read(p []byte) (int, error) {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.fs.mu.Lock()
+	defer r.fs.mu.Unlock()
+
+	currentValue, exists := r.fs.m[r.normalizedKey]
+	if !exists {
+		return 0, os.ErrNotExist
+	}
+	if int(r.pos) >= len(currentValue) {
+		return 0, io.EOF
+	}
+	wantEnd := int(r.pos) + len(p)
+	if wantEnd > len(currentValue) {
+		wantEnd = len(currentValue)
+	}
+	n := wantEnd - int(r.pos)
+	copy(p, currentValue[r.pos:])
+	r.pos = int64(wantEnd)
+	return n, nil
+}
+
+func (r *bytesReader) Close() error { return nil }
 func (r *bytesReader) Seek(offset int64, whence int) (int64, error) {
-	return r.impl.Seek(offset, whence)
+	r.mu.Lock()
+	defer r.mu.Unlock()
+
+	r.fs.mu.Lock()
+	defer r.fs.mu.Unlock()
+
+	currentValue, exists := r.fs.m[r.normalizedKey]
+	if !exists {
+		return 0, os.ErrNotExist
+	}
+	currentLen := len(currentValue)
+
+	wantPos := r.pos
+	switch whence {
+	case io.SeekCurrent:
+		wantPos = r.pos + offset
+	case io.SeekStart:
+		wantPos = offset
+	case io.SeekEnd:
+		wantPos = int64(currentLen) + offset
+	}
+	if wantPos < 0 {
+		return 0, fmt.Errorf("invalid seek position %d is before start of file", wantPos)
+	}
+	if int(wantPos) > currentLen {
+		return 0, fmt.Errorf("invalid seek position %d is after end of file", wantPos)
+	}
+	r.pos = wantPos
+	return r.pos, nil
 }

--- a/sdks/go/pkg/beam/io/filesystem/memfs/memory.go
+++ b/sdks/go/pkg/beam/io/filesystem/memfs/memory.go
@@ -19,7 +19,6 @@ package memfs
 import (
 	"bytes"
 	"context"
-	"fmt"
 	"io"
 	"os"
 	"regexp"

--- a/sdks/go/pkg/beam/io/filesystem/memfs/memory.go
+++ b/sdks/go/pkg/beam/io/filesystem/memfs/memory.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"context"
 	"io"
-	"io/ioutil"
 	"os"
 	"regexp"
 	"sort"
@@ -74,7 +73,7 @@ func (f *fs) OpenRead(_ context.Context, filename string) (io.ReadCloser, error)
 	defer f.mu.Unlock()
 
 	if v, ok := f.m[normalize(filename)]; ok {
-		return ioutil.NopCloser(bytes.NewReader(v)), nil
+		return &bytesReader{bytes.NewReader(v)}, nil
 	}
 	return nil, os.ErrNotExist
 }
@@ -161,4 +160,17 @@ func (w *commitWriter) Write(p []byte) (n int, err error) {
 
 func (w *commitWriter) Close() error {
 	return w.instance.write(w.key, w.buf.Bytes())
+}
+
+// bytesReader is like a bytes.Reader that implements io.Closer as well.
+type bytesReader struct {
+	impl *bytes.Reader
+}
+
+var _ io.ReadSeekCloser = (*bytesReader)(nil)
+
+func (r *bytesReader) Read(p []byte) (n int, err error) { return r.impl.Read(p) }
+func (r *bytesReader) Close() error                     { return nil }
+func (r *bytesReader) Seek(offset int64, whence int) (int64, error) {
+	return r.impl.Seek(offset, whence)
 }

--- a/sdks/go/pkg/beam/io/textio/textio_test.go
+++ b/sdks/go/pkg/beam/io/textio/textio_test.go
@@ -19,10 +19,16 @@ package textio
 import (
 	"context"
 	"errors"
+	"fmt"
+	"io"
 	"os"
+	"regexp"
+	"sort"
+	"strings"
 	"testing"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/io/filesystem"
 	_ "github.com/apache/beam/sdks/v2/go/pkg/beam/io/filesystem/local"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/testing/passert"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/testing/ptest"
@@ -113,3 +119,205 @@ func TestReadAllSdf(t *testing.T) {
 		t.Fatalf("Failed to execute job: %v", err)
 	}
 }
+
+func TestReadAllSdfSeeks(t *testing.T) {
+	oneKLine := repeatString("x", 999)
+	for _, tt := range []struct {
+		name          string
+		seekable      bool
+		contents      []byte
+		wantBytesRead int
+	}{
+		{
+			name:     "seekable",
+			seekable: true,
+			// 300 megabytes - 1 byte total length
+			contents: genFile(1000*300, func(_ int) string {
+				return oneKLine
+			}),
+			wantBytesRead: 300010747,
+		},
+		{
+			name:     "seekable",
+			seekable: false,
+			// 300 megabytes - 1 byte total length
+			contents: genFile(1000*300, func(_ int) string {
+				return oneKLine
+			}),
+			wantBytesRead: 971099383,
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			testFSInstance.reset()
+			testFSInstance.wantSeekable = tt.seekable
+			testFSInstance.m[normalize("example.txt")] = tt.contents
+
+			p, s := beam.NewPipelineWithRoot()
+			files := beam.Create(s, "testfs://example.txt")
+			lines := ReadAllSdf(s, files)
+			passert.Count(s, lines, "NumLines", 1000*300)
+
+			if _, err := beam.Run(context.Background(), "direct", p); err != nil {
+				t.Fatalf("Failed to execute job: %v", err)
+			}
+			if got, want := testFSInstance.readCounts["testfs://example.txt"], tt.wantBytesRead; got != want {
+				t.Errorf("got %d bytes read, want %d", got, want)
+			}
+		})
+	}
+}
+
+func genFile(lineCount int, makeLine func(lineNum int) string) []byte {
+	var lines []string
+	for i := 0; i < lineCount; i++ {
+		lines = append(lines, makeLine(i))
+	}
+	return []byte(strings.Join(lines, "\n"))
+}
+
+func repeatString(s string, n int) string {
+	out := &strings.Builder{}
+	for i := 0; i < n; i++ {
+		out.WriteString(s)
+	}
+	return out.String()
+}
+
+// Register a test file system so we can count reads.
+
+func init() {
+	filesystem.Register("testfs", New)
+}
+
+var testFSInstance = &testFS{m: make(map[string][]byte), readCounts: map[string]int{}}
+
+type testFS struct {
+	m            map[string][]byte
+	readCounts   map[string]int // key to # of bytes read
+	wantSeekable bool
+}
+
+// New returns the global memory filesystem.
+func New(_ context.Context) filesystem.Interface {
+	return testFSInstance
+}
+
+func (f *testFS) reset() {
+	f.readCounts = make(map[string]int)
+	f.m = make(map[string][]byte)
+	f.wantSeekable = true
+}
+
+func (f *testFS) Close() error {
+	return nil
+}
+
+func (f *testFS) List(_ context.Context, glob string) ([]string, error) {
+	pattern, err := regexp.Compile(glob)
+	if err != nil {
+		return nil, err
+	}
+
+	var ret []string
+	for k := range f.m {
+		if pattern.MatchString(k) {
+			ret = append(ret, k)
+		}
+	}
+	sort.Strings(ret)
+	return ret, nil
+}
+
+func (f *testFS) OpenRead(_ context.Context, filename string) (io.ReadCloser, error) {
+	normalizedKey := normalize(filename)
+
+	if _, ok := f.m[normalizedKey]; !ok {
+		return nil, os.ErrNotExist
+	}
+	if !f.wantSeekable {
+		return &bytesReader{instance: f, normalizedKey: normalizedKey}, nil
+	}
+	return &seekableReader{bytesReader{instance: f, normalizedKey: normalizedKey}}, nil
+}
+
+func (f *testFS) OpenWrite(_ context.Context, filename string) (io.WriteCloser, error) {
+	return nil, errors.New("unimplemented OpenWrite")
+	// Create the file if it does not exist.
+}
+
+func (f *testFS) Size(_ context.Context, filename string) (int64, error) {
+	if v, ok := f.m[normalize(filename)]; ok {
+		return int64(len(v)), nil
+	}
+	return -1, os.ErrNotExist
+}
+
+func normalize(key string) string {
+	if strings.HasPrefix(key, "testfs://") {
+		return key
+	}
+	return "testfs://" + key
+}
+
+// bytesReader implements io.Reader, io.Seeker, io.Cloer for memfs "files."
+type bytesReader struct {
+	instance      *testFS
+	normalizedKey string
+	pos           int64
+}
+
+func (r *bytesReader) Read(p []byte) (int, error) {
+	currentValue, exists := r.instance.m[r.normalizedKey]
+	if !exists {
+		return 0, os.ErrNotExist
+	}
+	if int(r.pos) >= len(currentValue) {
+		return 0, io.EOF
+	}
+	wantEnd := int(r.pos) + len(p)
+	if wantEnd > len(currentValue) {
+		wantEnd = len(currentValue)
+	}
+	n := wantEnd - int(r.pos)
+	copy(p, currentValue[r.pos:])
+	r.pos = int64(wantEnd)
+	r.instance.readCounts[r.normalizedKey] += n
+	return n, nil
+}
+
+func (r *bytesReader) Close() error { return nil }
+
+type seekableReader struct {
+	bytesReader
+}
+
+var _ io.ReadSeekCloser = (*seekableReader)(nil)
+
+func (r *seekableReader) Seek(offset int64, whence int) (int64, error) {
+
+	currentValue, exists := r.instance.m[r.normalizedKey]
+	if !exists {
+		return 0, os.ErrNotExist
+	}
+	currentLen := len(currentValue)
+
+	wantPos := r.pos
+	switch whence {
+	case io.SeekCurrent:
+		wantPos = r.pos + offset
+	case io.SeekStart:
+		wantPos = offset
+	case io.SeekEnd:
+		wantPos = int64(currentLen) + offset
+	}
+	if wantPos < 0 {
+		return 0, fmt.Errorf("%w: invalid seek position %d is before start of file", errBadSeek, wantPos)
+	}
+	if int(wantPos) > currentLen {
+		return 0, fmt.Errorf("%w: invalid seek position %d is after end of file", errBadSeek, wantPos)
+	}
+	r.pos = wantPos
+	return r.pos, nil
+}
+
+var errBadSeek = errors.New("bad seek")


### PR DESCRIPTION
When writing tests for spittable DoFns that need to seek within files, it's
helpful to use memfs. Before this change, memfs returned an io.ReadCloser that
did not implement io.Seeker.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
