### PR TITLE
[GitHub Actions] - Updates in Triaged on Assign to runs-on Self-hosted runners

### DIFF
--- a/.github/workflows/triaged-on-assign.yml
+++ b/.github/workflows/triaged-on-assign.yml
@@ -17,11 +17,10 @@ name: Mark issue as triaged when assigned
 on:
   issues:
     types: [assigned]
-
 jobs:
   assign:
     name: Mark issue as triaged when assigned
-    runs-on: ubuntu-latest
+    runs-on: [self-hosted, ubuntu-20.04]
     steps:
     - run: |
         ISSUE_NUMBER="$(jq '.issue.number' $GITHUB_EVENT_PATH)"


### PR DESCRIPTION
`DO NOT MERGE until the infrastructure is in place. Please talk to @dannymartinm @elink21 before merging`

As part of the issue [21106](https://github.com/apache/beam/issues/21106), @elink21 and I have implemented the self-hosted runners for the Ubuntu and Windows operating systems. 

Please see the Approved Pull Request ([PR#22703](https://github.com/apache/beam/pull/22703)) for reference.

In this PR you will find the following changes: 

* Updates in workflow Triaged on Assign to `runs-on` self-hosted runners
    * Ubuntu

[PR#16511 ](https://github.com/apache/beam/pull/16511): Previous PR for reference.
[BEAM-12812](https://issues.apache.org/jira/browse/BEAM-12812): Original Jira may contain additional context. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
