### PR TITLE
chore: Set permissions for GitHub actions

### DIFF
--- a/.github/workflows/build_playground_backend.yml
+++ b/.github/workflows/build_playground_backend.yml
@@ -23,6 +23,9 @@ on:
     paths: ['playground/backend/**']
     branches: ['playground-staging']
   workflow_dispatch:
+permissions:
+  contents: read
+
 jobs:
   build_playground_backend_docker_image:
     name: Build Playground Backend App

--- a/.github/workflows/build_playground_frontend.yml
+++ b/.github/workflows/build_playground_frontend.yml
@@ -24,6 +24,9 @@ on:
     branches: ['playground-staging']
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   build_playground_frontend_docker_image:
     name: Build Playground Frontend App

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -162,6 +162,8 @@ jobs:
 
 
   prepare_gcs:
+    permissions:
+      contents: none
     name: Prepare GCS
     needs:
       - build_source
@@ -178,6 +180,8 @@ jobs:
         run: gsutil rm -r ${{ env.GCP_PATH }} || true
 
   upload_source_to_gcs:
+    permissions:
+      contents: none
     name: Upload python source distribution to GCS bucket
     needs:
       - prepare_gcs
@@ -199,6 +203,8 @@ jobs:
         run: gsutil cp -r -a public-read source/* ${{ env.GCP_PATH }}
 
   build_wheels:
+    permissions:
+      contents: none
     name: Build python wheels on ${{matrix.arch}} for ${{ matrix.os_python.os }}
     needs: build_source
     env:
@@ -282,6 +288,8 @@ jobs:
         path: apache-beam-source-rc/wheelhouse/
 
   upload_wheels_to_gcs:
+    permissions:
+      contents: none
     name: Upload wheels to GCS bucket
     needs:
       - build_wheels
@@ -326,6 +334,8 @@ jobs:
       run: gsutil cp -a public-read ${GITHUB_EVENT_PATH} ${{ env.GCP_PATH }}
 
   list_files_on_gcs:
+    permissions:
+      contents: none
     name: List files on Google Cloud Storage Bucket
     needs:
      - upload_wheels_to_gcs

--- a/.github/workflows/go_tests.yml
+++ b/.github/workflows/go_tests.yml
@@ -30,6 +30,9 @@ on:
     tags: 'v*'
     paths: ['sdks/go/pkg/**', 'sdks/go.mod', 'sdks/go.sum']
 
+permissions:
+  contents: read
+
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/local_env_tests.yml
+++ b/.github/workflows/local_env_tests.yml
@@ -28,6 +28,9 @@ on:
     tags: 'v*'
     paths: ['dev-support/**', 'buildSrc/**', '**/build.gradle', 'sdks/python/setup.py', 'sdks/python/tox.ini']
 
+permissions:
+  contents: read
+
 jobs:
   run_local_env_install_ubuntu:
     timeout-minutes: 25

--- a/.github/workflows/playground_deploy_examples.yml
+++ b/.github/workflows/playground_deploy_examples.yml
@@ -27,6 +27,9 @@ env:
   BEAM_VERSION: 2.33.0
   K8S_NAMESPACE: playground-backend
   HELM_APP_NAME: playground-backend
+permissions:
+  contents: read
+
 jobs:
   check_examples:
     name: Check examples

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -36,6 +36,9 @@ on:
         default: false
 
 
+permissions:
+  contents: read
+
 jobs:
 
   check_gcp_variables:

--- a/.github/workflows/reportGenerator.yml
+++ b/.github/workflows/reportGenerator.yml
@@ -21,6 +21,9 @@ on:
   - cron: "0 10 * * 1-5"
   workflow_dispatch:
 
+permissions:
+  contents: read
+
 jobs:
   assign:
     name: Generate issue report

--- a/.github/workflows/typescript_tests.yml
+++ b/.github/workflows/typescript_tests.yml
@@ -32,6 +32,9 @@ on:
     paths: ['sdks/typescript/**']
 
 
+permissions:
+  contents: read
+
 jobs:
 
   typescript_unit_tests:


### PR DESCRIPTION
 Restrict the GitHub token permissions only to the required ones; this way, even if the attackers will succeed in compromising your workflow, they won’t be able to do much.

- Included permissions for the action. https://github.com/ossf/scorecard/blob/main/docs/checks.md#token-permissions

https://docs.github.com/en/actions/using-workflows/workflow-syntax-for-github-actions#permissions

https://docs.github.com/en/actions/using-jobs/assigning-permissions-to-jobs

[Keeping your GitHub Actions and workflows secure Part 1: Preventing pwn requests](https://securitylab.github.com/research/github-actions-preventing-pwn-requests/)

Signed-off-by: naveen <172697+naveensrinivasan@users.noreply.github.com>
