### PR TITLE
[Website] Correct spelling of structural

### DIFF
--- a/website/www/site/content/en/documentation/programming-guide.md
+++ b/website/www/site/content/en/documentation/programming-guide.md
@@ -1971,7 +1971,7 @@ as `DoFn`, `CombineFn`, and `WindowFn`, already implement `Serializable`;
 however, your subclass must not add any non-serializable members.</span>
 <span class="language-go">Funcs are serializable as long as
 they are registered with `register.FunctionXxY` (for simple functions) or
-`register.DoFnXxY` (for sturctural DoFns), and are not closures. Structural
+`register.DoFnXxY` (for structural DoFns), and are not closures. Structural
 `DoFn`s will have all exported fields serialized. Unexported fields are unable to
 be serialized, and will be silently ignored.</span>
 <span class="language-typescript">


### PR DESCRIPTION
Change "sturctural" to "structural"


 - R:@bullet03
