### PR TITLE
Support DECIMAL logical type in python SDK

### DIFF
--- a/model/fn-execution/src/main/resources/org/apache/beam/model/fnexecution/v1/standard_coders.yaml
+++ b/model/fn-execution/src/main/resources/org/apache/beam/model/fnexecution/v1/standard_coders.yaml
@@ -476,6 +476,18 @@ examples:
 ---
 
 coder:
+  urn: "beam:coder:row:v1"
+  # f_float: float32, f_decimal: logical(decimal)
+  payload: "\n\r\n\x07f_float\x1a\x02\x10\x05\n1\n\tf_decimal\x1a$:\"\n\x1cbeam:logical_type:decimal:v1\x1a\x02\x10\t\x12$800c44ae-a1b7-4def-bbf6-6217cca89ec4"
+examples:
+  "\x02\x00\x00\x00\x00\x00\x01\x01\x00": {f_float: "0.0", f_decimal: "0.0"}
+  "\x02\x00?\x80\x00\x00\x01\x01\n": {f_float: "1.0", f_decimal: "1.0"}
+  "\x02\x00@I\x0eV\x04\x02z\xb7": {f_float: "3.1415", f_decimal: "3.1415"}
+  "\x02\x00\xc2\xc8>\xfa\x03\x03\xfex\xe5": {f_float: "-100.123", f_decimal: "-100.123"}
+
+---
+
+coder:
   urn: "beam:coder:sharded_key:v1"
   components: [{urn: "beam:coder:string_utf8:v1"}]
 

--- a/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/schema.proto
+++ b/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/schema.proto
@@ -142,7 +142,7 @@ message LogicalTypes {
 
     // A URN for Decimal type
     //   - Representation type: BYTES
-    //   - A decimal number with specified scale and value. Its BYTES
+    //   - A decimal number with variable scale. Its BYTES
     //     representation consists of an integer (INT32) scale followed by a
     //     two's complement encoded big integer.
     DECIMAL = 3 [(org.apache.beam.model.pipeline.v1.beam_urn) =

--- a/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/schema.proto
+++ b/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/schema.proto
@@ -139,6 +139,14 @@ message LogicalTypes {
     //     corresponds to chronological order.
     MILLIS_INSTANT = 2 [(org.apache.beam.model.pipeline.v1.beam_urn) =
       "beam:logical_type:millis_instant:v1"];
+
+    // A URN for Decimal type
+    //   - Representation type: BYTES
+    //   - A decimal number with specified scale and value. Its BYTES
+    //     representation consists of an integer (INT32) scale followed by a
+    //     two's complement encoded big integer.
+    DECIMAL = 3 [(org.apache.beam.model.pipeline.v1.beam_urn) =
+      "beam:logical_type:decimal:v1"];
   }
 }
 

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/wire/CommonCoderTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/wire/CommonCoderTest.java
@@ -40,6 +40,7 @@ import com.google.auto.value.AutoValue;
 import java.io.IOException;
 import java.io.InputStream;
 import java.io.InputStreamReader;
+import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Collections;
@@ -425,6 +426,8 @@ public class CommonCoderTest {
       case DATETIME:
         // convert shifted millis to epoch millis as in InstantCoder
         return new Instant((Long) value + -9223372036854775808L);
+      case DECIMAL:
+        return new BigDecimal((String) value);
       case BYTES:
         // extract String as byte[]
         return ((String) value).getBytes(StandardCharsets.ISO_8859_1);
@@ -468,7 +471,7 @@ public class CommonCoderTest {
         return fieldType
             .getLogicalType()
             .toInputType(parseField(value, fieldType.getLogicalType().getBaseType()));
-      default: // DECIMAL
+      default:
         throw new IllegalArgumentException("Unsupported type name: " + fieldType.getTypeName());
     }
   }

--- a/sdks/go/test/regression/coders/fromyaml/fromyaml.go
+++ b/sdks/go/test/regression/coders/fromyaml/fromyaml.go
@@ -52,6 +52,7 @@ var filteredCases = []struct{ filter, reason string }{
 	{"logical", "BEAM-9615: Support logical types"},
 	{"30ea5a25-dcd8-4cdb-abeb-5332d15ab4b9", "https://github.com/apache/beam/issues/21206: Support encoding position."},
 	{"80be749a-5700-4ede-89d8-dd9a4433a3f8", "https://github.com/apache/beam/issues/19817: Support millis_instant."},
+	{"800c44ae-a1b7-4def-bbf6-6217cca89ec4", "https://github.com/apache/beam/issues/19817: Support decimal."},
 }
 
 // Coder is a representation a serialized beam coder.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java
@@ -22,6 +22,7 @@ import java.io.DataOutputStream;
 import java.io.IOException;
 import java.io.PipedInputStream;
 import java.io.PipedOutputStream;
+import java.lang.reflect.InvocationTargetException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Map;
@@ -43,6 +44,7 @@ import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.Schema.LogicalType;
 import org.apache.beam.sdk.schemas.Schema.TypeName;
+import org.apache.beam.sdk.schemas.logicaltypes.FixedPrecisionNumeric;
 import org.apache.beam.sdk.schemas.logicaltypes.MicrosInstant;
 import org.apache.beam.sdk.schemas.logicaltypes.PythonCallable;
 import org.apache.beam.sdk.schemas.logicaltypes.SchemaLogicalType;
@@ -65,7 +67,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 })
 public class SchemaTranslation {
 
-  private static final String URN_BEAM_LOGICAL_DECIMAL = "beam:logical_type:decimal:v1";
+  private static final String URN_BEAM_LOGICAL_DECIMAL = FixedPrecisionNumeric.BASE_IDENTIFIER;
   private static final String URN_BEAM_LOGICAL_JAVASDK = "beam:logical_type:javasdk:v1";
   private static final String URN_BEAM_LOGICAL_MILLIS_INSTANT =
       SchemaApi.LogicalTypes.Enum.MILLIS_INSTANT
@@ -79,6 +81,7 @@ public class SchemaTranslation {
   private static final ImmutableMap<String, Class<? extends LogicalType<?, ?>>>
       STANDARD_LOGICAL_TYPES =
           ImmutableMap.<String, Class<? extends LogicalType<?, ?>>>builder()
+              .put(FixedPrecisionNumeric.IDENTIFIER, FixedPrecisionNumeric.class)
               .put(MicrosInstant.IDENTIFIER, MicrosInstant.class)
               .put(SchemaLogicalType.IDENTIFIER, SchemaLogicalType.class)
               .put(PythonCallable.IDENTIFIER, PythonCallable.class)
@@ -147,17 +150,10 @@ public class SchemaTranslation {
       case LOGICAL_TYPE:
         LogicalType logicalType = fieldType.getLogicalType();
         SchemaApi.LogicalType.Builder logicalTypeBuilder;
-        if (STANDARD_LOGICAL_TYPES.containsKey(logicalType.getIdentifier())) {
-          Preconditions.checkArgument(
-              logicalType.getArgumentType() == null,
-              "Logical type '%s' cannot be used as a logical type, it has a non-null argument type.",
-              logicalType.getIdentifier());
-          logicalTypeBuilder =
-              SchemaApi.LogicalType.newBuilder()
-                  .setRepresentation(
-                      fieldTypeToProto(logicalType.getBaseType(), serializeLogicalType))
-                  .setUrn(logicalType.getIdentifier());
-        } else if (logicalType instanceof UnknownLogicalType) {
+        String identifier = logicalType.getIdentifier();
+        boolean isStandard = STANDARD_LOGICAL_TYPES.containsKey(identifier);
+
+        if (!isStandard && logicalType instanceof UnknownLogicalType) {
           logicalTypeBuilder =
               SchemaApi.LogicalType.newBuilder()
                   .setUrn(logicalType.getIdentifier())
@@ -173,14 +169,16 @@ public class SchemaTranslation {
                     fieldValueToProto(logicalType.getArgumentType(), logicalType.getArgument()));
           }
         } else {
+          // TODO(https://github.com/apache/beam/issues/19715): "javasdk" types should only
+          // be a last resort. Types defined in Beam should have their own URN, and there
+          // should be a mechanism for users to register their own types by URN.
+          String urn =
+              identifier.startsWith("beam:logical_type:") ? identifier : URN_BEAM_LOGICAL_JAVASDK;
           logicalTypeBuilder =
               SchemaApi.LogicalType.newBuilder()
                   .setRepresentation(
                       fieldTypeToProto(logicalType.getBaseType(), serializeLogicalType))
-                  // TODO(https://github.com/apache/beam/issues/19715): "javasdk" types should only
-                  // be a last resort. Types defined in Beam should have their own URN, and there
-                  // should be a mechanism for users to register their own types by URN.
-                  .setUrn(URN_BEAM_LOGICAL_JAVASDK);
+                  .setUrn(urn);
           if (logicalType.getArgumentType() != null) {
             logicalTypeBuilder =
                 logicalTypeBuilder
@@ -190,7 +188,8 @@ public class SchemaTranslation {
                         fieldValueToProto(
                             logicalType.getArgumentType(), logicalType.getArgument()));
           }
-          if (serializeLogicalType) {
+          // No need to embed serialized bytes to payload for standard (known) logical type
+          if (!isStandard && serializeLogicalType) {
             logicalTypeBuilder =
                 logicalTypeBuilder.setPayload(
                     ByteString.copyFrom(SerializableUtils.serializeToByteArray(logicalType)));
@@ -208,6 +207,8 @@ public class SchemaTranslation {
                 .build());
         break;
       case DECIMAL:
+        // DECIMAL without precision specified. Used as the representation type of
+        // FixedPrecisionNumeric logical type.
         builder.setLogicalType(
             SchemaApi.LogicalType.newBuilder()
                 .setUrn(URN_BEAM_LOGICAL_DECIMAL)
@@ -337,28 +338,74 @@ public class SchemaTranslation {
             fieldTypeFromProto(protoFieldType.getMapType().getKeyType()),
             fieldTypeFromProto(protoFieldType.getMapType().getValueType()));
       case LOGICAL_TYPE:
-        String urn = protoFieldType.getLogicalType().getUrn();
         SchemaApi.LogicalType logicalType = protoFieldType.getLogicalType();
+        String urn = logicalType.getUrn();
         Class<? extends LogicalType<?, ?>> logicalTypeClass = STANDARD_LOGICAL_TYPES.get(urn);
         if (logicalTypeClass != null) {
-          try {
-            return FieldType.logicalType(logicalTypeClass.getConstructor().newInstance());
-          } catch (NoSuchMethodException e) {
-            throw new RuntimeException(
-                String.format(
-                    "Standard logical type '%s' does not have a zero-argument constructor.", urn),
-                e);
-          } catch (IllegalAccessException e) {
-            throw new RuntimeException(
-                String.format(
-                    "Standard logical type '%s' has a zero-argument constructor, but it is not accessible.",
-                    urn),
-                e);
-          } catch (ReflectiveOperationException e) {
-            throw new RuntimeException(
-                String.format(
-                    "Error instantiating logical type '%s' with zero-argument constructor.", urn),
-                e);
+          boolean hasArgument = logicalType.hasArgument();
+          if (hasArgument) {
+            // Logical type with argument. Construct from compatible of() method with single
+            // argument type is either a primitive, List, Map, or Row.
+            FieldType fieldType = fieldTypeFromProto(logicalType.getArgumentType());
+            Object fieldValue =
+                Objects.requireNonNull(fieldValueFromProto(fieldType, logicalType.getArgument()));
+            Class clazz = fieldValue.getClass();
+            if (fieldValue instanceof List) {
+              // argument is ArrayValue or iterableValue
+              clazz = List.class;
+            }
+            if (fieldValue instanceof Map) {
+              // argument is Map
+              clazz = Map.class;
+            } else if (fieldValue instanceof Row) {
+              // argument is Row
+              clazz = Row.class;
+            }
+            String objectName = clazz.getName();
+            try {
+              return FieldType.logicalType(
+                  logicalTypeClass.cast(
+                      logicalTypeClass.getMethod("of", clazz).invoke(null, fieldValue)));
+            } catch (NoSuchMethodException e) {
+              throw new RuntimeException(
+                  String.format(
+                      "Standard logical type '%s' does not have a static of('%s') method.",
+                      urn, objectName),
+                  e);
+            } catch (IllegalAccessException e) {
+              throw new RuntimeException(
+                  String.format(
+                      "Standard logical type '%s' has an of('%s') method, but it is not accessible.",
+                      urn, objectName),
+                  e);
+            } catch (InvocationTargetException e) {
+              throw new RuntimeException(
+                  String.format(
+                      "Error instantiating logical type '%s' with of('%s') method.",
+                      urn, objectName),
+                  e);
+            }
+          } else {
+            // Logical type without argument. Construct from constructor without parameter
+            try {
+              return FieldType.logicalType(logicalTypeClass.getConstructor().newInstance());
+            } catch (NoSuchMethodException e) {
+              throw new RuntimeException(
+                  String.format(
+                      "Standard logical type '%s' does not have a zero-argument constructor.", urn),
+                  e);
+            } catch (IllegalAccessException e) {
+              throw new RuntimeException(
+                  String.format(
+                      "Standard logical type '%s' has a zero-argument constructor, but it is not accessible.",
+                      urn),
+                  e);
+            } catch (ReflectiveOperationException e) {
+              throw new RuntimeException(
+                  String.format(
+                      "Error instantiating logical type '%s' with zero-argument constructor.", urn),
+                  e);
+            }
           }
         }
         // Special-case for DATETIME and DECIMAL which are logical types in portable representation,

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/FixedPrecisionNumeric.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/FixedPrecisionNumeric.java
@@ -30,6 +30,9 @@ import org.apache.beam.sdk.values.Row;
 
 /** Fixed precision numeric types used to represent jdbc NUMERIC and DECIMAL types. */
 public class FixedPrecisionNumeric extends PassThroughLogicalType<BigDecimal> {
+  // TODO(https://github.com/apache/beam/issues/23373) promote this URN to schema.proto once logical
+  // types with arguments are fully supported and the implementation of this logical type can thus
+  // be considered standardized.
   public static final String IDENTIFIER = "beam:logical_type:fixed_decimal:v1";
 
   // TODO(https://github.com/apache/beam/issues/23374) implement beam:logical_type:decimal:v1 as

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/FixedPrecisionNumeric.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/FixedPrecisionNumeric.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas.logicaltypes;
+
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects.firstNonNull;
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+
+import java.math.BigDecimal;
+import java.math.MathContext;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.values.Row;
+
+/** Fixed precision numeric types used to represent jdbc NUMERIC and DECIMAL types. */
+public class FixedPrecisionNumeric extends PassThroughLogicalType<BigDecimal> {
+  public static final String IDENTIFIER = "beam:logical_type:fixed_decimal:v1";
+
+  // TODO(https://github.com/apache/beam/issues/19817) implement beam:logical_type:decimal:v1 as
+  // CoderLogicalType (once CoderLogicalType is implemented).
+  /**
+   * Identifier of the unspecified precision numeric type. It corresponds to Java SDK's {@link
+   * FieldType#DECIMAL}. It is the underlying representation type of FixedPrecisionNumeric logical
+   * type in order to be compatible with existing Java field types.
+   */
+  public static final String BASE_IDENTIFIER = "beam:logical_type:decimal:v1";
+
+  private final int precision;
+  private final int scale;
+
+  /**
+   * Create a FixedPrecisionNumeric instance with specified precision and scale. ``precision=-1``
+   * indicates unspecified precision.
+   */
+  public static FixedPrecisionNumeric of(int precision, int scale) {
+    Schema schema = Schema.builder().addInt32Field("precision").addInt32Field("scale").build();
+    return new FixedPrecisionNumeric(schema, precision, scale);
+  }
+
+  /** Create a FixedPrecisionNumeric instance with specified scale and unspecified precision. */
+  public static FixedPrecisionNumeric of(int scale) {
+    return of(-1, scale);
+  }
+
+  /** Create a FixedPrecisionNumeric instance with specified argument row. */
+  public static FixedPrecisionNumeric of(Row row) {
+    final Integer precision = row.getInt32("precision");
+    final Integer scale = row.getInt32("scale");
+    checkArgument(
+        precision != null && scale != null,
+        "precision and scale cannot be null for FixedPrecisionNumeric arguments.");
+    // firstNonNull is used to cast precision and scale to @NonNull input
+    return of(firstNonNull(precision, -1), firstNonNull(scale, 0));
+  }
+
+  private FixedPrecisionNumeric(Schema schema, int precision, int scale) {
+    super(
+        IDENTIFIER,
+        FieldType.row(schema),
+        Row.withSchema(schema).addValues(precision, scale).build(),
+        FieldType.DECIMAL);
+    this.precision = precision;
+    this.scale = scale;
+  }
+
+  @Override
+  public BigDecimal toInputType(BigDecimal base) {
+    checkArgument(
+        base == null
+            || (base.precision() <= precision && base.scale() <= scale)
+            // for cases when received values can be safely coerced to the schema
+            || base.round(new MathContext(precision)).compareTo(base) == 0,
+        "Expected BigDecimal base to be null or have precision <= %s (was %s), scale <= %s (was %s)",
+        precision,
+        (base == null) ? null : base.precision(),
+        scale,
+        (base == null) ? null : base.scale());
+    return base;
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/FixedPrecisionNumeric.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/FixedPrecisionNumeric.java
@@ -39,14 +39,18 @@ public class FixedPrecisionNumeric extends PassThroughLogicalType<BigDecimal> {
    * FieldType#DECIMAL}. It is the underlying representation type of FixedPrecisionNumeric logical
    * type in order to be compatible with existing Java field types.
    */
-  public static final String BASE_IDENTIFIER =
-      SchemaApi.LogicalTypes.Enum.DECIMAL
-          .getValueDescriptor()
-          .getOptions()
-          .getExtension(RunnerApi.beamUrn);
+  public static final String BASE_IDENTIFIER;
 
-  private static final Schema SCHEMA =
-      Schema.builder().addInt32Field("precision").addInt32Field("scale").build();
+  private static final Schema SCHEMA;
+
+  static {
+    BASE_IDENTIFIER =
+        SchemaApi.LogicalTypes.Enum.DECIMAL
+            .getValueDescriptor()
+            .getOptions()
+            .getExtension(RunnerApi.beamUrn);
+    SCHEMA = Schema.builder().addInt32Field("precision").addInt32Field("scale").build();
+  }
 
   private final int precision;
   private final int scale;

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/logicaltypes/LogicalTypesTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/logicaltypes/LogicalTypesTest.java
@@ -18,10 +18,13 @@
 package org.apache.beam.sdk.schemas.logicaltypes;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertThrows;
 
+import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
+import java.util.Random;
 import java.util.UUID;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.Field;
@@ -129,5 +132,52 @@ public class LogicalTypesTest {
     assertEquals(
         schemaValue,
         new SchemaLogicalType().toInputType(new SchemaLogicalType().toBaseType(schemaValue)));
+  }
+
+  @Test
+  public void testFixedPrecisionNumeric() {
+    final int precision = 10;
+    final int scale = 2;
+    Random random = new Random();
+
+    Schema argumentSchema =
+        Schema.builder().addInt32Field("precision").addInt32Field("scale").build();
+
+    // invalid schema
+    final Schema invalidArgumentSchema =
+        Schema.builder().addInt32Field("invalid").addInt32Field("schema").build();
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            FixedPrecisionNumeric.of(
+                Row.withSchema(invalidArgumentSchema).addValues(precision, scale).build()));
+
+    // FixedPrecisionNumeric specified precision and scale
+    FixedPrecisionNumeric numeric =
+        FixedPrecisionNumeric.of(
+            Row.withSchema(argumentSchema).addValues(precision, scale).build());
+    Schema schema = Schema.builder().addLogicalTypeField("decimal", numeric).build();
+
+    // check argument valid case
+    BigDecimal decimal = BigDecimal.valueOf(random.nextInt(), scale);
+    Row row = Row.withSchema(schema).addValues(decimal).build();
+    assertEquals(decimal, row.getLogicalTypeValue(0, BigDecimal.class));
+
+    // check argument invalid case
+    decimal = BigDecimal.valueOf(random.nextLong() + 100_000_000_000L, scale);
+    assertThrows(IllegalArgumentException.class, Row.withSchema(schema).addValues(decimal)::build);
+
+    // FixedPrecisionNumeric without specifying precision
+    numeric = FixedPrecisionNumeric.of(scale);
+    schema = Schema.builder().addLogicalTypeField("decimal", numeric).build();
+
+    // check argument always valid
+    decimal = BigDecimal.valueOf(random.nextInt(), scale);
+    row = Row.withSchema(schema).addValues(decimal).build();
+    assertEquals(decimal, row.getLogicalTypeValue(0, BigDecimal.class));
+
+    decimal = BigDecimal.valueOf(random.nextLong() + 100_000_000_000L, scale);
+    row = Row.withSchema(schema).addValues(decimal).build();
+    assertEquals(decimal, row.getLogicalTypeValue(0, BigDecimal.class));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/logicaltypes/LogicalTypesTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/logicaltypes/LogicalTypesTest.java
@@ -24,7 +24,6 @@ import java.math.BigDecimal;
 import java.time.Duration;
 import java.time.Instant;
 import java.util.Map;
-import java.util.Random;
 import java.util.UUID;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.Field;
@@ -138,7 +137,6 @@ public class LogicalTypesTest {
   public void testFixedPrecisionNumeric() {
     final int precision = 10;
     final int scale = 2;
-    Random random = new Random();
 
     Schema argumentSchema =
         Schema.builder().addInt32Field("precision").addInt32Field("scale").build();
@@ -159,24 +157,24 @@ public class LogicalTypesTest {
     Schema schema = Schema.builder().addLogicalTypeField("decimal", numeric).build();
 
     // check argument valid case
-    BigDecimal decimal = BigDecimal.valueOf(random.nextInt(), scale);
+    BigDecimal decimal = BigDecimal.valueOf(1_000_000_001, scale);
     Row row = Row.withSchema(schema).addValues(decimal).build();
     assertEquals(decimal, row.getLogicalTypeValue(0, BigDecimal.class));
 
-    // check argument invalid case
-    decimal = BigDecimal.valueOf(random.nextLong() + 100_000_000_000L, scale);
+    // check argument invalid case (value out of precision limit)
+    decimal = BigDecimal.valueOf(100_000_000_001L, scale);
     assertThrows(IllegalArgumentException.class, Row.withSchema(schema).addValues(decimal)::build);
 
     // FixedPrecisionNumeric without specifying precision
     numeric = FixedPrecisionNumeric.of(scale);
     schema = Schema.builder().addLogicalTypeField("decimal", numeric).build();
 
-    // check argument always valid
-    decimal = BigDecimal.valueOf(random.nextInt(), scale);
+    // check argument always valid  (precision limit unspecified)
+    decimal = BigDecimal.valueOf(1_000_000_001, scale);
     row = Row.withSchema(schema).addValues(decimal).build();
     assertEquals(decimal, row.getLogicalTypeValue(0, BigDecimal.class));
 
-    decimal = BigDecimal.valueOf(random.nextLong() + 100_000_000_000L, scale);
+    decimal = BigDecimal.valueOf(100_000_000_001L, scale);
     row = Row.withSchema(schema).addValues(decimal).build();
     assertEquals(decimal, row.getLogicalTypeValue(0, BigDecimal.class));
   }

--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/SchemaUtil.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/SchemaUtil.java
@@ -23,7 +23,6 @@ import static java.sql.JDBCType.LONGNVARCHAR;
 import static java.sql.JDBCType.LONGVARBINARY;
 import static java.sql.JDBCType.LONGVARCHAR;
 import static java.sql.JDBCType.NCHAR;
-import static java.sql.JDBCType.NUMERIC;
 import static java.sql.JDBCType.NVARCHAR;
 import static java.sql.JDBCType.VARBINARY;
 import static java.sql.JDBCType.VARCHAR;
@@ -53,6 +52,7 @@ import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.schemas.logicaltypes.FixedPrecisionNumeric;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 import org.joda.time.DateTime;
@@ -140,7 +140,7 @@ class SchemaUtil {
       case NCHAR:
         return beamLogicalField(NCHAR.getName(), LogicalTypes.FixedLengthString::of);
       case NUMERIC:
-        return beamLogicalNumericField(NUMERIC.getName());
+        return beamLogicalNumericField();
       case NVARCHAR:
         return beamLogicalField(NVARCHAR.getName(), LogicalTypes.VariableLengthString::of);
       case REAL:
@@ -211,11 +211,11 @@ class SchemaUtil {
   }
 
   /**
-   * Converts numeric fields with specified precision and scale to {@link
-   * LogicalTypes.FixedPrecisionNumeric}. If a precision of numeric field is not specified, then
-   * converts such field to {@link FieldType#DECIMAL}.
+   * Converts numeric fields with specified precision and scale to {@link FixedPrecisionNumeric}. If
+   * a precision of numeric field is not specified, then converts such field to {@link
+   * FieldType#DECIMAL}.
    */
-  private static BeamFieldConverter beamLogicalNumericField(String identifier) {
+  private static BeamFieldConverter beamLogicalNumericField() {
     return (index, md) -> {
       int precision = md.getPrecision(index);
       if (precision == Integer.MAX_VALUE || precision == -1) {
@@ -225,8 +225,7 @@ class SchemaUtil {
       }
       int scale = md.getScale(index);
       Schema.FieldType fieldType =
-          Schema.FieldType.logicalType(
-              LogicalTypes.FixedPrecisionNumeric.of(identifier, precision, scale));
+          Schema.FieldType.logicalType(FixedPrecisionNumeric.of(precision, scale));
       return beamFieldOfType(fieldType).create(index, md);
     };
   }
@@ -291,10 +290,16 @@ class SchemaUtil {
       final Schema.LogicalType<InputT, BaseT> fieldType) {
     String logicalTypeName = fieldType.getIdentifier();
 
+    JDBCType underlyingType;
+
     if (Objects.equals(fieldType, LogicalTypes.JDBC_UUID_TYPE.getLogicalType())) {
       return OBJECT_EXTRACTOR;
+    } else if (Objects.equals(logicalTypeName, FixedPrecisionNumeric.IDENTIFIER)) {
+      underlyingType = JDBCType.NUMERIC;
+    } else {
+      underlyingType = JDBCType.valueOf(logicalTypeName);
     }
-    JDBCType underlyingType = JDBCType.valueOf(logicalTypeName);
+
     switch (underlyingType) {
       case DATE:
         return DATE_EXTRACTOR;

--- a/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcIOTest.java
+++ b/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcIOTest.java
@@ -18,7 +18,6 @@
 package org.apache.beam.sdk.io.jdbc;
 
 import static java.sql.JDBCType.NULL;
-import static java.sql.JDBCType.NUMERIC;
 import static org.apache.beam.sdk.io.common.DatabaseTestHelper.assertRowCount;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.closeTo;
@@ -72,9 +71,9 @@ import org.apache.beam.sdk.io.common.TestRow;
 import org.apache.beam.sdk.io.jdbc.JdbcIO.DataSourceConfiguration;
 import org.apache.beam.sdk.io.jdbc.JdbcIO.PoolableDataSourceProvider;
 import org.apache.beam.sdk.io.jdbc.JdbcUtil.PartitioningFn;
-import org.apache.beam.sdk.io.jdbc.LogicalTypes.FixedPrecisionNumeric;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.schemas.logicaltypes.FixedPrecisionNumeric;
 import org.apache.beam.sdk.schemas.transforms.Select;
 import org.apache.beam.sdk.testing.ExpectedLogs;
 import org.apache.beam.sdk.testing.PAssert;
@@ -324,9 +323,7 @@ public class JdbcIOTest implements Serializable {
     Schema expectedSchema =
         Schema.of(
             Schema.Field.of(
-                "T1",
-                FieldType.logicalType(FixedPrecisionNumeric.of(NUMERIC.getName(), 1, 0))
-                    .withNullable(false)));
+                "T1", FieldType.logicalType(FixedPrecisionNumeric.of(1, 0)).withNullable(false)));
 
     assertEquals(expectedSchema, rows.getSchema());
 
@@ -379,9 +376,7 @@ public class JdbcIOTest implements Serializable {
     Schema expectedSchema =
         Schema.of(
             Schema.Field.of(
-                "T1",
-                FieldType.logicalType(FixedPrecisionNumeric.of(NUMERIC.getName(), 10, 2))
-                    .withNullable(false)));
+                "T1", FieldType.logicalType(FixedPrecisionNumeric.of(10, 2)).withNullable(false)));
 
     assertEquals(expectedSchema, rows.getSchema());
 

--- a/sdks/python/apache_beam/coders/coder_impl.pxd
+++ b/sdks/python/apache_beam/coders/coder_impl.pxd
@@ -107,6 +107,10 @@ cdef class BooleanCoderImpl(CoderImpl):
   pass
 
 
+cdef class SinglePrecisionFloatCoderImpl(StreamCoderImpl):
+  pass
+
+
 cdef class FloatCoderImpl(StreamCoderImpl):
   pass
 
@@ -266,3 +270,11 @@ cdef class LogicalTypeCoderImpl(StreamCoderImpl):
 
   cpdef decode_from_stream(self, InputStream stream, bint nested)
   cpdef encode_to_stream(self, value, OutputStream stream, bint nested)
+
+
+cdef class BigIntegerCoderImpl(StreamCoderImpl):
+  pass
+
+
+cdef class DecimalCoderImpl(StreamCoderImpl):
+  pass

--- a/sdks/python/apache_beam/coders/coder_impl.py
+++ b/sdks/python/apache_beam/coders/coder_impl.py
@@ -32,6 +32,7 @@ For internal use only; no backwards-compatibility guarantees.
 """
 # pytype: skip-file
 
+import decimal
 import enum
 import itertools
 import json
@@ -1740,3 +1741,47 @@ class LogicalTypeCoderImpl(StreamCoderImpl):
   def decode_from_stream(self, in_stream, nested):
     return self.logical_type.to_language_type(
         self.representation_coder.decode_from_stream(in_stream, nested))
+
+
+class BigIntegerCoderImpl(StreamCoderImpl):
+  """For internal use only; no backwards-compatibility guarantees.
+
+  For interoperability with Java SDK, encoding needs to match that of the Java
+  SDK BigIntegerCoder."""
+  def encode_to_stream(self, value, out, nested):
+    # type: (int, create_OutputStream, bool) -> None
+    if value < 0:
+      byte_length = ((value + 1).bit_length() + 8) // 8
+    else:
+      byte_length = (value.bit_length() + 8) // 8
+    encoded_value = value.to_bytes(
+        length=byte_length, byteorder='big', signed=True)
+    out.write(encoded_value, nested)
+
+  def decode_from_stream(self, in_stream, nested):
+    # type: (create_InputStream, bool) -> int
+    encoded_value = in_stream.read_all(nested)
+    return int.from_bytes(encoded_value, byteorder='big', signed=True)
+
+
+class DecimalCoderImpl(StreamCoderImpl):
+  """For internal use only; no backwards-compatibility guarantees.
+
+  For interoperability with Java SDK, encoding needs to match that of the Java
+  SDK BigDecimalCoder."""
+
+  BIG_INT_CODER_IMPL = BigIntegerCoderImpl()
+
+  def encode_to_stream(self, value, out, nested):
+    # type: (decimal.Decimal, create_OutputStream, bool) -> None
+    scale = -value.as_tuple().exponent
+    int_value = int(value.scaleb(scale))
+    out.write_var_int64(scale)
+    self.BIG_INT_CODER_IMPL.encode_to_stream(int_value, out, nested)
+
+  def decode_from_stream(self, in_stream, nested):
+    # type: (create_InputStream, bool) -> decimal.Decimal
+    scale = in_stream.read_var_int64()
+    int_value = self.BIG_INT_CODER_IMPL.decode_from_stream(in_stream, nested)
+    value = decimal.Decimal(int_value).scaleb(-scale)
+    return value

--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -37,6 +37,7 @@ encoded.
 # pytype: skip-file
 
 import base64
+import decimal
 import pickle
 from functools import lru_cache
 from typing import TYPE_CHECKING
@@ -110,7 +111,9 @@ __all__ = [
     'TupleSequenceCoder',
     'VarIntCoder',
     'WindowedValueCoder',
-    'ParamWindowedValueCoder'
+    'ParamWindowedValueCoder',
+    'BigIntegerCoder',
+    'DecimalCoder'
 ]
 
 T = TypeVar('T')
@@ -1737,3 +1740,39 @@ class TimestampPrefixingWindowCoder(FastCoder):
 
 Coder.register_structured_urn(
     common_urns.coders.CUSTOM_WINDOW.urn, TimestampPrefixingWindowCoder)
+
+
+class BigIntegerCoder(FastCoder):
+  def _create_impl(self):
+    return coder_impl.BigIntegerCoderImpl()
+
+  def is_deterministic(self):
+    # type: () -> bool
+    return True
+
+  def to_type_hint(self):
+    return int
+
+  def __eq__(self, other):
+    return type(self) == type(other)
+
+  def __hash__(self):
+    return hash(type(self))
+
+
+class DecimalCoder(FastCoder):
+  def _create_impl(self):
+    return coder_impl.DecimalCoderImpl()
+
+  def is_deterministic(self):
+    # type: () -> bool
+    return True
+
+  def to_type_hint(self):
+    return decimal.Decimal
+
+  def __eq__(self, other):
+    return type(self) == type(other)
+
+  def __hash__(self):
+    return hash(type(self))

--- a/sdks/python/apache_beam/coders/row_coder.py
+++ b/sdks/python/apache_beam/coders/row_coder.py
@@ -25,6 +25,7 @@ from apache_beam.coders.coder_impl import RowCoderImpl
 from apache_beam.coders.coders import BooleanCoder
 from apache_beam.coders.coders import BytesCoder
 from apache_beam.coders.coders import Coder
+from apache_beam.coders.coders import DecimalCoder
 from apache_beam.coders.coders import FastCoder
 from apache_beam.coders.coders import FloatCoder
 from apache_beam.coders.coders import IterableCoder
@@ -178,6 +179,8 @@ def _nonnull_coder_from_type(field_type):
       # millis Instant. It explicitly uses TimestampCoder which deals with fix
       # length 8-bytes big-endian-long instead of VarInt coder.
       return TimestampCoder()
+    elif field_type.logical_type.urn == 'beam:logical_type:decimal:v1':
+      return DecimalCoder()
 
     logical_type = LogicalType.from_runner_api(field_type.logical_type)
     return LogicalTypeCoder(

--- a/sdks/python/apache_beam/portability/common_urns.py
+++ b/sdks/python/apache_beam/portability/common_urns.py
@@ -79,6 +79,7 @@ displayData = StandardDisplayData.DisplayData
 
 java_class_lookup = ExpansionMethods.Enum.JAVA_CLASS_LOOKUP
 
+decimal = LogicalTypes.Enum.DECIMAL
 micros_instant = LogicalTypes.Enum.MICROS_INSTANT
 millis_instant = LogicalTypes.Enum.MILLIS_INSTANT
 python_callable = LogicalTypes.Enum.PYTHON_CALLABLE

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -811,6 +811,9 @@ class FixedPrecisionDecimalLogicalType(
 
   @classmethod
   def urn(cls):
+    # TODO(https://github.com/apache/beam/issues/23373) promote this URN to
+    # schema.proto once logical types with argument are fully supported and the
+    # implementation of this logical type can thus be considered standardized.
     return "beam:logical_type:fixed_decimal:v1"
 
   @classmethod
@@ -842,7 +845,6 @@ class FixedPrecisionDecimalLogicalType(
 
   @classmethod
   def _from_typing(cls, typ):
-    print(typ)
     return cls()
 
 

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -35,6 +35,7 @@ Imposes a mapping between common Python types and Beam portable schemas
   ByteString  ------> BYTES
   Timestamp   <-----> LogicalType(urn="beam:logical_type:micros_instant:v1")
   Timestamp   <------ LogicalType(urn="beam:logical_type:millis_instant:v1")
+  Decimal     <-----> LogicalType(urn="beam:logical_type:fixed_decimal:v1")
   Mapping     <-----> MapType
   Sequence    <-----> ArrayType
   NamedTuple  <-----> RowType
@@ -55,6 +56,7 @@ any backwards-compatibility guarantee.
 
 # pytype: skip-file
 
+import decimal
 from typing import Any
 from typing import ByteString
 from typing import Dict
@@ -267,12 +269,24 @@ class SchemaTranslation(object):
           logical_type=schema_pb2.LogicalType(urn=PYTHON_ANY_URN),
           nullable=True)
     else:
-      # TODO(bhulette): Add support for logical types that require arguments
-      return schema_pb2.FieldType(
-          logical_type=schema_pb2.LogicalType(
-              urn=logical_type.urn(),
-              representation=self.typing_to_runner_api(
-                  logical_type.representation_type())))
+      if logical_type.argument_type() is None:
+        return schema_pb2.FieldType(
+            logical_type=schema_pb2.LogicalType(
+                urn=logical_type.urn(),
+                representation=self.typing_to_runner_api(
+                    logical_type.representation_type())))
+      else:
+        # TODO(bhulette,yathu): Complete support for logical types that require
+        # arguments.
+        # This include implement SchemaTranslation.value_to_runner_api (see Java
+        # SDK's SchemaTranslation.fieldValueToProto)
+        return schema_pb2.FieldType(
+            logical_type=schema_pb2.LogicalType(
+                urn=logical_type.urn(),
+                representation=self.typing_to_runner_api(
+                    logical_type.representation_type()),
+                argument_type=self.typing_to_runner_api(
+                    logical_type.argument_type())))
 
   def option_from_runner_api(
       self, option_proto: schema_pb2.Option) -> Tuple[str, Any]:
@@ -751,3 +765,91 @@ class PythonCallable(NoArgumentLogicalType[PythonCallableWithSource, str]):
   def to_language_type(self, value):
     # type: (str) -> PythonCallableWithSource
     return PythonCallableWithSource(value)
+
+
+FixedPrecisionDecimalArgumentRepresentation = NamedTuple(
+    'FixedPrecisionDecimalArgumentRepresentation', [('precision', np.int32),
+                                                    ('scale', np.int32)])
+
+
+class DecimalLogicalType(NoArgumentLogicalType[decimal.Decimal, bytes]):
+  def __init__(self):
+    from apache_beam.coders.coder_impl import DecimalCoderImpl
+
+    self.coder_impl = DecimalCoderImpl()
+
+  @classmethod
+  def urn(cls):
+    return "beam:logical_type:decimal:v1"
+
+  @classmethod
+  def representation_type(cls):
+    # type: () -> type
+    return bytes
+
+  @classmethod
+  def language_type(cls):
+    return decimal.Decimal
+
+  def to_representation_type(self, value):
+    # type: (decimal.Decimal) -> bytes
+
+    return self.coder_impl.encode(value)
+
+  def to_language_type(self, value):
+    # type: (bytes) -> decimal.Decimal
+
+    return self.coder_impl.decode(value)
+
+
+@LogicalType.register_logical_type
+class FixedPrecisionDecimalLogicalType(
+    LogicalType[decimal.Decimal,
+                DecimalLogicalType,
+                FixedPrecisionDecimalArgumentRepresentation]):
+  """A wrapper of DecimalLogicalType that contains the precision value.
+  """
+  def __init__(self, precision=-1, scale=0):
+    self.precision = precision
+    self.scale = scale
+
+  @classmethod
+  def urn(cls):
+    return "beam:logical_type:fixed_decimal:v1"
+
+  @classmethod
+  def representation_type(cls):
+    # type: () -> type
+    return DecimalLogicalType
+
+  @classmethod
+  def language_type(cls):
+    return decimal.Decimal
+
+  def to_representation_type(self, value):
+    # type: (decimal.Decimal) -> bytes
+
+    return DecimalLogicalType().coder_impl.encode(value)
+
+  def to_language_type(self, value):
+    # type: (bytes) -> decimal.Decimal
+
+    return DecimalLogicalType().coder_impl.decode(value)
+
+  @classmethod
+  def argument_type(cls):
+    return FixedPrecisionDecimalArgumentRepresentation
+
+  def argument(self):
+    return FixedPrecisionDecimalArgumentRepresentation(
+        precision=self.precision, scale=self.scale)
+
+  @classmethod
+  def _from_typing(cls, typ):
+    print(typ)
+    return cls()
+
+
+# TODO(yathu,BEAM-10722): Investigate and resolve conflicts in logical type
+# registration when more than one logical types sharing the same language type
+LogicalType.register_logical_type(DecimalLogicalType)


### PR DESCRIPTION
The second part of #19817 (keep the issue open for as go support is still pending).

This change makes decimal type work for xlang transforms (such as jdbc) in python sdk. It also contains prerequisite changes for the minimum support of a portable logical type with argument in both Java and Python sdk.

Python SDK still cannot get the argument value from proto because `SchemaTranslation.value_to_runner_api` method does not exist yet (it is `SchemaTranslation.fieldValueToProto` in Java SDK). Nevertheless because the argument is just a wrapper, and the Decimal value can be recovered from the encoded data alone. This does not affect the decimal type.

Because the change is already large, value_to_runner_api and the complete support of argument values  in python is let as followup.

* migrate FixedPrecisionNumeric jdbclogicaltype to portable
  logical type

* Support DECIMAL type in python sdk xlang jdbc transform

* Support standard logical type with argument in java sdk

* proto support logical type's argument type in java sdk.
  Support of logical type's argument value is still pending

* Implement BigIntegerCoder and DecimalCoder in python sdk

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
