### PR TITLE
Fix deleteTimer in InMemoryTimerInternals and enable VR tests for GroupIntoBatches.

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/InMemoryTimerInternals.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/InMemoryTimerInternals.java
@@ -28,6 +28,7 @@ import org.apache.beam.sdk.state.TimeDomain;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.WindowTracing;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.HashBasedTable;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Table;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -155,10 +156,18 @@ public class InMemoryTimerInternals implements TimerInternals {
   @Override
   public void deleteTimer(
       StateNamespace namespace, String timerId, String timerFamilyId, TimeDomain timeDomain) {
-    throw new UnsupportedOperationException("Canceling a timer by ID is not yet supported.");
+    TimerData removedTimer = existingTimers.remove(namespace, timerId + '+' + timerFamilyId);
+    if (removedTimer != null) {
+      Preconditions.checkState(
+          removedTimer.getDomain().equals(timeDomain),
+          "%s doesn't match time domain %s of timer",
+          timeDomain,
+          removedTimer.getDomain());
+      timersForDomain(timeDomain).remove(removedTimer);
+    }
   }
 
-  /** @deprecated use {@link #deleteTimer(StateNamespace, String, TimeDomain)}. */
+  /** @deprecated use {@link #deleteTimer(StateNamespace, String, String, TimeDomain)}. */
   @Deprecated
   @Override
   public void deleteTimer(StateNamespace namespace, String timerId, String timerFamilyId) {
@@ -168,11 +177,12 @@ public class InMemoryTimerInternals implements TimerInternals {
     }
   }
 
-  /** @deprecated use {@link #deleteTimer(StateNamespace, String, TimeDomain)}. */
+  /** @deprecated use {@link #deleteTimer(StateNamespace, String, String, TimeDomain)}. */
   @Deprecated
   @Override
   public void deleteTimer(TimerData timer) {
-    deleteTimer(timer.getNamespace(), timer.getTimerId(), timer.getTimerFamilyId());
+    deleteTimer(
+        timer.getNamespace(), timer.getTimerId(), timer.getTimerFamilyId(), timer.getDomain());
   }
 
   @Override

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/GroupIntoBatchesTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/GroupIntoBatchesTest.java
@@ -35,10 +35,12 @@ import org.apache.beam.sdk.testing.TestStream.ElementEvent;
 import org.apache.beam.sdk.testing.TestStream.Event;
 import org.apache.beam.sdk.testing.TestStream.ProcessingTimeEvent;
 import org.apache.beam.sdk.testing.TestStream.WatermarkEvent;
+import org.apache.beam.sdk.testing.UsesOnWindowExpiration;
 import org.apache.beam.sdk.testing.UsesStatefulParDo;
 import org.apache.beam.sdk.testing.UsesTestStream;
 import org.apache.beam.sdk.testing.UsesTestStreamWithProcessingTime;
 import org.apache.beam.sdk.testing.UsesTimersInParDo;
+import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.transforms.windowing.AfterPane;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
@@ -97,7 +99,13 @@ public class GroupIntoBatchesTest implements Serializable {
   }
 
   @Test
-  @Category({NeedsRunner.class, UsesTimersInParDo.class, UsesStatefulParDo.class})
+  @Category({
+    ValidatesRunner.class,
+    NeedsRunner.class,
+    UsesTimersInParDo.class,
+    UsesStatefulParDo.class,
+    UsesOnWindowExpiration.class
+  })
   public void testInGlobalWindowBatchSizeCount() {
     PCollection<KV<String, Iterable<String>>> collection =
         pipeline
@@ -130,7 +138,13 @@ public class GroupIntoBatchesTest implements Serializable {
   }
 
   @Test
-  @Category({NeedsRunner.class, UsesTimersInParDo.class, UsesStatefulParDo.class})
+  @Category({
+    ValidatesRunner.class,
+    NeedsRunner.class,
+    UsesTimersInParDo.class,
+    UsesStatefulParDo.class,
+    UsesOnWindowExpiration.class
+  })
   public void testInGlobalWindowBatchSizeByteSize() {
     PCollection<KV<String, Iterable<String>>> collection =
         pipeline
@@ -172,7 +186,13 @@ public class GroupIntoBatchesTest implements Serializable {
   }
 
   @Test
-  @Category({NeedsRunner.class, UsesTimersInParDo.class, UsesStatefulParDo.class})
+  @Category({
+    ValidatesRunner.class,
+    NeedsRunner.class,
+    UsesTimersInParDo.class,
+    UsesStatefulParDo.class,
+    UsesOnWindowExpiration.class
+  })
   public void testInGlobalWindowBatchSizeByteSizeFn() {
     PCollection<KV<String, Iterable<String>>> collection =
         pipeline
@@ -223,7 +243,13 @@ public class GroupIntoBatchesTest implements Serializable {
   }
 
   @Test
-  @Category({NeedsRunner.class, UsesTimersInParDo.class, UsesStatefulParDo.class})
+  @Category({
+    ValidatesRunner.class,
+    NeedsRunner.class,
+    UsesTimersInParDo.class,
+    UsesStatefulParDo.class,
+    UsesOnWindowExpiration.class
+  })
   public void testWithShardedKeyInGlobalWindow() {
     // Since with default sharding, the number of subshards of a key is nondeterministic, create
     // a large number of input elements and a small batch size and check there is no batch larger
@@ -300,14 +326,22 @@ public class GroupIntoBatchesTest implements Serializable {
                       numFullBatches > totalNumBatches / 2);
                   return null;
                 });
-    pipeline
-        .runWithAdditionalOptionArgs(ImmutableList.of("--targetParallelism=1"))
-        .waitUntilFinish();
+    if (pipeline.getOptions().getRunner().getSimpleName().equals("DirectRunner")) {
+      pipeline.runWithAdditionalOptionArgs(ImmutableList.of("--targetParallelism=1"));
+    } else {
+      pipeline.run();
+    }
   }
 
   /** test behavior when the number of input elements is not evenly divisible by batch size. */
   @Test
-  @Category({NeedsRunner.class, UsesTimersInParDo.class, UsesStatefulParDo.class})
+  @Category({
+    ValidatesRunner.class,
+    NeedsRunner.class,
+    UsesTimersInParDo.class,
+    UsesStatefulParDo.class,
+    UsesOnWindowExpiration.class
+  })
   public void testWithUnevenBatches() {
     PCollection<KV<String, Iterable<String>>> collection =
         pipeline
@@ -315,6 +349,7 @@ public class GroupIntoBatchesTest implements Serializable {
             .apply(GroupIntoBatches.ofSize(BATCH_SIZE))
             // set output coder
             .setCoder(KvCoder.of(StringUtf8Coder.of(), IterableCoder.of(StringUtf8Coder.of())));
+
     PAssert.that("Incorrect batch size in one or more elements", collection)
         .satisfies(
             new SerializableFunction<Iterable<KV<String, Iterable<String>>>, Void>() {
@@ -345,10 +380,12 @@ public class GroupIntoBatchesTest implements Serializable {
 
   @Test
   @Category({
+    ValidatesRunner.class,
     NeedsRunner.class,
     UsesTimersInParDo.class,
     UsesTestStream.class,
-    UsesStatefulParDo.class
+    UsesStatefulParDo.class,
+    UsesOnWindowExpiration.class
   })
   public void testInStreamingMode() {
     int timestampInterval = 1;
@@ -449,11 +486,13 @@ public class GroupIntoBatchesTest implements Serializable {
 
   @Test
   @Category({
+    ValidatesRunner.class,
     NeedsRunner.class,
     UsesTimersInParDo.class,
     UsesTestStream.class,
     UsesTestStreamWithProcessingTime.class,
-    UsesStatefulParDo.class
+    UsesStatefulParDo.class,
+    UsesOnWindowExpiration.class
   })
   public void testBufferingTimerInFixedWindow() {
     final Duration windowDuration = Duration.standardSeconds(4);
@@ -572,11 +611,13 @@ public class GroupIntoBatchesTest implements Serializable {
 
   @Test
   @Category({
+    ValidatesRunner.class,
     NeedsRunner.class,
     UsesTimersInParDo.class,
     UsesTestStream.class,
     UsesTestStreamWithProcessingTime.class,
-    UsesStatefulParDo.class
+    UsesStatefulParDo.class,
+    UsesOnWindowExpiration.class
   })
   public void testBufferingTimerInGlobalWindow() {
     final Duration maxBufferingDuration = Duration.standardSeconds(5);


### PR DESCRIPTION
Fixes #21378

Fix deleteTimer in InMemoryTimerInternals and enable VR tests for GroupIntoBatches.

Make sure GroupIntoBatches / onWindowExpiration isn't used in Spark runner to prevent data loss, see #22524.



------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
