### PR TITLE
[Website] scroll to correct position if anchor is present

### DIFF
--- a/website/www/site/assets/js/anchor-content-jump-fix.js
+++ b/website/www/site/assets/js/anchor-content-jump-fix.js
@@ -1,0 +1,19 @@
+// Licensed under the Apache License, Version 2.0 (the 'License'); you may not
+// use this file except in compliance with the License. You may obtain a copy of
+// the License at
+//
+//   http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an 'AS IS' BASIS, WITHOUT
+// WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied. See the
+// License for the specific language governing permissions and limitations under
+// the License.
+
+$(document).ready(function() {
+  const hash = window.location.hash;
+  if(hash) {
+    const elementWithHash = $(`${hash}`)[0];
+    elementWithHash.scrollIntoView();
+  }
+});

--- a/website/www/site/assets/js/language-switch-v2.js
+++ b/website/www/site/assets/js/language-switch-v2.js
@@ -10,22 +10,22 @@
 // License for the specific language governing permissions and limitations under
 // the License.
 
-function getElementData(element) {
-    const clickedLangSwitchEl = element.target;
-    const elPreviousOffsetFromViewPort = clickedLangSwitchEl.getBoundingClientRect().top;
-    return {
-        elPreviousOffsetFromViewPort,
-        clickedLangSwitchEl,
-    }
-}
-
-function setScrollToNewPosition(clickedElementData) {
-    const { elPreviousOffsetFromViewPort, clickedLangSwitchEl } = clickedElementData;
-    const elCurrentHeight = window.pageYOffset + clickedLangSwitchEl.getBoundingClientRect().top;
-    $('html, body').scrollTop(elCurrentHeight - elPreviousOffsetFromViewPort);
-}
-
 $(document).ready(function() {
+    function getElementData(element) {
+        const clickedLangSwitchEl = element.target;
+        const elPreviousOffsetFromViewPort = clickedLangSwitchEl.getBoundingClientRect().top;
+        return {
+            elPreviousOffsetFromViewPort,
+            clickedLangSwitchEl,
+        }
+    }
+
+    function setScrollToNewPosition(clickedElementData) {
+        const { elPreviousOffsetFromViewPort, clickedLangSwitchEl } = clickedElementData;
+        const elCurrentHeight = window.pageYOffset + clickedLangSwitchEl.getBoundingClientRect().top;
+        $('html, body').scrollTop(elCurrentHeight - elPreviousOffsetFromViewPort);
+    }
+
     function Switcher(conf) {
         var id = conf["class-prefix"],
             def = conf["default"],

--- a/website/www/site/layouts/partials/head.html
+++ b/website/www/site/layouts/partials/head.html
@@ -63,6 +63,9 @@
 {{ $fixPlaygroundNestedScroll := resources.Get "js/fix-playground-nested-scroll.js" | minify | fingerprint }}
 <script type="text/javascript" src="{{ $fixPlaygroundNestedScroll.RelPermalink }}" defer></script>
 
+{{ $anchorContentJumpFix := resources.Get "js/anchor-content-jump-fix.js" | minify | fingerprint }}
+<script type="text/javascript" src="{{ $anchorContentJumpFix.RelPermalink }}" defer></script>
+
 <link rel="alternate" type="application/rss+xml" title="{{ .Site.Title }}" href="/feed.xml">
 <link rel="canonical" href="{{ .Site.Params.hostName }}{{ .Permalink | absURL }}" data-proofer-ignore>
 <link rel="shortcut icon" type="image/x-icon" href="/images/favicon.ico">


### PR DESCRIPTION
Resolves #22699

When load page with anchor with a lot of content in Firefox it scrolles to the bottom of the page since a lot of html elements added/removed initially in language-switch-v2.js. Firefox can't handle it correctly. Added function to detect hash and scroll page to correct position when paged is loaded initially
- add setScrollIntoView to work on page load
- add a new function to the head.html to be present on pages
- put getElementData and setScrollToNewPosition inside $(document).ready(function() {} in language-switch-v2.js, so they don't clutter the global namespace.
_______________________________________________________________________________________________________________________________________
before:
![anchor_before](https://user-images.githubusercontent.com/61748758/183684092-6009ba9d-5f82-44ce-8148-ec18eaa73494.gif)

after:
![anchor_after](https://user-images.githubusercontent.com/61748758/183684123-8dd93af3-7261-458f-9f7b-539432424ee4.gif)
 
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
