### PR TITLE
Fixes #21698: Use normal Container snapshots for Go Load Tests

### DIFF
--- a/.test-infra/jenkins/LoadTestsBuilder.groovy
+++ b/.test-infra/jenkins/LoadTestsBuilder.groovy
@@ -25,7 +25,8 @@ import static PythonTestProperties.LOAD_TEST_PYTHON_VERSION
 
 class LoadTestsBuilder {
   final static String DOCKER_CONTAINER_REGISTRY = 'gcr.io/apache-beam-testing/beam_portability'
-  final static String DOCKER_CONTAINER_REGISTRY_GO = 'gcr.io/apache-beam-testing/beam-sdk'
+  final static String DOCKER_CONTAINER_REGISTRY_SNAPSHOTS = 'gcr.io/apache-beam-testing/beam-sdk'
+  final static String GO_SDK_CONTAINER = "${DOCKER_CONTAINER_REGISTRY_SNAPSHOTS}/beam_go_sdk:latest"
   final static String DOCKER_BEAM_SDK_IMAGE = "beam_python${LOAD_TEST_PYTHON_VERSION}_sdk:latest"
 
   static void loadTests(scope, CommonTestProperties.SDK sdk, List testConfigurations, String test, String mode,

--- a/.test-infra/jenkins/LoadTestsBuilder.groovy
+++ b/.test-infra/jenkins/LoadTestsBuilder.groovy
@@ -25,6 +25,7 @@ import static PythonTestProperties.LOAD_TEST_PYTHON_VERSION
 
 class LoadTestsBuilder {
   final static String DOCKER_CONTAINER_REGISTRY = 'gcr.io/apache-beam-testing/beam_portability'
+  final static String DOCKER_CONTAINER_REGISTRY_GO = 'gcr.io/apache-beam-testing/beam_sdk'
   final static String DOCKER_BEAM_SDK_IMAGE = "beam_python${LOAD_TEST_PYTHON_VERSION}_sdk:latest"
 
   static void loadTests(scope, CommonTestProperties.SDK sdk, List testConfigurations, String test, String mode,

--- a/.test-infra/jenkins/LoadTestsBuilder.groovy
+++ b/.test-infra/jenkins/LoadTestsBuilder.groovy
@@ -25,7 +25,7 @@ import static PythonTestProperties.LOAD_TEST_PYTHON_VERSION
 
 class LoadTestsBuilder {
   final static String DOCKER_CONTAINER_REGISTRY = 'gcr.io/apache-beam-testing/beam_portability'
-  final static String DOCKER_CONTAINER_REGISTRY_GO = 'gcr.io/apache-beam-testing/beam_sdk'
+  final static String DOCKER_CONTAINER_REGISTRY_GO = 'gcr.io/apache-beam-testing/beam-sdk'
   final static String DOCKER_BEAM_SDK_IMAGE = "beam_python${LOAD_TEST_PYTHON_VERSION}_sdk:latest"
 
   static void loadTests(scope, CommonTestProperties.SDK sdk, List testConfigurations, String test, String mode,

--- a/.test-infra/jenkins/job_LoadTests_Combine_Flink_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Combine_Flink_Go.groovy
@@ -24,7 +24,7 @@ import Flink
 import InfluxDBCredentialsHelper
 
 import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY
-import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY_GO
+import static LoadTestsBuilder.GO_SDK_CONTAINER
 
 
 String now = new Date().format('MMddHHmmss', TimeZone.getTimeZone('UTC'))
@@ -48,7 +48,7 @@ def batchScenarios = {
         parallelism          : 5,
         endpoint             : 'localhost:8099',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -68,7 +68,7 @@ def batchScenarios = {
         parallelism          : 16,
         endpoint             : 'localhost:8099',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -88,7 +88,7 @@ def batchScenarios = {
         '"value_size": 90}\'',
         endpoint             : 'localhost:8099',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
   ].each { test -> test.pipelineOptions.putAll(additionalPipelineArgs) }
@@ -104,7 +104,7 @@ def loadTestJob = { scope, triggeringContext, mode ->
   def flink = new Flink(scope, "beam_LoadTests_Go_Combine_Flink_${mode.capitalize()}")
   flink.setUp(
       [
-        "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest"
+        GO_SDK_CONTAINER
       ],
       initialParallelism,
       "${DOCKER_CONTAINER_REGISTRY}/beam_flink1.13_job_server:latest")

--- a/.test-infra/jenkins/job_LoadTests_Combine_Flink_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Combine_Flink_Go.groovy
@@ -24,6 +24,8 @@ import Flink
 import InfluxDBCredentialsHelper
 
 import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY
+import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY_GO
+
 
 String now = new Date().format('MMddHHmmss', TimeZone.getTimeZone('UTC'))
 
@@ -46,7 +48,7 @@ def batchScenarios = {
         parallelism          : 5,
         endpoint             : 'localhost:8099',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -66,7 +68,7 @@ def batchScenarios = {
         parallelism          : 16,
         endpoint             : 'localhost:8099',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -86,7 +88,7 @@ def batchScenarios = {
         '"value_size": 90}\'',
         endpoint             : 'localhost:8099',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
   ].each { test -> test.pipelineOptions.putAll(additionalPipelineArgs) }
@@ -102,10 +104,10 @@ def loadTestJob = { scope, triggeringContext, mode ->
   def flink = new Flink(scope, "beam_LoadTests_Go_Combine_Flink_${mode.capitalize()}")
   flink.setUp(
       [
-        "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest"
+        "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest"
       ],
       initialParallelism,
-      "${DOCKER_CONTAINER_REGISTRY}/beam_flink1.12_job_server:latest")
+      "${DOCKER_CONTAINER_REGISTRY}/beam_flink1.13_job_server:latest")
 
   // Execute all scenarios connected with initial parallelism.
   loadTestsBuilder.loadTests(scope, CommonTestProperties.SDK.GO, initialScenarios, 'combine', mode)

--- a/.test-infra/jenkins/job_LoadTests_Combine_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Combine_Go.groovy
@@ -22,7 +22,7 @@ import LoadTestsBuilder as loadTestsBuilder
 import PhraseTriggeringPostCommitBuilder
 import InfluxDBCredentialsHelper
 
-import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY_GO
+import static LoadTestsBuilder.GO_SDK_CONTAINER
 
 
 String now = new Date().format('MMddHHmmss', TimeZone.getTimeZone('UTC'))
@@ -50,7 +50,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -74,7 +74,7 @@ def batchScenarios = {
         num_workers          : 16,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -98,7 +98,7 @@ def batchScenarios = {
         num_workers          : 16,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
   ].each { test -> test.pipelineOptions.putAll(additionalPipelineArgs) }

--- a/.test-infra/jenkins/job_LoadTests_Combine_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_Combine_Go.groovy
@@ -22,7 +22,7 @@ import LoadTestsBuilder as loadTestsBuilder
 import PhraseTriggeringPostCommitBuilder
 import InfluxDBCredentialsHelper
 
-import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY
+import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY_GO
 
 
 String now = new Date().format('MMddHHmmss', TimeZone.getTimeZone('UTC'))
@@ -50,7 +50,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -74,7 +74,7 @@ def batchScenarios = {
         num_workers          : 16,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -98,7 +98,7 @@ def batchScenarios = {
         num_workers          : 16,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
   ].each { test -> test.pipelineOptions.putAll(additionalPipelineArgs) }

--- a/.test-infra/jenkins/job_LoadTests_GBK_Flink_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_GBK_Flink_Go.groovy
@@ -24,6 +24,7 @@ import Flink
 import InfluxDBCredentialsHelper
 
 import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY
+import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY_GO
 
 String now = new Date().format('MMddHHmmss', TimeZone.getTimeZone('UTC'))
 
@@ -51,7 +52,7 @@ def batchScenarios = {
         parallelism        : 5,
         endpoint           : 'localhost:8099',
         environment_type   : 'DOCKER',
-        environment_config : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -71,7 +72,7 @@ def batchScenarios = {
         parallelism        : 5,
         endpoint           : 'localhost:8099',
         environment_type   : 'DOCKER',
-        environment_config : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -91,7 +92,7 @@ def batchScenarios = {
         '"value_size": 90000}\'',
         endpoint            : 'localhost:8099',
         environment_type    : 'DOCKER',
-        environment_config  : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config  : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -111,7 +112,7 @@ def batchScenarios = {
         '"value_size": 90}\'',
         endpoint           : 'localhost:8099',
         environment_type   : 'DOCKER',
-        environment_config : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -131,7 +132,7 @@ def batchScenarios = {
         '"value_size": 90}\'',
         endpoint           : 'localhost:8099',
         environment_type   : 'DOCKER',
-        environment_config : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -153,7 +154,7 @@ def batchScenarios = {
         '"hot_key_fraction": 1}\'',
         endpoint           : 'localhost:8099',
         environment_type   : 'DOCKER',
-        environment_config : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -175,7 +176,7 @@ def batchScenarios = {
         '"hot_key_fraction": 1}\'',
         endpoint           : 'localhost:8099',
         environment_type   : 'DOCKER',
-        environment_config : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
   ]
@@ -195,10 +196,10 @@ def loadTestJob = { scope, triggeringContext, mode ->
   def flink = new Flink(scope, "beam_LoadTests_Go_GBK_Flink_${mode.capitalize()}")
   flink.setUp(
       [
-        "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest"
+        "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest"
       ],
       initialParallelism,
-      "${DOCKER_CONTAINER_REGISTRY}/beam_flink1.12_job_server:latest")
+      "${DOCKER_CONTAINER_REGISTRY}/beam_flink1.13_job_server:latest")
 
   // Execute all scenarios connected with initial parallelism.
   loadTestsBuilder.loadTests(scope, CommonTestProperties.SDK.GO, initialScenarios, 'group_by_key', mode)

--- a/.test-infra/jenkins/job_LoadTests_GBK_Flink_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_GBK_Flink_Go.groovy
@@ -24,7 +24,7 @@ import Flink
 import InfluxDBCredentialsHelper
 
 import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY
-import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY_GO
+import static LoadTestsBuilder.GO_SDK_CONTAINER
 
 String now = new Date().format('MMddHHmmss', TimeZone.getTimeZone('UTC'))
 
@@ -52,7 +52,7 @@ def batchScenarios = {
         parallelism        : 5,
         endpoint           : 'localhost:8099',
         environment_type   : 'DOCKER',
-        environment_config : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -72,7 +72,7 @@ def batchScenarios = {
         parallelism        : 5,
         endpoint           : 'localhost:8099',
         environment_type   : 'DOCKER',
-        environment_config : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -92,7 +92,7 @@ def batchScenarios = {
         '"value_size": 90000}\'',
         endpoint            : 'localhost:8099',
         environment_type    : 'DOCKER',
-        environment_config  : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config  : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -112,7 +112,7 @@ def batchScenarios = {
         '"value_size": 90}\'',
         endpoint           : 'localhost:8099',
         environment_type   : 'DOCKER',
-        environment_config : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -132,7 +132,7 @@ def batchScenarios = {
         '"value_size": 90}\'',
         endpoint           : 'localhost:8099',
         environment_type   : 'DOCKER',
-        environment_config : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -154,7 +154,7 @@ def batchScenarios = {
         '"hot_key_fraction": 1}\'',
         endpoint           : 'localhost:8099',
         environment_type   : 'DOCKER',
-        environment_config : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -176,7 +176,7 @@ def batchScenarios = {
         '"hot_key_fraction": 1}\'',
         endpoint           : 'localhost:8099',
         environment_type   : 'DOCKER',
-        environment_config : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config : GO_SDK_CONTAINER,
       ]
     ],
   ]
@@ -196,7 +196,7 @@ def loadTestJob = { scope, triggeringContext, mode ->
   def flink = new Flink(scope, "beam_LoadTests_Go_GBK_Flink_${mode.capitalize()}")
   flink.setUp(
       [
-        "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest"
+        GO_SDK_CONTAINER
       ],
       initialParallelism,
       "${DOCKER_CONTAINER_REGISTRY}/beam_flink1.13_job_server:latest")

--- a/.test-infra/jenkins/job_LoadTests_GBK_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_GBK_Go.groovy
@@ -22,7 +22,7 @@ import LoadTestsBuilder as loadTestsBuilder
 import PhraseTriggeringPostCommitBuilder
 import InfluxDBCredentialsHelper
 
-import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY
+import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY_GO
 
 String now = new Date().format('MMddHHmmss', TimeZone.getTimeZone('UTC'))
 
@@ -49,7 +49,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -73,7 +73,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -97,7 +97,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -121,7 +121,7 @@ def batchScenarios = {
         num_workers          : 16,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -145,7 +145,7 @@ def batchScenarios = {
         num_workers          : 16,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -171,7 +171,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -197,7 +197,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
   ]

--- a/.test-infra/jenkins/job_LoadTests_GBK_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_GBK_Go.groovy
@@ -22,7 +22,7 @@ import LoadTestsBuilder as loadTestsBuilder
 import PhraseTriggeringPostCommitBuilder
 import InfluxDBCredentialsHelper
 
-import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY_GO
+import static LoadTestsBuilder.GO_SDK_CONTAINER
 
 String now = new Date().format('MMddHHmmss', TimeZone.getTimeZone('UTC'))
 
@@ -49,7 +49,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -73,7 +73,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -97,7 +97,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -121,7 +121,7 @@ def batchScenarios = {
         num_workers          : 16,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -145,7 +145,7 @@ def batchScenarios = {
         num_workers          : 16,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -171,7 +171,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -197,7 +197,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
   ]

--- a/.test-infra/jenkins/job_LoadTests_ParDo_Flink_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_ParDo_Flink_Go.groovy
@@ -24,7 +24,7 @@ import Flink
 import InfluxDBCredentialsHelper
 
 import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY
-import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY_GO
+import static LoadTestsBuilder.GO_SDK_CONTAINER
 
 String now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 
@@ -49,7 +49,7 @@ def batchScenarios = {
         parallelism          : 5,
         endpoint             : 'localhost:8099',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -70,7 +70,7 @@ def batchScenarios = {
         parallelism          : 5,
         endpoint             : 'localhost:8099',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -91,7 +91,7 @@ def batchScenarios = {
         parallelism          : 5,
         endpoint             : 'localhost:8099',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -112,7 +112,7 @@ def batchScenarios = {
         parallelism          : 5,
         endpoint             : 'localhost:8099',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
   ].each { test -> test.pipelineOptions.putAll(additionalPipelineArgs) }
@@ -124,7 +124,7 @@ def loadTestJob = { scope, triggeringContext, mode ->
   Flink flink = new Flink(scope, "beam_LoadTests_Go_ParDo_Flink_${mode.capitalize()}")
   flink.setUp(
       [
-        "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest"
+        GO_SDK_CONTAINER
       ],
       numberOfWorkers,
       "${DOCKER_CONTAINER_REGISTRY}/beam_flink1.13_job_server:latest")

--- a/.test-infra/jenkins/job_LoadTests_ParDo_Flink_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_ParDo_Flink_Go.groovy
@@ -24,6 +24,7 @@ import Flink
 import InfluxDBCredentialsHelper
 
 import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY
+import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY_GO
 
 String now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 
@@ -48,7 +49,7 @@ def batchScenarios = {
         parallelism          : 5,
         endpoint             : 'localhost:8099',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -69,7 +70,7 @@ def batchScenarios = {
         parallelism          : 5,
         endpoint             : 'localhost:8099',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -90,7 +91,7 @@ def batchScenarios = {
         parallelism          : 5,
         endpoint             : 'localhost:8099',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -111,7 +112,7 @@ def batchScenarios = {
         parallelism          : 5,
         endpoint             : 'localhost:8099',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
   ].each { test -> test.pipelineOptions.putAll(additionalPipelineArgs) }
@@ -123,10 +124,10 @@ def loadTestJob = { scope, triggeringContext, mode ->
   Flink flink = new Flink(scope, "beam_LoadTests_Go_ParDo_Flink_${mode.capitalize()}")
   flink.setUp(
       [
-        "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest"
+        "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest"
       ],
       numberOfWorkers,
-      "${DOCKER_CONTAINER_REGISTRY}/beam_flink1.12_job_server:latest")
+      "${DOCKER_CONTAINER_REGISTRY}/beam_flink1.13_job_server:latest")
 
   loadTestsBuilder.loadTests(scope, CommonTestProperties.SDK.GO, batchScenarios(), 'ParDo', mode)
 }

--- a/.test-infra/jenkins/job_LoadTests_ParDo_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_ParDo_Go.groovy
@@ -22,7 +22,7 @@ import LoadTestsBuilder as loadTestsBuilder
 import PhraseTriggeringPostCommitBuilder
 import InfluxDBCredentialsHelper
 
-import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY_GO
+import static LoadTestsBuilder.GO_SDK_CONTAINER
 
 String now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 
@@ -51,7 +51,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -76,7 +76,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -101,7 +101,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -126,7 +126,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
   ].each { test -> test.pipelineOptions.putAll(additionalPipelineArgs) }

--- a/.test-infra/jenkins/job_LoadTests_ParDo_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_ParDo_Go.groovy
@@ -22,7 +22,7 @@ import LoadTestsBuilder as loadTestsBuilder
 import PhraseTriggeringPostCommitBuilder
 import InfluxDBCredentialsHelper
 
-import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY
+import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY_GO
 
 String now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 
@@ -51,7 +51,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -76,7 +76,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -101,7 +101,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -126,7 +126,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
   ].each { test -> test.pipelineOptions.putAll(additionalPipelineArgs) }

--- a/.test-infra/jenkins/job_LoadTests_SideInput_Flink_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_SideInput_Flink_Go.groovy
@@ -23,6 +23,7 @@ import PhraseTriggeringPostCommitBuilder
 import InfluxDBCredentialsHelper
 
 import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY
+import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY_GO
 
 def now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 
@@ -44,7 +45,7 @@ def batchScenarios = {
         parallelism        : 10,
         endpoint           : 'localhost:8099',
         environment_type   : 'DOCKER',
-        environment_config : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -62,7 +63,7 @@ def batchScenarios = {
         parallelism        : 10,
         endpoint           : 'localhost:8099',
         environment_type   : 'DOCKER',
-        environment_config : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
   ]
@@ -75,10 +76,10 @@ def loadTestJob = { scope, triggeringContext, mode ->
   Flink flink = new Flink(scope, "beam_LoadTests_Go_SideInput_Flink_${mode.capitalize()}")
   flink.setUp(
       [
-        "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest"
+        "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest"
       ],
       numberOfWorkers,
-      "${DOCKER_CONTAINER_REGISTRY}/beam_flink1.12_job_server:latest")
+      "${DOCKER_CONTAINER_REGISTRY}/beam_flink1.13_job_server:latest")
 
   loadTestsBuilder.loadTests(scope, CommonTestProperties.SDK.GO,
       batchScenarios(), 'SideInput', mode)

--- a/.test-infra/jenkins/job_LoadTests_SideInput_Flink_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_SideInput_Flink_Go.groovy
@@ -23,7 +23,7 @@ import PhraseTriggeringPostCommitBuilder
 import InfluxDBCredentialsHelper
 
 import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY
-import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY_GO
+import static LoadTestsBuilder.GO_SDK_CONTAINER
 
 def now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 
@@ -45,7 +45,7 @@ def batchScenarios = {
         parallelism        : 10,
         endpoint           : 'localhost:8099',
         environment_type   : 'DOCKER',
-        environment_config : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -63,7 +63,7 @@ def batchScenarios = {
         parallelism        : 10,
         endpoint           : 'localhost:8099',
         environment_type   : 'DOCKER',
-        environment_config : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config : GO_SDK_CONTAINER,
       ]
     ],
   ]
@@ -76,7 +76,7 @@ def loadTestJob = { scope, triggeringContext, mode ->
   Flink flink = new Flink(scope, "beam_LoadTests_Go_SideInput_Flink_${mode.capitalize()}")
   flink.setUp(
       [
-        "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest"
+        GO_SDK_CONTAINER
       ],
       numberOfWorkers,
       "${DOCKER_CONTAINER_REGISTRY}/beam_flink1.13_job_server:latest")

--- a/.test-infra/jenkins/job_LoadTests_SideInput_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_SideInput_Go.groovy
@@ -22,7 +22,7 @@ import LoadTestsBuilder as loadTestsBuilder
 import PhraseTriggeringPostCommitBuilder
 import InfluxDBCredentialsHelper
 
-import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY
+import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY_GO
 
 String now = new Date().format('MMddHHmmss', TimeZone.getTimeZone('UTC'))
 
@@ -48,7 +48,7 @@ def batchScenarios = {
         num_workers          : 10,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -70,7 +70,7 @@ def batchScenarios = {
         num_workers          : 10,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ]
   ]

--- a/.test-infra/jenkins/job_LoadTests_SideInput_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_SideInput_Go.groovy
@@ -22,7 +22,7 @@ import LoadTestsBuilder as loadTestsBuilder
 import PhraseTriggeringPostCommitBuilder
 import InfluxDBCredentialsHelper
 
-import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY_GO
+import static LoadTestsBuilder.GO_SDK_CONTAINER
 
 String now = new Date().format('MMddHHmmss', TimeZone.getTimeZone('UTC'))
 
@@ -48,7 +48,7 @@ def batchScenarios = {
         num_workers          : 10,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -70,7 +70,7 @@ def batchScenarios = {
         num_workers          : 10,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ]
   ]

--- a/.test-infra/jenkins/job_LoadTests_coGBK_Flink_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_coGBK_Flink_Go.groovy
@@ -24,6 +24,7 @@ import Flink
 import InfluxDBCredentialsHelper
 
 import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY
+import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY_GO
 
 String now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 
@@ -58,7 +59,7 @@ def batchScenarios = {
         parallelism          : 5,
         endpoint             : 'localhost:8099',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -85,7 +86,7 @@ def batchScenarios = {
         parallelism          : 5,
         endpoint             : 'localhost:8099',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -112,7 +113,7 @@ def batchScenarios = {
         parallelism          : 5,
         endpoint             : 'localhost:8099',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -139,7 +140,7 @@ def batchScenarios = {
         parallelism          : 5,
         endpoint             : 'localhost:8099',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
   ]
@@ -155,10 +156,10 @@ def loadTestJob = { scope, triggeringContext, mode ->
   def flink = new Flink(scope, "beam_LoadTests_Go_CoGBK_Flink_${mode.capitalize()}")
   flink.setUp(
       [
-        "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest"
+        "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest"
       ],
       numberOfWorkers,
-      "${DOCKER_CONTAINER_REGISTRY}/beam_flink1.12_job_server:latest")
+      "${DOCKER_CONTAINER_REGISTRY}/beam_flink1.13_job_server:latest")
 
   loadTestsBuilder.loadTests(scope, CommonTestProperties.SDK.GO, batchScenarios(), 'CoGBK', mode)
 }

--- a/.test-infra/jenkins/job_LoadTests_coGBK_Flink_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_coGBK_Flink_Go.groovy
@@ -24,7 +24,7 @@ import Flink
 import InfluxDBCredentialsHelper
 
 import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY
-import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY_GO
+import static LoadTestsBuilder.GO_SDK_CONTAINER
 
 String now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 
@@ -59,7 +59,7 @@ def batchScenarios = {
         parallelism          : 5,
         endpoint             : 'localhost:8099',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -86,7 +86,7 @@ def batchScenarios = {
         parallelism          : 5,
         endpoint             : 'localhost:8099',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -113,7 +113,7 @@ def batchScenarios = {
         parallelism          : 5,
         endpoint             : 'localhost:8099',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -140,7 +140,7 @@ def batchScenarios = {
         parallelism          : 5,
         endpoint             : 'localhost:8099',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
   ]
@@ -156,7 +156,7 @@ def loadTestJob = { scope, triggeringContext, mode ->
   def flink = new Flink(scope, "beam_LoadTests_Go_CoGBK_Flink_${mode.capitalize()}")
   flink.setUp(
       [
-        "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest"
+        GO_SDK_CONTAINER
       ],
       numberOfWorkers,
       "${DOCKER_CONTAINER_REGISTRY}/beam_flink1.13_job_server:latest")

--- a/.test-infra/jenkins/job_LoadTests_coGBK_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_coGBK_Go.groovy
@@ -22,7 +22,7 @@ import LoadTestsBuilder as loadTestsBuilder
 import PhraseTriggeringPostCommitBuilder
 import InfluxDBCredentialsHelper
 
-import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY_GO
+import static LoadTestsBuilder.GO_SDK_CONTAINER
 
 String now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 
@@ -56,7 +56,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -87,7 +87,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -118,7 +118,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
     [
@@ -149,7 +149,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
+        environment_config   : GO_SDK_CONTAINER,
       ]
     ],
   ]

--- a/.test-infra/jenkins/job_LoadTests_coGBK_Go.groovy
+++ b/.test-infra/jenkins/job_LoadTests_coGBK_Go.groovy
@@ -22,7 +22,7 @@ import LoadTestsBuilder as loadTestsBuilder
 import PhraseTriggeringPostCommitBuilder
 import InfluxDBCredentialsHelper
 
-import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY
+import static LoadTestsBuilder.DOCKER_CONTAINER_REGISTRY_GO
 
 String now = new Date().format("MMddHHmmss", TimeZone.getTimeZone('UTC'))
 
@@ -56,7 +56,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -87,7 +87,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -118,7 +118,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
     [
@@ -149,7 +149,7 @@ def batchScenarios = {
         num_workers          : 5,
         autoscaling_algorithm: 'NONE',
         environment_type     : 'DOCKER',
-        environment_config   : "${DOCKER_CONTAINER_REGISTRY}/beam_go_sdk:latest",
+        environment_config   : "${DOCKER_CONTAINER_REGISTRY_GO}/beam_go_sdk:latest",
       ]
     ],
   ]

--- a/.test-infra/jenkins/job_Publish_Docker_Snapshots.groovy
+++ b/.test-infra/jenkins/job_Publish_Docker_Snapshots.groovy
@@ -44,7 +44,6 @@ job('beam_Publish_Docker_Snapshots') {
       SUPPORTED_CONTAINER_TASKS.each { taskVer ->
         tasks(":sdks:python:container:${taskVer}:dockerTagPush")
       }
-      tasks(':sdks:go:container:dockerTagPush')
       tasks(":runners:flink:${CommonTestProperties.getFlinkVersion()}:job-server-container:dockerTagPush")
       switches("-Pdocker-repository-root=gcr.io/apache-beam-testing/beam_portability")
       switches("-Pdocker-tag=latest")

--- a/.test-infra/jenkins/job_Publish_Docker_Snapshots.groovy
+++ b/.test-infra/jenkins/job_Publish_Docker_Snapshots.groovy
@@ -42,9 +42,9 @@ job('beam_Publish_Docker_Snapshots') {
       rootBuildScriptDir(commonJobProperties.checkoutDir)
       commonJobProperties.setGradleSwitches(delegate)
       SUPPORTED_CONTAINER_TASKS.each { taskVer ->
-        tasks(":sdks:python:container:${taskVer}:dockerTagPush")
+        tasks(":sdks:python:container:${taskVer}:dockerPush")
       }
-      tasks(":runners:flink:${CommonTestProperties.getFlinkVersion()}:job-server-container:dockerTagPush")
+      tasks(":runners:flink:${CommonTestProperties.getFlinkVersion()}:job-server-container:dockerPush")
       switches("-Pdocker-repository-root=gcr.io/apache-beam-testing/beam_portability")
       switches("-Pdocker-tag=latest")
     }

--- a/.test-infra/jenkins/job_Publish_Docker_Snapshots.groovy
+++ b/.test-infra/jenkins/job_Publish_Docker_Snapshots.groovy
@@ -42,10 +42,10 @@ job('beam_Publish_Docker_Snapshots') {
       rootBuildScriptDir(commonJobProperties.checkoutDir)
       commonJobProperties.setGradleSwitches(delegate)
       SUPPORTED_CONTAINER_TASKS.each { taskVer ->
-        tasks(":sdks:python:container:${taskVer}:dockerPush")
+        tasks(":sdks:python:container:${taskVer}:dockerTagPush")
       }
-      tasks(':sdks:go:container:dockerPush')
-      tasks(":runners:flink:${CommonTestProperties.getFlinkVersion()}:job-server-container:dockerPush")
+      tasks(':sdks:go:container:dockerTagPush')
+      tasks(":runners:flink:${CommonTestProperties.getFlinkVersion()}:job-server-container:dockerTagPush")
       switches("-Pdocker-repository-root=gcr.io/apache-beam-testing/beam_portability")
       switches("-Pdocker-tag=latest")
     }


### PR DESCRIPTION
Attempting to fix the loadtests by fixing #21698

The Docker Publish Snapshots jenkins task for the load tests doesn't seem to work for Go, while the general publish does. Move the load tests for Go to use the normal container snapshot.

Also tries to fix the flink loadtest runs by updating them to 1.13 from 1.12.

The two publish tasks 
https://github.com/apache/beam/blob/3d4454c4f08456918d3730d9eff4547db91138c4/.test-infra/jenkins/job_Publish_Docker_Snapshots.groovy
https://github.com/apache/beam/blob/243128a8fc52798e1b58b0cf1a271d95ee7aa241/.test-infra/jenkins/job_Publish_SDK_Image_Snapshots.groovy
are identical except the Go SDK build doesn't work and the latter uses dockerTagPush, which doesn't affect the container build run, so it's perplexing. 

However, removing the Go task should let the remainder of the publish pass, leaving the formerly broken task in the hands of the Python load tests.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
