### PR TITLE
Support VR test including TestStream for Spark runner in streaming mode

### DIFF
--- a/runners/spark/spark_runner.gradle
+++ b/runners/spark/spark_runner.gradle
@@ -265,7 +265,7 @@ def validatesRunnerStreaming = tasks.register("validatesRunnerStreaming", Test) 
   group = "Verification"
   // Disable gradle cache
   outputs.upToDateWhen { false }
-  systemProperties sparkTestProperties(["--enableSparkMetricSinks": "true", "--forceStreaming": "true"])
+  systemProperties sparkTestProperties(["--enableSparkMetricSinks": "true"])
 
   classpath = configurations.validatesRunner
   testClassesDirs += files(
@@ -278,25 +278,19 @@ def validatesRunnerStreaming = tasks.register("validatesRunnerStreaming", Test) 
     includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'
 
     filter {
-      // translation to UNBOUNDED read doesn't work for empty input
-      excludeTestsMatching 'org.apache.beam.sdk.transforms.FlattenTest.testEmptyFlattenAsSideInput'
-      excludeTestsMatching 'org.apache.beam.sdk.transforms.FlattenTest.testFlattenPCollectionsEmpty'
-      excludeTestsMatching 'org.apache.beam.sdk.transforms.FlattenTest.testFlattenPCollectionsEmptyThenParDo'
+      // UNBOUNDED View.CreatePCollectionView not supported
+      excludeTestsMatching 'org.apache.beam.sdk.transforms.ParDoTest$BundleInvariantsTests.testWatermarkUpdateMidBundle'
+      excludeTestsMatching 'org.apache.beam.sdk.transforms.ViewTest.testWindowedSideInputNotPresent'
     }
 
     // TestStream using processing time is not supported in Spark
     excludeCategories 'org.apache.beam.sdk.testing.UsesTestStreamWithProcessingTime'
-    // CreatePCollectionView not supported in streaming mode
-    excludeCategories 'org.apache.beam.sdk.testing.UsesSideInputs'
-    // BOUNDED, not applicable in streaming mode
-    excludeCategories 'org.apache.beam.sdk.testing.UsesImpulse'
 
     // Exceeds Java heap space
     excludeCategories 'org.apache.beam.sdk.testing.LargeKeys$Above100MB'
 
     // Should be run only in a properly configured SDK harness environment
     excludeCategories 'org.apache.beam.sdk.testing.UsesSdkHarnessEnvironment'
-    excludeCategories 'org.apache.beam.sdk.testing.UsesCustomWindowMerging'
 
     // State and Timers
     excludeCategories 'org.apache.beam.sdk.testing.UsesStatefulParDo'

--- a/runners/spark/spark_runner.gradle
+++ b/runners/spark/spark_runner.gradle
@@ -51,6 +51,7 @@ configurations {
 def sparkTestProperties(overrides = [:]) {
   def defaults = ["--runner": "TestSparkRunner"]
   [
+      "log4j.configuration"         : "log4j-test.properties",
       "spark.sql.shuffle.partitions": "4",
       "spark.ui.enabled"            : "false",
       "spark.ui.showConsoleProgress": "false",
@@ -106,7 +107,6 @@ if (copySourceBase) {
 
 test {
   systemProperties sparkTestProperties()
-  systemProperty "log4j.configuration", "log4j-test.properties"
   // Change log level to debug:
   // systemProperty "org.slf4j.simpleLogger.defaultLogLevel", "debug"
   // Change log level to debug only for the package and nested packages:
@@ -207,6 +207,11 @@ configurations.all {
   exclude group: "com.codahale.metrics", module: "metrics-core"
 }
 
+configurations.validatesRunner {
+  // Exclude to make sure log4j binding is used
+  exclude group: "org.slf4j", module: "slf4j-simple"
+}
+
 hadoopVersions.each { kv ->
   configurations."hadoopVersion$kv.key" {
     resolutionStrategy {
@@ -260,21 +265,60 @@ def validatesRunnerStreaming = tasks.register("validatesRunnerStreaming", Test) 
   group = "Verification"
   // Disable gradle cache
   outputs.upToDateWhen { false }
-  def pipelineOptions = JsonOutput.toJson([
-    "--runner=TestSparkRunner",
-    "--forceStreaming=true",
-    "--enableSparkMetricSinks=true",
-  ])
-  systemProperty "beamTestPipelineOptions", pipelineOptions
+  systemProperties sparkTestProperties(["--enableSparkMetricSinks": "true", "--forceStreaming": "true"])
 
   classpath = configurations.validatesRunner
-  testClassesDirs += files(project.sourceSets.test.output.classesDirs)
+  testClassesDirs += files(
+    project(":sdks:java:core").sourceSets.test.output.classesDirs,
+    project(":runners:core-java").sourceSets.test.output.classesDirs,
+  )
 
-  // Only one SparkContext may be running in a JVM (SPARK-2243)
-  forkEvery 1
   maxParallelForks 4
   useJUnit {
-    includeCategories 'org.apache.beam.runners.spark.StreamingTest'
+    includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'
+
+    filter {
+      // translation to UNBOUNDED read doesn't work for empty input
+      excludeTestsMatching 'org.apache.beam.sdk.transforms.FlattenTest.testEmptyFlattenAsSideInput'
+      excludeTestsMatching 'org.apache.beam.sdk.transforms.FlattenTest.testFlattenPCollectionsEmpty'
+      excludeTestsMatching 'org.apache.beam.sdk.transforms.FlattenTest.testFlattenPCollectionsEmptyThenParDo'
+    }
+
+    // TestStream using processing time is not supported in Spark
+    excludeCategories 'org.apache.beam.sdk.testing.UsesTestStreamWithProcessingTime'
+    // CreatePCollectionView not supported in streaming mode
+    excludeCategories 'org.apache.beam.sdk.testing.UsesSideInputs'
+    // BOUNDED, not applicable in streaming mode
+    excludeCategories 'org.apache.beam.sdk.testing.UsesImpulse'
+
+    // Exceeds Java heap space
+    excludeCategories 'org.apache.beam.sdk.testing.LargeKeys$Above100MB'
+
+    // Should be run only in a properly configured SDK harness environment
+    excludeCategories 'org.apache.beam.sdk.testing.UsesSdkHarnessEnvironment'
+    excludeCategories 'org.apache.beam.sdk.testing.UsesCustomWindowMerging'
+
+    // State and Timers
+    excludeCategories 'org.apache.beam.sdk.testing.UsesStatefulParDo'
+    excludeCategories 'org.apache.beam.sdk.testing.UsesTimersInParDo'
+    excludeCategories 'org.apache.beam.sdk.testing.UsesTimerMap'
+    excludeCategories 'org.apache.beam.sdk.testing.UsesLoopingTimer'
+    excludeCategories 'org.apache.beam.sdk.testing.UsesOnWindowExpiration'
+    excludeCategories 'org.apache.beam.sdk.testing.UsesOrderedListState'
+
+    // Metrics
+    excludeCategories 'org.apache.beam.sdk.testing.UsesCommittedMetrics'
+    excludeCategories 'org.apache.beam.sdk.testing.UsesSystemMetrics'
+    // SDF
+    excludeCategories 'org.apache.beam.sdk.testing.UsesUnboundedSplittableParDo'
+    excludeCategories 'org.apache.beam.sdk.testing.UsesBoundedSplittableParDo'
+    // Portability
+    excludeCategories 'org.apache.beam.sdk.testing.UsesJavaExpansionService'
+    excludeCategories 'org.apache.beam.sdk.testing.UsesPythonExpansionService'
+    excludeCategories 'org.apache.beam.sdk.testing.UsesBundleFinalizer'
+    // Ordering
+    excludeCategories 'org.apache.beam.sdk.testing.UsesPerKeyOrderedDelivery'
+    excludeCategories 'org.apache.beam.sdk.testing.UsesPerKeyOrderInBundle'
   }
 }
 

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkRunner.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkRunner.java
@@ -153,7 +153,7 @@ public final class SparkRunner extends PipelineRunner<SparkPipelineResult> {
     MetricsEnvironment.setMetricsSupported(true);
 
     // visit the pipeline to determine the translation mode
-    detectTranslationMode(pipeline);
+    detectTranslationMode(pipeline, pipelineOptions);
 
     // Default to using the primitive versions of Read.Bounded and Read.Unbounded.
     // TODO(https://github.com/apache/beam/issues/20530): Use SDF read as default when we address
@@ -273,12 +273,12 @@ public final class SparkRunner extends PipelineRunner<SparkPipelineResult> {
   }
 
   /** Visit the pipeline to determine the translation mode (batch/streaming). */
-  private void detectTranslationMode(Pipeline pipeline) {
+  static void detectTranslationMode(Pipeline pipeline, SparkPipelineOptions pipelineOptions) {
     TranslationModeDetector detector = new TranslationModeDetector();
     pipeline.traverseTopologically(detector);
     if (detector.getTranslationMode().equals(TranslationMode.STREAMING)) {
       // set streaming mode if it's a streaming pipeline
-      this.pipelineOptions.setStreaming(true);
+      pipelineOptions.setStreaming(true);
     }
   }
 

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/TestSparkRunner.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/TestSparkRunner.java
@@ -101,6 +101,8 @@ public final class TestSparkRunner extends PipelineRunner<SparkPipelineResult> {
     TestSparkPipelineOptions testSparkOptions =
         PipelineOptionsValidator.validate(TestSparkPipelineOptions.class, options);
 
+    SparkRunner.detectTranslationMode(pipeline, testSparkOptions);
+
     boolean isForceStreaming = testSparkOptions.isForceStreaming();
     boolean isStreaming = testSparkOptions.isStreaming();
 

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/TestSparkRunner.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/TestSparkRunner.java
@@ -17,8 +17,6 @@
  */
 package org.apache.beam.runners.spark;
 
-import static org.apache.beam.sdk.Pipeline.PipelineVisitor.CompositeBehavior.DO_NOT_ENTER_TRANSFORM;
-import static org.apache.beam.sdk.Pipeline.PipelineVisitor.CompositeBehavior.ENTER_TRANSFORM;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.is;
@@ -26,33 +24,16 @@ import static org.hamcrest.Matchers.isOneOf;
 
 import java.io.File;
 import java.io.IOException;
-import java.util.HashSet;
-import java.util.Map;
-import java.util.Set;
 import java.util.concurrent.TimeUnit;
-import org.apache.beam.runners.core.construction.ReplacementOutputs;
-import org.apache.beam.runners.core.construction.UnboundedReadFromBoundedSource;
 import org.apache.beam.runners.spark.aggregators.AggregatorsAccumulator;
 import org.apache.beam.runners.spark.metrics.MetricsAccumulator;
 import org.apache.beam.runners.spark.stateful.SparkTimerInternals;
 import org.apache.beam.runners.spark.util.GlobalWatermarkHolder;
 import org.apache.beam.sdk.Pipeline;
-import org.apache.beam.sdk.Pipeline.PipelineVisitor;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.PipelineRunner;
-import org.apache.beam.sdk.io.Read;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsValidator;
-import org.apache.beam.sdk.runners.AppliedPTransform;
-import org.apache.beam.sdk.runners.PTransformOverride;
-import org.apache.beam.sdk.runners.PTransformOverrideFactory;
-import org.apache.beam.sdk.runners.TransformHierarchy;
-import org.apache.beam.sdk.transforms.PTransform;
-import org.apache.beam.sdk.values.PBegin;
-import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PCollection.IsBounded;
-import org.apache.beam.sdk.values.TupleTag;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.util.concurrent.Uninterruptibles;
 import org.apache.commons.io.FileUtils;
 import org.joda.time.Duration;
@@ -102,8 +83,6 @@ public final class TestSparkRunner extends PipelineRunner<SparkPipelineResult> {
         PipelineOptionsValidator.validate(TestSparkPipelineOptions.class, options);
 
     SparkRunner.detectTranslationMode(pipeline, testSparkOptions);
-
-    boolean isForceStreaming = testSparkOptions.isForceStreaming();
     boolean isStreaming = testSparkOptions.isStreaming();
 
     SparkPipelineResult result = null;
@@ -116,26 +95,8 @@ public final class TestSparkRunner extends PipelineRunner<SparkPipelineResult> {
     LOG.info("About to run test pipeline {}", options.getJobName());
 
     // if the pipeline was executed in streaming mode, validate aggregators.
-    if (isStreaming || isForceStreaming) {
+    if (isStreaming) {
       try {
-        testSparkOptions.setStreaming(true);
-
-        if (isForceStreaming) {
-          FindBoundedReads boundedReadsVisitor = new FindBoundedReads();
-          pipeline.traverseTopologically(boundedReadsVisitor);
-
-          if (!boundedReadsVisitor.boundedReads.isEmpty()) {
-            // replace BOUNDED read with UNBOUNDED to force streaming
-            pipeline.replaceAll(
-                ImmutableList.of(
-                    PTransformOverride.of(
-                        app -> boundedReadsVisitor.contains(app.getTransform()),
-                        new UnboundedReadFromBoundedSourceOverrideFactory<>())));
-            // force UNBOUNDED PCollections
-            pipeline.traverseTopologically(new SetUnbounded());
-          }
-        }
-
         result = delegate.run(pipeline);
         awaitWatermarksOrTimeout(testSparkOptions, result);
         result.stop();
@@ -193,85 +154,5 @@ public final class TestSparkRunner extends PipelineRunner<SparkPipelineResult> {
       Uninterruptibles.sleepUninterruptibly(batchDurationMillis, TimeUnit.MILLISECONDS);
     } while ((timeoutMillis -= batchDurationMillis) > 0
         && globalWatermark.isBefore(stopPipelineWatermark));
-  }
-
-  /**
-   * Override factory to replace {@link Read.Unbounded} with {@link UnboundedReadFromBoundedSource}
-   * to force streaming mode.
-   */
-  private static class UnboundedReadFromBoundedSourceOverrideFactory<T>
-      implements PTransformOverrideFactory<PBegin, PCollection<T>, Read.Bounded<T>> {
-
-    @Override
-    public PTransformReplacement<PBegin, PCollection<T>> getReplacementTransform(
-        AppliedPTransform<PBegin, PCollection<T>, Read.Bounded<T>> transform) {
-      return PTransformReplacement.of(
-          transform.getPipeline().begin(),
-          new UnboundedReadFromBoundedSource<>(transform.getTransform().getSource()));
-    }
-
-    @Override
-    public Map<PCollection<?>, ReplacementOutput> mapOutputs(
-        Map<TupleTag<?>, PCollection<?>> outputs, PCollection<T> newOutput) {
-      return ReplacementOutputs.singleton(outputs, newOutput);
-    }
-  }
-
-  private static boolean isBoundedRead(PTransform<?, ?> transform) {
-    return transform != null && transform instanceof Read.Bounded;
-  }
-
-  /** Gathers all bounded test inputs of {@link Read.Bounded} except for usages in PAssert. */
-  private static class FindBoundedReads extends PipelineVisitor.Defaults {
-    private final Set<Read.Bounded<?>> boundedReads = new HashSet<>();
-
-    @Override
-    public CompositeBehavior enterCompositeTransform(TransformHierarchy.Node node) {
-      if (node.getFullName().contains("PAssert$")) {
-        return DO_NOT_ENTER_TRANSFORM;
-      } else if (isBoundedRead(node.getTransform())) {
-        boundedReads.add((Read.Bounded) node.getTransform());
-        return DO_NOT_ENTER_TRANSFORM;
-      }
-      return ENTER_TRANSFORM;
-    }
-
-    boolean contains(PTransform<?, ?> transform) {
-      return boundedReads.contains(transform);
-    }
-  }
-
-  /**
-   * Sets all {@link PCollection}s to {@link IsBounded#UNBOUNDED} excepts for outputs of remaining
-   * {@link Read.Bounded} (used in PAssert) and descendants.
-   */
-  private static class SetUnbounded extends PipelineVisitor.Defaults {
-    private final Set<PCollection<?>> excludes = new HashSet<>();
-
-    @Override
-    public CompositeBehavior enterCompositeTransform(TransformHierarchy.Node node) {
-      if (isBoundedRead(node.getTransform())) {
-        // Output of Read.Bounded (used in PAssert) has to remain BOUNDED
-        setIsBounded(node.getOutputs(), IsBounded.BOUNDED);
-        excludes.addAll(node.getOutputs().values());
-        return DO_NOT_ENTER_TRANSFORM;
-      } else {
-        visitPrimitiveTransform(node);
-        return ENTER_TRANSFORM;
-      }
-    }
-
-    @Override
-    public void visitPrimitiveTransform(TransformHierarchy.Node node) {
-      // Force UNBOUNDED PCollections
-      setIsBounded(node.getInputs(), IsBounded.UNBOUNDED);
-      setIsBounded(node.getOutputs(), IsBounded.UNBOUNDED);
-    }
-
-    private void setIsBounded(Map<TupleTag<?>, PCollection<?>> map, IsBounded isBounded) {
-      map.values().stream()
-          .filter(pc -> !excludes.contains(pc))
-          .forEach(in -> in.setIsBoundedInternal(isBounded));
-    }
   }
 }

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/TestDStream.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/translation/streaming/TestDStream.java
@@ -1,0 +1,143 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.spark.translation.streaming;
+
+import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.util.ArrayList;
+import java.util.List;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import org.apache.beam.runners.spark.coders.CoderHelpers;
+import org.apache.beam.runners.spark.util.GlobalWatermarkHolder;
+import org.apache.beam.runners.spark.util.GlobalWatermarkHolder.SparkWatermarks;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.testing.TestStream;
+import org.apache.beam.sdk.testing.TestStream.ElementEvent;
+import org.apache.beam.sdk.testing.TestStream.ProcessingTimeEvent;
+import org.apache.beam.sdk.testing.TestStream.WatermarkEvent;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.util.Preconditions;
+import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.beam.sdk.values.TimestampedValue;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.util.concurrent.Uninterruptibles;
+import org.apache.spark.api.java.JavaSparkContext;
+import org.apache.spark.api.java.JavaSparkContext$;
+import org.apache.spark.rdd.RDD;
+import org.apache.spark.streaming.StreamingContext;
+import org.apache.spark.streaming.Time;
+import org.apache.spark.streaming.dstream.InputDStream;
+import org.joda.time.Instant;
+import scala.Option;
+import scala.reflect.ClassTag;
+
+public class TestDStream<T> extends InputDStream<WindowedValue<T>> {
+  private final Coder<WindowedValue<T>> coder;
+
+  @SuppressFBWarnings("SE_TRANSIENT_FIELD_NOT_RESTORED") // not intended for use after serialization
+  private final transient List<TestStream.Event<T>> events;
+
+  private int event = 0;
+
+  private boolean insertEmptyBatch = false;
+
+  private long lastMillis = 0;
+
+  private Instant lastWatermark = Instant.EPOCH;
+
+  public TestDStream(TestStream<T> test, StreamingContext ssc) {
+    super(ssc, classTag());
+    this.coder = WindowedValue.getFullCoder(test.getValueCoder(), GlobalWindow.Coder.INSTANCE);
+    this.events = test.getEvents();
+  }
+
+  @Override
+  public Option<RDD<WindowedValue<T>>> compute(Time validTime) {
+    Preconditions.checkStateNotNull(events);
+
+    TestStream.Event<T> event = insertEmptyBatch ? null : nextEvent();
+
+    if (event == null) {
+      insertEmptyBatch = false;
+      waitForLastBatch(validTime);
+      return Option.apply(emptyRDD());
+
+    } else if (event instanceof ElementEvent) {
+      waitForLastBatch(validTime);
+      return Option.apply(buildRdd((ElementEvent<T>) event));
+
+    } else if (event instanceof WatermarkEvent) {
+      waitForLastBatch(validTime);
+      addWatermark(validTime, (WatermarkEvent<T>) event);
+      // insert an additional empty batch so watermark can propagate
+      insertEmptyBatch = true;
+      return Option.apply(emptyRDD());
+
+    } else if (event instanceof ProcessingTimeEvent) {
+      throw new UnsupportedOperationException(
+          "Advancing Processing time is not supported by the Spark Runner.");
+    } else {
+      throw new IllegalStateException("Unknown event type " + event);
+    }
+  }
+
+  private void waitForLastBatch(Time validTime) {
+    while (GlobalWatermarkHolder.getLastWatermarkedBatchTime() < lastMillis) {
+      Uninterruptibles.sleepUninterruptibly(10, TimeUnit.MILLISECONDS);
+    }
+    lastMillis = validTime.milliseconds();
+  }
+
+  private @Nullable TestStream.Event<T> nextEvent() {
+    return events.size() > event ? events.get(event++) : null;
+  }
+
+  private void addWatermark(Time time, WatermarkEvent<T> event) {
+    SparkWatermarks watermarks =
+        new SparkWatermarks(lastWatermark, event.getWatermark(), new Instant(time.milliseconds()));
+    lastWatermark = event.getWatermark();
+    GlobalWatermarkHolder.add(id(), watermarks);
+  }
+
+  @Override
+  public void start() {}
+
+  @Override
+  public void stop() {}
+
+  private RDD<WindowedValue<T>> emptyRDD() {
+    return ssc().sparkContext().emptyRDD(classTag());
+  }
+
+  private RDD<WindowedValue<T>> buildRdd(ElementEvent<T> event) {
+    List<byte[]> binaryData = new ArrayList<>();
+    for (TimestampedValue<T> elem : event.getElements()) {
+      WindowedValue<T> wv =
+          WindowedValue.timestampedValueInGlobalWindow(elem.getValue(), elem.getTimestamp());
+      binaryData.add(CoderHelpers.toByteArray(wv, coder));
+    }
+
+    return new JavaSparkContext(ssc().sparkContext())
+        .parallelize(binaryData)
+        .map(CoderHelpers.fromByteFunction(coder))
+        .rdd();
+  }
+
+  private static <T> ClassTag<WindowedValue<T>> classTag() {
+    return JavaSparkContext$.MODULE$.fakeClassTag();
+  }
+}

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/SparkRunnerDebuggerTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/SparkRunnerDebuggerTest.java
@@ -109,7 +109,7 @@ public class SparkRunnerDebuggerTest {
   public void debugStreamingPipeline() {
     PipelineOptions options = contextRule.configure(PipelineOptionsFactory.create());
     options.setRunner(SparkRunnerDebugger.class);
-    options.as(TestSparkPipelineOptions.class).setForceStreaming(true);
+    options.as(TestSparkPipelineOptions.class).setStreaming(true);
     Pipeline pipeline = Pipeline.create(options);
 
     KafkaIO.Read<String, String> read =

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/aggregators/metrics/sink/SparkMetricsSinkTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/aggregators/metrics/sink/SparkMetricsSinkTest.java
@@ -86,7 +86,7 @@ public class SparkMetricsSinkTest {
   @Category(StreamingTest.class)
   @Test
   public void testInStreamingMode() throws Exception {
-    pipeline.getOptions().as(TestSparkPipelineOptions.class).setForceStreaming(true);
+    pipeline.getOptions().as(TestSparkPipelineOptions.class).setStreaming(true);
     assertThat(InMemoryMetrics.valueOf("emptyLines"), is(nullValue()));
 
     Instant instant = new Instant(0);

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/metrics/SparkMetricsPusherTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/metrics/SparkMetricsPusherTest.java
@@ -69,7 +69,7 @@ public class SparkMetricsPusherTest {
   @Category(StreamingTest.class)
   @Test
   public void testInStreamingMode() throws Exception {
-    pipeline.getOptions().as(TestSparkPipelineOptions.class).setForceStreaming(true);
+    pipeline.getOptions().as(TestSparkPipelineOptions.class).setStreaming(true);
 
     Instant instant = new Instant(0);
     CreateStream<Integer> source =

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/CreateStreamTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/CreateStreamTest.java
@@ -529,7 +529,7 @@ public class CreateStreamTest implements Serializable {
 
   private static PipelineOptions streamingOptions() {
     PipelineOptions options = TestPipeline.testingPipelineOptions();
-    options.as(TestSparkPipelineOptions.class).setForceStreaming(true);
+    options.as(TestSparkPipelineOptions.class).setStreaming(true);
     return options;
   }
 }

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/ResumeFromCheckpointStreamingTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/ResumeFromCheckpointStreamingTest.java
@@ -279,7 +279,7 @@ public class ResumeFromCheckpointStreamingTest implements Serializable {
     options.setExpectedAssertions(expectedAssertions);
     options.setRunner(TestSparkRunner.class);
     options.setEnableSparkMetricSinks(false);
-    options.setForceStreaming(true);
+    options.setStreaming(true);
     options.setCheckpointDir(temporaryFolder.getRoot().getPath());
     // timeout is per execution so it can be injected by the caller.
     if (stopWatermarkOption.isPresent()) {

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/SparkCoGroupByKeyStreamingTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/SparkCoGroupByKeyStreamingTest.java
@@ -170,7 +170,7 @@ public class SparkCoGroupByKeyStreamingTest {
 
   private static PipelineOptions streamingOptions() {
     PipelineOptions options = TestPipeline.testingPipelineOptions();
-    options.as(TestSparkPipelineOptions.class).setForceStreaming(true);
+    options.as(TestSparkPipelineOptions.class).setStreaming(true);
     return options;
   }
 }

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/StreamingSourceMetricsTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/translation/streaming/StreamingSourceMetricsTest.java
@@ -92,7 +92,7 @@ public class StreamingSourceMetricsTest implements Serializable {
 
   private static PipelineOptions streamingOptions() {
     PipelineOptions options = TestPipeline.testingPipelineOptions();
-    options.as(TestSparkPipelineOptions.class).setForceStreaming(true);
+    options.as(TestSparkPipelineOptions.class).setStreaming(true);
     return options;
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestStreamTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/TestStreamTest.java
@@ -105,6 +105,9 @@ public class TestStreamTest implements Serializable {
             .advanceWatermarkTo(instant.plus(Duration.standardMinutes(6)))
             // These elements are late but within the allowed lateness
             .addElements(TimestampedValue.of(4L, instant), TimestampedValue.of(5L, instant))
+            .advanceWatermarkTo(instant.plus(Duration.standardMinutes(10)))
+            // FIXME: Without advancing the watermark once more the (lower) input watermark remains
+            // at 6 mins, but data in [0,5 min) won't be considered late until it passes 10 mins.
             .advanceWatermarkTo(instant.plus(Duration.standardMinutes(20)))
             // These elements are droppably late
             .addElements(


### PR DESCRIPTION
Run VR tests for Spark streaming runner rather than custom tests (test are already run as part of the "normal" unit test run).

If `forceStreaming` is set to `true`, the `TestSparkRunner` will replace `Read.Bounded` with `UnboundedReadFromBoundedSource` so tests are run in streaming mode.
Additionally this PR adds support for `TestStream`.

Closes #22472

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
