### PR TITLE
Move model class outside of run() function in pytorch_language_modeling example

### DIFF
--- a/sdks/python/apache_beam/examples/inference/pytorch_language_modeling.py
+++ b/sdks/python/apache_beam/examples/inference/pytorch_language_modeling.py
@@ -44,6 +44,48 @@ from transformers import BertTokenizer
 BERT_TOKENIZER = BertTokenizer.from_pretrained('bert-base-uncased')
 
 
+# TODO(https://github.com/apache/beam/issues/21863): Remove once optional
+# batching flag added
+class HuggingFaceStripBatchingWrapper(BertForMaskedLM):
+  """Wrapper class to convert output from dict of lists to list of dicts
+
+  The `forward()` function in Hugging Face models doesn't return a
+  standard torch.Tensor output. Instead, it can return a dictionary of
+  different outputs. To work with current RunInference implementation which
+  returns a PredictionResult object for each example, we must override the
+  `forward()` function and convert the standard Hugging Face forward output
+  into the appropriate format of List[Dict[str, torch.Tensor]].
+
+  Before:
+  output = {
+    'logit': torch.FloatTensor of shape
+      (batch_size, sequence_length, config.vocab_size),
+    'hidden_states': tuple(torch.FloatTensor) of shape
+      (batch_size, sequence_length, hidden_size)
+  }
+  After:
+  output = [
+    {
+      'logit': torch.FloatTensor of shape
+        (sequence_length, config.vocab_size),
+      'hidden_states': tuple(torch.FloatTensor) of
+        shape (sequence_length, hidden_size)
+    },
+    {
+      'logit': torch.FloatTensor of shape
+        (sequence_length, config.vocab_size),
+      'hidden_states': tuple(torch.FloatTensor) of shape
+        (sequence_length, hidden_size)
+    },
+    ...
+  ]
+  where len(output) is batch_size
+  """
+  def forward(self, **kwargs):
+    output = super().forward(**kwargs)
+    return [dict(zip(output, v)) for v in zip(*output.values())]
+
+
 def add_mask_to_last_word(text: str) -> Tuple[str, str]:
   text_list = text.split()
   return text, ' '.join(text_list[:-2] + ['[MASK]', text_list[-1]])
@@ -121,49 +163,8 @@ def run(argv=None, model_class=None, model_params=None, save_main_session=True):
 
   if not model_class:
     model_config = BertConfig(is_decoder=False, return_dict=True)
-    model_class = BertForMaskedLM
+    model_class = HuggingFaceStripBatchingWrapper
     model_params = {'config': model_config}
-
-  # TODO(https://github.com/apache/beam/issues/21863): Remove once optional
-  # batching flag added
-  class HuggingFaceStripBatchingWrapper(model_class):
-    """Wrapper class to convert output from dict of lists to list of dicts
-
-    The `forward()` function in Hugging Face models doesn't return a
-    standard torch.Tensor output. Instead, it can return a dictionary of
-    different outputs. To work with current RunInference implementation which
-    returns a PredictionResult object for each example, we must override the
-    `forward()` function and convert the standard Hugging Face forward output
-    into the appropriate format of List[Dict[str, torch.Tensor]].
-
-    Before:
-    output = {
-      'logit': torch.FloatTensor of shape
-        (batch_size, sequence_length, config.vocab_size),
-      'hidden_states': tuple(torch.FloatTensor) of shape
-        (batch_size, sequence_length, hidden_size)
-    }
-    After:
-    output = [
-      {
-        'logit': torch.FloatTensor of shape
-          (sequence_length, config.vocab_size),
-        'hidden_states': tuple(torch.FloatTensor) of
-          shape (sequence_length, hidden_size)
-      },
-      {
-        'logit': torch.FloatTensor of shape
-          (sequence_length, config.vocab_size),
-        'hidden_states': tuple(torch.FloatTensor) of shape
-          (sequence_length, hidden_size)
-      },
-      ...
-    ]
-    where len(output) is batch_size
-    """
-    def forward(self, **kwargs):
-      output = super().forward(**kwargs)
-      return [dict(zip(output, v)) for v in zip(*output.values())]
 
   # TODO: Remove once nested tensors https://github.com/pytorch/nestedtensor
   # is officially released.


### PR DESCRIPTION
`dill` was bumped to 0.3.5.1 last month. With this version, there were no issues pickling the classes defined in `pytorch_language_modeling.py` during development. However, since we only recently reverted `dill` back to `0.3.1.1`, and haven't had a chance to test `pytorch_language_modeling.py` till `apache_beam==2.40.0rc1` was released, we didn't realize that dill version `0.3.1.1` has issues with pickling some of the classes. See error [here](https://gist.github.com/yeandy/4c51243213e24eef9417ff386b24cd0e)

**Solution**: Move the wrapper class outside of the `run()` function. This example now works for the current dill package `dill==0.3.1.1`.


Note: I tested a hacky solution by adding the following code to `pytorch_language_modeling.py`.
```
from apache_beam.internal import pickler
pickler.set_library('cloudpickle')
```
But this is not good practice, so I went with the change in this PR.
