### PR TITLE
task: Migrate use of `JacksonFactory` to `GsonFactory`

### DIFF
--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -99,8 +99,8 @@ dependencies {
   implementation library.java.google_auth_library_credentials
   implementation library.java.google_auth_library_oauth2_http
   implementation library.java.google_http_client
-  implementation library.java.google_http_client_jackson2
-  permitUnusedDeclared library.java.google_http_client_jackson2 // BEAM-11761
+  implementation library.java.google_http_client_gson
+  permitUnusedDeclared library.java.google_http_client_gson // BEAM-11761
   implementation library.java.hamcrest
   implementation library.java.jackson_annotations
   implementation library.java.jackson_core

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/util/PackageUtilTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/util/PackageUtilTest.java
@@ -44,7 +44,7 @@ import com.google.api.client.http.LowLevelHttpRequest;
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.Json;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.testing.http.HttpTesting;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
@@ -578,7 +578,7 @@ public class PackageUtilTest {
   /** Builds a fake GoogleJsonResponseException for testing API error handling. */
   private static GoogleJsonResponseException googleJsonResponseException(
       final int status, final String reason, final String message) throws IOException {
-    final JsonFactory jsonFactory = new JacksonFactory();
+    final JsonFactory jsonFactory = GsonFactory.getDefaultInstance();
     HttpTransport transport =
         new MockHttpTransport() {
           @Override

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/graph/LengthPrefixUnknownCodersTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/graph/LengthPrefixUnknownCodersTest.java
@@ -31,7 +31,7 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotSame;
 
 import com.google.api.client.json.GenericJson;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.dataflow.model.InstructionOutput;
 import com.google.api.services.dataflow.model.ParDoInstruction;
 import com.google.api.services.dataflow.model.ParallelInstruction;
@@ -98,7 +98,7 @@ public class LengthPrefixUnknownCodersTest {
   public void setup() {
     MockitoAnnotations.initMocks(this);
     instruction = new ParallelInstruction();
-    instruction.setFactory(new JacksonFactory());
+    instruction.setFactory(GsonFactory.getDefaultInstance());
     instructionOutputNode = createInstructionOutputNode("parDo.out", windowedValueCoder);
   }
 
@@ -152,7 +152,7 @@ public class LengthPrefixUnknownCodersTest {
   public void testLengthPrefixInstructionOutputCoder() throws Exception {
     InstructionOutput output = new InstructionOutput();
     output.setCodec(CloudObjects.asCloudObject(windowedValueCoder, /*sdkComponents=*/ null));
-    output.setFactory(new JacksonFactory());
+    output.setFactory(GsonFactory.getDefaultInstance());
 
     InstructionOutput prefixedOutput = forInstructionOutput(output, false);
     assertEqualsAsJson(
@@ -327,11 +327,11 @@ public class LengthPrefixUnknownCodersTest {
 
   private static SideInputInfo createSideInputInfosWithCoders(Coder<?>... coders) {
     SideInputInfo sideInputInfo = new SideInputInfo().setSources(new ArrayList<>());
-    sideInputInfo.setFactory(new JacksonFactory());
+    sideInputInfo.setFactory(GsonFactory.getDefaultInstance());
     for (Coder<?> coder : coders) {
       Source source =
           new Source().setCodec(CloudObjects.asCloudObject(coder, /*sdkComponents=*/ null));
-      source.setFactory(new JacksonFactory());
+      source.setFactory(GsonFactory.getDefaultInstance());
       sideInputInfo.getSources().add(source);
     }
     return sideInputInfo;
@@ -356,7 +356,7 @@ public class LengthPrefixUnknownCodersTest {
                             .setCodec(CloudObjects.asCloudObject(coder, /*sdkComponents=*/ null))
                             .setSpec(CloudObject.forClassName(readClassName))));
 
-    parallelInstruction.setFactory(new JacksonFactory());
+    parallelInstruction.setFactory(GsonFactory.getDefaultInstance());
     return ParallelInstructionNode.create(parallelInstruction, Nodes.ExecutionLocation.UNKNOWN);
   }
 
@@ -365,7 +365,7 @@ public class LengthPrefixUnknownCodersTest {
         new InstructionOutput()
             .setName(name)
             .setCodec(CloudObjects.asCloudObject(coder, /*sdkComponents=*/ null));
-    instructionOutput.setFactory(new JacksonFactory());
+    instructionOutput.setFactory(GsonFactory.getDefaultInstance());
     return InstructionOutputNode.create(instructionOutput, "fakeId");
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/testing/GenericJsonMatcher.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/testing/GenericJsonMatcher.java
@@ -18,7 +18,8 @@
 package org.apache.beam.runners.dataflow.worker.testing;
 
 import com.google.api.client.json.GenericJson;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.JsonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import java.io.IOException;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
@@ -35,11 +36,11 @@ public final class GenericJsonMatcher extends TypeSafeMatcher<GenericJson> {
 
   private String expectedJsonText;
 
-  private static final JacksonFactory jacksonFactory = JacksonFactory.getDefaultInstance();
+  private static final JsonFactory jsonFactory = GsonFactory.getDefaultInstance();
 
   private GenericJsonMatcher(GenericJson expected) {
     try {
-      expectedJsonText = jacksonFactory.toString(expected);
+      expectedJsonText = jsonFactory.toString(expected);
     } catch (IOException ex) {
       throw new IllegalArgumentException("Could not parse JSON", ex);
     }
@@ -52,7 +53,7 @@ public final class GenericJsonMatcher extends TypeSafeMatcher<GenericJson> {
   @Override
   protected boolean matchesSafely(GenericJson actual) {
     try {
-      String actualJsonText = jacksonFactory.toString(actual);
+      String actualJsonText = jsonFactory.toString(actual);
       JSONCompareResult result =
           JSONCompare.compareJSON(expectedJsonText, actualJsonText, JSONCompareMode.STRICT);
       return result.passed();

--- a/sdks/java/extensions/google-cloud-platform-core/build.gradle
+++ b/sdks/java/extensions/google-cloud-platform-core/build.gradle
@@ -39,7 +39,7 @@ dependencies {
   implementation library.java.vendored_guava_26_0_jre
   implementation project(path: ":sdks:java:core", configuration: "shadow")
   implementation project(path: ":runners:core-java")
-  implementation library.java.google_http_client_jackson2
+  implementation library.java.google_http_client_gson
   implementation library.java.google_auth_library_oauth2_http
   implementation library.java.google_api_client
   implementation library.java.bigdataoss_gcsio

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/Transport.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/Transport.java
@@ -21,7 +21,7 @@ import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpTransport;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.storage.Storage;
 import com.google.auth.Credentials;
 import com.google.auth.http.HttpCredentialsAdapter;
@@ -47,7 +47,7 @@ public class Transport {
 
     static {
       try {
-        JSON_FACTORY = JacksonFactory.getDefaultInstance();
+        JSON_FACTORY = GsonFactory.getDefaultInstance();
         HTTP_TRANSPORT = GoogleNetHttpTransport.newTrustedTransport();
       } catch (GeneralSecurityException | IOException e) {
         throw new RuntimeException(e);

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/util/GcsUtilTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/util/GcsUtilTest.java
@@ -49,7 +49,7 @@ import com.google.api.client.http.LowLevelHttpResponse;
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.Json;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.testing.http.HttpTesting;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
@@ -465,7 +465,7 @@ public class GcsUtilTest {
 
   @Test
   public void testGetSizeBytesWhenFileNotFoundBatch() throws Exception {
-    JsonFactory jsonFactory = new JacksonFactory();
+    JsonFactory jsonFactory = GsonFactory.getDefaultInstance();
 
     String contentBoundary = "batch_foobarbaz";
     String contentBoundaryLine = "--" + contentBoundary;
@@ -505,7 +505,7 @@ public class GcsUtilTest {
 
   @Test
   public void testGetSizeBytesWhenFileNotFoundBatchRetry() throws Exception {
-    JsonFactory jsonFactory = new JacksonFactory();
+    JsonFactory jsonFactory = GsonFactory.getDefaultInstance();
 
     String contentBoundary = "batch_foobarbaz";
     String contentBoundaryLine = "--" + contentBoundary;
@@ -566,7 +566,7 @@ public class GcsUtilTest {
 
   @Test
   public void testRemoveWhenFileNotFound() throws Exception {
-    JsonFactory jsonFactory = new JacksonFactory();
+    JsonFactory jsonFactory = GsonFactory.getDefaultInstance();
 
     String contentBoundary = "batch_foobarbaz";
     String contentBoundaryLine = "--" + contentBoundary;
@@ -875,7 +875,7 @@ public class GcsUtilTest {
   /** Builds a fake GoogleJsonResponseException for testing API error handling. */
   private static GoogleJsonResponseException googleJsonResponseException(
       final int status, final String reason, final String message) throws IOException {
-    final JsonFactory jsonFactory = new JacksonFactory();
+    final JsonFactory jsonFactory = GsonFactory.getDefaultInstance();
     HttpTransport transport =
         new MockHttpTransport() {
           @Override

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/util/LatencyRecordingHttpRequestInitializerTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/util/LatencyRecordingHttpRequestInitializerTest.java
@@ -34,7 +34,7 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.LowLevelHttpRequest;
 import com.google.api.client.http.LowLevelHttpResponse;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.storage.Storage;
 import java.io.IOException;
 import org.apache.beam.sdk.metrics.Histogram;
@@ -61,7 +61,7 @@ public class LatencyRecordingHttpRequestInitializerTest {
   @Mock private LowLevelHttpResponse mockLowLevelResponse;
   @Mock private Histogram mockHistogram;
 
-  private final JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
+  private final JsonFactory jsonFactory = GsonFactory.getDefaultInstance();
   private Storage storage;
 
   @Before

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/util/RetryHttpRequestInitializerTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/util/RetryHttpRequestInitializerTest.java
@@ -39,7 +39,7 @@ import com.google.api.client.http.HttpTransport;
 import com.google.api.client.http.LowLevelHttpRequest;
 import com.google.api.client.http.LowLevelHttpResponse;
 import com.google.api.client.json.JsonFactory;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.http.MockLowLevelHttpResponse;
@@ -78,7 +78,7 @@ public class RetryHttpRequestInitializerTest {
   @Mock private LowLevelHttpResponse mockLowLevelResponse;
   @Mock private HttpResponseInterceptor mockHttpResponseInterceptor;
 
-  private final JsonFactory jsonFactory = JacksonFactory.getDefaultInstance();
+  private final JsonFactory jsonFactory = GsonFactory.getDefaultInstance();
   private Storage storage;
 
   // Used to test retrying a request more than the default 10 times.

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImplTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImplTest.java
@@ -44,7 +44,7 @@ import com.google.api.client.http.HttpResponseException;
 import com.google.api.client.http.LowLevelHttpResponse;
 import com.google.api.client.json.GenericJson;
 import com.google.api.client.json.Json;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.client.testing.http.MockHttpTransport;
 import com.google.api.client.testing.http.MockLowLevelHttpRequest;
 import com.google.api.client.testing.util.MockSleeper;
@@ -1397,12 +1397,12 @@ public class BigQueryServicesImplTest {
   /** A helper to convert a string response back to a {@link GenericJson} subclass. */
   private static <T extends GenericJson> T fromString(String content, Class<T> clazz)
       throws IOException {
-    return JacksonFactory.getDefaultInstance().fromString(content, clazz);
+    return GsonFactory.getDefaultInstance().fromString(content, clazz);
   }
 
   /** A helper to wrap a {@link GenericJson} object in a content stream. */
   private static InputStream toStream(GenericJson content) throws IOException {
-    return new ByteArrayInputStream(JacksonFactory.getDefaultInstance().toByteArray(content));
+    return new ByteArrayInputStream(GsonFactory.getDefaultInstance().toByteArray(content));
   }
 
   /** A helper that generates the error JSON payload that Google APIs produce. */

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/healthcare/FhirIOTestUtil.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/healthcare/FhirIOTestUtil.java
@@ -20,7 +20,7 @@ package org.apache.beam.sdk.io.gcp.healthcare;
 import com.google.api.client.http.HttpHeaders;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.javanet.NetHttpTransport;
-import com.google.api.client.json.jackson2.JacksonFactory;
+import com.google.api.client.json.gson.GsonFactory;
 import com.google.api.services.healthcare.v1.model.HttpBody;
 import com.google.api.services.storage.Storage;
 import com.google.api.services.storage.model.StorageObject;
@@ -136,7 +136,8 @@ class FhirIOTestUtil {
           request.setReadTimeout(60000); // 1 minute read timeout
         };
     Storage storage =
-        new Storage.Builder(new NetHttpTransport(), new JacksonFactory(), requestInitializer)
+        new Storage.Builder(
+            new NetHttpTransport(), GsonFactory.getDefaultInstance(), requestInitializer)
             .build();
     List<StorageObject> blobs = storage.objects().list(DEFAULT_TEMP_BUCKET).execute().getItems();
     if (blobs != null) {


### PR DESCRIPTION
In one case, also switches use from an explicit Jackson serializer (`ObjectMapper`) to the `JsonFactory`'s created `JsonGenerator` for serialization, so they're symmetric.

Fixes #22018.
