### PR TITLE
Fixes #22438. Ensure that WindmillStateReader completes all batched read futures on exceptions

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WindmillStateReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WindmillStateReader.java
@@ -453,30 +453,40 @@ class WindmillStateReader {
   public void startBatchAndBlock() {
     // First, drain work out of the pending lookups into a set. These will be the items we fetch.
     HashSet<StateTag<?>> toFetch = Sets.newHashSet();
-    while (!pendingLookups.isEmpty()) {
-      StateTag<?> stateTag = pendingLookups.poll();
-      if (stateTag == null) {
-        break;
+    try {
+      while (!pendingLookups.isEmpty()) {
+        StateTag<?> stateTag = pendingLookups.poll();
+        if (stateTag == null) {
+          break;
+        }
+
+        if (!toFetch.add(stateTag)) {
+          throw new IllegalStateException("Duplicate tags being fetched.");
+        }
       }
 
-      if (!toFetch.add(stateTag)) {
-        throw new IllegalStateException("Duplicate tags being fetched.");
+      // If we failed to drain anything, some other thread pulled it off the queue. We have no work
+      // to do.
+      if (toFetch.isEmpty()) {
+        return;
       }
-    }
 
-    // If we failed to drain anything, some other thread pulled it off the queue. We have no work
-    // to do.
-    if (toFetch.isEmpty()) {
-      return;
-    }
+      Windmill.KeyedGetDataRequest request = createRequest(toFetch);
+      Windmill.KeyedGetDataResponse response = server.getStateData(computation, request);
+      if (response == null) {
+        throw new RuntimeException("Windmill unexpectedly returned null for request " + request);
+      }
 
-    Windmill.KeyedGetDataRequest request = createRequest(toFetch);
-    Windmill.KeyedGetDataResponse response = server.getStateData(computation, request);
-    if (response == null) {
-      throw new RuntimeException("Windmill unexpectedly returned null for request " + request);
+      // Removes tags from toFetch as they are processed.
+      consumeResponse(response, toFetch);
+    } catch (Exception e) {
+      // Set up all the remaining futures for this key to throw an exception. This ensures that if
+      // the exception is caught that all futures have been completed and do not block.
+      for (StateTag<?> stateTag : toFetch) {
+        waiting.get(stateTag).future.setException(e);
+      }
+      throw e;
     }
-
-    consumeResponse(response, toFetch);
   }
 
   public long getBytesRead() {
@@ -576,15 +586,8 @@ class WindmillStateReader {
 
   private void consumeResponse(Windmill.KeyedGetDataResponse response, Set<StateTag<?>> toFetch) {
     bytesRead += response.getSerializedSize();
-
     if (response.getFailed()) {
-      // Set up all the futures for this key to throw an exception:
-      KeyTokenInvalidException keyTokenInvalidException =
-          new KeyTokenInvalidException(key.toStringUtf8());
-      for (StateTag<?> stateTag : toFetch) {
-        waiting.get(stateTag).future.setException(keyTokenInvalidException);
-      }
-      return;
+      throw new KeyTokenInvalidException(key.toStringUtf8());
     }
 
     if (!key.equals(response.getKey())) {
@@ -773,11 +776,15 @@ class WindmillStateReader {
         getWaiting(stateTag, shouldRemove);
     SettableFuture<ValuesAndContPosition<T, Long>> future =
         coderAndFuture.getNonDoneFuture(stateTag);
-    Coder<T> coder = coderAndFuture.<T>getAndClearCoder();
-    List<T> values = this.bagPageValues(bag, coder);
-    future.set(
-        new ValuesAndContPosition<>(
-            values, bag.hasContinuationPosition() ? bag.getContinuationPosition() : null));
+    try {
+      Coder<T> coder = coderAndFuture.<T>getAndClearCoder();
+      List<T> values = this.bagPageValues(bag, coder);
+      future.set(
+          new ValuesAndContPosition<>(
+              values, bag.hasContinuationPosition() ? bag.getContinuationPosition() : null));
+    } catch (Exception e) {
+      future.setException(new RuntimeException("Error parsing bag response", e));
+    }
   }
 
   private void consumeWatermark(Windmill.WatermarkHold watermarkHold, StateTag<Long> stateTag) {
@@ -813,7 +820,7 @@ class WindmillStateReader {
         T value = coder.decode(inputStream, Coder.Context.OUTER);
         future.set(value);
       } catch (IOException e) {
-        throw new IllegalStateException("Unable to decode value using " + coder, e);
+        future.setException(new IllegalStateException("Unable to decode value using " + coder, e));
       }
     } else {
       future.set(null);
@@ -840,14 +847,18 @@ class WindmillStateReader {
     SettableFuture<ValuesAndContPosition<Map.Entry<ByteString, V>, ByteString>> future =
         coderAndFuture.getNonDoneFuture(stateTag);
     Coder<V> valueCoder = coderAndFuture.getAndClearCoder();
-    List<Map.Entry<ByteString, V>> values =
-        this.tagPrefixPageTagValues(tagValuePrefixResponse, valueCoder);
-    future.set(
-        new ValuesAndContPosition<>(
-            values,
-            tagValuePrefixResponse.hasContinuationPosition()
-                ? tagValuePrefixResponse.getContinuationPosition()
-                : null));
+    try {
+      List<Map.Entry<ByteString, V>> values =
+          this.tagPrefixPageTagValues(tagValuePrefixResponse, valueCoder);
+      future.set(
+          new ValuesAndContPosition<>(
+              values,
+              tagValuePrefixResponse.hasContinuationPosition()
+                  ? tagValuePrefixResponse.getContinuationPosition()
+                  : null));
+    } catch (Exception e) {
+      future.setException(new RuntimeException("Error parsing tag value prefix", e));
+    }
   }
 
   private <T> void consumeSortedList(
@@ -870,13 +881,17 @@ class WindmillStateReader {
     SettableFuture<ValuesAndContPosition<TimestampedValue<T>, ByteString>> future =
         coderAndFuture.getNonDoneFuture(stateTag);
     Coder<T> coder = coderAndFuture.getAndClearCoder();
-    List<TimestampedValue<T>> values = this.sortedListPageValues(sortedListFetchResponse, coder);
-    future.set(
-        new ValuesAndContPosition<>(
-            values,
-            sortedListFetchResponse.hasContinuationPosition()
-                ? sortedListFetchResponse.getContinuationPosition()
-                : null));
+    try {
+      List<TimestampedValue<T>> values = this.sortedListPageValues(sortedListFetchResponse, coder);
+      future.set(
+          new ValuesAndContPosition<>(
+              values,
+              sortedListFetchResponse.hasContinuationPosition()
+                  ? sortedListFetchResponse.getContinuationPosition()
+                  : null));
+    } catch (Exception e) {
+      future.setException(new RuntimeException("Error parsing ordered list", e));
+    }
   }
   /**
    * An iterable over elements backed by paginated GetData requests to Windmill. The iterable may be

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WindmillStateReaderTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WindmillStateReaderTest.java
@@ -38,6 +38,7 @@ import org.apache.beam.sdk.values.TimestampedValue;
 import org.apache.beam.vendor.grpc.v1p43p2.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Charsets;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Range;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.io.BaseEncoding;
 import org.hamcrest.Matchers;
 import org.joda.time.Instant;
 import org.junit.Before;
@@ -763,7 +764,7 @@ public class WindmillStateReaderTest {
 
   @Test
   public void testKeyTokenInvalid() throws Exception {
-    // Reads two bags and verifies that we batch them up correctly.
+    // Reads two states and verifies that we batch them up correctly.
     Future<Instant> watermarkFuture = underTest.watermarkFuture(STATE_KEY_2, STATE_FAMILY);
     Future<Iterable<Integer>> bagFuture = underTest.bagFuture(STATE_KEY_1, STATE_FAMILY, INT_CODER);
 
@@ -790,6 +791,164 @@ public class WindmillStateReaderTest {
     } catch (Exception e) {
       assertTrue(KeyTokenInvalidException.isKeyTokenInvalidException(e));
     }
+  }
+
+  @Test
+  public void testBatchingReadException() throws Exception {
+    // Reads two states and verifies that we batch them up correctly and propagate the read
+    // exception to both, not just the issuing future.
+    Future<Instant> watermarkFuture = underTest.watermarkFuture(STATE_KEY_2, STATE_FAMILY);
+    Future<Iterable<Integer>> bagFuture = underTest.bagFuture(STATE_KEY_1, STATE_FAMILY, INT_CODER);
+
+    Mockito.verifyNoMoreInteractions(mockWindmill);
+
+    RuntimeException expectedException = new RuntimeException("expected exception");
+
+    Mockito.when(
+            mockWindmill.getStateData(
+                Mockito.eq(COMPUTATION), Mockito.isA(Windmill.KeyedGetDataRequest.class)))
+        .thenThrow(expectedException);
+
+    try {
+      watermarkFuture.get();
+      fail("Expected RuntimeException");
+    } catch (Exception e) {
+      assertThat(e.toString(), Matchers.containsString("expected exception"));
+    }
+
+    try {
+      bagFuture.get();
+      fail("Expected RuntimeException");
+    } catch (Exception e) {
+      assertThat(e.toString(), Matchers.containsString("expected exception"));
+    }
+  }
+
+  @Test
+  public void testBatchingCoderExceptions() throws Exception {
+    // Read a batch of states with coder errors and verify it only affects the
+    // relevant futures.
+    Future<Integer> valueFuture = underTest.valueFuture(STATE_KEY_1, STATE_FAMILY, INT_CODER);
+    Future<Iterable<Integer>> bagFuture = underTest.bagFuture(STATE_KEY_1, STATE_FAMILY, INT_CODER);
+    Future<Iterable<Map.Entry<ByteString, Integer>>> valuePrefixFuture =
+        underTest.valuePrefixFuture(STATE_KEY_PREFIX, STATE_FAMILY, INT_CODER);
+    long beginning = SortedListRange.getDefaultInstance().getStart();
+    long end = SortedListRange.getDefaultInstance().getLimit();
+    Future<Iterable<TimestampedValue<Integer>>> orderedListFuture =
+        underTest.orderedListFuture(
+            Range.closedOpen(beginning, end), STATE_KEY_1, STATE_FAMILY, INT_CODER);
+    // This should be the final part of the response, and we should process it successfully.
+    Future<Instant> watermarkFuture = underTest.watermarkFuture(STATE_KEY_1, STATE_FAMILY);
+
+    Mockito.verifyNoMoreInteractions(mockWindmill);
+
+    ByteString invalidByteString = ByteString.copyFrom(BaseEncoding.base16().decode("FFFF"));
+    Windmill.Value invalidValue = intValue(0).toBuilder().setData(invalidByteString).build();
+
+    Windmill.KeyedGetDataRequest.Builder expectedRequest =
+        Windmill.KeyedGetDataRequest.newBuilder()
+            .setKey(DATA_KEY)
+            .setShardingKey(SHARDING_KEY)
+            .setWorkToken(WORK_TOKEN)
+            .setMaxBytes(WindmillStateReader.MAX_KEY_BYTES)
+            .addValuesToFetch(
+                Windmill.TagValue.newBuilder()
+                    .setTag(STATE_KEY_1)
+                    .setStateFamily(STATE_FAMILY)
+                    .build())
+            .addBagsToFetch(
+                Windmill.TagBag.newBuilder()
+                    .setTag(STATE_KEY_1)
+                    .setStateFamily(STATE_FAMILY)
+                    .setFetchMaxBytes(WindmillStateReader.INITIAL_MAX_BAG_BYTES))
+            .addTagValuePrefixesToFetch(
+                Windmill.TagValuePrefixRequest.newBuilder()
+                    .setTagPrefix(STATE_KEY_PREFIX)
+                    .setStateFamily(STATE_FAMILY)
+                    .setFetchMaxBytes(WindmillStateReader.MAX_TAG_VALUE_PREFIX_BYTES))
+            .addSortedListsToFetch(
+                Windmill.TagSortedListFetchRequest.newBuilder()
+                    .setTag(STATE_KEY_1)
+                    .setStateFamily(STATE_FAMILY)
+                    .addFetchRanges(SortedListRange.newBuilder().setStart(beginning).setLimit(end))
+                    .setFetchMaxBytes(WindmillStateReader.MAX_ORDERED_LIST_BYTES))
+            .addWatermarkHoldsToFetch(
+                Windmill.WatermarkHold.newBuilder()
+                    .setTag(STATE_KEY_1)
+                    .setStateFamily(STATE_FAMILY));
+
+    Windmill.KeyedGetDataResponse.Builder response =
+        Windmill.KeyedGetDataResponse.newBuilder()
+            .setKey(DATA_KEY)
+            .addValues(
+                Windmill.TagValue.newBuilder()
+                    .setTag(STATE_KEY_1)
+                    .setStateFamily(STATE_FAMILY)
+                    .setValue(invalidValue))
+            .addBags(
+                Windmill.TagBag.newBuilder()
+                    .setTag(STATE_KEY_1)
+                    .setStateFamily(STATE_FAMILY)
+                    .addValues(invalidByteString))
+            .addTagValuePrefixes(
+                Windmill.TagValuePrefixResponse.newBuilder()
+                    .setTagPrefix(STATE_KEY_PREFIX)
+                    .setStateFamily(STATE_FAMILY)
+                    .addTagValues(
+                        Windmill.TagValue.newBuilder()
+                            .setTag(STATE_KEY_1)
+                            .setStateFamily(STATE_FAMILY)
+                            .setValue(invalidValue)))
+            .addTagSortedLists(
+                Windmill.TagSortedListFetchResponse.newBuilder()
+                    .setTag(STATE_KEY_1)
+                    .setStateFamily(STATE_FAMILY)
+                    .addEntries(
+                        SortedListEntry.newBuilder()
+                            .setValue(invalidByteString)
+                            .setSortKey(5000)
+                            .setId(5))
+                    .addFetchRanges(SortedListRange.newBuilder().setStart(beginning).setLimit(end)))
+            .addWatermarkHolds(
+                Windmill.WatermarkHold.newBuilder()
+                    .setTag(STATE_KEY_1)
+                    .setStateFamily(STATE_FAMILY)
+                    .addTimestamps(5000000)
+                    .addTimestamps(6000000));
+
+    Mockito.when(mockWindmill.getStateData(COMPUTATION, expectedRequest.build()))
+        .thenReturn(response.build());
+    Mockito.verifyNoMoreInteractions(mockWindmill);
+
+    try {
+      valueFuture.get();
+      fail("Expected RuntimeException");
+    } catch (Exception e) {
+      assertThat(e.toString(), Matchers.containsString("Unable to decode value"));
+    }
+
+    try {
+      bagFuture.get();
+      fail("Expected RuntimeException");
+    } catch (Exception e) {
+      assertThat(e.toString(), Matchers.containsString("Error parsing bag"));
+    }
+
+    try {
+      orderedListFuture.get();
+      fail("Expected RuntimeException");
+    } catch (Exception e) {
+      assertThat(e.toString(), Matchers.containsString("Error parsing ordered list"));
+    }
+
+    try {
+      valuePrefixFuture.get();
+      fail("Expected RuntimeException");
+    } catch (Exception e) {
+      assertThat(e.toString(), Matchers.containsString("Error parsing tag value prefix"));
+    }
+
+    assertThat(watermarkFuture.get(), Matchers.equalTo(new Instant(5000)));
   }
 
   /**


### PR DESCRIPTION
Previously it would throw an exception when processing the response, but leave some futures corresponding to the batch uncompleted.  This could result in hanging calls to get() if the thrown exception was caught and the batched state was then attempted to be read.

Also improve decoder exceptions to only affect the corresponding state not the rest of batched reads.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
