### PR TITLE
Fix direct running mode multi_processing on win32

### DIFF
--- a/sdks/python/apache_beam/runners/portability/local_job_service.py
+++ b/sdks/python/apache_beam/runners/portability/local_job_service.py
@@ -23,6 +23,7 @@ import os
 import queue
 import shutil
 import subprocess
+import sys
 import tempfile
 import threading
 import time
@@ -184,7 +185,11 @@ class SubprocessSdkWorker(object):
       control_address,
       provision_info,
       worker_id=None):
-    self._worker_command_line = worker_command_line
+    if sys.platform == 'win32' and isinstance(worker_command_line, bytes):
+      # Fix subprocess.Popen not support bytes args
+      self._worker_command_line = worker_command_line.decode()
+    else:
+      self._worker_command_line = worker_command_line
     self._control_address = control_address
     self._provision_info = provision_info
     self._worker_id = worker_id

--- a/sdks/python/apache_beam/runners/portability/local_job_service.py
+++ b/sdks/python/apache_beam/runners/portability/local_job_service.py
@@ -23,7 +23,6 @@ import os
 import queue
 import shutil
 import subprocess
-import sys
 import tempfile
 import threading
 import time
@@ -185,11 +184,10 @@ class SubprocessSdkWorker(object):
       control_address,
       provision_info,
       worker_id=None):
-    if sys.platform == 'win32' and isinstance(worker_command_line, bytes):
-      # Fix subprocess.Popen not support bytes args
-      self._worker_command_line = worker_command_line.decode()
-    else:
-      self._worker_command_line = worker_command_line
+    # worker_command_line is of bytes type received from grpc. It was encoded in
+    # apache_beam.transforms.environments.SubprocessSDKEnvironment earlier.
+    # decode it back as subprocess.Popen does not support bytes args in win32.
+    self._worker_command_line = worker_command_line.decode('utf-8')
     self._control_address = control_address
     self._provision_info = provision_info
     self._worker_id = worker_id

--- a/sdks/python/apache_beam/runners/portability/portable_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner_test.py
@@ -25,7 +25,6 @@ import time
 import unittest
 
 import grpc
-import pytest
 
 import apache_beam as beam
 from apache_beam.options.pipeline_options import DebugOptions
@@ -263,9 +262,6 @@ class PortableRunnerTestWithExternalEnv(PortableRunnerTest):
     return options
 
 
-@pytest.mark.skipif(
-    sys.platform == "win32",
-    reason="[https://github.com/apache/beam/issues/20427]")
 class PortableRunnerTestWithSubprocesses(PortableRunnerTest):
   _use_subprocesses = True
 


### PR DESCRIPTION
Fixes #20427
Fixes #22039

Currently the subprocess worker make calls of `subprocess.Popen` with arguments of bytes type (received from grpc). This will cause error in win32: 
`TypeError: bytes args is not allowed on Windows`

This PR encodes the argument passed to subprocess.Popen to str.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
