### PR TITLE
Pass user specified destination type to UpdateSchemaDestination 

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -21,6 +21,7 @@ import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.resolveTempLoc
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkState;
 
+import com.google.api.services.bigquery.model.TableReference;
 import com.google.api.services.bigquery.model.TableRow;
 import java.util.Collections;
 import java.util.List;
@@ -794,15 +795,26 @@ class BatchLoads<DestinationT, ElementT>
                     null))
             .setCoder(KvCoder.of(destinationCoder, WriteTables.ResultCoder.INSTANCE));
 
+    BigQueryOptions options = input.getPipeline().getOptions().as(BigQueryOptions.class);
+    String defaultProjectId = options.getBigQueryProject() == null
+        ? options.getProject()
+        : options.getBigQueryProject();
+
     return successfulWrites
         .apply(Keys.create())
-        .apply(
-            ParDo.of(
-                new DoFn<DestinationT, TableDestination>() {
-                  @ProcessElement
-                  public void processElement(
-                      @Element DestinationT dest, OutputReceiver<TableDestination> o) {
-                    o.output(dynamicDestinations.getTable(dest));
+        .apply("Convert to TableDestinations", MapElements.via(
+                new SimpleFunction<DestinationT, TableDestination>() {
+                  @Override
+                  public TableDestination apply(DestinationT dest) {
+                    TableDestination tableDestination = dynamicDestinations.getTable(dest);
+                    TableReference tableReference = tableDestination.getTableReference();
+
+                    // get project ID from options if it's not included in the table reference
+                    if (Strings.isNullOrEmpty(tableReference.getProjectId())) {
+                      tableReference.setProjectId(defaultProjectId);
+                      tableDestination = tableDestination.withTableReference(tableReference);
+                    }
+                    return tableDestination;
                   }
                 }))
         .setCoder(tableDestinationCoder);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/UpdateSchemaDestination.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/UpdateSchemaDestination.java
@@ -18,7 +18,6 @@
 package org.apache.beam.sdk.io.gcp.bigquery;
 
 import com.google.api.client.http.ByteArrayContent;
-import com.google.api.client.util.Strings;
 import com.google.api.services.bigquery.model.Clustering;
 import com.google.api.services.bigquery.model.EncryptionConfiguration;
 import com.google.api.services.bigquery.model.JobConfigurationLoad;
@@ -40,6 +39,7 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Strings;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -174,7 +174,8 @@ public class UpdateSchemaDestination<DestinationT>
     }
     List<KV<TableDestination, WriteTables.Result>> tableDestinations = new ArrayList<>();
     for (KV<DestinationT, WriteTables.Result> entry : element) {
-      tableDestinations.add(KV.of(getTableWithDefaultProject(destination, options), entry.getValue()));
+      tableDestinations.add(
+          KV.of(getTableWithDefaultProject(destination, options), entry.getValue()));
     }
     context.output(tableDestinations);
   }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
@@ -2236,20 +2236,25 @@ public class BigQueryIOWriteTest implements Serializable {
         writeTablesInput
             .apply(writeTables)
             .setCoder(KvCoder.of(StringUtf8Coder.of(), WriteTables.ResultCoder.INSTANCE))
-            .apply(ParDo.of(new DoFn<KV<String, WriteTables.Result>, KV<TableDestination, WriteTables.Result>>() {
-              @ProcessElement
-              public void processElement(@Element KV<String, WriteTables.Result> e, OutputReceiver<KV<TableDestination, WriteTables.Result>> o) {
-                o.output(KV.of(dynamicDestinations.getTable(e.getKey()), e.getValue()));
-              }
-            }));
-
-
+            .apply(
+                ParDo.of(
+                    new DoFn<
+                        KV<String, WriteTables.Result>,
+                        KV<TableDestination, WriteTables.Result>>() {
+                      @ProcessElement
+                      public void processElement(
+                          @Element KV<String, WriteTables.Result> e,
+                          OutputReceiver<KV<TableDestination, WriteTables.Result>> o) {
+                        o.output(KV.of(dynamicDestinations.getTable(e.getKey()), e.getValue()));
+                      }
+                    }));
 
     PAssert.thatMultimap(writeTablesOutput)
         .satisfies(
             input -> {
               assertEquals(expectedTempTables.keySet(), input.keySet());
-              for (Map.Entry<TableDestination, Iterable<WriteTables.Result>> entry : input.entrySet()) {
+              for (Map.Entry<TableDestination, Iterable<WriteTables.Result>> entry :
+                  input.entrySet()) {
                 Iterable<String> tableNames =
                     StreamSupport.stream(entry.getValue().spliterator(), false)
                         .map(Result::getTableName)


### PR DESCRIPTION
Fixes #22543

When using multiple partitions for a BigQuery `FILE_LOADS` write, the user's dynamic destination type isn't properly passed into `UpdateSchemaDestination`. This leads to a `ClassCastException` when attempting to get the table and schema using the dynamic destination object.

The user's dynamic destination object is configured with a particular parameter type (represented by `DestinationT`) for `getTable()` and `getSchema` (see [here](https://github.com/apache/beam/blob/70cee1d125db0b62b2d660fc399e5a23845eb0e3/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/DynamicDestinations.java#L147-L155)). The current implementation from #17365 doesn't respect this user type and instead passes in a fixed TableDestination argument.