### PR TITLE
Fix TextSource incorrect handling in channels that return short reads.

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOReadTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOReadTest.java
@@ -389,6 +389,8 @@ public class TextIOReadTest {
               FileSystems.matchSingleFileSpec(source.getFileOrPatternSpec()).resourceId());
       InputStream stream = Channels.newInputStream(channel);
       reader.startReading(
+          // Placeholder channel that only yields 0- and 1-length buffers.
+          // Data is read at most one byte at a time from line parameter.
           new ReadableByteChannel() {
             int readCount = 0;
 
@@ -492,6 +494,8 @@ public class TextIOReadTest {
               FileSystems.matchSingleFileSpec(source.getFileOrPatternSpec()).resourceId());
       InputStream stream = Channels.newInputStream(channel);
       reader.startReading(
+          // Placeholder channel that only yields 0- and 1-length buffers.
+          // Data is read at most one byte at a time from testCase parameter.
           new ReadableByteChannel() {
             int readCount = 0;
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOReadTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/TextIOReadTest.java
@@ -43,9 +43,13 @@ import java.io.BufferedWriter;
 import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
+import java.io.InputStream;
 import java.io.OutputStream;
 import java.io.PrintStream;
 import java.io.Writer;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
 import java.nio.charset.Charset;
 import java.nio.file.Files;
 import java.nio.file.Path;
@@ -59,7 +63,9 @@ import java.util.zip.ZipOutputStream;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.io.FileBasedSource.FileBasedReader;
 import org.apache.beam.sdk.io.fs.EmptyMatchTreatment;
+import org.apache.beam.sdk.io.fs.MatchResult.Metadata;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.ValueProvider;
@@ -337,7 +343,7 @@ public class TextIOReadTest {
 
   /** Tests for reading files with various delimiters. */
   @RunWith(Parameterized.class)
-  public static class ReadWithDelimiterTest {
+  public static class ReadWithDefaultDelimiterTest {
     private static final ImmutableList<String> EXPECTED = ImmutableList.of("asdf", "hjkl", "xyz");
     @Rule public TemporaryFolder tempFolder = new TemporaryFolder();
 
@@ -363,8 +369,55 @@ public class TextIOReadTest {
     public ImmutableList<String> expected;
 
     @Test
-    public void testReadLinesWithDelimiter() throws Exception {
+    public void testReadLinesWithDefaultDelimiter() throws Exception {
       runTestReadWithData(line.getBytes(UTF_8), expected);
+    }
+
+    @Test
+    public void testReadLinesWithDefaultDelimiterAndZeroAndOneLengthReturningChannel()
+        throws Exception {
+      Path path = tempFolder.newFile().toPath();
+      Files.write(path, line.getBytes(UTF_8));
+      Metadata metadata = FileSystems.matchSingleFileSpec(path.toString());
+      FileBasedSource source =
+          getTextSource(path.toString(), null)
+              .createForSubrangeOfFile(metadata, 0, metadata.sizeBytes());
+      FileBasedReader<String> reader =
+          source.createSingleFileReader(PipelineOptionsFactory.create());
+      ReadableByteChannel channel =
+          FileSystems.open(
+              FileSystems.matchSingleFileSpec(source.getFileOrPatternSpec()).resourceId());
+      InputStream stream = Channels.newInputStream(channel);
+      reader.startReading(
+          new ReadableByteChannel() {
+            int readCount = 0;
+
+            @Override
+            public int read(ByteBuffer dst) throws IOException {
+              if (++readCount % 3 == 0) {
+                if (dst.hasRemaining()) {
+                  int value = stream.read();
+                  if (value == -1) {
+                    return -1;
+                  }
+                  dst.put((byte) value);
+                  return 1;
+                }
+              }
+              return 0;
+            }
+
+            @Override
+            public boolean isOpen() {
+              return channel.isOpen();
+            }
+
+            @Override
+            public void close() throws IOException {
+              stream.close();
+            }
+          });
+      assertEquals(expected, SourceTestUtils.readFromStartedReader(reader));
     }
 
     @Test
@@ -420,6 +473,56 @@ public class TextIOReadTest {
       SourceTestUtils.assertSplitAtFractionExhaustive(
           TextIOReadTest.prepareSource(tempFolder, testCase.getBytes(UTF_8), new byte[] {'|', '*'}),
           PipelineOptionsFactory.create());
+    }
+
+    @Test
+    public void testReadLinesWithCustomDelimiterAndZeroAndOneLengthReturningChannel()
+        throws Exception {
+      byte[] delimiter = new byte[] {'|', '*'};
+      Path path = tempFolder.newFile().toPath();
+      Files.write(path, testCase.getBytes(UTF_8));
+      Metadata metadata = FileSystems.matchSingleFileSpec(path.toString());
+      FileBasedSource source =
+          getTextSource(path.toString(), delimiter)
+              .createForSubrangeOfFile(metadata, 0, metadata.sizeBytes());
+      FileBasedReader<String> reader =
+          source.createSingleFileReader(PipelineOptionsFactory.create());
+      ReadableByteChannel channel =
+          FileSystems.open(
+              FileSystems.matchSingleFileSpec(source.getFileOrPatternSpec()).resourceId());
+      InputStream stream = Channels.newInputStream(channel);
+      reader.startReading(
+          new ReadableByteChannel() {
+            int readCount = 0;
+
+            @Override
+            public int read(ByteBuffer dst) throws IOException {
+              if (++readCount % 3 == 0) {
+                if (dst.hasRemaining()) {
+                  int value = stream.read();
+                  if (value == -1) {
+                    return -1;
+                  }
+                  dst.put((byte) value);
+                  return 1;
+                }
+              }
+              return 0;
+            }
+
+            @Override
+            public boolean isOpen() {
+              return channel.isOpen();
+            }
+
+            @Override
+            public void close() throws IOException {
+              stream.close();
+            }
+          });
+      assertEquals(
+          SourceTestUtils.readFromSource(source, PipelineOptionsFactory.create()),
+          SourceTestUtils.readFromStartedReader(reader));
     }
   }
 


### PR DESCRIPTION
The issue is that readDefaultLine and readCustomLine was incorrectly calculating the appendLength when the buffer returned was 0 length. This was solved by ensuring that the internal read loop always read at least one byte allowing for the code to ensure that we were making progress. For readDefaultLine we kept track of whether we need to skip an LF in the next buffer if the current buffer ended with a CR and for readCustomLine we had to remember how much of the delimiter we have read so far in this buffer.

The bug was introduced in https://github.com/apache/beam/commit/30a48f05cf2ee0eea0a304fea01eb40f323f9f3c

There was no noticeable change in the TextSourceBenchmark performance results.

Fixes #23375

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
