### PR TITLE
Minor: Bump flake8 to 4.0.1

### DIFF
--- a/sdks/python/apache_beam/dataframe/transforms.py
+++ b/sdks/python/apache_beam/dataframe/transforms.py
@@ -116,7 +116,7 @@ class DataframeTransform(transforms.PTransform):
     input_frames = {
         k: convert.to_dataframe(pc, proxies[k])
         for k, pc in input_dict.items()
-    }  # type: Dict[Any, DeferredFrame]
+    }  # type: Dict[Any, DeferredFrame] # noqa: F821
 
     # Apply the function.
     frames_input = _substitute(input_pcolls, input_frames)

--- a/sdks/python/apache_beam/io/azure/blobstoragefilesystem.py
+++ b/sdks/python/apache_beam/io/azure/blobstoragefilesystem.py
@@ -145,7 +145,7 @@ class BlobStorageFileSystem(FileSystem):
       path,
       mime_type='application/octet-stream',
       compression_type=CompressionTypes.AUTO):
-    # type: (...) -> BinaryIO
+    # type: (...) -> BinaryIO # noqa: F821
 
     """Returns a write channel for the given file path.
 
@@ -163,7 +163,7 @@ class BlobStorageFileSystem(FileSystem):
       path,
       mime_type='application/octet-stream',
       compression_type=CompressionTypes.AUTO):
-    # type: (...) -> BinaryIO
+    # type: (...) -> BinaryIO # noqa: F821
 
     """Returns a read channel for the given file path.
 

--- a/sdks/python/apache_beam/io/gcp/bigquery_avro_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_avro_tools.py
@@ -64,7 +64,7 @@ BIG_QUERY_TO_AVRO_TYPES = {
 
 def get_record_schema_from_dict_table_schema(
     schema_name, table_schema, namespace="apache_beam.io.gcp.bigquery"):
-  # type: (Text, Dict[Text, Any], Text) -> Dict[Text, Any]
+  # type: (Text, Dict[Text, Any], Text) -> Dict[Text, Any] # noqa: F821
 
   """Convert a table schema into an Avro schema.
 
@@ -91,7 +91,7 @@ def get_record_schema_from_dict_table_schema(
 
 
 def table_field_to_avro_field(table_field, namespace):
-  # type: (Dict[Text, Any], str) -> Dict[Text, Any]
+  # type: (Dict[Text, Any], str) -> Dict[Text, Any] # noqa: F821
 
   """Convert a BigQuery field to an avro field.
 

--- a/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
+++ b/sdks/python/apache_beam/runners/dataflow/dataflow_runner.py
@@ -261,7 +261,7 @@ class DataflowRunner(PipelineRunner):
 
   @staticmethod
   def _only_element(iterable):
-    # type: (Iterable[T]) -> T
+    # type: (Iterable[T]) -> T # noqa: F821
     element, = iterable
     return element
 

--- a/sdks/python/apache_beam/runners/direct/test_stream_impl.py
+++ b/sdks/python/apache_beam/runners/direct/test_stream_impl.py
@@ -309,7 +309,8 @@ class _TestStream(PTransform):
       return not (shutdown_requested or evaluation_context.shutdown_requested)
 
     # The shared queue that allows the producer and consumer to communicate.
-    channel = Queue()  # type: Queue[Union[test_stream.Event, _EndOfStream]]
+    channel = Queue(
+    )  # type: Queue[Union[test_stream.Event, _EndOfStream]] # noqa: F821
     event_stream = Thread(
         target=_TestStream._stream_events_from_rpc,
         args=(endpoint, output_tags, coder, channel, is_alive))

--- a/sdks/python/apache_beam/runners/interactive/interactive_beam.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_beam.py
@@ -272,7 +272,7 @@ class Recordings():
   following methods allow for introspection into that background recording job.
   """
   def describe(self, pipeline=None):
-    # type: (Optional[beam.Pipeline]) -> dict[str, Any]
+    # type: (Optional[beam.Pipeline]) -> dict[str, Any] # noqa: F821
 
     """Returns a description of all the recordings for the given pipeline.
 
@@ -683,7 +683,7 @@ def show(
     visualize_data=False,
     n='inf',
     duration='inf'):
-  # type: (*Union[Dict[Any, PCollection], Iterable[PCollection], PCollection], bool, bool, Union[int, str], Union[int, str]) -> None
+  # type: (*Union[Dict[Any, PCollection], Iterable[PCollection], PCollection], bool, bool, Union[int, str], Union[int, str]) -> None # noqa: F821
 
   """Shows given PCollections in an interactive exploratory way if used within
   a notebook, or prints a heading sampled data if used within an ipython shell.

--- a/sdks/python/apache_beam/runners/interactive/options/capture_control.py
+++ b/sdks/python/apache_beam/runners/interactive/options/capture_control.py
@@ -46,7 +46,7 @@ class CaptureControl(object):
     self._test_limiters = None
 
   def limiters(self):
-    # type: () -> List[capture_limiters.Limiter]
+    # type: () -> List[capture_limiters.Limiter] # noqa: F821
     if self._test_limiters:
       return self._test_limiters
     return [
@@ -55,7 +55,7 @@ class CaptureControl(object):
     ]
 
   def set_limiters_for_test(self, limiters):
-    # type: (List[capture_limiters.Limiter]) -> None
+    # type: (List[capture_limiters.Limiter]) -> None # noqa: F821
     self._test_limiters = limiters
 
 

--- a/sdks/python/apache_beam/runners/interactive/options/capture_limiters.py
+++ b/sdks/python/apache_beam/runners/interactive/options/capture_limiters.py
@@ -44,7 +44,7 @@ class ElementLimiter(Limiter):
   element.
   """
   def update(self, e):
-    # type: (Any) -> None
+    # type: (Any) -> None # noqa: F821
 
     """Update the internal state based on some property of an element.
 
@@ -75,7 +75,7 @@ class DurationLimiter(Limiter):
   """Limits the duration of the capture."""
   def __init__(
       self,
-      duration_limit  # type: datetime.timedelta
+      duration_limit  # type: datetime.timedelta # noqa: F821
   ):
     self._duration_limit = duration_limit
     self._timer = threading.Timer(duration_limit.total_seconds(), self._trigger)

--- a/sdks/python/apache_beam/runners/interactive/recording_manager.py
+++ b/sdks/python/apache_beam/runners/interactive/recording_manager.py
@@ -85,19 +85,19 @@ class ElementStream:
     return utils.obfuscate(self._cache_key, suffix)
 
   def is_computed(self):
-    # type: () -> boolean
+    # type: () -> boolean # noqa: F821
 
     """Returns True if no more elements will be recorded."""
     return self._pcoll in ie.current_env().computed_pcollections
 
   def is_done(self):
-    # type: () -> boolean
+    # type: () -> boolean # noqa: F821
 
     """Returns True if no more new elements will be yielded."""
     return self._done
 
   def read(self, tail=True):
-    # type: (boolean) -> Any
+    # type: (boolean) -> Any # noqa: F821
 
     """Reads the elements currently recorded."""
 
@@ -155,7 +155,7 @@ class Recording:
   def __init__(
       self,
       user_pipeline,  # type: beam.Pipeline
-      pcolls,  # type: List[beam.pvalue.PCollection]
+      pcolls,  # type: List[beam.pvalue.PCollection] # noqa: F821
       result,  # type: beam.runner.PipelineResult
       max_n,  # type: int
       max_duration_secs,  # type: float
@@ -217,7 +217,7 @@ class Recording:
       ie.current_env().mark_pcollection_computed(self._pcolls)
 
   def is_computed(self):
-    # type: () -> boolean
+    # type: () -> boolean # noqa: F821
 
     """Returns True if all PCollections are computed."""
     return all(s.is_computed() for s in self._streams.values())
@@ -275,7 +275,7 @@ class Recording:
 class RecordingManager:
   """Manages recordings of PCollections for a given pipeline."""
   def __init__(self, user_pipeline, pipeline_var=None, test_limiters=None):
-    # type: (beam.Pipeline, str, list[Limiter]) -> None
+    # type: (beam.Pipeline, str, list[Limiter]) -> None # noqa: F821
 
     self.user_pipeline = user_pipeline  # type: beam.Pipeline
     self.pipeline_var = pipeline_var if pipeline_var else ''  # type: str
@@ -284,7 +284,7 @@ class RecordingManager:
     self._test_limiters = test_limiters if test_limiters else []
 
   def _watch(self, pcolls):
-    # type: (List[beam.pvalue.PCollection]) -> None
+    # type: (List[beam.pvalue.PCollection]) -> None # noqa: F821
 
     """Watch any pcollections not being watched.
 
@@ -413,7 +413,7 @@ class RecordingManager:
     return False
 
   def record(self, pcolls, max_n, max_duration):
-    # type: (List[beam.pvalue.PCollection], int, Union[int,str]) -> Recording
+    # type: (List[beam.pvalue.PCollection], int, Union[int,str]) -> Recording # noqa: F821
 
     """Records the given PCollections."""
 
@@ -470,7 +470,7 @@ class RecordingManager:
     return recording
 
   def read(self, pcoll_name, pcoll, max_n, max_duration_secs):
-    # type: (str, beam.pvalue.PValue, int, float) -> Union[None, ElementStream]
+    # type: (str, beam.pvalue.PValue, int, float) -> Union[None, ElementStream] # noqa: F821
 
     """Reads an ElementStream of a computed PCollection.
 

--- a/sdks/python/apache_beam/runners/interactive/utils.py
+++ b/sdks/python/apache_beam/runners/interactive/utils.py
@@ -56,13 +56,13 @@ _INTERACTIVE_LOG_STYLE = """
 
 
 def to_element_list(
-    reader,  # type: Generator[Union[beam_runner_api_pb2.TestStreamPayload.Event, WindowedValueHolder]]
-    coder,  # type: Coder
+    reader,  # type: Generator[Union[beam_runner_api_pb2.TestStreamPayload.Event, WindowedValueHolder]] # noqa: F821
+    coder,  # type: Coder # noqa: F821
     include_window_info,  # type: bool
     n=None,  # type: int
     include_time_events=False, # type: bool
 ):
-  # type: (...) -> List[WindowedValue]
+  # type: (...) -> List[WindowedValue] # noqa: F821
 
   """Returns an iterator that properly decodes the elements from the reader.
   """
@@ -102,7 +102,7 @@ def to_element_list(
 
 
 def elements_to_df(elements, include_window_info=False, element_type=None):
-  # type: (List[WindowedValue], bool, Any) -> DataFrame
+  # type: (List[WindowedValue], bool, Any) -> DataFrame # noqa: F821
 
   """Parses the given elements into a Dataframe.
 
@@ -267,7 +267,7 @@ class ProgressIndicator(object):
 
 
 def progress_indicated(func):
-  # type: (Callable[..., Any]) -> Callable[..., Any]
+  # type: (Callable[..., Any]) -> Callable[..., Any] # noqa: F821
 
   """A decorator using a unique progress indicator as a context manager to
   execute the given function within."""
@@ -280,7 +280,7 @@ def progress_indicated(func):
 
 
 def as_json(func):
-  # type: (Callable[..., Any]) -> Callable[..., str]
+  # type: (Callable[..., Any]) -> Callable[..., str] # noqa: F821
 
   """A decorator convert python objects returned by callables to json
   string.

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/watermark_manager.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/watermark_manager.py
@@ -190,11 +190,11 @@ class WatermarkManager(object):
             'At least one main input is necessary.' % s.name)
 
   def get_stage_node(self, name):
-    # type: (str) -> StageNode
+    # type: (str) -> StageNode # noqa: F821
     return self._stages_by_name[name]
 
   def get_pcoll_node(self, name):
-    # type: (str) -> PCollectionNode
+    # type: (str) -> PCollectionNode # noqa: F821
     return self._pcollections_by_name[name]
 
   def set_pcoll_watermark(self, name, watermark):

--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -1889,7 +1889,7 @@ def create_merge_windows(
       original_windows = set(windows)  # type: Set[window.BoundedWindow]
       merged_windows = collections.defaultdict(
           set
-      )  # type: MutableMapping[window.BoundedWindow, Set[window.BoundedWindow]]
+      )  # type: MutableMapping[window.BoundedWindow, Set[window.BoundedWindow]] # noqa: F821
 
       class RecordingMergeContext(window.WindowFn.MergeContext):
         def merge(

--- a/sdks/python/apache_beam/transforms/window.py
+++ b/sdks/python/apache_beam/transforms/window.py
@@ -133,7 +133,7 @@ class WindowFn(urns.RunnerApiFn, metaclass=abc.ABCMeta):
 
   @abc.abstractmethod
   def assign(self, assign_context):
-    # type: (AssignContext) -> Iterable[BoundedWindow]
+    # type: (AssignContext) -> Iterable[BoundedWindow] # noqa: F821
 
     """Associates windows to an element.
 

--- a/sdks/python/apache_beam/typehints/decorators.py
+++ b/sdks/python/apache_beam/typehints/decorators.py
@@ -348,7 +348,7 @@ class IOTypeHints(NamedTuple):
       my_type,            # type: any
       has_my_type,        # type: Callable[[], bool]
       my_key,             # type: str
-      special_containers,   # type: List[Union[PBegin, PDone, PCollection]]
+      special_containers,   # type: List[Union[PBegin, PDone, PCollection]] # noqa: F821
       error_str,          # type: str
       source_str          # type: str
       ):

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -151,7 +151,7 @@ _BEAM_SCHEMA_ID = "_beam_schema_id"
 
 
 def named_fields_to_schema(names_and_types):
-  # type: (Union[Dict[str, type], Sequence[Tuple[str, type]]]) -> schema_pb2.Schema
+  # type: (Union[Dict[str, type], Sequence[Tuple[str, type]]]) -> schema_pb2.Schema # noqa: F821
   if isinstance(names_and_types, dict):
     names_and_types = names_and_types.items()
   return schema_pb2.Schema(

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -111,7 +111,7 @@ setenv =
 deps =
   -r build-requirements.txt
   astroid<2.9,>=2.8.0
-  pycodestyle==2.3.1
+  pycodestyle==2.8.0
   pylint==2.11.1
   isort==4.2.15
   flake8==4.0.1

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -114,7 +114,7 @@ deps =
   pycodestyle==2.3.1
   pylint==2.11.1
   isort==4.2.15
-  flake8==3.5.0
+  flake8==4.0.1
 commands =
   pylint --version
   time {toxinidir}/scripts/run_pylint.sh


### PR DESCRIPTION
Upgrade flake8 from 3.5.0 to 4.0.1. Also upgrades dependency pycodestyle. This introduces some new `F821 undefined name` errors for unimported typehints in type comments. f3ef96b3e4f362601968ef2bdf17b61664024880 resovles by adding `noqa` comments as needed.

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
