### PR TITLE
Updates ExpansionService to support dynamically discovering and expanding SchemaTransforms

### DIFF
--- a/model/job-management/src/main/proto/org/apache/beam/model/job_management/v1/beam_expansion_api.proto
+++ b/model/job-management/src/main/proto/org/apache/beam/model/job_management/v1/beam_expansion_api.proto
@@ -30,6 +30,7 @@ option java_package = "org.apache.beam.model.expansion.v1";
 option java_outer_classname = "ExpansionApi";
 
 import "org/apache/beam/model/pipeline/v1/beam_runner_api.proto";
+import "org/apache/beam/model/pipeline/v1/schema.proto";
 
 message ExpansionRequest {
   // Set of components needed to interpret the transform, or which
@@ -72,7 +73,33 @@ message ExpansionResponse {
   string error = 10;
 }
 
+message DiscoverSchemaTransformRequest  {
+}
+
+message SchemaTransformConfig {
+  // Config schema of the SchemaTransform
+  org.apache.beam.model.pipeline.v1.Schema config_schema = 1;
+
+  // Names of input PCollections
+  repeated string input_pcollection_names = 2;
+
+  // Names of output PCollections
+  repeated string output_pcollection_names = 3;
+}
+
+message DiscoverSchemaTransformResponse {
+  // A mapping from SchemaTransform ID to schema transform config of discovered
+  // SchemaTransforms
+  map <string, SchemaTransformConfig> schema_transform_configs = 1;
+
+  // If list of identifies are empty, this may contain an error.
+  string error = 2;
+}
+
 // Job Service for constructing pipelines
 service ExpansionService {
   rpc Expand (ExpansionRequest) returns (ExpansionResponse);
+
+  //A RPC to discover already registered SchemaTransformProviders.
+  rpc DiscoverSchemaTransform (DiscoverSchemaTransformRequest) returns (DiscoverSchemaTransformResponse);
 }

--- a/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/external_transforms.proto
+++ b/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/external_transforms.proto
@@ -51,6 +51,9 @@ message ExpansionMethods {
     // Transform payload will be of type JavaClassLookupPayload.
     JAVA_CLASS_LOOKUP = 0 [(org.apache.beam.model.pipeline.v1.beam_urn) =
       "beam:expansion:payload:java_class_lookup:v1"];
+
+    SCHEMATRANSFORM = 1 [(org.apache.beam.model.pipeline.v1.beam_urn) =
+      "beam:expansion:payload:schematransform:v1"];
   }
 }
 
@@ -106,4 +109,13 @@ message BuilderMethod {
   bytes payload = 3;
 }
 
+message SchemaTransformPayload {
+  // Identifier of the SchemaTransform
+  string identifier = 1;
 
+  // The config of the SchemaTransform.
+  // Should be decodable via beam:coder:row:v1.
+  // The schema of the Row should be compatible with the schema of the
+  // SchemaTransform denoted by the identifier.
+  bytes config_row = 2;
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/TypedSchemaTransformProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/TypedSchemaTransformProvider.java
@@ -59,7 +59,7 @@ public abstract class TypedSchemaTransformProvider<ConfigT> implements SchemaTra
   }
 
   @Override
-  public final Schema configurationSchema() {
+  public Schema configurationSchema() {
     try {
       return SchemaRegistry.createDefault().getSchema(configurationClass());
     } catch (NoSuchSchemaException e) {

--- a/sdks/java/expansion-service/src/main/java/org/apache/beam/sdk/expansion/service/ExpansionService.java
+++ b/sdks/java/expansion-service/src/main/java/org/apache/beam/sdk/expansion/service/ExpansionService.java
@@ -35,6 +35,9 @@ import java.util.ServiceLoader;
 import java.util.Set;
 import java.util.stream.Collectors;
 import org.apache.beam.model.expansion.v1.ExpansionApi;
+import org.apache.beam.model.expansion.v1.ExpansionApi.DiscoverSchemaTransformRequest;
+import org.apache.beam.model.expansion.v1.ExpansionApi.DiscoverSchemaTransformResponse;
+import org.apache.beam.model.expansion.v1.ExpansionApi.SchemaTransformConfig;
 import org.apache.beam.model.expansion.v1.ExpansionServiceGrpc;
 import org.apache.beam.model.pipeline.v1.ExternalTransforms.ExpansionMethods;
 import org.apache.beam.model.pipeline.v1.ExternalTransforms.ExternalConfigurationPayload;
@@ -63,6 +66,7 @@ import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.SchemaCoder;
 import org.apache.beam.sdk.schemas.SchemaRegistry;
 import org.apache.beam.sdk.schemas.SchemaTranslation;
+import org.apache.beam.sdk.schemas.transforms.SchemaTransformProvider;
 import org.apache.beam.sdk.transforms.ExternalTransformBuilder;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.SerializableFunction;
@@ -436,6 +440,10 @@ public class ExpansionService extends ExpansionServiceGrpc.ExpansionServiceImplB
     return registeredTransforms;
   }
 
+  private Iterable<SchemaTransformProvider> getRegisteredSchemaTransforms() {
+    return ExpansionServiceSchemaTransformProvider.of().getAllProviders();
+  }
+
   private Map<String, TransformProvider> loadRegisteredTransforms() {
     ImmutableMap.Builder<String, TransformProvider> registeredTransformsBuilder =
         ImmutableMap.builder();
@@ -500,6 +508,8 @@ public class ExpansionService extends ExpansionServiceGrpc.ExpansionServiceImplB
           pipelineOptions.as(ExpansionServiceOptions.class).getJavaClassLookupAllowlist();
       assert allowList != null;
       transformProvider = new JavaClassLookupTransformProvider(allowList);
+    } else if (getUrn(ExpansionMethods.Enum.SCHEMATRANSFORM).equals(urn)) {
+      transformProvider = ExpansionServiceSchemaTransformProvider.of();
     } else {
       transformProvider = getRegisteredTransforms().get(urn);
       if (transformProvider == null) {
@@ -604,6 +614,42 @@ public class ExpansionService extends ExpansionServiceGrpc.ExpansionServiceImplB
     }
   }
 
+  DiscoverSchemaTransformResponse discover(DiscoverSchemaTransformRequest request) {
+    ExpansionServiceSchemaTransformProvider transformProvider =
+        ExpansionServiceSchemaTransformProvider.of();
+    DiscoverSchemaTransformResponse.Builder responseBuilder =
+        DiscoverSchemaTransformResponse.newBuilder();
+    for (org.apache.beam.sdk.schemas.transforms.SchemaTransformProvider provider :
+        transformProvider.getAllProviders()) {
+      SchemaTransformConfig.Builder schemaTransformConfigBuider =
+          SchemaTransformConfig.newBuilder();
+      schemaTransformConfigBuider.setConfigSchema(
+          SchemaTranslation.schemaToProto(provider.configurationSchema(), true));
+      schemaTransformConfigBuider.addAllInputPcollectionNames(provider.inputCollectionNames());
+      schemaTransformConfigBuider.addAllOutputPcollectionNames(provider.outputCollectionNames());
+      responseBuilder.putSchemaTransformConfigs(
+          provider.identifier(), schemaTransformConfigBuider.build());
+    }
+
+    return responseBuilder.build();
+  }
+
+  @Override
+  public void discoverSchemaTransform(
+      DiscoverSchemaTransformRequest request,
+      StreamObserver<DiscoverSchemaTransformResponse> responseObserver) {
+    try {
+      responseObserver.onNext(discover(request));
+      responseObserver.onCompleted();
+    } catch (RuntimeException exn) {
+      responseObserver.onNext(
+          ExpansionApi.DiscoverSchemaTransformResponse.newBuilder()
+              .setError(Throwables.getStackTraceAsString(exn))
+              .build());
+      responseObserver.onCompleted();
+    }
+  }
+
   @Override
   public void close() throws Exception {
     // Nothing to do because the expansion service is stateless.
@@ -618,9 +664,36 @@ public class ExpansionService extends ExpansionServiceGrpc.ExpansionServiceImplB
 
     @SuppressWarnings("nullness")
     ExpansionService service = new ExpansionService(Arrays.copyOfRange(args, 1, args.length));
+
+    StringBuilder registeredTransformsLog = new StringBuilder();
+    boolean registeredTransformsFound = false;
+    registeredTransformsLog.append("\n");
+    registeredTransformsLog.append("Registered transforms:");
+
     for (Map.Entry<String, TransformProvider> entry :
         service.getRegisteredTransforms().entrySet()) {
-      System.out.println("\t" + entry.getKey() + ": " + entry.getValue());
+      registeredTransformsFound = true;
+      registeredTransformsLog.append("\n\t" + entry.getKey() + ": " + entry.getValue());
+    }
+
+    StringBuilder registeredSchemaTransformProvidersLog = new StringBuilder();
+    boolean registeredSchemaTransformProvidersFound = false;
+    registeredSchemaTransformProvidersLog.append("\n");
+    registeredSchemaTransformProvidersLog.append("Registered SchemaTransformProviders:");
+
+    for (SchemaTransformProvider provider : service.getRegisteredSchemaTransforms()) {
+      registeredSchemaTransformProvidersFound = true;
+      registeredSchemaTransformProvidersLog.append("\n\t" + provider.identifier());
+    }
+
+    if (registeredTransformsFound) {
+      System.out.println(registeredTransformsLog.toString());
+    }
+    if (registeredSchemaTransformProvidersFound) {
+      System.out.println(registeredSchemaTransformProvidersLog.toString());
+    }
+    if (!registeredTransformsFound && !registeredSchemaTransformProvidersFound) {
+      System.out.println("\nDid not find any registered transforms or SchemaTransforms.\n");
     }
 
     Server server =

--- a/sdks/java/expansion-service/src/main/java/org/apache/beam/sdk/expansion/service/ExpansionServiceSchemaTransformProvider.java
+++ b/sdks/java/expansion-service/src/main/java/org/apache/beam/sdk/expansion/service/ExpansionServiceSchemaTransformProvider.java
@@ -1,0 +1,153 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.expansion.service;
+
+import static org.apache.beam.runners.core.construction.BeamUrns.getUrn;
+
+import java.io.IOException;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.ServiceLoader;
+import org.apache.beam.model.pipeline.v1.ExternalTransforms.ExpansionMethods;
+import org.apache.beam.model.pipeline.v1.ExternalTransforms.SchemaTransformPayload;
+import org.apache.beam.model.pipeline.v1.RunnerApi.FunctionSpec;
+import org.apache.beam.sdk.coders.RowCoder;
+import org.apache.beam.sdk.expansion.service.ExpansionService.TransformProvider;
+import org.apache.beam.sdk.schemas.transforms.TypedSchemaTransformProvider;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionRowTuple;
+import org.apache.beam.sdk.values.PDone;
+import org.apache.beam.sdk.values.PInput;
+import org.apache.beam.sdk.values.POutput;
+import org.apache.beam.sdk.values.PValue;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.vendor.grpc.v1p43p2.com.google.protobuf.InvalidProtocolBufferException;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings({"rawtypes"})
+public class ExpansionServiceSchemaTransformProvider
+    implements TransformProvider {
+
+  // private static final Logger LOG = LoggerFactory.getLogger(ExpansionServiceSchemaTransformProvider.class);
+
+  static final String INPUT_TAG = "INPUT";
+  static final String OUTPUT_TAG = "OUTPUT";
+
+  private Map<String, org.apache.beam.sdk.schemas.transforms.SchemaTransformProvider>
+      schemaTransformProviders = new HashMap<>();
+  private static ExpansionServiceSchemaTransformProvider transformProvider = null;
+
+  private void loadSchemaTransforms() {
+    try {
+      for (org.apache.beam.sdk.schemas.transforms.SchemaTransformProvider schemaTransformProvider :
+          ServiceLoader.load(
+              org.apache.beam.sdk.schemas.transforms.SchemaTransformProvider.class)) {
+        if (schemaTransformProviders.containsKey(schemaTransformProvider.identifier())) {
+          throw new IllegalArgumentException(
+              "Found multiple SchemaTransformProvider implementations with the same identifier "
+                  + schemaTransformProvider.identifier());
+        }
+        schemaTransformProviders.put(schemaTransformProvider.identifier(), schemaTransformProvider);
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e.getMessage());
+    }
+  }
+
+  private ExpansionServiceSchemaTransformProvider() {
+    loadSchemaTransforms();
+  }
+
+  public static ExpansionServiceSchemaTransformProvider of() {
+    if (transformProvider == null) {
+      transformProvider = new ExpansionServiceSchemaTransformProvider();
+    }
+
+    return transformProvider;
+  }
+
+  static class RowTransform extends PTransform {
+   private PTransform<PCollectionRowTuple, PCollectionRowTuple> rowTuplePTransform;
+
+    public RowTransform(PTransform<PCollectionRowTuple, PCollectionRowTuple> rowTuplePTransform) {
+      this.rowTuplePTransform = rowTuplePTransform;
+    }
+
+    @Override
+    public POutput expand(PInput input) {
+      PCollectionRowTuple inputRowTuple;
+
+      if (input instanceof PCollectionRowTuple) {
+        inputRowTuple = (PCollectionRowTuple) input;
+      } else if (input instanceof PCollection) {
+        inputRowTuple = PCollectionRowTuple.of(INPUT_TAG, (PCollection) input);
+      } else if (input instanceof PBegin) {
+        inputRowTuple = PCollectionRowTuple.empty(input.getPipeline());
+      } else {
+        throw new RuntimeException(String.format("Unsupported input type: %s", input));
+      }
+      PCollectionRowTuple output = inputRowTuple.apply(this.rowTuplePTransform);
+
+      if (output.getAll().size() > 1) {
+        throw new UnsupportedOperationException("TODO");
+      } else if (output.getAll().size() == 1) {
+        return output.getAll().values().iterator().next();
+      } else {
+        return PDone.in(input.getPipeline());
+      }
+    }
+  }
+
+  @Override
+  public PTransform getTransform(FunctionSpec spec) {
+    SchemaTransformPayload payload;
+    try {
+      payload = SchemaTransformPayload.parseFrom(spec.getPayload());
+      String identifier = payload.getIdentifier();
+      if (!schemaTransformProviders.containsKey(identifier)) {
+        throw new RuntimeException(
+            "Did not find a SchemaTransformProvider with the identifier " + identifier);
+      }
+
+    } catch (InvalidProtocolBufferException e) {
+      throw new IllegalArgumentException(
+          "Invalid payload type for URN " + getUrn(ExpansionMethods.Enum.SCHEMATRANSFORM), e);
+    }
+
+    String identifier = payload.getIdentifier();
+    org.apache.beam.sdk.schemas.transforms.SchemaTransformProvider provider =
+        schemaTransformProviders.get(identifier);
+
+    Row configRow;
+    try {
+      configRow =
+          RowCoder.of(provider.configurationSchema()).decode(payload.getConfigRow().newInput());
+    } catch (IOException e) {
+      throw new RuntimeException("Error decoding payload", e);
+    }
+
+    return new RowTransform(provider.from(configRow).buildTransform());
+  }
+
+  Iterable<org.apache.beam.sdk.schemas.transforms.SchemaTransformProvider> getAllProviders() {
+    return schemaTransformProviders.values();
+  }
+}

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KVConfig.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KVConfig.java
@@ -1,0 +1,35 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.beam.sdk.io.kafka;
+
+import org.apache.beam.sdk.schemas.JavaFieldSchema;
+import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
+import org.apache.beam.sdk.schemas.annotations.SchemaCreate;
+
+@DefaultSchema(JavaFieldSchema.class)
+public class KVConfig {
+  public final byte[] key;
+  public final byte[] value;
+
+  @SchemaCreate
+  public KVConfig(byte[] key, byte[] value) {
+    this.key = key;
+    this.value = value;
+  }
+}

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriteSchemaTransform.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriteSchemaTransform.java
@@ -1,0 +1,118 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.kafka;
+
+import org.apache.beam.sdk.schemas.NoSuchSchemaException;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.SchemaRegistry;
+import org.apache.beam.sdk.schemas.transforms.SchemaTransform;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.SimpleFunction;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionRowTuple;
+import org.apache.beam.sdk.values.Row;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings({"rawtypes"})
+public class KafkaWriteSchemaTransform implements SchemaTransform {
+
+  private final KafkaWriteSchemaTransformConfiguration configuration;
+
+  private static final SchemaRegistry SCHEMA_REGISTRY = SchemaRegistry.createDefault();
+
+  KafkaWriteSchemaTransform(KafkaWriteSchemaTransformConfiguration configuration) {
+    this.configuration = configuration;
+  }
+
+  @Override
+  public PTransform<PCollectionRowTuple, PCollectionRowTuple> buildTransform() {
+    return new PCollectionRowTupleTransform(this.configuration);
+  }
+
+  static class RowToKVFn extends SimpleFunction<Row, KV<byte[], byte[]>> {
+    private SerializableFunction<Row, KVConfig> fromRowFunc;
+
+    @Override
+    public KV<byte[], byte[]> apply(Row input) {
+      if (fromRowFunc == null) {
+        Schema kvConfigSchema;
+        try {
+          kvConfigSchema = SCHEMA_REGISTRY.getSchema(KVConfig.class);
+        } catch (NoSuchSchemaException e) {
+          throw new RuntimeException(e);
+        }
+
+        if (!input.getSchema().assignableTo(kvConfigSchema)) {
+          throw new RuntimeException(
+              String.format(
+                  "Expected rows with schema %s but received rows with schema %s",
+                  kvConfigSchema, input.getSchema()));
+        }
+
+        try {
+          fromRowFunc = SCHEMA_REGISTRY.getFromRowFunction(KVConfig.class);
+        } catch (NoSuchSchemaException e) {
+          throw new RuntimeException(e);
+        }
+      }
+
+      KVConfig config = fromRowFunc.apply(input);
+      return KV.of(config.key, config.value);
+    }
+  }
+
+  static class PCollectionRowTupleTransform
+      extends PTransform<PCollectionRowTuple, PCollectionRowTuple> {
+    private final KafkaWriteSchemaTransformConfiguration configuration;
+
+    PCollectionRowTupleTransform(KafkaWriteSchemaTransformConfiguration configuration) {
+      this.configuration = configuration;
+    }
+
+    private static Class resolveClass(String className) {
+      try {
+        return Class.forName(className);
+      } catch (ClassNotFoundException e) {
+        throw new RuntimeException("Could not find class: " + className);
+      }
+    }
+
+    @Override
+    public PCollectionRowTuple expand(PCollectionRowTuple input) {
+      PCollection<Row> rowPCollection = input.get(KafkaWriteSchemaTransformProvider.INPUT_TAG);
+
+      Class keySerializer = resolveClass(this.configuration.keySerializer);
+      Class valSerializer = resolveClass(this.configuration.valueSerializer);
+
+      rowPCollection
+          .apply(MapElements.via(new RowToKVFn()))
+          .apply(
+              KafkaIO.writeRecords()
+                  .withBootstrapServers(this.configuration.bootstrapServers)
+                  .withTopic(this.configuration.topic)
+                  .withKeySerializer(keySerializer)
+                  .withValueSerializer(valSerializer));
+
+      return PCollectionRowTuple.empty(input.getPipeline());
+    }
+  }
+}

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriteSchemaTransformConfiguration.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriteSchemaTransformConfiguration.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.kafka;
+
+import java.io.Serializable;
+import org.apache.beam.sdk.schemas.JavaFieldSchema;
+import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
+import org.apache.beam.sdk.schemas.annotations.SchemaCreate;
+
+@DefaultSchema(JavaFieldSchema.class)
+public class KafkaWriteSchemaTransformConfiguration implements Serializable {
+  public final String bootstrapServers;
+  public final String topic;
+  public final String keySerializer;
+  public final String valueSerializer;
+
+  @SchemaCreate
+  public KafkaWriteSchemaTransformConfiguration(
+      String bootstrapServers, String topic, String keySerializer, String valueSerializer) {
+    this.bootstrapServers = bootstrapServers;
+    this.topic = topic;
+    this.keySerializer = keySerializer;
+    this.valueSerializer = valueSerializer;
+  }
+}

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriteSchemaTransformProvider.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaWriteSchemaTransformProvider.java
@@ -1,0 +1,68 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.kafka;
+
+import com.google.auto.service.AutoService;
+import java.util.Collections;
+import java.util.List;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.transforms.SchemaTransform;
+import org.apache.beam.sdk.schemas.transforms.SchemaTransformProvider;
+import org.apache.beam.sdk.schemas.transforms.TypedSchemaTransformProvider;
+
+@AutoService(SchemaTransformProvider.class)
+public class KafkaWriteSchemaTransformProvider
+    extends TypedSchemaTransformProvider<KafkaWriteSchemaTransformConfiguration> {
+
+  static final String INPUT_TAG = "INPUT";
+
+  @Override
+  protected Class<KafkaWriteSchemaTransformConfiguration> configurationClass() {
+    return KafkaWriteSchemaTransformConfiguration.class;
+  }
+
+  @Override
+  protected SchemaTransform from(KafkaWriteSchemaTransformConfiguration configuration) {
+    return new KafkaWriteSchemaTransform(configuration);
+  }
+
+  @Override
+  public Schema configurationSchema() {
+    return Schema.builder()
+        .addStringField("bootstrapServers")
+        .addStringField("topic")
+        .addStringField("keySerializer")
+        .addStringField("valueSerializer")
+        .build();
+  }
+
+  @Override
+  public String identifier() {
+    return "kafkaio:write";
+  }
+
+  @Override
+  public List<String> inputCollectionNames() {
+    return Collections.singletonList(INPUT_TAG);
+  }
+
+  @Override
+  public List<String> outputCollectionNames() {
+    return Collections.emptyList();
+  }
+}

--- a/sdks/python/apache_beam/portability/common_urns.py
+++ b/sdks/python/apache_beam/portability/common_urns.py
@@ -78,6 +78,7 @@ requirements = StandardRequirements.Enum
 displayData = StandardDisplayData.DisplayData
 
 java_class_lookup = ExpansionMethods.Enum.JAVA_CLASS_LOOKUP
+schematransform_based_expand = ExpansionMethods.Enum.SCHEMATRANSFORM
 
 micros_instant = LogicalTypes.Enum.MICROS_INSTANT
 python_callable = LogicalTypes.Enum.PYTHON_CALLABLE


### PR DESCRIPTION
This is a prototype implementation of https://s.apache.org/easy-multi-language

This adds:
* Support for dynamically discovering and registering SchemaTransforms in the Java expansion service.
* Support for dynamically discovering registered SchemaTransforms from the Python side.
* Support for using SchemaTransforms in Python pipelines.

End-to-end tested this by running a pipeline that writes to Kafka using a SchemaTransform-based Kafka Write implementation. Also updated kafka.py to dynamically discover the identifier of the Kafka Write transform using the new transform discovery API.


WIP (do not merge)

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
