### PR TITLE
[BEAM-13015, #21250, fixes #22053] Improve PCollectionConsumerRegistry performance by swapping element count and sampled byte size to use a faster counter.

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/DistributionData.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/DistributionData.java
@@ -50,6 +50,14 @@ public abstract class DistributionData implements Serializable {
     return create(value, 1, value, value);
   }
 
+  public DistributionData combine(long value) {
+    return create(sum() + value, count() + 1, Math.min(value, min()), Math.max(value, max()));
+  }
+
+  public DistributionData combine(long sum, long count, long min, long max) {
+    return create(sum() + sum, count() + count, Math.min(min, min()), Math.max(max, max()));
+  }
+
   public DistributionData combine(DistributionData value) {
     return create(
         sum() + value.sum(),

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/ShortIdMap.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/ShortIdMap.java
@@ -17,8 +17,13 @@
  */
 package org.apache.beam.runners.core.metrics;
 
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import java.util.NoSuchElementException;
 import org.apache.beam.model.pipeline.v1.MetricsApi.MonitoringInfo;
+import org.apache.beam.vendor.grpc.v1p43p2.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.BiMap;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.HashBiMap;
@@ -47,5 +52,31 @@ public class ShortIdMap {
       throw new NoSuchElementException(shortId);
     }
     return monitoringInfo;
+  }
+
+  public synchronized Map<String, MonitoringInfo> get(List<String> shortIds) {
+    Map<String, MonitoringInfo> monitoringInfos = new HashMap<>(shortIds.size());
+    for (String shortId : shortIds) {
+      MonitoringInfo info = monitoringInfoMap.get(shortId);
+      if (info == null) {
+        throw new NoSuchElementException(shortId);
+      }
+      monitoringInfos.put(shortId, info);
+    }
+    return monitoringInfos;
+  }
+
+  public synchronized Iterable<MonitoringInfo> toMonitoringInfo(
+      Map<String, ByteString> shortIdToData) {
+    List<MonitoringInfo> monitoringInfos = new ArrayList<>(shortIdToData.size());
+    for (Map.Entry<String, ByteString> entry : shortIdToData.entrySet()) {
+      String shortId = entry.getKey();
+      MonitoringInfo info = monitoringInfoMap.get(shortId);
+      if (info == null) {
+        throw new NoSuchElementException(shortId);
+      }
+      monitoringInfos.add(info.toBuilder().setPayload(entry.getValue()).build());
+    }
+    return monitoringInfos;
   }
 }

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/SimpleMonitoringInfoBuilder.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/SimpleMonitoringInfoBuilder.java
@@ -154,6 +154,12 @@ public class SimpleMonitoringInfoBuilder {
     return this;
   }
 
+  /** Adds all the labels to the MonitoringInfo overwriting any duplicated keys. */
+  public SimpleMonitoringInfoBuilder setLabels(Map<String, String> labels) {
+    this.builder.putAllLabels(labels);
+    return this;
+  }
+
   public void clear() {
     this.builder = MonitoringInfo.newBuilder();
   }

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/DistributionDataTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/DistributionDataTest.java
@@ -1,0 +1,67 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.core.metrics;
+
+import static org.junit.Assert.assertEquals;
+
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link DistributionData}. */
+@RunWith(JUnit4.class)
+public class DistributionDataTest {
+  @Test
+  public void testSingleton() {
+    DistributionData data = DistributionData.singleton(5);
+    assertEquals(5, data.sum());
+    assertEquals(1, data.count());
+    assertEquals(5, data.min());
+    assertEquals(5, data.max());
+  }
+
+  @Test
+  public void testCreate() {
+    DistributionData data = DistributionData.create(5, 2, 1, 4);
+    assertEquals(5, data.sum());
+    assertEquals(2, data.count());
+    assertEquals(1, data.min());
+    assertEquals(4, data.max());
+  }
+
+  @Test
+  public void testCombine() {
+    DistributionData data = DistributionData.create(5, 2, 1, 4).combine(7);
+    assertEquals(12, data.sum());
+    assertEquals(3, data.count());
+    assertEquals(1, data.min());
+    assertEquals(7, data.max());
+
+    data = DistributionData.create(5, 2, 1, 4).combine(1, 2, 0, 1);
+    assertEquals(6, data.sum());
+    assertEquals(4, data.count());
+    assertEquals(0, data.min());
+    assertEquals(4, data.max());
+
+    data = DistributionData.create(5, 2, 1, 4).combine(DistributionData.EMPTY);
+    assertEquals(5, data.sum());
+    assertEquals(2, data.count());
+    assertEquals(1, data.min());
+    assertEquals(4, data.max());
+  }
+}

--- a/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/SimpleMonitoringInfoBuilderTest.java
+++ b/runners/core-java/src/test/java/org/apache/beam/runners/core/metrics/SimpleMonitoringInfoBuilderTest.java
@@ -23,6 +23,7 @@ import static org.junit.Assert.assertNull;
 import static org.junit.Assert.assertTrue;
 
 import org.apache.beam.model.pipeline.v1.MetricsApi.MonitoringInfo;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -67,8 +68,12 @@ public class SimpleMonitoringInfoBuilderTest {
     SimpleMonitoringInfoBuilder builder = new SimpleMonitoringInfoBuilder();
     builder.setUrn(MonitoringInfoConstants.Urns.USER_DISTRIBUTION_INT64);
     builder.setLabel(MonitoringInfoConstants.Labels.NAME, "myName");
-    builder.setLabel(MonitoringInfoConstants.Labels.NAMESPACE, "myNamespace");
-    builder.setLabel(MonitoringInfoConstants.Labels.PTRANSFORM, "myStep");
+    builder.setLabels(
+        ImmutableMap.of(
+            MonitoringInfoConstants.Labels.NAMESPACE,
+            "myNamespace",
+            MonitoringInfoConstants.Labels.PTRANSFORM,
+            "myStep"));
     assertNull(builder.build());
 
     builder.setInt64DistributionValue(DistributionData.create(10, 2, 1, 9));

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
@@ -30,6 +30,7 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
+import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -54,6 +55,7 @@ import java.util.concurrent.ScheduledExecutorService;
 import java.util.concurrent.ScheduledFuture;
 import java.util.concurrent.ThreadFactory;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicReference;
 import java.util.function.Function;
 import org.apache.beam.fn.harness.Caches;
 import org.apache.beam.fn.harness.FnHarness;
@@ -937,11 +939,14 @@ public class RemoteExecutionTest implements Serializable {
               (Coder<WindowedValue<?>>) remoteOutputCoder.getValue(), outputContents::add));
     }
 
+    AtomicReference<List<MonitoringInfo>> progressMonitoringInfos = new AtomicReference<>();
+
     final String testPTransformId = "create-ParMultiDo-Metrics-";
     BundleProgressHandler progressHandler =
         new BundleProgressHandler() {
           @Override
           public void onProgress(ProcessBundleProgressResponse response) {
+            progressMonitoringInfos.set(response.getMonitoringInfosList());
             MetricsDoFn.ALLOW_COMPLETION.get(metricsDoFn.uuid).countDown();
             List<Matcher<MonitoringInfo>> matchers = new ArrayList<>();
 
@@ -1149,9 +1154,15 @@ public class RemoteExecutionTest implements Serializable {
                     MonitoringInfoMatchers.matchSetFields(builder.build()),
                     MonitoringInfoMatchers.counterValueGreaterThanOrEqualTo(3)));
 
-            assertThat(
-                response.getMonitoringInfosList(),
-                Matchers.hasItems(matchers.toArray(new Matcher[0])));
+            List<MonitoringInfo> oldMonitoringInfos = progressMonitoringInfos.get();
+            if (oldMonitoringInfos == null) {
+              throw new IllegalStateException(
+                  "Progress request did not complete before timeout allowing for bundle to complete.");
+            }
+            List<MonitoringInfo> mergedMonitoringInfos =
+                mergeMonitoringInfos(oldMonitoringInfos, response.getMonitoringInfosList());
+
+            assertThat(mergedMonitoringInfos, Matchers.hasItems(matchers.toArray(new Matcher[0])));
           }
         };
 
@@ -1172,6 +1183,18 @@ public class RemoteExecutionTest implements Serializable {
           });
     }
     executor.shutdown();
+  }
+
+  private static List<MonitoringInfo> mergeMonitoringInfos(
+      List<MonitoringInfo> oldMonitoringInfos, List<MonitoringInfo> newMonitoringInfos) {
+    Map<MonitoringInfo, MonitoringInfo> miKeyToMiWithPayload = new HashMap<>();
+    for (MonitoringInfo monitoringInfo : oldMonitoringInfos) {
+      miKeyToMiWithPayload.put(monitoringInfo.toBuilder().clearPayload().build(), monitoringInfo);
+    }
+    for (MonitoringInfo monitoringInfo : newMonitoringInfos) {
+      miKeyToMiWithPayload.put(monitoringInfo.toBuilder().clearPayload().build(), monitoringInfo);
+    }
+    return ImmutableList.copyOf(miKeyToMiWithPayload.values());
   }
 
   @Test

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
@@ -30,7 +30,6 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
 import static org.junit.Assert.fail;
 
-import com.google.common.collect.ImmutableList;
 import java.io.Serializable;
 import java.util.ArrayList;
 import java.util.Arrays;
@@ -1194,7 +1193,7 @@ public class RemoteExecutionTest implements Serializable {
     for (MonitoringInfo monitoringInfo : newMonitoringInfos) {
       miKeyToMiWithPayload.put(monitoringInfo.toBuilder().clearPayload().build(), monitoringInfo);
     }
-    return ImmutableList.copyOf(miKeyToMiWithPayload.values());
+    return new ArrayList<>(miKeyToMiWithPayload.values());
   }
 
   @Test

--- a/sdks/java/harness/jmh/src/main/java/org/apache/beam/fn/harness/jmh/control/MetricsBenchmark.java
+++ b/sdks/java/harness/jmh/src/main/java/org/apache/beam/fn/harness/jmh/control/MetricsBenchmark.java
@@ -1,0 +1,97 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.fn.harness.jmh.control;
+
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkState;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.beam.fn.harness.control.Metrics;
+import org.apache.beam.fn.harness.control.Metrics.BundleCounter;
+import org.apache.beam.runners.core.metrics.CounterCell;
+import org.apache.beam.runners.core.metrics.MonitoringInfoEncodings;
+import org.apache.beam.sdk.metrics.MetricName;
+import org.apache.beam.vendor.grpc.v1p43p2.com.google.protobuf.ByteString;
+import org.openjdk.jmh.annotations.Benchmark;
+import org.openjdk.jmh.annotations.Level;
+import org.openjdk.jmh.annotations.Scope;
+import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.TearDown;
+import org.openjdk.jmh.annotations.Threads;
+
+/** Benchmarks for updating metrics objects during processing. */
+public class MetricsBenchmark {
+  private static final MetricName TEST_NAME = MetricName.named("testNamespace", "testName");
+  private static final String TEST_ID = "testId";
+
+  @State(Scope.Benchmark)
+  public static class SerialMutatorAndFinalReaderBundleCounterState {
+    public BundleCounter bundleCounter =
+        Metrics.serialMutatorAndFinalReaderBundleCounter(TEST_ID, TEST_NAME);
+
+    @TearDown(Level.Trial)
+    public void check() {
+      Map<String, ByteString> reported = new HashMap<>();
+      bundleCounter.updateFinalMonitoringData(reported);
+      checkState(reported.containsKey(TEST_ID));
+      checkState(MonitoringInfoEncodings.decodeInt64Counter(reported.get(TEST_ID)) > 0);
+      bundleCounter.reset();
+    }
+  }
+
+  @State(Scope.Benchmark)
+  public static class CounterCellState {
+    public CounterCell counterCell = new CounterCell(TEST_NAME);
+
+    @TearDown(Level.Trial)
+    public void check() {
+      checkState(counterCell.getCumulative() > 0);
+      counterCell.reset();
+    }
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void testCounterCellMutation(CounterCellState counterState) throws Exception {
+    counterState.counterCell.inc();
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void testCounterCellReset(CounterCellState counterState) throws Exception {
+    counterState.counterCell.inc();
+    counterState.counterCell.reset();
+    counterState.counterCell.inc();
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void testSerialMutatorAndFinalReaderBundleCounterMutation(
+      SerialMutatorAndFinalReaderBundleCounterState counterState) throws Exception {
+    counterState.bundleCounter.inc();
+  }
+
+  @Benchmark
+  @Threads(1)
+  public void testSerialMutatorAndFinalReaderBundleCounterReset(
+      SerialMutatorAndFinalReaderBundleCounterState counterState) throws Exception {
+    counterState.bundleCounter.inc();
+    counterState.bundleCounter.reset();
+    counterState.bundleCounter.inc();
+  }
+}

--- a/sdks/java/harness/jmh/src/main/java/org/apache/beam/fn/harness/jmh/control/MetricsBenchmark.java
+++ b/sdks/java/harness/jmh/src/main/java/org/apache/beam/fn/harness/jmh/control/MetricsBenchmark.java
@@ -40,9 +40,8 @@ public class MetricsBenchmark {
   private static final String TEST_ID = "testId";
 
   @State(Scope.Benchmark)
-  public static class SerialMutatorAndFinalReaderBundleCounterState {
-    public BundleCounter bundleCounter =
-        Metrics.serialMutatorAndFinalReaderBundleCounter(TEST_ID, TEST_NAME);
+  public static class BundleProcessingThreadCounterState {
+    public BundleCounter bundleCounter = Metrics.bundleProcessingThreadCounter(TEST_ID, TEST_NAME);
 
     @TearDown(Level.Trial)
     public void check() {
@@ -81,15 +80,15 @@ public class MetricsBenchmark {
 
   @Benchmark
   @Threads(1)
-  public void testSerialMutatorAndFinalReaderBundleCounterMutation(
-      SerialMutatorAndFinalReaderBundleCounterState counterState) throws Exception {
+  public void testBundleProcessingThreadCounterMutation(
+      BundleProcessingThreadCounterState counterState) throws Exception {
     counterState.bundleCounter.inc();
   }
 
   @Benchmark
   @Threads(1)
-  public void testSerialMutatorAndFinalReaderBundleCounterReset(
-      SerialMutatorAndFinalReaderBundleCounterState counterState) throws Exception {
+  public void testBundleProcessingThreadCounterReset(
+      BundleProcessingThreadCounterState counterState) throws Exception {
     counterState.bundleCounter.inc();
     counterState.bundleCounter.reset();
     counterState.bundleCounter.inc();

--- a/sdks/java/harness/jmh/src/main/java/org/apache/beam/fn/harness/jmh/control/package-info.java
+++ b/sdks/java/harness/jmh/src/main/java/org/apache/beam/fn/harness/jmh/control/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Benchmarks for the SDK harness. */
+package org.apache.beam.fn.harness.jmh.control;

--- a/sdks/java/harness/jmh/src/test/java/org/apache/beam/fn/harness/jmh/control/MetricsBenchmarkTest.java
+++ b/sdks/java/harness/jmh/src/test/java/org/apache/beam/fn/harness/jmh/control/MetricsBenchmarkTest.java
@@ -17,8 +17,8 @@
  */
 package org.apache.beam.fn.harness.jmh.control;
 
+import org.apache.beam.fn.harness.jmh.control.MetricsBenchmark.BundleProcessingThreadCounterState;
 import org.apache.beam.fn.harness.jmh.control.MetricsBenchmark.CounterCellState;
-import org.apache.beam.fn.harness.jmh.control.MetricsBenchmark.SerialMutatorAndFinalReaderBundleCounterState;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -26,18 +26,16 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class MetricsBenchmarkTest {
   @Test
-  public void testSerialMutatorAndFinalReaderBundleCounterMutation() throws Exception {
-    SerialMutatorAndFinalReaderBundleCounterState state =
-        new SerialMutatorAndFinalReaderBundleCounterState();
-    new MetricsBenchmark().testSerialMutatorAndFinalReaderBundleCounterMutation(state);
+  public void testBundleProcessingThreadCounterMutation() throws Exception {
+    BundleProcessingThreadCounterState state = new BundleProcessingThreadCounterState();
+    new MetricsBenchmark().testBundleProcessingThreadCounterMutation(state);
     state.check();
   }
 
   @Test
-  public void testSerialMutatorAndFinalReaderBundleCounterReset() throws Exception {
-    SerialMutatorAndFinalReaderBundleCounterState state =
-        new SerialMutatorAndFinalReaderBundleCounterState();
-    new MetricsBenchmark().testSerialMutatorAndFinalReaderBundleCounterReset(state);
+  public void testBundleProcessingThreadCounterReset() throws Exception {
+    BundleProcessingThreadCounterState state = new BundleProcessingThreadCounterState();
+    new MetricsBenchmark().testBundleProcessingThreadCounterReset(state);
     state.check();
   }
 

--- a/sdks/java/harness/jmh/src/test/java/org/apache/beam/fn/harness/jmh/control/MetricsBenchmarkTest.java
+++ b/sdks/java/harness/jmh/src/test/java/org/apache/beam/fn/harness/jmh/control/MetricsBenchmarkTest.java
@@ -1,0 +1,57 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.fn.harness.jmh.control;
+
+import org.apache.beam.fn.harness.jmh.control.MetricsBenchmark.CounterCellState;
+import org.apache.beam.fn.harness.jmh.control.MetricsBenchmark.SerialMutatorAndFinalReaderBundleCounterState;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class MetricsBenchmarkTest {
+  @Test
+  public void testSerialMutatorAndFinalReaderBundleCounterMutation() throws Exception {
+    SerialMutatorAndFinalReaderBundleCounterState state =
+        new SerialMutatorAndFinalReaderBundleCounterState();
+    new MetricsBenchmark().testSerialMutatorAndFinalReaderBundleCounterMutation(state);
+    state.check();
+  }
+
+  @Test
+  public void testSerialMutatorAndFinalReaderBundleCounterReset() throws Exception {
+    SerialMutatorAndFinalReaderBundleCounterState state =
+        new SerialMutatorAndFinalReaderBundleCounterState();
+    new MetricsBenchmark().testSerialMutatorAndFinalReaderBundleCounterReset(state);
+    state.check();
+  }
+
+  @Test
+  public void testCounterCellMutation() throws Exception {
+    CounterCellState state = new CounterCellState();
+    new MetricsBenchmark().testCounterCellMutation(state);
+    state.check();
+  }
+
+  @Test
+  public void testCounterCellReset() throws Exception {
+    CounterCellState state = new CounterCellState();
+    new MetricsBenchmark().testCounterCellReset(state);
+    state.check();
+  }
+}

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/BeamFnDataWriteRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/BeamFnDataWriteRunner.java
@@ -34,7 +34,6 @@ import org.apache.beam.runners.core.construction.RehydratedComponents;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.fn.data.RemoteGrpcPortWrite;
 import org.apache.beam.sdk.util.WindowedValue;
-import org.apache.beam.sdk.util.WindowedValue.WindowedValueCoder;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 
 /**
@@ -92,8 +91,7 @@ public class BeamFnDataWriteRunner<InputT> {
                   });
       context.addPCollectionConsumer(
           getOnlyElement(context.getPTransform().getInputsMap().values()),
-          context.addOutgoingDataEndpoint(port.getApiServiceDescriptor(), coder),
-          ((WindowedValueCoder<InputT>) coder).getValueCoder());
+          context.addOutgoingDataEndpoint(port.getApiServiceDescriptor(), coder));
 
       return new BeamFnDataWriteRunner();
     }

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/CombineRunners.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/CombineRunners.java
@@ -170,8 +170,8 @@ public class CombineRunners {
       context.addStartBundleFunction(runner::startBundle);
       context.addPCollectionConsumer(
           Iterables.getOnlyElement(context.getPTransform().getInputsMap().values()),
-          (FnDataReceiver) (FnDataReceiver<WindowedValue<KV<KeyT, InputT>>>) runner::processElement,
-          inputCoder);
+          (FnDataReceiver)
+              (FnDataReceiver<WindowedValue<KV<KeyT, InputT>>>) runner::processElement);
       context.addFinishBundleFunction(runner::finishBundle);
 
       return runner;

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FlattenRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FlattenRunner.java
@@ -22,13 +22,9 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.I
 import com.google.auto.service.AutoService;
 import java.io.IOException;
 import java.util.Map;
-import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
-import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
 import org.apache.beam.runners.core.construction.PTransformTranslation;
-import org.apache.beam.runners.core.construction.RehydratedComponents;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.util.WindowedValue;
-import org.apache.beam.sdk.util.WindowedValue.WindowedValueCoder;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 
 /** Executes flatten PTransforms. */
@@ -50,41 +46,16 @@ public class FlattenRunner<InputT> {
   static class Factory<InputT> implements PTransformRunnerFactory<FlattenRunner<InputT>> {
     @Override
     public FlattenRunner<InputT> createRunnerForPTransform(Context context) throws IOException {
-
       // Give each input a MultiplexingFnDataReceiver to all outputs of the flatten.
       String output = getOnlyElement(context.getPTransform().getOutputsMap().values());
       FnDataReceiver<WindowedValue<?>> receiver = context.getPCollectionConsumer(output);
 
-      RehydratedComponents components =
-          RehydratedComponents.forComponents(
-              Components.newBuilder().putAllCoders(context.getCoders()).build());
-
       FlattenRunner<InputT> runner = new FlattenRunner<>();
       for (String pCollectionId : context.getPTransform().getInputsMap().values()) {
-        context.addPCollectionConsumer(
-            pCollectionId,
-            (FnDataReceiver) receiver,
-            getValueCoder(components, context.getPCollections(), pCollectionId));
+        context.addPCollectionConsumer(pCollectionId, (FnDataReceiver) receiver);
       }
 
       return runner;
-    }
-
-    private org.apache.beam.sdk.coders.Coder<?> getValueCoder(
-        RehydratedComponents components,
-        Map<String, PCollection> pCollections,
-        String pCollectionId)
-        throws IOException {
-      if (!pCollections.containsKey(pCollectionId)) {
-        throw new IllegalArgumentException(
-            String.format("Missing PCollection for id: %s", pCollectionId));
-      }
-      org.apache.beam.sdk.coders.Coder<?> coder =
-          components.getCoder(pCollections.get(pCollectionId).getCoderId());
-      if (coder instanceof WindowedValueCoder) {
-        coder = ((WindowedValueCoder<InputT>) coder).getValueCoder();
-      }
-      return coder;
     }
   }
 }

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnHarness.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnHarness.java
@@ -22,8 +22,6 @@ import java.util.EnumMap;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
-import java.util.stream.Collectors;
-import java.util.stream.StreamSupport;
 import javax.annotation.Nullable;
 import org.apache.beam.fn.harness.control.BeamFnControlClient;
 import org.apache.beam.fn.harness.control.FinalizeBundleHandler;
@@ -316,15 +314,8 @@ public class FnHarness {
                   .setMonitoringInfos(
                       BeamFnApi.MonitoringInfosMetadataResponse.newBuilder()
                           .putAllMonitoringInfo(
-                              StreamSupport.stream(
-                                      request
-                                          .getMonitoringInfos()
-                                          .getMonitoringInfoIdList()
-                                          .spliterator(),
-                                      false)
-                                  .collect(
-                                      Collectors.toMap(
-                                          Function.identity(), metricsShortIds::get)))));
+                              metricsShortIds.get(
+                                  request.getMonitoringInfos().getMonitoringInfoIdList()))));
 
       HarnessMonitoringInfosInstructionHandler processWideHandler =
           new HarnessMonitoringInfosInstructionHandler(metricsShortIds);

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/MapFnRunners.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/MapFnRunners.java
@@ -20,15 +20,10 @@ package org.apache.beam.fn.harness;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables.getOnlyElement;
 
 import java.io.IOException;
-import java.util.Map;
-import org.apache.beam.model.pipeline.v1.RunnerApi.Components;
-import org.apache.beam.model.pipeline.v1.RunnerApi.PCollection;
 import org.apache.beam.model.pipeline.v1.RunnerApi.PTransform;
-import org.apache.beam.runners.core.construction.RehydratedComponents;
 import org.apache.beam.sdk.fn.data.FnDataReceiver;
 import org.apache.beam.sdk.function.ThrowingFunction;
 import org.apache.beam.sdk.util.WindowedValue;
-import org.apache.beam.sdk.util.WindowedValue.WindowedValueCoder;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 
 /**
@@ -93,43 +88,17 @@ public abstract class MapFnRunners {
 
     @Override
     public Mapper<InputT, OutputT> createRunnerForPTransform(Context context) throws IOException {
-
       FnDataReceiver<WindowedValue<InputT>> consumer =
-          (FnDataReceiver)
-              context.getPCollectionConsumer(
-                  getOnlyElement(context.getPTransform().getOutputsMap().values()));
+          context.getPCollectionConsumer(
+              getOnlyElement(context.getPTransform().getOutputsMap().values()));
 
       Mapper<InputT, OutputT> mapper =
           mapperFactory.create(context.getPTransformId(), context.getPTransform(), consumer);
 
-      RehydratedComponents components =
-          RehydratedComponents.forComponents(
-              Components.newBuilder().putAllCoders(context.getCoders()).build());
       String pCollectionId =
           Iterables.getOnlyElement(context.getPTransform().getInputsMap().values());
-      context.addPCollectionConsumer(
-          pCollectionId,
-          (FnDataReceiver) (FnDataReceiver<WindowedValue<InputT>>) mapper::map,
-          getValueCoder(components, context.getPCollections(), pCollectionId));
+      context.addPCollectionConsumer(pCollectionId, mapper::map);
       return mapper;
-    }
-
-    private org.apache.beam.sdk.coders.Coder<?> getValueCoder(
-        RehydratedComponents components,
-        Map<String, PCollection> pCollections,
-        String pCollectionId)
-        throws IOException {
-      if (!pCollections.containsKey(pCollectionId)) {
-        throw new IllegalArgumentException(
-            String.format("Missing PCollection for id: %s", pCollectionId));
-      }
-
-      org.apache.beam.sdk.coders.Coder<?> coder =
-          components.getCoder(pCollections.get(pCollectionId).getCoderId());
-      if (coder instanceof WindowedValueCoder) {
-        coder = ((WindowedValueCoder<InputT>) coder).getValueCoder();
-      }
-      return coder;
     }
   }
 

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/PTransformRunnerFactory.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/PTransformRunnerFactory.java
@@ -22,6 +22,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.function.Supplier;
+import org.apache.beam.fn.harness.control.BundleProgressReporter;
 import org.apache.beam.fn.harness.control.BundleSplitListener;
 import org.apache.beam.fn.harness.data.BeamFnDataClient;
 import org.apache.beam.fn.harness.state.BeamFnStateClient;
@@ -141,6 +142,18 @@ public interface PTransformRunnerFactory<T> {
      * startFunctionRegistry}, and {@code finishFunctionRegistry}.
      */
     void addProgressRequestCallback(ProgressRequestCallback progressRequestCallback);
+
+    /**
+     * Register a callback whenever progress is being requested.
+     *
+     * <p>{@link BundleProgressReporter#updateIntermediateMonitoringData} will be called by a single
+     * arbitrary thread at a time and will be invoked concurrently to the main bundle processing
+     * thread. {@link BundleProgressReporter#updateFinalMonitoringData} will be invoked exclusively
+     * by the main bundle processing thread and {@link
+     * BundleProgressReporter#updateIntermediateMonitoringData} will not be invoked until a new
+     * bundle starts processing. See {@link BundleProgressReporter} for additional details.
+     */
+    void addBundleProgressReporter(BundleProgressReporter bundleProgressReporter);
 
     /**
      * A listener to be invoked when the PTransform splits itself. This method will be called

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/PTransformRunnerFactory.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/PTransformRunnerFactory.java
@@ -88,7 +88,7 @@ public interface PTransformRunnerFactory<T> {
 
     /** Register as a consumer for a given PCollection id. */
     <T> void addPCollectionConsumer(
-        String pCollectionId, FnDataReceiver<WindowedValue<T>> consumer, Coder<T> valueCoder);
+        String pCollectionId, FnDataReceiver<WindowedValue<T>> consumer);
 
     /** Returns a {@link FnDataReceiver} to send output to for the specified PCollection id. */
     <T> FnDataReceiver<T> getPCollectionConsumer(String pCollectionId);

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/BundleProgressReporter.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/BundleProgressReporter.java
@@ -21,6 +21,7 @@ import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
 import javax.annotation.concurrent.NotThreadSafe;
+import org.apache.beam.fn.harness.control.ProcessBundleHandler.BundleProcessor;
 import org.apache.beam.vendor.grpc.v1p43p2.com.google.protobuf.ByteString;
 
 /**
@@ -41,14 +42,15 @@ public interface BundleProgressReporter {
   /**
    * Update the monitoring data for a bundle that is currently being processed.
    *
-   * <p>Will be executed exclusively by any thread.
+   * <p>Must be invoked while holding the {@link BundleProcessor#getProgressRequestLock}.
    */
   void updateIntermediateMonitoringData(Map<String, ByteString> monitoringData);
 
   /**
    * Update the monitoring data for a bundle that has finished processing.
    *
-   * <p>Guaranteed to be executed exclusively from the main bundle processing thread.
+   * <p>Must be invoked from the main bundle processing thread and while holding the {@link
+   * BundleProcessor#getProgressRequestLock}.
    */
   void updateFinalMonitoringData(Map<String, ByteString> monitoringData);
 
@@ -56,7 +58,8 @@ public interface BundleProgressReporter {
    * Reset the monitoring data after a bundle has finished processing to be re-used for a future
    * bundle.
    *
-   * <p>Guaranteed to be executed exclusively from the main bundle processing thread.
+   * <p>Must be invoked from the main bundle processing thread and while holding the {@link
+   * BundleProcessor#getProgressRequestLock}.
    */
   void reset();
 

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/BundleProgressReporter.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/BundleProgressReporter.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.fn.harness.control;
+
+import java.util.ArrayList;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.concurrent.NotThreadSafe;
+import org.apache.beam.vendor.grpc.v1p43p2.com.google.protobuf.ByteString;
+
+/**
+ * Reports metrics related to bundle processing.
+ *
+ * <p>Each method is guaranteed to be invoked exclusively. The call flow for a single bundle is
+ * always: {@link #updateIntermediateMonitoringData}* -> {@link #updateFinalMonitoringData} ->
+ * {@link #reset}. After {@link #reset}, the progress reporter will be used for another thread.
+ */
+public interface BundleProgressReporter {
+
+  /** Maintains a set of {@link BundleProgressReporter}s. */
+  interface Registrar {
+    /** Adds the reporter to be reported on. It is an error to add a reporter more than once. */
+    void register(BundleProgressReporter reporter);
+  }
+
+  /**
+   * Update the monitoring data for a bundle that is currently being processed.
+   *
+   * <p>Will be executed exclusively by any thread.
+   */
+  void updateIntermediateMonitoringData(Map<String, ByteString> monitoringData);
+
+  /**
+   * Update the monitoring data for a bundle that has finished processing.
+   *
+   * <p>Guaranteed to be executed exclusively from the main bundle processing thread.
+   */
+  void updateFinalMonitoringData(Map<String, ByteString> monitoringData);
+
+  /**
+   * Reset the monitoring data after a bundle has finished processing to be re-used for a future
+   * bundle.
+   *
+   * <p>Guaranteed to be executed exclusively from the main bundle processing thread.
+   */
+  void reset();
+
+  /**
+   * An in-memory bundle progress reporter and registrar.
+   *
+   * <p>Synchronization must be provided between {@link #register} and {@link
+   * BundleProgressReporter} methods to ensure that all registered reporters are seen.
+   */
+  @NotThreadSafe
+  class InMemory implements BundleProgressReporter, Registrar {
+    private final List<BundleProgressReporter> reporters = new ArrayList<>();
+
+    @Override
+    public void register(BundleProgressReporter reporter) {
+      if (reporters.contains(reporter)) {
+        throw new IllegalStateException(reporter + " was being added multiple times.");
+      }
+      reporters.add(reporter);
+    }
+
+    @Override
+    public void updateIntermediateMonitoringData(Map<String, ByteString> monitoringData) {
+      for (BundleProgressReporter reporter : reporters) {
+        reporter.updateIntermediateMonitoringData(monitoringData);
+      }
+    }
+
+    @Override
+    public void updateFinalMonitoringData(Map<String, ByteString> monitoringData) {
+      for (BundleProgressReporter reporter : reporters) {
+        reporter.updateFinalMonitoringData(monitoringData);
+      }
+    }
+
+    @Override
+    public void reset() {
+      for (BundleProgressReporter reporter : reporters) {
+        reporter.reset();
+      }
+    }
+  }
+}

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/Metrics.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/Metrics.java
@@ -47,35 +47,28 @@ public class Metrics {
   /**
    * Returns a counter that will report an accurate final value.
    *
-   * <p>All invocations to {@link Counter} methods, {@link
-   * BundleProgressReporter#updateFinalMonitoringData}, and {@link BundleProgressReporter#reset()}
-   * must be done by the same thread.
+   * <p>All invocations to {@link Counter} methods must be done by the main bundle processing
+   * thread.
    *
-   * <p>All invocations to {@link BundleProgressReporter} methods must be done serially.
-   *
-   * <p>Invocations to {@link Counter} methods can be done concurrently to {@link
-   * BundleProgressReporter#updateIntermediateMonitoringData}.
+   * <p>All invocations to {@link BundleProgressReporter} methods must be done while holding the
+   * {@link BundleProcessor#getProgressRequestLock}.
    */
-  public static BundleCounter serialMutatorAndFinalReaderBundleCounter(
-      String shortId, MetricName name) {
-    return new SerialMutatorAndFinalReaderBundleCounter(shortId, name);
+  public static BundleCounter bundleProcessingThreadCounter(String shortId, MetricName name) {
+    return new BundleProcessingThreadCounter(shortId, name);
   }
 
   /**
    * Returns a {@link Distribution} that will report an accurate final value.
    *
-   * <p>All invocations to {@link Distribution} methods, {@link
-   * BundleProgressReporter#updateFinalMonitoringData}, and {@link BundleProgressReporter#reset()}
-   * must be done by the same thread.
+   * <p>All invocations to {@link Distribution} methods must be done by the main bundle processing
+   * thread.
    *
-   * <p>All invocations to {@link BundleProgressReporter} methods must be done serially.
-   *
-   * <p>Invocations to {@link Distribution} methods can be done concurrently to {@link
-   * BundleProgressReporter#updateIntermediateMonitoringData}.
+   * <p>All invocations to {@link BundleProgressReporter} methods must be done while holding the
+   * {@link BundleProcessor#getProgressRequestLock}.
    */
-  public static BundleDistribution serialMutatorAndFinalReaderBundleDistribution(
+  public static BundleDistribution bundleProcessingThreadDistribution(
       String shortId, MetricName name) {
-    return new SerialMutatorAndFinalReaderBundleDistribution(shortId, name);
+    return new BundleProcessingThreadDistribution(shortId, name);
   }
 
   /**
@@ -85,7 +78,7 @@ public class Metrics {
    * value.
    */
   @NotThreadSafe
-  private static class SerialMutatorAndFinalReaderBundleCounter implements BundleCounter {
+  private static class BundleProcessingThreadCounter implements BundleCounter {
     private final MetricName name;
     private final String shortId;
     /** Guarded by {@link BundleProcessor#getProgressRequestLock}. */
@@ -96,7 +89,7 @@ public class Metrics {
     private final AtomicLong lazyCount;
     private long count;
 
-    public SerialMutatorAndFinalReaderBundleCounter(String shortId, MetricName name) {
+    public BundleProcessingThreadCounter(String shortId, MetricName name) {
       this.shortId = shortId;
       this.name = name;
       this.lazyCount = new AtomicLong();
@@ -169,7 +162,7 @@ public class Metrics {
    * value.
    */
   @NotThreadSafe
-  private static class SerialMutatorAndFinalReaderBundleDistribution implements BundleDistribution {
+  private static class BundleProcessingThreadDistribution implements BundleDistribution {
     private final MetricName name;
     private final String shortId;
     @Nullable private DistributionData lastReportedValue;
@@ -177,7 +170,7 @@ public class Metrics {
     // Consider using a strategy that doesn't create a new object on each update
     private DistributionData data;
 
-    public SerialMutatorAndFinalReaderBundleDistribution(String shortId, MetricName name) {
+    public BundleProcessingThreadDistribution(String shortId, MetricName name) {
       this.shortId = shortId;
       this.name = name;
       this.data = DistributionData.EMPTY;

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/Metrics.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/Metrics.java
@@ -1,0 +1,234 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.fn.harness.control;
+
+import java.util.Map;
+import java.util.concurrent.atomic.AtomicLong;
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.NotThreadSafe;
+import org.apache.beam.fn.harness.control.ProcessBundleHandler.BundleProcessor;
+import org.apache.beam.runners.core.metrics.DistributionData;
+import org.apache.beam.runners.core.metrics.MonitoringInfoEncodings;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Distribution;
+import org.apache.beam.sdk.metrics.MetricName;
+import org.apache.beam.vendor.grpc.v1p43p2.com.google.protobuf.ByteString;
+
+public class Metrics {
+
+  /**
+   * A {@link Counter} that is designed to report intermediate and final results and can be re-used
+   * after being reset.
+   */
+  public interface BundleCounter extends BundleProgressReporter, Counter {}
+
+  /**
+   * A {@link Distribution} that is designed to report intermediate and final results and can be
+   * re-used after being reset.
+   */
+  public interface BundleDistribution extends BundleProgressReporter, Distribution {}
+
+  /**
+   * Returns a counter that will report an accurate final value.
+   *
+   * <p>All invocations to {@link Counter} methods, {@link
+   * BundleProgressReporter#updateFinalMonitoringData}, and {@link BundleProgressReporter#reset()}
+   * must be done by the same thread.
+   *
+   * <p>All invocations to {@link BundleProgressReporter} methods must be done serially.
+   *
+   * <p>Invocations to {@link Counter} methods can be done concurrently to {@link
+   * BundleProgressReporter#updateIntermediateMonitoringData}.
+   */
+  public static BundleCounter serialMutatorAndFinalReaderBundleCounter(
+      String shortId, MetricName name) {
+    return new SerialMutatorAndFinalReaderBundleCounter(shortId, name);
+  }
+
+  /**
+   * Returns a {@link Distribution} that will report an accurate final value.
+   *
+   * <p>All invocations to {@link Distribution} methods, {@link
+   * BundleProgressReporter#updateFinalMonitoringData}, and {@link BundleProgressReporter#reset()}
+   * must be done by the same thread.
+   *
+   * <p>All invocations to {@link BundleProgressReporter} methods must be done serially.
+   *
+   * <p>Invocations to {@link Distribution} methods can be done concurrently to {@link
+   * BundleProgressReporter#updateIntermediateMonitoringData}.
+   */
+  public static BundleDistribution serialMutatorAndFinalReaderBundleDistribution(
+      String shortId, MetricName name) {
+    return new SerialMutatorAndFinalReaderBundleDistribution(shortId, name);
+  }
+
+  /**
+   * A {@link Counter} that shares the data using {@link AtomicReference#lazySet} to reduce
+   * synchronization overhead. This guarantees that intermediate progress reports will report a
+   * value that has been recently updated while the final progress report will get the true final
+   * value.
+   */
+  @NotThreadSafe
+  private static class SerialMutatorAndFinalReaderBundleCounter implements BundleCounter {
+    private final MetricName name;
+    private final String shortId;
+    /** Guarded by {@link BundleProcessor#getProgressRequestLock}. */
+    private boolean hasReportedValue;
+    /** Guarded by {@link BundleProcessor#getProgressRequestLock}. */
+    private long lastReportedValue;
+
+    private final AtomicLong lazyCount;
+    private long count;
+
+    public SerialMutatorAndFinalReaderBundleCounter(String shortId, MetricName name) {
+      this.shortId = shortId;
+      this.name = name;
+      this.lazyCount = new AtomicLong();
+    }
+
+    @Override
+    public void inc() {
+      count += 1;
+      lazyCount.lazySet(count);
+    }
+
+    @Override
+    public void inc(long n) {
+      count += n;
+      lazyCount.lazySet(count);
+    }
+
+    @Override
+    public void dec() {
+      count -= 1;
+      lazyCount.lazySet(count);
+    }
+
+    @Override
+    public void dec(long n) {
+      count -= n;
+      lazyCount.lazySet(count);
+    }
+
+    @Override
+    public MetricName getName() {
+      return name;
+    }
+
+    @Override
+    public void updateIntermediateMonitoringData(Map<String, ByteString> monitoringData) {
+      long valueToReport = lazyCount.get();
+      if (hasReportedValue && valueToReport == lastReportedValue) {
+        return;
+      }
+      monitoringData.put(shortId, MonitoringInfoEncodings.encodeInt64Counter(valueToReport));
+      lastReportedValue = valueToReport;
+      hasReportedValue = true;
+    }
+
+    @Override
+    public void updateFinalMonitoringData(Map<String, ByteString> monitoringData) {
+      if (hasReportedValue && count == lastReportedValue) {
+        return;
+      }
+      monitoringData.put(shortId, MonitoringInfoEncodings.encodeInt64Counter(count));
+      lastReportedValue = count;
+      hasReportedValue = true;
+    }
+
+    @Override
+    public void reset() {
+      if (hasReportedValue) {
+        count = 0;
+        lazyCount.set(count);
+        lastReportedValue = 0;
+      }
+    }
+  }
+
+  /**
+   * A {@link Distribution} that shares the data using {@link AtomicReference#lazySet} to reduce
+   * synchronization overhead. This guarantees that intermediate progress reports will report a
+   * value that has been recently updated while the final progress report will get the true final
+   * value.
+   */
+  @NotThreadSafe
+  private static class SerialMutatorAndFinalReaderBundleDistribution implements BundleDistribution {
+    private final MetricName name;
+    private final String shortId;
+    @Nullable private DistributionData lastReportedValue;
+    private AtomicReference<DistributionData> lazyData;
+    // Consider using a strategy that doesn't create a new object on each update
+    private DistributionData data;
+
+    public SerialMutatorAndFinalReaderBundleDistribution(String shortId, MetricName name) {
+      this.shortId = shortId;
+      this.name = name;
+      this.data = DistributionData.EMPTY;
+      this.lazyData = new AtomicReference<>(data);
+      this.lastReportedValue = null;
+    }
+
+    @Override
+    public void update(long value) {
+      data = data.combine(value);
+      lazyData.lazySet(data);
+    }
+
+    @Override
+    public void update(long sum, long count, long min, long max) {
+      data = data.combine(sum, count, min, max);
+      lazyData.lazySet(data);
+    }
+
+    @Override
+    public MetricName getName() {
+      return name;
+    }
+
+    @Override
+    public void updateIntermediateMonitoringData(Map<String, ByteString> monitoringData) {
+      DistributionData valueToReport = lazyData.get();
+      if (valueToReport.equals(lastReportedValue)) {
+        return;
+      }
+      monitoringData.put(shortId, MonitoringInfoEncodings.encodeInt64Distribution(lazyData.get()));
+      lastReportedValue = valueToReport;
+    }
+
+    @Override
+    public void updateFinalMonitoringData(Map<String, ByteString> monitoringData) {
+      if (data.equals(lastReportedValue)) {
+        return;
+      }
+      monitoringData.put(shortId, MonitoringInfoEncodings.encodeInt64Distribution(data));
+      lastReportedValue = data;
+    }
+
+    @Override
+    public void reset() {
+      // Use faster equality check
+      if (lastReportedValue != null && lastReportedValue != DistributionData.EMPTY) {
+        data = DistributionData.EMPTY;
+        lazyData.set(DistributionData.EMPTY);
+        lastReportedValue = DistributionData.EMPTY;
+      }
+    }
+  }
+}

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
@@ -365,11 +365,8 @@ public class ProcessBundleHandler {
 
                     @Override
                     public <T> void addPCollectionConsumer(
-                        String pCollectionId,
-                        FnDataReceiver<WindowedValue<T>> consumer,
-                        org.apache.beam.sdk.coders.Coder<T> valueCoder) {
-                      pCollectionConsumerRegistry.register(
-                          pCollectionId, pTransformId, consumer, valueCoder);
+                        String pCollectionId, FnDataReceiver<WindowedValue<T>> consumer) {
+                      pCollectionConsumerRegistry.register(pCollectionId, pTransformId, consumer);
                     }
 
                     @Override
@@ -778,7 +775,11 @@ public class ProcessBundleHandler {
         new ExecutionStateTracker(ExecutionStateSampler.instance());
     PCollectionConsumerRegistry pCollectionConsumerRegistry =
         new PCollectionConsumerRegistry(
-            metricsContainerRegistry, stateTracker, shortIds, bundleProgressReporterAndRegistrar);
+            metricsContainerRegistry,
+            stateTracker,
+            shortIds,
+            bundleProgressReporterAndRegistrar,
+            bundleDescriptor);
     HashSet<String> processedPTransformIds = new HashSet<>();
 
     PTransformFunctionRegistry startFunctionRegistry =

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
@@ -24,6 +24,7 @@ import java.time.Duration;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
+import java.util.HashMap;
 import java.util.HashSet;
 import java.util.LinkedHashMap;
 import java.util.List;
@@ -34,6 +35,8 @@ import java.util.WeakHashMap;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import java.util.concurrent.Phaser;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.BiConsumer;
 import java.util.function.Consumer;
 import java.util.function.Function;
@@ -46,6 +49,7 @@ import org.apache.beam.fn.harness.PTransformRunnerFactory;
 import org.apache.beam.fn.harness.PTransformRunnerFactory.Context;
 import org.apache.beam.fn.harness.PTransformRunnerFactory.ProgressRequestCallback;
 import org.apache.beam.fn.harness.PTransformRunnerFactory.Registrar;
+import org.apache.beam.fn.harness.control.BundleProgressReporter.InMemory;
 import org.apache.beam.fn.harness.control.FinalizeBundleHandler.CallbackRegistration;
 import org.apache.beam.fn.harness.data.BeamFnDataClient;
 import org.apache.beam.fn.harness.data.PCollectionConsumerRegistry;
@@ -231,6 +235,7 @@ public class ProcessBundleHandler {
       BiConsumer<Endpoints.ApiServiceDescriptor, DataEndpoint<?>> addDataEndpoint,
       Consumer<TimerEndpoint<?>> addTimerEndpoint,
       Consumer<ProgressRequestCallback> addProgressRequestCallback,
+      Consumer<BundleProgressReporter> addBundleProgressReporter,
       BundleSplitListener splitListener,
       BundleFinalizer bundleFinalizer,
       Collection<BeamFnDataReadRunner> channelRoots,
@@ -263,6 +268,7 @@ public class ProcessBundleHandler {
             addDataEndpoint,
             addTimerEndpoint,
             addProgressRequestCallback,
+            addBundleProgressReporter,
             splitListener,
             bundleFinalizer,
             channelRoots,
@@ -274,13 +280,15 @@ public class ProcessBundleHandler {
     if (!pTransform.hasSpec()) {
       throw new IllegalArgumentException(
           String.format(
-              "Cannot process transform with no spec: %s", TextFormat.printToString(pTransform)));
+              "Cannot process transform with no spec: %s",
+              TextFormat.printer().printToString(pTransform)));
     }
 
     if (pTransform.getSubtransformsCount() > 0) {
       throw new IllegalArgumentException(
           String.format(
-              "Cannot process composite transform: %s", TextFormat.printToString(pTransform)));
+              "Cannot process composite transform: %s",
+              TextFormat.printer().printToString(pTransform)));
     }
 
     // Skip reprocessing processed pTransforms.
@@ -458,6 +466,12 @@ public class ProcessBundleHandler {
                     }
 
                     @Override
+                    public void addBundleProgressReporter(
+                        BundleProgressReporter bundleProgressReporter) {
+                      addBundleProgressReporter.accept(bundleProgressReporter);
+                    }
+
+                    @Override
                     public BundleSplitListener getSplitListener() {
                       return splitListener;
                     }
@@ -546,7 +560,7 @@ public class ProcessBundleHandler {
         response.addAllResidualRoots(bundleProcessor.getSplitListener().getResidualRoots());
 
         // Add all metrics to the response.
-        Map<String, ByteString> monitoringData = monitoringData(bundleProcessor);
+        Map<String, ByteString> monitoringData = finalMonitoringData(bundleProcessor);
         if (runnerAcceptsShortIds) {
           response.putAllMonitoringData(monitoringData);
         } else {
@@ -616,8 +630,6 @@ public class ProcessBundleHandler {
       throws Exception {
     BundleProcessor bundleProcessor =
         bundleProcessorCache.find(request.getProcessBundleProgress().getInstructionId());
-    BeamFnApi.ProcessBundleProgressResponse.Builder response =
-        BeamFnApi.ProcessBundleProgressResponse.newBuilder();
 
     if (bundleProcessor == null) {
       // We might be unable to find an active bundle if ProcessBundleProgressRequest is received by
@@ -627,7 +639,29 @@ public class ProcessBundleHandler {
           .setProcessBundleProgress(BeamFnApi.ProcessBundleProgressResponse.getDefaultInstance());
     }
 
-    Map<String, ByteString> monitoringData = monitoringData(bundleProcessor);
+    // Try to capture the progress lock, the lock will only be held if the bundle is
+    // being finished or another progress request is in progress.
+    if (!bundleProcessor.getProgressRequestLock().tryLock()) {
+      return BeamFnApi.InstructionResponse.newBuilder()
+          .setProcessBundleProgress(BeamFnApi.ProcessBundleProgressResponse.getDefaultInstance());
+    }
+
+    Map<String, ByteString> monitoringData;
+    try {
+      // While holding the lock we check to see if this bundle processor is still active.
+      if (bundleProcessorCache.find(request.getProcessBundleProgress().getInstructionId())
+          == null) {
+        return BeamFnApi.InstructionResponse.newBuilder()
+            .setProcessBundleProgress(BeamFnApi.ProcessBundleProgressResponse.getDefaultInstance());
+      }
+
+      monitoringData = intermediateMonitoringData(bundleProcessor);
+    } finally {
+      bundleProcessor.getProgressRequestLock().unlock();
+    }
+
+    BeamFnApi.ProcessBundleProgressResponse.Builder response =
+        BeamFnApi.ProcessBundleProgressResponse.newBuilder();
     if (runnerAcceptsShortIds) {
       response.putAllMonitoringData(monitoringData);
     } else {
@@ -640,20 +674,21 @@ public class ProcessBundleHandler {
     return BeamFnApi.InstructionResponse.newBuilder().setProcessBundleProgress(response);
   }
 
-  private ImmutableMap<String, ByteString> monitoringData(BundleProcessor bundleProcessor)
+  private Map<String, ByteString> intermediateMonitoringData(BundleProcessor bundleProcessor)
       throws Exception {
-    ImmutableMap.Builder<String, ByteString> result = ImmutableMap.builder();
+    Map<String, ByteString> monitoringData = new HashMap<>();
     // Get start bundle Execution Time Metrics.
-    result.putAll(
+    monitoringData.putAll(
         bundleProcessor.getStartFunctionRegistry().getExecutionTimeMonitoringData(shortIds));
     // Get process bundle Execution Time Metrics.
-    result.putAll(
+    monitoringData.putAll(
         bundleProcessor.getpCollectionConsumerRegistry().getExecutionTimeMonitoringData(shortIds));
     // Get finish bundle Execution Time Metrics.
-    result.putAll(
+    monitoringData.putAll(
         bundleProcessor.getFinishFunctionRegistry().getExecutionTimeMonitoringData(shortIds));
     // Extract MonitoringInfos that come from the metrics container registry.
-    result.putAll(bundleProcessor.getMetricsContainerRegistry().getMonitoringData(shortIds));
+    monitoringData.putAll(
+        bundleProcessor.getMetricsContainerRegistry().getMonitoringData(shortIds));
     // Add any additional monitoring infos that the "runners" report explicitly.
     for (ProgressRequestCallback progressRequestCallback :
         bundleProcessor.getProgressRequestCallbacks()) {
@@ -663,10 +698,47 @@ public class ProcessBundleHandler {
         ByteString payload = monitoringInfo.getPayload();
         String shortId =
             shortIds.getOrCreateShortId(monitoringInfo.toBuilder().clearPayload().build());
-        result.put(shortId, payload);
+        monitoringData.put(shortId, payload);
       }
     }
-    return result.build();
+    bundleProcessor
+        .getBundleProgressReporterAndRegistrar()
+        .updateIntermediateMonitoringData(monitoringData);
+    return monitoringData;
+  }
+
+  private Map<String, ByteString> finalMonitoringData(BundleProcessor bundleProcessor)
+      throws Exception {
+    bundleProcessor.getProgressRequestLock().lock();
+    HashMap<String, ByteString> monitoringData = new HashMap<>();
+    // Get start bundle Execution Time Metrics.
+    monitoringData.putAll(
+        bundleProcessor.getStartFunctionRegistry().getExecutionTimeMonitoringData(shortIds));
+    // Get process bundle Execution Time Metrics.
+    monitoringData.putAll(
+        bundleProcessor.getpCollectionConsumerRegistry().getExecutionTimeMonitoringData(shortIds));
+    // Get finish bundle Execution Time Metrics.
+    monitoringData.putAll(
+        bundleProcessor.getFinishFunctionRegistry().getExecutionTimeMonitoringData(shortIds));
+    // Extract MonitoringInfos that come from the metrics container registry.
+    monitoringData.putAll(
+        bundleProcessor.getMetricsContainerRegistry().getMonitoringData(shortIds));
+    // Add any additional monitoring infos that the "runners" report explicitly.
+    for (ProgressRequestCallback progressRequestCallback :
+        bundleProcessor.getProgressRequestCallbacks()) {
+      // TODO(BEAM-6597): Plumb reporting monitoring infos using the short id system upstream.
+      for (MetricsApi.MonitoringInfo monitoringInfo :
+          progressRequestCallback.getMonitoringInfos()) {
+        ByteString payload = monitoringInfo.getPayload();
+        String shortId =
+            shortIds.getOrCreateShortId(monitoringInfo.toBuilder().clearPayload().build());
+        monitoringData.put(shortId, payload);
+      }
+    }
+    bundleProcessor
+        .getBundleProgressReporterAndRegistrar()
+        .updateFinalMonitoringData(monitoringData);
+    return monitoringData;
   }
 
   /** Splits an active bundle. */
@@ -700,11 +772,13 @@ public class ProcessBundleHandler {
     BeamFnApi.ProcessBundleDescriptor bundleDescriptor = fnApiRegistry.apply(bundleId);
 
     SetMultimap<String, String> pCollectionIdsToConsumingPTransforms = HashMultimap.create();
+    InMemory bundleProgressReporterAndRegistrar = new InMemory();
     MetricsContainerStepMap metricsContainerRegistry = new MetricsContainerStepMap();
     ExecutionStateTracker stateTracker =
         new ExecutionStateTracker(ExecutionStateSampler.instance());
     PCollectionConsumerRegistry pCollectionConsumerRegistry =
-        new PCollectionConsumerRegistry(metricsContainerRegistry, stateTracker);
+        new PCollectionConsumerRegistry(
+            metricsContainerRegistry, stateTracker, shortIds, bundleProgressReporterAndRegistrar);
     HashSet<String> processedPTransformIds = new HashSet<>();
 
     PTransformFunctionRegistry startFunctionRegistry =
@@ -752,6 +826,7 @@ public class ProcessBundleHandler {
     BundleProcessor bundleProcessor =
         BundleProcessor.create(
             processWideCache,
+            bundleProgressReporterAndRegistrar,
             bundleDescriptor,
             startFunctionRegistry,
             finishFunctionRegistry,
@@ -816,6 +891,7 @@ public class ProcessBundleHandler {
             bundleProcessor.getTimerEndpoints().add(timerEndpoint);
           },
           progressRequestCallbacks::add,
+          bundleProgressReporterAndRegistrar::register,
           splitListener,
           bundleFinalizer,
           bundleProcessor.getChannelRoots(),
@@ -944,6 +1020,7 @@ public class ProcessBundleHandler {
   public abstract static class BundleProcessor {
     public static BundleProcessor create(
         Cache<Object, Object> processWideCache,
+        InMemory bundleProgressReporterAndRegistrar,
         ProcessBundleDescriptor processBundleDescriptor,
         PTransformFunctionRegistry startFunctionRegistry,
         PTransformFunctionRegistry finishFunctionRegistry,
@@ -959,6 +1036,7 @@ public class ProcessBundleHandler {
         Set<String> runnerCapabilities) {
       return new AutoValue_ProcessBundleHandler_BundleProcessor(
           processWideCache,
+          bundleProgressReporterAndRegistrar,
           processBundleDescriptor,
           startFunctionRegistry,
           finishFunctionRegistry,
@@ -977,7 +1055,8 @@ public class ProcessBundleHandler {
           /*channelRoots=*/ new ArrayList<>(),
           // We rely on the stable iteration order of outboundAggregators, thus using LinkedHashMap.
           /*outboundAggregators=*/ new LinkedHashMap<>(),
-          runnerCapabilities);
+          runnerCapabilities,
+          new ReentrantLock());
     }
 
     private String instructionId;
@@ -985,6 +1064,8 @@ public class ProcessBundleHandler {
     private ClearableCache<Object, Object> bundleCache;
 
     abstract Cache<?, ?> getProcessWideCache();
+
+    abstract BundleProgressReporter.InMemory getBundleProgressReporterAndRegistrar();
 
     abstract ProcessBundleDescriptor getProcessBundleDescriptor();
 
@@ -1021,6 +1102,8 @@ public class ProcessBundleHandler {
     abstract Map<ApiServiceDescriptor, BeamFnDataOutboundAggregator> getOutboundAggregators();
 
     abstract Set<String> getRunnerCapabilities();
+
+    abstract Lock getProgressRequestLock();
 
     synchronized String getInstructionId() {
       return this.instructionId;
@@ -1079,6 +1162,8 @@ public class ProcessBundleHandler {
         resetFunction.run();
       }
       getInboundObserver().reset();
+      getBundleProgressReporterAndRegistrar().reset();
+      getProgressRequestLock().unlock();
     }
 
     void discard() {

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/data/PCollectionConsumerRegistry.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/data/PCollectionConsumerRegistry.java
@@ -257,8 +257,7 @@ public class PCollectionConsumerRegistry {
                   .setLabels(labels)
                   .build());
       this.elementCountCounter =
-          Metrics.serialMutatorAndFinalReaderBundleCounter(
-              elementCountShortId, elementCountMetricName);
+          Metrics.bundleProcessingThreadCounter(elementCountShortId, elementCountMetricName);
       bundleProgressReporterRegistrar.register(elementCountCounter);
 
       MonitoringInfoMetricName sampledByteSizeMetricName =
@@ -271,7 +270,7 @@ public class PCollectionConsumerRegistry {
                   .setLabels(labels)
                   .build());
       BundleDistribution sampledByteSizeUnderlyingDistribution =
-          Metrics.serialMutatorAndFinalReaderBundleDistribution(
+          Metrics.bundleProcessingThreadDistribution(
               sampledByteSizeShortId, sampledByteSizeMetricName);
       this.sampledByteSizeDistribution =
           new SampleByteSizeDistribution<>(sampledByteSizeUnderlyingDistribution);
@@ -332,8 +331,7 @@ public class PCollectionConsumerRegistry {
                   .setLabels(labels)
                   .build());
       this.elementCountCounter =
-          Metrics.serialMutatorAndFinalReaderBundleCounter(
-              elementCountShortId, elementCountMetricName);
+          Metrics.bundleProcessingThreadCounter(elementCountShortId, elementCountMetricName);
       bundleProgressReporterRegistrar.register(elementCountCounter);
 
       MonitoringInfoMetricName sampledByteSizeMetricName =
@@ -346,7 +344,7 @@ public class PCollectionConsumerRegistry {
                   .setLabels(labels)
                   .build());
       BundleDistribution sampledByteSizeUnderlyingDistribution =
-          Metrics.serialMutatorAndFinalReaderBundleDistribution(
+          Metrics.bundleProcessingThreadDistribution(
               sampledByteSizeShortId, sampledByteSizeMetricName);
       this.sampledByteSizeDistribution =
           new SampleByteSizeDistribution<>(sampledByteSizeUnderlyingDistribution);

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/AssignWindowsRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/AssignWindowsRunnerTest.java
@@ -196,7 +196,7 @@ public class AssignWindowsRunnerTest implements Serializable {
             .coders(Collections.singletonMap("coder-id", coder))
             .build();
     Collection<WindowedValue<?>> outputs = new ArrayList<>();
-    context.addPCollectionConsumer("output", outputs::add, VarIntCoder.of());
+    context.addPCollectionConsumer("output", outputs::add);
 
     MapFnRunners.forWindowedValueMapFnFactory(new AssignWindowsMapFnFactory<>())
         .createRunnerForPTransform(context);

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BeamFnDataReadRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/BeamFnDataReadRunnerTest.java
@@ -141,7 +141,7 @@ public class BeamFnDataReadRunnerTest {
               .coders(COMPONENTS.getCodersMap())
               .windowingStrategies(COMPONENTS.getWindowingStrategiesMap())
               .build();
-      context.addPCollectionConsumer(localOutputId, outputValues::add, StringUtf8Coder.of());
+      context.<String>addPCollectionConsumer(localOutputId, outputValues::add);
 
       new BeamFnDataReadRunner.Factory<String>().createRunnerForPTransform(context);
 
@@ -179,7 +179,7 @@ public class BeamFnDataReadRunnerTest {
               .coders(COMPONENTS.getCodersMap())
               .windowingStrategies(COMPONENTS.getWindowingStrategiesMap())
               .build();
-      context.addPCollectionConsumer(localOutputId, outputValues::add, StringUtf8Coder.of());
+      context.<String>addPCollectionConsumer(localOutputId, outputValues::add);
 
       BeamFnDataReadRunner<String> readRunner =
           new BeamFnDataReadRunner.Factory<String>().createRunnerForPTransform(context);
@@ -659,7 +659,7 @@ public class BeamFnDataReadRunnerTest {
             .coders(COMPONENTS.getCodersMap())
             .windowingStrategies(COMPONENTS.getWindowingStrategiesMap())
             .build();
-    context.addPCollectionConsumer(localOutputId, consumer, StringUtf8Coder.of());
+    context.addPCollectionConsumer(localOutputId, consumer);
 
     return new BeamFnDataReadRunner.Factory<String>().createRunnerForPTransform(context);
   }

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/CombineRunnersTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/CombineRunnersTest.java
@@ -128,8 +128,8 @@ public class CombineRunnersTest {
     Deque<WindowedValue<KV<String, Integer>>> mainOutputValues = new ArrayDeque<>();
     context.addPCollectionConsumer(
         Iterables.getOnlyElement(pTransform.getOutputsMap().values()),
-        (FnDataReceiver) (FnDataReceiver<WindowedValue<KV<String, Integer>>>) mainOutputValues::add,
-        KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of()));
+        (FnDataReceiver)
+            (FnDataReceiver<WindowedValue<KV<String, Integer>>>) mainOutputValues::add);
 
     // Create runner.
     new CombineRunners.PrecombineFactory<>().createRunnerForPTransform(context);
@@ -208,8 +208,8 @@ public class CombineRunnersTest {
     Deque<WindowedValue<KV<String, Integer>>> mainOutputValues = new ArrayDeque<>();
     context.addPCollectionConsumer(
         Iterables.getOnlyElement(pTransform.getOutputsMap().values()),
-        (FnDataReceiver) (FnDataReceiver<WindowedValue<KV<String, Integer>>>) mainOutputValues::add,
-        KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of()));
+        (FnDataReceiver)
+            (FnDataReceiver<WindowedValue<KV<String, Integer>>>) mainOutputValues::add);
 
     // Create runner.
     MapFnRunners.forValueMapFnFactory(CombineRunners::createMergeAccumulatorsMapFunction)
@@ -269,8 +269,8 @@ public class CombineRunnersTest {
     Deque<WindowedValue<KV<String, Integer>>> mainOutputValues = new ArrayDeque<>();
     context.addPCollectionConsumer(
         Iterables.getOnlyElement(pTransform.getOutputsMap().values()),
-        (FnDataReceiver) (FnDataReceiver<WindowedValue<KV<String, Integer>>>) mainOutputValues::add,
-        KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of()));
+        (FnDataReceiver)
+            (FnDataReceiver<WindowedValue<KV<String, Integer>>>) mainOutputValues::add);
 
     // Create runner.
     MapFnRunners.forValueMapFnFactory(CombineRunners::createExtractOutputsMapFunction)
@@ -313,8 +313,8 @@ public class CombineRunnersTest {
     Deque<WindowedValue<KV<String, Integer>>> mainOutputValues = new ArrayDeque<>();
     context.addPCollectionConsumer(
         Iterables.getOnlyElement(pTransform.getOutputsMap().values()),
-        (FnDataReceiver) (FnDataReceiver<WindowedValue<KV<String, Integer>>>) mainOutputValues::add,
-        KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of()));
+        (FnDataReceiver)
+            (FnDataReceiver<WindowedValue<KV<String, Integer>>>) mainOutputValues::add);
 
     // Create runner.
     MapFnRunners.forValueMapFnFactory(CombineRunners::createConvertToAccumulatorsMapFunction)
@@ -380,8 +380,8 @@ public class CombineRunnersTest {
     Deque<WindowedValue<KV<String, Integer>>> mainOutputValues = new ArrayDeque<>();
     context.addPCollectionConsumer(
         Iterables.getOnlyElement(pTransform.getOutputsMap().values()),
-        (FnDataReceiver) (FnDataReceiver<WindowedValue<KV<String, Integer>>>) mainOutputValues::add,
-        KvCoder.of(StringUtf8Coder.of(), BigEndianIntegerCoder.of()));
+        (FnDataReceiver)
+            (FnDataReceiver<WindowedValue<KV<String, Integer>>>) mainOutputValues::add);
 
     // Create runner.
     MapFnRunners.forValueMapFnFactory(CombineRunners::createCombineGroupedValuesMapFunction)

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FlattenRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FlattenRunnerTest.java
@@ -96,8 +96,7 @@ public class FlattenRunnerTest {
     List<WindowedValue<String>> mainOutputValues = new ArrayList<>();
     context.addPCollectionConsumer(
         "mainOutputTarget",
-        (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add,
-        StringUtf8Coder.of());
+        (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add);
 
     new FlattenRunner.Factory<>().createRunnerForPTransform(context);
 
@@ -157,8 +156,7 @@ public class FlattenRunnerTest {
     List<WindowedValue<String>> mainOutputValues = new ArrayList<>();
     context.addPCollectionConsumer(
         "mainOutputTarget",
-        (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add,
-        StringUtf8Coder.of());
+        (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add);
 
     new FlattenRunner.Factory<>().createRunnerForPTransform(context);
 

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
@@ -269,8 +269,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
       List<WindowedValue<String>> mainOutputValues = new ArrayList<>();
       context.addPCollectionConsumer(
           outputPCollectionId,
-          (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add,
-          StringUtf8Coder.of());
+          (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add);
 
       new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
 
@@ -431,12 +430,10 @@ public class FnApiDoFnRunnerTest implements Serializable {
       List<WindowedValue<String>> additionalOutputValues = new ArrayList<>();
       context.addPCollectionConsumer(
           outputPCollectionId,
-          (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add,
-          StringUtf8Coder.of());
+          (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add);
       context.addPCollectionConsumer(
           additionalPCollectionId,
-          (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) additionalOutputValues::add,
-          StringUtf8Coder.of());
+          (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) additionalOutputValues::add);
 
       new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
 
@@ -536,12 +533,10 @@ public class FnApiDoFnRunnerTest implements Serializable {
       List<WindowedValue<String>> additionalOutputValues = new ArrayList<>();
       context.addPCollectionConsumer(
           outputPCollectionId,
-          (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add,
-          StringUtf8Coder.of());
+          (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add);
       context.addPCollectionConsumer(
           additionalPCollectionId,
-          (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) additionalOutputValues::add,
-          StringUtf8Coder.of());
+          (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) additionalOutputValues::add);
 
       new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
 
@@ -676,8 +671,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
       List<WindowedValue<Iterable<String>>> mainOutputValues = new ArrayList<>();
       context.addPCollectionConsumer(
           Iterables.getOnlyElement(pTransform.getOutputsMap().values()),
-          (FnDataReceiver) (FnDataReceiver<WindowedValue<Iterable<String>>>) mainOutputValues::add,
-          IterableCoder.of(StringUtf8Coder.of()));
+          (FnDataReceiver) (FnDataReceiver<WindowedValue<Iterable<String>>>) mainOutputValues::add);
 
       new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
 
@@ -779,8 +773,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
       List<WindowedValue<Iterable<String>>> mainOutputValues = new ArrayList<>();
       context.addPCollectionConsumer(
           Iterables.getOnlyElement(pTransform.getOutputsMap().values()),
-          (FnDataReceiver) (FnDataReceiver<WindowedValue<Iterable<String>>>) mainOutputValues::add,
-          IterableCoder.of(StringUtf8Coder.of()));
+          (FnDataReceiver) (FnDataReceiver<WindowedValue<Iterable<String>>>) mainOutputValues::add);
 
       new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
 
@@ -952,8 +945,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
               .build();
       context.addPCollectionConsumer(
           outputPCollectionId,
-          (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add,
-          StringUtf8Coder.of());
+          (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add);
 
       new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
 
@@ -1642,8 +1634,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
       List<WindowedValue<String>> mainOutputValues = new ArrayList<>();
       context.addPCollectionConsumer(
           outputPCollectionId,
-          (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add,
-          StringUtf8Coder.of());
+          (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add);
 
       new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
 
@@ -1969,8 +1960,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
       List<WindowedValue<String>> mainOutputValues = new ArrayList<>();
       context.addPCollectionConsumer(
           outputPCollectionId,
-          (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add,
-          StringUtf8Coder.of());
+          (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add);
 
       new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
 
@@ -2420,10 +2410,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
               .windowingStrategies(pProto.getComponents().getWindowingStrategiesMap())
               .build();
       List<WindowedValue<KV<String, OffsetRange>>> mainOutputValues = new ArrayList<>();
-      context.addPCollectionConsumer(
-          outputPCollectionId,
-          ((List) mainOutputValues)::add,
-          KvCoder.of(StringUtf8Coder.of(), KvCoder.of(OffsetRange.Coder.of(), InstantCoder.of())));
+      context.addPCollectionConsumer(outputPCollectionId, ((List) mainOutputValues)::add);
 
       new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
 
@@ -2508,10 +2495,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
               .windowingStrategies(pProto.getComponents().getWindowingStrategiesMap())
               .build();
       List<WindowedValue<KV<String, OffsetRange>>> mainOutputValues = new ArrayList<>();
-      context.addPCollectionConsumer(
-          outputPCollectionId,
-          ((List) mainOutputValues)::add,
-          KvCoder.of(StringUtf8Coder.of(), KvCoder.of(OffsetRange.Coder.of(), InstantCoder.of())));
+      context.addPCollectionConsumer(outputPCollectionId, ((List) mainOutputValues)::add);
 
       new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
 
@@ -2622,10 +2606,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
               .windowingStrategies(pProto.getComponents().getWindowingStrategiesMap())
               .build();
       List<WindowedValue<KV<String, OffsetRange>>> mainOutputValues = new ArrayList<>();
-      context.addPCollectionConsumer(
-          outputPCollectionId,
-          ((List) mainOutputValues)::add,
-          KvCoder.of(StringUtf8Coder.of(), KvCoder.of(OffsetRange.Coder.of(), InstantCoder.of())));
+      context.addPCollectionConsumer(outputPCollectionId, ((List) mainOutputValues)::add);
 
       new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
 
@@ -2725,7 +2706,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
               KvCoder.of(
                   StringUtf8Coder.of(), KvCoder.of(OffsetRange.Coder.of(), InstantCoder.of())),
               DoubleCoder.of());
-      context.addPCollectionConsumer(outputPCollectionId, ((List) mainOutputValues)::add, coder);
+      context.addPCollectionConsumer(outputPCollectionId, ((List) mainOutputValues)::add);
 
       new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
 
@@ -2824,7 +2805,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
               KvCoder.of(
                   StringUtf8Coder.of(), KvCoder.of(OffsetRange.Coder.of(), InstantCoder.of())),
               DoubleCoder.of());
-      context.addPCollectionConsumer(outputPCollectionId, ((List) mainOutputValues)::add, coder);
+      context.addPCollectionConsumer(outputPCollectionId, ((List) mainOutputValues)::add);
 
       new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
 
@@ -2965,7 +2946,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
               KvCoder.of(
                   StringUtf8Coder.of(), KvCoder.of(OffsetRange.Coder.of(), InstantCoder.of())),
               DoubleCoder.of());
-      context.addPCollectionConsumer(outputPCollectionId, ((List) mainOutputValues)::add, coder);
+      context.addPCollectionConsumer(outputPCollectionId, ((List) mainOutputValues)::add);
 
       new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
 
@@ -3161,9 +3142,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
                   StringUtf8Coder.of(), KvCoder.of(OffsetRange.Coder.of(), InstantCoder.of())),
               DoubleCoder.of());
       context.addPCollectionConsumer(
-          outputPCollectionId,
-          (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues),
-          coder);
+          outputPCollectionId, (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues));
 
       new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
       FnDataReceiver<WindowedValue<?>> mainInput =
@@ -3309,9 +3288,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
       Coder coder =
           KvCoder.of(KvCoder.of(StringUtf8Coder.of(), OffsetRange.Coder.of()), DoubleCoder.of());
       context.addPCollectionConsumer(
-          outputPCollectionId,
-          (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues),
-          coder);
+          outputPCollectionId, (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues));
 
       new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
       FnDataReceiver<WindowedValue<?>> mainInput =
@@ -3370,9 +3347,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
                   StringUtf8Coder.of(), KvCoder.of(OffsetRange.Coder.of(), InstantCoder.of())),
               DoubleCoder.of());
       context.addPCollectionConsumer(
-          outputPCollectionId,
-          (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues),
-          coder);
+          outputPCollectionId, (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues));
 
       new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
 
@@ -3470,9 +3445,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
                   StringUtf8Coder.of(), KvCoder.of(OffsetRange.Coder.of(), InstantCoder.of())),
               DoubleCoder.of());
       context.addPCollectionConsumer(
-          outputPCollectionId,
-          (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues),
-          coder);
+          outputPCollectionId, (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues));
 
       new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
 
@@ -3590,9 +3563,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
                   StringUtf8Coder.of(), KvCoder.of(OffsetRange.Coder.of(), InstantCoder.of())),
               DoubleCoder.of());
       context.addPCollectionConsumer(
-          outputPCollectionId,
-          (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues),
-          coder);
+          outputPCollectionId, (FnDataReceiver) new SplittableFnDataReceiver(mainOutputValues));
 
       new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
 
@@ -3716,7 +3687,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
       List<WindowedValue<String>> mainOutputValues = new ArrayList<>();
       Coder coder = StringUtf8Coder.of();
       context.addPCollectionConsumer(
-          outputPCollectionId, (FnDataReceiver) new OutputFnDataReceiver(mainOutputValues), coder);
+          outputPCollectionId, (FnDataReceiver) new OutputFnDataReceiver(mainOutputValues));
 
       new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
 
@@ -3774,7 +3745,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
               .build();
       Coder coder = StringUtf8Coder.of();
       context.addPCollectionConsumer(
-          outputPCollectionId, (FnDataReceiver) new OutputFnDataReceiver(mainOutputValues), coder);
+          outputPCollectionId, (FnDataReceiver) new OutputFnDataReceiver(mainOutputValues));
 
       new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
 

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/MapFnRunnersTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/MapFnRunnersTest.java
@@ -75,7 +75,7 @@ public class MapFnRunnersTest {
             .coders(Collections.singletonMap("coder-id", valueCoder))
             .build();
     List<WindowedValue<?>> outputConsumer = new ArrayList<>();
-    context.addPCollectionConsumer("outputPC", outputConsumer::add, StringUtf8Coder.of());
+    context.addPCollectionConsumer("outputPC", outputConsumer::add);
 
     ValueMapFnFactory<String, String> factory = (ptId, pt) -> String::toUpperCase;
     MapFnRunners.forValueMapFnFactory(factory).createRunnerForPTransform(context);
@@ -101,7 +101,7 @@ public class MapFnRunnersTest {
             .coders(Collections.singletonMap("coder-id", valueCoder))
             .build();
     List<WindowedValue<?>> outputConsumer = new ArrayList<>();
-    context.addPCollectionConsumer("outputPC", outputConsumer::add, StringUtf8Coder.of());
+    context.addPCollectionConsumer("outputPC", outputConsumer::add);
     MapFnRunners.forWindowedValueMapFnFactory(this::createMapFunctionForPTransform)
         .createRunnerForPTransform(context);
 
@@ -126,7 +126,7 @@ public class MapFnRunnersTest {
             .coders(Collections.singletonMap("coder-id", valueCoder))
             .build();
     List<WindowedValue<?>> outputConsumer = new ArrayList<>();
-    context.addPCollectionConsumer("outputPC", outputConsumer::add, StringUtf8Coder.of());
+    context.addPCollectionConsumer("outputPC", outputConsumer::add);
 
     MapFnRunners.forWindowedValueMapFnFactory(this::createMapFunctionForPTransform)
         .createRunnerForPTransform(context);

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/PTransformRunnerFactoryTestContext.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/PTransformRunnerFactoryTestContext.java
@@ -29,6 +29,7 @@ import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.function.Supplier;
 import org.apache.beam.fn.harness.PTransformRunnerFactory.ProgressRequestCallback;
+import org.apache.beam.fn.harness.control.BundleProgressReporter;
 import org.apache.beam.fn.harness.control.BundleSplitListener;
 import org.apache.beam.fn.harness.data.BeamFnDataClient;
 import org.apache.beam.fn.harness.state.BeamFnStateClient;
@@ -116,6 +117,7 @@ public abstract class PTransformRunnerFactoryTestContext
         .finishBundleFunctions(new ArrayList<>())
         .resetFunctions(new ArrayList<>())
         .tearDownFunctions(new ArrayList<>())
+        .bundleProgressReporters(new ArrayList<>())
         .progressRequestCallbacks(new ArrayList<>())
         .incomingDataEndpoints(new HashMap<>())
         .incomingTimerEndpoints(new ArrayList<>())
@@ -190,6 +192,8 @@ public abstract class PTransformRunnerFactoryTestContext
     Builder tearDownFunctions(List<ThrowingRunnable> value);
 
     Builder progressRequestCallbacks(List<ProgressRequestCallback> value);
+
+    Builder bundleProgressReporters(List<BundleProgressReporter> value);
 
     Builder splitListener(BundleSplitListener value);
 
@@ -343,6 +347,17 @@ public abstract class PTransformRunnerFactoryTestContext
   @Override
   public void addTearDownFunction(ThrowingRunnable tearDownFunction) {
     getTearDownFunctions().add(tearDownFunction);
+  }
+
+  /**
+   * Returns a list of methods registered to return additional monitoring data during bundle
+   * processing.
+   */
+  public abstract List<BundleProgressReporter> getBundleProgressReporters();
+
+  @Override
+  public void addBundleProgressReporter(BundleProgressReporter bundleProgressReporter) {
+    getBundleProgressReporters().add(bundleProgressReporter);
   }
 
   /**

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/PTransformRunnerFactoryTestContext.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/PTransformRunnerFactoryTestContext.java
@@ -215,9 +215,7 @@ public abstract class PTransformRunnerFactoryTestContext
 
   @Override
   public <T> void addPCollectionConsumer(
-      String pCollectionId,
-      FnDataReceiver<WindowedValue<T>> consumer,
-      org.apache.beam.sdk.coders.Coder<T> valueCoder) {
+      String pCollectionId, FnDataReceiver<WindowedValue<T>> consumer) {
     getPCollectionConsumers()
         .computeIfAbsent(pCollectionId, (unused) -> new ArrayList<>())
         .add(consumer);

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/BundleProgressReporterTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/BundleProgressReporterTest.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.fn.harness.control;
+
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.verifyNoInteractions;
+import static org.mockito.Mockito.verifyNoMoreInteractions;
+
+import java.util.HashMap;
+import java.util.Map;
+import org.apache.beam.vendor.grpc.v1p43p2.com.google.protobuf.ByteString;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class BundleProgressReporterTest {
+  @Test
+  public void testInMemory() {
+    Map<String, ByteString> valuesToReport = new HashMap<>();
+    BundleProgressReporter reporter = mock(BundleProgressReporter.class);
+    BundleProgressReporter.InMemory value = new BundleProgressReporter.InMemory();
+
+    value.register(reporter);
+    verifyNoInteractions(reporter);
+
+    value.updateIntermediateMonitoringData(valuesToReport);
+    verify(reporter).updateIntermediateMonitoringData(valuesToReport);
+    verifyNoMoreInteractions(reporter);
+
+    value.updateFinalMonitoringData(valuesToReport);
+    verify(reporter).updateFinalMonitoringData(valuesToReport);
+    verifyNoMoreInteractions(reporter);
+
+    value.reset();
+    verify(reporter).reset();
+    verifyNoMoreInteractions(reporter);
+  }
+}

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/MetricsTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/MetricsTest.java
@@ -1,0 +1,308 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.fn.harness.control;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.Comparator;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
+import org.apache.beam.fn.harness.control.Metrics.BundleCounter;
+import org.apache.beam.fn.harness.control.Metrics.BundleDistribution;
+import org.apache.beam.runners.core.metrics.DistributionData;
+import org.apache.beam.runners.core.metrics.MonitoringInfoEncodings;
+import org.apache.beam.sdk.fn.test.TestExecutors;
+import org.apache.beam.sdk.fn.test.TestExecutors.TestExecutorService;
+import org.apache.beam.sdk.metrics.MetricName;
+import org.apache.beam.vendor.grpc.v1p43p2.com.google.protobuf.ByteString;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link Metrics}. */
+@RunWith(JUnit4.class)
+public class MetricsTest {
+  private static final MetricName TEST_NAME = MetricName.named("testNamespace", "testName");
+  private static final String TEST_ID = "testId";
+
+  private interface MetricMutator {
+    void mutate();
+  }
+
+  @Rule public TestExecutorService executor = TestExecutors.from(Executors::newCachedThreadPool);
+
+  @Test
+  public void testAccurateBundleCounterReportsValueFirstTimeWithoutMutations() throws Exception {
+    Map<String, ByteString> report = new HashMap<>();
+    BundleCounter bundleCounter =
+        Metrics.serialMutatorAndFinalReaderBundleCounter(TEST_ID, TEST_NAME);
+    bundleCounter.updateIntermediateMonitoringData(report);
+    assertEquals(
+        report, Collections.singletonMap(TEST_ID, MonitoringInfoEncodings.encodeInt64Counter(0)));
+    report.clear();
+    // Test that a reported value isn't reported again on final update
+    bundleCounter.updateFinalMonitoringData(report);
+    assertEquals(report, Collections.emptyMap());
+
+    // Test that the value is not reported after reset if no mutations after being
+    // reported the first time.
+    bundleCounter.reset();
+    bundleCounter.updateFinalMonitoringData(report);
+    assertEquals(report, Collections.emptyMap());
+  }
+
+  @Test
+  public void testAccurateBundleDistributionReportsValueFirstTimeWithoutMutations()
+      throws Exception {
+    Map<String, ByteString> report = new HashMap<>();
+    BundleDistribution bundleDistribution =
+        Metrics.serialMutatorAndFinalReaderBundleDistribution(TEST_ID, TEST_NAME);
+    bundleDistribution.updateIntermediateMonitoringData(report);
+    assertEquals(
+        report,
+        Collections.singletonMap(
+            TEST_ID, MonitoringInfoEncodings.encodeInt64Distribution(DistributionData.EMPTY)));
+    report.clear();
+
+    // Test that a reported value isn't reported again on final update
+    bundleDistribution.updateFinalMonitoringData(report);
+    assertEquals(report, Collections.emptyMap());
+
+    // Test that the value is not reported after reset if no mutations after being
+    // reported the first time.
+    bundleDistribution.reset();
+    bundleDistribution.updateFinalMonitoringData(report);
+    assertEquals(report, Collections.emptyMap());
+  }
+
+  @Test
+  public void testAccurateBundleCounterWithMutations() throws Exception {
+    Map<String, ByteString> report = new HashMap<>();
+    BundleCounter bundleCounter =
+        Metrics.serialMutatorAndFinalReaderBundleCounter(TEST_ID, TEST_NAME);
+
+    bundleCounter.inc(7);
+    bundleCounter.updateIntermediateMonitoringData(report);
+    assertEquals(
+        report, Collections.singletonMap(TEST_ID, MonitoringInfoEncodings.encodeInt64Counter(7)));
+    report.clear();
+
+    bundleCounter.updateIntermediateMonitoringData(report);
+    assertEquals(report, Collections.emptyMap());
+
+    bundleCounter.inc();
+    bundleCounter.updateIntermediateMonitoringData(report);
+    assertEquals(
+        report, Collections.singletonMap(TEST_ID, MonitoringInfoEncodings.encodeInt64Counter(8)));
+    report.clear();
+
+    bundleCounter.dec(4);
+    bundleCounter.updateIntermediateMonitoringData(report);
+    assertEquals(
+        report, Collections.singletonMap(TEST_ID, MonitoringInfoEncodings.encodeInt64Counter(4)));
+
+    bundleCounter.dec();
+    bundleCounter.updateFinalMonitoringData(report);
+    assertEquals(
+        report, Collections.singletonMap(TEST_ID, MonitoringInfoEncodings.encodeInt64Counter(3)));
+
+    // Test re-use of the metrics after reset
+    bundleCounter.reset();
+    bundleCounter.inc(7);
+    bundleCounter.updateIntermediateMonitoringData(report);
+    assertEquals(
+        report, Collections.singletonMap(TEST_ID, MonitoringInfoEncodings.encodeInt64Counter(7)));
+    report.clear();
+
+    bundleCounter.updateIntermediateMonitoringData(report);
+    assertEquals(report, Collections.emptyMap());
+
+    bundleCounter.inc();
+    bundleCounter.updateIntermediateMonitoringData(report);
+    assertEquals(
+        report, Collections.singletonMap(TEST_ID, MonitoringInfoEncodings.encodeInt64Counter(8)));
+    report.clear();
+
+    bundleCounter.dec(4);
+    bundleCounter.updateIntermediateMonitoringData(report);
+    assertEquals(
+        report, Collections.singletonMap(TEST_ID, MonitoringInfoEncodings.encodeInt64Counter(4)));
+
+    bundleCounter.dec();
+    bundleCounter.updateFinalMonitoringData(report);
+    assertEquals(
+        report, Collections.singletonMap(TEST_ID, MonitoringInfoEncodings.encodeInt64Counter(3)));
+  }
+
+  @Test
+  public void testAccurateBundleDistributionWithMutations() throws Exception {
+    Map<String, ByteString> report = new HashMap<>();
+    BundleDistribution bundleDistribution =
+        Metrics.serialMutatorAndFinalReaderBundleDistribution(TEST_ID, TEST_NAME);
+
+    bundleDistribution.update(7);
+    bundleDistribution.updateIntermediateMonitoringData(report);
+    assertEquals(
+        report,
+        Collections.singletonMap(
+            TEST_ID,
+            MonitoringInfoEncodings.encodeInt64Distribution(DistributionData.singleton(7))));
+    report.clear();
+
+    bundleDistribution.updateIntermediateMonitoringData(report);
+    assertEquals(report, Collections.emptyMap());
+
+    bundleDistribution.update(5, 2, 2, 3);
+    bundleDistribution.updateIntermediateMonitoringData(report);
+    assertEquals(
+        report,
+        Collections.singletonMap(
+            TEST_ID,
+            MonitoringInfoEncodings.encodeInt64Distribution(DistributionData.create(12, 3, 2, 7))));
+    report.clear();
+
+    // Test re-use of the metrics after reset
+    bundleDistribution.reset();
+    bundleDistribution.update(7);
+    bundleDistribution.updateIntermediateMonitoringData(report);
+    assertEquals(
+        report,
+        Collections.singletonMap(
+            TEST_ID,
+            MonitoringInfoEncodings.encodeInt64Distribution(DistributionData.singleton(7))));
+    report.clear();
+
+    bundleDistribution.updateIntermediateMonitoringData(report);
+    assertEquals(report, Collections.emptyMap());
+
+    bundleDistribution.update(5, 2, 2, 3);
+    bundleDistribution.updateIntermediateMonitoringData(report);
+    assertEquals(
+        report,
+        Collections.singletonMap(
+            TEST_ID,
+            MonitoringInfoEncodings.encodeInt64Distribution(DistributionData.create(12, 3, 2, 7))));
+  }
+
+  @Test
+  public void testAccurateBundleCounterUsingMultipleThreads() throws Exception {
+    BundleCounter bundleCounter =
+        Metrics.serialMutatorAndFinalReaderBundleCounter(TEST_ID, TEST_NAME);
+    List<ByteString> values =
+        testAccurateBundleMetricUsingMultipleThreads(bundleCounter, () -> bundleCounter.inc());
+    assertTrue(values.size() >= 10);
+    List<Long> sortedValues = new ArrayList<>();
+    for (ByteString value : values) {
+      sortedValues.add(MonitoringInfoEncodings.decodeInt64Counter(value));
+    }
+    Collections.sort(sortedValues);
+    List<ByteString> sortedEncodedValues = new ArrayList<>();
+    for (Long value : sortedValues) {
+      sortedEncodedValues.add(MonitoringInfoEncodings.encodeInt64Counter(value));
+    }
+    assertThat(values, contains(sortedEncodedValues.toArray()));
+  }
+
+  @Test
+  public void testAccurateBundleDistributionUsingMultipleThreads() throws Exception {
+    BundleDistribution bundleDistribution =
+        Metrics.serialMutatorAndFinalReaderBundleDistribution(TEST_ID, TEST_NAME);
+    List<ByteString> values =
+        testAccurateBundleMetricUsingMultipleThreads(
+            bundleDistribution, () -> bundleDistribution.update(1));
+
+    assertTrue(values.size() >= 10);
+    List<DistributionData> sortedValues = new ArrayList<>();
+    for (ByteString value : values) {
+      sortedValues.add(MonitoringInfoEncodings.decodeInt64Distribution(value));
+    }
+    Collections.sort(sortedValues, Comparator.comparingLong(DistributionData::count));
+    List<ByteString> sortedEncodedValues = new ArrayList<>();
+    for (DistributionData value : sortedValues) {
+      sortedEncodedValues.add(MonitoringInfoEncodings.encodeInt64Distribution(value));
+    }
+    assertThat(values, contains(sortedEncodedValues.toArray()));
+  }
+
+  private List<ByteString> testAccurateBundleMetricUsingMultipleThreads(
+      BundleProgressReporter metric, MetricMutator metricMutator) throws Exception {
+    Lock progressLock = new ReentrantLock();
+    List<ByteString> reportedValues = new ArrayList<>(); // Guarded by progressLock
+    AtomicBoolean shouldMainExit = new AtomicBoolean();
+    AtomicBoolean shouldProgressExit = new AtomicBoolean();
+    Future<?> intermediateProgressTask =
+        executor.submit(
+            () -> {
+              while (!shouldProgressExit.get()) {
+                Map<String, ByteString> data = new HashMap<>();
+                progressLock.lock();
+                try {
+                  metric.updateIntermediateMonitoringData(data);
+                  if (!data.isEmpty()) {
+                    reportedValues.add(data.get(TEST_ID));
+                    if (reportedValues.size() >= 10) {
+                      shouldMainExit.set(true);
+                    }
+                  }
+                } finally {
+                  progressLock.unlock();
+                }
+              }
+              return null;
+            });
+
+    Future<?> mainTask =
+        executor.submit(
+            () -> {
+              Map<String, ByteString> data = new HashMap<>();
+
+              while (!shouldMainExit.get()) {
+                metricMutator.mutate();
+              }
+
+              progressLock.lock();
+              try {
+                metric.updateFinalMonitoringData(data);
+                if (!data.isEmpty()) {
+                  reportedValues.add(data.get(TEST_ID));
+                }
+              } finally {
+                progressLock.unlock();
+              }
+              shouldProgressExit.set(true);
+              return null;
+            });
+
+    intermediateProgressTask.get();
+    mainTask.get();
+
+    return reportedValues;
+  }
+}

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/MetricsTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/MetricsTest.java
@@ -61,8 +61,7 @@ public class MetricsTest {
   @Test
   public void testAccurateBundleCounterReportsValueFirstTimeWithoutMutations() throws Exception {
     Map<String, ByteString> report = new HashMap<>();
-    BundleCounter bundleCounter =
-        Metrics.serialMutatorAndFinalReaderBundleCounter(TEST_ID, TEST_NAME);
+    BundleCounter bundleCounter = Metrics.bundleProcessingThreadCounter(TEST_ID, TEST_NAME);
     bundleCounter.updateIntermediateMonitoringData(report);
     assertEquals(
         report, Collections.singletonMap(TEST_ID, MonitoringInfoEncodings.encodeInt64Counter(0)));
@@ -83,7 +82,7 @@ public class MetricsTest {
       throws Exception {
     Map<String, ByteString> report = new HashMap<>();
     BundleDistribution bundleDistribution =
-        Metrics.serialMutatorAndFinalReaderBundleDistribution(TEST_ID, TEST_NAME);
+        Metrics.bundleProcessingThreadDistribution(TEST_ID, TEST_NAME);
     bundleDistribution.updateIntermediateMonitoringData(report);
     assertEquals(
         report,
@@ -105,8 +104,7 @@ public class MetricsTest {
   @Test
   public void testAccurateBundleCounterWithMutations() throws Exception {
     Map<String, ByteString> report = new HashMap<>();
-    BundleCounter bundleCounter =
-        Metrics.serialMutatorAndFinalReaderBundleCounter(TEST_ID, TEST_NAME);
+    BundleCounter bundleCounter = Metrics.bundleProcessingThreadCounter(TEST_ID, TEST_NAME);
 
     bundleCounter.inc(7);
     bundleCounter.updateIntermediateMonitoringData(report);
@@ -165,7 +163,7 @@ public class MetricsTest {
   public void testAccurateBundleDistributionWithMutations() throws Exception {
     Map<String, ByteString> report = new HashMap<>();
     BundleDistribution bundleDistribution =
-        Metrics.serialMutatorAndFinalReaderBundleDistribution(TEST_ID, TEST_NAME);
+        Metrics.bundleProcessingThreadDistribution(TEST_ID, TEST_NAME);
 
     bundleDistribution.update(7);
     bundleDistribution.updateIntermediateMonitoringData(report);
@@ -213,8 +211,7 @@ public class MetricsTest {
 
   @Test
   public void testAccurateBundleCounterUsingMultipleThreads() throws Exception {
-    BundleCounter bundleCounter =
-        Metrics.serialMutatorAndFinalReaderBundleCounter(TEST_ID, TEST_NAME);
+    BundleCounter bundleCounter = Metrics.bundleProcessingThreadCounter(TEST_ID, TEST_NAME);
     List<ByteString> values =
         testAccurateBundleMetricUsingMultipleThreads(bundleCounter, () -> bundleCounter.inc());
     assertTrue(values.size() >= 10);
@@ -233,7 +230,7 @@ public class MetricsTest {
   @Test
   public void testAccurateBundleDistributionUsingMultipleThreads() throws Exception {
     BundleDistribution bundleDistribution =
-        Metrics.serialMutatorAndFinalReaderBundleDistribution(TEST_ID, TEST_NAME);
+        Metrics.bundleProcessingThreadDistribution(TEST_ID, TEST_NAME);
     List<ByteString> values =
         testAccurateBundleMetricUsingMultipleThreads(
             bundleDistribution, () -> bundleDistribution.update(1));

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/ProcessBundleHandlerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/ProcessBundleHandlerTest.java
@@ -1794,9 +1794,9 @@ public class ProcessBundleHandlerTest {
     startLatch.await();
     bundleProcessor.set(bundleProcessorCache.find("999L"));
 
-    final int MIN_NUM_RESULTS = 5;
+    final int minNumResults = 5;
     CountDownLatch progressLatch = new CountDownLatch(1);
-    CountDownLatch someProgressIsDone = new CountDownLatch(MIN_NUM_RESULTS);
+    CountDownLatch someProgressIsDone = new CountDownLatch(minNumResults);
     List<Future<InstructionResponse>> progressReportingTasks = new ArrayList<>();
     for (int i = 0; i < 20; ++i) {
       final int threadId = i;
@@ -1850,9 +1850,9 @@ public class ProcessBundleHandlerTest {
 
     // We validate the lifecycle of intermediate -> final -> reset was invoked
 
-    // We should see that there is at least MIN_NUM_RESULTS intermediate results representing the
+    // We should see that there is at least minNumResults intermediate results representing the
     // set [0, 'counter.get()') with the final result having 'counter.get()'
-    assertTrue(progressReportingResults.size() >= MIN_NUM_RESULTS);
+    assertTrue(progressReportingResults.size() >= minNumResults);
     List<ByteString> expectedIntermediateResults = new ArrayList<>();
     for (int i = 0; i < counter.get(); ++i) {
       expectedIntermediateResults.add(ByteString.copyFromUtf8(Long.toString(i)));

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/ProcessBundleHandlerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/ProcessBundleHandlerTest.java
@@ -28,6 +28,8 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsEmptyCollection.empty;
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertNotSame;
 import static org.junit.Assert.assertNull;
@@ -54,7 +56,15 @@ import java.util.List;
 import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
+import java.util.concurrent.CountDownLatch;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicInteger;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.concurrent.locks.Lock;
+import java.util.concurrent.locks.ReentrantLock;
 import java.util.function.Supplier;
 import org.apache.beam.fn.harness.BeamFnDataReadRunner;
 import org.apache.beam.fn.harness.Cache;
@@ -76,6 +86,7 @@ import org.apache.beam.model.fnexecution.v1.BeamFnApi.Elements.Timers;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.InstructionRequest;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.InstructionResponse;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.ProcessBundleDescriptor;
+import org.apache.beam.model.fnexecution.v1.BeamFnApi.ProcessBundleProgressRequest;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.ProcessBundleRequest;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.ProcessBundleRequest.CacheToken;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.StateRequest;
@@ -112,6 +123,8 @@ import org.apache.beam.sdk.fn.data.BeamFnDataOutboundAggregator;
 import org.apache.beam.sdk.fn.data.CloseableFnDataReceiver;
 import org.apache.beam.sdk.fn.data.DataEndpoint;
 import org.apache.beam.sdk.fn.data.TimerEndpoint;
+import org.apache.beam.sdk.fn.test.TestExecutors;
+import org.apache.beam.sdk.fn.test.TestExecutors.TestExecutorService;
 import org.apache.beam.sdk.function.ThrowingRunnable;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.state.TimeDomain;
@@ -137,6 +150,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.util.concurrent.Uninterruptibles;
 import org.joda.time.Instant;
 import org.junit.Before;
+import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -155,6 +169,7 @@ public class ProcessBundleHandlerTest {
   private static final String DATA_INPUT_URN = "beam:runner:source:v1";
   private static final String DATA_OUTPUT_URN = "beam:runner:sink:v1";
 
+  @Rule public TestExecutorService executor = TestExecutors.from(Executors::newCachedThreadPool);
   @Mock private BeamFnDataClient beamFnDataClient;
 
   @Before
@@ -223,6 +238,11 @@ public class ProcessBundleHandlerTest {
     @Override
     Cache<?, ?> getProcessWideCache() {
       return wrappedBundleProcessor.getProcessWideCache();
+    }
+
+    @Override
+    BundleProgressReporter.InMemory getBundleProgressReporterAndRegistrar() {
+      return wrappedBundleProcessor.getBundleProgressReporterAndRegistrar();
     }
 
     @Override
@@ -313,6 +333,11 @@ public class ProcessBundleHandlerTest {
     @Override
     Set<String> getRunnerCapabilities() {
       return wrappedBundleProcessor.getRunnerCapabilities();
+    }
+
+    @Override
+    Lock getProgressRequestLock() {
+      return wrappedBundleProcessor.getProgressRequestLock();
     }
 
     @Override
@@ -699,6 +724,7 @@ public class ProcessBundleHandlerTest {
     BundleProcessor bundleProcessor =
         BundleProcessor.create(
             processWideCache,
+            new BundleProgressReporter.InMemory(),
             ProcessBundleDescriptor.getDefaultInstance(),
             startFunctionRegistry,
             finishFunctionRegistry,
@@ -724,6 +750,7 @@ public class ProcessBundleHandlerTest {
     Cache<Object, Object> bundleCache = bundleProcessor.getBundleCache();
     bundleCache.put("A", "B");
     assertEquals("B", bundleCache.peek("A"));
+    assertTrue(bundleProcessor.getProgressRequestLock().tryLock());
     bundleProcessor.reset();
     assertNull(bundleProcessor.getInstructionId());
     assertNull(bundleProcessor.getCacheTokens());
@@ -1654,6 +1681,188 @@ public class ProcessBundleHandlerTest {
                         BeamFnApi.ProcessBundleRequest.newBuilder()
                             .setProcessBundleDescriptorId("1L"))
                     .build()));
+  }
+
+  @Test
+  public void testProgressReportingIsExecutedSerially() throws Exception {
+    BeamFnApi.ProcessBundleDescriptor processBundleDescriptor =
+        BeamFnApi.ProcessBundleDescriptor.newBuilder()
+            .putTransforms(
+                "2L",
+                RunnerApi.PTransform.newBuilder()
+                    .setSpec(RunnerApi.FunctionSpec.newBuilder().setUrn(DATA_INPUT_URN).build())
+                    .putOutputs("2L-output", "2L-output-pc")
+                    .build())
+            .putPcollections("2L-output-pc", RunnerApi.PCollection.getDefaultInstance())
+            .build();
+    Map<String, BeamFnApi.ProcessBundleDescriptor> fnApiRegistry =
+        ImmutableMap.of("1L", processBundleDescriptor);
+
+    CountDownLatch startLatch = new CountDownLatch(1);
+    CountDownLatch finishLatch = new CountDownLatch(1);
+
+    AtomicReference<BundleProcessor> bundleProcessor = new AtomicReference<>();
+    AtomicReference<Thread> mainBundleProcessingThread = new AtomicReference<>();
+    AtomicInteger counter = new AtomicInteger();
+    AtomicBoolean finalWasCalled = new AtomicBoolean();
+    AtomicBoolean resetWasCalled = new AtomicBoolean();
+    BundleProgressReporter testReporter =
+        new BundleProgressReporter() {
+          @Override
+          public void updateIntermediateMonitoringData(Map<String, ByteString> monitoringData) {
+            assertTrue(
+                ((ReentrantLock) bundleProcessor.get().getProgressRequestLock())
+                    .isHeldByCurrentThread());
+            assertNotEquals(Thread.currentThread(), mainBundleProcessingThread.get());
+            assertFalse(finalWasCalled.get());
+            assertFalse(resetWasCalled.get());
+            monitoringData.put(
+                "testId", ByteString.copyFromUtf8(Long.toString(counter.getAndIncrement())));
+          }
+
+          @Override
+          public void updateFinalMonitoringData(Map<String, ByteString> monitoringData) {
+            assertTrue(
+                ((ReentrantLock) bundleProcessor.get().getProgressRequestLock())
+                    .isHeldByCurrentThread());
+            assertEquals(Thread.currentThread(), mainBundleProcessingThread.get());
+            assertFalse(finalWasCalled.getAndSet(true));
+            assertFalse(resetWasCalled.get());
+            monitoringData.put("testId", ByteString.copyFromUtf8(Long.toString(counter.get())));
+          }
+
+          @Override
+          public void reset() {
+            assertTrue(
+                ((ReentrantLock) bundleProcessor.get().getProgressRequestLock())
+                    .isHeldByCurrentThread());
+            assertEquals(Thread.currentThread(), mainBundleProcessingThread.get());
+            assertTrue(finalWasCalled.get());
+            assertFalse(resetWasCalled.getAndSet(true));
+          }
+        };
+    PTransformRunnerFactory<Object> startFinishGuard =
+        (context) -> {
+          String pTransformId = context.getPTransformId();
+          Supplier<String> processBundleInstructionId =
+              context.getProcessBundleInstructionIdSupplier();
+          context.addBundleProgressReporter(testReporter);
+          context.addStartBundleFunction(
+              () -> {
+                startLatch.countDown();
+              });
+          context.addFinishBundleFunction(
+              () -> {
+                finishLatch.await();
+              });
+          return null;
+        };
+
+    BundleProcessorCache bundleProcessorCache = new BundleProcessorCache();
+    ProcessBundleHandler handler =
+        new ProcessBundleHandler(
+            PipelineOptionsFactory.create(),
+            Collections.singleton(
+                BeamUrns.getUrn(RunnerApi.StandardRunnerProtocols.Enum.MONITORING_INFO_SHORT_IDS)),
+            fnApiRegistry::get,
+            beamFnDataClient,
+            null /* beamFnStateClient */,
+            null /* finalizeBundleHandler */,
+            new ShortIdMap(),
+            ImmutableMap.of(DATA_INPUT_URN, startFinishGuard),
+            Caches.noop(),
+            bundleProcessorCache);
+
+    AtomicBoolean progressShouldExit = new AtomicBoolean();
+    Future<InstructionResponse> bundleProcessorTask =
+        executor.submit(
+            () -> {
+              mainBundleProcessingThread.set(Thread.currentThread());
+              InstructionResponse response =
+                  handler
+                      .processBundle(
+                          BeamFnApi.InstructionRequest.newBuilder()
+                              .setInstructionId("999L")
+                              .setProcessBundle(
+                                  BeamFnApi.ProcessBundleRequest.newBuilder()
+                                      .setProcessBundleDescriptorId("1L"))
+                              .build())
+                      .build();
+              progressShouldExit.set(true);
+              return response;
+            });
+    startLatch.await();
+    bundleProcessor.set(bundleProcessorCache.find("999L"));
+
+    final int MIN_NUM_RESULTS = 5;
+    CountDownLatch progressLatch = new CountDownLatch(1);
+    CountDownLatch someProgressIsDone = new CountDownLatch(MIN_NUM_RESULTS);
+    List<Future<InstructionResponse>> progressReportingTasks = new ArrayList<>();
+    for (int i = 0; i < 20; ++i) {
+      final int threadId = i;
+      progressReportingTasks.add(
+          executor.submit(
+              () -> {
+                // Wait till progress threads have all been started.
+                progressLatch.await();
+                int requestCount = 0;
+                InstructionResponse.Builder response;
+                try {
+                  do {
+                    response =
+                        handler.progress(
+                            BeamFnApi.InstructionRequest.newBuilder()
+                                .setInstructionId("thread-" + threadId + "-" + (++requestCount))
+                                .setProcessBundleProgress(
+                                    ProcessBundleProgressRequest.newBuilder()
+                                        .setInstructionId("999L")
+                                        .build())
+                                .build());
+                  } while (!response
+                          .getProcessBundleProgress()
+                          .getMonitoringDataMap()
+                          .containsKey("testId")
+                      && !progressShouldExit.get());
+                } finally {
+                  someProgressIsDone.countDown();
+                }
+                return response.build();
+              }));
+    }
+    // Allow progress reporting requests to start
+    progressLatch.countDown();
+    // Wait till some progress reports are done before allowing the main processing thread to
+    // finish.
+    someProgressIsDone.await();
+    finishLatch.countDown();
+
+    List<ByteString> progressReportingResults = new ArrayList<>();
+    for (Future<InstructionResponse> progressReportingTask : progressReportingTasks) {
+      ByteString result =
+          progressReportingTask
+              .get()
+              .getProcessBundleProgress()
+              .getMonitoringDataOrDefault("testId", null);
+      if (result != null) {
+        progressReportingResults.add(result);
+      }
+    }
+
+    // We validate the lifecycle of intermediate -> final -> reset was invoked
+
+    // We should see that there is at least MIN_NUM_RESULTS intermediate results representing the
+    // set [0, 'counter.get()') with the final result having 'counter.get()'
+    assertTrue(progressReportingResults.size() >= MIN_NUM_RESULTS);
+    List<ByteString> expectedIntermediateResults = new ArrayList<>();
+    for (int i = 0; i < counter.get(); ++i) {
+      expectedIntermediateResults.add(ByteString.copyFromUtf8(Long.toString(i)));
+    }
+    assertThat(progressReportingResults, containsInAnyOrder(expectedIntermediateResults.toArray()));
+    assertEquals(
+        ByteString.copyFromUtf8(Long.toString(counter.get())),
+        bundleProcessorTask.get().getProcessBundle().getMonitoringDataOrThrow("testId"));
+    assertTrue(finalWasCalled.get());
+    assertTrue(resetWasCalled.get());
   }
 
   @Test


### PR DESCRIPTION
This counter is limited to be used with a specific thread interaction pattern that is well suited to be used as a system level bundle specific counter and may not be suitable as a user counter.

The new counter is 8.5x faster on updates and even more on reset.
```
Benchmark                                                               Mode  Cnt          Score          Error  Units
MetricsBenchmark.testCounterCellMutation                               thrpt   25  101509847.937 ±   100089.022  ops/s
MetricsBenchmark.testCounterCellReset                                  thrpt   25   34072850.016 ±    70718.608  ops/s
MetricsBenchmark.testSerialMutatorAndFinalReaderBundleCounterMutation  thrpt   25  854084919.952 ± 41010094.337  ops/s
MetricsBenchmark.testSerialMutatorAndFinalReaderBundleCounterReset     thrpt   25  415817398.009 ±   869847.035  ops/s
```

Also clean-up the short id reporting mechanism to bind the short id once during instantiation instead of during each progress report. This clean-up has a tiny impact on the bundle benchmarks as can be seen:
Before this change:
```
Benchmark                                Mode  Cnt     Score      Error  Units
ProcessBundleBenchmark.testLargeBundle  thrpt   25  1155.848  ±   7.517  ops/s
ProcessBundleBenchmark.testTinyBundle   thrpt   25  28858.064 ±  98.341  ops/s
```

After this change:
```
Benchmark                                Mode  Cnt     Score      Error  Units
ProcessBundleBenchmark.testLargeBundle  thrpt   25  1155.204  ±   9.236  ops/s
ProcessBundleBenchmark.testTinyBundle   thrpt   25  29000.767 ± 195.753  ops/s
```

The perf profiles show a better change of CPU usage reduction since the above benchmarks also include the runner side setup and JMH overhead:
* -0.587% for processBundle on larger bundles
* -0.282% for processBundle on smaller bundles

Future work would be to update msec counters which are also on the hot path and reduce the cost of state tracking.

Also fixed an issue where we were not handling the case where there were no PCollection consumers which missed out on PCollection element sizing for PCollections that don't have any consumers.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
