### PR TITLE
GA Migration Python PreCommit Sharding Runners Portability Flink

### DIFF
--- a/.github/workflows/job-precommit-python-runners-portability-flink.yml
+++ b/.github/workflows/job-precommit-python-runners-portability-flink.yml
@@ -20,17 +20,18 @@
 
 name: Python Precommit Runners Portability Flink
 on:
-  workflow_dispatch:
   schedule:
     - cron: '0 */6 * * *'
   push:
     branches: ['master', 'release-*']
     tags: ['v*']
-  pull_request:
+  pull_request_target:
     branches: ['master', 'release-*']
     tags: ['v*']
-    #paths: ['sdks/python/apache_beam/examples/**',
-    #        'sdks/python/apache_beam/examples/**']
+    paths: ['sdks/python/apache_beam/runners/portability/flink_runner.py',
+            'sdks/python/apache_beam/runners/portability/flink_runner_test.py',
+            'sdks/python/apache_beam/runners/portability/flink_uber_jar_job_server.py',
+            'sdks/python/apache_beam/runners/portability/flink_uber_jar_job_server_test.py']
 permissions: read-all
 
 env:
@@ -41,13 +42,14 @@ env:
 
 jobs:
   set-properties:
-    runs-on: self-hosted
+    runs-on: [self-hosted, ubuntu-20.04]
     outputs:
       properties: ${{ steps.test-properties.outputs.properties }}
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
           submodules: recursive
       - id: test-properties
@@ -65,6 +67,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v3
         with:
+          ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
           submodules: recursive
       - name: Set python version and tox env

--- a/.github/workflows/job-precommit-python-runners-portability-flink.yml
+++ b/.github/workflows/job-precommit-python-runners-portability-flink.yml
@@ -1,0 +1,84 @@
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+
+# Test for Python Precommit Runners Portability Flink
+
+
+name: Python Precommit Runners Portability Flink
+on:
+  workflow_dispatch:
+  schedule:
+    - cron: '0 */6 * * *'
+  push:
+    branches: ['master', 'release-*']
+    tags: ['v*']
+  pull_request:
+    branches: ['master', 'release-*']
+    tags: ['v*']
+    #paths: ['sdks/python/apache_beam/examples/**',
+    #        'sdks/python/apache_beam/examples/**']
+permissions: read-all
+
+env:
+  tests: "'apache_beam/runners/portability/flink_runner.py \
+  apache_beam/runners/portability/flink_runner_test.py \
+  apache_beam/runners/portability/flink_uber_jar_job_server.py \
+  apache_beam/runners/portability/flink_uber_jar_job_server_test.py'"
+
+jobs:
+  set-properties:
+    runs-on: self-hosted
+    outputs:
+      properties: ${{ steps.test-properties.outputs.properties }}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - id: test-properties
+        uses: ./.github/actions/setup-default-test-properties
+
+  runners_portability_flink:
+    needs: set-properties
+    name: Python Runners Portability Flink
+    runs-on: self-hosted
+    strategy:
+      fail-fast: false
+      matrix:
+        version: ${{fromJson(needs.set-properties.outputs.properties).PythonTestProperties.ALL_SUPPORTED_VERSIONS}}
+    steps:
+      - name: Checkout code
+        uses: actions/checkout@v3
+        with:
+          persist-credentials: false
+          submodules: recursive
+      - name: Set python version and tox env
+        run: |
+          echo "PYTHON_VERSION=$(echo ${{ matrix.version }} | sed -e 's/\.//g')" >> $GITHUB_ENV
+      - name: Setup environment
+        uses: ./.github/actions/setup-self-hosted-action
+      - name: Run :sdks:python:test-suites:tox:${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cloud
+        uses: ./.github/actions/gradle-command-self-hosted-action
+        with:
+          gradle-command: :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cloud
+          arguments: "-Pposargs=${{env.tests}}"
+      - name: Run :sdks:python:test-suites:tox:y${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cython
+        uses: ./.github/actions/gradle-command-self-hosted-action
+        with:
+          gradle-command: :sdks:python:test-suites:tox:py${{ env.PYTHON_VERSION }}:testPy${{ env.PYTHON_VERSION }}Cython
+          arguments: "-Pposargs=${{env.tests}}"

--- a/.github/workflows/job-precommit-python-runners-portability-flink.yml
+++ b/.github/workflows/job-precommit-python-runners-portability-flink.yml
@@ -25,6 +25,10 @@ on:
   push:
     branches: ['master', 'release-*']
     tags: ['v*']
+    paths: [ 'sdks/python/apache_beam/runners/portability/flink_runner.py',
+             'sdks/python/apache_beam/runners/portability/flink_runner_test.py',
+             'sdks/python/apache_beam/runners/portability/flink_uber_jar_job_server.py',
+             'sdks/python/apache_beam/runners/portability/flink_uber_jar_job_server_test.py' ]
   pull_request_target:
     branches: ['master', 'release-*']
     tags: ['v*']

--- a/.github/workflows/job-precommit-python-runners-portability-flink.yml
+++ b/.github/workflows/job-precommit-python-runners-portability-flink.yml
@@ -55,7 +55,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
-          submodules: recursive
       - id: test-properties
         uses: ./.github/actions/setup-default-test-properties
 
@@ -73,7 +72,6 @@ jobs:
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           persist-credentials: false
-          submodules: recursive
       - name: Set python version and tox env
         run: |
           echo "PYTHON_VERSION=$(echo ${{ matrix.version }} | sed -e 's/\.//g')" >> $GITHUB_ENV

--- a/CI.md
+++ b/CI.md
@@ -135,7 +135,7 @@ Service Account shall have following permissions ([IAM roles](https://cloud.goog
 ### PreCommit Workflows
 | Workflow                                                                         | Description             | Requires GCP Credentials  |
 |----------------------------------------------------------------------------------|-------------------------|---------------------------|
-| [job-precommit-placeholder.yml](.github/workflows/job-precommit-placeholder.yml) | Description placeholder | Yes/No                    |
+| [job-precommit-python-runners-portability-flink.yml](.github/workflows/job-precommit-python-runners-portability-flink.yml) | Run Python Precommit Runners Portability Flink | Yes/No                    |
 
 ### PostCommit Workflows
 | Workflow                                                                           | Description             | Requires GCP Credentials |


### PR DESCRIPTION
As part of the migration of Precommit and Postcommit Jobs from Jenkins to GA in self-hosted runners, this PR contains:

- Migrated workflow [job-precommit-python-runners-portability-flink.yml](https://github.com/apache/beam/blob/4d2bba1d60e56386e2c7fe57406398ff0ea4c9b4/.github/workflows/job-precommit-python-runners-portability-flink.yml)

The migrated workflow was added to [CI.md](https://github.com/apache/beam/blob/4d2bba1d60e56386e2c7fe57406398ff0ea4c9b4/CI.md)

`DO NOT MERGE` until the effort to use self-hosted runners is completed https://github.com/apache/beam/pull/22703

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
