### PR TITLE
[CdapIO] Fixed necessary warnings

### DIFF
--- a/sdks/java/io/cdap/src/main/java/org/apache/beam/sdk/io/cdap/Plugin.java
+++ b/sdks/java/io/cdap/src/main/java/org/apache/beam/sdk/io/cdap/Plugin.java
@@ -132,7 +132,6 @@ public abstract class Plugin {
   /** Sets a plugin Hadoop configuration. */
   public Plugin withHadoopConfiguration(Configuration hadoopConfiguration) {
     this.hadoopConfiguration = hadoopConfiguration;
-
     return this;
   }
 

--- a/sdks/java/io/cdap/src/main/java/org/apache/beam/sdk/io/cdap/PluginConfigInstantiationUtils.java
+++ b/sdks/java/io/cdap/src/main/java/org/apache/beam/sdk/io/cdap/PluginConfigInstantiationUtils.java
@@ -30,11 +30,11 @@ import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
+import org.checkerframework.checker.initialization.qual.Initialized;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /** Class for getting any filled {@link PluginConfig} configuration object. */
-@SuppressWarnings("nullness")
 public class PluginConfigInstantiationUtils {
 
   private static final Logger LOG = LoggerFactory.getLogger(PluginConfigInstantiationUtils.class);
@@ -66,7 +66,7 @@ public class PluginConfigInstantiationUtils {
     }
     InstantiatorFactory instantiatorFactory = new InstantiatorFactory(false);
 
-    T config = instantiatorFactory.get(TypeToken.of(configClass)).create();
+    @Initialized T config = instantiatorFactory.get(TypeToken.of(configClass)).create();
 
     if (config != null) {
       for (Field field : allFields) {

--- a/sdks/java/io/cdap/src/test/java/org/apache/beam/sdk/io/cdap/CdapIOTest.java
+++ b/sdks/java/io/cdap/src/test/java/org/apache/beam/sdk/io/cdap/CdapIOTest.java
@@ -27,8 +27,6 @@ import java.io.IOException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
-
-import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.cdap.context.BatchSinkContextImpl;
@@ -39,7 +37,6 @@ import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollectionViews;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 import org.apache.hadoop.mapreduce.OutputCommitter;
 import org.junit.Before;
@@ -230,9 +227,8 @@ public class CdapIOTest {
   @Test
   public void testWriteExpandingFailsMissingCdapPluginClass() {
     PBegin testPBegin = PBegin.in(TestPipeline.create());
-    PCollection<KV<String, String>> testPCollection = Create.empty(
-              KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()))
-            .expand(testPBegin);
+    PCollection<KV<String, String>> testPCollection =
+        Create.empty(KvCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())).expand(testPBegin);
     CdapIO.Write<String, String> write = CdapIO.write();
     assertThrows(IllegalArgumentException.class, () -> write.expand(testPCollection));
   }

--- a/sdks/java/io/cdap/src/test/java/org/apache/beam/sdk/io/cdap/CdapIOTest.java
+++ b/sdks/java/io/cdap/src/test/java/org/apache/beam/sdk/io/cdap/CdapIOTest.java
@@ -119,12 +119,6 @@ public class CdapIOTest {
   }
 
   @Test
-  public void testReadValidationFailsMissingCdapPluginClass() {
-    CdapIO.Read<String, String> read = CdapIO.read();
-    assertThrows(IllegalArgumentException.class, read::validateTransform);
-  }
-
-  @Test
   public void testReadObjectCreationFailsIfCdapPluginClassIsNotSupported() {
     assertThrows(
         UnsupportedOperationException.class,
@@ -218,12 +212,6 @@ public class CdapIOTest {
     assertThrows(
         IllegalArgumentException.class,
         () -> CdapIO.<String, String>write().withLocksDirPath(null));
-  }
-
-  @Test
-  public void testWriteValidationFailsMissingCdapPluginClass() {
-    CdapIO.Write<String, String> write = CdapIO.write();
-    assertThrows(IllegalArgumentException.class, write::validateTransform);
   }
 
   @Test


### PR DESCRIPTION
In CdapIO we have some warnings that come out when trying to build a project. Previously, we suppressed these warnings with the @SuppressWarnings annotation.

The purpose of this PR is to solve the necessary warnings without the @SuppressWarnings annotation and loss of IO functionality.