### PR TITLE
Allow and test pyarrow 8.x and 9.x

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -129,7 +129,7 @@ except ImportError:
 if sys.platform == 'win32' and sys.maxsize <= 2**32:
   pyarrow_dependency = ''
 else:
-  pyarrow_dependency = 'pyarrow>=0.15.1,<8.0.0'
+  pyarrow_dependency = 'pyarrow>=0.15.1,<10.0.0'
 
 # We must generate protos after setup_requires are installed.
 def generate_protos_first():

--- a/sdks/python/test-suites/tox/py38/build.gradle
+++ b/sdks/python/test-suites/tox/py38/build.gradle
@@ -68,6 +68,14 @@ toxTask "testPy38pyarrow-7", "py38-pyarrow-7"
 test.dependsOn "testPy38pyarrow-7"
 preCommitPy38.dependsOn "testPy38pyarrow-7"
 
+toxTask "testPy38pyarrow-8", "py38-pyarrow-8"
+test.dependsOn "testPy38pyarrow-8"
+preCommitPy38.dependsOn "testPy38pyarrow-8"
+
+toxTask "testPy38pyarrow-9", "py38-pyarrow-9"
+test.dependsOn "testPy38pyarrow-9"
+preCommitPy38.dependsOn "testPy38pyarrow-9"
+
 // Create a test task for each minor version of pandas
 toxTask "testPy38pandas-11", "py38-pandas-11"
 test.dependsOn "testPy38pandas-11"

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -233,7 +233,7 @@ extras = test
 commands =
   {toxinidir}/scripts/pytest_validates_runner.sh {envname} {toxinidir}/apache_beam/runners/portability/spark_runner_test.py {posargs}
 
-[testenv:py{37,38,39}-pyarrow-{0,1,2,3,4,5,6,7}]
+[testenv:py{37,38,39}-pyarrow-{0,1,2,3,4,5,6,7,8,9}]
 deps =
   0: pyarrow>=0.15.1,<0.18.0
   1: pyarrow>=1,<2
@@ -246,6 +246,8 @@ deps =
   5: pyarrow>=5,<6
   6: pyarrow>=6,<7
   7: pyarrow>=7,<8
+  8: pyarrow>=8,<9
+  9: pyarrow>=9,<10
 commands =
   # Log pyarrow and numpy version for debugging
   /bin/sh -c "pip freeze | grep -E '(pyarrow|numpy)'"


### PR DESCRIPTION
GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
