### PR TITLE
Include ffmpeg in Python SDK Docker images

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,6 +63,7 @@
 ## New Features / Improvements
 
 * X feature added (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
+* Prebuilt Python SDK Docker image now includes ffmpeg and tensorflow_datasets by default for creating audio & video datasets
 
 ## Breaking Changes
 

--- a/sdks/python/container/Dockerfile
+++ b/sdks/python/container/Dockerfile
@@ -29,6 +29,8 @@ RUN apt-get update && \
        libyaml-dev \
        # This is used to speed up the re-installation of the sdk.
        ccache \
+       # Required by tensorflow_datasets for decoding audio/video
+       ffmpeg \
        && \
     rm -rf /var/lib/apt/lists/*
 

--- a/sdks/python/container/base_image_requirements_manual.txt
+++ b/sdks/python/container/base_image_requirements_manual.txt
@@ -41,3 +41,4 @@ python-snappy  # Optimzes execution of some Beam codepaths.
 scipy
 scikit-learn
 tensorflow
+tensorflow_datasets


### PR DESCRIPTION
## Background
https://github.com/tensorflow/datasets lets users create versioned datasets for training machine learning (ML) models on raw multimedia data (text, images, audio, video), and [it integrates wonderfully with Beam](https://www.tensorflow.org/datasets/beam_datasets) (and Dataflow).

## Problem
A current pain point in the user journey is that in order to use `tfds.features.Audio` or `tfds.features.Video`, the worker runtime has to have `ffmpeg` available which means that `setup.py` hackery (with `apt-get` commands within it), or prebuilding your own image with e.g. Google Cloud Build is necessary. This significantly worsens the UX for ML engineers who expect that a requirements.txt mentioning `librosa` and `apache_beam` should suffice. Frustrations are especially exacerbated by the fact that DirectRunner development usually just works (since many have `ffmpeg` or equivalent on their development machines), and that these issues surface quite late at runtime.

## Solution?
Thus, I'm curious if we couldn't just include `ffmpeg` in Beam's Docker Hub hosted images, with the goal of making it easier to create large audio and video datasets. Thoughts?

## Examples of user journeys
- https://stackoverflow.com/questions/55581449/installing-ffmpeg-package-from-setup-py-in-apache-beam-pipeline-running-on-goo
- https://stackoverflow.com/questions/45494952/reading-video-during-cloud-dataflow-using-gcsfuse-download-locally-or-write-n
- https://stackoverflow.com/questions/35321113/can-google-cloud-dataflow-apache-beam-use-ffmpeg-to-process-video-or-image-dat
- https://stackoverflow.com/questions/56996028/google-cloud-dataflow-dependencies
- https://stackoverflow.com/questions/45124289/posthoc-connect-ffmpeg-to-opencv-python-binary-for-google-cloud-dataflow-job
- https://lists.apache.org/thread/jhgfb2o3c7ms4mg1qlsgqh470nltoosj :wave: 
