### PR TITLE
Rename 'clean' Gradle task that required Flutter and has been breaking nightly build

### DIFF
--- a/.test-infra/jenkins/job_Release_NightlySnapshot.groovy
+++ b/.test-infra/jenkins/job_Release_NightlySnapshot.groovy
@@ -50,7 +50,7 @@ job('beam_Release_NightlySnapshot') {
     }
     /*
      * Skipping verification on 'ubuntu' labelled nodes since they don't have access to the
-     * some required GCP resouces.
+     * some required GCP resources.
      * TODO: Uncomment this after we publishing snapshots on 'beam' nodes.
      gradle {
      rootBuildScriptDir(commonJobProperties.checkoutDir)

--- a/playground/frontend/build.gradle
+++ b/playground/frontend/build.gradle
@@ -113,7 +113,7 @@ task precommit {
 }
 
 task generate {
-  dependsOn("flutterClean")
+  dependsOn("cleanFlutter")
   dependsOn("pubGet")
 
   group = "build"
@@ -127,7 +127,7 @@ task generate {
   }
 }
 
-task flutterClean {
+task cleanFlutter {
   group = "build"
   description = "Remove build artifacts"
 

--- a/playground/frontend/playground_components/build.gradle.kts
+++ b/playground/frontend/playground_components/build.gradle.kts
@@ -51,7 +51,7 @@ tasks.register("test") {
   }
 }
 
-tasks.register("clean") {
+tasks.register("cleanFlutter") {
   group = "build"
   description = "Remove build artifacts"
   doLast {
@@ -75,7 +75,7 @@ tasks.register("pubGet") {
 }
 
 tasks.register("generate") {
-  dependsOn("clean")
+  dependsOn("cleanFlutter")
   dependsOn("pubGet")
 
   group = "build"


### PR DESCRIPTION
This PR renames the Playground's `clean` Gradle task to `cleanFlutter` so it does not automatically start when `clean` is run in all sub-projects.

A task `flutterClean` in another component is also renamed to `cleanFlutter` for consistency.

The new naming is in line with `cleanPython` tasks found elsewhere in the project.

- Resolves #23514

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
