### PR TITLE
GA Migrations Python PreCommit Sharding DataFlow Direct Interactive Runners

### DIFF
--- a/.github/workflows/job-precommit-python-dataflow-runners.yml
+++ b/.github/workflows/job-precommit-python-dataflow-runners.yml
@@ -22,6 +22,7 @@
 name: PreCommit Python Runners DataFlow
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 */6 * * *'
   push:
@@ -30,6 +31,7 @@ on:
   pull_request_target:
     branches: ['master', 'release-*']
     tags: 'v*'
+    paths: [ 'sdks/python/apache_beam/runners/dataflow/**' ]
 permissions: read-all
 
 jobs:

--- a/.github/workflows/job-precommit-python-dataflow-runners.yml
+++ b/.github/workflows/job-precommit-python-dataflow-runners.yml
@@ -34,7 +34,7 @@ permissions: read-all
 
 jobs:
   set-properties:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ubuntu-20.04]
     outputs:
       properties: ${{ steps.test-properties.outputs.properties }}
     steps:
@@ -50,7 +50,7 @@ jobs:
   precommit_python_runners-dataflow:
     needs: set-properties
     name: PreCommit Python Runners DataFlow
-    runs-on: self-hosted
+    runs-on: [self-hosted, ubuntu-20.04]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/job-precommit-python-dataflow-runners.yml
+++ b/.github/workflows/job-precommit-python-dataflow-runners.yml
@@ -28,9 +28,10 @@ on:
   push:
     branches: ['master', 'release-*']
     tags: 'v*'
-  pull_request:
+  pull_request_target:
     branches: ['master', 'release-*']
     tags: 'v*'
+permissions: read-all
 
 jobs:
   set-properties:
@@ -39,8 +40,9 @@ jobs:
       properties: ${{ steps.test-properties.outputs.properties }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
           submodules: recursive
       - id: test-properties
@@ -54,23 +56,20 @@ jobs:
       fail-fast: false
       matrix:
         version: ${{fromJson(needs.set-properties.outputs.properties).PythonTestProperties.ALL_SUPPORTED_VERSIONS}}
+        tox-env: ${{fromJson(needs.set-properties.outputs.properties).PythonTestProperties.TOX_ENV}}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
           submodules: recursive
       - name: Set python version
         run: echo "PYTHON_VERSION=$(echo ${{ matrix.version }} | sed -e 's/\.//g')" >> $GITHUB_ENV
       - name: Setup environment
         uses: ./.github/actions/setup-self-hosted-action
-      - name: Run :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cloud
+      - name: Run :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}${{matrix.tox-env}}
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:
-          gradle-command: :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cloud
-          arguments: "-Pposargs=apache_beam/runners/dataflow/"
-      - name: Run :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cython
-        uses: ./.github/actions/gradle-command-self-hosted-action
-        with:
-          gradle-command: :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cython
+          gradle-command: :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}${{matrix.tox-env}}
           arguments: "-Pposargs=apache_beam/runners/dataflow/"

--- a/.github/workflows/job-precommit-python-dataflow-runners.yml
+++ b/.github/workflows/job-precommit-python-dataflow-runners.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
-          submodules: recursive
+          submodules: false
       - id: test-properties
         uses: ./.github/actions/setup-default-test-properties
 
@@ -64,7 +64,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
-          submodules: recursive
+          submodules: false
       - name: Set python version
         run: echo "PYTHON_VERSION=$(echo ${{ matrix.version }} | sed -e 's/\.//g')" >> $GITHUB_ENV
       - name: Setup environment

--- a/.github/workflows/job-precommit-python-dataflow-runners.yml
+++ b/.github/workflows/job-precommit-python-dataflow-runners.yml
@@ -22,7 +22,6 @@
 name: PreCommit Python Runners DataFlow
 
 on:
-  workflow_dispatch:
   schedule:
     - cron: '0 */6 * * *'
   push:

--- a/.github/workflows/job-precommit-python-dataflow-runners.yml
+++ b/.github/workflows/job-precommit-python-dataflow-runners.yml
@@ -59,6 +59,14 @@ jobs:
         version: ${{fromJson(needs.set-properties.outputs.properties).PythonTestProperties.ALL_SUPPORTED_VERSIONS}}
         tox-env: ${{fromJson(needs.set-properties.outputs.properties).PythonTestProperties.TOX_ENV}}
     steps:
+      - name: Checking out composite
+        uses: actions/checkout@v3
+        with:
+          ref: master
+      - name: Activating Service Account
+        uses: ./.github/actions/activate-service-account
+        with:      
+          GCP_SERVICE_ACCOUNT: ${{secrets.GCP_SELF_HOSTED_SA_KEY}}
       - name: Checkout code
         uses: actions/checkout@v3
         with:

--- a/.github/workflows/job-precommit-python-dataflow-runners.yml
+++ b/.github/workflows/job-precommit-python-dataflow-runners.yml
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# To learn more about GitHub Actions in Apache Beam check the CI.md
+
+# Runs PreCommit Python Runners DataFlow scheduled on cron, on push to master and on pull request
+
+name: PreCommit Python Runners DataFlow
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */6 * * *'
+  push:
+    branches: ['master', 'release-*']
+    tags: 'v*'
+  pull_request:
+    branches: ['master', 'release-*']
+    tags: 'v*'
+
+jobs:
+  set-properties:
+    runs-on: self-hosted
+    outputs:
+      properties: ${{ steps.test-properties.outputs.properties }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - id: test-properties
+        uses: ./.github/actions/setup-default-test-properties
+
+  precommit_python_runners-dataflow:
+    needs: set-properties
+    name: PreCommit Python Runners DataFlow
+    runs-on: self-hosted
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{fromJson(needs.set-properties.outputs.properties).PythonTestProperties.ALL_SUPPORTED_VERSIONS}}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - name: Set python version
+        run: echo "PYTHON_VERSION=$(echo ${{ matrix.version }} | sed -e 's/\.//g')" >> $GITHUB_ENV
+      - name: Setup environment
+        uses: ./.github/actions/setup-self-hosted-action
+      - name: Run :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cloud
+        uses: ./.github/actions/gradle-command-self-hosted-action
+        with:
+          gradle-command: :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cloud
+          arguments: "-Pposargs=apache_beam/runners/dataflow/"
+      - name: Run :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cython
+        uses: ./.github/actions/gradle-command-self-hosted-action
+        with:
+          gradle-command: :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cython
+          arguments: "-Pposargs=apache_beam/runners/dataflow/"

--- a/.github/workflows/job-precommit-python-direct-runners.yml
+++ b/.github/workflows/job-precommit-python-direct-runners.yml
@@ -28,9 +28,10 @@ on:
   push:
     branches: ['master', 'release-*']
     tags: 'v*'
-  pull_request:
+  pull_request_target:
     branches: ['master', 'release-*']
     tags: 'v*'
+permissions: read-all
 
 jobs:
   set-properties:
@@ -39,8 +40,9 @@ jobs:
       properties: ${{ steps.test-properties.outputs.properties }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
           submodules: recursive
       - id: test-properties
@@ -54,23 +56,20 @@ jobs:
       fail-fast: false
       matrix:
         version: ${{fromJson(needs.set-properties.outputs.properties).PythonTestProperties.ALL_SUPPORTED_VERSIONS}}
+        tox-env: ${{fromJson(needs.set-properties.outputs.properties).PythonTestProperties.TOX_ENV}}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
           submodules: recursive
       - name: Set python version
         run: echo "PYTHON_VERSION=$(echo ${{ matrix.version }} | sed -e 's/\.//g')" >> $GITHUB_ENV
       - name: Setup environment
         uses: ./.github/actions/setup-self-hosted-action
-      - name: Run :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cloud
+      - name: Run :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}${{matrix.tox-env}}
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:
-          gradle-command: :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cloud
-          arguments: "-Pposargs=apache_beam/runners/direct/"
-      - name: Run :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cython
-        uses: ./.github/actions/gradle-command-self-hosted-action
-        with:
-          gradle-command: :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cython
+          gradle-command: :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}${{matrix.tox-env}}
           arguments: "-Pposargs=apache_beam/runners/direct/"

--- a/.github/workflows/job-precommit-python-direct-runners.yml
+++ b/.github/workflows/job-precommit-python-direct-runners.yml
@@ -22,6 +22,7 @@
 name: PreCommit Python Runners Direct
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 */6 * * *'
   push:
@@ -30,6 +31,7 @@ on:
   pull_request_target:
     branches: ['master', 'release-*']
     tags: 'v*'
+    paths: [ 'sdks/python/apache_beam/runners/direct/**' ]
 permissions: read-all
 
 jobs:

--- a/.github/workflows/job-precommit-python-direct-runners.yml
+++ b/.github/workflows/job-precommit-python-direct-runners.yml
@@ -22,7 +22,6 @@
 name: PreCommit Python Runners Direct
 
 on:
-  workflow_dispatch:
   schedule:
     - cron: '0 */6 * * *'
   push:

--- a/.github/workflows/job-precommit-python-direct-runners.yml
+++ b/.github/workflows/job-precommit-python-direct-runners.yml
@@ -34,7 +34,7 @@ permissions: read-all
 
 jobs:
   set-properties:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ubuntu-20.04]
     outputs:
       properties: ${{ steps.test-properties.outputs.properties }}
     steps:
@@ -50,7 +50,7 @@ jobs:
   precommit_python_runners-direct:
     needs: set-properties
     name: PreCommit Python Runners Direct
-    runs-on: self-hosted
+    runs-on: [self-hosted, ubuntu-20.04]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/job-precommit-python-direct-runners.yml
+++ b/.github/workflows/job-precommit-python-direct-runners.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
-          submodules: recursive
+          submodules: false
       - id: test-properties
         uses: ./.github/actions/setup-default-test-properties
 
@@ -64,7 +64,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
-          submodules: recursive
+          submodules: false
       - name: Set python version
         run: echo "PYTHON_VERSION=$(echo ${{ matrix.version }} | sed -e 's/\.//g')" >> $GITHUB_ENV
       - name: Setup environment

--- a/.github/workflows/job-precommit-python-direct-runners.yml
+++ b/.github/workflows/job-precommit-python-direct-runners.yml
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# To learn more about GitHub Actions in Apache Beam check the CI.md
+
+# Runs PreCommit Python Runners Direct scheduled on cron, on push to master and on pull request
+
+name: PreCommit Python Runners Direct
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */6 * * *'
+  push:
+    branches: ['master', 'release-*']
+    tags: 'v*'
+  pull_request:
+    branches: ['master', 'release-*']
+    tags: 'v*'
+
+jobs:
+  set-properties:
+    runs-on: self-hosted
+    outputs:
+      properties: ${{ steps.test-properties.outputs.properties }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - id: test-properties
+        uses: ./.github/actions/setup-default-test-properties
+
+  precommit_python_runners-direct:
+    needs: set-properties
+    name: PreCommit Python Runners Direct
+    runs-on: self-hosted
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{fromJson(needs.set-properties.outputs.properties).PythonTestProperties.ALL_SUPPORTED_VERSIONS}}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - name: Set python version
+        run: echo "PYTHON_VERSION=$(echo ${{ matrix.version }} | sed -e 's/\.//g')" >> $GITHUB_ENV
+      - name: Setup environment
+        uses: ./.github/actions/setup-self-hosted-action
+      - name: Run :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cloud
+        uses: ./.github/actions/gradle-command-self-hosted-action
+        with:
+          gradle-command: :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cloud
+          arguments: "-Pposargs=apache_beam/runners/direct/"
+      - name: Run :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cython
+        uses: ./.github/actions/gradle-command-self-hosted-action
+        with:
+          gradle-command: :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cython
+          arguments: "-Pposargs=apache_beam/runners/direct/"

--- a/.github/workflows/job-precommit-python-interactive-runners.yml
+++ b/.github/workflows/job-precommit-python-interactive-runners.yml
@@ -22,7 +22,6 @@
 name: PreCommit Python Runners Interactive
 
 on:
-  workflow_dispatch:
   schedule:
     - cron: '0 */6 * * *'
   push:

--- a/.github/workflows/job-precommit-python-interactive-runners.yml
+++ b/.github/workflows/job-precommit-python-interactive-runners.yml
@@ -22,6 +22,7 @@
 name: PreCommit Python Runners Interactive
 
 on:
+  workflow_dispatch:
   schedule:
     - cron: '0 */6 * * *'
   push:
@@ -30,6 +31,7 @@ on:
   pull_request_target:
     branches: ['master', 'release-*']
     tags: 'v*'
+    paths: [ 'sdks/python/apache_beam/runners/interactive/**' ]
 permissions: read-all
 
 jobs:

--- a/.github/workflows/job-precommit-python-interactive-runners.yml
+++ b/.github/workflows/job-precommit-python-interactive-runners.yml
@@ -28,9 +28,10 @@ on:
   push:
     branches: ['master', 'release-*']
     tags: 'v*'
-  pull_request:
+  pull_request_target:
     branches: ['master', 'release-*']
     tags: 'v*'
+permissions: read-all
 
 jobs:
   set-properties:
@@ -39,8 +40,9 @@ jobs:
       properties: ${{ steps.test-properties.outputs.properties }}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
           submodules: recursive
       - id: test-properties
@@ -54,23 +56,20 @@ jobs:
       fail-fast: false
       matrix:
         version: ${{fromJson(needs.set-properties.outputs.properties).PythonTestProperties.ALL_SUPPORTED_VERSIONS}}
+        tox-env: ${{fromJson(needs.set-properties.outputs.properties).PythonTestProperties.TOX_ENV}}
     steps:
       - name: Checkout code
-        uses: actions/checkout@v2
+        uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
           submodules: recursive
       - name: Set python version
         run: echo "PYTHON_VERSION=$(echo ${{ matrix.version }} | sed -e 's/\.//g')" >> $GITHUB_ENV
       - name: Setup environment
         uses: ./.github/actions/setup-self-hosted-action
-      - name: Run :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cloud
+      - name: Run :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}${{matrix.tox-env}}
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:
-          gradle-command: :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cloud
-          arguments: "-Pposargs=apache_beam/runners/interactive/"
-      - name: Run :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cython
-        uses: ./.github/actions/gradle-command-self-hosted-action
-        with:
-          gradle-command: :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cython
+          gradle-command: :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}${{matrix.tox-env}}
           arguments: "-Pposargs=apache_beam/runners/interactive/"

--- a/.github/workflows/job-precommit-python-interactive-runners.yml
+++ b/.github/workflows/job-precommit-python-interactive-runners.yml
@@ -34,7 +34,7 @@ permissions: read-all
 
 jobs:
   set-properties:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ubuntu-20.04]
     outputs:
       properties: ${{ steps.test-properties.outputs.properties }}
     steps:
@@ -50,7 +50,7 @@ jobs:
   precommit_python_runners-interactive:
     needs: set-properties
     name: PreCommit Python Runners Interactive
-    runs-on: self-hosted
+    runs-on: [self-hosted, ubuntu-20.04]
     strategy:
       fail-fast: false
       matrix:

--- a/.github/workflows/job-precommit-python-interactive-runners.yml
+++ b/.github/workflows/job-precommit-python-interactive-runners.yml
@@ -45,7 +45,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
-          submodules: recursive
+          submodules: false
       - id: test-properties
         uses: ./.github/actions/setup-default-test-properties
 
@@ -64,7 +64,7 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
-          submodules: recursive
+          submodules: false
       - name: Set python version
         run: echo "PYTHON_VERSION=$(echo ${{ matrix.version }} | sed -e 's/\.//g')" >> $GITHUB_ENV
       - name: Setup environment

--- a/.github/workflows/job-precommit-python-interactive-runners.yml
+++ b/.github/workflows/job-precommit-python-interactive-runners.yml
@@ -1,0 +1,76 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# To learn more about GitHub Actions in Apache Beam check the CI.md
+
+# Runs PreCommit Python Runners Interactive scheduled on cron, on push to master and on pull request
+
+name: PreCommit Python Runners Interactive
+
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */6 * * *'
+  push:
+    branches: ['master', 'release-*']
+    tags: 'v*'
+  pull_request:
+    branches: ['master', 'release-*']
+    tags: 'v*'
+
+jobs:
+  set-properties:
+    runs-on: self-hosted
+    outputs:
+      properties: ${{ steps.test-properties.outputs.properties }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - id: test-properties
+        uses: ./.github/actions/setup-default-test-properties
+
+  precommit_python_runners-interactive:
+    needs: set-properties
+    name: PreCommit Python Runners Interactive
+    runs-on: self-hosted
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{fromJson(needs.set-properties.outputs.properties).PythonTestProperties.ALL_SUPPORTED_VERSIONS}}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v2
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - name: Set python version
+        run: echo "PYTHON_VERSION=$(echo ${{ matrix.version }} | sed -e 's/\.//g')" >> $GITHUB_ENV
+      - name: Setup environment
+        uses: ./.github/actions/setup-self-hosted-action
+      - name: Run :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cloud
+        uses: ./.github/actions/gradle-command-self-hosted-action
+        with:
+          gradle-command: :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cloud
+          arguments: "-Pposargs=apache_beam/runners/interactive/"
+      - name: Run :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cython
+        uses: ./.github/actions/gradle-command-self-hosted-action
+        with:
+          gradle-command: :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cython
+          arguments: "-Pposargs=apache_beam/runners/interactive/"

--- a/CI.md
+++ b/CI.md
@@ -125,28 +125,28 @@ Service Account shall have following permissions ([IAM roles](https://cloud.goog
 | Java Wordcount Direct Runner | Runs Java WordCount example with Direct Runner.                                               | Yes              | Yes                   | Yes           | -                        |
 | Java Wordcount Dataflow      | Runs Java WordCount example with DataFlow Runner.                                             | -                | Yes                   | Yes           | Yes                      |
 
+### All migrated workflows run based on the following triggers
+
+| Description | Pull Request Run | Direct Push/Merge Run | Scheduled Run | Workflow Dispatch |
+|-------------|------------------|-----------------------|---------------|-------------------|
+| PostCommit  | No               | Yes                   | Yes           | Yes               |
+| PreCommit   | Yes              | Yes                   | Yes           | Yes               |
+
 ### PreCommit Workflows
+| Workflow                                                                                                       | Description                               | Requires GCP Credentials |
+|----------------------------------------------------------------------------------------------------------------|-------------------------------------------|--------------------------|
+| [job-precommit-python-dataflow-runners.yml](.github/workflows/job-precommit-python-dataflow-runners.yml)       | Runs Python PreCommit Runners DataFlow    | No                       |
+| [job-precommit-python-direct-runners.yml](.github/workflows/job-precommit-python-direct-runners.yml)           | Runs Python PreCommit Runners Direct      | No                       |
+| [job-precommit-python-interactive-runners.yml](.github/workflows/job-precommit-python-interactive-runners.yml) | Runs Python PreCommit Runners Interactive | No                       |
 
-#### Python PreCommit Runners DataFlow - [job-precommit-python-dataflow-runners.yml](.github/workflows/job-precommit-python-dataflow-runners.yml)
-
-| Job                                   | Description                            | Pull Request Run | Direct Push/Merge Run | Scheduled Run | Requires GCP Credentials |
-|---------------------------------------|----------------------------------------|------------------|-----------------------|---------------|--------------------------|
-| Run Python PreCommit Runners DataFlow | Runs Python PreCommit Runners DataFlow | Yes              | Yes                   | Yes           | No                       |
-
-#### Python PreCommit Runners Direct - [job-precommit-python-direct-runners.yml](.github/workflows/job-precommit-python-direct-runners.yml)
-
-| Job                                  | Description                           | Pull Request Run | Direct Push/Merge Run | Scheduled Run | Requires GCP Credentials |
-|--------------------------------------|---------------------------------------|------------------|-----------------------|---------------|--------------------------|
-| Run Python PreCommit Runners Direct  | Runs Python PreCommit Runners Direct  | Yes              | Yes                   | Yes           | No                       |
-
-#### Python PreCommit Runners Interactive - [job-precommit-python-interactive-runners.yml](.github/workflows/job-precommit-python-interactive-runners.yml)
-
-| Job                                      | Description                               | Pull Request Run | Direct Push/Merge Run | Scheduled Run | Requires GCP Credentials |
-|------------------------------------------|-------------------------------------------|------------------|-----------------------|---------------|--------------------------|
-| Run Python PreCommit Runners Interactive | Runs Python PreCommit Runners Interactive | Yes              | Yes                   | Yes           | No                       |
+### PostCommit Workflows
+| Workflow                                                                           | Description             | Requires GCP Credentials |
+|------------------------------------------------------------------------------------|-------------------------|--------------------------|
+| [job-postcommit-placeholder.yml](.github/workflows/job-postcommit-placeholder.yml) | Description placeholder | Yes/No                   |
 
 ### GitHub Action Tips
 
+* All migrated workflows get executed on **pre-configured self-hosted** runners. For this reason, GCP credentials are **only** needed when running the workflows in a different runner.
 * If you introduce changes to the workflow it is possible that your changes will not be present in the check run triggered in Pull Request.
 In this case please attach link to the modified workflow run executed on your fork.
 * Possible timeouts with macOS runner - existing issue: [(X) This check failed - sometimes happens on macOS runner #841](https://github.com/actions/virtual-environments/issues/841)

--- a/CI.md
+++ b/CI.md
@@ -125,6 +125,26 @@ Service Account shall have following permissions ([IAM roles](https://cloud.goog
 | Java Wordcount Direct Runner | Runs Java WordCount example with Direct Runner.                                               | Yes              | Yes                   | Yes           | -                        |
 | Java Wordcount Dataflow      | Runs Java WordCount example with DataFlow Runner.                                             | -                | Yes                   | Yes           | Yes                      |
 
+### PreCommit Workflows
+
+#### Python PreCommit Runners DataFlow - [job-precommit-python-dataflow-runners.yml](.github/workflows/job-precommit-python-dataflow-runners.yml)
+
+| Job                                   | Description                            | Pull Request Run | Direct Push/Merge Run | Scheduled Run | Requires GCP Credentials |
+|---------------------------------------|----------------------------------------|------------------|-----------------------|---------------|--------------------------|
+| Run Python PreCommit Runners DataFlow | Runs Python PreCommit Runners DataFlow | Yes              | Yes                   | Yes           | No                       |
+
+#### Python PreCommit Runners Direct - [job-precommit-python-direct-runners.yml](.github/workflows/job-precommit-python-direct-runners.yml)
+
+| Job                                  | Description                           | Pull Request Run | Direct Push/Merge Run | Scheduled Run | Requires GCP Credentials |
+|--------------------------------------|---------------------------------------|------------------|-----------------------|---------------|--------------------------|
+| Run Python PreCommit Runners Direct  | Runs Python PreCommit Runners Direct  | Yes              | Yes                   | Yes           | No                       |
+
+#### Python PreCommit Runners Interactive - [job-precommit-python-interactive-runners.yml](.github/workflows/job-precommit-python-interactive-runners.yml)
+
+| Job                                      | Description                               | Pull Request Run | Direct Push/Merge Run | Scheduled Run | Requires GCP Credentials |
+|------------------------------------------|-------------------------------------------|------------------|-----------------------|---------------|--------------------------|
+| Run Python PreCommit Runners Interactive | Runs Python PreCommit Runners Interactive | Yes              | Yes                   | Yes           | No                       |
+
 ### GitHub Action Tips
 
 * If you introduce changes to the workflow it is possible that your changes will not be present in the check run triggered in Pull Request.


### PR DESCRIPTION
As part of the migration of Precommit and Postcommit Jobs from Jenkins to GA in self-hosted runners, this PR contains:

Migrated workflow [job-precommit-python-dataflow-runners](https://github.com/fernando-wizeline/beam/blob/gam-precommit-python-sharding-dataflow-direct-interactive-runners/.github/workflows/job-precommit-python-dataflow-runners.yml)
Migrated workflow [job-precommit-python-direct-runners](https://github.com/fernando-wizeline/beam/blob/gam-precommit-python-sharding-dataflow-direct-interactive-runners/.github/workflows/job-precommit-python-direct-runners.yml)
Migrated workflow [job-precommit-python-interactive-runners](https://github.com/fernando-wizeline/beam/blob/gam-precommit-python-sharding-dataflow-direct-interactive-runners/.github/workflows/job-precommit-python-interactive-runners.yml)

The migrated workflows were added to [CI.md](https://github.com/fernando-wizeline/beam/blob/gam-precommit-python-sharding-dataflow-direct-interactive-runners/CI.md)

DO NOT MERGE until the effort to use self-hosted runners is completed https://github.com/apache/beam/pull/22703
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
