### PR TITLE
Increase streaming server timeout 

### DIFF
--- a/runners/spark/job-server/spark_job_server.gradle
+++ b/runners/spark/job-server/spark_job_server.gradle
@@ -102,7 +102,7 @@ def portableValidatesRunnerTask(String name, boolean streaming, boolean docker, 
   } else {
     if (streaming) {
       pipelineOptions += "--streaming"
-      pipelineOptions += "--streamingTimeoutMs=60000"
+      pipelineOptions += "--streamingTimeoutMs=120000"
 
       testCategories = {
         includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'

--- a/runners/spark/job-server/spark_job_server.gradle
+++ b/runners/spark/job-server/spark_job_server.gradle
@@ -102,7 +102,7 @@ def portableValidatesRunnerTask(String name, boolean streaming, boolean docker, 
   } else {
     if (streaming) {
       pipelineOptions += "--streaming"
-      pipelineOptions += "--streamingTimeoutMs=30000"
+      pipelineOptions += "--streamingTimeoutMs=60000"
 
       testCategories = {
         includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'


### PR DESCRIPTION
Increases the timeout for the streaming server to 60s which appears to allow sufficient time for the PVR Spark 2 tests to complete. In local testing this addresses #21473 

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
