### PR TITLE
Add `schema_options` and `field_options` on RowTypeConstraint

### DIFF
--- a/sdks/python/apache_beam/typehints/row_type.py
+++ b/sdks/python/apache_beam/typehints/row_type.py
@@ -31,9 +31,21 @@ from apache_beam.typehints.native_type_compatibility import match_is_named_tuple
 # the corresponding schema ID
 _BEAM_SCHEMA_ID = "_beam_schema_id"
 
+from collections import defaultdict
+from typing import Any
+from typing import List
+from typing import Dict
+from typing import Optional
+from typing import Tuple
+
 
 class RowTypeConstraint(typehints.TypeConstraint):
-  def __init__(self, fields: List[Tuple[str, type]], user_type=None):
+  def __init__(
+      self,
+      fields: List[Tuple[str, type]],
+      user_type=None,
+      schema_options: Optional[List[Tuple[str, Any]]] = None,
+      field_options: Optional[Dict[str, List[Tuple[str, Any]]]] = None):
     """For internal use only, no backwards comatibility guaratees.  See
     https://beam.apache.org/documentation/programming-guide/#schemas-for-pl-types
     for guidance on creating PCollections with inferred schemas.
@@ -60,6 +72,11 @@ class RowTypeConstraint(typehints.TypeConstraint):
         from user_type.
       user_type: constructor for a user type (e.g. NamedTuple class) that is
         used to represent this schema in user code.
+      schema_options: A list of (key, value) tuples representing schema-level
+        options.
+      field_options: A dictionary representing field-level options. Dictionary
+        keys are field names, and dictionary values are lists of (key, value)
+        tuples representing field-level options for that field.
     """
     # Recursively wrap row types in a RowTypeConstraint
     self._fields = tuple((name, RowTypeConstraint.from_user_type(typ) or typ)
@@ -76,13 +93,26 @@ class RowTypeConstraint(typehints.TypeConstraint):
     else:
       self._schema_id = None
 
+    self._schema_options = schema_options or []
+    self._field_options = field_options or {}
+
   @staticmethod
-  def from_user_type(user_type: type) -> Optional[RowTypeConstraint]:
+  def from_user_type(
+      user_type: type,
+      schema_options: Optional[List[Tuple[str, Any]]] = None,
+      field_options: Optional[Dict[str, List[Tuple[str, Any]]]] = None
+  ) -> Optional[RowTypeConstraint]:
     if match_is_named_tuple(user_type):
       fields = [(name, user_type.__annotations__[name])
                 for name in user_type._fields]
 
-      return RowTypeConstraint(fields=fields, user_type=user_type)
+      # TODO(https://github.com/apache/beam/issues/22125): Add user API for
+      # specifying schema/field options
+      return RowTypeConstraint(
+          fields=fields,
+          user_type=user_type,
+          schema_options=schema_options,
+          field_options=field_options)
 
     return None
 
@@ -102,6 +132,14 @@ class RowTypeConstraint(typehints.TypeConstraint):
   @property
   def schema_id(self):
     return self._schema_id
+
+  @property
+  def schema_options(self):
+    return self._schema_options
+
+  def field_options(self, field_name):
+    # Raise if field_name is not one of the fields?
+    return self._field_options.get(field_name, [])
 
   def _consistent_with_check_(self, sub):
     return self == sub

--- a/sdks/python/apache_beam/typehints/row_type.py
+++ b/sdks/python/apache_beam/typehints/row_type.py
@@ -19,6 +19,8 @@
 
 from __future__ import annotations
 
+from typing import Any
+from typing import Dict
 from typing import List
 from typing import Optional
 from typing import Sequence
@@ -30,13 +32,6 @@ from apache_beam.typehints.native_type_compatibility import match_is_named_tuple
 # Name of the attribute added to user types (existing and generated) to store
 # the corresponding schema ID
 _BEAM_SCHEMA_ID = "_beam_schema_id"
-
-from collections import defaultdict
-from typing import Any
-from typing import List
-from typing import Dict
-from typing import Optional
-from typing import Tuple
 
 
 class RowTypeConstraint(typehints.TypeConstraint):

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -204,10 +204,20 @@ class SchemaTranslation(object):
         schema = schema_pb2.Schema(
             fields=[
                 schema_pb2.Field(
-                    name=name, type=self.typing_to_runner_api(field_type))
-                for (name, field_type) in type_._fields
+                    name=field_name,
+                    type=self.typing_to_runner_api(field_type),
+                    options=[
+                        self.option_to_runner_api(option_tuple)
+                        for option_tuple in type_.field_options(field_name)
+                    ],
+                ) for (field_name, field_type) in type_._fields
             ],
-            id=schema_id)
+            id=schema_id,
+            options=[
+                self.option_to_runner_api(option_tuple)
+                for option_tuple in type_.schema_options
+            ],
+        )
         self.schema_registry.add(type_.user_type, schema)
       return schema_pb2.FieldType(row_type=schema_pb2.RowType(schema=schema))
     else:
@@ -260,6 +270,86 @@ class SchemaTranslation(object):
               representation=self.typing_to_runner_api(
                   logical_type.representation_type())))
 
+  def option_from_runner_api(
+      self, option_proto: schema_pb2.Option) -> Tuple[str, Any]:
+    if not option_proto.HasField('type'):
+      return option_proto.name, None
+
+    fieldtype_proto = option_proto.type
+    if not fieldtype_proto.WhichOneof("type_info") == "atomic_type":
+      raise ValueError(
+          "Encounterd option with unsupported type. Only "
+          f"atomic_type options are supported: {option_proto}")
+
+    if fieldtype_proto.atomic_type == schema_pb2.BYTE:
+      value = np.int8(option_proto.value.atomic_value.byte)
+    elif fieldtype_proto.atomic_type == schema_pb2.INT16:
+      value = np.int16(option_proto.value.atomic_value.int16)
+    elif fieldtype_proto.atomic_type == schema_pb2.INT32:
+      value = np.int32(option_proto.value.atomic_value.int32)
+    elif fieldtype_proto.atomic_type == schema_pb2.INT64:
+      value = np.int64(option_proto.value.atomic_value.int64)
+    elif fieldtype_proto.atomic_type == schema_pb2.FLOAT:
+      value = np.float32(option_proto.value.atomic_value.float)
+    elif fieldtype_proto.atomic_type == schema_pb2.DOUBLE:
+      value = np.float64(option_proto.value.atomic_value.double)
+    elif fieldtype_proto.atomic_type == schema_pb2.STRING:
+      value = option_proto.value.atomic_value.string
+    elif fieldtype_proto.atomic_type == schema_pb2.BOOLEAN:
+      value = option_proto.value.atomic_value.boolean
+    elif fieldtype_proto.atomic_type == schema_pb2.BYTES:
+      value = option_proto.value.atomic_value.bytes
+    else:
+      raise ValueError(
+          "Unrecognized atomic_type ({fieldtype_proto.atomic_type}) "
+          "when decoding option {option_proto!r}")
+
+    return option_proto.name, value
+
+  def option_to_runner_api(self, option: Tuple[str, Any]) -> schema_pb2.Option:
+    name, value = option
+
+    if value is None:
+      # a value of None indicates the option is just a flag.
+      # Don't set type, value
+      return schema_pb2.Option(name=name)
+
+    fieldtype_proto = self.typing_to_runner_api(type(value))
+    if not fieldtype_proto.WhichOneof("type_info") == "atomic_type":
+      # TODO: Allow other value types
+      raise ValueError(
+          "Only atomic_type option values are currently supported in Python. "
+          f"Got {value!r}, which maps to fieldtype {fieldtype_proto!r}.")
+
+    if fieldtype_proto.atomic_type == schema_pb2.BYTE:
+      atomictypevalue_proto = schema_pb2.AtomicTypeValue(byte=value)
+    elif fieldtype_proto.atomic_type == schema_pb2.INT16:
+      atomictypevalue_proto = schema_pb2.AtomicTypeValue(int16=value)
+    elif fieldtype_proto.atomic_type == schema_pb2.INT32:
+      atomictypevalue_proto = schema_pb2.AtomicTypeValue(int32=value)
+    elif fieldtype_proto.atomic_type == schema_pb2.INT64:
+      atomictypevalue_proto = schema_pb2.AtomicTypeValue(int64=value)
+    elif fieldtype_proto.atomic_type == schema_pb2.FLOAT:
+      atomictypevalue_proto = schema_pb2.AtomicTypeValue(float=value)
+    elif fieldtype_proto.atomic_type == schema_pb2.DOUBLE:
+      atomictypevalue_proto = schema_pb2.AtomicTypeValue(double=value)
+    elif fieldtype_proto.atomic_type == schema_pb2.STRING:
+      atomictypevalue_proto = schema_pb2.AtomicTypeValue(string=value)
+    elif fieldtype_proto.atomic_type == schema_pb2.BOOLEAN:
+      atomictypevalue_proto = schema_pb2.AtomicTypeValue(boolean=value)
+    elif fieldtype_proto.atomic_type == schema_pb2.BYTES:
+      atomictypevalue_proto = schema_pb2.AtomicTypeValue(bytes=value)
+    else:
+      raise ValueError(
+          "Unrecognized atomic_type in fieldtype_proto="
+          f"{fieldtype_proto!r} when encoding option {option!r}")
+
+    return schema_pb2.Option(
+        name=name,
+        type=fieldtype_proto,
+        value=schema_pb2.FieldValue(atomic_value=atomictypevalue_proto),
+    )
+
   def typing_from_runner_api(
       self, fieldtype_proto: schema_pb2.FieldType) -> type:
     if fieldtype_proto.nullable:
@@ -290,6 +380,17 @@ class SchemaTranslation(object):
           self.typing_from_runner_api(fieldtype_proto.map_type.value_type)]
     elif type_info == "row_type":
       schema = fieldtype_proto.row_type.schema
+      schema_options = [
+          self.option_from_runner_api(option_proto)
+          for option_proto in schema.options
+      ]
+      field_options = {
+          field.name: [
+              self.option_from_runner_api(option_proto)
+              for option_proto in field.options
+          ]
+          for field in schema.fields if field.options
+      }
       # First look for user type in the registry
       user_type = self.schema_registry.get_typing_by_id(schema.id)
 
@@ -326,11 +427,17 @@ class SchemaTranslation(object):
 
         self.schema_registry.add(user_type, schema)
         coders.registry.register_coder(user_type, coders.RowCoder)
-        result = row_type.RowTypeConstraint.from_user_type(user_type)
+        result = row_type.RowTypeConstraint.from_user_type(
+            user_type,
+            schema_options=schema_options,
+            field_options=field_options)
         result.set_schema_id(schema.id)
         return result
       else:
-        return row_type.RowTypeConstraint.from_user_type(user_type)
+        return row_type.RowTypeConstraint.from_user_type(
+            user_type,
+            schema_options=schema_options,
+            field_options=field_options)
 
     elif type_info == "logical_type":
       if fieldtype_proto.logical_type.urn == PYTHON_ANY_URN:

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -276,7 +276,7 @@ class SchemaTranslation(object):
       return option_proto.name, None
 
     fieldtype_proto = option_proto.type
-    if not fieldtype_proto.WhichOneof("type_info") == "atomic_type":
+    if fieldtype_proto.WhichOneof("type_info") != "atomic_type":
       raise ValueError(
           "Encounterd option with unsupported type. Only "
           f"atomic_type options are supported: {option_proto}")
@@ -301,8 +301,8 @@ class SchemaTranslation(object):
       value = option_proto.value.atomic_value.bytes
     else:
       raise ValueError(
-          "Unrecognized atomic_type ({fieldtype_proto.atomic_type}) "
-          "when decoding option {option_proto!r}")
+          f"Unrecognized atomic_type ({fieldtype_proto.atomic_type}) "
+          f"when decoding option {option_proto!r}")
 
     return option_proto.name, value
 
@@ -315,7 +315,7 @@ class SchemaTranslation(object):
       return schema_pb2.Option(name=name)
 
     fieldtype_proto = self.typing_to_runner_api(type(value))
-    if not fieldtype_proto.WhichOneof("type_info") == "atomic_type":
+    if fieldtype_proto.WhichOneof("type_info") != "atomic_type":
       # TODO: Allow other value types
       raise ValueError(
           "Only atomic_type option values are currently supported in Python. "

--- a/sdks/python/apache_beam/typehints/schemas_test.py
+++ b/sdks/python/apache_beam/typehints/schemas_test.py
@@ -97,6 +97,140 @@ class ComplexSchema(NamedTuple):
   timestamp: Timestamp
 
 
+def get_test_beam_fieldtype_protos():
+  all_nonoptional_primitives = [
+      schema_pb2.FieldType(atomic_type=typ)
+      for typ in schema_pb2.AtomicType.values()
+      if typ is not schema_pb2.UNSPECIFIED
+  ]
+
+  all_optional_primitives = [
+      schema_pb2.FieldType(nullable=True, atomic_type=typ)
+      for typ in schema_pb2.AtomicType.values()
+      if typ is not schema_pb2.UNSPECIFIED
+  ]
+
+  all_primitives = all_nonoptional_primitives + all_optional_primitives
+
+  basic_array_types = [
+      schema_pb2.FieldType(array_type=schema_pb2.ArrayType(element_type=typ))
+      for typ in all_primitives
+  ]
+
+  basic_map_types = [
+      schema_pb2.FieldType(
+          map_type=schema_pb2.MapType(key_type=key_type, value_type=value_type))
+      for key_type,
+      value_type in itertools.product(all_primitives, all_primitives)
+  ]
+
+  selected_schemas = [
+      schema_pb2.FieldType(
+          row_type=schema_pb2.RowType(
+              schema=schema_pb2.Schema(
+                  id='32497414-85e8-46b7-9c90-9a9cc62fe390',
+                  fields=[
+                      schema_pb2.Field(name='field%d' % i, type=typ) for i,
+                      typ in enumerate(all_primitives)
+                  ]))),
+      schema_pb2.FieldType(
+          row_type=schema_pb2.RowType(
+              schema=schema_pb2.Schema(
+                  id='dead1637-3204-4bcb-acf8-99675f338600',
+                  fields=[
+                      schema_pb2.Field(
+                          name='id',
+                          type=schema_pb2.FieldType(
+                              atomic_type=schema_pb2.INT64)),
+                      schema_pb2.Field(
+                          name='name',
+                          type=schema_pb2.FieldType(
+                              atomic_type=schema_pb2.STRING)),
+                      schema_pb2.Field(
+                          name='optional_map',
+                          type=schema_pb2.FieldType(
+                              nullable=True,
+                              map_type=schema_pb2.MapType(
+                                  key_type=schema_pb2.FieldType(
+                                      atomic_type=schema_pb2.STRING),
+                                  value_type=schema_pb2.FieldType(
+                                      atomic_type=schema_pb2.DOUBLE)))),
+                      schema_pb2.Field(
+                          name='optional_array',
+                          type=schema_pb2.FieldType(
+                              nullable=True,
+                              array_type=schema_pb2.ArrayType(
+                                  element_type=schema_pb2.FieldType(
+                                      atomic_type=schema_pb2.FLOAT)))),
+                      schema_pb2.Field(
+                          name='array_optional',
+                          type=schema_pb2.FieldType(
+                              array_type=schema_pb2.ArrayType(
+                                  element_type=schema_pb2.FieldType(
+                                      nullable=True,
+                                      atomic_type=schema_pb2.BYTES)))),
+                  ]))),
+      schema_pb2.FieldType(
+          row_type=schema_pb2.RowType(
+              schema=schema_pb2.Schema(
+                  id='a-schema-with-options',
+                  fields=[
+                      schema_pb2.Field(name='field%d' % i, type=typ) for i,
+                      typ in enumerate(all_primitives)
+                  ],
+                  options=[
+                      schema_pb2.Option(
+                          name='some_metadata',
+                          type=schema_pb2.FieldType(
+                              atomic_type=schema_pb2.STRING),
+                          value=schema_pb2.FieldValue(
+                              atomic_value=schema_pb2.AtomicTypeValue(
+                                  string='foo'))),
+                      schema_pb2.Option(
+                          name='an_integer_option',
+                          type=schema_pb2.FieldType(
+                              atomic_type=schema_pb2.INT32),
+                          value=schema_pb2.FieldValue(
+                              atomic_value=schema_pb2.AtomicTypeValue(
+                                  int32=123456))),
+                      schema_pb2.Option(name='a_flag',
+                                        )
+                  ]))),
+      schema_pb2.FieldType(
+          row_type=schema_pb2.RowType(
+              schema=schema_pb2.Schema(
+                  id='a-schema-with-field-options',
+                  fields=[
+                      schema_pb2.Field(
+                          name='field%d' % i,
+                          type=typ,
+                          options=[
+                              schema_pb2.Option(
+                                  name='some_metadata',
+                                  type=schema_pb2.FieldType(
+                                      atomic_type=schema_pb2.STRING),
+                                  value=schema_pb2.FieldValue(
+                                      atomic_value=schema_pb2.AtomicTypeValue(
+                                          string='foo'))),
+                              schema_pb2.Option(name='a_flag')
+                          ]) for i,
+                      typ in enumerate(all_primitives)
+                  ]))),
+  ]
+
+  return all_primitives + \
+      basic_array_types + \
+      basic_map_types + \
+      selected_schemas
+
+
+def get_test_beam_schemas_protos():
+  return [
+      fieldtype.row_type.schema for fieldtype in get_test_beam_fieldtype_protos()
+      if fieldtype.WhichOneof('type_info') == 'row_type'
+  ]
+
+
 class SchemaTest(unittest.TestCase):
   """ Tests for Runner API Schema proto to/from typing conversions
 
@@ -127,6 +261,104 @@ class SchemaTest(unittest.TestCase):
     self.assertIsInstance(roundtripped, row_type.RowTypeConstraint)
     self.assert_namedtuple_equivalent(roundtripped.user_type, user_type)
 
+  def test_row_type_constraint_to_schema(self):
+    result_type = typing_to_runner_api(
+        row_type.RowTypeConstraint([
+            ('foo', np.int8),
+            ('bar', float),
+            ('baz', bytes),
+        ]))
+
+    self.assertIsInstance(result_type, schema_pb2.FieldType)
+    self.assertEqual(result_type.WhichOneof("type_info"), "row_type")
+
+    schema = result_type.row_type.schema
+
+    self.assertIsNotNone(schema.id)
+    expected = [
+        schema_pb2.Field(
+            name='foo', type=schema_pb2.FieldType(atomic_type=schema_pb2.BYTE)),
+        schema_pb2.Field(
+            name='bar',
+            type=schema_pb2.FieldType(atomic_type=schema_pb2.DOUBLE)),
+        schema_pb2.Field(
+            name='baz',
+            type=schema_pb2.FieldType(atomic_type=schema_pb2.BYTES)),
+    ]
+    self.assertEqual(list(schema.fields), expected)
+
+  def test_row_type_constraint_to_schema_with_options(self):
+    row_type_with_options = row_type.RowTypeConstraint(
+        [
+            ('foo', np.int8),
+            ('bar', float),
+            ('baz', bytes),
+        ],
+        schema_options=[
+            ('some_metadata', 'foo'),
+            ('some_other_metadata', 'baz'),
+            ('some_metadata', 'bar'),
+            ('an_integer_option', np.int32(123456)),
+        ])
+    result_type = typing_to_runner_api(row_type_with_options)
+
+    self.assertIsInstance(result_type, schema_pb2.FieldType)
+    self.assertEqual(result_type.WhichOneof("type_info"), "row_type")
+
+    schema = result_type.row_type.schema
+
+    expected = [
+        schema_pb2.Option(
+            name='some_metadata',
+            type=schema_pb2.FieldType(atomic_type=schema_pb2.STRING),
+            value=schema_pb2.FieldValue(
+                atomic_value=schema_pb2.AtomicTypeValue(string='foo'))),
+        schema_pb2.Option(
+            name='some_other_metadata',
+            type=schema_pb2.FieldType(atomic_type=schema_pb2.STRING),
+            value=schema_pb2.FieldValue(
+                atomic_value=schema_pb2.AtomicTypeValue(string='baz'))),
+        schema_pb2.Option(
+            name='some_metadata',
+            type=schema_pb2.FieldType(atomic_type=schema_pb2.STRING),
+            value=schema_pb2.FieldValue(
+                atomic_value=schema_pb2.AtomicTypeValue(string='bar'))),
+        schema_pb2.Option(
+            name='an_integer_option',
+            type=schema_pb2.FieldType(atomic_type=schema_pb2.INT32),
+            value=schema_pb2.FieldValue(
+                atomic_value=schema_pb2.AtomicTypeValue(int32=123456))),
+    ]
+    self.assertEqual(list(schema.options), expected)
+
+  def test_row_type_constraint_to_schema_with_field_options(self):
+    result_type = typing_to_runner_api(
+        row_type.RowTypeConstraint([
+            ('foo', np.int8),
+            ('bar', float),
+            ('baz', bytes),
+        ],
+                                   field_options={
+                                       'foo': [('some_metadata', 123),
+                                               ('some_flag', None)]
+                                   }))
+
+    self.assertIsInstance(result_type, schema_pb2.FieldType)
+    self.assertEqual(result_type.WhichOneof("type_info"), "row_type")
+
+    field = result_type.row_type.schema.fields[0]
+
+    expected = [
+        schema_pb2.Option(
+            name='some_metadata',
+            type=schema_pb2.FieldType(atomic_type=schema_pb2.INT64),
+            value=schema_pb2.FieldValue(
+                atomic_value=schema_pb2.AtomicTypeValue(int64=123)),
+        ),
+        schema_pb2.Option(name='some_flag')
+    ]
+    self.assertEqual(list(field.options), expected)
+
   def assert_namedtuple_equivalent(self, actual, expected):
     # Two types are only considered equal if they are literally the same
     # object (i.e. `actual == expected` is the same as `actual is expected` in
@@ -149,93 +381,14 @@ class SchemaTest(unittest.TestCase):
     #for attr in dir(expected):
     #  self.assertEqual(getattr(actual, attr), getattr(expected, attr))
 
-  def test_proto_survives_typing_roundtrip(self):
-    all_nonoptional_primitives = [
-        schema_pb2.FieldType(atomic_type=typ)
-        for typ in schema_pb2.AtomicType.values()
-        if typ is not schema_pb2.UNSPECIFIED
-    ]
-
-    all_optional_primitives = [
-        schema_pb2.FieldType(nullable=True, atomic_type=typ)
-        for typ in schema_pb2.AtomicType.values()
-        if typ is not schema_pb2.UNSPECIFIED
-    ]
-
-    all_primitives = all_nonoptional_primitives + all_optional_primitives
-
-    basic_array_types = [
-        schema_pb2.FieldType(array_type=schema_pb2.ArrayType(element_type=typ))
-        for typ in all_primitives
-    ]
-
-    basic_map_types = [
-        schema_pb2.FieldType(
-            map_type=schema_pb2.MapType(
-                key_type=key_type, value_type=value_type)) for key_type,
-        value_type in itertools.product(all_primitives, all_primitives)
-    ]
-
-    selected_schemas = [
-        schema_pb2.FieldType(
-            row_type=schema_pb2.RowType(
-                schema=schema_pb2.Schema(
-                    id='32497414-85e8-46b7-9c90-9a9cc62fe390',
-                    fields=[
-                        schema_pb2.Field(name='field%d' % i, type=typ) for i,
-                        typ in enumerate(all_primitives)
-                    ]))),
-        schema_pb2.FieldType(
-            row_type=schema_pb2.RowType(
-                schema=schema_pb2.Schema(
-                    id='dead1637-3204-4bcb-acf8-99675f338600',
-                    fields=[
-                        schema_pb2.Field(
-                            name='id',
-                            type=schema_pb2.FieldType(
-                                atomic_type=schema_pb2.INT64)),
-                        schema_pb2.Field(
-                            name='name',
-                            type=schema_pb2.FieldType(
-                                atomic_type=schema_pb2.STRING)),
-                        schema_pb2.Field(
-                            name='optional_map',
-                            type=schema_pb2.FieldType(
-                                nullable=True,
-                                map_type=schema_pb2.MapType(
-                                    key_type=schema_pb2.FieldType(
-                                        atomic_type=schema_pb2.STRING),
-                                    value_type=schema_pb2.FieldType(
-                                        atomic_type=schema_pb2.DOUBLE)))),
-                        schema_pb2.Field(
-                            name='optional_array',
-                            type=schema_pb2.FieldType(
-                                nullable=True,
-                                array_type=schema_pb2.ArrayType(
-                                    element_type=schema_pb2.FieldType(
-                                        atomic_type=schema_pb2.FLOAT)))),
-                        schema_pb2.Field(
-                            name='array_optional',
-                            type=schema_pb2.FieldType(
-                                array_type=schema_pb2.ArrayType(
-                                    element_type=schema_pb2.FieldType(
-                                        nullable=True,
-                                        atomic_type=schema_pb2.BYTES)))),
-                    ]))),
-    ]
-
-    test_cases = all_primitives + \
-                 basic_array_types + \
-                 basic_map_types + \
-                 selected_schemas
-
-    for test_case in test_cases:
-      self.assertEqual(
-          test_case,
-          typing_to_runner_api(
-              typing_from_runner_api(
-                  test_case, schema_registry=SchemaTypeRegistry()),
-              schema_registry=SchemaTypeRegistry()))
+  @parameterized.expand([(fieldtype_proto,) for fieldtype_proto in get_test_beam_fieldtype_protos()])
+  def test_proto_survives_typing_roundtrip(self, fieldtype_proto):
+    self.assertEqual(
+        fieldtype_proto,
+        typing_to_runner_api(
+            typing_from_runner_api(
+                fieldtype_proto, schema_registry=SchemaTypeRegistry()),
+            schema_registry=SchemaTypeRegistry()))
 
   def test_unknown_primitive_maps_to_any(self):
     self.assertEqual(

--- a/sdks/python/apache_beam/typehints/schemas_test.py
+++ b/sdks/python/apache_beam/typehints/schemas_test.py
@@ -179,22 +179,70 @@ def get_test_beam_fieldtype_protos():
                       typ in enumerate(all_primitives)
                   ],
                   options=[
+                      schema_pb2.Option(name='a_flag'),
                       schema_pb2.Option(
-                          name='some_metadata',
+                          name='a_byte',
                           type=schema_pb2.FieldType(
-                              atomic_type=schema_pb2.STRING),
+                              atomic_type=schema_pb2.BYTE),
                           value=schema_pb2.FieldValue(
                               atomic_value=schema_pb2.AtomicTypeValue(
-                                  string='foo'))),
+                                  byte=127))),
                       schema_pb2.Option(
-                          name='an_integer_option',
+                          name='a_int16',
+                          type=schema_pb2.FieldType(
+                              atomic_type=schema_pb2.INT16),
+                          value=schema_pb2.FieldValue(
+                              atomic_value=schema_pb2.AtomicTypeValue(
+                                  int16=255))),
+                      schema_pb2.Option(
+                          name='a_int32',
                           type=schema_pb2.FieldType(
                               atomic_type=schema_pb2.INT32),
                           value=schema_pb2.FieldValue(
                               atomic_value=schema_pb2.AtomicTypeValue(
-                                  int32=123456))),
-                      schema_pb2.Option(name='a_flag',
-                                        )
+                                  int32=255))),
+                      schema_pb2.Option(
+                          name='a_int64',
+                          type=schema_pb2.FieldType(
+                              atomic_type=schema_pb2.INT64),
+                          value=schema_pb2.FieldValue(
+                              atomic_value=schema_pb2.AtomicTypeValue(
+                                  int64=255))),
+                      schema_pb2.Option(
+                          name='a_float',
+                          type=schema_pb2.FieldType(
+                              atomic_type=schema_pb2.FLOAT),
+                          value=schema_pb2.FieldValue(
+                              atomic_value=schema_pb2.AtomicTypeValue(
+                                  float=3.14))),
+                      schema_pb2.Option(
+                          name='a_double',
+                          type=schema_pb2.FieldType(
+                              atomic_type=schema_pb2.DOUBLE),
+                          value=schema_pb2.FieldValue(
+                              atomic_value=schema_pb2.AtomicTypeValue(
+                                  double=2.718))),
+                      schema_pb2.Option(
+                          name='a_str',
+                          type=schema_pb2.FieldType(
+                              atomic_type=schema_pb2.STRING),
+                          value=schema_pb2.FieldValue(
+                              atomic_value=schema_pb2.AtomicTypeValue(
+                                  string='str'))),
+                      schema_pb2.Option(
+                          name='a_bool',
+                          type=schema_pb2.FieldType(
+                              atomic_type=schema_pb2.BOOLEAN),
+                          value=schema_pb2.FieldValue(
+                              atomic_value=schema_pb2.AtomicTypeValue(
+                                  boolean=True))),
+                      schema_pb2.Option(
+                          name='a_bytes',
+                          type=schema_pb2.FieldType(
+                              atomic_type=schema_pb2.BYTES),
+                          value=schema_pb2.FieldValue(
+                              atomic_value=schema_pb2.AtomicTypeValue(
+                                  bytes=b'bytes!'))),
                   ]))),
       schema_pb2.FieldType(
           row_type=schema_pb2.RowType(
@@ -205,14 +253,14 @@ def get_test_beam_fieldtype_protos():
                           name='field%d' % i,
                           type=typ,
                           options=[
+                              schema_pb2.Option(name='a_flag'),
                               schema_pb2.Option(
-                                  name='some_metadata',
+                                  name='a_str',
                                   type=schema_pb2.FieldType(
                                       atomic_type=schema_pb2.STRING),
                                   value=schema_pb2.FieldValue(
                                       atomic_value=schema_pb2.AtomicTypeValue(
-                                          string='foo'))),
-                              schema_pb2.Option(name='a_flag')
+                                          string='str'))),
                           ]) for i,
                       typ in enumerate(all_primitives)
                   ]))),

--- a/sdks/python/apache_beam/typehints/schemas_test.py
+++ b/sdks/python/apache_beam/typehints/schemas_test.py
@@ -226,7 +226,8 @@ def get_test_beam_fieldtype_protos():
 
 def get_test_beam_schemas_protos():
   return [
-      fieldtype.row_type.schema for fieldtype in get_test_beam_fieldtype_protos()
+      fieldtype.row_type.schema
+      for fieldtype in get_test_beam_fieldtype_protos()
       if fieldtype.WhichOneof('type_info') == 'row_type'
   ]
 
@@ -381,7 +382,10 @@ class SchemaTest(unittest.TestCase):
     #for attr in dir(expected):
     #  self.assertEqual(getattr(actual, attr), getattr(expected, attr))
 
-  @parameterized.expand([(fieldtype_proto,) for fieldtype_proto in get_test_beam_fieldtype_protos()])
+  @parameterized.expand([
+      (fieldtype_proto, )
+      for fieldtype_proto in get_test_beam_fieldtype_protos()
+  ])
   def test_proto_survives_typing_roundtrip(self, fieldtype_proto):
     self.assertEqual(
         fieldtype_proto,


### PR DESCRIPTION
Fixes #22083. This PR adds a Python-native representation for [Beam schema options](https://cwiki.apache.org/confluence/display/BEAM/%5BBIP-1%5D+Beam+Schema+Options).

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
