### PR TITLE
Add support when writing to locked buckets by handling retentionPolicyNotMet error

### DIFF
--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/GcsUtil.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/GcsUtil.java
@@ -902,11 +902,9 @@ public class GcsUtil {
           && e.getErrors().size() == 1
           && e.getErrors().get(0).getReason().equals("retentionPolicyNotMet")) {
         List<StorageObjectOrIOException> srcAndDestObjects = getObjects(Arrays.asList(from, to));
-        if (srcAndDestObjects
-            .get(0)
-            .storageObject()
-            .getMd5Hash()
-            .equals(srcAndDestObjects.get(1).storageObject().getMd5Hash())) {
+        String srcHash = srcAndDestObjects.get(0).storageObject().getMd5Hash();
+        String destHash = srcAndDestObjects.get(1).storageObject().getMd5Hash();
+        if (srcHash != null && srcHash.equals(destHash)) {
           // Source and destination are identical. Treat this as a successful rewrite
           LOG.warn(
               "Caught retentionPolicyNotMet error while rewriting to a bucket with retention "

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/util/GcsUtilTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/util/GcsUtilTest.java
@@ -1020,6 +1020,8 @@ public class GcsUtilTest {
                 GoogleJsonError error = new GoogleJsonError();
                 error.setCode(HttpStatusCodes.STATUS_CODE_NOT_FOUND);
                 cb.onFailure(error, null);
+              } catch (GoogleJsonResponseException e) {
+                cb.onFailure(e.getDetails(), null);
               } catch (Exception e) {
                 System.out.println("Propagating exception as server error " + e);
                 e.printStackTrace();
@@ -1181,8 +1183,7 @@ public class GcsUtilTest {
   }
 
   @Test
-  public void testIgnoreRetentionPolicyNotMetErrorWhenIdenticalChecksum() throws IOException {
-    // ./gradlew sdks:java:extensions:google-cloud-platform-core:test --tests org.apache.beam.sdk.extensions.gcp.util.GcsUtilTest.testIgnoreRetentionPolicyNotMetErrorWhenIdenticalChecksum
+  public void testIgnoreRetentionPolicyNotMetErrorWhenEqualChecksum() throws IOException {
     GcsUtil gcsUtil = gcsOptionsWithTestCredential().getGcsUtil();
 
     Storage mockStorage = Mockito.mock(Storage.class);
@@ -1190,54 +1191,37 @@ public class GcsUtilTest {
     gcsUtil.setBatchRequestSupplier(() -> new FakeBatcher());
 
     Storage.Objects mockStorageObjects = Mockito.mock(Storage.Objects.class);
+    Storage.Objects.Get mockGetRequest = Mockito.mock(Storage.Objects.Get.class);
     Storage.Objects.Rewrite mockStorageRewrite1 = Mockito.mock(Storage.Objects.Rewrite.class);
     Storage.Objects.Rewrite mockStorageRewrite2 = Mockito.mock(Storage.Objects.Rewrite.class);
-    Storage.Objects.Delete mockStorageDelete1 = Mockito.mock(Storage.Objects.Delete.class);
-    Storage.Objects.Delete mockStorageDelete2 = Mockito.mock(Storage.Objects.Delete.class);
+    Storage.Objects.Delete mockStorageDelete = Mockito.mock(Storage.Objects.Delete.class);
 
-    StorageObjectOrIOException srcObject = new StorageObjectOrIOException() {
-      @Override
-      public @Nullable StorageObject storageObject() {
-        return new StorageObject().setMd5Hash("a");
-      }
-      @Override
-      public @Nullable IOException ioException() {
-        return null;
-      }
-    };
-
-    StorageObjectOrIOException destObject = new StorageObjectOrIOException() {
-      @Override
-      public @Nullable StorageObject storageObject() {
-        return new StorageObject().setMd5Hash("a");
-      }
-      @Override
-      public @Nullable IOException ioException() {
-        return null;
-      }
-    };
-
-    List<StorageObjectOrIOException> mockSrcAndDest = Arrays.asList(srcObject, destObject);
+    // Gcs object to be used when checking the hash of the files during rewrite fail.
+    StorageObject gcsObject = new StorageObject().setMd5Hash("a");
 
     when(mockStorage.objects()).thenReturn(mockStorageObjects);
+    // First rewrite with retentionPolicyNotMet error.
     when(mockStorageObjects.rewrite("bucket", "s0", "bucket", "d0", null))
         .thenReturn(mockStorageRewrite1);
     when(mockStorageRewrite1.execute())
         .thenThrow(googleJsonResponseException(403, "retentionPolicyNotMet", "Too soon"));
-    when(gcsUtil.getObjects(
-        Arrays.asList(GcsPath.fromUri("gs://bucket/s0"), GcsPath.fromUri("gs://bucket/d0"))))
-        .thenReturn(mockSrcAndDest);
+    when(mockStorageObjects.get(any(), any())) // to access object hash during error handling
+        .thenReturn(mockGetRequest);
+    when(mockGetRequest.execute())
+        .thenReturn(gcsObject); // both source and destination will get the same hash
+    when(mockStorageObjects.delete("bucket", "s0")).thenReturn(mockStorageDelete);
+
+    // Second rewrite should not be affected.
     when(mockStorageObjects.rewrite("bucket", "s1", "bucket", "d1", null))
         .thenReturn(mockStorageRewrite2);
-    when(mockStorageObjects.delete("bucket", "s0")).thenReturn(mockStorageDelete1);
-    when(mockStorageObjects.delete("bucket", "s1")).thenReturn(mockStorageDelete1);
+    when(mockStorageRewrite2.execute()).thenReturn(new RewriteResponse().setDone(true));
+    when(mockStorageObjects.delete("bucket", "s1")).thenReturn(mockStorageDelete);
 
     gcsUtil.rename(makeStrings("s", 2), makeStrings("d", 2));
 
     verify(mockStorageRewrite1, times(1)).execute();
     verify(mockStorageRewrite2, times(1)).execute();
-    verify(mockStorageDelete1, times(1)).execute();
-    verify(mockStorageDelete2, times(1)).execute();
+    verify(mockStorageDelete, times(2)).execute();
   }
 
   @Test


### PR DESCRIPTION
There is an edge case when Beam issues multiple rewrites to a GCS bucket. A bundle that rewrites files can succeed, but the fact of its success may not persist in Beam (e.g. autoscaling workers, worker restart). On bundle retry, the rewrite is issued again with the same destination. If this happens when writing to a bucket with a retention policy, we will run into the retentionPolicyNotMet error.

PR adds support for this case by handling the retentionPolicyNotMet error as such:
- If source and destination files have the same checksum, assume they are identical and skip the rewrite
- otherwise, throw an early error

More information in this design document: https://docs.google.com/document/d/11kXzI90KmAyknszSFmtfPcL_GWaVzpt8MojQfifZOoM/edit#heading=h.f8k9hty17wf5