### PR TITLE
Fix bug in StructUtils of SpannerIO

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/StructUtils.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/StructUtils.java
@@ -357,7 +357,7 @@ final class StructUtils {
       case STRING:
         return struct.getStringList(column);
       case NUMERIC:
-        return struct.getBigDecimal(column);
+        return struct.getBigDecimalList(column);
       case ARRAY:
         throw new IllegalStateException(
             String.format("Column %s has array of arrays which is prohibited in Spanner.", column));

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/StructUtilsTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/StructUtilsTest.java
@@ -46,10 +46,64 @@ public class StructUtilsTest {
 
   @Test
   public void testStructToBeamRow() {
-    Schema schema = getSchemaTemplate().addDateTimeField("f_date").build();
-    Row row = getRowTemplate(schema).withFieldValue("f_date", DateTime.parse("2077-10-24")).build();
+    Schema schema =
+        getSchemaTemplate()
+            .addDateTimeField("f_date")
+            .addDecimalField("f_decimal")
+            .addArrayField("f_boolean_array", Schema.FieldType.BOOLEAN)
+            .addArrayField("f_string_array", Schema.FieldType.STRING)
+            .addArrayField("f_double_array", Schema.FieldType.DOUBLE)
+            .addArrayField("f_decimal_array", Schema.FieldType.DECIMAL)
+            .addArrayField("f_date_array", Schema.FieldType.DATETIME)
+            .addArrayField("f_timestamp_array", Schema.FieldType.DATETIME)
+            .build();
+
+    Row row =
+        getRowTemplate(schema)
+            .withFieldValue("f_date", DateTime.parse("2077-10-24"))
+            .withFieldValue("f_decimal", BigDecimal.valueOf(Long.MIN_VALUE))
+            .withFieldValue("f_boolean_array", ImmutableList.of(false, true))
+            .withFieldValue("f_string_array", ImmutableList.of("donald_duck", "micky_mouse"))
+            .withFieldValue("f_double_array", ImmutableList.of(1., 2.))
+            .withFieldValue(
+                "f_decimal_array",
+                ImmutableList.of(
+                    BigDecimal.valueOf(Long.MIN_VALUE), BigDecimal.valueOf(Long.MAX_VALUE)))
+            .withFieldValue(
+                "f_date_array",
+                ImmutableList.of(DateTime.parse("2077-10-24"), DateTime.parse("2077-10-24")))
+            .withFieldValue(
+                "f_timestamp_array",
+                ImmutableList.of(DateTime.parse("2077-01-10"), DateTime.parse("2077-01-10")))
+            .build();
     Struct struct =
-        getStructTemplate().set("f_date").to(Date.fromYearMonthDay(2077, 10, 24)).build();
+        getStructTemplate()
+            .set("f_date")
+            .to(Date.fromYearMonthDay(2077, 10, 24))
+            .set("f_decimal")
+            .to(BigDecimal.valueOf(Long.MIN_VALUE))
+            .set("f_boolean_array")
+            .toBoolArray(ImmutableList.of(false, true))
+            .set("f_string_array")
+            .toStringArray(ImmutableList.of("donald_duck", "micky_mouse"))
+            .set("f_double_array")
+            .toFloat64Array(ImmutableList.of(1., 2.))
+            .set("f_decimal_array")
+            .toNumericArray(
+                ImmutableList.of(
+                    BigDecimal.valueOf(Long.MIN_VALUE), BigDecimal.valueOf(Long.MAX_VALUE)))
+            .set("f_date_array")
+            .toDateArray(
+                ImmutableList.of(
+                    Date.fromYearMonthDay(2077, 10, 24), Date.fromYearMonthDay(2077, 10, 24)))
+            .set("f_timestamp_array")
+            .toTimestampArray(
+                ImmutableList.of(
+                    Timestamp.ofTimeMicroseconds(
+                        DateTime.parse("2077-01-10").toInstant().getMillis() * 1000L),
+                    Timestamp.ofTimeMicroseconds(
+                        DateTime.parse("2077-01-10").toInstant().getMillis() * 1000L)))
+            .build();
     assertEquals(row, StructUtils.structToBeamRow(struct, schema));
   }
 
@@ -79,11 +133,40 @@ public class StructUtilsTest {
         getSchemaTemplate()
             .addIterableField("f_iterable", Schema.FieldType.INT64)
             .addDecimalField("f_decimal")
+            .addFloatField("f_float")
+            .addInt16Field("f_int16")
+            .addInt32Field("f_int32")
+            .addByteField("f_byte")
+            .addArrayField("f_double_array", Schema.FieldType.DOUBLE)
+            .addArrayField("f_decimal_array", Schema.FieldType.DECIMAL)
+            .addArrayField("f_boolean_array", Schema.FieldType.BOOLEAN)
+            .addArrayField("f_string_array", Schema.FieldType.STRING)
+            .addArrayField("f_bytes_array", Schema.FieldType.BYTES)
+            .addArrayField("f_datetime_array", Schema.FieldType.DATETIME)
             .build();
     Row row =
         getRowTemplate(schema)
             .withFieldValue("f_iterable", ImmutableList.of(20L))
             .withFieldValue("f_decimal", BigDecimal.ONE)
+            .withFieldValue("f_float", 0.0f)
+            .withFieldValue("f_int16", (short) 2)
+            .withFieldValue("f_int32", 0x7fffffff)
+            .withFieldValue("f_byte", Byte.parseByte("127"))
+            .withFieldValue("f_double_array", ImmutableList.of(1., 2.))
+            .withFieldValue(
+                "f_decimal_array",
+                ImmutableList.of(
+                    BigDecimal.valueOf(Long.MIN_VALUE), BigDecimal.valueOf(Long.MAX_VALUE)))
+            .withFieldValue("f_boolean_array", ImmutableList.of(false, true))
+            .withFieldValue("f_string_array", ImmutableList.of("donald_duck", "micky_mouse"))
+            .withFieldValue(
+                "f_bytes_array",
+                ImmutableList.of("some_bytes".getBytes(UTF_8), "some_bytes".getBytes(UTF_8)))
+            .withFieldValue(
+                "f_datetime_array",
+                ImmutableList.of(
+                    DateTime.parse("2077-10-15T00:00:00+00:00"),
+                    DateTime.parse("2077-10-15T00:00:00+00:00")))
             .build();
     Struct struct =
         getStructTemplate()
@@ -91,6 +174,34 @@ public class StructUtilsTest {
             .toInt64Array(ImmutableList.of(20L))
             .set("f_decimal")
             .to(BigDecimal.ONE)
+            .set("f_float")
+            .to(0.0f)
+            .set("f_int16")
+            .to((short) 2)
+            .set("f_int32")
+            .to(0x7fffffff)
+            .set("f_byte")
+            .to(Byte.parseByte("127"))
+            .set("f_double_array")
+            .toFloat64Array(ImmutableList.of(1., 2.))
+            .set("f_decimal_array")
+            .toNumericArray(
+                ImmutableList.of(
+                    BigDecimal.valueOf(Long.MIN_VALUE), BigDecimal.valueOf(Long.MAX_VALUE)))
+            .set("f_boolean_array")
+            .toBoolArray(ImmutableList.of(false, true))
+            .set("f_string_array")
+            .toStringArray(ImmutableList.of("donald_duck", "micky_mouse"))
+            .set("f_bytes_array")
+            .toBytesArray(
+                ImmutableList.of(
+                    ByteArray.copyFrom("some_bytes".getBytes(UTF_8)),
+                    ByteArray.copyFrom("some_bytes".getBytes(UTF_8))))
+            .set("f_datetime_array")
+            .toTimestampArray(
+                ImmutableList.of(
+                    Timestamp.parseTimestamp("2077-10-15T00:00:00Z"),
+                    Timestamp.parseTimestamp("2077-10-15T00:00:00Z")))
             .build();
     assertEquals(struct, StructUtils.beamRowToStruct(row));
   }


### PR DESCRIPTION
- Adds more unit tests to `StructUtilsTest` for better code coverage.
- Fixes a bug in `StructUtils` which would cause `BigDecimal` struct arrays to be incorrectly converted from a `Spanner Struct` to a `Beam Row`.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
