### PR TITLE
(BQ Python) Pass project field from options or parameter when writing with dynamic destinations

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -2363,6 +2363,7 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
       output = pcoll | BigQueryBatchFileLoads(
           destination=self.table_reference,
           schema=self.schema,
+          project=self._project,
           create_disposition=self.create_disposition,
           write_disposition=self.write_disposition,
           triggering_frequency=triggering_frequency,

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -2090,8 +2090,7 @@ class WriteToBigQuery(PTransform):
       dataset (str): The ID of the dataset containing this table or
         :data:`None` if the table reference is specified entirely by the table
         argument.
-      project (str): The ID of the project containing this table. This will
-        take precedence over the project the pipeline is running in. Is
+      project (str): The ID of the project containing this table or
         :data:`None` if the table reference is specified entirely by the table
         argument.
       schema (str,dict,ValueProvider,callable): The schema to be used if the
@@ -2279,9 +2278,8 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
 
     if (isinstance(self.table_reference, TableReference) and
         self.table_reference.projectId is None):
-      # project argument takes precedence over pipeline project
-      self.table_reference.projectId = self._project or \
-          pcoll.pipeline.options.view_as(GoogleCloudOptions).project
+      self.table_reference.projectId = pcoll.pipeline.options.view_as(
+          GoogleCloudOptions).project
 
     # TODO(pabloem): Use a different method to determine if streaming or batch.
     is_streaming_pipeline = p.options.view_as(StandardOptions).streaming

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -2278,8 +2278,8 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
 
     if (isinstance(self.table_reference, TableReference) and
         self.table_reference.projectId is None):
-      self.table_reference.projectId = pcoll.pipeline.options.view_as(
-          GoogleCloudOptions).project
+      self.table_reference.projectId = self._project or \
+          pcoll.pipeline.options.view_as(GoogleCloudOptions).project
 
     # TODO(pabloem): Use a different method to determine if streaming or batch.
     is_streaming_pipeline = p.options.view_as(StandardOptions).streaming

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -2090,7 +2090,8 @@ class WriteToBigQuery(PTransform):
       dataset (str): The ID of the dataset containing this table or
         :data:`None` if the table reference is specified entirely by the table
         argument.
-      project (str): The ID of the project containing this table or
+      project (str): The ID of the project containing this table. This will
+        take precedence over the project the pipeline is running in. Is
         :data:`None` if the table reference is specified entirely by the table
         argument.
       schema (str,dict,ValueProvider,callable): The schema to be used if the
@@ -2278,6 +2279,7 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
 
     if (isinstance(self.table_reference, TableReference) and
         self.table_reference.projectId is None):
+      # project argument takes precedence over pipeline project
       self.table_reference.projectId = self._project or \
           pcoll.pipeline.options.view_as(GoogleCloudOptions).project
 

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -342,11 +342,13 @@ class UpdateDestinationSchema(beam.DoFn):
   """
   def __init__(
       self,
+      project=None,
       write_disposition=None,
       test_client=None,
       additional_bq_parameters=None,
       step_name=None,
       load_job_project_id=None):
+    self.project = project
     self._test_client = test_client
     self._write_disposition = write_disposition
     self._additional_bq_parameters = additional_bq_parameters or {}
@@ -386,7 +388,7 @@ class UpdateDestinationSchema(beam.DoFn):
     table_reference = bigquery_tools.parse_table_reference(destination)
     if table_reference.projectId is None:
       table_reference.projectId = vp.RuntimeValueProvider.get_value(
-          'project', str, '')
+          'project', str, '') or self.project
 
     try:
       # Check if destination table exists
@@ -1045,6 +1047,7 @@ class BigQueryBatchFileLoads(beam.PTransform):
         finished_temp_tables_load_jobs_pc
         | beam.ParDo(
             UpdateDestinationSchema(
+                project=self.project,
                 write_disposition=self.write_disposition,
                 test_client=self.test_client,
                 additional_bq_parameters=self.additional_bq_parameters,


### PR DESCRIPTION
Currently dynamic destinations cannot be passed in as `<DATASET>.<TABLE>`. For single destinations, the project ID is [added from pipeline options](https://github.com/apache/beam/blob/0d937d4cd725965572d4720811fa2d6efaa8edf8/sdks/python/apache_beam/io/gcp/bigquery.py#L2281-L2282) earlier in the workflow. This isn't applied to dynamic destinations because the actual destinations are determined later.

These changes will provide the project ID at the moments when they are needed, ie. when submitting:
1. load jobs
2. schema update jobs
3. copy jobs
4. delete table operations

These changes will also give precedence to the project parameter in `WriteToBigQuery` over the project found in pipeline options. The reasoning is that a user may have one pipeline writing to tables in different projects.