### PR TITLE
Revert "Persist ghprbPullId parameter in seed job"

### DIFF
--- a/.test-infra/jenkins/job_00_seed.groovy
+++ b/.test-infra/jenkins/job_00_seed.groovy
@@ -63,10 +63,6 @@ job('beam_SeedJob') {
         'sha1',
         'master',
         'Commit id or refname (eg: origin/pr/4001/head) you want to build against.')
-    stringParam(
-        'ghprbPullId',
-        '',
-        'PR number (e.g. 4001) if build from a PR.')
   }
 
   wrappers {


### PR DESCRIPTION
Reverts apache/beam#22579

This seems to have broken the seed job as Pablo suggested it might (since merging, only seed jobs for PRs have worked - https://ci-beam.apache.org/job/beam_SeedJob/ - I don't really understand why that is, but it seems likely this is the culprit)