### PR TITLE
Parallelizable DataFrame/Series mean

### DIFF
--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -136,6 +136,7 @@ HAND_IMPLEMENTED_GLOBAL_AGGREGATIONS = {
     'quantile',
     'std',
     'var',
+    'mean',
     'nunique',
     'corr',
     'cov',
@@ -1580,6 +1581,17 @@ class DeferredSeries(DeferredDataFrameOrSeries):
   @frame_base.with_docs_from(pd.Series)
   @frame_base.args_to_kwargs(pd.Series)
   @frame_base.populate_defaults(pd.Series)
+  def mean(self, skipna, **kwargs):
+    if skipna:
+      size = self.count()
+    else:
+      size = self.length()
+
+    return self.sum(skipna=skipna, **kwargs) / size
+
+  @frame_base.with_docs_from(pd.Series)
+  @frame_base.args_to_kwargs(pd.Series)
+  @frame_base.populate_defaults(pd.Series)
   def var(self, axis, skipna, level, ddof, **kwargs):
     """Per-level aggregation is not yet supported
     (https://github.com/apache/beam/issues/21829). Only the default,
@@ -2068,7 +2080,6 @@ class DeferredSeries(DeferredDataFrameOrSeries):
   max = _agg_method(pd.Series, 'max')
   prod = product = _agg_method(pd.Series, 'prod')
   sum = _agg_method(pd.Series, 'sum')
-  mean = _agg_method(pd.Series, 'mean')
   median = _agg_method(pd.Series, 'median')
   sem = _agg_method(pd.Series, 'sem')
   mad = _agg_method(pd.Series, 'mad')

--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -1924,8 +1924,7 @@ class AggregationTest(_AbstractFrameTest):
   def test_series_agg(self, agg_method):
     s = pd.Series(list(range(16)))
 
-    nonparallel = agg_method in (
-        'quantile', 'mean', 'describe', 'median', 'sem', 'mad')
+    nonparallel = agg_method in ('quantile', 'describe', 'median', 'sem', 'mad')
 
     # TODO(https://github.com/apache/beam/issues/20926): max and min produce
     # the wrong proxy
@@ -1944,8 +1943,7 @@ class AggregationTest(_AbstractFrameTest):
   def test_series_agg_method(self, agg_method):
     s = pd.Series(list(range(16)))
 
-    nonparallel = agg_method in (
-        'quantile', 'mean', 'describe', 'median', 'sem', 'mad')
+    nonparallel = agg_method in ('quantile', 'describe', 'median', 'sem', 'mad')
 
     # TODO(https://github.com/apache/beam/issues/20926): max and min produce
     # the wrong proxy
@@ -1961,8 +1959,7 @@ class AggregationTest(_AbstractFrameTest):
   def test_dataframe_agg(self, agg_method):
     df = pd.DataFrame({'A': [1, 2, 3, 4], 'B': [2, 3, 5, 7]})
 
-    nonparallel = agg_method in (
-        'quantile', 'mean', 'describe', 'median', 'sem', 'mad')
+    nonparallel = agg_method in ('quantile', 'describe', 'median', 'sem', 'mad')
 
     # TODO(https://github.com/apache/beam/issues/20926): max and min produce
     # the wrong proxy
@@ -1979,8 +1976,7 @@ class AggregationTest(_AbstractFrameTest):
   def test_dataframe_agg_method(self, agg_method):
     df = pd.DataFrame({'A': [1, 2, 3, 4], 'B': [2, 3, 5, 7]})
 
-    nonparallel = agg_method in (
-        'quantile', 'mean', 'describe', 'median', 'sem', 'mad')
+    nonparallel = agg_method in ('quantile', 'describe', 'median', 'sem', 'mad')
 
     # TODO(https://github.com/apache/beam/issues/20926): max and min produce
     # the wrong proxy
@@ -1996,27 +1992,18 @@ class AggregationTest(_AbstractFrameTest):
     s = pd.Series(list(range(16)))
     self._run_test(lambda s: s.agg('sum'), s)
     self._run_test(lambda s: s.agg(['sum']), s)
-    self._run_test(lambda s: s.agg(['sum', 'mean']), s, nonparallel=True)
-    self._run_test(lambda s: s.agg(['mean']), s, nonparallel=True)
-    self._run_test(lambda s: s.agg('mean'), s, nonparallel=True)
+    self._run_test(lambda s: s.agg(['sum', 'mean']), s)
+    self._run_test(lambda s: s.agg(['mean']), s)
+    self._run_test(lambda s: s.agg('mean'), s)
 
   def test_dataframe_agg_modes(self):
     df = pd.DataFrame({'A': [1, 2, 3, 4], 'B': [2, 3, 5, 7]})
     self._run_test(lambda df: df.agg('sum'), df)
-    self._run_test(lambda df: df.agg(['sum', 'mean']), df, nonparallel=True)
+    self._run_test(lambda df: df.agg(['sum', 'mean']), df)
     self._run_test(lambda df: df.agg({'A': 'sum', 'B': 'sum'}), df)
-    self._run_test(
-        lambda df: df.agg({
-            'A': 'sum', 'B': 'mean'
-        }), df, nonparallel=True)
-    self._run_test(
-        lambda df: df.agg({'A': ['sum', 'mean']}), df, nonparallel=True)
-    self._run_test(
-        lambda df: df.agg({
-            'A': ['sum', 'mean'], 'B': 'min'
-        }),
-        df,
-        nonparallel=True)
+    self._run_test(lambda df: df.agg({'A': 'sum', 'B': 'mean'}), df)
+    self._run_test(lambda df: df.agg({'A': ['sum', 'mean']}), df)
+    self._run_test(lambda df: df.agg({'A': ['sum', 'mean'], 'B': 'min'}), df)
 
   def test_series_agg_level(self):
     self._run_test(
@@ -2089,6 +2076,21 @@ class AggregationTest(_AbstractFrameTest):
         lambda df: df.set_index(['group', 'foo']).bar.agg(['min', 'max'],
                                                           level=0),
         GROUPBY_DF)
+
+  def test_series_mean_skipna(self):
+    df = pd.DataFrame({
+        'one': [i if i % 8 == 0 else np.nan for i in range(8)],
+        'two': [i if i % 4 == 0 else np.nan for i in range(8)],
+        'three': [i if i % 2 == 0 else np.nan for i in range(8)],
+    })
+
+    self._run_test(lambda df: df.one.mean(skipna=False), df)
+    self._run_test(lambda df: df.two.mean(skipna=False), df)
+    self._run_test(lambda df: df.three.mean(skipna=False), df)
+
+    self._run_test(lambda df: df.one.mean(skipna=True), df)
+    self._run_test(lambda df: df.two.mean(skipna=True), df)
+    self._run_test(lambda df: df.three.mean(skipna=True), df)
 
   def test_dataframe_agg_multifunc_level(self):
     # level= is ignored for multiple agg fns


### PR DESCRIPTION
Fixes #22171

This adds a parallelizable custom implementation of `DeferredSeries.mean`, which uses `sum()/count()`. In addition:
- `DeferredDataFrame` leverages this implementation through `_agg_method`
- Updates tests which previously verified that mean is _not_ parallelizable. Added new tests for `mean(skipna=False)`.

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
