### PR TITLE
Making gcpTempLocation default tolerates double slash

### DIFF
--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/storage/GcsPathValidator.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/storage/GcsPathValidator.java
@@ -38,7 +38,7 @@ public class GcsPathValidator implements PathValidator {
     return new GcsPathValidator(options.as(GcsOptions.class));
   }
 
-  /** Validates the the input GCS path is accessible and that the path is well formed. */
+  /** Validates the input GCS path is accessible and that the path is well formed. */
   @Override
   public void validateInputFilePatternSupported(String filepattern) {
     getGcsPath(filepattern);
@@ -46,7 +46,7 @@ public class GcsPathValidator implements PathValidator {
     verifyPathIsAccessible(filepattern, "Could not find file %s");
   }
 
-  /** Validates the the output GCS path is accessible and that the path is well formed. */
+  /** Validates the output GCS path is accessible and that the path is well formed. */
   @Override
   public void validateOutputFilePrefixSupported(String filePrefix) {
     verifyPath(filePrefix);

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/options/GcpOptionsTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/options/GcpOptionsTest.java
@@ -221,6 +221,14 @@ public class GcpOptionsTest {
     }
 
     @Test
+    public void testCreateGcpTempLocationTolerateRedundantSlashes() {
+      String tempLocation = "gs://dataflow-staging-us-north1-1/temp//test1/";
+      options.setTempLocation(tempLocation);
+      String gcpTempLocation = options.as(GcpOptions.class).getGcpTempLocation();
+      assertEquals("gs://dataflow-staging-us-north1-1/temp/test1/", gcpTempLocation);
+    }
+
+    @Test
     public void testCreateBucket() throws Exception {
       doReturn(fakeProject).when(mockGet).execute();
       when(mockGcsUtil.bucketOwner(any(GcsPath.class))).thenReturn(1L);


### PR DESCRIPTION
Fixes #19191.

* Normalize tempLocation uri when validator detected consecutive slashes

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
