### PR TITLE
Track time on Cloud Dataflow streaming data reads and export via heartbeats

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/FakeWindmillServer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/FakeWindmillServer.java
@@ -280,7 +280,16 @@ class FakeWindmillServer extends WindmillServerStub {
       }
 
       @Override
-      public void refreshActiveWork(Map<String, List<KeyedGetDataRequest>> active) {}
+      public void refreshActiveWork(Map<String, List<KeyedGetDataRequest>> active) {
+        Windmill.GetDataRequest.Builder builder = Windmill.GetDataRequest.newBuilder();
+        for (Map.Entry<String, List<KeyedGetDataRequest>> entry : active.entrySet()) {
+          builder.addRequests(
+              ComputationGetDataRequest.newBuilder()
+                  .setComputationId(entry.getKey())
+                  .addAllRequests(entry.getValue()));
+        }
+        getData(builder.build());
+      }
 
       @Override
       public void close() {}

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/FakeWindmillServer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/FakeWindmillServer.java
@@ -52,6 +52,7 @@ import org.apache.beam.runners.dataflow.worker.windmill.Windmill.WorkItemCommitR
 import org.apache.beam.runners.dataflow.worker.windmill.WindmillServerStub;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.net.HostAndPort;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.util.concurrent.Uninterruptibles;
+import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.junit.rules.ErrorCollector;
 import org.slf4j.Logger;
@@ -61,8 +62,48 @@ import org.slf4j.LoggerFactory;
 class FakeWindmillServer extends WindmillServerStub {
   private static final Logger LOG = LoggerFactory.getLogger(FakeWindmillServer.class);
 
+  static class ResponseQueue<T, U> {
+    private final Queue<Function<T, U>> responses = new ConcurrentLinkedQueue<>();
+    private Function<T, U> defaultResponse;
+    Duration sleep = Duration.ZERO;
+
+    // (Fluent) interface for response producers, accessible from tests.
+
+    ResponseQueue<T, U> thenAnswer(Function<T, U> mapFun) {
+      responses.add(mapFun);
+      return this;
+    }
+
+    ResponseQueue<T, U> thenReturn(U response) {
+      return thenAnswer((request) -> response);
+    }
+
+    ResponseQueue<T, U> answerByDefault(Function<T, U> mapFun) {
+      defaultResponse = mapFun;
+      return this;
+    }
+
+    ResponseQueue<T, U> returnByDefault(U response) {
+      return answerByDefault((request) -> response);
+    }
+
+    ResponseQueue<T, U> delayEachResponseBy(Duration sleep) {
+      this.sleep = sleep;
+      return this;
+    }
+
+    // Interface for response consumers, accessible from the enclosing class.
+
+    private U getOrDefault(T request) {
+      Function<T, U> mapFun = responses.poll();
+      U response = mapFun == null ? defaultResponse.apply(request) : mapFun.apply(request);
+      Uninterruptibles.sleepUninterruptibly(sleep.getMillis(), TimeUnit.MILLISECONDS);
+      return response;
+    }
+  }
+
   private final Queue<Windmill.GetWorkResponse> workToOffer;
-  private final Queue<Function<GetDataRequest, GetDataResponse>> dataToOffer;
+  private final ResponseQueue<GetDataRequest, GetDataResponse> dataToOffer;
   // Keys are work tokens.
   private final Map<Long, WorkItemCommitRequest> commitsReceived;
   private final ArrayList<Windmill.ReportStatsRequest> statsReceived;
@@ -77,7 +118,11 @@ class FakeWindmillServer extends WindmillServerStub {
 
   public FakeWindmillServer(ErrorCollector errorCollector) {
     workToOffer = new ConcurrentLinkedQueue<>();
-    dataToOffer = new ConcurrentLinkedQueue<>();
+    dataToOffer =
+        new ResponseQueue<GetDataRequest, GetDataResponse>()
+            .returnByDefault(GetDataResponse.getDefaultInstance())
+            // Sleep for a little bit to ensure that *-windmill-read state-sampled counters show up.
+            .delayEachResponseBy(Duration.millis(500));
     commitsReceived = new ConcurrentHashMap<>();
     exceptions = new LinkedBlockingQueue<>();
     expectedExceptionCount = new AtomicInteger();
@@ -94,12 +139,8 @@ class FakeWindmillServer extends WindmillServerStub {
     workToOffer.add(work);
   }
 
-  public void addDataToOffer(Windmill.GetDataResponse data) {
-    dataToOffer.add((GetDataRequest request) -> data);
-  }
-
-  public void addDataFnToOffer(Function<GetDataRequest, GetDataResponse> f) {
-    dataToOffer.add(f);
+  public ResponseQueue<GetDataRequest, GetDataResponse> whenGetDataCalled() {
+    return dataToOffer;
   }
 
   @Override
@@ -129,20 +170,7 @@ class FakeWindmillServer extends WindmillServerStub {
     LOG.info("getDataRequest: {}", request.toString());
     validateGetDataRequest(request);
     ++numGetDataRequests;
-    GetDataResponse response;
-    Function<GetDataRequest, GetDataResponse> responseFn = dataToOffer.poll();
-    if (responseFn == null) {
-      response = Windmill.GetDataResponse.newBuilder().build();
-    } else {
-      response = responseFn.apply(request);
-      try {
-        // Sleep for a little bit to ensure that *-windmill-read state-sampled counters
-        // show up.
-        sleepMillis(500);
-      } catch (InterruptedException e) {
-        Thread.currentThread().interrupt();
-      }
-    }
+    GetDataResponse response = dataToOffer.getOrDefault(request);
     LOG.debug("getDataResponse: {}", response.toString());
     return response;
   }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
@@ -3068,10 +3068,6 @@ public class StreamingDataflowWorkerTest {
 
   @Test
   public void testActiveWorkRefresh() throws Exception {
-    if (streamingEngine) {
-      // TODO: This test needs to be adapted to work with streamingEngine=true.
-      return;
-    }
     List<ParallelInstruction> instructions =
         Arrays.asList(
             makeSourceInstruction(StringUtf8Coder.of()),

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
@@ -1668,7 +1668,7 @@ public class StreamingDataflowWorkerTest {
         .getValueBuilder()
         .setTimestamp(0)
         .setData(ByteString.EMPTY);
-    server.addDataToOffer(dataResponse.build());
+    server.whenGetDataCalled().thenReturn(dataResponse.build());
 
     expectedBytesRead += dataBuilder.build().getSerializedSize();
 
@@ -1965,7 +1965,7 @@ public class StreamingDataflowWorkerTest {
         .getValueBuilder()
         .setTimestamp(0)
         .setData(ByteString.EMPTY);
-    server.addDataToOffer(dataResponse.build());
+    server.whenGetDataCalled().thenReturn(dataResponse.build());
 
     expectedBytesRead += dataBuilder.build().getSerializedSize();
 
@@ -2135,9 +2135,7 @@ public class StreamingDataflowWorkerTest {
     worker.start();
 
     // Respond to any GetData requests with empty state.
-    for (int i = 0; i < 1000; ++i) {
-      server.addDataFnToOffer(EMPTY_DATA_RESPONDER);
-    }
+    server.whenGetDataCalled().answerByDefault(EMPTY_DATA_RESPONDER);
 
     for (int i = 0; i < actions.size(); ++i) {
       Action action = actions.get(i);
@@ -2920,7 +2918,7 @@ public class StreamingDataflowWorkerTest {
           .getValueBuilder()
           .setTimestamp(0)
           .setData(state);
-      server.addDataToOffer(dataResponse.build());
+      server.whenGetDataCalled().thenReturn(dataResponse.build());
     }
 
     // Three GetWork requests and commits

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
@@ -687,7 +687,8 @@ public class StreamingDataflowWorkerTest {
   private StreamingDataflowWorker makeWorker(
       List<ParallelInstruction> instructions,
       StreamingDataflowWorkerOptions options,
-      boolean publishCounters)
+      boolean publishCounters,
+      Supplier<Instant> clock)
       throws Exception {
     StreamingDataflowWorker worker =
         new StreamingDataflowWorker(
@@ -698,10 +699,19 @@ public class StreamingDataflowWorkerTest {
             null /* pipeline */,
             SdkHarnessRegistries.emptySdkHarnessRegistry(),
             publishCounters,
-            hotKeyLogger);
+            hotKeyLogger,
+            clock);
     worker.addStateNameMappings(
         ImmutableMap.of(DEFAULT_PARDO_USER_NAME, DEFAULT_PARDO_STATE_FAMILY));
     return worker;
+  }
+
+  private StreamingDataflowWorker makeWorker(
+      List<ParallelInstruction> instructions,
+      StreamingDataflowWorkerOptions options,
+      boolean publishCounters)
+      throws Exception {
+    return makeWorker(instructions, options, publishCounters, Instant::now);
   }
 
   @Test
@@ -2672,7 +2682,8 @@ public class StreamingDataflowWorkerTest {
 
     public MockWork(long workToken) {
       super(
-          Windmill.WorkItem.newBuilder().setKey(ByteString.EMPTY).setWorkToken(workToken).build());
+          Windmill.WorkItem.newBuilder().setKey(ByteString.EMPTY).setWorkToken(workToken).build(),
+          Instant::now);
     }
 
     @Override


### PR DESCRIPTION
This change affects google-cloud-dataflow-runner only. It
1. adds a new state 'READING' to `StreamingDataflowWorker.Work.State,`
2. extends StreamingDataflowWorker.Work to track time spent in each state,
3. populates KeyedGetDataRequest heartbeats to forward the time spend in each Work.State to Google Cloud Dataflow.

This change addresses #23262