### PR TITLE
Persist ghprbPullId parameter in seed job

### DIFF
--- a/.test-infra/jenkins/job_00_seed.groovy
+++ b/.test-infra/jenkins/job_00_seed.groovy
@@ -63,6 +63,10 @@ job('beam_SeedJob') {
         'sha1',
         'master',
         'Commit id or refname (eg: origin/pr/4001/head) you want to build against.')
+    stringParam(
+        'ghprbPullId',
+        '',
+        'PR number (e.g. 4001) if build from a PR.')
   }
 
   wrappers {


### PR DESCRIPTION
Currently we advise committers to [create this parameter manually](https://drive.google.com/file/d/1Yk4TIF3Qw_ur4P8fTx1I1469TDFdCHHq/view) when running the seed job for a non-committer PR, but the parameter goes away when the seed job is re-run. I think we can persist the parameter this way to make our lives easier.

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
