### PR TITLE
[cherry-pick][release-2.42.0][BEAM-12164]: fix throughput estimator to only report backlog bytes on data records (#23493)

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/action/QueryChangeStreamAction.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/action/QueryChangeStreamAction.java
@@ -20,7 +20,6 @@ package org.apache.beam.sdk.io.gcp.spanner.changestreams.action;
 import com.google.cloud.Timestamp;
 import com.google.cloud.spanner.ErrorCode;
 import com.google.cloud.spanner.SpannerException;
-import java.nio.charset.StandardCharsets;
 import java.util.List;
 import java.util.Optional;
 import org.apache.beam.sdk.io.gcp.spanner.changestreams.ChangeStreamMetrics;
@@ -189,7 +188,8 @@ public class QueryChangeStreamAction {
                     (DataChangeRecord) record,
                     tracker,
                     receiver,
-                    watermarkEstimator);
+                    watermarkEstimator,
+                    throughputEstimator);
           } else if (record instanceof HeartbeatRecord) {
             maybeContinuation =
                 heartbeatRecordAction.run(
@@ -202,12 +202,6 @@ public class QueryChangeStreamAction {
             LOG.error("[" + token + "] Unknown record type " + record.getClass());
             throw new IllegalArgumentException("Unknown record type " + record.getClass());
           }
-
-          // The size of a record is represented by the number of bytes needed for the
-          // string representation of the record. Here, we only try to achieve an estimate
-          // instead of an accurate throughput.
-          this.throughputEstimator.update(
-              Timestamp.now(), record.toString().getBytes(StandardCharsets.UTF_8).length);
 
           if (maybeContinuation.isPresent()) {
             LOG.debug("[" + token + "] Continuation present, returning " + maybeContinuation);

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/ReadChangeStreamPartitionDoFnTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dofn/ReadChangeStreamPartitionDoFnTest.java
@@ -149,7 +149,7 @@ public class ReadChangeStreamPartitionDoFnTest {
     verify(queryChangeStreamAction)
         .run(partition, tracker, receiver, watermarkEstimator, bundleFinalizer);
 
-    verify(dataChangeRecordAction, never()).run(any(), any(), any(), any(), any());
+    verify(dataChangeRecordAction, never()).run(any(), any(), any(), any(), any(), any());
     verify(heartbeatRecordAction, never()).run(any(), any(), any(), any());
     verify(childPartitionsRecordAction, never()).run(any(), any(), any(), any());
     verify(tracker, never()).tryClaim(any());


### PR DESCRIPTION
Merge the fix to only report backlog bytes on data records (https://github.com/apache/beam/pull/23493) into release 2.42.0