### PR TITLE
Optimize varint reading and writing for small ints.

### DIFF
--- a/sdks/python/apache_beam/coders/stream.pyx
+++ b/sdks/python/apache_beam/coders/stream.pyx
@@ -59,6 +59,12 @@ cdef class OutputStream(object):
   cpdef write_var_int64(self, libc.stdint.int64_t signed_v):
     """Encode a long using variable-length encoding to a stream."""
     cdef libc.stdint.uint64_t v = signed_v
+    # Inline common case.
+    if v <= 0x7F and self.pos < self.buffer_size - 1:
+      self.data[self.pos] = v
+      self.pos += 1
+      return
+
     cdef long bits
     while True:
       bits = v & 0x7F
@@ -136,6 +142,9 @@ cdef class ByteCountingOutputStream(OutputStream):
       self.write_var_int64(blen)
     self.count += blen
 
+  cpdef write_var_int64(self, libc.stdint.int64_t signed_v):
+    self.count += get_varint_size(signed_v)
+
   cpdef write_byte(self, unsigned char _):
     self.count += 1
 
@@ -183,15 +192,16 @@ cdef class InputStream(object):
 
   cpdef libc.stdint.int64_t read_var_int64(self) except? -1:
     """Decode a variable-length encoded long from a stream."""
-    cdef long byte
+    # Inline common case.
+    cdef long byte = <unsigned char> self.allc[self.pos]
+    self.pos += 1
+    if byte < 0x7F:
+      return byte
+
     cdef libc.stdint.int64_t bits
     cdef long shift = 0
     cdef libc.stdint.int64_t result = 0
     while True:
-      byte = self.read_byte()
-      if byte < 0:
-        raise RuntimeError('VarInt not terminated.')
-
       bits = byte & 0x7F
       if (shift >= sizeof(libc.stdint.int64_t) * 8 or
           (shift >= (sizeof(libc.stdint.int64_t) * 8 - 1) and bits > 1)):
@@ -200,6 +210,10 @@ cdef class InputStream(object):
       shift += 7
       if not (byte & 0x80):
         break
+      byte = self.read_byte()
+      if byte < 0:
+        raise RuntimeError('VarInt not terminated.')
+
     return result
 
   cpdef libc.stdint.int64_t read_bigendian_int64(self) except? -1:

--- a/sdks/python/apache_beam/coders/stream.pyx
+++ b/sdks/python/apache_beam/coders/stream.pyx
@@ -195,7 +195,7 @@ cdef class InputStream(object):
     # Inline common case.
     cdef long byte = <unsigned char> self.allc[self.pos]
     self.pos += 1
-    if byte < 0x7F:
+    if byte <= 0x7F:
       return byte
 
     cdef libc.stdint.int64_t bits


### PR DESCRIPTION
This is used as a primitive for several other coders.

Before:

tiny_row, RowCoder, 1000 element(s)    : p. element median time cost: 7.22051e-07 sec, relative std: 12.45%
large_row, RowCoder, 1000 element(s)   : p. element median time cost: 3.12304e-06 sec, relative std: 5.01%
nullable_row, RowCoder, 1000 element(s): p. element median time cost: 3.27158e-06 sec, relative std: 6.49%
diverse_row, RowCoder, 1000 element(s) : p. element median time cost: 2.33555e-06 sec, relative std: 7.48%
small_int, FastPrimitivesCoder, 1000 element(s)                   : p. element median time cost: 1.66655e-07 sec, relative std: 9.18%
large_int, FastPrimitivesCoder, 1000 element(s)                   : p. element median time cost: 3.39985e-07 sec, relative std: 3.05%
small_int, LengthPrefixCoder[FastPrimitivesCoder], 1000 element(s): p. element median time cost: 5.70536e-07 sec, relative std: 4.27%
small_list, FastPrimitivesCoder, 1000 element(s)               : p. element median time cost: 1.57607e-06 sec, relative std: 3.05%
large_list, FastPrimitivesCoder, 1000 element(s)               : p. element median time cost: 4.76551e-05 sec, relative std: 4.31%
small_list, IterableCoder[FastPrimitivesCoder], 1000 element(s): p. element median time cost: 1.59943e-06 sec, relative std: 2.11%
large_list, IterableCoder[FastPrimitivesCoder], 1000 element(s): p. element median time cost: 4.66548e-05 sec, relative std: 3.59%

After:

tiny_row, RowCoder, 1000 element(s)    : p. element median time cost: 6.68406e-07 sec, relative std: 13.95%
large_row, RowCoder, 1000 element(s)   : p. element median time cost: 2.88701e-06 sec, relative std: 6.26%
nullable_row, RowCoder, 1000 element(s): p. element median time cost: 3.19052e-06 sec, relative std: 8.06%
diverse_row, RowCoder, 1000 element(s) : p. element median time cost: 2.24805e-06 sec, relative std: 6.15%
small_int, FastPrimitivesCoder, 1000 element(s)                   : p. element median time cost: 1.65582e-07 sec, relative std: 13.75%
large_int, FastPrimitivesCoder, 1000 element(s)                   : p. element median time cost: 3.14236e-07 sec, relative std: 6.83%
small_int, LengthPrefixCoder[FastPrimitivesCoder], 1000 element(s): p. element median time cost: 5.85556e-07 sec, relative std: 4.98%
small_list, FastPrimitivesCoder, 1000 element(s)               : p. element median time cost: 1.48404e-06 sec, relative std: 42.11%
large_list, FastPrimitivesCoder, 1000 element(s)               : p. element median time cost: 4.77622e-05 sec, relative std: 4.20%
small_list, IterableCoder[FastPrimitivesCoder], 1000 element(s): p. element median time cost: 1.50216e-06 sec, relative std: 1.90%
large_list, IterableCoder[FastPrimitivesCoder], 1000 element(s): p. element median time cost: 4.57406e-05 sec, relative std: 3.11%


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
