### PR TITLE
Attempt to fix SpannerIO test flakes

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/SerializableCoderCloudObjectTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/SerializableCoderCloudObjectTranslator.java
@@ -42,7 +42,8 @@ class SerializableCoderCloudObjectTranslator implements CloudObjectTranslator<Se
     String className = Structs.getString(cloudObject, TYPE_FIELD);
     try {
       Class<? extends Serializable> targetClass =
-          (Class<? extends Serializable>) Class.forName(className);
+          (Class<? extends Serializable>)
+              Class.forName(className, false, Thread.currentThread().getContextClassLoader());
       checkArgument(
           Serializable.class.isAssignableFrom(targetClass),
           "Target class %s does not extend %s",


### PR DESCRIPTION
We are seeing spanner test failures due to timeouts: https://ci-beam.apache.org/job/beam_PostCommit_Java_DataflowV1/1963/testReport/junit/org.apache.beam.sdk.io.gcp.spanner/SpannerWriteIT/testReportFailures/

After investigation, it appears that the issue is due to a JVM deadlock when trying to deserialize the dialect class:   ```com.google.cloud.spanner.Dialect.(Dialect.java:37)
  java.lang.Class.forName0(Native Method)
  java.lang.Class.forName(Class.java:264) org.apache.beam.runners.dataflow.util.SerializableCoderCloudObjectTranslator.fromCloudObject(SerializableCoderCloudObjectTranslator.java:45)
org.apache.beam.runners.dataflow.util.SerializableCoderCloudObjectTranslator.fromCloudObject(SerializableCoderCloudObjectTranslator.java:27)
  org.apache.beam.runners.dataflow.util.CloudObjects.coderFromCloudObject(CloudObjects.java:128)```

After consultation, we think the issue is similar to https://bugs.openjdk.org/browse/JDK-8072592

As such, this change is to prevent initialization of the class, and to ensure we are using the thread local class loader to prevent collisions 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
