### PR TITLE
Make sure `astype(CategoricalDtype)` works

### DIFF
--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -642,7 +642,11 @@ class DeferredDataFrameOrSeries(frame_base.DeferredFrame):
           "memory-sharing semantics that are not compatible with the Beam "
           "model.")
 
-    if dtype == 'category':
+    # An instance of CategoricalDtype is actualy considered equal to the string
+    # 'category', so we have to explicitly check if dtype is an instance of
+    # CategoricalDtype, and allow it.
+    # See https://github.com/apache/beam/issues/23276
+    if dtype == 'category' and not isinstance(dtype, pd.CategoricalDtype):
       raise frame_base.WontImplementError(
           "astype(dtype='category') is not supported because the type of the "
           "output column depends on the data. Please use pd.CategoricalDtype "

--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -1011,6 +1011,29 @@ class DeferredFrameTest(_AbstractFrameTest):
     self._run_test(lambda df: df.groupby(level=0).sum(), df, nonparallel=True)
     self._run_test(lambda df: df.groupby(level=0).mean(), df, nonparallel=True)
 
+  def test_astype_categorical(self):
+    df = pd.DataFrame({'A': np.arange(6), 'B': list('aabbca')})
+    categorical_dtype = pd.CategoricalDtype(df.B.unique())
+
+    self._run_test(lambda df: df.B.astype(categorical_dtype), df)
+
+
+  def test_astype_categorical_with_unstack(self):
+    df = pd.DataFrame({
+        'index1': ['one', 'one', 'two', 'two'],
+        'index2': ['a', 'b', 'a', 'b'],
+        'data': np.arange(1.0, 5.0),
+    })
+
+    def with_categorical_index(df):
+      df.index1 = df.index1.astype(pd.CategoricalDtype(['one', 'two']))
+      df.index2 = df.index2.astype(pd.CategoricalDtype(['a', 'b']))
+      df.set_index(['index1' ,'index2'], drop=True)
+      return df
+
+    self._run_test(lambda df: with_categorical_index(df).unstack(level=-1), df,
+                   check_proxy=False)
+
   def test_dataframe_sum_nonnumeric_raises(self):
     # Attempting a numeric aggregation with the str column present should
     # raise, and suggest the numeric_only argument
@@ -2795,6 +2818,14 @@ class BeamSpecificTest(unittest.TestCase):
         lambda s: s.str.split(r"\.jpg", regex=True, expand=False), s)
     self.assert_frame_data_equivalent(
         result, s.str.split(r"\.jpg", regex=True, expand=False))
+
+  def test_astype_categorical_rejected(self):
+    df = pd.DataFrame({'A': np.arange(6), 'B': list('aabbca')})
+    categorical_dtype = pd.CategoricalDtype(df.B.unique())
+
+    with self.assertRaisesRegex(frame_base.WontImplementError,
+                                r"astype\(dtype='category'\)"):
+      self._evaluate(lambda df: df.B.astype('category'), df)
 
 
 class AllowNonParallelTest(unittest.TestCase):


### PR DESCRIPTION
Fixes #23276

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
