### PR TITLE
Update element_type inference (default_type_hints) for batched DoFns with yields_batches/yields_elements  

### DIFF
--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
@@ -357,13 +357,15 @@ class FnApiRunnerTest(unittest.TestCase):
         return np.int64
 
     with self.create_pipeline() as p:
-      res = (
+      pc = (
           p
           | beam.Create(np.array([1, 2, 3], dtype=np.int64)).with_output_types(
               np.int64)
-          | beam.ParDo(ArrayProduceDoFn())
-          | beam.ParDo(ArrayMultiplyDoFn())
-          | beam.Map(lambda x: x * 3))
+          | beam.ParDo(ArrayProduceDoFn()))
+
+      self.assertEqual(pc.element_type, np.int64)
+
+      res = (pc | beam.ParDo(ArrayMultiplyDoFn()) | beam.Map(lambda x: x * 3))
 
       assert_that(res, equal_to([6, 12, 12, 18, 18, 18]))
 

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
@@ -357,15 +357,13 @@ class FnApiRunnerTest(unittest.TestCase):
         return np.int64
 
     with self.create_pipeline() as p:
-      pc = (
+      res = (
           p
           | beam.Create(np.array([1, 2, 3], dtype=np.int64)).with_output_types(
               np.int64)
-          | beam.ParDo(ArrayProduceDoFn()))
-
-      self.assertEqual(pc.element_type, np.int64)
-
-      res = (pc | beam.ParDo(ArrayMultiplyDoFn()) | beam.Map(lambda x: x * 3))
+          | beam.ParDo(ArrayProduceDoFn())
+          | beam.ParDo(ArrayMultiplyDoFn())
+          | beam.Map(lambda x: x * 3))
 
       assert_that(res, equal_to([6, 12, 12, 18, 18, 18]))
 

--- a/sdks/python/apache_beam/transforms/batch_dofn_test.py
+++ b/sdks/python/apache_beam/transforms/batch_dofn_test.py
@@ -193,7 +193,7 @@ class MismatchedElementProducingDoFn(beam.DoFn):
 
   @beam.DoFn.yields_elements
   def process_batch(self, batch: List[int], *args, **kwargs) -> Iterator[int]:
-    yield element[0]
+    yield batch[0]
 
 
 class BatchDoFnTest(unittest.TestCase):
@@ -237,7 +237,8 @@ class BatchDoFnTest(unittest.TestCase):
     # https://docs.python.org/3.4/library/re.html#regular-expression-syntax
     with self.assertRaisesRegex(
         TypeError,
-        r'(?ms)MismatchedBatchProducingDoFn.*process: List\[int\].*process_batch: List\[float\]'
+        (r'(?ms)MismatchedBatchProducingDoFn.*'
+         r'process: List\[int\].*process_batch: List\[float\]')
     ):
       _ = pc | beam.ParDo(MismatchedBatchProducingDoFn())
 

--- a/sdks/python/apache_beam/transforms/batch_dofn_test.py
+++ b/sdks/python/apache_beam/transforms/batch_dofn_test.py
@@ -175,7 +175,8 @@ class BatchDoFnNoInputAnnotation(beam.DoFn):
 
 class MismatchedBatchProducingDoFn(beam.DoFn):
   """A DoFn that produces batches from both process and process_batch, with
-  mismatched types. Should yield a construction time error when applied."""
+  mismatched return types (one yields floats, the other ints). Should yield
+  a construction time error when applied."""
   @beam.DoFn.yields_batches
   def process(self, element: int, *args, **kwargs) -> Iterator[List[int]]:
     yield [element]
@@ -187,7 +188,8 @@ class MismatchedBatchProducingDoFn(beam.DoFn):
 
 class MismatchedElementProducingDoFn(beam.DoFn):
   """A DoFn that produces elements from both process and process_batch, with
-  mismatched types. Should yield a construction time error when applied."""
+  mismatched return types (one yields floats, the other ints). Should yield
+  a construction time error when applied."""
   def process(self, element: int, *args, **kwargs) -> Iterator[float]:
     yield element / 2
 

--- a/sdks/python/apache_beam/transforms/batch_dofn_test.py
+++ b/sdks/python/apache_beam/transforms/batch_dofn_test.py
@@ -238,8 +238,7 @@ class BatchDoFnTest(unittest.TestCase):
     with self.assertRaisesRegex(
         TypeError,
         (r'(?ms)MismatchedBatchProducingDoFn.*'
-         r'process: List\[int\].*process_batch: List\[float\]')
-    ):
+         r'process: List\[int\].*process_batch: List\[float\]')):
       _ = pc | beam.ParDo(MismatchedBatchProducingDoFn())
 
   def test_mismatched_element_producer_raises(self):

--- a/sdks/python/apache_beam/transforms/batch_dofn_test.py
+++ b/sdks/python/apache_beam/transforms/batch_dofn_test.py
@@ -71,6 +71,9 @@ class ElementToBatchDoFn(beam.DoFn):
   def process(self, element: int, *args, **kwargs) -> Iterator[List[int]]:
     yield [element] * element
 
+  def infer_output_type(self, input_element_type):
+    return input_element_type
+
 
 class BatchToElementDoFn(beam.DoFn):
   @beam.DoFn.yields_elements
@@ -170,6 +173,29 @@ class BatchDoFnNoInputAnnotation(beam.DoFn):
     yield [element * 2 for element in batch]
 
 
+class MismatchedBatchProducingDoFn(beam.DoFn):
+  """A DoFn that produces batches from both process and process_batch, with
+  mismatched types. Should yield a construction time error when applied."""
+  @beam.DoFn.yields_batches
+  def process(self, element: int, *args, **kwargs) -> Iterator[List[int]]:
+    yield [element]
+
+  def process_batch(self, batch: List[int], *args,
+                    **kwargs) -> Iterator[List[float]]:
+    yield [element / 2 for element in batch]
+
+
+class MismatchedElementProducingDoFn(beam.DoFn):
+  """A DoFn that produces elements from both process and process_batch, with
+  mismatched types. Should yield a construction time error when applied."""
+  def process(self, element: int, *args, **kwargs) -> Iterator[float]:
+    yield element / 2
+
+  @beam.DoFn.yields_elements
+  def process_batch(self, batch: List[int], *args, **kwargs) -> Iterator[int]:
+    yield element[0]
+
+
 class BatchDoFnTest(unittest.TestCase):
   def test_map_pardo(self):
     # verify batch dofn accessors work well with beam.Map generated DoFn
@@ -199,8 +225,51 @@ class BatchDoFnTest(unittest.TestCase):
     pc = p | beam.Create([1, 2, 3])
 
     with self.assertRaisesRegex(NotImplementedError,
-                                r'.*BatchDoFnBadParam.*KeyParam'):
+                                r'BatchDoFnBadParam.*KeyParam'):
       _ = pc | beam.ParDo(BatchDoFnBadParam())
+
+  def test_mismatched_batch_producer_raises(self):
+    p = beam.Pipeline()
+    pc = p | beam.Create([1, 2, 3])
+
+    # Note (?ms) makes this a multiline regex, where . matches newlines.
+    # See (?aiLmsux) at
+    # https://docs.python.org/3.4/library/re.html#regular-expression-syntax
+    with self.assertRaisesRegex(
+        TypeError,
+        r'(?ms)MismatchedBatchProducingDoFn.*process: List\[int\].*process_batch: List\[float\]'
+    ):
+      _ = pc | beam.ParDo(MismatchedBatchProducingDoFn())
+
+  def test_mismatched_element_producer_raises(self):
+    p = beam.Pipeline()
+    pc = p | beam.Create([1, 2, 3])
+
+    # Note (?ms) makes this a multiline regex, where . matches newlines.
+    # See (?aiLmsux) at
+    # https://docs.python.org/3.4/library/re.html#regular-expression-syntax
+    with self.assertRaisesRegex(
+        TypeError,
+        r'(?ms)MismatchedElementProducingDoFn.*process:.*process_batch:'):
+      _ = pc | beam.ParDo(MismatchedElementProducingDoFn())
+
+  def test_element_to_batch_dofn_typehint(self):
+    # Verify that element to batch DoFn sets the correct typehint on the output
+    # PCollection.
+
+    p = beam.Pipeline()
+    pc = (p | beam.Create([1, 2, 3]) | beam.ParDo(ElementToBatchDoFn()))
+
+    self.assertEqual(pc.element_type, int)
+
+  def test_batch_to_element_dofn_typehint(self):
+    # Verify that batch to element DoFn sets the correct typehint on the output
+    # PCollection.
+
+    p = beam.Pipeline()
+    pc = (p | beam.Create([1, 2, 3]) | beam.ParDo(BatchToElementDoFn()))
+
+    self.assertEqual(pc.element_type, beam.typehints.Tuple[int, int])
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -718,7 +718,8 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
             typehints.decorators.IOTypeHints.empty())
 
       # process_batch produces elements, use its output typehint
-      if self._process_batch_yields_elements and batch_fn_type_hints is not None:
+      if (self._process_batch_yields_elements and
+          batch_fn_type_hints is not None):
         if (fn_type_hints.output_types !=
             typehints.decorators.IOTypeHints.empty().output_types and
             batch_fn_type_hints.output_types != fn_type_hints.output_types):
@@ -732,7 +733,8 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
             batch_fn_type_hints)
     else:  # no typehints from process
       # process_batch produces elements, grab its output typehint
-      if self._process_batch_yields_elements and batch_fn_type_hints is not None:
+      if (self._process_batch_yields_elements and
+          batch_fn_type_hints is not None):
         fn_type_hints = batch_fn_type_hints.with_input_types_from(
             typehints.decorators.IOTypeHints.empty())
 

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -707,44 +707,44 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
     return get_function_arguments(self, func)
 
   def default_type_hints(self):
-    fn_type_hints = typehints.decorators.IOTypeHints.from_callable(self.process)
-    batch_fn_type_hints = typehints.decorators.IOTypeHints.from_callable(
-        self.process_batch)
+    process_type_hints = typehints.decorators.IOTypeHints.from_callable(
+        self.process) or typehints.decorators.IOTypeHints.empty()
 
-    if fn_type_hints is not None:
-      # process method produces batches, don't use its output typehint
-      if self._process_yields_batches:
-        fn_type_hints = fn_type_hints.with_output_types_from(
-            typehints.decorators.IOTypeHints.empty())
+    if self._process_yields_batches:
+      # process() produces batches, don't use it's output typehint
+      process_type_hints = process_type_hints.with_output_types_from(
+          typehints.decorators.IOTypeHints.empty())
 
-      # process_batch produces elements, use its output typehint
-      if (self._process_batch_yields_elements and
-          batch_fn_type_hints is not None):
-        if (fn_type_hints.output_types !=
+    if self._process_batch_yields_elements:
+      # process_batch() produces elements, *do* use it's output typehint
+
+      # First access the typehint
+      process_batch_type_hints = typehints.decorators.IOTypeHints.from_callable(
+          self.process_batch) or typehints.decorators.IOTypeHints.empty()
+
+      # Then we deconflict with the typehint from process, if it exists
+      if (process_batch_type_hints.output_types !=
+          typehints.decorators.IOTypeHints.empty().output_types):
+        if (process_type_hints.output_types !=
             typehints.decorators.IOTypeHints.empty().output_types and
-            batch_fn_type_hints.output_types != fn_type_hints.output_types):
+            process_batch_type_hints.output_types !=
+            process_type_hints.output_types):
           raise TypeError(
               f"DoFn {self!r} yields element from both process and "
               "process_batch, but they have mismatched output typehints:\n"
-              f" process: {fn_type_hints.output_types}\n"
-              f" process_batch: {batch_fn_type_hints.output_types}")
+              f" process: {process_type_hints.output_types}\n"
+              f" process_batch: {process_batch_type_hints.output_types}")
 
-        fn_type_hints = fn_type_hints.with_output_types_from(
-            batch_fn_type_hints)
-    else:  # no typehints from process
-      # process_batch produces elements, grab its output typehint
-      if (self._process_batch_yields_elements and
-          batch_fn_type_hints is not None):
-        fn_type_hints = batch_fn_type_hints.with_input_types_from(
-            typehints.decorators.IOTypeHints.empty())
+        process_type_hints = process_type_hints.with_output_types_from(
+            process_batch_type_hints)
 
-    if fn_type_hints is not None:
-      try:
-        fn_type_hints = fn_type_hints.strip_iterable()
-      except ValueError as e:
-        raise ValueError('Return value not iterable: %s: %s' % (self, e))
+    try:
+      process_type_hints = process_type_hints.strip_iterable()
+    except ValueError as e:
+      raise ValueError('Return value not iterable: %s: %s' % (self, e))
+
     # Prefer class decorator type hints for backwards compatibility.
-    return get_type_hints(self.__class__).with_defaults(fn_type_hints)
+    return get_type_hints(self.__class__).with_defaults(process_type_hints)
 
   # TODO(sourabhbajaj): Do we want to remove the responsibility of these from
   # the DoFn or maybe the runner

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -708,6 +708,34 @@ class DoFn(WithTypeHints, HasDisplayData, urns.RunnerApiFn):
 
   def default_type_hints(self):
     fn_type_hints = typehints.decorators.IOTypeHints.from_callable(self.process)
+    batch_fn_type_hints = typehints.decorators.IOTypeHints.from_callable(
+        self.process_batch)
+
+    if fn_type_hints is not None:
+      # process method produces batches, don't use its output typehint
+      if self._process_yields_batches:
+        fn_type_hints = fn_type_hints.with_output_types_from(
+            typehints.decorators.IOTypeHints.empty())
+
+      # process_batch produces elements, use its output typehint
+      if self._process_batch_yields_elements and batch_fn_type_hints is not None:
+        if (fn_type_hints.output_types !=
+            typehints.decorators.IOTypeHints.empty().output_types and
+            batch_fn_type_hints.output_types != fn_type_hints.output_types):
+          raise TypeError(
+              f"DoFn {self!r} yields element from both process and "
+              "process_batch, but they have mismatched output typehints:\n"
+              f" process: {fn_type_hints.output_types}\n"
+              f" process_batch: {batch_fn_type_hints.output_types}")
+
+        fn_type_hints = fn_type_hints.with_output_types_from(
+            batch_fn_type_hints)
+    else:  # no typehints from process
+      # process_batch produces elements, grab its output typehint
+      if self._process_batch_yields_elements and batch_fn_type_hints is not None:
+        fn_type_hints = batch_fn_type_hints.with_input_types_from(
+            typehints.decorators.IOTypeHints.empty())
+
     if fn_type_hints is not None:
       try:
         fn_type_hints = fn_type_hints.strip_iterable()

--- a/sdks/python/apache_beam/typehints/decorators.py
+++ b/sdks/python/apache_beam/typehints/decorators.py
@@ -302,6 +302,16 @@ class IOTypeHints(NamedTuple):
     return self._replace(
         output_types=(args, kwargs), origin=self._make_origin([self]))
 
+  def with_input_types_from(self, other):
+    # type: (IOTypeHints) -> IOTypeHints
+    return self._replace(
+        input_types=other.input_types, origin=self._make_origin([self]))
+
+  def with_output_types_from(self, other):
+    # type: (IOTypeHints) -> IOTypeHints
+    return self._replace(
+        output_types=other.output_types, origin=self._make_origin([self]))
+
   def simple_output_type(self, context):
     if self._has_output_types():
       args, kwargs = self.output_types

--- a/sdks/python/apache_beam/typehints/decorators_test.py
+++ b/sdks/python/apache_beam/typehints/decorators_test.py
@@ -97,6 +97,46 @@ class IOTypeHintsTest(unittest.TestCase):
     after = th.strip_iterable()
     self.assertEqual(((expected_after, ), {}), after.output_types)
 
+  def test_with_output_types_from(self):
+    th = decorators.IOTypeHints(
+        input_types=((int), {
+            'foo': str
+        }),
+        output_types=((int, str), {}),
+        origin=[])
+
+    self.assertEqual(
+        th.with_output_types_from(decorators.IOTypeHints.empty()),
+        decorators.IOTypeHints(
+            input_types=((int), {
+                'foo': str
+            }), output_types=None, origin=[]))
+
+    self.assertEqual(
+        decorators.IOTypeHints.empty().with_output_types_from(th),
+        decorators.IOTypeHints(
+            input_types=None, output_types=((int, str), {}), origin=[]))
+
+  def test_with_input_types_from(self):
+    th = decorators.IOTypeHints(
+        input_types=((int), {
+            'foo': str
+        }),
+        output_types=((int, str), {}),
+        origin=[])
+
+    self.assertEqual(
+        th.with_input_types_from(decorators.IOTypeHints.empty()),
+        decorators.IOTypeHints(
+            input_types=None, output_types=((int, str), {}), origin=[]))
+
+    self.assertEqual(
+        decorators.IOTypeHints.empty().with_input_types_from(th),
+        decorators.IOTypeHints(
+            input_types=((int), {
+                'foo': str
+            }), output_types=None, origin=[]))
+
   def _test_strip_iterable_fail(self, before):
     with self.assertRaisesRegex(ValueError, r'not iterable'):
       self._test_strip_iterable(before, None)


### PR DESCRIPTION
Fixes #22197 

This updates `DoFn.default_type_hints` to inspect the output type annotation for the appropriate method (process, or process_batch) depending on the yields_batches/yields_elements decorators.

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
