### PR TITLE
[release-2.40.0] Fix RunInference example due to dill errror

### DIFF
--- a/sdks/python/apache_beam/examples/inference/pytorch_language_modeling.py
+++ b/sdks/python/apache_beam/examples/inference/pytorch_language_modeling.py
@@ -44,6 +44,48 @@ from transformers import BertTokenizer
 BERT_TOKENIZER = BertTokenizer.from_pretrained('bert-base-uncased')
 
 
+# TODO(https://github.com/apache/beam/issues/21863): Remove once optional
+# batching flag added
+class HuggingFaceStripBatchingWrapper(BertForMaskedLM):
+  """Wrapper class to convert output from dict of lists to list of dicts
+
+  The `forward()` function in Hugging Face models doesn't return a
+  standard torch.Tensor output. Instead, it can return a dictionary of
+  different outputs. To work with current RunInference implementation which
+  returns a PredictionResult object for each example, we must override the
+  `forward()` function and convert the standard Hugging Face forward output
+  into the appropriate format of List[Dict[str, torch.Tensor]].
+
+  Before:
+  output = {
+    'logit': torch.FloatTensor of shape
+      (batch_size, sequence_length, config.vocab_size),
+    'hidden_states': tuple(torch.FloatTensor) of shape
+      (batch_size, sequence_length, hidden_size)
+  }
+  After:
+  output = [
+    {
+      'logit': torch.FloatTensor of shape
+        (sequence_length, config.vocab_size),
+      'hidden_states': tuple(torch.FloatTensor) of
+        shape (sequence_length, hidden_size)
+    },
+    {
+      'logit': torch.FloatTensor of shape
+        (sequence_length, config.vocab_size),
+      'hidden_states': tuple(torch.FloatTensor) of shape
+        (sequence_length, hidden_size)
+    },
+    ...
+  ]
+  where len(output) is batch_size
+  """
+  def forward(self, **kwargs):
+    output = super().forward(**kwargs)
+    return [dict(zip(output, v)) for v in zip(*output.values())]
+
+
 def add_mask_to_last_word(text: str) -> Tuple[str, str]:
   text_list = text.split()
   return text, ' '.join(text_list[:-2] + ['[MASK]', text_list[-1]])
@@ -121,49 +163,8 @@ def run(argv=None, model_class=None, model_params=None, save_main_session=True):
 
   if not model_class:
     model_config = BertConfig(is_decoder=False, return_dict=True)
-    model_class = BertForMaskedLM
+    model_class = HuggingFaceStripBatchingWrapper
     model_params = {'config': model_config}
-
-  # TODO(https://github.com/apache/beam/issues/21863): Remove once optional
-  # batching flag added
-  class HuggingFaceStripBatchingWrapper(model_class):
-    """Wrapper class to convert output from dict of lists to list of dicts
-
-    The `forward()` function in Hugging Face models doesn't return a
-    standard torch.Tensor output. Instead, it can return a dictionary of
-    different outputs. To work with current RunInference implementation which
-    returns a PredictionResult object for each example, we must override the
-    `forward()` function and convert the standard Hugging Face forward output
-    into the appropriate format of List[Dict[str, torch.Tensor]].
-
-    Before:
-    output = {
-      'logit': torch.FloatTensor of shape
-        (batch_size, sequence_length, config.vocab_size),
-      'hidden_states': tuple(torch.FloatTensor) of shape
-        (batch_size, sequence_length, hidden_size)
-    }
-    After:
-    output = [
-      {
-        'logit': torch.FloatTensor of shape
-          (sequence_length, config.vocab_size),
-        'hidden_states': tuple(torch.FloatTensor) of
-          shape (sequence_length, hidden_size)
-      },
-      {
-        'logit': torch.FloatTensor of shape
-          (sequence_length, config.vocab_size),
-        'hidden_states': tuple(torch.FloatTensor) of shape
-          (sequence_length, hidden_size)
-      },
-      ...
-    ]
-    where len(output) is batch_size
-    """
-    def forward(self, **kwargs):
-      output = super().forward(**kwargs)
-      return [dict(zip(output, v)) for v in zip(*output.values())]
 
   # TODO: Remove once nested tensors https://github.com/pytorch/nestedtensor
   # is officially released.


### PR DESCRIPTION
Cherry picking https://github.com/apache/beam/pull/22001 to fix a `dill`-related issue in a RunInference example where there was a pickle error of a Python class because it was in the wrong scope.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
