### PR TITLE
Remove locks around ExecutionStateSampler

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/ExecutionStateTracker.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/ExecutionStateTracker.java
@@ -25,6 +25,7 @@ import java.util.Map;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicIntegerFieldUpdater;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -45,6 +46,8 @@ public class ExecutionStateTracker implements Comparable<ExecutionStateTracker> 
       new ConcurrentHashMap<>();
 
   private static final long LULL_REPORT_MS = TimeUnit.MINUTES.toMillis(5);
+  private static final AtomicIntegerFieldUpdater<ExecutionStateTracker> SAMPLING_UPDATER =
+      AtomicIntegerFieldUpdater.newUpdater(ExecutionStateTracker.class, "sampling");
 
   public static final String START_STATE_NAME = "start";
   public static final String PROCESS_STATE_NAME = "process";
@@ -116,6 +119,9 @@ public class ExecutionStateTracker implements Comparable<ExecutionStateTracker> 
    * reporting threads, thus it being marked volatile.
    */
   private volatile @Nullable ExecutionState currentState;
+
+  @SuppressWarnings("UnusedVariable")
+  private volatile int sampling = 0;
 
   /**
    * The current number of times that this {@link ExecutionStateTracker} has transitioned state.
@@ -298,7 +304,17 @@ public class ExecutionStateTracker implements Comparable<ExecutionStateTracker> 
     return nextLullReportMs;
   }
 
-  protected void takeSample(long millisSinceLastSample) {
+  void takeSample(long millisSinceLastSample) {
+    if (SAMPLING_UPDATER.compareAndSet(this, 0, 1)) {
+      try {
+        takeSampleOnce(millisSinceLastSample);
+      } finally {
+        SAMPLING_UPDATER.set(this, 0);
+      }
+    }
+  }
+
+  protected void takeSampleOnce(long millisSinceLastSample) {
     // These variables are read by Sampler thread, and written by Execution and Progress Reporting
     // threads.
     // Because there is no read/modify/write cycle in the Sampler thread, making them volatile

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionContext.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionContext.java
@@ -282,9 +282,9 @@ public abstract class DataflowExecutionContext<T extends DataflowStepContext> {
     }
 
     @Override
-    protected void takeSample(long millisSinceLastSample) {
+    protected void takeSampleOnce(long millisSinceLastSample) {
       elementExecutionTracker.takeSample(millisSinceLastSample);
-      super.takeSample(millisSinceLastSample);
+      super.takeSampleOnce(millisSinceLastSample);
     }
 
     @Override

--- a/sdks/java/harness/jmh/src/main/java/org/apache/beam/fn/harness/jmh/control/ExecutionStateSamplerBenchmark.java
+++ b/sdks/java/harness/jmh/src/main/java/org/apache/beam/fn/harness/jmh/control/ExecutionStateSamplerBenchmark.java
@@ -29,7 +29,6 @@ import org.apache.beam.runners.core.metrics.SimpleExecutionState;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.vendor.grpc.v1p43p2.com.google.protobuf.ByteString;
 import org.openjdk.jmh.annotations.Benchmark;
-import org.openjdk.jmh.annotations.Fork;
 import org.openjdk.jmh.annotations.Level;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
@@ -105,7 +104,6 @@ public class ExecutionStateSamplerBenchmark {
 
   @Benchmark
   @Threads(10)
-  @Fork(1)
   public void testTinyBundleRunnersCoreStateSampler(RunnersCoreStateSampler state, Blackhole bh)
       throws Exception {
     ExecutionStateTracker tracker = new ExecutionStateTracker(state.sampler);
@@ -125,7 +123,7 @@ public class ExecutionStateSamplerBenchmark {
   }
 
   @Benchmark
-  @Threads(1)
+  @Threads(10)
   public void testTinyBundleHarnessStateSampler(HarnessStateSampler state, Blackhole bh)
       throws Exception {
     state.tracker.start("processBundleId");
@@ -144,8 +142,7 @@ public class ExecutionStateSamplerBenchmark {
   }
 
   @Benchmark
-  @Threads(1)
-  @Fork(1)
+  @Threads(10)
   public void testLargeBundleRunnersCoreStateSampler(RunnersCoreStateSampler state, Blackhole bh)
       throws Exception {
     ExecutionStateTracker tracker = new ExecutionStateTracker(state.sampler);
@@ -165,7 +162,7 @@ public class ExecutionStateSamplerBenchmark {
   }
 
   @Benchmark
-  @Threads(1)
+  @Threads(10)
   public void testLargeBundleHarnessStateSampler(HarnessStateSampler state, Blackhole bh)
       throws Exception {
     state.tracker.start("processBundleId");

--- a/sdks/java/harness/jmh/src/test/java/org/apache/beam/fn/harness/jmh/control/ExecutionStateSamplerBenchmarkTest.java
+++ b/sdks/java/harness/jmh/src/test/java/org/apache/beam/fn/harness/jmh/control/ExecutionStateSamplerBenchmarkTest.java
@@ -46,7 +46,7 @@ public class ExecutionStateSamplerBenchmarkTest {
     state.setup();
     threadState.setup(state);
     new ExecutionStateSamplerBenchmark()
-        .testTinyBundleRunnersCoreStateSampler(state, threadState, blackhole);
+        .testTinyBundleRunnersCoreStateSampler(threadState, blackhole);
     state.tearDown();
   }
 
@@ -57,7 +57,7 @@ public class ExecutionStateSamplerBenchmarkTest {
     state.setup();
     threadState.setup(state);
     new ExecutionStateSamplerBenchmark()
-        .testLargeBundleRunnersCoreStateSampler(state, threadState, blackhole);
+        .testLargeBundleRunnersCoreStateSampler(threadState, blackhole);
     state.tearDown();
   }
 

--- a/sdks/java/harness/jmh/src/test/java/org/apache/beam/fn/harness/jmh/control/ExecutionStateSamplerBenchmarkTest.java
+++ b/sdks/java/harness/jmh/src/test/java/org/apache/beam/fn/harness/jmh/control/ExecutionStateSamplerBenchmarkTest.java
@@ -19,18 +19,29 @@ package org.apache.beam.fn.harness.jmh.control;
 
 import org.apache.beam.fn.harness.jmh.control.ExecutionStateSamplerBenchmark.HarnessStateSampler;
 import org.apache.beam.fn.harness.jmh.control.ExecutionStateSamplerBenchmark.RunnersCoreStateSampler;
+import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.openjdk.jmh.infra.Blackhole;
 
 /** Tests for {@link ExecutionStateSamplerBenchmark}. */
 @RunWith(JUnit4.class)
 public class ExecutionStateSamplerBenchmarkTest {
+  private Blackhole blackhole;
+
+  @Before
+  public void before() {
+    blackhole =
+        new Blackhole(
+            "Today's password is swordfish. I understand instantiating Blackholes directly is dangerous.");
+  }
+
   @Test
   public void testTinyBundleRunnersCoreStateSampler() throws Exception {
     RunnersCoreStateSampler state = new RunnersCoreStateSampler();
     state.setup();
-    new ExecutionStateSamplerBenchmark().testTinyBundleRunnersCoreStateSampler(state);
+    new ExecutionStateSamplerBenchmark().testTinyBundleRunnersCoreStateSampler(state, blackhole);
     state.tearDown();
   }
 
@@ -38,21 +49,21 @@ public class ExecutionStateSamplerBenchmarkTest {
   public void testLargeBundleRunnersCoreStateSampler() throws Exception {
     RunnersCoreStateSampler state = new RunnersCoreStateSampler();
     state.setup();
-    new ExecutionStateSamplerBenchmark().testLargeBundleRunnersCoreStateSampler(state);
+    new ExecutionStateSamplerBenchmark().testLargeBundleRunnersCoreStateSampler(state, blackhole);
     state.tearDown();
   }
 
   @Test
   public void testTinyBundleHarnessStateSampler() throws Exception {
     HarnessStateSampler state = new HarnessStateSampler();
-    new ExecutionStateSamplerBenchmark().testTinyBundleHarnessStateSampler(state);
+    new ExecutionStateSamplerBenchmark().testTinyBundleHarnessStateSampler(state, blackhole);
     state.tearDown();
   }
 
   @Test
   public void testLargeBundleHarnessStateSampler() throws Exception {
     HarnessStateSampler state = new HarnessStateSampler();
-    new ExecutionStateSamplerBenchmark().testLargeBundleHarnessStateSampler(state);
+    new ExecutionStateSamplerBenchmark().testLargeBundleHarnessStateSampler(state, blackhole);
     state.tearDown();
   }
 }

--- a/sdks/java/harness/jmh/src/test/java/org/apache/beam/fn/harness/jmh/control/ExecutionStateSamplerBenchmarkTest.java
+++ b/sdks/java/harness/jmh/src/test/java/org/apache/beam/fn/harness/jmh/control/ExecutionStateSamplerBenchmarkTest.java
@@ -18,7 +18,9 @@
 package org.apache.beam.fn.harness.jmh.control;
 
 import org.apache.beam.fn.harness.jmh.control.ExecutionStateSamplerBenchmark.HarnessStateSampler;
+import org.apache.beam.fn.harness.jmh.control.ExecutionStateSamplerBenchmark.HarnessStateTracker;
 import org.apache.beam.fn.harness.jmh.control.ExecutionStateSamplerBenchmark.RunnersCoreStateSampler;
+import org.apache.beam.fn.harness.jmh.control.ExecutionStateSamplerBenchmark.RunnersCoreStateTracker;
 import org.junit.Before;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -40,30 +42,42 @@ public class ExecutionStateSamplerBenchmarkTest {
   @Test
   public void testTinyBundleRunnersCoreStateSampler() throws Exception {
     RunnersCoreStateSampler state = new RunnersCoreStateSampler();
+    RunnersCoreStateTracker threadState = new RunnersCoreStateTracker();
     state.setup();
-    new ExecutionStateSamplerBenchmark().testTinyBundleRunnersCoreStateSampler(state, blackhole);
+    threadState.setup(state);
+    new ExecutionStateSamplerBenchmark()
+        .testTinyBundleRunnersCoreStateSampler(state, threadState, blackhole);
     state.tearDown();
   }
 
   @Test
   public void testLargeBundleRunnersCoreStateSampler() throws Exception {
     RunnersCoreStateSampler state = new RunnersCoreStateSampler();
+    RunnersCoreStateTracker threadState = new RunnersCoreStateTracker();
     state.setup();
-    new ExecutionStateSamplerBenchmark().testLargeBundleRunnersCoreStateSampler(state, blackhole);
+    threadState.setup(state);
+    new ExecutionStateSamplerBenchmark()
+        .testLargeBundleRunnersCoreStateSampler(state, threadState, blackhole);
     state.tearDown();
   }
 
   @Test
   public void testTinyBundleHarnessStateSampler() throws Exception {
     HarnessStateSampler state = new HarnessStateSampler();
-    new ExecutionStateSamplerBenchmark().testTinyBundleHarnessStateSampler(state, blackhole);
+    HarnessStateTracker threadState = new HarnessStateTracker();
+    threadState.setup(state);
+    new ExecutionStateSamplerBenchmark().testTinyBundleHarnessStateSampler(threadState, blackhole);
     state.tearDown();
+    threadState.tearDown();
   }
 
   @Test
   public void testLargeBundleHarnessStateSampler() throws Exception {
     HarnessStateSampler state = new HarnessStateSampler();
-    new ExecutionStateSamplerBenchmark().testLargeBundleHarnessStateSampler(state, blackhole);
+    HarnessStateTracker threadState = new HarnessStateTracker();
+    threadState.setup(state);
+    new ExecutionStateSamplerBenchmark().testLargeBundleHarnessStateSampler(threadState, blackhole);
     state.tearDown();
+    threadState.tearDown();
   }
 }


### PR DESCRIPTION
This fixes the ExecutionStateSampler portion of #22161.

There's a couple options I've tried to remove the lock there:

- Switch activeTrackers back to a concurrent set, the problem here was that deactivating a tracker could still race with the sampler thread and double-sample a sampler. I'm not sure if this is a big enough deal to worry about?
- Rather than worry about synchronization at all, push all add/remove/sample operations into a queue and have a single thread consuming from it and maintaining activeTrackers and doing the sampling. Doing so removes the race above and simplifies the logic a lot (I think). I used the LMAX Disruptor queue to handle the multi-consumer-single-producer setup here, but you could probably use a built-in java concurrent blocking queue for this as well.

Benchmark results are as follows:

![image](https://user-images.githubusercontent.com/1882981/178150077-64f9aac3-45bd-428f-9240-74a5951540c2.png)

The machine I was running these tests on has 24 logical cores, which is why we see a big drop in throughput between 20 -> 50 threads.

Both the LMAX and stock (synchronized) implementations have a significant throughput dropoff after the number of cores is saturated.  The synchronized one due to lock contention, and the LMAX one due to the disruptor queue filling up (because the worker thread gets scheduled out).

The ConcurrentSet implementation seems the best here, with no scalability dropoff after core saturation.

One thing to note: I was still unable to reproduce the significant blocking I saw in a real dataflow job with the JMH benchmarks, even at 100 threads the contention was very low (~1 second of blocked threads over a 1 minute sample, vs 30 seconds over a 1 minute sample in dataflow).

R: @lukecwik 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
