### PR TITLE
Publish results of JMH benchmark runs (Java SDK) to InfluxDB (#22238).

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -1413,6 +1413,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
         project.tasks.register("jmh", JavaExec)  {
           dependsOn project.classes
+          // Note: this will wrap the default JMH runner publishing results to InfluxDB
           mainClass = "org.apache.beam.sdk.testutils.jmh.Main"
           classpath = project.sourceSets.main.runtimeClasspath
 
@@ -1454,7 +1455,7 @@ class BeamModulePlugin implements Plugin<Project> {
         // Note that these tests will fail on JVMs that JMH doesn't support.
         def jmhTest = project.tasks.register("jmhTest", JavaExec) {
           dependsOn project.classes
-          // Note: this will delegate to the default JMH runner
+          // Note: this will just delegate to the default JMH runner, single shot times are not published to InfluxDB
           mainClass = "org.apache.beam.sdk.testutils.jmh.Main"
           classpath = project.sourceSets.main.runtimeClasspath
 

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -1417,6 +1417,7 @@ class BeamModulePlugin implements Plugin<Project> {
           classpath = project.sourceSets.main.runtimeClasspath
 
           environment([
+            // Prefix all JMH measurement names for InfluxDB with `java_jmh_` and append the gradle module path excluding redudant components
             'INFLUXDB_MEASUREMENT': 'java_jmh_' + (getPath().split(':') - ['', 'sdks', 'java', 'jmh']).join('_')
           ])
 

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -665,6 +665,7 @@ class BeamModulePlugin implements Plugin<Project> {
         jamm                                        : 'io.github.stephankoelle:jamm:0.4.1',
         jaxb_api                                    : "jakarta.xml.bind:jakarta.xml.bind-api:$jaxb_api_version",
         jaxb_impl                                   : "com.sun.xml.bind:jaxb-impl:$jaxb_api_version",
+        jmh_core                                    : "org.openjdk.jmh:jmh-core:$jmh_version",
         joda_time                                   : "joda-time:joda-time:2.10.10",
         jsonassert                                  : "org.skyscreamer:jsonassert:1.5.0",
         jsr305                                      : "com.google.code.findbugs:jsr305:$jsr305_version",
@@ -1393,8 +1394,9 @@ class BeamModulePlugin implements Plugin<Project> {
 
       if (configuration.enableJmh) {
         project.dependencies {
+          runtimeOnly it.project(path: ":sdks:java:testing:test-utils")
           annotationProcessor "org.openjdk.jmh:jmh-generator-annprocess:$jmh_version"
-          implementation "org.openjdk.jmh:jmh-core:$jmh_version"
+          implementation project.library.java.jmh_core
         }
 
         project.compileJava {
@@ -1411,8 +1413,13 @@ class BeamModulePlugin implements Plugin<Project> {
 
         project.tasks.register("jmh", JavaExec)  {
           dependsOn project.classes
-          mainClass = "org.openjdk.jmh.Main"
+          mainClass = "org.apache.beam.sdk.testutils.jmh.Main"
           classpath = project.sourceSets.main.runtimeClasspath
+
+          environment([
+            'INFLUXDB_MEASUREMENT': 'java_jmh_' + (getPath().split(':') - ['', 'sdks', 'java', 'jmh']).join('_')
+          ])
+
           // For a list of arguments, see
           // https://github.com/guozheng/jmh-tutorial/blob/master/README.md
           //
@@ -1449,7 +1456,8 @@ class BeamModulePlugin implements Plugin<Project> {
         // Note that these tests will fail on JVMs that JMH doesn't support.
         def jmhTest = project.tasks.register("jmhTest", JavaExec) {
           dependsOn project.classes
-          mainClass = "org.openjdk.jmh.Main"
+          // Note: this will delegate to the default JMH runner
+          mainClass = "org.apache.beam.sdk.testutils.jmh.Main"
           classpath = project.sourceSets.main.runtimeClasspath
 
           // We filter for only Apache Beam benchmarks to ensure that we aren't

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -1416,10 +1416,7 @@ class BeamModulePlugin implements Plugin<Project> {
           mainClass = "org.apache.beam.sdk.testutils.jmh.Main"
           classpath = project.sourceSets.main.runtimeClasspath
 
-          environment([
-            // Prefix all JMH measurement names for InfluxDB with `java_jmh_` and append the gradle module path excluding redudant components
-            'INFLUXDB_MEASUREMENT': 'java_jmh_' + (getPath().split(':') - ['', 'sdks', 'java', 'jmh']).join('_')
-          ])
+          environment 'INFLUXDB_BASE_MEASUREMENT', 'java_jmh'
 
           // For a list of arguments, see
           // https://github.com/guozheng/jmh-tutorial/blob/master/README.md

--- a/sdks/java/testing/test-utils/build.gradle
+++ b/sdks/java/testing/test-utils/build.gradle
@@ -37,6 +37,7 @@ dependencies {
   implementation library.java.http_client
   implementation library.java.http_core
   implementation library.java.slf4j_api
+  provided library.java.jmh_core
 
   testImplementation library.java.junit
   testRuntimeOnly project(path: ":runners:direct-java", configuration: "shadowTest")

--- a/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/jmh/Main.java
+++ b/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/jmh/Main.java
@@ -50,7 +50,7 @@ import org.openjdk.jmh.runner.options.CommandLineOptions;
  *
  * <h3>Schema</h3>
  *
- * <p>The wrapper writes an aggregated InfluxDB datapoint for each benchmark to <b> measurement</b>
+ * <p>The wrapper writes an aggregated InfluxDB datapoint for each benchmark to <b>measurement</b>
  * {@code {INFLUXDB_BASE_MEASUREMENT}_{mode}}. Typically this is {@code java_jmh_thrpt}.
  *
  * <p>The <b>timestamp</b> of the datapoint corresponds to the start time of the respective
@@ -60,7 +60,7 @@ import org.openjdk.jmh.runner.options.CommandLineOptions;
  * corresponding to additional benchmark parameters in case of parameterized benchmarks:
  *
  * <ul>
- *   <li>{@code benchmark} (string) : Fully qualified name of the benchmark
+ *   <li>{@code benchmark} (string): Fully qualified name of the benchmark
  *   <li>{@code scoreUnit} (string): JMH score unit
  *   <li>optionally, additional parameters in case of a parameterized benchmark (string)
  * </ul>

--- a/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/jmh/Main.java
+++ b/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/jmh/Main.java
@@ -45,8 +45,36 @@ import org.openjdk.jmh.runner.options.CommandLineOptionException;
 import org.openjdk.jmh.runner.options.CommandLineOptions;
 
 /**
- * Custom main wrapper around the {@link Runner JMH runner} that supports publishing benchmarks to
- * InfluxDB.
+ * Custom main wrapper around the {@link Runner JMH runner} that supports publishing JMH benchmark
+ * results to InfluxDB.
+ *
+ * <h3>Schema</h3>
+ *
+ * <p>The wrapper writes an aggregated InfluxDB datapoint for each benchmark to a <b>single
+ * measurement</b> according to environment variable {@code INFLUXDB_MEASUREMENT}. The
+ * <b>timestamp</b> of the datapoint corresponds to the start time of the respective benchmark.
+ *
+ * <p>Individual timeseries are discriminated using the following <b>tags</b> including tags
+ * corresponding to additional benchmark parameters in case of parameterized benchmarks:
+ *
+ * <ul>
+ *   <li>{@code benchmark} (string) : Fully qualified name of the benchmark
+ *   <li>{@code mode} (string): JMH benchmark mode
+ *   <li>{@code scoreUnit} (string): JMH score unit
+ *   <li>optionally, additional parameters in case of a parameterized benchmark (string)
+ * </ul>
+ *
+ * <p>The following fields are captured for each benchmark:
+ *
+ * <ul>
+ *   <li>{@code score} (float): JMH score
+ *   <li>{@code scoreMean} (float): Mean score of all iterations
+ *   <li>{@code scoreMedian} (float): Median score of all iterations
+ *   <li>{@code scoreError} (float): Mean error of the score
+ *   <li>{@code durationMs} (integer): Total duration (including warmups)
+ * </ul>
+ *
+ * <h3>Configuration</h3>
  *
  * <p>If {@link InfluxDBSettings} can be inferred from the environment, benchmark results will be
  * published to InfluxDB. Otherwise this will just delegate to the default {@link

--- a/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/jmh/Main.java
+++ b/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/jmh/Main.java
@@ -1,0 +1,150 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.testutils.jmh;
+
+import static java.util.function.Function.identity;
+import static java.util.stream.Collectors.toList;
+import static java.util.stream.Collectors.toMap;
+import static org.openjdk.jmh.annotations.Mode.SingleShotTime;
+
+import java.io.IOException;
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.TimeUnit;
+import java.util.stream.Stream;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.testutils.publishing.InfluxDBPublisher;
+import org.apache.beam.sdk.testutils.publishing.InfluxDBPublisher.DataPoint;
+import org.apache.beam.sdk.testutils.publishing.InfluxDBSettings;
+import org.openjdk.jmh.annotations.Mode;
+import org.openjdk.jmh.infra.BenchmarkParams;
+import org.openjdk.jmh.results.BenchmarkResult;
+import org.openjdk.jmh.results.BenchmarkResultMetaData;
+import org.openjdk.jmh.results.Result;
+import org.openjdk.jmh.results.RunResult;
+import org.openjdk.jmh.runner.Runner;
+import org.openjdk.jmh.runner.RunnerException;
+import org.openjdk.jmh.runner.options.CommandLineOptionException;
+import org.openjdk.jmh.runner.options.CommandLineOptions;
+
+/**
+ * Custom main wrapper around the {@link Runner JMH runner} that supports publishing benchmarks to
+ * InfluxDB.
+ *
+ * <p>If {@link InfluxDBSettings} can be inferred from the environment, benchmark results will be
+ * published to InfluxDB. Otherwise this will just delegate to the default {@link
+ * org.openjdk.jmh.Main JMH Main} class.
+ *
+ * <p>Use the following environment variables to configure {@link InfluxDBSettings}:
+ *
+ * <ul>
+ *   <li>{@link #INFLUXDB_HOST}
+ *   <li>{@link #INFLUXDB_DATABASE}
+ *   <li>{@link #INFLUXDB_MEASUREMENT}
+ * </ul>
+ */
+public class Main {
+  private static final String INFLUXDB_HOST = "INFLUXDB_HOST";
+  private static final String INFLUXDB_DATABASE = "INFLUXDB_DATABASE";
+  private static final String INFLUXDB_MEASUREMENT = "INFLUXDB_MEASUREMENT";
+
+  public static void main(String[] args)
+      throws CommandLineOptionException, IOException, RunnerException {
+    final CommandLineOptions opts = new CommandLineOptions(args);
+    final InfluxDBSettings influxDB = influxDBSettings();
+
+    if (influxDB == null
+        || isSingleShotTimeOnly(opts.getBenchModes())
+        || opts.shouldHelp()
+        || opts.shouldList()
+        || opts.shouldListWithParams()
+        || opts.shouldListProfilers()
+        || opts.shouldListResultFormats()) {
+      // delegate to JMH runner
+      org.openjdk.jmh.Main.main(args);
+      return;
+    }
+
+    final Runner runner = new Runner(opts);
+    final Collection<RunResult> results = runner.run();
+
+    final Collection<DataPoint> dataPoints =
+        results.stream()
+            .filter(r -> r.getParams().getMode() != SingleShotTime)
+            .map(r -> dataPoint(influxDB.measurement, r))
+            .collect(toList());
+
+    InfluxDBPublisher.publish(influxDB, dataPoints);
+  }
+
+  private static boolean isSingleShotTimeOnly(Collection<Mode> modes) {
+    return !modes.isEmpty() && modes.stream().allMatch(SingleShotTime::equals);
+  }
+
+  private static DataPoint dataPoint(String measurement, RunResult run) {
+    final BenchmarkParams params = run.getParams();
+    final Result<?> result = run.getPrimaryResult();
+
+    final long startTimeMs =
+        metaDataStream(run).mapToLong(BenchmarkResultMetaData::getStartTime).min().getAsLong();
+    final long stopTimeMs =
+        metaDataStream(run).mapToLong(BenchmarkResultMetaData::getStopTime).max().getAsLong();
+
+    final Map<String, String> tags = new HashMap<>();
+    tags.put("benchmark", params.getBenchmark());
+    tags.put("mode", params.getMode().shortLabel());
+    tags.put("scoreUnit", result.getScoreUnit());
+    tags.putAll(params.getParamsKeys().stream().collect(toMap(identity(), params::getParam)));
+
+    final Map<String, Number> fields = new HashMap<>();
+    fields.put("score", result.getScore());
+    fields.put("scoreMean", result.getStatistics().getMean());
+    fields.put("scoreMedian", result.getStatistics().getPercentile(0.5));
+    if (!Double.isNaN(result.getScoreError())) {
+      fields.put("scoreError", result.getScoreError());
+    }
+    fields.put("durationMs", stopTimeMs - startTimeMs);
+
+    return InfluxDBPublisher.dataPoint(
+        measurement, tags, fields, startTimeMs, TimeUnit.MILLISECONDS);
+  }
+
+  private static Stream<BenchmarkResultMetaData> metaDataStream(RunResult runResult) {
+    return runResult.getBenchmarkResults().stream()
+        .map(BenchmarkResult::getMetadata)
+        .filter(Objects::nonNull);
+  }
+
+  /** Construct InfluxDB settings from environment variables to not mess with JMH args. */
+  private static @Nullable InfluxDBSettings influxDBSettings() {
+    String host = System.getenv(INFLUXDB_HOST);
+    String database = System.getenv(INFLUXDB_DATABASE);
+    String measurement = System.getenv(INFLUXDB_MEASUREMENT);
+    if (measurement == null || database == null) {
+      return null;
+    }
+
+    InfluxDBSettings.Builder builder = InfluxDBSettings.builder();
+    if (host != null) {
+      builder.withHost(host); // default to localhost otherwise
+    }
+    return builder.withDatabase(database).withMeasurement(measurement).get();
+  }
+}

--- a/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/jmh/package-info.java
+++ b/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/jmh/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Tools for running JMH benchmarks and collecting results. */
+package org.apache.beam.sdk.testutils.jmh;

--- a/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/publishing/InfluxDBPublisher.java
+++ b/sdks/java/testing/test-utils/src/main/java/org/apache/beam/sdk/testutils/publishing/InfluxDBPublisher.java
@@ -106,6 +106,17 @@ public final class InfluxDBPublisher {
         measurement, tags, fields, timestampSecs, TimeUnit.SECONDS);
   }
 
+  /** Creates an InfluxDB data point. */
+  public static DataPoint dataPoint(
+      String measurement,
+      Map<String, String> tags,
+      Map<String, Number> fields,
+      @Nullable Long timestamp,
+      TimeUnit timestampUnit) {
+    return new AutoValue_InfluxDBPublisher_DataPoint(
+        measurement, tags, fields, timestamp, timestampUnit);
+  }
+
   /** @deprecated Use {@link #publish} instead. */
   @Deprecated
   public static void publishNexmarkResults(


### PR DESCRIPTION
Adds a custom main wrapper around the JMH runner that supports publishing JMH benchmark results to InfluxDB.

<h3>Schema</h3>

The wrapper writes an aggregated InfluxDB datapoint for each benchmark to <b>measurement</b>
 `{INFLUXDB_BASE_MEASUREMENT}_{mode}`. Typically this is `java_jmh_thrpt`.

The <b>timestamp</b> of the datapoint corresponds to the start time of the respective benchmark.

Individual timeseries are discriminated using the following <b>tags</b> including tags corresponding to additional benchmark parameters in case of parameterized benchmarks:

- `benchmark` (string): Fully qualified name of the benchmark
- `scoreUnit` (string): JMH score unit
- optionally, additional parameters in case of a parameterized benchmark (string)
</ul>

The following fields are captured for each benchmark:
- `score` (float): JMH score
- `scoreMean` (float): Mean score of all iterations
- `scoreMedian` (float): Median score of all iterations
- `scoreError` (float): Mean error of the score
- `sampleCount` (integer): Number of score samples
- `durationMs` (integer): Total benchmark duration (including warmups)

<h3>Configuration</h3>
If settings can be inferred from the environment, benchmark results will be published to
InfluxDB. Otherwise this will just delegate to the default JMH Main class.

Use the following environment variables to configure the publisher:
- `INFLUXDB_HOST`: InfluxDB host
- `INFLUXDB_DATABASE`: InfluxDB database
- `INFLUXDB_USER`: InfluxDB user
- `INFLUXDB_USER_PASSWORD`: InfluxDB user password
- `INFLUXDB_BASE_MEASUREMENT`: Prefix for measurement name, the benchmark mode will be appended to this


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
