### PR TITLE
Add WriteParquetBatched 

### DIFF
--- a/sdks/python/apache_beam/io/parquetio.py
+++ b/sdks/python/apache_beam/io/parquetio.py
@@ -43,7 +43,6 @@ from apache_beam.io.iobase import Write
 from apache_beam.transforms import DoFn
 from apache_beam.transforms import ParDo
 from apache_beam.transforms import PTransform
-from apache_beam.transforms.util import BatchElements
 from apache_beam.transforms import window
 
 try:
@@ -551,7 +550,8 @@ class WriteToParquetBatched(PTransform):
   """Initialize a WriteToParquetBatched transform.
 
      Writes parquet files from a :class:`~apache_beam.pvalue.PCollection` of
-     batches. Each batch is a pa.Table. Schema must be specified like the example below.
+     batches. Each batch is a pa.Table. Schema must be specified like the
+     example below.
      """
   def __init__(
       self,

--- a/sdks/python/apache_beam/io/parquetio.py
+++ b/sdks/python/apache_beam/io/parquetio.py
@@ -547,12 +547,12 @@ class WriteToParquet(PTransform):
 
 
 class WriteToParquetBatched(PTransform):
-  """Initialize a WriteToParquetBatched transform.
+  """A ``PTransform`` for writing parquet files from a `PCollection` of
+    `pyarrow.Table`.
 
-     Writes parquet files from a :class:`~apache_beam.pvalue.PCollection` of
-     batches. Each batch is a pa.Table. Schema must be specified like the
-     example below.
-     """
+    This ``PTransform`` is currently experimental. No backward-compatibility
+    guarantees.
+  """
   def __init__(
       self,
       file_path_prefix,
@@ -579,8 +579,8 @@ class WriteToParquetBatched(PTransform):
       import pyarrow
 
       filename = NamedTemporaryFile(delete=False).name
-      table =  pyarrow.Table.from_pylist([{'name': 'foo', 'age': 10},
-                                          {'name': 'bar', 'age': 20}])
+      table = pyarrow.Table.from_pylist([{'name': 'foo', 'age': 10},
+                                         {'name': 'bar', 'age': 20}])
 
     .. testcode::
 

--- a/sdks/python/apache_beam/io/parquetio.py
+++ b/sdks/python/apache_beam/io/parquetio.py
@@ -664,8 +664,8 @@ class _ParquetSink(filebasedsink.FileBasedSink):
         use_deprecated_int96_timestamps=self._use_deprecated_int96_timestamps,
         use_compliant_nested_type=self._use_compliant_nested_type)
 
-  def write_record(self, writer, value):
-    writer.write_table(value)
+  def write_record(self, writer, table: pa.Table):
+    writer.write_table(table)
 
   def close(self, writer):
     writer.close()

--- a/sdks/python/apache_beam/io/parquetio.py
+++ b/sdks/python/apache_beam/io/parquetio.py
@@ -571,7 +571,7 @@ class WriteToParquetBatched(PTransform):
     records. Each record is a pa.Table Schema must be specified like the
     example below.
 
-    .. testsetup::
+    .. testsetup:: batched
 
       from tempfile import NamedTemporaryFile
       import glob
@@ -579,11 +579,11 @@ class WriteToParquetBatched(PTransform):
       import pyarrow
 
       filename = NamedTemporaryFile(delete=False).name
+
+    .. testcode:: batched
+
       table = pyarrow.Table.from_pylist([{'name': 'foo', 'age': 10},
                                          {'name': 'bar', 'age': 20}])
-
-    .. testcode::
-
       with beam.Pipeline() as p:
         records = p | 'Read' >> beam.Create([table])
         _ = records | 'Write' >> beam.io.WriteToParquetBatched(filename,
@@ -592,7 +592,7 @@ class WriteToParquetBatched(PTransform):
             )
         )
 
-    .. testcleanup::
+    .. testcleanup:: batched
 
       for output in glob.glob('{}*'.format(filename)):
         os.remove(output)

--- a/sdks/python/apache_beam/io/parquetio_test.py
+++ b/sdks/python/apache_beam/io/parquetio_test.py
@@ -286,8 +286,6 @@ class TestParquet(unittest.TestCase):
         file_name,
         self.SCHEMA,
         'none',
-        1024 * 1024,
-        1000,
         False,
         False,
         '.end',
@@ -301,7 +299,6 @@ class TestParquet(unittest.TestCase):
             'file_pattern',
             'some_parquet_sink-%(shard_num)05d-of-%(num_shards)05d.end'),
         DisplayDataItemMatcher('codec', 'none'),
-        DisplayDataItemMatcher('row_group_buffer_size', str(1024 * 1024)),
         DisplayDataItemMatcher('compression', 'uncompressed')
     ]
     hc.assert_that(dd.items, hc.contains_inanyorder(*expected_items))
@@ -310,10 +307,26 @@ class TestParquet(unittest.TestCase):
     file_name = 'some_parquet_sink'
     write = WriteToParquet(file_name, self.SCHEMA)
     dd = DisplayData.create_from(write)
+
     expected_items = [
         DisplayDataItemMatcher('codec', 'none'),
         DisplayDataItemMatcher('schema', str(self.SCHEMA)),
         DisplayDataItemMatcher('row_group_buffer_size', str(64 * 1024 * 1024)),
+        DisplayDataItemMatcher(
+            'file_pattern',
+            'some_parquet_sink-%(shard_num)05d-of-%(num_shards)05d'),
+        DisplayDataItemMatcher('compression', 'uncompressed')
+    ]
+    hc.assert_that(dd.items, hc.contains_inanyorder(*expected_items))
+
+  def test_write_batched_display_data(self):
+    file_name = 'some_parquet_sink'
+    write = WriteToParquetBatched(file_name, self.SCHEMA)
+    dd = DisplayData.create_from(write)
+
+    expected_items = [
+        DisplayDataItemMatcher('codec', 'none'),
+        DisplayDataItemMatcher('schema', str(self.SCHEMA)),
         DisplayDataItemMatcher(
             'file_pattern',
             'some_parquet_sink-%(shard_num)05d-of-%(num_shards)05d'),

--- a/sdks/python/apache_beam/io/parquetio_test.py
+++ b/sdks/python/apache_beam/io/parquetio_test.py
@@ -41,7 +41,6 @@ from apache_beam.io.parquetio import ReadFromParquet
 from apache_beam.io.parquetio import ReadFromParquetBatched
 from apache_beam.io.parquetio import WriteToParquet
 from apache_beam.io.parquetio import WriteToParquetBatched
-
 from apache_beam.io.parquetio import _create_parquet_sink
 from apache_beam.io.parquetio import _create_parquet_source
 from apache_beam.testing.test_pipeline import TestPipeline

--- a/sdks/python/apache_beam/io/parquetio_test.py
+++ b/sdks/python/apache_beam/io/parquetio_test.py
@@ -40,6 +40,8 @@ from apache_beam.io.parquetio import ReadAllFromParquetBatched
 from apache_beam.io.parquetio import ReadFromParquet
 from apache_beam.io.parquetio import ReadFromParquetBatched
 from apache_beam.io.parquetio import WriteToParquet
+from apache_beam.io.parquetio import WriteToParquetBatched
+
 from apache_beam.io.parquetio import _create_parquet_sink
 from apache_beam.io.parquetio import _create_parquet_source
 from apache_beam.testing.test_pipeline import TestPipeline
@@ -339,6 +341,22 @@ class TestParquet(unittest.TestCase):
         _ = p \
         | Create(self.RECORDS) \
         | WriteToParquet(
+            path, self.SCHEMA, num_shards=1, shard_name_template='')
+      with TestPipeline() as p:
+        # json used for stable sortability
+        readback = \
+            p \
+            | ReadFromParquet(path) \
+            | Map(json.dumps)
+        assert_that(readback, equal_to([json.dumps(r) for r in self.RECORDS]))
+
+  def test_sink_transform_batched(self):
+    with TemporaryDirectory() as tmp_dirname:
+      path = os.path.join(tmp_dirname + "tmp_filename")
+      with TestPipeline() as p:
+        _ = p \
+        | Create([self._records_as_arrow()]) \
+        | WriteToParquetBatched(
             path, self.SCHEMA, num_shards=1, shard_name_template='')
       with TestPipeline() as p:
         # json used for stable sortability


### PR DESCRIPTION
This is a start to addressing #22813. @TheNeuralBit I put up a draft. Let me know if this still would be worth adding to the sdk or if there is way to do this already.

This is an example of the pipeline:
```python
with TestPipeline() as p:
  _ = p \
  | RunInference(...) \
  | BatchToArrowTable() \  # turns a dict of vectors into a pa.Table,
                           # e.g. {'id': [1, 2, 3], 'score': [0.9, 0.1, 0.8]} -> pa.Table     
  | WriteToParquetBatched(
      path, self.SCHEMA, num_shards=1, shard_name_template='')
```

### Motivation
* Don't need to un-batch into a series of python dicts, which hurts performance.
* Models naturally return batches, so it works
* I didn't add it in yet, but you can infer the schema from the first batch (possibly will break something, but worked with dataflow)

### Open Questions
1. Controlling `row_group_size` would need to be handled upstream
2. A lot of duplicate code. Possibly some smart ways to refactor a bit (let me know)


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
