### PR TITLE
Support keyed executors in Samza Runner to process bundles for stateful ParDo

### DIFF
--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/AsyncDoFnRunner.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/AsyncDoFnRunner.java
@@ -59,8 +59,7 @@ public class AsyncDoFnRunner<InT, OutT> implements DoFnRunner<InT, OutT> {
    * all futures of a key have been complete, the key entry will be removed. The map is bounded by
    * (bundle size * 2).
    */
-  private final @Nullable Map<Object, CompletableFuture<Collection<WindowedValue<OutT>>>>
-      keyedOutputFutures;
+  private final Map<Object, CompletableFuture<Collection<WindowedValue<OutT>>>> keyedOutputFutures;
 
   public static <InT, OutT> AsyncDoFnRunner<InT, OutT> create(
       DoFnRunner<InT, OutT> runner,
@@ -84,7 +83,7 @@ public class AsyncDoFnRunner<InT, OutT> implements DoFnRunner<InT, OutT> {
     this.emitter = emitter;
     this.futureCollector = futureCollector;
     this.isStateful = isStateful;
-    this.keyedOutputFutures = isStateful ? new ConcurrentHashMap<>() : null;
+    this.keyedOutputFutures = new ConcurrentHashMap<>();
   }
 
   @Override
@@ -175,7 +174,12 @@ public class AsyncDoFnRunner<InT, OutT> implements DoFnRunner<InT, OutT> {
   }
 
   private Object getKey(WindowedValue<InT> elem) {
-    Object key = ((KV) elem.getValue()).getKey();
-    return key == null ? NULL_KEY : key;
+    KV<?, ?> kv = (KV<?, ?>) elem.getValue();
+    if (kv == null) {
+      return NULL_KEY;
+    } else {
+      Object key = kv.getKey();
+      return key == null ? NULL_KEY : key;
+    }
   }
 }

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/AsyncDoFnRunner.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/AsyncDoFnRunner.java
@@ -31,6 +31,7 @@ import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.KV;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -58,7 +59,8 @@ public class AsyncDoFnRunner<InT, OutT> implements DoFnRunner<InT, OutT> {
    * all futures of a key have been complete, the key entry will be removed. The map is bounded by
    * (bundle size * 2).
    */
-  private final Map<Object, CompletableFuture<Collection<WindowedValue<OutT>>>> keyedOutputFutures;
+  private final @Nullable Map<Object, CompletableFuture<Collection<WindowedValue<OutT>>>>
+      keyedOutputFutures;
 
   public static <InT, OutT> AsyncDoFnRunner<InT, OutT> create(
       DoFnRunner<InT, OutT> runner,
@@ -100,7 +102,7 @@ public class AsyncDoFnRunner<InT, OutT> implements DoFnRunner<InT, OutT> {
 
   private CompletableFuture<Collection<WindowedValue<OutT>>> processElement(
       WindowedValue<InT> elem,
-      CompletableFuture<Collection<WindowedValue<OutT>>> prevOutputFuture) {
+      @Nullable CompletableFuture<Collection<WindowedValue<OutT>>> prevOutputFuture) {
 
     final CompletableFuture<Collection<WindowedValue<OutT>>> prevFuture =
         prevOutputFuture == null

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/OpAdapter.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/OpAdapter.java
@@ -159,12 +159,12 @@ public class OpAdapter<InT, OutT, K>
     op.close();
   }
 
-  private static class OpEmitterImpl<OutT> implements OpEmitter<OutT> {
+  static class OpEmitterImpl<OutT> implements OpEmitter<OutT> {
     private final Queue<OpMessage<OutT>> outputQueue;
     private CompletionStage<Collection<OpMessage<OutT>>> outputFuture;
     private Instant outputWatermark;
 
-    private OpEmitterImpl() {
+    OpEmitterImpl() {
       outputQueue = new ConcurrentLinkedQueue<>();
     }
 

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaDoFnRunners.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/SamzaDoFnRunners.java
@@ -153,7 +153,8 @@ public class SamzaDoFnRunners {
     }
 
     return pipelineOptions.getNumThreadsForProcessElement() > 1
-        ? AsyncDoFnRunner.create(doFnRunnerWithStates, emitter, futureCollector, pipelineOptions)
+        ? AsyncDoFnRunner.create(
+            doFnRunnerWithStates, emitter, futureCollector, keyedInternals != null, pipelineOptions)
         : doFnRunnerWithStates;
   }
 

--- a/runners/samza/src/test/java/org/apache/beam/runners/samza/runtime/AsyncDoFnRunnerTest.java
+++ b/runners/samza/src/test/java/org/apache/beam/runners/samza/runtime/AsyncDoFnRunnerTest.java
@@ -217,6 +217,7 @@ public class AsyncDoFnRunnerTest implements Serializable {
 
     asyncDoFnRunner.processElement(input1);
     asyncDoFnRunner.processElement(input2);
+    // Resume input1 process afterwards
     latch.countDown();
 
     // Waiting for the futures to be resolved

--- a/runners/samza/src/test/java/org/apache/beam/runners/samza/runtime/AsyncDoFnRunnerTest.java
+++ b/runners/samza/src/test/java/org/apache/beam/runners/samza/runtime/AsyncDoFnRunnerTest.java
@@ -159,7 +159,7 @@ public class AsyncDoFnRunnerTest implements Serializable {
                 KV.of("banana", 5L)));
 
     // TODO: remove after SAMZA-2761 fix
-    for (int i = 0; i < 20; i++) {
+    for (int i = 0; i < 50; i++) {
       input.add(KV.of("*", 0L));
     }
 


### PR DESCRIPTION
In pr #23313, we added the executor support for processing elements within a ParDo bundle in parallel. This pr provides the ordering by key for stateful ParDo processing. Instead of dispatching the processing in the thread pool directly, we chain the element processing onto the output future of the last element with the same key, to ensure the ordering by key.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
