### PR TITLE
LoadTestsBuilder: Disallow whitespace in option values

### DIFF
--- a/.test-infra/jenkins/LoadTestsBuilder.groovy
+++ b/.test-infra/jenkins/LoadTestsBuilder.groovy
@@ -63,6 +63,11 @@ class LoadTestsBuilder {
       // Flags are indicated by null values
       if (entry.value == null) {
         "--${entry.key}"
+      } else if (entry.value.toString().matches(".*\\s.*")) {
+        throw new IllegalArgumentException("""
+          '${entry.key}' has an invalid value, '${entry.value}', values must
+          not contain whitespace.
+          """)
       } else {
         "--${entry.key}=$entry.value".replace('\"', '\\\"').replace('\'', '\\\'')
       }

--- a/.test-infra/jenkins/LoadTestsBuilder.groovy
+++ b/.test-infra/jenkins/LoadTestsBuilder.groovy
@@ -74,8 +74,8 @@ class LoadTestsBuilder {
       } else if (entry.value.toString().matches(".*\\s.*") &&
       !entry.value.toString().matches("'[^']*'")) {
         throw new IllegalArgumentException("""
-          '${entry.key}' has an invalid value, '${entry.value}'. Values must
-          not contain whitespace, or they must be wrapped in singe quotes.
+          Option '${entry.key}' has an invalid value, '${entry.value}'. Values
+          must not contain whitespace, or they must be wrapped in singe quotes.
           """)
       } else {
         "--${entry.key}=$entry.value".replace('\"', '\\\"').replace('\'', '\\\'')

--- a/.test-infra/jenkins/LoadTestsBuilder.groovy
+++ b/.test-infra/jenkins/LoadTestsBuilder.groovy
@@ -60,13 +60,22 @@ class LoadTestsBuilder {
 
   static String parseOptions(Map<String, ?> options) {
     options.collect { entry ->
+
+      if (entry.key.matches(".*\\s.*")) {
+        throw new IllegalArgumentException("""
+          Encountered invalid option name '${entry.key}'. Names must not
+          contain whitespace.
+          """)
+      }
+
       // Flags are indicated by null values
       if (entry.value == null) {
         "--${entry.key}"
-      } else if (entry.value.toString().matches(".*\\s.*")) {
+      } else if (entry.value.toString().matches(".*\\s.*") &&
+      !entry.value.toString().matches("'[^']*'")) {
         throw new IllegalArgumentException("""
-          '${entry.key}' has an invalid value, '${entry.value}', values must
-          not contain whitespace.
+          '${entry.key}' has an invalid value, '${entry.value}'. Values must
+          not contain whitespace, or they must be wrapped in singe quotes.
           """)
       } else {
         "--${entry.key}=$entry.value".replace('\"', '\\\"').replace('\'', '\\\'')

--- a/.test-infra/jenkins/job_LoadTests_ParDo_Python.groovy
+++ b/.test-infra/jenkins/job_LoadTests_ParDo_Python.groovy
@@ -132,7 +132,7 @@ def addStreamingOptions(test) {
     // See https://cloud.google.com/dataflow/docs/guides/deploying-a-pipeline#dataflow-runner-v2
     // for more details.
     // TODO(https://github.com/apache/beam/issues/20806) remove shuffle_mode=appliance with runner v2 once issue is resolved.
-    experiments: 'use_runner_v2, shuffle_mode=appliance',
+    experiments: 'use_runner_v2,shuffle_mode=appliance',
   ]
 }
 

--- a/.test-infra/jenkins/job_LoadTests_ParDo_Python.groovy
+++ b/.test-infra/jenkins/job_LoadTests_ParDo_Python.groovy
@@ -132,7 +132,7 @@ def addStreamingOptions(test) {
     // See https://cloud.google.com/dataflow/docs/guides/deploying-a-pipeline#dataflow-runner-v2
     // for more details.
     // TODO(https://github.com/apache/beam/issues/20806) remove shuffle_mode=appliance with runner v2 once issue is resolved.
-    experiments: 'use_runner_v2,shuffle_mode=appliance',
+    experiments: 'use_runner_v2, shuffle_mode=appliance',
   ]
 }
 


### PR DESCRIPTION
Follow-up for #22422

Add an explicit check for pipeline option values that contain whitespace. This will prevent us from introducing another option that is incorrectly parsed in the future.

Verified by adding back a bad option value and running the seed job: https://ci-beam.apache.org/job/beam_SeedJob/10035/console

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
