### PR TITLE
Python 3.10 Fix jump offsets opcodes

### DIFF
--- a/sdks/python/apache_beam/typehints/opcodes.py
+++ b/sdks/python/apache_beam/typehints/opcodes.py
@@ -421,6 +421,12 @@ def delete_fast(state, arg):
   state.vars[arg] = Any  # really an error
 
 
+# bpo-43683 Adds GEN_START in Python 3.10, but removed in Python 3.11
+# https://github.com/python/cpython/pull/25138
+def gen_start(state, arg):
+  assert len(state.stack) == 0
+
+
 def load_closure(state, arg):
   state.stack.append(state.get_closure(arg))
 

--- a/sdks/python/apache_beam/typehints/trivial_inference.py
+++ b/sdks/python/apache_beam/typehints/trivial_inference.py
@@ -376,10 +376,10 @@ def infer_return_type_func(f, input_types, debug=False, depth=0):
   inst_size = 2
   opt_arg_size = 0
 
-  # Python 3.10: bpo-27129 changes jump offsets to use instruction offsets,
-  # not byte offsets. The offsets were halved (16 bits fro instructions vs 8
+  # Python 3.10+: bpo-27129 changes jump offsets to use instruction offsets,
+  # not byte offsets. The offsets were halved (16 bits for instructions vs 8
   # bits for bytes), so we have to double the value of arg.
-  if (sys.version_info.major, sys.version_info.minor) == (3, 10):
+  if (sys.version_info.major, sys.version_info.minor) >= (3, 10):
     jump_multiplier = 2
   else:
     jump_multiplier = 1

--- a/sdks/python/apache_beam/typehints/trivial_inference.py
+++ b/sdks/python/apache_beam/typehints/trivial_inference.py
@@ -376,9 +376,9 @@ def infer_return_type_func(f, input_types, debug=False, depth=0):
   inst_size = 2
   opt_arg_size = 0
 
-  # Python 3.10: bpo-27129 changes to instruction offsets, not byte offsets. The
-  # offsets were halved (16 bits fro instructions vs 8 bits for bytes), so we
-  # have to double the value of arg.
+  # Python 3.10: bpo-27129 changes jump offsets to use instruction offsets,
+  # not byte offsets. The offsets were halved (16 bits fro instructions vs 8
+  # bits for bytes), so we have to double the value of arg.
   if (sys.version_info.major, sys.version_info.minor) == (3, 10):
     jump_multiplier = 2
   else:

--- a/sdks/python/apache_beam/typehints/trivial_inference.py
+++ b/sdks/python/apache_beam/typehints/trivial_inference.py
@@ -376,6 +376,14 @@ def infer_return_type_func(f, input_types, debug=False, depth=0):
   inst_size = 2
   opt_arg_size = 0
 
+  # Python 3.10: bpo-27129 changes to instruction offsets, not byte offsets. The
+  # offsets were halved (16 bits fro instructions vs 8 bits for bytes), so we
+  # have to double the value of arg.
+  if (sys.version_info.major, sys.version_info.minor) == (3, 10):
+    jump_multiplier = 2
+  else:
+    jump_multiplier = 1
+
   last_pc = -1
   while pc < end:  # pylint: disable=too-many-nested-blocks
     start = pc
@@ -495,23 +503,23 @@ def infer_return_type_func(f, input_types, debug=False, depth=0):
     elif opname == 'YIELD_VALUE':
       yields.add(state.stack[-1])
     elif opname == 'JUMP_FORWARD':
-      jmp = pc + arg
+      jmp = pc + arg * jump_multiplier
       jmp_state = state
       state = None
     elif opname == 'JUMP_ABSOLUTE':
-      jmp = arg
+      jmp = arg * jump_multiplier
       jmp_state = state
       state = None
     elif opname in ('POP_JUMP_IF_TRUE', 'POP_JUMP_IF_FALSE'):
       state.stack.pop()
-      jmp = arg
+      jmp = arg * jump_multiplier
       jmp_state = state.copy()
     elif opname in ('JUMP_IF_TRUE_OR_POP', 'JUMP_IF_FALSE_OR_POP'):
-      jmp = arg
+      jmp = arg * jump_multiplier
       jmp_state = state.copy()
       state.stack.pop()
     elif opname == 'FOR_ITER':
-      jmp = pc + arg
+      jmp = pc + arg * jump_multiplier
       jmp_state = state.copy()
       jmp_state.stack.pop()
       state.stack.append(element_type(state.stack[-1]))

--- a/sdks/python/apache_beam/typehints/trivial_inference_test.py
+++ b/sdks/python/apache_beam/typehints/trivial_inference_test.py
@@ -36,6 +36,14 @@ class TrivialInferenceTest(unittest.TestCase):
         expected,
         trivial_inference.infer_return_type(f, inputs, debug=True, depth=depth))
 
+  # The meaning of Jump Offsets in Python 3.10 was changed.
+  # https://github.com/python/cpython/issues/71316
+  # Reported as a bug in Beam https://github.com/apache/beam/issues/21671
+  def testJumpOffsets(self):
+    fn = lambda x: False
+    wrapper = lambda x, *args, **kwargs: [x] if fn(x, *args, **kwargs) else []
+    self.assertReturnType(typehints.List[int], wrapper, [int])
+
   def testBuildListUnpack(self):
     # Lambda uses BUILD_LIST_UNPACK opcode in Python 3.
     self.assertReturnType(


### PR DESCRIPTION
Fixes https://github.com/apache/beam/issues/21671

The issue was caused by a deliberate [change in behavior](https://github.com/python/cpython/issues/93060#issuecomment-1133791913) in Python 3.10 due to [bpo-27129](https://bugs.python.org/issue?@action=redirect&bpo=27129). The offsets were originally byte (8 bits) offsets in Python 3.9, but instruction (16 bits) offsets in Python 3.10. The opcode numbers were halved, so to compensate, I had to double them again when reading it.

A few other tests were failing too. I had to add an opcode due to [bpo-43683](https://bugs.python.org/issue?@action=redirect&bpo=43683) in which a [new bytecode GEN_START](https://github.com/python/cpython/issues/87849) was added. 


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
