### PR TITLE
Return type for _ExpandIntoRanges DoFn should be Iterable.

### DIFF
--- a/sdks/python/apache_beam/io/filebasedsource.py
+++ b/sdks/python/apache_beam/io/filebasedsource.py
@@ -29,6 +29,7 @@ For an example implementation of :class:`FileBasedSource` see
 # pytype: skip-file
 
 from typing import Callable
+from typing import Iterable
 from typing import Tuple
 from typing import Union
 
@@ -347,7 +348,7 @@ class _ExpandIntoRanges(DoFn):
     self._compression_type = compression_type
 
   def process(self, element: Union[str, FileMetadata], *args,
-              **kwargs) -> Tuple[FileMetadata, OffsetRange]:
+              **kwargs) -> Iterable[Tuple[FileMetadata, OffsetRange]]:
     if isinstance(element, FileMetadata):
       metadata_list = [element]
     else:


### PR DESCRIPTION
The following fails otherwise:

```
import apache_beam as beam
from apache_beam.io import textio
with beam.Pipeline(options=beam.options.pipeline_options.PipelineOptions(
        runtime_type_check=True, type_check_additional='all')) as p:
    p | beam.Create(['/bin/sh']) | textio.ReadAllFromText()
```

```
apache_beam.typehints.typehints.CompositeTypeHintError: Union[FileMetadata, OffsetRange] type-constraint violated. Expected an instance of one of: ('FileMetadata', 'OffsetRange'), received tuple instead.
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/#make-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
