### PR TITLE
Add bag state support

### DIFF
--- a/sdks/go/pkg/beam/core/graph/fn.go
+++ b/sdks/go/pkg/beam/core/graph/fn.go
@@ -1274,11 +1274,10 @@ func validateState(fn *DoFn, numIn mainInputs) error {
 					"unique per DoFn", k, orig, s)
 			}
 			t := s.StateType()
-			// TODO(#22736) - Add more state types as they become supported
-			if t != state.StateTypeValue {
-				err := errors.Errorf("Non-value state type %v for state %v", t, s)
-				return errors.SetTopLevelMsgf(err, "Non-value state type %v for state %v. Currently the only supported state"+
-					"type is state.Value", t, s)
+			if t != state.StateTypeValue && t != state.StateTypeBag {
+				err := errors.Errorf("Unrecognized state type %v for state %v", t, s)
+				return errors.SetTopLevelMsgf(err, "Unrecognized state type %v for state %v. Currently the only supported state"+
+					"type is state.Value and state.Bag", t, s)
 			}
 			stateKeys[k] = s
 		}

--- a/sdks/go/pkg/beam/core/graph/fn_test.go
+++ b/sdks/go/pkg/beam/core/graph/fn_test.go
@@ -53,7 +53,8 @@ func TestNewDoFn(t *testing.T) {
 			{dfn: &GoodDoFnCoGbk2{}, opt: CoGBKMainInput(3)},
 			{dfn: &GoodDoFnCoGbk7{}, opt: CoGBKMainInput(8)},
 			{dfn: &GoodDoFnCoGbk1wSide{}, opt: NumMainInputs(MainKv)},
-			{dfn: &GoodStatefulDoFn{State1: state.Value[int](state.MakeValueState[int]("state1"))}, opt: NumMainInputs(MainKv)},
+			{dfn: &GoodStatefulDoFn{State1: state.MakeValueState[int]("state1")}, opt: NumMainInputs(MainKv)},
+			{dfn: &GoodStatefulDoFn2{State1: state.MakeBagState[int]("state1")}, opt: NumMainInputs(MainKv)},
 		}
 
 		for _, test := range tests {
@@ -1084,6 +1085,14 @@ type GoodStatefulDoFn struct {
 }
 
 func (fn *GoodStatefulDoFn) ProcessElement(state.Provider, int, int) int {
+	return 0
+}
+
+type GoodStatefulDoFn2 struct {
+	State1 state.Bag[int]
+}
+
+func (fn *GoodStatefulDoFn2) ProcessElement(state.Provider, int, int) int {
 	return 0
 }
 

--- a/sdks/go/pkg/beam/core/runtime/exec/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/translate.go
@@ -469,7 +469,12 @@ func (b *builder) makeLink(from string, id linkID) (Node, error) {
 						stateIDToCoder := make(map[string]*coder.Coder)
 						for key, spec := range userState {
 							// TODO(#22736) - this will eventually need to be aware of which type of state its modifying to support non-Value state types.
-							cID := spec.GetReadModifyWriteSpec().CoderId
+							var cID string
+							if rmw := spec.GetReadModifyWriteSpec(); rmw != nil {
+								cID = rmw.CoderId
+							} else if bs := spec.GetBagSpec(); bs != nil {
+								cID = bs.ElementCoderId
+							}
 							c, err := b.coders.Coder(cID)
 							if err != nil {
 								return nil, err

--- a/sdks/go/pkg/beam/core/runtime/exec/userstate_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/userstate_test.go
@@ -82,6 +82,7 @@ func buildStateProvider() stateProvider {
 		window:            []byte{1},
 		transactionsByKey: make(map[string][]state.Transaction),
 		initialValueByKey: make(map[string]interface{}),
+		initialBagByKey:   make(map[string][]interface{}),
 		readersByKey:      make(map[string]io.ReadCloser),
 		appendersByKey:    make(map[string]io.Writer),
 		clearersByKey:     make(map[string]io.Writer),

--- a/sdks/go/pkg/beam/core/state/state.go
+++ b/sdks/go/pkg/beam/core/state/state.go
@@ -31,8 +31,12 @@ const (
 	TransactionTypeSet TransactionTypeEnum = 0
 	// TransactionTypeClear is the set transaction type
 	TransactionTypeClear TransactionTypeEnum = 1
+	// TransactionTypeAppend is the append transaction type
+	TransactionTypeAppend TransactionTypeEnum = 2
 	// StateTypeValue represents a value state
 	StateTypeValue StateTypeEnum = 0
+	// StateTypeValue represents a bag state
+	StateTypeBag StateTypeEnum = 1
 )
 
 var (
@@ -57,6 +61,8 @@ type Transaction struct {
 type Provider interface {
 	ReadValueState(id string) (interface{}, []Transaction, error)
 	WriteValueState(val Transaction) error
+	ReadBagState(id string) ([]interface{}, []Transaction, error)
+	WriteBagState(val Transaction) error
 }
 
 // PipelineState is an interface representing different kinds of PipelineState (currently just state.Value).
@@ -130,6 +136,76 @@ func (s Value[T]) StateType() StateTypeEnum {
 // MakeValueState is a factory function to create an instance of ValueState with the given key.
 func MakeValueState[T any](k string) Value[T] {
 	return Value[T]{
+		Key: k,
+	}
+}
+
+// Bag is used to read and write global pipeline state representing a collection of values.
+// Key represents the key used to lookup this state.
+type Bag[T any] struct {
+	Key string
+}
+
+// Add is used to write append to the bag pipeline state.
+func (s *Bag[T]) Add(p Provider, val T) error {
+	return p.WriteBagState(Transaction{
+		Key:  s.Key,
+		Type: TransactionTypeAppend,
+		Val:  val,
+	})
+}
+
+// Read is used to read this instance of global pipeline state representing a bag.
+// When a value is not found, returns an empty list and false.
+func (s *Bag[T]) Read(p Provider) ([]T, bool, error) {
+	// This replays any writes that have happened to this value since we last read
+	// For more detail, see "State Transactionality" below for buffered transactions
+	initialValue, bufferedTransactions, err := p.ReadBagState(s.Key)
+	if err != nil {
+		var val []T
+		return val, false, err
+	}
+	cur := []T{}
+	for _, v := range initialValue {
+		cur = append(cur, v.(T))
+	}
+	for _, t := range bufferedTransactions {
+		switch t.Type {
+		case TransactionTypeAppend:
+			cur = append(cur, t.Val.(T))
+		case TransactionTypeClear:
+			cur = []T{}
+		}
+	}
+	if len(cur) == 0 {
+		return cur, false, nil
+	}
+	return cur, true, nil
+}
+
+// StateKey returns the key for this pipeline state entry.
+func (s Bag[T]) StateKey() string {
+	if s.Key == "" {
+		// TODO(#22736) - infer the state from the member variable name during pipeline construction.
+		panic("Value state exists on struct but has not been initialized with a key.")
+	}
+	return s.Key
+}
+
+// CoderType returns the type of the bag state which should be used for a coder.
+func (s Bag[T]) CoderType() reflect.Type {
+	var t T
+	return reflect.TypeOf(t)
+}
+
+// StateType returns the type of the state (in this case always Bag).
+func (s Bag[T]) StateType() StateTypeEnum {
+	return StateTypeBag
+}
+
+// MakeBagState is a factory function to create an instance of BagState with the given key.
+func MakeBagState[T any](k string) Bag[T] {
+	return Bag[T]{
 		Key: k,
 	}
 }

--- a/sdks/go/pkg/beam/core/state/state.go
+++ b/sdks/go/pkg/beam/core/state/state.go
@@ -35,7 +35,7 @@ const (
 	TransactionTypeAppend TransactionTypeEnum = 2
 	// StateTypeValue represents a value state
 	StateTypeValue StateTypeEnum = 0
-	// StateTypeValue represents a bag state
+	// StateTypeBag represents a bag state
 	StateTypeBag StateTypeEnum = 1
 )
 

--- a/sdks/go/pkg/beam/core/state/state_test.go
+++ b/sdks/go/pkg/beam/core/state/state_test.go
@@ -25,9 +25,10 @@ var (
 )
 
 type fakeProvider struct {
-	initialState map[string]interface{}
-	transactions map[string][]Transaction
-	err          map[string]error
+	initialState    map[string]interface{}
+	initialBagState map[string][]interface{}
+	transactions    map[string][]Transaction
+	err             map[string]error
 }
 
 func (s *fakeProvider) ReadValueState(userStateID string) (interface{}, []Transaction, error) {
@@ -43,6 +44,27 @@ func (s *fakeProvider) ReadValueState(userStateID string) (interface{}, []Transa
 }
 
 func (s *fakeProvider) WriteValueState(val Transaction) error {
+	if transactions, ok := s.transactions[val.Key]; ok {
+		s.transactions[val.Key] = append(transactions, val)
+	} else {
+		s.transactions[val.Key] = []Transaction{val}
+	}
+	return nil
+}
+
+func (s *fakeProvider) ReadBagState(userStateID string) ([]interface{}, []Transaction, error) {
+	if err, ok := s.err[userStateID]; ok {
+		return nil, nil, err
+	}
+	base := s.initialBagState[userStateID]
+	trans, ok := s.transactions[userStateID]
+	if !ok {
+		trans = []Transaction{}
+	}
+	return base, trans, nil
+}
+
+func (s *fakeProvider) WriteBagState(val Transaction) error {
 	if transactions, ok := s.transactions[val.Key]; ok {
 		s.transactions[val.Key] = append(transactions, val)
 	} else {
@@ -128,13 +150,124 @@ func TestValueWrite(t *testing.T) {
 		}
 		val, ok, err := vs.Read(&f)
 		if err != nil {
-			t.Errorf("Value.Read() returned error %v when it shouldn't have after writing: %v", err, tt.writes)
+			t.Errorf("Value.Write() returned error %v when it shouldn't have after writing: %v", err, tt.writes)
 		} else if ok && !tt.ok {
-			t.Errorf("Value.Read() returned a value %v when it shouldn't have after writing: %v", val, tt.writes)
+			t.Errorf("Value.Write() returned a value %v when it shouldn't have after writing: %v", val, tt.writes)
 		} else if !ok && tt.ok {
-			t.Errorf("Value.Read() didn't return a value when it should have returned %v after writing: %v", tt.val, tt.writes)
+			t.Errorf("Value.Write() didn't return a value when it should have returned %v after writing: %v", tt.val, tt.writes)
 		} else if val != tt.val {
-			t.Errorf("Value.Read()=%v, want %v after writing: %v", val, tt.val, tt.writes)
+			t.Errorf("Value.Write()=%v, want %v after writing: %v", val, tt.val, tt.writes)
+		}
+	}
+}
+
+func TestBagRead(t *testing.T) {
+	is := make(map[string][]interface{})
+	ts := make(map[string][]Transaction)
+	es := make(map[string]error)
+	is["no_transactions"] = []interface{}{1}
+	ts["no_transactions"] = nil
+	is["basic_append"] = []interface{}{}
+	ts["basic_append"] = []Transaction{{Key: "basic_append", Type: TransactionTypeAppend, Val: 3}}
+	is["multi_append"] = []interface{}{}
+	ts["multi_append"] = []Transaction{{Key: "multi_append", Type: TransactionTypeAppend, Val: 3}, {Key: "multi_append", Type: TransactionTypeAppend, Val: 2}}
+	is["basic_clear"] = []interface{}{1}
+	ts["basic_clear"] = []Transaction{{Key: "basic_clear", Type: TransactionTypeClear, Val: nil}}
+	is["append_then_clear"] = []interface{}{1}
+	ts["append_then_clear"] = []Transaction{{Key: "append_then_clear", Type: TransactionTypeAppend, Val: 3}, {Key: "append_then_clear", Type: TransactionTypeClear, Val: nil}}
+	is["append_then_clear_then_append"] = []interface{}{1}
+	ts["append_then_clear_then_append"] = []Transaction{{Key: "append_then_clear_then_append", Type: TransactionTypeAppend, Val: 3}, {Key: "append_then_clear_then_append", Type: TransactionTypeClear, Val: nil}, {Key: "append_then_clear_then_append", Type: TransactionTypeAppend, Val: 4}}
+	is["err"] = []interface{}{1}
+	ts["err"] = []Transaction{{Key: "err", Type: TransactionTypeAppend, Val: 3}}
+	es["err"] = errFake
+
+	f := fakeProvider{
+		initialBagState: is,
+		transactions:    ts,
+		err:             es,
+	}
+
+	var tests = []struct {
+		vs  Bag[int]
+		val []int
+		ok  bool
+		err error
+	}{
+		{MakeBagState[int]("no_transactions"), []int{1}, true, nil},
+		{MakeBagState[int]("basic_append"), []int{3}, true, nil},
+		{MakeBagState[int]("multi_append"), []int{3, 2}, true, nil},
+		{MakeBagState[int]("basic_clear"), []int{}, false, nil},
+		{MakeBagState[int]("append_then_clear"), []int{}, false, nil},
+		{MakeBagState[int]("append_then_clear_then_append"), []int{4}, true, nil},
+		{MakeBagState[int]("err"), []int{}, false, errFake},
+	}
+
+	for _, tt := range tests {
+		val, ok, err := tt.vs.Read(&f)
+		if err != nil && tt.err == nil {
+			t.Errorf("Bag.Read() returned error %v for state key %v when it shouldn't have", err, tt.vs.Key)
+		} else if err == nil && tt.err != nil {
+			t.Errorf("Bag.Read() returned no error for state key %v when it should have returned %v", tt.vs.Key, err)
+		} else if ok && !tt.ok {
+			t.Errorf("Bag.Read() returned a value %v for state key %v when it shouldn't have", val, tt.vs.Key)
+		} else if !ok && tt.ok {
+			t.Errorf("Bag.Read() didn't return a value for state key %v when it should have returned %v", tt.vs.Key, tt.val)
+		} else if len(val) != len(tt.val) {
+			t.Errorf("Bag.Read()=%v, want %v for state key %v", val, tt.val, tt.vs.Key)
+		} else {
+			eq := true
+			for idx, v := range val {
+				if v != tt.val[idx] {
+					eq = false
+				}
+			}
+			if !eq {
+				t.Errorf("Bag.Read()=%v, want %v for state key %v", val, tt.val, tt.vs.Key)
+			}
+		}
+	}
+}
+
+func TestBagWrite(t *testing.T) {
+	var tests = []struct {
+		writes []int
+		val    []int
+		ok     bool
+	}{
+		{[]int{}, []int{}, false},
+		{[]int{3}, []int{3}, true},
+		{[]int{1, 5}, []int{1, 5}, true},
+	}
+
+	for _, tt := range tests {
+		f := fakeProvider{
+			initialState: make(map[string]interface{}),
+			transactions: make(map[string][]Transaction),
+			err:          make(map[string]error),
+		}
+		vs := MakeBagState[int]("vs")
+		for _, val := range tt.writes {
+			vs.Add(&f, val)
+		}
+		val, ok, err := vs.Read(&f)
+		if err != nil {
+			t.Errorf("Bag.Write() returned error %v when it shouldn't have after writing: %v", err, tt.writes)
+		} else if ok && !tt.ok {
+			t.Errorf("Bag.Write() returned a value %v when it shouldn't have after writing: %v", val, tt.writes)
+		} else if !ok && tt.ok {
+			t.Errorf("Bag.Write() didn't return a value when it should have returned %v after writing: %v", tt.val, tt.writes)
+		} else if len(val) != len(tt.val) {
+			t.Errorf("Bag.Write()=%v, want %v after writing: %v", val, tt.val, tt.writes)
+		} else {
+			eq := true
+			for idx, v := range val {
+				if v != tt.val[idx] {
+					eq = false
+				}
+			}
+			if !eq {
+				t.Errorf("Bag.Write()=%v, want %v after writing: %v", val, tt.val, tt.writes)
+			}
 		}
 	}
 }


### PR DESCRIPTION
This continues to grow our state support by adding bag state support. Once both this and #22815 are in, I'll add a follow up PR with an integration test. In the meantime, I tested manually by running the hacked wordcount found here - https://github.com/damccorm/beam/pull/86/files#diff-46f0bd8f9f6b541e840079960d684ba78e6513f1293b673d08faaec94d48a234 - and it produced output like:

```
...
away([]): 1
away([I]): 1
away([I I]): 1
away([I I I]): 1
away([I I I I]): 1
away([I I I I I]): 1
away([I I I I I I]): 1
away([I I I I I I I]): 1
away([I I I I I I I I]): 1
away([I I I I I I I I I]): 1
away([I I I I I I I I I I]): 1
away([I I I I I I I I I I I]): 1
away([I I I I I I I I I I I I]): 1
away([I I I I I I I I I I I I I]): 1
away([I I I I I I I I I I I I I I]): 1
away([I I I I I I I I I I I I I I I]): 1
away([I I I I I I I I I I I I I I I I]): 1
away([I I I I I I I I I I I I I I I I I]): 1
away([I I I I I I I I I I I I I I I I I I]): 1
away([I I I I I I I I I I I I I I I I I I I]): 1
away([I I I I I I I I I I I I I I I I I I I I]): 1
away([I I I I I I I I I I I I I I I I I I I I I]): 1
away([I I I I I I I I I I I I I I I I I I I I I I]): 1
away([I I I I I I I I I I I I I I I I I I I I I I I]): 1
away([I I I I I I I I I I I I I I I I I I I I I I I I]): 1
away([I I I I I I I I I I I I I I I I I I I I I I I I I]): 1
away([I I I I I I I I I I I I I I I I I I I I I I I I I I]): 1
away([I I I I I I I I I I I I I I I I I I I I I I I I I I I]): 1
away([I I I I I I I I I I I I I I I I I I I I I I I I I I I I]): 1
away([I I I I I I I I I I I I I I I I I I I I I I I I I I I I I]): 1
injuries([]): 1
injuries([I]): 1
injuries([I I]): 1
necessities([]): 1
Be([]): 1
Be([I]): 1
Be([I I]): 1
Be([I I I]): 1
Be([I I I I]): 1
Be([I I I I I]): 1
Be([I I I I I I]): 1
Be([I I I I I I I]): 1
Be([I I I I I I I I]): 1
Be([I I I I I I I I I]): 1
Be([I I I I I I I I I I]): 1
Be([I I I I I I I I I I I]): 1
Be([I I I I I I I I I I I I]): 1
Be([I I I I I I I I I I I I I]): 1
Be([I I I I I I I I I I I I I I]): 1
Be([I I I I I I I I I I I I I I I]): 1
...
```

Part of #22736
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
