### PR TITLE
Fix failing Py37 BQ file loads test

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -329,25 +329,11 @@ tasks.register("pythonFormatterPreCommit") {
 }
 
 tasks.register("python37PostCommit") {
-  dependsOn(":sdks:python:test-suites:dataflow:py37:postCommitIT")
-  dependsOn(":sdks:python:test-suites:direct:py37:postCommitIT")
   dependsOn(":sdks:python:test-suites:direct:py37:directRunnerIT")
-  dependsOn(":sdks:python:test-suites:direct:py37:hdfsIntegrationTest")
-  dependsOn(":sdks:python:test-suites:direct:py37:mongodbioIT")
-  dependsOn(":sdks:python:test-suites:portable:py37:postCommitPy37")
-  dependsOn(":sdks:python:test-suites:dataflow:py37:spannerioIT")
-  dependsOn(":sdks:python:test-suites:direct:py37:spannerioIT")
-  dependsOn(":sdks:python:test-suites:portable:py37:xlangSpannerIOIT")
-  dependsOn(":sdks:python:test-suites:direct:py37:inferencePostCommitIT")
 }
 
 tasks.register("python38PostCommit") {
-  dependsOn(":sdks:python:test-suites:dataflow:py38:postCommitIT")
-  dependsOn(":sdks:python:test-suites:direct:py38:postCommitIT")
-  dependsOn(":sdks:python:test-suites:direct:py38:hdfsIntegrationTest")
-  dependsOn(":sdks:python:test-suites:portable:py38:postCommitPy38")
-  // TODO: https://github.com/apache/beam/issues/22651
-  dependsOn(":sdks:python:test-suites:dataflow:py38:inferencePostCommitIT")
+  dependsOn(":sdks:python:test-suites:direct:py38:directRunnerIT")
 }
 
 tasks.register("python39PostCommit") {

--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -329,11 +329,25 @@ tasks.register("pythonFormatterPreCommit") {
 }
 
 tasks.register("python37PostCommit") {
+  dependsOn(":sdks:python:test-suites:dataflow:py37:postCommitIT")
+  dependsOn(":sdks:python:test-suites:direct:py37:postCommitIT")
   dependsOn(":sdks:python:test-suites:direct:py37:directRunnerIT")
+  dependsOn(":sdks:python:test-suites:direct:py37:hdfsIntegrationTest")
+  dependsOn(":sdks:python:test-suites:direct:py37:mongodbioIT")
+  dependsOn(":sdks:python:test-suites:portable:py37:postCommitPy37")
+  dependsOn(":sdks:python:test-suites:dataflow:py37:spannerioIT")
+  dependsOn(":sdks:python:test-suites:direct:py37:spannerioIT")
+  dependsOn(":sdks:python:test-suites:portable:py37:xlangSpannerIOIT")
+  dependsOn(":sdks:python:test-suites:direct:py37:inferencePostCommitIT")
 }
 
 tasks.register("python38PostCommit") {
-  dependsOn(":sdks:python:test-suites:direct:py38:directRunnerIT")
+  dependsOn(":sdks:python:test-suites:dataflow:py38:postCommitIT")
+  dependsOn(":sdks:python:test-suites:direct:py38:postCommitIT")
+  dependsOn(":sdks:python:test-suites:direct:py38:hdfsIntegrationTest")
+  dependsOn(":sdks:python:test-suites:portable:py38:postCommitPy38")
+  // TODO: https://github.com/apache/beam/issues/22651
+  dependsOn(":sdks:python:test-suites:dataflow:py38:inferencePostCommitIT")
 }
 
 tasks.register("python39PostCommit") {

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
@@ -932,11 +932,12 @@ class BigQueryFileLoadsIT(unittest.TestCase):
     bq_matcher = BigqueryFullResultStreamingMatcher(
         project=self.project,
         query="SELECT Integr FROM %s" % output_table,
-        data=[(i, ) for i in range(100)],
-        timeout=30)
+        data=[(i, ) for i in range(100)])
 
     args = self.test_pipeline.get_full_options_as_args(
-        streaming=True, allow_unsafe_triggers=True)
+        on_success_matcher=bq_matcher,
+        streaming=True,
+        allow_unsafe_triggers=True)
     with beam.Pipeline(argv=args) as p:
       stream_source = (
           TestStream().advance_watermark_to(0).advance_processing_time(
@@ -973,7 +974,9 @@ class BigQueryFileLoadsIT(unittest.TestCase):
         data=[(i, ) for i in range(100)])
 
     args = self.test_pipeline.get_full_options_as_args(
-        streaming=True, allow_unsafe_triggers=True)
+        on_success_matcher=bq_matcher,
+        streaming=True,
+        allow_unsafe_triggers=True)
 
     # Override these parameters to induce copy jobs
     bqfl._DEFAULT_MAX_FILE_SIZE = 100
@@ -1025,7 +1028,9 @@ class BigQueryFileLoadsIT(unittest.TestCase):
     ]
 
     args = self.test_pipeline.get_full_options_as_args(
-        streaming=True, allow_unsafe_triggers=True)
+        on_success_matcher=all_of(*pipeline_verifiers),
+        streaming=True,
+        allow_unsafe_triggers=True)
 
     with beam.Pipeline(argv=args) as p:
       stream_source = (

--- a/sdks/python/test-suites/direct/common.gradle
+++ b/sdks/python/test-suites/direct/common.gradle
@@ -163,7 +163,7 @@ tasks.register("directRunnerIT") {
         "apache_beam/io/gcp/bigquery_test.py::PubSubBigQueryIT",
         "apache_beam/io/gcp/bigquery_file_loads_test.py::BigQueryFileLoadsIT::test_bqfl_streaming",
         "apache_beam/io/gcp/bigquery_file_loads_test.py::BigQueryFileLoadsIT::test_bqfl_streaming_with_dynamic_destinations",
-        "apache_beam/io/gcp/bigquery_file_loads_test.py::BigQueryFileLoadsIT::test_one_job_fails_all_jobs_fail",
+        "apache_beam/io/gcp/bigquery_file_loads_test.py::BigQueryFileLoadsIT::test_bqfl_streaming_with_copy_jobs",
     ]
     def streamingTestOpts = basicTestOpts + ["${tests.join(' ')}"]
     def argMap = ["runner": "TestDirectRunner",

--- a/sdks/python/test-suites/direct/common.gradle
+++ b/sdks/python/test-suites/direct/common.gradle
@@ -162,6 +162,8 @@ tasks.register("directRunnerIT") {
         "apache_beam/io/gcp/bigquery_test.py::BigQueryStreamingInsertTransformIntegrationTests::test_multiple_destinations_transform",
         "apache_beam/io/gcp/bigquery_test.py::PubSubBigQueryIT",
         "apache_beam/io/gcp/bigquery_file_loads_test.py::BigQueryFileLoadsIT::test_bqfl_streaming",
+        "apache_beam/io/gcp/bigquery_file_loads_test.py::BigQueryFileLoadsIT::test_bqfl_streaming_with_dynamic_destinations",
+        "apache_beam/io/gcp/bigquery_file_loads_test.py::BigQueryFileLoadsIT::test_one_job_fails_all_jobs_fail",
     ]
     def streamingTestOpts = basicTestOpts + ["${tests.join(' ')}"]
     def argMap = ["runner": "TestDirectRunner",


### PR DESCRIPTION
Fixes #23264

In #23012, testing with `on_success_matcher` is switched out for `hamcrest_assert(p, bq_matcher)` because it is less noisy and more accurate.

However, [PostCommits test with `TestDirectRunner`](https://github.com/apache/beam/blob/468e02b7c1f41f25543edbafb84becb07974eebe/sdks/python/test-suites/direct/common.gradle#L169-L177). The problem is that `TestDirectRunner` does not run the pipeline without the `on_success_matcher` argument. 

Error results because `hamcrest_assert` queries a table that the pipeline is supposed to create. Pipeline doesn't run so results in 404 error.