### PR TITLE
Add map state in the Go Sdk

### DIFF
--- a/sdks/go/pkg/beam/core/graph/fn.go
+++ b/sdks/go/pkg/beam/core/graph/fn.go
@@ -1274,10 +1274,10 @@ func validateState(fn *DoFn, numIn mainInputs) error {
 					"unique per DoFn", k, orig, s)
 			}
 			t := s.StateType()
-			if t != state.TypeValue && t != state.TypeBag && t != state.TypeCombining {
+			if t != state.TypeValue && t != state.TypeBag && t != state.TypeCombining && t != state.TypeMap {
 				err := errors.Errorf("Unrecognized state type %v for state %v", t, s)
 				return errors.SetTopLevelMsgf(err, "Unrecognized state type %v for state %v. Currently the only supported state"+
-					"types are state.Value, state.Combining, and state.Bag", t, s)
+					"types are state.Value, state.Combining, state.Bag, and state.Map", t, s)
 			}
 			stateKeys[k] = s
 		}

--- a/sdks/go/pkg/beam/core/graph/fn_test.go
+++ b/sdks/go/pkg/beam/core/graph/fn_test.go
@@ -58,6 +58,7 @@ func TestNewDoFn(t *testing.T) {
 			{dfn: &GoodStatefulDoFn3{State1: state.MakeCombiningState[int, int, int]("state1", func(a, b int) int {
 				return a * b
 			})}, opt: NumMainInputs(MainKv)},
+			{dfn: &GoodStatefulDoFn4{State1: state.MakeMapState[string, int]("state1")}, opt: NumMainInputs(MainKv)},
 		}
 
 		for _, test := range tests {
@@ -1104,6 +1105,14 @@ type GoodStatefulDoFn3 struct {
 }
 
 func (fn *GoodStatefulDoFn3) ProcessElement(state.Provider, int, int) int {
+	return 0
+}
+
+type GoodStatefulDoFn4 struct {
+	State1 state.Map[string, int]
+}
+
+func (fn *GoodStatefulDoFn4) ProcessElement(state.Provider, int, int) int {
 	return 0
 }
 

--- a/sdks/go/pkg/beam/core/runtime/exec/data.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/data.go
@@ -77,6 +77,16 @@ type StateReader interface {
 	OpenBagUserStateAppender(ctx context.Context, id StreamID, userStateID string, key []byte, w []byte) (io.Writer, error)
 	// OpenBagUserStateClearer opens a byte stream for clearing user bag state.
 	OpenBagUserStateClearer(ctx context.Context, id StreamID, userStateID string, key []byte, w []byte) (io.Writer, error)
+	// OpenMultimapUserStateReader opens a byte stream for reading user multimap state.
+	OpenMultimapUserStateReader(ctx context.Context, id StreamID, userStateID string, key []byte, w []byte, mk []byte) (io.ReadCloser, error)
+	// OpenMultimapUserStateAppender opens a byte stream for appending user multimap state.
+	OpenMultimapUserStateAppender(ctx context.Context, id StreamID, userStateID string, key []byte, w []byte, mk []byte) (io.Writer, error)
+	// OpenMultimapUserStateClearer opens a byte stream for clearing user multimap state by key.
+	OpenMultimapUserStateClearer(ctx context.Context, id StreamID, userStateID string, key []byte, w []byte, mk []byte) (io.Writer, error)
+	// OpenMultimapKeysUserStateReader opens a byte stream for reading the keys of user multimap state.
+	OpenMultimapKeysUserStateReader(ctx context.Context, id StreamID, userStateID string, key []byte, w []byte) (io.ReadCloser, error)
+	// OpenMultimapKeysUserStateClearer opens a byte stream for clearing all keys of user multimap state.
+	OpenMultimapKeysUserStateClearer(ctx context.Context, id StreamID, userStateID string, key []byte, w []byte) (io.Writer, error)
 	// GetSideInputCache returns the SideInputCache being used at the harness level.
 	GetSideInputCache() SideCache
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/sideinput_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sideinput_test.go
@@ -148,6 +148,31 @@ func (t *testStateReader) OpenBagUserStateClearer(ctx context.Context, id Stream
 	return nil, nil
 }
 
+// OpenMultimapUserStateReader opens a byte stream for reading user multimap state.
+func (s *testStateReader) OpenMultimapUserStateReader(ctx context.Context, id StreamID, userStateID string, key []byte, w []byte, mk []byte) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+// OpenMultimapUserStateAppender opens a byte stream for appending user multimap state.
+func (s *testStateReader) OpenMultimapUserStateAppender(ctx context.Context, id StreamID, userStateID string, key []byte, w []byte, mk []byte) (io.Writer, error) {
+	return nil, nil
+}
+
+// OpenMultimapUserStateClearer opens a byte stream for clearing user multimap state by key.
+func (s *testStateReader) OpenMultimapUserStateClearer(ctx context.Context, id StreamID, userStateID string, key []byte, w []byte, mk []byte) (io.Writer, error) {
+	return nil, nil
+}
+
+// OpenMultimapKeysUserStateReader opens a byte stream for reading the keys of user multimap state.
+func (s *testStateReader) OpenMultimapKeysUserStateReader(ctx context.Context, id StreamID, userStateID string, key []byte, w []byte) (io.ReadCloser, error) {
+	return nil, nil
+}
+
+// OpenMultimapKeysUserStateClearer opens a byte stream for clearing all keys of user multimap state.
+func (s *testStateReader) OpenMultimapKeysUserStateClearer(ctx context.Context, id StreamID, userStateID string, key []byte, w []byte) (io.Writer, error) {
+	return nil, nil
+}
+
 func (t *testStateReader) GetSideInputCache() SideCache {
 	return &testSideCache{}
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/userstate.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/userstate.go
@@ -382,18 +382,6 @@ func (s *stateProvider) getMultiMapKeyReader(userStateID string) (io.ReadCloser,
 	return s.readersByKey[userStateID], nil
 }
 
-func (s *stateProvider) getMultiMapKeyClearer(userStateID string) (io.Writer, error) {
-	if w, ok := s.clearersByKey[userStateID]; ok {
-		return w, nil
-	}
-	w, err := s.sr.OpenMultimapKeysUserStateClearer(s.ctx, s.SID, userStateID, s.elementKey, s.window)
-	if err != nil {
-		return nil, err
-	}
-	s.clearersByKey[userStateID] = w
-	return s.clearersByKey[userStateID], nil
-}
-
 func (s *stateProvider) encodeKey(userStateID string, key interface{}) ([]byte, error) {
 	fv := FullValue{Elm: key}
 	enc := MakeElementEncoder(coder.SkipW(s.keyCodersByID[userStateID]))

--- a/sdks/go/pkg/beam/core/runtime/exec/userstate.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/userstate.go
@@ -110,7 +110,7 @@ func (s *stateProvider) WriteValueState(val state.Transaction) error {
 	return nil
 }
 
-// ReadBagState reads a BagState state from the State API
+// ReadBagState reads a bag state from the State API
 func (s *stateProvider) ReadBagState(userStateID string) ([]interface{}, []state.Transaction, error) {
 	initialValue, ok := s.initialBagByKey[userStateID]
 	if !ok {
@@ -165,7 +165,7 @@ func (s *stateProvider) WriteBagState(val state.Transaction) error {
 	return nil
 }
 
-// ReadMapStateValue reads a value from the map state given a key.
+// ReadMapStateValue reads a value from the map state for a given key.
 func (s *stateProvider) ReadMapStateValue(userStateID string, key interface{}) (interface{}, []state.Transaction, error) {
 	_, ok := s.initialMapValuesByKey[userStateID]
 	if !ok {

--- a/sdks/go/pkg/beam/core/runtime/exec/userstate.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/userstate.go
@@ -16,6 +16,7 @@
 package exec
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -34,21 +35,24 @@ type stateProvider struct {
 	elementKey []byte
 	window     []byte
 
-	transactionsByKey map[string][]state.Transaction
-	initialValueByKey map[string]interface{}
-	initialBagByKey   map[string][]interface{}
-	readersByKey      map[string]io.ReadCloser
-	appendersByKey    map[string]io.Writer
-	clearersByKey     map[string]io.Writer
-	codersByKey       map[string]*coder.Coder
-	combineFnsByKey   map[string]*graph.CombineFn
+	transactionsByKey     map[string][]state.Transaction
+	initialValueByKey     map[string]interface{}
+	initialBagByKey       map[string][]interface{}
+	initialMapValuesByKey map[string]map[string]interface{}
+	initialMapKeysByKey   map[string][]interface{}
+	readersByKey          map[string]io.ReadCloser
+	appendersByKey        map[string]io.Writer
+	clearersByKey         map[string]io.Writer
+	codersByKey           map[string]*coder.Coder
+	keyCodersByID         map[string]*coder.Coder
+	combineFnsByKey       map[string]*graph.CombineFn
 }
 
 // ReadValueState reads a value state from the State API
 func (s *stateProvider) ReadValueState(userStateID string) (interface{}, []state.Transaction, error) {
 	initialValue, ok := s.initialValueByKey[userStateID]
 	if !ok {
-		rw, err := s.getReader(userStateID)
+		rw, err := s.getBagReader(userStateID)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -75,13 +79,13 @@ func (s *stateProvider) ReadValueState(userStateID string) (interface{}, []state
 // WriteValueState writes a value state to the State API
 // For value states, this is done by clearing a bag state and writing a value to it.
 func (s *stateProvider) WriteValueState(val state.Transaction) error {
-	cl, err := s.getClearer(val.Key)
+	cl, err := s.getBagClearer(val.Key)
 	if err != nil {
 		return err
 	}
 	cl.Write([]byte{})
 
-	ap, err := s.getAppender(val.Key)
+	ap, err := s.getBagAppender(val.Key)
 	if err != nil {
 		return err
 	}
@@ -106,12 +110,12 @@ func (s *stateProvider) WriteValueState(val state.Transaction) error {
 	return nil
 }
 
-// ReadBagState reads a ReadBagState state from the State API
+// ReadBagState reads a BagState state from the State API
 func (s *stateProvider) ReadBagState(userStateID string) ([]interface{}, []state.Transaction, error) {
 	initialValue, ok := s.initialBagByKey[userStateID]
 	if !ok {
 		initialValue = []interface{}{}
-		rw, err := s.getReader(userStateID)
+		rw, err := s.getBagReader(userStateID)
 		if err != nil {
 			return nil, nil, err
 		}
@@ -136,10 +140,9 @@ func (s *stateProvider) ReadBagState(userStateID string) ([]interface{}, []state
 	return initialValue, transactions, nil
 }
 
-// WriteValueState writes a value state to the State API
-// For value states, this is done by clearing a bag state and writing a value to it.
+// WriteBagState writes a bag state to the State API
 func (s *stateProvider) WriteBagState(val state.Transaction) error {
-	ap, err := s.getAppender(val.Key)
+	ap, err := s.getBagAppender(val.Key)
 	if err != nil {
 		return err
 	}
@@ -152,6 +155,105 @@ func (s *stateProvider) WriteBagState(val state.Transaction) error {
 	}
 
 	// TODO(#22736) - optimize this a bit once all state types are added.
+	if transactions, ok := s.transactionsByKey[val.Key]; ok {
+		transactions = append(transactions, val)
+		s.transactionsByKey[val.Key] = transactions
+	} else {
+		s.transactionsByKey[val.Key] = []state.Transaction{val}
+	}
+
+	return nil
+}
+
+// ReadMapStateValue reads a value from the map state given a key.
+func (s *stateProvider) ReadMapStateValue(userStateID string, key interface{}) (interface{}, []state.Transaction, error) {
+	_, ok := s.initialMapValuesByKey[userStateID]
+	if !ok {
+		s.initialMapValuesByKey[userStateID] = make(map[string]interface{})
+	}
+	b, err := s.encodeKey(userStateID, key)
+	if err != nil {
+		return nil, nil, err
+	}
+	initialValue, ok := s.initialMapValuesByKey[userStateID][string(b)]
+	if !ok {
+		rw, err := s.getMultiMapReader(userStateID, key)
+		if err != nil {
+			return nil, nil, err
+		}
+		dec := MakeElementDecoder(coder.SkipW(s.codersByKey[userStateID]))
+		resp, err := dec.Decode(rw)
+		if err != nil && err != io.EOF {
+			return nil, nil, err
+		}
+		if resp == nil {
+			return nil, []state.Transaction{}, nil
+		}
+		initialValue = resp.Elm
+		s.initialValueByKey[userStateID] = initialValue
+	}
+
+	transactions, ok := s.transactionsByKey[userStateID]
+	if !ok {
+		transactions = []state.Transaction{}
+	}
+
+	return initialValue, transactions, nil
+}
+
+// ReadMapStateKeys reads all the keys in a map state.
+func (s *stateProvider) ReadMapStateKeys(userStateID string) ([]interface{}, []state.Transaction, error) {
+	initialValue, ok := s.initialMapKeysByKey[userStateID]
+	if !ok {
+		initialValue = []interface{}{}
+		rw, err := s.getMultiMapKeyReader(userStateID)
+		if err != nil {
+			return nil, nil, err
+		}
+		dec := MakeElementDecoder(coder.SkipW(s.keyCodersByID[userStateID]))
+		for err == nil {
+			var resp *FullValue
+			resp, err = dec.Decode(rw)
+			if err == nil {
+				initialValue = append(initialValue, resp.Elm)
+			} else if err != io.EOF {
+				return nil, nil, err
+			}
+		}
+		s.initialMapKeysByKey[userStateID] = initialValue
+	}
+
+	transactions, ok := s.transactionsByKey[userStateID]
+	if !ok {
+		transactions = []state.Transaction{}
+	}
+
+	return initialValue, transactions, nil
+}
+
+// WriteMapState writes a key value pair to the global map state.
+func (s *stateProvider) WriteMapState(val state.Transaction) error {
+	cl, err := s.getMultiMapClearer(val.Key, val.MapKey)
+	if err != nil {
+		return err
+	}
+	cl.Write([]byte{})
+
+	ap, err := s.getMultiMapAppender(val.Key, val.MapKey)
+	if err != nil {
+		return err
+	}
+	fv := FullValue{Elm: val.Val}
+	// TODO(#22736) - consider caching this a proprty of stateProvider
+	enc := MakeElementEncoder(coder.SkipW(s.codersByKey[val.Key]))
+	err = enc.Encode(&fv, ap)
+	if err != nil {
+		return err
+	}
+
+	// TODO(#22736) - optimize this a bit once all state types are added. In the case of sets/clears,
+	// we can remove the transactions. We can also consider combining other transactions on read (or sooner)
+	// so that we don't need to use as much memory/time replaying transactions.
 	if transactions, ok := s.transactionsByKey[val.Key]; ok {
 		transactions = append(transactions, val)
 		s.transactionsByKey[val.Key] = transactions
@@ -196,7 +298,7 @@ func (s *stateProvider) ExtractOutputFn(userStateID string) reflectx.Func {
 	return nil
 }
 
-func (s *stateProvider) getReader(userStateID string) (io.ReadCloser, error) {
+func (s *stateProvider) getBagReader(userStateID string) (io.ReadCloser, error) {
 	if r, ok := s.readersByKey[userStateID]; ok {
 		return r, nil
 	}
@@ -208,7 +310,7 @@ func (s *stateProvider) getReader(userStateID string) (io.ReadCloser, error) {
 	return s.readersByKey[userStateID], nil
 }
 
-func (s *stateProvider) getAppender(userStateID string) (io.Writer, error) {
+func (s *stateProvider) getBagAppender(userStateID string) (io.Writer, error) {
 	if w, ok := s.appendersByKey[userStateID]; ok {
 		return w, nil
 	}
@@ -220,7 +322,7 @@ func (s *stateProvider) getAppender(userStateID string) (io.Writer, error) {
 	return s.appendersByKey[userStateID], nil
 }
 
-func (s *stateProvider) getClearer(userStateID string) (io.Writer, error) {
+func (s *stateProvider) getBagClearer(userStateID string) (io.Writer, error) {
 	if w, ok := s.clearersByKey[userStateID]; ok {
 		return w, nil
 	}
@@ -230,6 +332,77 @@ func (s *stateProvider) getClearer(userStateID string) (io.Writer, error) {
 	}
 	s.clearersByKey[userStateID] = w
 	return s.clearersByKey[userStateID], nil
+}
+
+func (s *stateProvider) getMultiMapReader(userStateID string, key interface{}) (io.ReadCloser, error) {
+	ek, err := s.encodeKey(userStateID, key)
+	if err != nil {
+		return nil, err
+	}
+	r, err := s.sr.OpenMultimapUserStateReader(s.ctx, s.SID, userStateID, s.elementKey, s.window, ek)
+	if err != nil {
+		return nil, err
+	}
+	return r, nil
+}
+
+func (s *stateProvider) getMultiMapAppender(userStateID string, key interface{}) (io.Writer, error) {
+	ek, err := s.encodeKey(userStateID, key)
+	if err != nil {
+		return nil, err
+	}
+	w, err := s.sr.OpenMultimapUserStateAppender(s.ctx, s.SID, userStateID, s.elementKey, s.window, ek)
+	if err != nil {
+		return nil, err
+	}
+	return w, nil
+}
+
+func (s *stateProvider) getMultiMapClearer(userStateID string, key interface{}) (io.Writer, error) {
+	ek, err := s.encodeKey(userStateID, key)
+	if err != nil {
+		return nil, err
+	}
+	w, err := s.sr.OpenMultimapUserStateClearer(s.ctx, s.SID, userStateID, s.elementKey, s.window, ek)
+	if err != nil {
+		return nil, err
+	}
+	return w, nil
+}
+
+func (s *stateProvider) getMultiMapKeyReader(userStateID string) (io.ReadCloser, error) {
+	if r, ok := s.readersByKey[userStateID]; ok {
+		return r, nil
+	}
+	r, err := s.sr.OpenMultimapKeysUserStateReader(s.ctx, s.SID, userStateID, s.elementKey, s.window)
+	if err != nil {
+		return nil, err
+	}
+	s.readersByKey[userStateID] = r
+	return s.readersByKey[userStateID], nil
+}
+
+func (s *stateProvider) getMultiMapKeyClearer(userStateID string) (io.Writer, error) {
+	if w, ok := s.clearersByKey[userStateID]; ok {
+		return w, nil
+	}
+	w, err := s.sr.OpenMultimapKeysUserStateClearer(s.ctx, s.SID, userStateID, s.elementKey, s.window)
+	if err != nil {
+		return nil, err
+	}
+	s.clearersByKey[userStateID] = w
+	return s.clearersByKey[userStateID], nil
+}
+
+func (s *stateProvider) encodeKey(userStateID string, key interface{}) ([]byte, error) {
+	fv := FullValue{Elm: key}
+	enc := MakeElementEncoder(coder.SkipW(s.keyCodersByID[userStateID]))
+	var b bytes.Buffer
+	err := enc.Encode(&fv, &b)
+	if err != nil {
+		return nil, err
+	}
+	return b.Bytes(), nil
 }
 
 // UserStateAdapter provides a state provider to be used for user state.
@@ -242,13 +415,14 @@ type userStateAdapter struct {
 	wc                 WindowEncoder
 	kc                 ElementEncoder
 	stateIDToCoder     map[string]*coder.Coder
+	stateIDToKeyCoder  map[string]*coder.Coder
 	stateIDToCombineFn map[string]*graph.CombineFn
 	c                  *coder.Coder
 }
 
 // NewUserStateAdapter returns a user state adapter for the given StreamID and coder.
 // It expects a W<V> or W<KV<K,V>> coder, because the protocol requires windowing information.
-func NewUserStateAdapter(sid StreamID, c *coder.Coder, stateIDToCoder map[string]*coder.Coder, stateIDToCombineFn map[string]*graph.CombineFn) UserStateAdapter {
+func NewUserStateAdapter(sid StreamID, c *coder.Coder, stateIDToCoder map[string]*coder.Coder, stateIDToKeyCoder map[string]*coder.Coder, stateIDToCombineFn map[string]*graph.CombineFn) UserStateAdapter {
 	if !coder.IsW(c) {
 		panic(fmt.Sprintf("expected WV coder for user state %v: %v", sid, c))
 	}
@@ -258,7 +432,7 @@ func NewUserStateAdapter(sid StreamID, c *coder.Coder, stateIDToCoder map[string
 	if coder.IsKV(coder.SkipW(c)) {
 		kc = MakeElementEncoder(coder.SkipW(c).Components[0])
 	}
-	return &userStateAdapter{sid: sid, wc: wc, kc: kc, c: c, stateIDToCoder: stateIDToCoder, stateIDToCombineFn: stateIDToCombineFn}
+	return &userStateAdapter{sid: sid, wc: wc, kc: kc, c: c, stateIDToCoder: stateIDToCoder, stateIDToKeyCoder: stateIDToKeyCoder, stateIDToCombineFn: stateIDToCombineFn}
 }
 
 // NewStateProvider creates a stateProvider with the ability to talk to the state API.
@@ -276,19 +450,22 @@ func (s *userStateAdapter) NewStateProvider(ctx context.Context, reader StateRea
 		return stateProvider{}, err
 	}
 	sp := stateProvider{
-		ctx:               ctx,
-		sr:                reader,
-		SID:               s.sid,
-		elementKey:        elementKey,
-		window:            win,
-		transactionsByKey: make(map[string][]state.Transaction),
-		initialValueByKey: make(map[string]interface{}),
-		initialBagByKey:   make(map[string][]interface{}),
-		readersByKey:      make(map[string]io.ReadCloser),
-		appendersByKey:    make(map[string]io.Writer),
-		clearersByKey:     make(map[string]io.Writer),
-		combineFnsByKey:   s.stateIDToCombineFn,
-		codersByKey:       s.stateIDToCoder,
+		ctx:                   ctx,
+		sr:                    reader,
+		SID:                   s.sid,
+		elementKey:            elementKey,
+		window:                win,
+		transactionsByKey:     make(map[string][]state.Transaction),
+		initialValueByKey:     make(map[string]interface{}),
+		initialBagByKey:       make(map[string][]interface{}),
+		initialMapValuesByKey: make(map[string]map[string]interface{}),
+		initialMapKeysByKey:   make(map[string][]interface{}),
+		readersByKey:          make(map[string]io.ReadCloser),
+		appendersByKey:        make(map[string]io.Writer),
+		clearersByKey:         make(map[string]io.Writer),
+		combineFnsByKey:       s.stateIDToCombineFn,
+		codersByKey:           s.stateIDToCoder,
+		keyCodersByID:         s.stateIDToKeyCoder,
 	}
 
 	return sp, nil

--- a/sdks/go/pkg/beam/core/runtime/graphx/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate.go
@@ -1404,7 +1404,7 @@ func UserStateCoderId(ps state.PipelineState) string {
 	return fmt.Sprintf("val_%v", ps.StateKey())
 }
 
-// UserStateCoderId returns the key coder id of a user state
+// UserStateKeyCoderId returns the key coder id of a user state
 func UserStateKeyCoderId(ps state.PipelineState) string {
 	return fmt.Sprintf("key_%v", ps.StateKey())
 }

--- a/sdks/go/pkg/beam/core/state/state.go
+++ b/sdks/go/pkg/beam/core/state/state.go
@@ -42,6 +42,8 @@ const (
 	TypeBag TypeEnum = 1
 	// TypeCombining represents a combining state
 	TypeCombining TypeEnum = 2
+	// TypeMap represents a map state
+	TypeMap TypeEnum = 3
 )
 
 var (
@@ -54,9 +56,10 @@ var (
 // Transaction is used to represent a pending state transaction. This should not be manipulated directly;
 // it is primarily used for implementations of the Provider interface to talk to the various State objects.
 type Transaction struct {
-	Key  string
-	Type TransactionTypeEnum
-	Val  interface{}
+	Key    string
+	Type   TransactionTypeEnum
+	MapKey interface{}
+	Val    interface{}
 }
 
 // Provider represents the DoFn parameter used to get and manipulate pipeline state
@@ -72,12 +75,16 @@ type Provider interface {
 	AddInputFn(userStateID string) reflectx.Func
 	MergeAccumulatorsFn(userStateID string) reflectx.Func
 	ExtractOutputFn(userStateID string) reflectx.Func
+	ReadMapStateValue(userStateID string, key interface{}) (interface{}, []Transaction, error)
+	ReadMapStateKeys(userStateID string) ([]interface{}, []Transaction, error)
+	WriteMapState(val Transaction) error
 }
 
 // PipelineState is an interface representing different kinds of PipelineState (currently just state.Value).
 // It is primarily meant for Beam packages to use and is probably not useful for most pipeline authors.
 type PipelineState interface {
 	StateKey() string
+	KeyCoderType() reflect.Type
 	CoderType() reflect.Type
 	StateType() TypeEnum
 }
@@ -135,6 +142,11 @@ func (s Value[T]) StateKey() string {
 		panic("Value state exists on struct but has not been initialized with a key.")
 	}
 	return s.Key
+}
+
+// KeyCoderType returns nil since Value types aren't keyed.
+func (s Value[T]) KeyCoderType() reflect.Type {
+	return nil
 }
 
 // CoderType returns the type of the value state which should be used for a coder.
@@ -205,6 +217,11 @@ func (s Bag[T]) StateKey() string {
 		panic("Value state exists on struct but has not been initialized with a key.")
 	}
 	return s.Key
+}
+
+// KeyCoderType returns nil since Bag types aren't keyed.
+func (s Bag[T]) KeyCoderType() reflect.Type {
+	return nil
 }
 
 // CoderType returns the type of the bag state which should be used for a coder.
@@ -343,6 +360,11 @@ func (s Combining[T1, T2, T3]) StateKey() string {
 	return s.Key
 }
 
+// KeyCoderType returns nil since combining state types aren't keyed.
+func (s Combining[T1, T2, T3]) KeyCoderType() reflect.Type {
+	return nil
+}
+
 // CoderType returns the type of the bag state which should be used for a coder.
 func (s Combining[T1, T2, T3]) CoderType() reflect.Type {
 	var t T1
@@ -366,5 +388,131 @@ func MakeCombiningState[T1, T2, T3 any](k string, combiner interface{}) Combinin
 	return Combining[T1, T2, T3]{
 		Key:     k,
 		accumFn: combiner,
+	}
+}
+
+// Map is used to read and write global pipeline state representing a map.
+// Key represents the key used to lookup this state (not the key of map entries).
+type Map[K comparable, V any] struct {
+	Key string
+}
+
+// Put is used to write a key/value pair to this instance of global map state.
+func (s *Map[K, V]) Put(p Provider, key K, val V) error {
+	return p.WriteMapState(Transaction{
+		Key:    s.Key,
+		Type:   TransactionTypeSet,
+		MapKey: key,
+		Val:    val,
+	})
+}
+
+// Keys is used to read the keys of this map state.
+// When a value is not found, returns an empty list and false.
+func (s *Map[K, V]) Keys(p Provider) ([]K, bool, error) {
+	// This replays any writes that have happened to this value since we last read
+	// For more detail, see "State Transactionality" below for buffered transactions
+	initialValue, bufferedTransactions, err := p.ReadMapStateKeys(s.Key)
+	if err != nil {
+		return []K{}, false, err
+	}
+	cur := []K{}
+	for _, v := range initialValue {
+		cur = append(cur, v.(K))
+	}
+	for _, t := range bufferedTransactions {
+		switch t.Type {
+		case TransactionTypeSet:
+			seen := false
+			mk := t.MapKey.(K)
+			for _, k := range cur {
+				if k == mk {
+					seen = true
+				}
+			}
+			if !seen {
+				cur = append(cur, mk)
+			}
+		case TransactionTypeClear:
+			if t.MapKey == nil {
+				cur = []K{}
+			} else {
+				k := t.MapKey.(K)
+				for idx, v := range cur {
+					if v == k {
+						// Remove this key since its been cleared
+						cur[idx] = cur[len(cur)-1]
+						cur = cur[:len(cur)-1]
+						break
+					}
+				}
+			}
+		}
+	}
+	if len(cur) == 0 {
+		return cur, false, nil
+	}
+	return cur, true, nil
+}
+
+// Get is used to read a value given a key.
+// When a value is not found, returns the 0 value and false.
+func (s *Map[K, V]) Get(p Provider, key K) (V, bool, error) {
+	// This replays any writes that have happened to this value since we last read
+	// For more detail, see "State Transactionality" below for buffered transactions
+	cur, bufferedTransactions, err := p.ReadMapStateValue(s.Key, key)
+	if err != nil {
+		var val V
+		return val, false, err
+	}
+	for _, t := range bufferedTransactions {
+		switch t.Type {
+		case TransactionTypeSet:
+			if t.MapKey.(K) == key {
+				cur = t.Val
+			}
+		case TransactionTypeClear:
+			if t.MapKey == nil || t.MapKey.(K) == key {
+				cur = nil
+			}
+		}
+	}
+	if cur == nil {
+		var val V
+		return val, false, nil
+	}
+	return cur.(V), true, nil
+}
+
+// StateKey returns the key for this pipeline state entry.
+func (s Map[K, V]) StateKey() string {
+	if s.Key == "" {
+		// TODO(#22736) - infer the state from the member variable name during pipeline construction.
+		panic("Value state exists on struct but has not been initialized with a key.")
+	}
+	return s.Key
+}
+
+// KeyCoderType returns the type of the value state which should be used for a coder for map keys.
+func (s Map[K, V]) KeyCoderType() reflect.Type {
+	var k K
+	return reflect.TypeOf(k)
+}
+
+// CoderType returns the type of the value state which should be used for a coder for map values.
+func (s Map[K, V]) CoderType() reflect.Type {
+	var v V
+	return reflect.TypeOf(v)
+}
+
+// StateType returns the type of the state (in this case always Map).
+func (s Map[K, V]) StateType() TypeEnum {
+	return TypeMap
+}
+
+// MakeValueState is a factory function to create an instance of ValueState with the given key.
+func MakeMapState[K comparable, V any](k string) Map[K, V] {
+	return Map[K, V]{
+		Key: k,
 	}
 }

--- a/sdks/go/pkg/beam/core/state/state_test.go
+++ b/sdks/go/pkg/beam/core/state/state_test.go
@@ -117,10 +117,6 @@ func (s *fakeProvider) ExtractOutputFn(userStateID string) reflectx.Func {
 	return nil
 }
 
-// ReadMapStateValue(userStateID string, key interface{}) (interface{}, []Transaction, error)
-// 	ReadMapStateKeys(userStateID string) ([]interface{}, []Transaction, error)
-// 	WriteMapState(val Transaction) error
-
 func (s *fakeProvider) ReadMapStateValue(userStateID string, key interface{}) (interface{}, []Transaction, error) {
 	keyString := key.(string)
 	if err, ok := s.err[userStateID]; ok {

--- a/sdks/go/pkg/beam/core/state/state_test.go
+++ b/sdks/go/pkg/beam/core/state/state_test.go
@@ -29,6 +29,7 @@ var (
 type fakeProvider struct {
 	initialState      map[string]interface{}
 	initialBagState   map[string][]interface{}
+	initialMapState   map[string]map[string]interface{}
 	transactions      map[string][]Transaction
 	err               map[string]error
 	createAccumForKey map[string]bool
@@ -113,6 +114,50 @@ func (s *fakeProvider) ExtractOutputFn(userStateID string) reflectx.Func {
 		})
 	}
 
+	return nil
+}
+
+// ReadMapStateValue(userStateID string, key interface{}) (interface{}, []Transaction, error)
+// 	ReadMapStateKeys(userStateID string) ([]interface{}, []Transaction, error)
+// 	WriteMapState(val Transaction) error
+
+func (s *fakeProvider) ReadMapStateValue(userStateID string, key interface{}) (interface{}, []Transaction, error) {
+	keyString := key.(string)
+	if err, ok := s.err[userStateID]; ok {
+		return nil, nil, err
+	}
+	base := s.initialMapState[userStateID][keyString]
+	trans, ok := s.transactions[userStateID]
+	if !ok {
+		trans = []Transaction{}
+	}
+	return base, trans, nil
+}
+
+func (s *fakeProvider) ReadMapStateKeys(userStateID string) ([]interface{}, []Transaction, error) {
+	if err, ok := s.err[userStateID]; ok {
+		return nil, nil, err
+	}
+	base := s.initialMapState[userStateID]
+	keys := make([]interface{}, len(base))
+	i := 0
+	for k := range base {
+		keys[i] = k
+		i++
+	}
+	trans, ok := s.transactions[userStateID]
+	if !ok {
+		trans = []Transaction{}
+	}
+	return keys, trans, nil
+}
+
+func (s *fakeProvider) WriteMapState(val Transaction) error {
+	if transactions, ok := s.transactions[val.Key]; ok {
+		s.transactions[val.Key] = append(transactions, val)
+	} else {
+		s.transactions[val.Key] = []Transaction{val}
+	}
 	return nil
 }
 
@@ -472,6 +517,174 @@ func TestCombiningAdd(t *testing.T) {
 			t.Errorf("Bag.Read() didn't return a value when it should have returned %v after writing: %v", tt.val, tt.writes)
 		} else if val != tt.val {
 			t.Errorf("Bag.Read()=%v, want %v after writing: %v", val, tt.val, tt.writes)
+		}
+	}
+}
+
+func TestMapGet(t *testing.T) {
+	is := make(map[string]interface{})
+	im := make(map[string]map[string]interface{})
+	ts := make(map[string][]Transaction)
+	es := make(map[string]error)
+	ca := make(map[string]bool)
+	eo := make(map[string]bool)
+	ts["no_transactions"] = nil
+	im["basic_set"] = map[string]interface{}{"foo": 2}
+	ts["basic_set"] = []Transaction{{Key: "basic_set", Type: TransactionTypeSet, Val: 3, MapKey: "foo"}, {Key: "basic_set", Type: TransactionTypeSet, Val: 1, MapKey: "bar"}}
+	im["basic_clear"] = map[string]interface{}{"foo": 2, "bar": 1}
+	ts["basic_clear"] = []Transaction{{Key: "basic_clear", Type: TransactionTypeClear, Val: nil, MapKey: "foo"}}
+	im["set_then_clear"] = map[string]interface{}{"foo": 2, "bar": 1}
+	ts["set_then_clear"] = []Transaction{{Key: "set_then_clear", Type: TransactionTypeSet, Val: 3, MapKey: "foo"}, {Key: "set_then_clear", Type: TransactionTypeClear, Val: nil, MapKey: "foo"}}
+	im["err"] = map[string]interface{}{"foo": 2}
+	ts["err"] = []Transaction{{Key: "err", Type: TransactionTypeSet, Val: 3}}
+	es["err"] = errFake
+
+	f := fakeProvider{
+		initialMapState:   im,
+		initialState:      is,
+		transactions:      ts,
+		err:               es,
+		createAccumForKey: ca,
+		extractOutForKey:  eo,
+	}
+
+	var tests = []struct {
+		vs    Map[string, int]
+		foo   int
+		bar   int
+		fooOk bool
+		barOk bool
+		err   error
+	}{
+		{MakeMapState[string, int]("no_transactions"), 0, 0, false, false, nil},
+		{MakeMapState[string, int]("basic_set"), 3, 1, true, true, nil},
+		{MakeMapState[string, int]("basic_clear"), 0, 1, false, true, nil},
+		{MakeMapState[string, int]("set_then_clear"), 0, 1, false, true, nil},
+		{MakeMapState[string, int]("err"), 0, 0, false, false, errFake},
+	}
+
+	for _, tt := range tests {
+		val, ok, err := tt.vs.Get(&f, "foo")
+		if err != nil && tt.err == nil {
+			t.Errorf("Map.Get() returned error %v for state key %v and map key foo when it shouldn't have", err, tt.vs.Key)
+		} else if err == nil && tt.err != nil {
+			t.Errorf("Map.Get() returned no error for state key %v and map key foo when it should have returned %v", tt.vs.Key, err)
+		} else if ok && !tt.fooOk {
+			t.Errorf("Map.Get() returned a value %v for state key %v and map key foo when it shouldn't have", val, tt.vs.Key)
+		} else if !ok && tt.fooOk {
+			t.Errorf("Map.Get() didn't return a value for state key %v and map key foo when it should have returned %v", tt.vs.Key, tt.foo)
+		} else if val != tt.foo {
+			t.Errorf("Map.Get()=%v, want %v for state key %v and map key foo", val, tt.foo, tt.vs.Key)
+		}
+		val, ok, err = tt.vs.Get(&f, "bar")
+		if err != nil && tt.err == nil {
+			t.Errorf("Map.Get() returned error %v for state key %v and map key bar when it shouldn't have", err, tt.vs.Key)
+		} else if err == nil && tt.err != nil {
+			t.Errorf("Map.Get() returned no error for state key %v and map key bar when it should have returned %v", tt.vs.Key, err)
+		} else if ok && !tt.barOk {
+			t.Errorf("Map.Get() returned a value %v for state key %v and map key bar when it shouldn't have", val, tt.vs.Key)
+		} else if !ok && tt.barOk {
+			t.Errorf("Map.Get() didn't return a value for state key %v and map key bar when it should have returned %v", tt.vs.Key, tt.bar)
+		} else if val != tt.bar {
+			t.Errorf("Map.Get()=%v, want %v for state key %v and map key bar", val, tt.bar, tt.vs.Key)
+		}
+	}
+}
+
+func TestMapKeys(t *testing.T) {
+	is := make(map[string]interface{})
+	im := make(map[string]map[string]interface{})
+	ts := make(map[string][]Transaction)
+	es := make(map[string]error)
+	ca := make(map[string]bool)
+	eo := make(map[string]bool)
+	ts["no_transactions"] = nil
+	im["basic_set"] = map[string]interface{}{"foo": 2}
+	ts["basic_set"] = []Transaction{{Key: "basic_set", Type: TransactionTypeSet, Val: 3, MapKey: "foo"}, {Key: "basic_set", Type: TransactionTypeSet, Val: 1, MapKey: "bar"}}
+	im["basic_clear"] = map[string]interface{}{"foo": 2, "bar": 1}
+	ts["basic_clear"] = []Transaction{{Key: "basic_clear", Type: TransactionTypeClear, Val: nil, MapKey: "foo"}}
+	im["set_then_clear"] = map[string]interface{}{"foo": 2, "bar": 1}
+	ts["set_then_clear"] = []Transaction{{Key: "set_then_clear", Type: TransactionTypeSet, Val: 3, MapKey: "foo"}, {Key: "set_then_clear", Type: TransactionTypeClear, Val: nil, MapKey: "foo"}}
+	im["err"] = map[string]interface{}{"foo": 2}
+	ts["err"] = []Transaction{{Key: "err", Type: TransactionTypeSet, Val: 3}}
+	es["err"] = errFake
+
+	f := fakeProvider{
+		initialMapState:   im,
+		initialState:      is,
+		transactions:      ts,
+		err:               es,
+		createAccumForKey: ca,
+		extractOutForKey:  eo,
+	}
+
+	var tests = []struct {
+		vs   Map[string, int]
+		keys []string
+		ok   bool
+		err  error
+	}{
+		{MakeMapState[string, int]("no_transactions"), []string{}, false, nil},
+		{MakeMapState[string, int]("basic_set"), []string{"foo", "bar"}, true, nil},
+		{MakeMapState[string, int]("basic_clear"), []string{"bar"}, true, nil},
+		{MakeMapState[string, int]("set_then_clear"), []string{"bar"}, true, nil},
+		{MakeMapState[string, int]("err"), []string{}, false, errFake},
+	}
+
+	for _, tt := range tests {
+		val, ok, err := tt.vs.Keys(&f)
+		if err != nil && tt.err == nil {
+			t.Errorf("Map.Keys() returned error %v for state key %v when it shouldn't have", err, tt.vs.Key)
+		} else if err == nil && tt.err != nil {
+			t.Errorf("Map.Keys() returned no error for state key %v when it should have returned %v", tt.vs.Key, err)
+		} else if ok && !tt.ok {
+			t.Errorf("Map.Keys() returned a value %v for state key %v when it shouldn't have", val, tt.vs.Key)
+		} else if len(val) != len(tt.keys) {
+			t.Errorf("Map.Keys()=%v, want %v for state key %v", val, tt.keys, tt.vs.Key)
+		} else {
+			eq := true
+			for idx, v := range val {
+				if v != tt.keys[idx] {
+					eq = false
+				}
+			}
+			if !eq {
+				t.Errorf("Map.Keys()=%v, want %v for state key %v", val, tt.keys, tt.vs.Key)
+			}
+		}
+	}
+}
+
+func TestMapPut(t *testing.T) {
+	var tests = []struct {
+		writes []int
+		val    int
+		ok     bool
+	}{
+		{[]int{}, 0, false},
+		{[]int{3}, 3, true},
+		{[]int{1, 5}, 5, true},
+	}
+
+	for _, tt := range tests {
+		f := fakeProvider{
+			initialState: make(map[string]interface{}),
+			transactions: make(map[string][]Transaction),
+			err:          make(map[string]error),
+		}
+		vs := MakeMapState[string, int]("vs")
+		for _, val := range tt.writes {
+			vs.Put(&f, "foo", val)
+		}
+		val, ok, err := vs.Get(&f, "foo")
+		if err != nil {
+			t.Errorf("Map.Get(\"foo\") returned error %v when it shouldn't have after writing: %v", err, tt.writes)
+		} else if ok && !tt.ok {
+			t.Errorf("Map.Get(\"foo\") returned a value %v when it shouldn't have after writing: %v", val, tt.writes)
+		} else if !ok && tt.ok {
+			t.Errorf("Map.Get(\"foo\") didn't return a value when it should have returned %v after writing: %v", tt.val, tt.writes)
+		} else if val != tt.val {
+			t.Errorf("Map.Get(\"foo\")=%v, want %v after writing: %v", val, tt.val, tt.writes)
 		}
 	}
 }

--- a/sdks/go/pkg/beam/pardo.go
+++ b/sdks/go/pkg/beam/pardo.go
@@ -23,6 +23,7 @@ import (
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/coder"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/window"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime/graphx"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/typex"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/internal/errors"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/log"
@@ -101,7 +102,15 @@ func TryParDo(s Scope, dofn interface{}, col PCollection, opts ...Option) ([]PCo
 			if err != nil {
 				return nil, addParDoCtx(err, s)
 			}
-			edge.StateCoders[ps.StateKey()] = c
+			edge.StateCoders[graphx.UserStateCoderId(ps)] = c
+			if kct := ps.KeyCoderType(); kct != nil {
+				kT := typex.New(kct)
+				kc, err := inferCoder(kT)
+				if err != nil {
+					return nil, addParDoCtx(err, s)
+				}
+				edge.StateCoders[graphx.UserStateKeyCoderId(ps)] = kc
+			}
 		}
 	}
 


### PR DESCRIPTION
This continues to grow our state support by adding map state support. Once this is in, I'll add a follow up PR with an integration test. In the meantime, I tested manually by running the hacked wordcount found here - https://github.com/damccorm/beam/pull/94/files#diff-46f0bd8f9f6b541e840079960d684ba78e6513f1293b673d08faaec94d48a234 - and it produced output like:

```
any, 1. Total num keys: 2. With keys: [any5 any]
any, 2. Total num keys: 3. With keys: [any7 any5 any]
any, 3. Total num keys: 4. With keys: [any28 any7 any5 any]
any, 4. Total num keys: 5. With keys: [any28 any7 any5 any any13]
any, 5. Total num keys: 6. First 5 keys: [any28 any7 any5 any any13]
any, 6. Total num keys: 7. First 5 keys: [any28 any7 any5 any any13]
any, 7. Total num keys: 8. First 5 keys: [any28 any5 any13 any97 any98]
any, 8. Total num keys: 9. First 5 keys: [any28 any5 any13 any97 any98]
any, 9. Total num keys: 10. First 5 keys: [any28 any5 any13 any97 any98]
any, 10. Total num keys: 11. First 5 keys: [any28 any5 any13 any97 any98]
any, 11. Total num keys: 12. First 5 keys: [any28 any5 any13 any97 any98]
any, 12. Total num keys: 13. First 5 keys: [any28 any5 any13 any97 any98]
any, 13. Total num keys: 14. First 5 keys: [any28 any5 any13 any97 any98]
any, 14. Total num keys: 14. First 5 keys: [any28 any5 any13 any97 any98]
any, 15. Total num keys: 15. First 5 keys: [any33 any8 any28 any5 any6]
any, 16. Total num keys: 16. First 5 keys: [any33 any8 any28 any5 any6]
any, 17. Total num keys: 17. First 5 keys: [any33 any9 any8 any28 any5]
any, 18. Total num keys: 18. First 5 keys: [any33 any9 any8 any28 any5]
Camelot, 1. Total num keys: 2. With keys: [Camelot Camelot17]
Mean, 1. Total num keys: 2. With keys: [Mean87 Mean]
Reverbs, 1. Total num keys: 2. With keys: [Reverbs Reverbs73]
devour, 1. Total num keys: 2. With keys: [devour devour26]
vengeance, 1. Total num keys: 2. With keys: [vengeance vengeance6]
vengeance, 2. Total num keys: 3. With keys: [vengeance72 vengeance vengeance6]
vengeance, 3. Total num keys: 4. With keys: [vengeance64 vengeance6 vengeance72 vengeance]
...
```

Note that this doesn't add support for Remove (to remove a single key). This will come in a future pr and has been noted in #22736

Part of #22736

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
