### PR TITLE
Run cred rotation every month

### DIFF
--- a/.test-infra/jenkins/job_IODatastoresCredentialsRotation.groovy
+++ b/.test-infra/jenkins/job_IODatastoresCredentialsRotation.groovy
@@ -25,7 +25,7 @@ job('Rotate IO-Datastores Cluster Credentials') {
   commonJobProperties.setTopLevelMainJobProperties(delegate)
 
   // Sets that this is a cron job.
-  commonJobProperties.setCronJob(delegate, 'H 2 1 */2 *')// At 00:02am every second month.
+  commonJobProperties.setCronJob(delegate, 'H 2 1 * *')// At 00:02am every month.
   def date = new Date().format('E MMM dd HH:mm:ss z yyyy')
 
   steps {

--- a/.test-infra/jenkins/job_MetricsCredentialsRotation.groovy
+++ b/.test-infra/jenkins/job_MetricsCredentialsRotation.groovy
@@ -25,7 +25,7 @@ job('Rotate Metrics Cluster Credentials') {
   commonJobProperties.setTopLevelMainJobProperties(delegate)
 
   // Sets that this is a cron job.
-  commonJobProperties.setCronJob(delegate, 'H 2 1 */2 *')// At 00:02am every second month.
+  commonJobProperties.setCronJob(delegate, 'H 2 1 * *')// At 00:02am every month.
   def date = new Date().format('E MMM dd HH:mm:ss z yyyy')
 
   steps {


### PR DESCRIPTION
Jenkins recently went down for a while because our creds expired. Running the IODatastores rotation job fixed it. Given that its relatively cheap, we should probably run that job every month so that we're not cutting it close on expirations. I could actually be convinced that running it even more frequently is a good idea.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
