### PR TITLE
[Go SDK] Stream decode values in single iterations

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/datasource.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasource.go
@@ -204,13 +204,13 @@ func (n *DataSource) makeReStream(ctx context.Context, cv ElementDecoder, bcr *b
 		// decode elements on demand instead to reduce memory usage.
 		switch {
 		case size >= 0:
-			return &decodeReStream{
+			return &singleUseReStream{
 				r:    bcr,
 				d:    cv,
 				size: int(size),
 			}, nil
 		case size == -1:
-			return &decodeMultiChunkReStream{
+			return &singleUseMultiChunkReStream{
 				r: bcr,
 				d: cv,
 				open: func(bcr *byteCountReader) (Stream, error) {

--- a/sdks/go/pkg/beam/core/runtime/exec/datasource.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasource.go
@@ -55,6 +55,9 @@ type DataSource struct {
 	su chan SplittableUnit
 
 	mu sync.Mutex
+
+	// Whether the downstream transform only iterates a GBK coder once.
+	singleIterate bool
 }
 
 // InitSplittable initializes the SplittableUnit channel from the output unit,
@@ -75,6 +78,14 @@ func (n *DataSource) ID() UnitID {
 
 // Up initializes this datasource.
 func (n *DataSource) Up(ctx context.Context) error {
+	safeToSingleIterate := true
+	switch n.Out.(type) {
+	case *Expand, *Multiplex:
+		// CoGBK Expands aren't safe, as they may re-iterate the GBK stream.
+		// Multiplexes aren't safe, since they re-iterate the GBK stream by default.
+		safeToSingleIterate = false
+	}
+	n.singleIterate = safeToSingleIterate
 	return nil
 }
 
@@ -165,7 +176,7 @@ func (n *DataSource) Process(ctx context.Context) error {
 
 		var valReStreams []ReStream
 		for _, cv := range cvs {
-			values, err := n.makeReStream(ctx, pe, cv, &bcr)
+			values, err := n.makeReStream(ctx, cv, &bcr, len(cvs) == 1 && n.singleIterate)
 			if err != nil {
 				return err
 			}
@@ -181,11 +192,47 @@ func (n *DataSource) Process(ctx context.Context) error {
 	}
 }
 
-func (n *DataSource) makeReStream(ctx context.Context, key *FullValue, cv ElementDecoder, bcr *byteCountReader) (ReStream, error) {
+func (n *DataSource) makeReStream(ctx context.Context, cv ElementDecoder, bcr *byteCountReader, onlyStream bool) (ReStream, error) {
 	// TODO(lostluck) 2020/02/22: Do we include the chunk size, or just the element sizes?
 	size, err := coder.DecodeInt32(bcr.reader)
 	if err != nil {
 		return nil, errors.Wrap(err, "stream size decoding failed")
+	}
+
+	if onlyStream {
+		// If we know the stream won't be re-iterated,
+		// decode elements on demand instead to reduce memory usage.
+		switch {
+		case size >= 0:
+			return &decodeReStream{
+				r:    bcr,
+				d:    cv,
+				size: int(size),
+			}, nil
+		case size == -1:
+			return &decodeMultiChunkReStream{
+				r: bcr,
+				d: cv,
+				open: func(bcr *byteCountReader) (Stream, error) {
+					tokenLen, err := coder.DecodeVarInt(bcr.reader)
+					if err != nil {
+						return nil, err
+					}
+					token, err := ioutilx.ReadN(bcr.reader, (int)(tokenLen))
+					if err != nil {
+						return nil, err
+					}
+					r, err := n.state.OpenIterable(ctx, n.SID, token)
+					if err != nil {
+						return nil, err
+					}
+					// We can't re-use the original bcr, since we may get new iterables,
+					// but we can re-use the count itself.
+					r = &byteCountReader{reader: r, count: bcr.count}
+					return &elementStream{r: r, ec: cv}, nil
+				},
+			}, nil
+		}
 	}
 
 	switch {

--- a/sdks/go/pkg/beam/core/runtime/exec/fn.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/fn.go
@@ -235,6 +235,9 @@ func (n *invoker) Invoke(ctx context.Context, pn typex.PaneInfo, ws []typex.Wind
 			it := makeIter(param.T, iter)
 			it.Init()
 			args[in[i]] = it.Value()
+			// Ensure main value iterators are reset & closed after the invoke to avoid
+			// short read problems.
+			defer it.Reset()
 			i++
 		}
 	}

--- a/sdks/go/pkg/beam/core/runtime/exec/fullvalue.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/fullvalue.go
@@ -20,9 +20,11 @@ import (
 	"io"
 	"reflect"
 
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/coder"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/sdf"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/typex"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/util/reflectx"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/internal/errors"
 )
 
 // TODO(herohde) 1/29/2018: using FullValue for nested KVs is somewhat of a hack
@@ -188,4 +190,174 @@ func ReadAll(rs ReStream) ([]FullValue, error) {
 		}
 		ret = append(ret, *elm)
 	}
+}
+
+// decodeReStream is a decode on demand ReStream.
+// Can only produce a single Stream because it consumes the reader.
+// Must not be used for streams that might be re-iterated, causing Open
+// to be called twice.
+type decodeReStream struct {
+	r    io.Reader
+	d    ElementDecoder
+	size int // The number of elements in this stream.
+}
+
+// Open returns the Stream from the start of the in-memory reader. Returns error if called twice.
+func (n *decodeReStream) Open() (Stream, error) {
+	if n.r == nil {
+		return nil, errors.New("decodeReStream opened twice!")
+	}
+	ret := &decodeStream{r: n.r, d: n.d, size: n.size}
+	n.r = nil
+	n.d = nil
+	return ret, nil
+}
+
+// decodeStream is a decode on demand Stream, that decodes size elements from the provided
+// io.Reader.
+type decodeStream struct {
+	r          io.Reader
+	d          ElementDecoder
+	next, size int
+	ret        FullValue
+}
+
+// Close causes subsequent calls to Read to return io.EOF, and drains the remaining element count
+// from the reader.
+func (s *decodeStream) Close() error {
+	// On close, if next != size, we must iterate through the rest of the decoding
+	// until the reader is drained. Otherwise we corrupt the read for the next element.
+	// TODO: Optimize the case where we have length prefixed values
+	// so we can avoid allocating the values in the first place.
+	for s.next < s.size {
+		err := s.d.DecodeTo(s.r, &s.ret)
+		if err != nil {
+			return errors.Wrap(err, "decodeStream value decode failed on close")
+		}
+		s.next++
+	}
+	s.r = nil
+	s.d = nil
+	s.ret = FullValue{}
+	return nil
+}
+
+// Read produces the next value in the stream.
+func (s *decodeStream) Read() (*FullValue, error) {
+	if s.r == nil || s.next == s.size {
+		return nil, io.EOF
+	}
+	err := s.d.DecodeTo(s.r, &s.ret)
+	if err != nil {
+		return nil, errors.Wrap(err, "decodeStream value decode failed")
+	}
+	s.next++
+	return &s.ret, nil
+}
+
+// decodeMultiChunkReStream is a decode on demand stream, that can handle a multi-chunk streams.
+// Can only produce a single Stream because it consumes the reader.
+// Must not be used for streams that might be re-iterated, causing Open to be called twice.
+type decodeMultiChunkReStream struct {
+	r *byteCountReader
+	d ElementDecoder
+
+	open func(*byteCountReader) (Stream, error)
+}
+
+// Open returns the Stream from the start of the in-memory ReStream. Returns error if called twice.
+func (n *decodeMultiChunkReStream) Open() (Stream, error) {
+	if n.r == nil {
+		return nil, errors.New("decodeReStream opened twice!")
+	}
+	ret := &decodeMultiChunkStream{r: n.r, d: n.d, open: n.open}
+	n.r = nil
+	n.d = nil
+	return ret, nil
+}
+
+// decodeMultiChunkStream is a simple decode on demand Stream.
+type decodeMultiChunkStream struct {
+	r           *byteCountReader
+	d           ElementDecoder
+	ret         FullValue
+	next, chunk int64
+
+	open   func(r *byteCountReader) (Stream, error)
+	stream Stream
+}
+
+// Close releases the buffer, closing the stream.
+func (s *decodeMultiChunkStream) Close() error {
+	// On close, if next < size, we must iterate through the rest of the decoding
+	// until the reader is drained. Otherwise we corrupt the read for the next element.
+	// TODO(https://github.com/apache/beam/issues/22901):
+	// Optimize the case where we have length prefixed values
+	// so we can avoid allocating the values in the first place.
+	for s.next < s.chunk {
+		err := s.d.DecodeTo(s.r, &s.ret)
+		if err != nil {
+			return errors.Wrap(err, "decodeStream value decode failed on close")
+		}
+		s.next++
+	}
+	if s.stream != nil {
+		s.stream.Close()
+		s.stream = nil
+	}
+	s.r = nil
+	s.d = nil
+	s.ret = FullValue{}
+	return nil
+}
+
+// Read produces the next value in the stream.
+func (s *decodeMultiChunkStream) Read() (*FullValue, error) {
+	// No Reader? We're done.
+	if s.r == nil {
+		return nil, io.EOF
+	}
+	// If we have a stream already, use that.
+	if s.stream != nil {
+		return s.stream.Read()
+	}
+
+	// If our next value is at the chunk size, then re-set the chunk and size.
+	if s.next == s.chunk {
+		s.chunk = 0
+		s.next = 0
+	}
+
+	// We're at the start of a chunk, see if there's a next chunk.
+	if s.chunk == 0 && s.next == 0 {
+		chunk, err := coder.DecodeVarInt(s.r.reader)
+		if err != nil {
+			return nil, errors.Wrap(err, "decodeMultiChunkStream chunk size decoding failed")
+		}
+		s.chunk = chunk
+	}
+	switch {
+	case s.chunk == 0:
+		// If the chunk is still 0, then we're done.
+		s.r = nil
+		s.d = nil
+		s.ret = FullValue{}
+		return nil, io.EOF
+	case s.chunk > 0:
+		err := s.d.DecodeTo(s.r, &s.ret)
+		if err != nil {
+			return nil, errors.Wrap(err, "decodeStream value decode failed")
+		}
+		s.next++
+		return &s.ret, nil
+	case s.chunk == -1:
+		// State Backed Iterable!
+		stream, err := s.open(s.r)
+		if err != nil {
+			return nil, err
+		}
+		s.stream = stream
+		return s.stream.Read()
+	}
+	return nil, errors.Errorf("decodeMultiChunkStream invalid chunk size: %v", s.chunk)
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/fullvalue_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/fullvalue_test.go
@@ -20,12 +20,11 @@ import (
 	"reflect"
 	"testing"
 
-	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/typex"
-	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/util/reflectx"
-
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/coder"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/mtime"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/window"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/typex"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/util/reflectx"
 )
 
 func makeInput(vs ...interface{}) []MainInput {
@@ -251,7 +250,7 @@ func TestDecodeStream(t *testing.T) {
 	d := MakeElementDecoder(c)
 
 	const size = 10
-	setup := func() *decodeReStream {
+	setup := func() *singleUseReStream {
 		r, w := io.Pipe()
 		// Since the io.Pipe is blocking, run in a goroutine.
 		go func() {
@@ -259,7 +258,7 @@ func TestDecodeStream(t *testing.T) {
 				e.Encode(&FullValue{Elm: i}, w)
 			}
 		}()
-		return &decodeReStream{d: d, r: r, size: int(size)}
+		return &singleUseReStream{d: d, r: r, size: int(size)}
 	}
 
 	t.Run("ReadAll", func(t *testing.T) {
@@ -332,7 +331,7 @@ func TestDecodeMultiChunkStream(t *testing.T) {
 	d := MakeElementDecoder(c)
 
 	const size = 10
-	setup := func() *decodeMultiChunkReStream {
+	setup := func() *singleUseMultiChunkReStream {
 		r, w := io.Pipe()
 		// Since the io.Pipe is blocking, run in a goroutine.
 		go func() {
@@ -344,7 +343,7 @@ func TestDecodeMultiChunkStream(t *testing.T) {
 		}()
 		var byteCount int
 		bcr := &byteCountReader{reader: r, count: &byteCount}
-		return &decodeMultiChunkReStream{d: d, r: bcr}
+		return &singleUseMultiChunkReStream{d: d, r: bcr}
 	}
 
 	t.Run("ReadAll", func(t *testing.T) {

--- a/sdks/go/pkg/beam/core/runtime/exec/fullvalue_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/fullvalue_test.go
@@ -16,12 +16,14 @@
 package exec
 
 import (
+	"io"
 	"reflect"
 	"testing"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/typex"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/util/reflectx"
 
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/coder"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/mtime"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/window"
 )
@@ -241,4 +243,170 @@ func TestConvert(t *testing.T) {
 			}
 		})
 	}
+}
+
+func TestDecodeStream(t *testing.T) {
+	c := coder.NewVarInt()
+	e := MakeElementEncoder(c)
+	d := MakeElementDecoder(c)
+
+	const size = 10
+	setup := func() *decodeReStream {
+		r, w := io.Pipe()
+		// Since the io.Pipe is blocking, run in a goroutine.
+		go func() {
+			for i := int64(0); i < size; i++ {
+				e.Encode(&FullValue{Elm: i}, w)
+			}
+		}()
+		return &decodeReStream{d: d, r: r, size: int(size)}
+	}
+
+	t.Run("ReadAll", func(t *testing.T) {
+		drs := setup()
+		vals, err := ReadAll(drs)
+		if err != nil {
+			t.Fatalf("unable to ReadAll from decodeStream: %v", err)
+		}
+		if got, want := len(vals), int(size); got != want {
+			t.Errorf("unable to ReadAll from decodeStream, got %v elements, want %v elements", got, want)
+		}
+		var wants []interface{}
+		for i := int64(0); i < size; i++ {
+			wants = append(wants, i)
+		}
+		if got, want := vals, makeValuesNoWindowOrTime(wants...); !equalList(got, want) {
+			t.Errorf("unable to ReadAll from decodeStream got %v, want %v", got, want)
+		}
+	})
+	t.Run("ShortReadAndClose", func(t *testing.T) {
+		const shortSize = 5
+		drs := setup()
+		ds, err := drs.Open()
+		if err != nil {
+			t.Fatalf("unable to create decodeStream: %v", err)
+		}
+		var vals []FullValue
+		for i := 0; i < 5; i++ {
+			fv, err := ds.Read()
+			if err != nil {
+				t.Fatalf("unexpected error on decodeStream.Read: %v", err)
+			}
+			vals = append(vals, *fv)
+		}
+		if got, want := len(vals), int(shortSize); got != want {
+			t.Errorf("unable to ReadAll from decodeStream, got %v elements, want %v elements", got, want)
+		}
+		var wants []interface{}
+		for i := int64(0); i < shortSize; i++ {
+			wants = append(wants, i)
+		}
+		if got, want := vals, makeValuesNoWindowOrTime(wants...); !equalList(got, want) {
+			t.Errorf("unable to short read from decodeStream got %v, want %v", got, want)
+		}
+
+		// Check close Behavior.
+		if err := ds.Close(); err != nil {
+			t.Fatalf("unexpected error on decodeStream.Close: %v", err)
+		}
+
+		if fv, err := ds.Read(); err != io.EOF {
+			t.Errorf("unexpected error on decodeStream.Read after close: %v, %v", fv, err)
+		}
+		// Check that next was iterated to equal size
+		dds := ds.(*decodeStream)
+		if got, want := dds.next, size; got != want {
+			t.Errorf("unexpected configuration after decodeStream.Close: got %v, want %v", got, want)
+		}
+
+		// Check that a 2nd stream will fail:
+		if s, err := drs.Open(); err == nil || s != nil {
+			t.Fatalf("unexpected values for second decodeReStream.Open: %T, %v", s, err)
+		}
+	})
+}
+
+func TestDecodeMultiChunkStream(t *testing.T) {
+	c := coder.NewVarInt()
+	e := MakeElementEncoder(c)
+	d := MakeElementDecoder(c)
+
+	const size = 10
+	setup := func() *decodeMultiChunkReStream {
+		r, w := io.Pipe()
+		// Since the io.Pipe is blocking, run in a goroutine.
+		go func() {
+			coder.EncodeVarInt(size, w)
+			for i := int64(0); i < size; i++ {
+				e.Encode(&FullValue{Elm: i}, w)
+			}
+			coder.EncodeVarInt(0, w)
+		}()
+		var byteCount int
+		bcr := &byteCountReader{reader: r, count: &byteCount}
+		return &decodeMultiChunkReStream{d: d, r: bcr}
+	}
+
+	t.Run("ReadAll", func(t *testing.T) {
+		drs := setup()
+		vals, err := ReadAll(drs)
+		if err != nil {
+			t.Fatalf("unable to ReadAll from decodeStream: %v", err)
+		}
+		if got, want := len(vals), int(size); got != want {
+			t.Errorf("unable to ReadAll from decodeStream, got %v elements, want %v elements", got, want)
+		}
+		var wants []interface{}
+		for i := int64(0); i < size; i++ {
+			wants = append(wants, i)
+		}
+		if got, want := vals, makeValuesNoWindowOrTime(wants...); !equalList(got, want) {
+			t.Errorf("unable to ReadAll from decodeStream got %v, want %v", got, want)
+		}
+	})
+	t.Run("ShortReadAndClose", func(t *testing.T) {
+		const shortSize = 5
+		drs := setup()
+		ds, err := drs.Open()
+		if err != nil {
+			t.Fatalf("unable to create decodeStream: %v", err)
+		}
+		var vals []FullValue
+		for i := 0; i < 5; i++ {
+			fv, err := ds.Read()
+			if err != nil {
+				t.Fatalf("unexpected error on decodeStream.Read: %v", err)
+			}
+			vals = append(vals, *fv)
+		}
+		if got, want := len(vals), int(shortSize); got != want {
+			t.Errorf("unable to ReadAll from decodeStream, got %v elements, want %v elements", got, want)
+		}
+		var wants []interface{}
+		for i := int64(0); i < shortSize; i++ {
+			wants = append(wants, i)
+		}
+		if got, want := vals, makeValuesNoWindowOrTime(wants...); !equalList(got, want) {
+			t.Errorf("unable to short read from decodeStream got %v, want %v", got, want)
+		}
+
+		// Check close Behavior.
+		if err := ds.Close(); err != nil {
+			t.Fatalf("unexpected error on decodeStream.Close: %v", err)
+		}
+
+		if fv, err := ds.Read(); err != io.EOF {
+			t.Errorf("unexpected error on decodeStream.Read after close: %v, %v", fv, err)
+		}
+		// Check that next was iterated to equal size
+		dds := ds.(*decodeMultiChunkStream)
+		if got, want := dds.next, int64(size); got != want {
+			t.Errorf("unexpected configuration after decodeStream.Close: got %v, want %v", got, want)
+		}
+
+		// Check that a 2nd stream will fail:
+		if s, err := drs.Open(); err == nil || s != nil {
+			t.Fatalf("unexpected values for second decodeReStream.Open: %T, %v", s, err)
+		}
+	})
 }

--- a/sdks/go/test/integration/primitives/cogbk.go
+++ b/sdks/go/test/integration/primitives/cogbk.go
@@ -44,6 +44,25 @@ func genC(_ []byte, emit func(string, string)) {
 	emit("d", "delta")
 }
 
+func genD(_ []byte, emit func(string, int)) {
+	emit("a", 1)
+	emit("a", 1)
+	emit("a", 1)
+	emit("b", 4)
+	emit("b", 4)
+	emit("c", 6)
+	emit("c", 6)
+	emit("c", 6)
+	emit("c", 6)
+	emit("c", 6)
+}
+
+func shortFn(_ string, ds func(*int) bool, emit func(int)) {
+	var v int
+	ds(&v)
+	emit(v)
+}
+
 func sum(nums func(*int) bool) int {
 	var ret, i int
 	for nums(&i) {
@@ -97,6 +116,19 @@ func CoGBK() *beam.Pipeline {
 	passert.Sum(s, b, "b", 1, 17)
 	passert.Sum(s, c, "c", 1, 13)
 	passert.Sum(s, d, "d", 1, 14)
+
+	return p
+}
+
+// GBKShortRead tests GBK with a short read on the iterator.
+func GBKShortRead() *beam.Pipeline {
+	p, s := beam.NewPipelineWithRoot()
+
+	ds := beam.ParDo(s, genD, beam.Impulse(s))
+	grouped := beam.GroupByKey(s, ds)
+	short := beam.ParDo(s, shortFn, grouped)
+
+	passert.Sum(s, short, "shorted", 3, 11)
 
 	return p
 }

--- a/sdks/go/test/integration/primitives/cogbk_test.go
+++ b/sdks/go/test/integration/primitives/cogbk_test.go
@@ -38,3 +38,8 @@ func TestReshuffleKV(t *testing.T) {
 	integration.CheckFilters(t)
 	ptest.RunAndValidate(t, ReshuffleKV())
 }
+
+func TestGBKShortRead(t *testing.T) {
+	integration.CheckFilters(t)
+	ptest.RunAndValidate(t, GBKShortRead())
+}


### PR DESCRIPTION
Fixes #22900 

This adds one time use stream decoders for use whenever we know reiterations won't occur (see issue).

Adds tests, and improves test coverage with a datasource tests for the various iterator handlers (on demand and fixed), unit tests for the on demand decode streams, a new test for pardo short reads, and a primitives test for GBK short reads.

Fixes previous benign issue where value iteration streams were not being closed after the processing DoFn finished, and test for same. Since we always fully read the byte stream for a value, we never ran into a short read problem before. Streaming decode short reads on the data side would cause problems that don't occur with short reads for Side Inputs.

There's a followup task for optimizing short reads when the coder being used is length prefixed, filed in #22901. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
