### PR TITLE
Fix InputStream on platform with 4 byte long system (Windows)

### DIFF
--- a/sdks/python/apache_beam/coders/stream.pyx
+++ b/sdks/python/apache_beam/coders/stream.pyx
@@ -65,7 +65,7 @@ cdef class OutputStream(object):
       v >>= 7
       if v:
         bits |= 0x80
-      self.write_byte(bits)
+      self.write_byte(<unsigned char>bits)
       if not v:
         break
 
@@ -181,7 +181,7 @@ cdef class InputStream(object):
   cpdef libc.stdint.int64_t read_var_int64(self) except? -1:
     """Decode a variable-length encoded long from a stream."""
     cdef long byte
-    cdef long bits
+    cdef libc.stdint.int64_t bits
     cdef long shift = 0
     cdef libc.stdint.int64_t result = 0
     while True:
@@ -190,8 +190,8 @@ cdef class InputStream(object):
         raise RuntimeError('VarInt not terminated.')
 
       bits = byte & 0x7F
-      if (shift >= sizeof(long) * 8 or
-          (shift >= (sizeof(long) * 8 - 1) and bits > 1)):
+      if (shift >= sizeof(libc.stdint.int64_t) * 8 or
+          (shift >= (sizeof(libc.stdint.int64_t) * 8 - 1) and bits > 1)):
         raise RuntimeError('VarLong too long.')
       result |= bits << shift
       shift += 7


### PR DESCRIPTION
Fixes #20633

Unit tests are actually failing when cythonized. Current precommit only tests cython on linux (jenkins). May consider ad test suites for other systems.

* Explicitly use int64_t rather than long type in pyx

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
