### PR TITLE
Improve exception when requested error tag does not exist (#22401)

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteResult.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteResult.java
@@ -167,11 +167,11 @@ public final class WriteResult implements POutput {
     Preconditions.checkArgumentNotNull(
         failedInsertsTag,
         "Cannot use getFailedInserts as this WriteResult uses extended errors"
-            + " information. Use getFailedInsertsWithErr instead");
+            + " information. Use getFailedInsertsWithErr or getFailedStorageApiInserts instead");
     return Preconditions.checkStateNotNull(
         failedInserts,
         "Cannot use getFailedInserts as this WriteResult uses extended errors"
-            + " information. Use getFailedInsertsWithErr instead");
+            + " information. Use getFailedInsertsWithErr or getFailedStorageApiInserts instead");
   }
 
   /**
@@ -185,11 +185,11 @@ public final class WriteResult implements POutput {
     Preconditions.checkArgumentNotNull(
         failedInsertsWithErrTag,
         "Cannot use getFailedInsertsWithErr as this WriteResult does not use"
-            + " extended errors. Use getFailedInserts instead");
+            + " extended errors. Use getFailedInserts or getFailedStorageApiInserts instead");
     return Preconditions.checkArgumentNotNull(
         failedInsertsWithErr,
         "Cannot use getFailedInsertsWithErr as this WriteResult does not use"
-            + " extended errors. Use getFailedInserts instead");
+            + " extended errors. Use getFailedInserts or getFailedStorageApiInserts instead");
   }
 
   public PCollection<BigQueryStorageApiInsertError> getFailedStorageApiInserts() {

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
@@ -2610,7 +2610,7 @@ public class BigQueryIOWriteTest implements Serializable {
           e.getMessage(),
           is(
               "Cannot use getFailedInsertsWithErr as this WriteResult "
-                  + "does not use extended errors. Use getFailedInserts instead"));
+                  + "does not use extended errors. Use getFailedInserts or getFailedStorageApiInserts instead"));
     }
 
     try {
@@ -2623,7 +2623,7 @@ public class BigQueryIOWriteTest implements Serializable {
           e.getMessage(),
           is(
               "Cannot use getFailedInserts as this WriteResult "
-                  + "uses extended errors information. Use getFailedInsertsWithErr instead"));
+                  + "uses extended errors information. Use getFailedInsertsWithErr or getFailedStorageApiInserts instead"));
     }
   }
 


### PR DESCRIPTION
After 2.40.0 (this PR https://github.com/apache/beam/pull/17423), there are three to get the failed inserts from a `BigQueryIO` Write, as it was now added a specific tag/PCollection when using the write method via Storage API (`STORAGE_WRITE_API` or `STORAGE_API_AT_LEAST_ONCE`).

The exception when the requested tag is null is misleading now, as it explicitly says that the other method should be used. However, in the case of Storage API, the recommended method won't work either.


Closes https://github.com/apache/beam/issues/22401

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] ~Update `CHANGES.md` with noteworthy changes~.
 - [x] ~If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf)~.

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
