### PR TITLE
Include the GCP scope when creating a scoped credential token.

### DIFF
--- a/sdks/python/apache_beam/internal/gcp/auth.py
+++ b/sdks/python/apache_beam/internal/gcp/auth.py
@@ -45,6 +45,7 @@ executing_project = None
 _LOGGER = logging.getLogger(__name__)
 
 CLIENT_SCOPES = [
+    'https://www.googleapis.com/auth/cloud-platform',
     'https://www.googleapis.com/auth/bigquery',
     'https://www.googleapis.com/auth/cloud-platform',
     'https://www.googleapis.com/auth/devstorage.full_control',


### PR DESCRIPTION
It's recommended to use GCP scope in clients talking to GCP: https://cloud.google.com/compute/docs/access/service-accounts#accesscopesiam . This scope is used in Java SDK: https://github.com/apache/beam/blob/master/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/auth/GcpCredentialFactory.java#L47