### PR TITLE
Add BatchConverter implementations for pandas types, use Batched DoFns in DataFrame convert utilities

### DIFF
--- a/sdks/python/apache_beam/dataframe/convert.py
+++ b/sdks/python/apache_beam/dataframe/convert.py
@@ -29,6 +29,7 @@ import pandas as pd
 import apache_beam as beam
 from apache_beam import pvalue
 from apache_beam.dataframe import expressions
+from apache_beam.typehints.pandas_type_compatibility import dtype_to_fieldtype
 from apache_beam.dataframe import frame_base
 from apache_beam.dataframe import schemas
 from apache_beam.dataframe import transforms
@@ -168,7 +169,7 @@ class SeriesToElementsFn(beam.DoFn):
 
   def infer_output_type(self, input_element_type):
     # Raise a TypeError if proxy has an unknown type
-    output_type = schemas._dtype_to_fieldtype(self._proxy.dtype)
+    output_type = dtype_to_fieldtype(self._proxy.dtype)
     return output_type
 
 

--- a/sdks/python/apache_beam/dataframe/convert.py
+++ b/sdks/python/apache_beam/dataframe/convert.py
@@ -30,8 +30,9 @@ import apache_beam as beam
 from apache_beam import pvalue
 from apache_beam.dataframe import expressions
 from apache_beam.dataframe import frame_base
-from apache_beam.dataframe import schemas
 from apache_beam.dataframe import transforms
+from apache_beam.dataframe.schemas import element_typehint_from_dataframe_proxy
+from apache_beam.dataframe.schemas import generate_proxy
 from apache_beam.typehints.pandas_type_compatibility import dtype_to_fieldtype
 
 if TYPE_CHECKING:
@@ -71,7 +72,7 @@ def to_dataframe(
       # Attempt to come up with a reasonable, stable label by retrieving
       # the name of these variables in the calling context.
       label = 'BatchElements(%s)' % _var_name(pcoll, 2)
-    proxy = schemas.generate_proxy(pcoll.element_type)
+    proxy = generate_proxy(pcoll.element_type)
 
     shim_dofn: beam.DoFn
     if isinstance(proxy, pd.DataFrame):
@@ -152,7 +153,7 @@ class DataFrameToRowsFn(beam.DoFn):
     yield element
 
   def infer_output_type(self, input_element_type):
-    return schemas.element_typehint_from_dataframe_proxy(
+    return element_typehint_from_dataframe_proxy(
         self._proxy, self._include_indexes)
 
 

--- a/sdks/python/apache_beam/dataframe/convert.py
+++ b/sdks/python/apache_beam/dataframe/convert.py
@@ -19,8 +19,8 @@ import warnings
 import weakref
 from typing import TYPE_CHECKING
 from typing import Any
-from typing import Iterable
 from typing import Dict
+from typing import Iterable
 from typing import Tuple
 from typing import Union
 
@@ -29,10 +29,10 @@ import pandas as pd
 import apache_beam as beam
 from apache_beam import pvalue
 from apache_beam.dataframe import expressions
-from apache_beam.typehints.pandas_type_compatibility import dtype_to_fieldtype
 from apache_beam.dataframe import frame_base
 from apache_beam.dataframe import schemas
 from apache_beam.dataframe import transforms
+from apache_beam.typehints.pandas_type_compatibility import dtype_to_fieldtype
 
 if TYPE_CHECKING:
   # pylint: disable=ungrouped-imports
@@ -60,9 +60,6 @@ def to_dataframe(
   A proxy object must be given if the schema for the PCollection is not known.
   """
   if proxy is None:
-    # TODO: Find a better way to ensure pandas BatchConverters are registered
-    import apache_beam.typehints.pandas_type_compatibility
-
     if pcoll.element_type is None:
       raise ValueError(
           "Cannot infer a proxy because the input PCollection does not have a "
@@ -280,8 +277,6 @@ def to_pcollection(
   }
 
   if yield_elements == "schemas":
-    # TODO: Find a better way to ensure pandas BatchConverters are registered
-    import apache_beam.typehints.pandas_type_compatibility
 
     def maybe_unbatch(pc, value):
       if isinstance(value, frame_base._DeferredScalar):

--- a/sdks/python/apache_beam/dataframe/convert.py
+++ b/sdks/python/apache_beam/dataframe/convert.py
@@ -166,9 +166,7 @@ class SeriesToElementsFn(beam.DoFn):
     yield element
 
   def infer_output_type(self, input_element_type):
-    # Raise a TypeError if proxy has an unknown type
-    output_type = dtype_to_fieldtype(self._proxy.dtype)
-    return output_type
+    return dtype_to_fieldtype(self._proxy.dtype)
 
 
 # TODO: Or should this be called from_dataframe?

--- a/sdks/python/apache_beam/dataframe/schemas_test.py
+++ b/sdks/python/apache_beam/dataframe/schemas_test.py
@@ -117,7 +117,8 @@ INDEX_DF_TESTS = [(
 
 NOINDEX_DF_TESTS = [(NICE_TYPES_DF, DF_RESULT, BEAM_SCHEMA)]
 
-PD_VERSION = tuple(int(n) for n in pd.__version__.split('.'))
+# Get major, minor, bugfix version
+PD_VERSION = tuple(map(int, pd.__version__.split('.')[0:3]))
 
 
 def test_name_func(testcase_func, param_num, params):
@@ -279,6 +280,12 @@ class SchemasTest(unittest.TestCase):
   @parameterized.expand(SERIES_TESTS + INDEX_DF_TESTS, name_func=test_name_func)
   def test_unbatch_with_index(self, df_or_series, rows, _):
     proxy = df_or_series[:0]
+
+    if (PD_VERSION < (1, 2) and
+        set(['i32_nullable', 'i64_nullable']).intersection(proxy.index.names)):
+      self.skipTest(
+          "pandas<1.2 incorrectly changes Int64Dtype to int64 when "
+          "moved to index.")
 
     with TestPipeline() as p:
       res = (

--- a/sdks/python/apache_beam/dataframe/schemas_test.py
+++ b/sdks/python/apache_beam/dataframe/schemas_test.py
@@ -34,6 +34,7 @@ from apache_beam.dataframe import transforms
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
+from apache_beam.typehints import row_type
 from apache_beam.typehints import typehints
 from apache_beam.typehints.native_type_compatibility import match_is_named_tuple
 
@@ -52,10 +53,7 @@ def matches_df(expected):
         drop=True)
     sorted_expected = expected.sort_values(
         by=list(expected.columns)).reset_index(drop=True)
-    if not sorted_actual.equals(sorted_expected):
-      raise AssertionError(
-          'Dataframes not equal: \n\nActual:\n%s\n\nExpected:\n%s' %
-          (sorted_actual, sorted_expected))
+    pd.testing.assert_frame_equal(sorted_actual, sorted_expected)
 
   return check_df_pcoll_equal
 
@@ -145,6 +143,8 @@ class SchemasTest(unittest.TestCase):
     },
                             columns=['name', 'id', 'height'])
 
+    expected.name = expected.name.astype(pd.StringDtype())
+
     with TestPipeline() as p:
       res = (
           p
@@ -160,6 +160,7 @@ class SchemasTest(unittest.TestCase):
         'height': list(float(i) for i in range(5))
     },
                             columns=['name', 'id', 'height'])
+    expected.name = expected.name.astype(pd.StringDtype())
 
     with TestPipeline() as p:
       res = (
@@ -242,8 +243,14 @@ class SchemasTest(unittest.TestCase):
         assert_that(res, equal_to([('Falcon', 375.), ('Parrot', 25.)]))
 
   def assert_typehints_equal(self, left, right):
-    left = typehints.normalize(left)
-    right = typehints.normalize(right)
+    def maybe_drop_rowtypeconstraint(typehint):
+      if isinstance(typehint, row_type.RowTypeConstraint):
+        return typehint.user_type
+      else:
+        return typehint
+
+    left = maybe_drop_rowtypeconstraint(typehints.normalize(left))
+    right = maybe_drop_rowtypeconstraint(typehints.normalize(right))
 
     if match_is_named_tuple(left):
       self.assertTrue(match_is_named_tuple(right))
@@ -279,6 +286,16 @@ class SchemasTest(unittest.TestCase):
           | schemas.UnbatchPandas(proxy, include_indexes=True))
 
       assert_that(res, equal_to(rows))
+
+  @parameterized.expand(SERIES_TESTS, name_func=test_name_func)
+  def test_unbatch_series_with_index_warns(
+      self, series, unused_rows, unused_type):
+    proxy = series[:0]
+
+    with TestPipeline() as p:
+      input_pc = p | beam.Create([series[::2], series[1::2]])
+      with self.assertWarns(UserWarning):
+        _ = input_pc | schemas.UnbatchPandas(proxy, include_indexes=True)
 
   def test_unbatch_include_index_unnamed_index_raises(self):
     df = pd.DataFrame({'foo': [1, 2, 3, 4]})

--- a/sdks/python/apache_beam/runners/interactive/interactive_runner_test.py
+++ b/sdks/python/apache_beam/runners/interactive/interactive_runner_test.py
@@ -351,7 +351,9 @@ class InteractiveRunnerTest(unittest.TestCase):
     aggregate = lambda df: df.groupby(['name', 'height']).mean()
 
     deferred_df = aggregate(to_dataframe(p | beam.Create(data)))
-    df_expected = aggregate(pd.DataFrame(data))
+    df_input = pd.DataFrame(data)
+    df_input.name = df_input.name.astype(pd.StringDtype())
+    df_expected = aggregate(df_input)
 
     # Watch the local scope for Interactive Beam so that values will be cached.
     ib.watch(locals())
@@ -378,7 +380,9 @@ class InteractiveRunnerTest(unittest.TestCase):
     aggregate = lambda df: df.groupby(['name', 'height']).mean()['age']
 
     deferred_df = aggregate(to_dataframe(p | beam.Create(data)))
-    df_expected = aggregate(pd.DataFrame(data))
+    df_input = pd.DataFrame(data)
+    df_input.name = df_input.name.astype(pd.StringDtype())
+    df_expected = aggregate(df_input)
 
     # Watch the local scope for Interactive Beam so that values will be cached.
     ib.watch(locals())

--- a/sdks/python/apache_beam/typehints/__init__.py
+++ b/sdks/python/apache_beam/typehints/__init__.py
@@ -20,3 +20,12 @@
 # pylint: disable=wildcard-import
 from apache_beam.typehints.typehints import *
 from apache_beam.typehints.decorators import *
+from apache_beam.typehints.batch import *
+
+# pylint: disable=ungrouped-imports
+try:
+  import pandas as _
+except ImportError:
+  pass
+else:
+  from apache_beam.typehints.pandas_type_compatibility import *

--- a/sdks/python/apache_beam/typehints/batch.py
+++ b/sdks/python/apache_beam/typehints/batch.py
@@ -44,6 +44,8 @@ E = TypeVar('E')
 
 BATCH_CONVERTER_REGISTRY: List[Callable[[type, type], 'BatchConverter']] = []
 
+__all__ = ['BatchConverter']
+
 
 class BatchConverter(Generic[B, E]):
   def __init__(self, batch_type, element_type):

--- a/sdks/python/apache_beam/typehints/pandas_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/pandas_type_compatibility.py
@@ -15,7 +15,7 @@
 # limitations under the License.
 #
 
-"""Utilities for converting between Beam schemas and pandas DataFrames.
+r"""Utilities for converting between Beam schemas and pandas DataFrames.
 
 Imposes a mapping between native Python typings (specifically those compatible
 with :mod:`apache_beam.typehints.schemas`), and common pandas dtypes::
@@ -51,19 +51,21 @@ Note utilities in this package are for internal use only, we make no backward
 compatibility guarantees, except for the type mapping itself.
 """
 
+from typing import Any
+from typing import List
+from typing import Optional
+
+import numpy as np
+import pandas as pd
+
 from apache_beam.typehints.batch import BatchConverter
+from apache_beam.typehints.row_type import RowTypeConstraint
 from apache_beam.typehints.typehints import is_nullable
 from apache_beam.typehints.typehints import normalize
-from apache_beam.typehints.row_type import RowTypeConstraint
 
-import pandas as pd
-import numpy as np
-
-from typing import Any
-from typing import Optional
-from typing import List
-from typing import Tuple
-from typing import Dict
+# No public API currently, this just exists to register BatchConverter
+# implementations.
+__all__ = []
 
 # Name for a valueless field-level option which, when present, indicates that
 # a field should map to an index in the Beam DataFrame API.

--- a/sdks/python/apache_beam/typehints/pandas_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/pandas_type_compatibility.py
@@ -1,0 +1,195 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Utilities for converting between Beam schemas and pandas DataFrames.
+
+For internal use only, no backward compatibility guarantees.
+"""
+
+from apache_beam.typehints.batch import BatchConverter
+from apache_beam.typehints.typehints import is_nullable
+from apache_beam.typehints.row_type import RowTypeConstraint
+from apache_beam.dataframe.schemas import dtype_from_typehint
+from apache_beam.dataframe.schemas import generate_proxy
+
+import pandas as pd
+import numpy as np
+
+from typing import Any
+from typing import Optional
+from typing import List
+from typing import Tuple
+from typing import Dict
+
+# Name for a valueless field-level option which, when present, indicates that
+# a field should map to an index in the Beam DataFrame API.
+INDEX_OPTION_NAME = 'beam:dataframe:index'
+
+
+class DataFrameBatchConverter(BatchConverter):
+  def __init__(
+      self,
+      element_type: RowTypeConstraint,
+  ):
+    super().__init__(pd.DataFrame, element_type)
+    self._columns = [name for name, _ in element_type._fields]
+
+  @staticmethod
+  @BatchConverter.register
+  def from_typehints(element_type,
+                     batch_type) -> Optional['DataFrameBatchConverter']:
+    if not batch_type == pd.DataFrame:
+      return None
+
+    if not isinstance(element_type, RowTypeConstraint):
+      element_type = RowTypeConstraint.from_user_type(element_type)
+      if element_type is None:
+        return None
+
+    index_columns = [
+        field_name
+        for (field_name, field_options) in element_type._field_options.items()
+        if any(key == INDEX_OPTION_NAME for key, value in field_options)
+    ]
+
+    if index_columns:
+      return DataFrameBatchConverterKeepIndex(element_type, index_columns)
+    else:
+      return DataFrameBatchConverterDropIndex(element_type)
+
+  def _get_series(self, batch: pd.DataFrame):
+    raise NotImplementedError
+
+  def explode_batch(self, batch: pd.DataFrame):
+    # TODO: Only do null checks for nullable types
+    def make_null_checking_generator(series):
+      nulls = pd.isnull(series)
+      return (None if isnull else value for isnull, value in zip(nulls, series))
+
+    all_series = self._get_series(batch)
+    iterators = [make_null_checking_generator(series) for series in all_series]
+
+    for values in zip(*iterators):
+      yield self._element_type.user_type(
+          **{column: value
+             for column, value in zip(self._columns, values)})
+
+  def combine_batches(self, batches: List[pd.DataFrame]):
+    return pd.concat(batches)
+
+  def estimate_byte_size(self, batch: pd.DataFrame):
+    return batch.memory_usage().sum()
+
+  def get_length(self, batch: pd.DataFrame):
+    return len(batch)
+
+
+class DataFrameBatchConverterDropIndex(DataFrameBatchConverter):
+  """A DataFrameBatchConverter that assumes the DataFrame index has no meaning.
+
+  When producing a DataFrame from Rows, a meaningless index will be generated.
+  When exploding a DataFrame into Rows, the index will be dropped.
+  """
+  def _get_series(self, batch: pd.DataFrame):
+    return [batch[column] for column in batch.columns]
+
+  def produce_batch(self, elements):
+    # Note from_records has an index= parameter
+    batch = pd.DataFrame.from_records(elements, columns=self._columns)
+
+    for column, typehint in self._element_type._fields:
+      batch[column] = batch[column].astype(dtype_from_typehint(typehint))
+
+    return batch
+
+
+class DataFrameBatchConverterKeepIndex(DataFrameBatchConverter):
+  """A DataFrameBatchConverter that preserves the DataFrame index.
+
+  This is tracked via options on the Beam schema. Each field in the schema that
+  should map to the index is tagged in an option with name 'dataframe:index'.
+  """
+  def __init__(self, element_type: RowTypeConstraint, index_columns: List[Any]):
+    super().__init__(element_type)
+    self._index_columns = index_columns
+
+  def _get_series(self, batch: pd.DataFrame):
+    assert list(batch.index.names) == self._index_columns
+    return [
+        batch.index.get_level_values(i) for i in range(len(batch.index.names))
+    ] + [batch[column] for column in batch.columns]
+
+  def produce_batch(self, elements):
+    # Note from_records has an index= parameter
+    batch = pd.DataFrame.from_records(elements, columns=self._columns)
+
+    for column, typehint in self._element_type._fields:
+      batch[column] = batch[column].astype(dtype_from_typehint(typehint))
+
+    return batch.set_index(self._index_columns)
+
+
+class SeriesBatchConverter(BatchConverter):
+  def __init__(
+      self,
+      element_type: type,
+      dtype,
+  ):
+    super().__init__(pd.DataFrame, element_type)
+    self._dtype = dtype
+
+    if is_nullable(element_type):
+
+      def unbatch(series):
+        for isnull, value in zip(pd.isnull(series), series):
+          yield None if isnull else value
+    else:
+
+      def unbatch(series):
+        yield from series
+
+    self.explode_batch = unbatch
+
+  @staticmethod
+  @BatchConverter.register
+  def from_typehints(element_type,
+                     batch_type) -> Optional['SeriesBatchConverter']:
+    if not batch_type == pd.Series:
+      return None
+
+    dtype = dtype_from_typehint(element_type)
+    if dtype == np.object:
+      # Don't create Any <-> Series[np.object] mapping
+      return None
+
+    return SeriesBatchConverter(element_type, dtype)
+
+  def produce_batch(self, elements: List[Any]) -> pd.Series:
+    return pd.Series(elements, dtype=self._dtype)
+
+  def explode_batch(self, batch: pd.Series):
+    raise NotImplementedError(
+        "explode_batch should be generated in SeriesBatchConverter.__init__")
+
+  def combine_batches(self, batches: List[pd.Series]):
+    return pd.concat(batches)
+
+  def estimate_byte_size(self, batch: pd.Series):
+    return batch.memory_usage()
+
+  def get_length(self, batch: pd.Series):
+    return len(batch)

--- a/sdks/python/apache_beam/typehints/pandas_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/pandas_type_compatibility.py
@@ -183,7 +183,8 @@ class DataFrameBatchConverter(BatchConverter):
     raise NotImplementedError
 
   def explode_batch(self, batch: pd.DataFrame):
-    # TODO: Only do null checks for nullable types
+    # TODO(https://github.com/apache/beam/issues/22948): Only do null checks for
+    # nullable types
     def make_null_checking_generator(series):
       nulls = pd.isnull(series)
       return (None if isnull else value for isnull, value in zip(nulls, series))
@@ -216,7 +217,6 @@ class DataFrameBatchConverterDropIndex(DataFrameBatchConverter):
     return [batch[column] for column in batch.columns]
 
   def produce_batch(self, elements):
-    # Note from_records has an index= parameter
     batch = pd.DataFrame.from_records(elements, columns=self._columns)
 
     for column, typehint in self._element_type._fields:

--- a/sdks/python/apache_beam/typehints/pandas_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/pandas_type_compatibility_test.py
@@ -1,0 +1,192 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for pandas batched type converters."""
+
+from typing import Optional
+import unittest
+
+import pandas as pd
+import numpy as np
+from parameterized import parameterized
+from parameterized import parameterized_class
+
+from apache_beam.typehints import typehints
+from apache_beam.typehints import row_type
+from apache_beam.typehints.batch import BatchConverter
+from apache_beam.typehints.pandas_type_compatibility import DataFrameBatchConverter
+
+
+@parameterized_class([
+    {
+        'batch_typehint': pd.DataFrame,
+        'element_typehint': row_type.RowTypeConstraint.from_fields([
+            ('foo', int),
+            ('bar', float),
+            ('baz', str),
+        ]),
+        'match_index': False,
+        'batch': pd.DataFrame({
+            'foo': pd.Series(range(100), dtype='int64'),
+            'bar': pd.Series([i / 100 for i in range(100)], dtype='float64'),
+            'baz': pd.Series([str(i) for i in range(100)],
+                             dtype=pd.StringDtype()),
+        }),
+    },
+    {
+        'batch_typehint': pd.DataFrame,
+        'element_typehint': row_type.RowTypeConstraint.from_fields(
+            [
+                ('an_index', int),
+                ('foo', int),
+                ('bar', float),
+                ('baz', str),
+            ],
+            field_options={'an_index': [('beam:dataframe:index', None)]},
+        ),
+        'match_index': True,
+        'batch': pd.DataFrame({
+            'foo': pd.Series(range(100), dtype='int64'),
+            'bar': pd.Series([i / 100 for i in range(100)], dtype='float64'),
+            'baz': pd.Series([str(i) for i in range(100)],
+                             dtype=pd.StringDtype()),
+        }).set_index(pd.Int64Index(range(123, 223), name='an_index')),
+    },
+    {
+        'batch_typehint': pd.DataFrame,
+        'element_typehint': row_type.RowTypeConstraint.from_fields(
+            [
+                ('an_index', int),
+                ('another_index', int),
+                ('foo', int),
+                ('bar', float),
+                ('baz', str),
+            ],
+            field_options={
+                'an_index': [('beam:dataframe:index', None)],
+                'another_index': [('beam:dataframe:index', None)],
+            }),
+        'match_index': True,
+        'batch': pd.DataFrame({
+            'foo': pd.Series(range(100), dtype='int64'),
+            'bar': pd.Series([i / 100 for i in range(100)], dtype='float64'),
+            'baz': pd.Series([str(i) for i in range(100)],
+                             dtype=pd.StringDtype()),
+        }).set_index([
+            pd.Int64Index(range(123, 223), name='an_index'),
+            pd.Int64Index(range(475, 575), name='another_index'),
+        ]),
+    },
+    {
+        'batch_typehint': pd.Series,
+        'element_typehint': int,
+        'match_index': False,
+        'batch': pd.Series(range(500)),
+    },
+    {
+        'batch_typehint': pd.Series,
+        'element_typehint': str,
+        'batch': pd.Series(['foo', 'bar', 'baz', 'def', 'ghi', 'abc'] * 10,
+                           dtype=pd.StringDtype()),
+    },
+    {
+        'batch_typehint': pd.Series,
+        'element_typehint': Optional[np.int64],
+        'batch': pd.Series((i if i % 11 else None for i in range(500)),
+                           dtype=pd.Int64Dtype()),
+    },
+    {
+        'batch_typehint': pd.Series,
+        'element_typehint': Optional[str],
+        'batch': pd.Series(['foo', None, 'bar', 'baz', None, 'def', 'ghi'] * 10,
+                           dtype=pd.StringDtype()),
+    },
+])
+class DataFrameBatchConverterTest(unittest.TestCase):
+  def create_batch_converter(self):
+    return BatchConverter.from_typehints(
+        element_type=self.element_typehint, batch_type=self.batch_typehint)
+
+  def setUp(self):
+    self.converter = self.create_batch_converter()
+    self.normalized_batch_typehint = typehints.normalize(self.batch_typehint)
+    self.normalized_element_typehint = typehints.normalize(
+        self.element_typehint)
+
+  def equality_check(self, left, right):
+    if isinstance(left, pd.DataFrame):
+      if self.match_index:
+        pd.testing.assert_frame_equal(left.sort_index(), right.sort_index())
+      else:
+        pd.testing.assert_frame_equal(
+            left.sort_values(by=list(left.columns)).reset_index(drop=True),
+            right.sort_values(by=list(right.columns)).reset_index(drop=True))
+    elif isinstance(left, pd.Series):
+      pd.testing.assert_series_equal(
+          left.sort_values().reset_index(drop=True),
+          right.sort_values().reset_index(drop=True))
+    else:
+      raise TypeError(f"Encountered unexpected type, left is a {type(left)!r}")
+
+  def test_typehint_validates(self):
+    typehints.validate_composite_type_param(self.batch_typehint, '')
+    typehints.validate_composite_type_param(self.element_typehint, '')
+
+  def test_type_check(self):
+    typehints.check_constraint(self.normalized_batch_typehint, self.batch)
+
+  def test_type_check_element(self):
+    for element in self.converter.explode_batch(self.batch):
+      typehints.check_constraint(self.normalized_element_typehint, element)
+
+  def test_explode_rebatch(self):
+    exploded = list(self.converter.explode_batch(self.batch))
+    rebatched = self.converter.produce_batch(exploded)
+
+    typehints.check_constraint(self.normalized_batch_typehint, rebatched)
+    self.equality_check(self.batch, rebatched)
+
+  @parameterized.expand([
+      (2, ),
+      (3, ),
+      (10, ),
+  ])
+  def test_combine_batches(self, N):
+    elements = list(self.converter.explode_batch(self.batch))
+
+    # Split elements into N contiguous partitions, create a batch out of each
+    batches = [
+        self.converter.produce_batch(
+            elements[len(elements) * i // N:len(elements) * (i + 1) // N])
+        for i in range(N)
+    ]
+
+    # Combine the batches, output should be equivalent to the original batch
+    combined = self.converter.combine_batches(batches)
+
+    self.equality_check(self.batch, combined)
+
+  def test_equals(self):
+    self.assertTrue(self.converter == self.create_batch_converter())
+    self.assertTrue(self.create_batch_converter() == self.converter)
+
+  def test_hash(self):
+    self.assertEqual(hash(self.create_batch_converter()), hash(self.converter))
+
+
+if __name__ == '__main__':
+  unittest.main()

--- a/sdks/python/apache_beam/typehints/pandas_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/pandas_type_compatibility_test.py
@@ -17,18 +17,17 @@
 
 """Unit tests for pandas batched type converters."""
 
-from typing import Optional
 import unittest
+from typing import Optional
 
-import pandas as pd
 import numpy as np
+import pandas as pd
 from parameterized import parameterized
 from parameterized import parameterized_class
 
-from apache_beam.typehints import typehints
 from apache_beam.typehints import row_type
+from apache_beam.typehints import typehints
 from apache_beam.typehints.batch import BatchConverter
-from apache_beam.typehints.pandas_type_compatibility import DataFrameBatchConverter
 
 
 @parameterized_class([

--- a/sdks/python/apache_beam/typehints/pandas_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/pandas_type_compatibility_test.py
@@ -169,8 +169,10 @@ class DataFrameBatchConverterTest(unittest.TestCase):
     ]
 
     lengths = [len(element_batch) for element_batch in element_batches]
-    batches = [self.converter.produce_batch(element_batch)
-               for element_batch in element_batches]
+    batches = [
+        self.converter.produce_batch(element_batch)
+        for element_batch in element_batches
+    ]
 
     return batches, lengths
 
@@ -192,12 +194,11 @@ class DataFrameBatchConverterTest(unittest.TestCase):
       (3, ),
       (10, ),
   ])
-  def test_get_lenth(self, N):
+  def test_get_length(self, N):
     batches, lengths = self._split_batch_into_n_partitions(N)
 
     for batch, expected_length in zip(batches, lengths):
       self.assertEqual(self.converter.get_length(batch), expected_length)
-
 
   def test_equals(self):
     self.assertTrue(self.converter == self.create_batch_converter())


### PR DESCRIPTION
Fixes #22678

This PR moves the pandas - Beam type mapping from `apache_beam.dataframe.schemas` to `apache_beam.typehints.pandas_type_compatibility`, and modifies `apache_beam.dataframe.convert` to leverage that mapping by defining batch-producing and -consuming DoFns. 

The new module now provides `BatchConverter` implementations that can be re-used in other DoFns that wish to process structured data using the pandas API.  It also makes one slight modification in the type mapping: we now have a special field option, `beam:dataframe:index:v1`. This option is used to indicate that a Beam schema field should map to an index in the pandas DataFrame type system. If a Beam schema has no fields identified as an index, then we assume the user does not care about the index, and a "meaningless" one will be generated when mapping to DataFrames. Similarly when mapping a DataFrame back to the Beam type system, the index will be dropped.

Note `apache_beam.dataframe.schemas` still exists, for two purposes:
- To maintain backwards compatibility, we still define `BatchRowsAsDataFrame` and `UnbatchPandas` transforms. These transforms are no longer used in `apache_beam.dataframe.convert` though.
- To handle proxy generation and consumption (`generate_proxy`, `element_type_from_dataframe`). These functions _are_ still used in `apache_beam.dataframe.convert`.

All of the logic in `apache_beam.dataframe.schemas` defers to `apache_beam.typehints.pandas_type_compatibility` as much as possible.

The following PRs were separated from this one to ease review:
- #22626
- #22630
- #22679
- #22680

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
