### PR TITLE
Add accept-language header for MPL license

### DIFF
--- a/sdks/java/container/license_scripts/pull_licenses_java.py
+++ b/sdks/java/container/license_scripts/pull_licenses_java.py
@@ -55,7 +55,12 @@ def pull_from_url(file_name, url, dep, no_list):
         logging.info('Replaced local file URL with {url} for {dep}'.format(url=url, dep=dep))
 
     try:
-        url_read = urlopen(Request(url, headers={'User-Agent': 'Apache Beam'}))
+        url_read = urlopen(Request(url, headers={
+            'User-Agent': 'Apache Beam',
+            # MPL license fails to resolve redirects without this header
+            # see https://github.com/apache/beam/issues/22394
+            'accept-language': 'en-US,en;q=0.9',
+        }))
         with open(file_name, 'wb') as temp_write:
             shutil.copyfileobj(url_read, temp_write)
         logging.debug(


### PR DESCRIPTION
Fixes #22394

https://www.mozilla.org/MPL/1.1/ redirects to https://www.mozilla.org/en-US/MPL/1.1/, but only if the accept-language header is present. Otherwise it yields a 404, breaking `:sdks:java:container:pullLicenses`.

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
