### PR TITLE
Go SDK: Update memfs to parse the List() pattern as a glob, not a regexp

### DIFF
--- a/sdks/go/pkg/beam/io/filesystem/memfs/memory.go
+++ b/sdks/go/pkg/beam/io/filesystem/memfs/memory.go
@@ -19,10 +19,11 @@ package memfs
 import (
 	"bytes"
 	"context"
+	"fmt"
 	"io"
 	"io/ioutil"
 	"os"
-	"regexp"
+	"path"
 	"sort"
 	"strings"
 	"sync"
@@ -54,14 +55,18 @@ func (f *fs) List(_ context.Context, glob string) ([]string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
-	pattern, err := regexp.Compile(glob)
-	if err != nil {
-		return nil, err
+	globNoScheme := strings.TrimPrefix(glob, "memfs://")
+	if globNoScheme == glob {
+		return nil, fmt.Errorf("invalid pattern %q does not have prefix memfs://", glob)
 	}
 
 	var ret []string
 	for k := range f.m {
-		if pattern.MatchString(k) {
+		matched, err := path.Match(globNoScheme, strings.TrimPrefix(k, "memfs://"))
+		if err != nil {
+			return nil, fmt.Errorf("invalid glob pattern: %w", err)
+		}
+		if matched {
 			ret = append(ret, k)
 		}
 	}

--- a/sdks/go/pkg/beam/io/filesystem/memfs/memory.go
+++ b/sdks/go/pkg/beam/io/filesystem/memfs/memory.go
@@ -23,7 +23,7 @@ import (
 	"io"
 	"io/ioutil"
 	"os"
-	"path"
+	"path/filepath"
 	"sort"
 	"strings"
 	"sync"
@@ -55,14 +55,12 @@ func (f *fs) List(_ context.Context, glob string) ([]string, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
 
+	// As with other functions, the memfs:// prefix is optional.
 	globNoScheme := strings.TrimPrefix(glob, "memfs://")
-	if globNoScheme == glob {
-		return nil, fmt.Errorf("invalid pattern %q does not have prefix memfs://", glob)
-	}
 
 	var ret []string
 	for k := range f.m {
-		matched, err := path.Match(globNoScheme, strings.TrimPrefix(k, "memfs://"))
+		matched, err := filepath.Match(globNoScheme, strings.TrimPrefix(k, "memfs://"))
 		if err != nil {
 			return nil, fmt.Errorf("invalid glob pattern: %w", err)
 		}

--- a/sdks/go/pkg/beam/io/filesystem/memfs/memory_test.go
+++ b/sdks/go/pkg/beam/io/filesystem/memfs/memory_test.go
@@ -105,7 +105,7 @@ func TestList(t *testing.T) {
 			t.Fatalf("Write(%q) error = %v", name, err)
 		}
 	}
-	glob := "memfs://foo.*"
+	glob := "memfs://foo*"
 	got, err := fs.List(ctx, glob)
 	if err != nil {
 		t.Errorf("error List(%q) = %v", glob, err)
@@ -114,6 +114,14 @@ func TestList(t *testing.T) {
 	want := []string{"memfs://foo", "memfs://foobar"}
 	if d := cmp.Diff(want, got); d != "" {
 		t.Errorf("List(%q) = %v, want %v", glob, got, want)
+	}
+
+	{
+		glob := "foo*"
+		_, err := fs.List(ctx, glob)
+		if err == nil {
+			t.Errorf("List(%q) was successful, wanted error", glob)
+		}
 	}
 }
 
@@ -133,14 +141,14 @@ func TestRemove(t *testing.T) {
 		t.Errorf("error Remove(%q) = %v", toremove, err)
 	}
 
-	got, err := fs.List(ctx, ".*")
+	got, err := fs.List(ctx, "memfs://*")
 	if err != nil {
-		t.Errorf("error List(\".*\") = %v", err)
+		t.Errorf("error List(\"*\") = %v", err)
 	}
 
 	want := []string{"memfs://bazfoo", "memfs://fizzbuzz"}
 	if d := cmp.Diff(want, got); d != "" {
-		t.Errorf("After Remove fs.List(\".*\") = %v, want %v", got, want)
+		t.Errorf("After Remove fs.List(\"*\") = %v, want %v", got, want)
 	}
 }
 
@@ -156,7 +164,7 @@ func TestCopy(t *testing.T) {
 	if err := filesystem.Copy(ctx, fs, "memfs://fizzbuzz", "memfs://fizzbang"); err != nil {
 		t.Fatalf("Copy() error = %v", err)
 	}
-	glob := "memfs://fizz.*"
+	glob := "memfs://fizz*"
 	got, err := fs.List(ctx, glob)
 	if err != nil {
 		t.Errorf("error List(%q) = %v", glob, err)
@@ -188,7 +196,7 @@ func TestRename(t *testing.T) {
 	if err := filesystem.Rename(ctx, fs, "memfs://fizzbuzz", "memfs://fizzbang"); err != nil {
 		t.Fatalf("Rename() error = %v", err)
 	}
-	glob := "memfs://fizz.*"
+	glob := "memfs://fizz*"
 	got, err := fs.List(ctx, glob)
 	if err != nil {
 		t.Errorf("error List(%q) = %v", glob, err)


### PR DESCRIPTION
This makes the memfs implementation consistent with the filesystem
implementation of List().

The docstring for filesystem.Interface.List does not specify how the pattern
should be interpretted. It says: "List expands a pattern to a list of
filenames." Perhaps that docstring should be updated to be more specific.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
