### PR TITLE
Migrate BINARY, VARBINARY, CHAR, VARCHAR jdbc logical types to portable

### DIFF
--- a/model/fn-execution/src/main/resources/org/apache/beam/model/fnexecution/v1/standard_coders.yaml
+++ b/model/fn-execution/src/main/resources/org/apache/beam/model/fnexecution/v1/standard_coders.yaml
@@ -488,6 +488,17 @@ examples:
 ---
 
 coder:
+  urn: "beam:coder:row:v1"
+  # f_char: logical(fixed_char(5)), f_varchar: logical(var_char(5)), f_bytes: logical(fixed_bytes(5)), f_varbytes: logical(var_bytes(5))
+  payload: "\n=\n\x06f_char\x1a3\x08\x01:/\n\x1fbeam:logical_type:fixed_char:v1\x1a\x02\x10\x07\"\x02\x10\x03*\x04\n\x02\x18\x05\nB\n\tf_varchar\x1a1\x08\x01:-\n\x1dbeam:logical_type:var_char:v1\x1a\x02\x10\x07\"\x02\x10\x03*\x04\n\x02\x18\n \x01(\x01\nC\n\x07f_bytes\x1a4\x08\x01:0\n beam:logical_type:fixed_bytes:v1\x1a\x02\x10\t\"\x02\x10\x03*\x04\n\x02\x18\x05 \x02(\x02\nD\n\nf_varbytes\x1a2\x08\x01:.\n\x1ebeam:logical_type:var_bytes:v1\x1a\x02\x10\t\"\x02\x10\x03*\x04\n\x02\x18\n \x03(\x03\x12$f0ffb3a4-f46f-41ca-a942-85e3e939452a"
+examples:
+  "\x04\x00\x05ABCDE\x05ABCDE\x05ABCDE\x05ABCDE": {f_char: "ABCDE", f_varchar: "ABCDE", f_bytes: "ABCDE", f_varbytes: "ABCDE"}
+  "\x04\x00\x05A\n   \x02A\n\x05A\n\x00\x00\x00\x02A\n": {f_char: "A\n   ", f_varchar: "A\n", f_bytes: "A\n\x00\x00\x00", f_varbytes: "A\n"}
+  "\x04\x01\x06\x05null?\x04null": {f_char: "null?", f_varchar: null, f_bytes: null, f_varbytes: "null"}
+
+---
+
+coder:
   urn: "beam:coder:sharded_key:v1"
   components: [{urn: "beam:coder:string_utf8:v1"}]
 

--- a/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/schema.proto
+++ b/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/schema.proto
@@ -147,6 +147,34 @@ message LogicalTypes {
     //     two's complement encoded big integer.
     DECIMAL = 3 [(org.apache.beam.model.pipeline.v1.beam_urn) =
       "beam:logical_type:decimal:v1"];
+
+    // A URN for FixedLengthBytes type
+    //   - Representation type: BYTES
+    //   - Argument type: INT32.
+    //     A fixed-length bytes with its length as the argument.
+    FIXED_BYTES = 4 [(org.apache.beam.model.pipeline.v1.beam_urn) =
+      "beam:logical_type:fixed_bytes:v1"];
+
+    // A URN for VariableLengthBytes type
+    //   - Representation type: BYTES
+    //   - Argument type: INT32.
+    //     A variable-length bytes with its maximum length as the argument.
+    VAR_BYTES = 5 [(org.apache.beam.model.pipeline.v1.beam_urn) =
+      "beam:logical_type:var_bytes:v1"];
+
+    // A URN for FixedLengthString type
+    //   - Representation type: STRING
+    //   - Argument type: INT32.
+    //     A fixed-length string with its length as the argument.
+    FIXED_CHAR = 6 [(org.apache.beam.model.pipeline.v1.beam_urn) =
+      "beam:logical_type:fixed_char:v1"];
+
+    // A URN for VariableLengthString type
+    //   - Representation type: STRING
+    //   - Argument type: INT32.
+    //     A variable-length string with its maximum length as the argument.
+    VAR_CHAR = 7 [(org.apache.beam.model.pipeline.v1.beam_urn) =
+      "beam:logical_type:var_char:v1"];
   }
 }
 

--- a/sdks/go/test/regression/coders/fromyaml/fromyaml.go
+++ b/sdks/go/test/regression/coders/fromyaml/fromyaml.go
@@ -53,6 +53,7 @@ var filteredCases = []struct{ filter, reason string }{
 	{"30ea5a25-dcd8-4cdb-abeb-5332d15ab4b9", "https://github.com/apache/beam/issues/21206: Support encoding position."},
 	{"80be749a-5700-4ede-89d8-dd9a4433a3f8", "https://github.com/apache/beam/issues/19817: Support millis_instant."},
 	{"800c44ae-a1b7-4def-bbf6-6217cca89ec4", "https://github.com/apache/beam/issues/19817: Support decimal."},
+	{"f0ffb3a4-f46f-41ca-a942-85e3e939452a", "https://github.com/apache/beam/issues/23526: Support char/varchar, binary/varbinary."},
 }
 
 // Coder is a representation a serialized beam coder.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/FixedString.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/FixedString.java
@@ -19,45 +19,44 @@ package org.apache.beam.sdk.schemas.logicaltypes;
 
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
 
-import java.util.Arrays;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.SchemaApi;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.commons.lang3.StringUtils;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-/** A LogicalType representing a fixed-length byte array. */
-public class FixedBytes extends PassThroughLogicalType<byte[]> {
+/** A LogicalType representing a fixed-length string. */
+public class FixedString extends PassThroughLogicalType<String> {
   public static final String IDENTIFIER =
-      SchemaApi.LogicalTypes.Enum.FIXED_BYTES
+      SchemaApi.LogicalTypes.Enum.FIXED_CHAR
           .getValueDescriptor()
           .getOptions()
           .getExtension(RunnerApi.beamUrn);
-
   private final @Nullable String name;
-  private final int byteArrayLength;
+  private final int stringLength;
 
   /**
-   * Return an instance of FixedBytes with specified byte array length.
+   * Return an instance of FixedString with specified string length.
    *
-   * <p>The name, if set, refers to the TYPE name in the underlying database, for example, BINARY.
+   * <p>The name, if set, refers to the TYPE name in the underlying database, for example, CHAR.
    */
-  public static FixedBytes of(@Nullable String name, int byteArrayLength) {
-    return new FixedBytes(name, byteArrayLength);
+  public static FixedString of(@Nullable String name, int stringLength) {
+    return new FixedString(name, stringLength);
   }
 
-  /** Return an instance of FixedBytes with specified byte array length. */
-  public static FixedBytes of(int byteArrayLength) {
-    return of(null, byteArrayLength);
+  /** Return an instance of FixedString with specified string length. */
+  public static FixedString of(int stringLength) {
+    return new FixedString(null, stringLength);
   }
 
-  private FixedBytes(@Nullable String name, int byteArrayLength) {
-    super(IDENTIFIER, FieldType.INT32, byteArrayLength, FieldType.BYTES);
+  private FixedString(@Nullable String name, int stringLength) {
+    super(IDENTIFIER, FieldType.INT32, stringLength, FieldType.STRING);
     this.name = name;
-    this.byteArrayLength = byteArrayLength;
+    this.stringLength = stringLength;
   }
 
   public int getLength() {
-    return byteArrayLength;
+    return stringLength;
   }
 
   public @Nullable String getName() {
@@ -65,23 +64,14 @@ public class FixedBytes extends PassThroughLogicalType<byte[]> {
   }
 
   @Override
-  public byte[] toBaseType(byte[] input) {
-    checkArgument(input.length == byteArrayLength);
-    return input;
-  }
+  public String toInputType(String base) {
+    checkArgument(base.length() <= stringLength);
 
-  @Override
-  public byte[] toInputType(byte[] base) {
-    checkArgument(base.length <= byteArrayLength);
-    if (base.length == byteArrayLength) {
-      return base;
-    } else {
-      return Arrays.copyOf(base, byteArrayLength);
-    }
+    return StringUtils.rightPad(base, stringLength);
   }
 
   @Override
   public String toString() {
-    return "FixedBytes: " + byteArrayLength;
+    return "FixedString: " + stringLength;
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/VariableBytes.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/VariableBytes.java
@@ -19,45 +19,44 @@ package org.apache.beam.sdk.schemas.logicaltypes;
 
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
 
-import java.util.Arrays;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.SchemaApi;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-/** A LogicalType representing a fixed-length byte array. */
-public class FixedBytes extends PassThroughLogicalType<byte[]> {
+/** A LogicalType representing a variable-length byte array with specified maximum length. */
+public class VariableBytes extends PassThroughLogicalType<byte[]> {
   public static final String IDENTIFIER =
-      SchemaApi.LogicalTypes.Enum.FIXED_BYTES
+      SchemaApi.LogicalTypes.Enum.VAR_BYTES
           .getValueDescriptor()
           .getOptions()
           .getExtension(RunnerApi.beamUrn);
-
   private final @Nullable String name;
-  private final int byteArrayLength;
+  private final int maxByteArrayLength;
 
   /**
-   * Return an instance of FixedBytes with specified byte array length.
+   * Return an instance of VariableBytes with specified max byte array length.
    *
-   * <p>The name, if set, refers to the TYPE name in the underlying database, for example, BINARY.
+   * <p>The name, if set, refers to the TYPE name in the underlying database, for example, VARBINARY
+   * and LONGVARBINARY.
    */
-  public static FixedBytes of(@Nullable String name, int byteArrayLength) {
-    return new FixedBytes(name, byteArrayLength);
+  public static VariableBytes of(@Nullable String name, int maxByteArrayLength) {
+    return new VariableBytes(name, maxByteArrayLength);
   }
 
-  /** Return an instance of FixedBytes with specified byte array length. */
-  public static FixedBytes of(int byteArrayLength) {
-    return of(null, byteArrayLength);
+  /** Return an instance of VariableBytes with specified max byte array length. */
+  public static VariableBytes of(int maxByteArrayLength) {
+    return of(null, maxByteArrayLength);
   }
 
-  private FixedBytes(@Nullable String name, int byteArrayLength) {
-    super(IDENTIFIER, FieldType.INT32, byteArrayLength, FieldType.BYTES);
+  private VariableBytes(@Nullable String name, int maxByteArrayLength) {
+    super(IDENTIFIER, FieldType.INT32, maxByteArrayLength, FieldType.BYTES);
     this.name = name;
-    this.byteArrayLength = byteArrayLength;
+    this.maxByteArrayLength = maxByteArrayLength;
   }
 
-  public int getLength() {
-    return byteArrayLength;
+  public int getMaxLength() {
+    return maxByteArrayLength;
   }
 
   public @Nullable String getName() {
@@ -65,23 +64,13 @@ public class FixedBytes extends PassThroughLogicalType<byte[]> {
   }
 
   @Override
-  public byte[] toBaseType(byte[] input) {
-    checkArgument(input.length == byteArrayLength);
-    return input;
-  }
-
-  @Override
   public byte[] toInputType(byte[] base) {
-    checkArgument(base.length <= byteArrayLength);
-    if (base.length == byteArrayLength) {
-      return base;
-    } else {
-      return Arrays.copyOf(base, byteArrayLength);
-    }
+    checkArgument(base.length <= maxByteArrayLength);
+    return base;
   }
 
   @Override
   public String toString() {
-    return "FixedBytes: " + byteArrayLength;
+    return "VariableBytes: " + maxByteArrayLength;
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/VariableString.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/VariableString.java
@@ -24,7 +24,7 @@ import org.apache.beam.model.pipeline.v1.SchemaApi;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-/** A LogicalType representing a variable-length byte array with specified maximum length. */
+/** A LogicalType representing a variable-length string with specified maximum length. */
 public class VariableString extends PassThroughLogicalType<String> {
   public static final String IDENTIFIER =
       SchemaApi.LogicalTypes.Enum.VAR_CHAR

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/VariableString.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/VariableString.java
@@ -19,45 +19,44 @@ package org.apache.beam.sdk.schemas.logicaltypes;
 
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
 
-import java.util.Arrays;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.SchemaApi;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-/** A LogicalType representing a fixed-length byte array. */
-public class FixedBytes extends PassThroughLogicalType<byte[]> {
+/** A LogicalType representing a variable-length byte array with specified maximum length. */
+public class VariableString extends PassThroughLogicalType<String> {
   public static final String IDENTIFIER =
-      SchemaApi.LogicalTypes.Enum.FIXED_BYTES
+      SchemaApi.LogicalTypes.Enum.VAR_CHAR
           .getValueDescriptor()
           .getOptions()
           .getExtension(RunnerApi.beamUrn);
-
   private final @Nullable String name;
-  private final int byteArrayLength;
+  private final int maxStringLength;
 
   /**
-   * Return an instance of FixedBytes with specified byte array length.
+   * Return an instance of VariableString with specified max string length.
    *
-   * <p>The name, if set, refers to the TYPE name in the underlying database, for example, BINARY.
+   * <p>The name, if set, refers to the TYPE name in the underlying database, for example, VARCHAR
+   * and LONGVARCHAR.
    */
-  public static FixedBytes of(@Nullable String name, int byteArrayLength) {
-    return new FixedBytes(name, byteArrayLength);
+  public static VariableString of(@Nullable String name, int maxStringLength) {
+    return new VariableString(name, maxStringLength);
   }
 
-  /** Return an instance of FixedBytes with specified byte array length. */
-  public static FixedBytes of(int byteArrayLength) {
-    return of(null, byteArrayLength);
+  /** Return an instance of VariableString with specified max string length. */
+  public static VariableString of(int maxStringLength) {
+    return of(null, maxStringLength);
   }
 
-  private FixedBytes(@Nullable String name, int byteArrayLength) {
-    super(IDENTIFIER, FieldType.INT32, byteArrayLength, FieldType.BYTES);
+  private VariableString(@Nullable String name, int maxStringLength) {
+    super(IDENTIFIER, FieldType.INT32, maxStringLength, FieldType.STRING);
     this.name = name;
-    this.byteArrayLength = byteArrayLength;
+    this.maxStringLength = maxStringLength;
   }
 
-  public int getLength() {
-    return byteArrayLength;
+  public int getMaxLength() {
+    return maxStringLength;
   }
 
   public @Nullable String getName() {
@@ -65,23 +64,13 @@ public class FixedBytes extends PassThroughLogicalType<byte[]> {
   }
 
   @Override
-  public byte[] toBaseType(byte[] input) {
-    checkArgument(input.length == byteArrayLength);
-    return input;
-  }
-
-  @Override
-  public byte[] toInputType(byte[] base) {
-    checkArgument(base.length <= byteArrayLength);
-    if (base.length == byteArrayLength) {
-      return base;
-    } else {
-      return Arrays.copyOf(base, byteArrayLength);
-    }
+  public String toInputType(String base) {
+    checkArgument(base.length() <= maxStringLength);
+    return base;
   }
 
   @Override
   public String toString() {
-    return "FixedBytes: " + byteArrayLength;
+    return "VariableString: " + maxStringLength;
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AvroUtils.java
@@ -74,7 +74,10 @@ import org.apache.beam.sdk.schemas.SchemaCoder;
 import org.apache.beam.sdk.schemas.SchemaUserTypeCreator;
 import org.apache.beam.sdk.schemas.logicaltypes.EnumerationType;
 import org.apache.beam.sdk.schemas.logicaltypes.FixedBytes;
+import org.apache.beam.sdk.schemas.logicaltypes.FixedString;
 import org.apache.beam.sdk.schemas.logicaltypes.OneOfType;
+import org.apache.beam.sdk.schemas.logicaltypes.VariableBytes;
+import org.apache.beam.sdk.schemas.logicaltypes.VariableString;
 import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.ConvertType;
 import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.ConvertValueForGetter;
 import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.ConvertValueForSetter;
@@ -899,48 +902,44 @@ public class AvroUtils {
         break;
 
       case LOGICAL_TYPE:
-        switch (fieldType.getLogicalType().getIdentifier()) {
-          case FixedBytes.IDENTIFIER:
-            FixedBytesField fixedBytesField =
-                checkNotNull(FixedBytesField.fromBeamFieldType(fieldType));
-            baseType = fixedBytesField.toAvroType("fixed", namespace + "." + fieldName);
-            break;
-          case EnumerationType.IDENTIFIER:
-            EnumerationType enumerationType = fieldType.getLogicalType(EnumerationType.class);
-            baseType =
-                org.apache.avro.Schema.createEnum(fieldName, "", "", enumerationType.getValues());
-            break;
-          case OneOfType.IDENTIFIER:
-            OneOfType oneOfType = fieldType.getLogicalType(OneOfType.class);
-            baseType =
-                org.apache.avro.Schema.createUnion(
-                    oneOfType.getOneOfSchema().getFields().stream()
-                        .map(x -> getFieldSchema(x.getType(), x.getName(), namespace))
-                        .collect(Collectors.toList()));
-            break;
-          case "CHAR":
-          case "NCHAR":
-            baseType =
-                buildHiveLogicalTypeSchema("char", (int) fieldType.getLogicalType().getArgument());
-            break;
-          case "NVARCHAR":
-          case "VARCHAR":
-          case "LONGNVARCHAR":
-          case "LONGVARCHAR":
-            baseType =
-                buildHiveLogicalTypeSchema(
-                    "varchar", (int) fieldType.getLogicalType().getArgument());
-            break;
-          case "DATE":
-            baseType = LogicalTypes.date().addToSchema(org.apache.avro.Schema.create(Type.INT));
-            break;
-          case "TIME":
-            baseType =
-                LogicalTypes.timeMillis().addToSchema(org.apache.avro.Schema.create(Type.INT));
-            break;
-          default:
-            throw new RuntimeException(
-                "Unhandled logical type " + fieldType.getLogicalType().getIdentifier());
+        String identifier = fieldType.getLogicalType().getIdentifier();
+        if (FixedBytes.IDENTIFIER.equals(identifier)) {
+          FixedBytesField fixedBytesField =
+              checkNotNull(FixedBytesField.fromBeamFieldType(fieldType));
+          baseType = fixedBytesField.toAvroType("fixed", namespace + "." + fieldName);
+        } else if (VariableBytes.IDENTIFIER.equals(identifier)) {
+          // treat VARBINARY as bytes as that is what avro supports
+          baseType = org.apache.avro.Schema.create(Type.BYTES);
+        } else if (FixedString.IDENTIFIER.equals(identifier)
+            || "CHAR".equals(identifier)
+            || "NCHAR".equals(identifier)) {
+          baseType =
+              buildHiveLogicalTypeSchema("char", (int) fieldType.getLogicalType().getArgument());
+        } else if (VariableString.IDENTIFIER.equals(identifier)
+            || "NVARCHAR".equals(identifier)
+            || "VARCHAR".equals(identifier)
+            || "LONGNVARCHAR".equals(identifier)
+            || "LONGVARCHAR".equals(identifier)) {
+          baseType =
+              buildHiveLogicalTypeSchema("varchar", (int) fieldType.getLogicalType().getArgument());
+        } else if (EnumerationType.IDENTIFIER.equals(identifier)) {
+          EnumerationType enumerationType = fieldType.getLogicalType(EnumerationType.class);
+          baseType =
+              org.apache.avro.Schema.createEnum(fieldName, "", "", enumerationType.getValues());
+        } else if (OneOfType.IDENTIFIER.equals(identifier)) {
+          OneOfType oneOfType = fieldType.getLogicalType(OneOfType.class);
+          baseType =
+              org.apache.avro.Schema.createUnion(
+                  oneOfType.getOneOfSchema().getFields().stream()
+                      .map(x -> getFieldSchema(x.getType(), x.getName(), namespace))
+                      .collect(Collectors.toList()));
+        } else if ("DATE".equals(identifier)) {
+          baseType = LogicalTypes.date().addToSchema(org.apache.avro.Schema.create(Type.INT));
+        } else if ("TIME".equals(identifier)) {
+          baseType = LogicalTypes.timeMillis().addToSchema(org.apache.avro.Schema.create(Type.INT));
+        } else {
+          throw new RuntimeException(
+              "Unhandled logical type " + fieldType.getLogicalType().getIdentifier());
         }
         break;
 
@@ -1022,45 +1021,51 @@ public class AvroUtils {
         return ByteBuffer.wrap((byte[]) value);
 
       case LOGICAL_TYPE:
-        switch (fieldType.getLogicalType().getIdentifier()) {
-          case FixedBytes.IDENTIFIER:
-            FixedBytesField fixedBytesField =
-                checkNotNull(FixedBytesField.fromBeamFieldType(fieldType));
-            byte[] byteArray = (byte[]) value;
-            if (byteArray.length != fixedBytesField.getSize()) {
-              throw new IllegalArgumentException("Incorrectly sized byte array.");
-            }
-            return GenericData.get().createFixed(null, (byte[]) value, typeWithNullability.type);
-          case EnumerationType.IDENTIFIER:
-            EnumerationType enumerationType = fieldType.getLogicalType(EnumerationType.class);
-            return GenericData.get()
-                .createEnum(
-                    enumerationType.toString((EnumerationType.Value) value),
-                    typeWithNullability.type);
-          case OneOfType.IDENTIFIER:
-            OneOfType oneOfType = fieldType.getLogicalType(OneOfType.class);
-            OneOfType.Value oneOfValue = (OneOfType.Value) value;
-            FieldType innerFieldType = oneOfType.getFieldType(oneOfValue);
-            if (typeWithNullability.nullable && oneOfValue.getValue() == null) {
-              return null;
-            } else {
-              return genericFromBeamField(
-                  innerFieldType.withNullable(false),
-                  typeWithNullability.type.getTypes().get(oneOfValue.getCaseType().getValue()),
-                  oneOfValue.getValue());
-            }
-          case "NVARCHAR":
-          case "VARCHAR":
-          case "LONGNVARCHAR":
-          case "LONGVARCHAR":
-            return new Utf8((String) value);
-          case "DATE":
-            return Days.daysBetween(Instant.EPOCH, (Instant) value).getDays();
-          case "TIME":
-            return (int) ((Instant) value).getMillis();
-          default:
-            throw new RuntimeException(
-                "Unhandled logical type " + fieldType.getLogicalType().getIdentifier());
+        String identifier = fieldType.getLogicalType().getIdentifier();
+        if (FixedBytes.IDENTIFIER.equals(identifier)) {
+          FixedBytesField fixedBytesField =
+              checkNotNull(FixedBytesField.fromBeamFieldType(fieldType));
+          byte[] byteArray = (byte[]) value;
+          if (byteArray.length != fixedBytesField.getSize()) {
+            throw new IllegalArgumentException("Incorrectly sized byte array.");
+          }
+          return GenericData.get().createFixed(null, (byte[]) value, typeWithNullability.type);
+        } else if (VariableBytes.IDENTIFIER.equals(identifier)) {
+          return GenericData.get().createFixed(null, (byte[]) value, typeWithNullability.type);
+        } else if (FixedString.IDENTIFIER.equals(identifier)
+            || "CHAR".equals(identifier)
+            || "NCHAR".equals(identifier)) {
+          return new Utf8((String) value);
+        } else if (VariableString.IDENTIFIER.equals(identifier)
+            || "NVARCHAR".equals(identifier)
+            || "VARCHAR".equals(identifier)
+            || "LONGNVARCHAR".equals(identifier)
+            || "LONGVARCHAR".equals(identifier)) {
+          return new Utf8((String) value);
+        } else if (EnumerationType.IDENTIFIER.equals(identifier)) {
+          EnumerationType enumerationType = fieldType.getLogicalType(EnumerationType.class);
+          return GenericData.get()
+              .createEnum(
+                  enumerationType.toString((EnumerationType.Value) value),
+                  typeWithNullability.type);
+        } else if (OneOfType.IDENTIFIER.equals(identifier)) {
+          OneOfType oneOfType = fieldType.getLogicalType(OneOfType.class);
+          OneOfType.Value oneOfValue = (OneOfType.Value) value;
+          FieldType innerFieldType = oneOfType.getFieldType(oneOfValue);
+          if (typeWithNullability.nullable && oneOfValue.getValue() == null) {
+            return null;
+          } else {
+            return genericFromBeamField(
+                innerFieldType.withNullable(false),
+                typeWithNullability.type.getTypes().get(oneOfValue.getCaseType().getValue()),
+                oneOfValue.getValue());
+          }
+        } else if ("DATE".equals(identifier)) {
+          return Days.daysBetween(Instant.EPOCH, (Instant) value).getDays();
+        } else if ("TIME".equals(identifier)) {
+          return (int) ((Instant) value).getMillis();
+        } else {
+          throw new RuntimeException("Unhandled logical type " + identifier);
         }
 
       case ARRAY:

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/logicaltypes/LogicalTypesTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/logicaltypes/LogicalTypesTest.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.schemas.logicaltypes;
 
+import static org.junit.Assert.assertArrayEquals;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertThrows;
 
@@ -177,5 +178,57 @@ public class LogicalTypesTest {
     decimal = BigDecimal.valueOf(100_000_000_001L, scale);
     row = Row.withSchema(schema).addValues(decimal).build();
     assertEquals(decimal, row.getLogicalTypeValue(0, BigDecimal.class));
+  }
+
+  @Test
+  public void testFixedBytes() {
+    FixedBytes fixedBytes = FixedBytes.of(5);
+
+    // check argument valid case, with padding
+    byte[] resultBytes = fixedBytes.toInputType(new byte[] {0x1, 0x2, 0x3});
+    assertArrayEquals(new byte[] {0x1, 0x2, 0x3, 0x0, 0x0}, resultBytes);
+
+    // check argument invalid case
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> fixedBytes.toInputType(new byte[] {0x1, 0x2, 0x3, 0x4, 0x5, 0x6}));
+  }
+
+  @Test
+  public void testVariableBytes() {
+    VariableBytes variableBytes = VariableBytes.of(5);
+
+    // check argument valid case, no padding
+    byte[] resultBytes = variableBytes.toInputType(new byte[] {0x1, 0x2, 0x3});
+    assertArrayEquals(new byte[] {0x1, 0x2, 0x3}, resultBytes);
+
+    // check argument invalid case
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> variableBytes.toInputType(new byte[] {0x1, 0x2, 0x3, 0x4, 0x5, 0x6}));
+  }
+
+  @Test
+  public void testFixedString() {
+    FixedString fixedString = FixedString.of(5);
+
+    // check argument valid case, with padding
+    String resultString = fixedString.toInputType("123");
+    assertEquals("123  ", resultString);
+
+    // check argument invalid case
+    assertThrows(IllegalArgumentException.class, () -> fixedString.toInputType("123456"));
+  }
+
+  @Test
+  public void testVariableString() {
+    VariableString varibaleString = VariableString.of(5);
+
+    // check argument valid case, no padding
+    String resultString = varibaleString.toInputType("123");
+    assertEquals("123", resultString);
+
+    // check argument invalid case
+    assertThrows(IllegalArgumentException.class, () -> varibaleString.toInputType("123456"));
   }
 }

--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/LogicalTypes.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/LogicalTypes.java
@@ -17,20 +17,20 @@
  */
 package org.apache.beam.sdk.io.jdbc;
 
-import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
-
 import java.sql.JDBCType;
 import java.time.Instant;
-import java.util.Arrays;
 import java.util.Objects;
-import org.apache.beam.repackaged.core.org.apache.commons.lang3.StringUtils;
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.schemas.logicaltypes.FixedBytes;
 import org.apache.beam.sdk.schemas.logicaltypes.FixedPrecisionNumeric;
+import org.apache.beam.sdk.schemas.logicaltypes.FixedString;
 import org.apache.beam.sdk.schemas.logicaltypes.PassThroughLogicalType;
 import org.apache.beam.sdk.schemas.logicaltypes.UuidLogicalType;
+import org.apache.beam.sdk.schemas.logicaltypes.VariableBytes;
+import org.apache.beam.sdk.schemas.logicaltypes.VariableString;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
@@ -78,27 +78,42 @@ class LogicalTypes {
 
   @VisibleForTesting
   static Schema.FieldType fixedLengthString(JDBCType jdbcType, int length) {
-    return Schema.FieldType.logicalType(FixedLengthString.of(jdbcType.getName(), length));
+    return Schema.FieldType.logicalType(FixedString.of(jdbcType.getName(), length));
   }
 
   @VisibleForTesting
   static Schema.FieldType fixedLengthBytes(JDBCType jdbcType, int length) {
-    return Schema.FieldType.logicalType(FixedLengthBytes.of(jdbcType.getName(), length));
+    return Schema.FieldType.logicalType(FixedBytes.of(jdbcType.getName(), length));
   }
 
   @VisibleForTesting
   static Schema.FieldType variableLengthString(JDBCType jdbcType, int length) {
-    return Schema.FieldType.logicalType(VariableLengthString.of(jdbcType.getName(), length));
+    return Schema.FieldType.logicalType(VariableString.of(jdbcType.getName(), length));
   }
 
   @VisibleForTesting
   static Schema.FieldType variableLengthBytes(JDBCType jdbcType, int length) {
-    return Schema.FieldType.logicalType(VariableLengthBytes.of(jdbcType.getName(), length));
+    return Schema.FieldType.logicalType(VariableBytes.of(jdbcType.getName(), length));
   }
 
   @VisibleForTesting
   static Schema.FieldType numeric(int precision, int scale) {
     return Schema.FieldType.logicalType(FixedPrecisionNumeric.of(precision, scale));
+  }
+
+  /**
+   * Returns a {@link FixedBytes}, or {@link VariableBytes} when length is Integer.MAX_VALUE.
+   *
+   * <p>In some database, certain variable bytes type (e.g. bytea in postgresql) also returns BINARY
+   * jdbc type. This helper method make BINARY(Integer.MAX_VALUE) returns a variable bytes logical
+   * type thus avoid out-of-memory due to padding in fixed-length bytes.
+   */
+  static Schema.LogicalType<byte[], byte[]> fixedOrVariableBytes(String name, int length) {
+    if (length == Integer.MAX_VALUE) {
+      return VariableBytes.of(name, length);
+    } else {
+      return FixedBytes.of(name, length);
+    }
   }
 
   /** Base class for JDBC logical types. */
@@ -162,90 +177,6 @@ class LogicalTypes {
     @Override
     public int hashCode() {
       return Objects.hash(identifier, baseType, argument);
-    }
-  }
-
-  /** Fixed length string types such as CHAR. */
-  static final class FixedLengthString extends JdbcLogicalType<String> {
-    private final int length;
-
-    static FixedLengthString of(String identifier, int length) {
-      return new FixedLengthString(identifier, length);
-    }
-
-    private FixedLengthString(String identifier, int length) {
-      super(identifier, FieldType.INT32, Schema.FieldType.STRING, length);
-      this.length = length;
-    }
-
-    @Override
-    public String toInputType(String base) {
-      checkArgument(base == null || base.length() <= length);
-      return StringUtils.rightPad(base, length);
-    }
-  }
-
-  /** Fixed length byte types such as BINARY. */
-  static final class FixedLengthBytes extends JdbcLogicalType<byte[]> {
-    private final int length;
-
-    static FixedLengthBytes of(String identifier, int length) {
-      return new FixedLengthBytes(identifier, length);
-    }
-
-    private FixedLengthBytes(String identifier, int length) {
-      super(identifier, FieldType.INT32, Schema.FieldType.BYTES, length);
-      this.length = length;
-    }
-
-    @Override
-    public byte[] toInputType(byte[] base) {
-      checkArgument(base == null || base.length <= length);
-      if (base == null || base.length == length) {
-        return base;
-      } else {
-        return Arrays.copyOf(base, length);
-      }
-    }
-  }
-
-  /** Variable length string types such as VARCHAR and LONGVARCHAR. */
-  static final class VariableLengthString extends JdbcLogicalType<String> {
-    private final int maxLength;
-
-    static VariableLengthString of(String identifier, int maxLength) {
-      return new VariableLengthString(identifier, maxLength);
-    }
-
-    private VariableLengthString(String identifier, int maxLength) {
-      super(identifier, FieldType.INT32, Schema.FieldType.STRING, maxLength);
-      this.maxLength = maxLength;
-    }
-
-    @Override
-    public String toInputType(String base) {
-      checkArgument(base == null || base.length() <= maxLength);
-      return base;
-    }
-  }
-
-  /** Variable length bytes types such as VARBINARY and LONGVARBINARY. */
-  static final class VariableLengthBytes extends JdbcLogicalType<byte[]> {
-    private final int maxLength;
-
-    static VariableLengthBytes of(String identifier, int maxLength) {
-      return new VariableLengthBytes(identifier, maxLength);
-    }
-
-    private VariableLengthBytes(String identifier, int maxLength) {
-      super(identifier, FieldType.INT32, Schema.FieldType.BYTES, maxLength);
-      this.maxLength = maxLength;
-    }
-
-    @Override
-    public byte[] toInputType(byte[] base) {
-      checkArgument(base == null || base.length <= maxLength);
-      return base;
     }
   }
 }

--- a/sdks/python/apache_beam/coders/coder_impl.py
+++ b/sdks/python/apache_beam/coders/coder_impl.py
@@ -112,6 +112,7 @@ else:
   globals()['create_OutputStream'] = create_OutputStream
   globals()['ByteCountingOutputStream'] = ByteCountingOutputStream
   # pylint: enable=wrong-import-order, wrong-import-position, ungrouped-imports
+  is_compiled = True
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -611,6 +612,12 @@ class BytesCoderImpl(CoderImpl):
   A coder for bytes/str objects."""
   def encode_to_stream(self, value, out, nested):
     # type: (bytes, create_OutputStream, bool) -> None
+
+    # value might be of type np.bytes if passed from encode_batch, and cython
+    # does not recognize it as bytes.
+    if is_compiled and isinstance(value, np.bytes_):
+      value = bytes(value)
+
     out.write(value, nested)
 
   def decode_from_stream(self, in_stream, nested):

--- a/sdks/python/apache_beam/io/external/xlang_jdbcio_it_test.py
+++ b/sdks/python/apache_beam/io/external/xlang_jdbcio_it_test.py
@@ -17,7 +17,6 @@
 
 # pytype: skip-file
 
-import datetime
 import logging
 import time
 import typing
@@ -26,7 +25,6 @@ from decimal import Decimal
 from typing import Callable
 from typing import Union
 
-import pytz
 from parameterized import parameterized
 
 import apache_beam as beam
@@ -58,18 +56,13 @@ except ImportError:
 
 ROW_COUNT = 10
 
-JdbcReadTestRow = typing.NamedTuple(
-    "JdbcReadTestRow",
-    [("f_int", int), ("f_timestamp", Timestamp), ("f_decimal", Decimal)],
+JdbcTestRow = typing.NamedTuple(
+    "JdbcTestRow",
+    [("f_id", int), ("f_float", float), ("f_char", str), ("f_varchar", str),
+     ("f_bytes", bytes), ("f_varbytes", bytes), ("f_timestamp", Timestamp),
+     ("f_decimal", Decimal)],
 )
-coders.registry.register_coder(JdbcReadTestRow, coders.RowCoder)
-
-JdbcWriteTestRow = typing.NamedTuple(
-    "JdbcWriteTestRow",
-    [("f_id", int), ("f_real", float), ("f_string", str),
-     ("f_timestamp", Timestamp), ("f_decimal", Decimal)],
-)
-coders.registry.register_coder(JdbcWriteTestRow, coders.RowCoder)
+coders.registry.register_coder(JdbcTestRow, coders.RowCoder)
 
 
 @unittest.skipIf(sqlalchemy is None, 'sql alchemy package is not installed.')
@@ -123,29 +116,60 @@ class CrossLanguageJdbcIOTest(unittest.TestCase):
       logging.error('Could not stop the postgreSQL container.')
 
   @parameterized.expand(['postgres', 'mysql'])
-  def test_xlang_jdbc_write(self, database):
+  def test_xlang_jdbc_write_read(self, database):
     container_init, classpath, db_string, driver = (
         CrossLanguageJdbcIOTest.DB_CONTAINER_CLASSPATH_STRING[database])
     self._setUpTestCase(container_init, db_string, driver)
-    table_name = 'jdbc_external_test_write'
+    table_name = 'jdbc_external_test'
+    if database == 'postgres':
+      # postgres does not have BINARY and VARBINARY type, use equvalent.
+      binary_type = ('BYTEA', 'BYTEA')
+    else:
+      binary_type = ('BINARY(10)', 'VARBINARY(10)')
+
     self.engine.execute(
-        "CREATE TABLE {}(f_id INTEGER, f_real FLOAT, f_string VARCHAR(100), f_timestamp TIMESTAMP(3), f_decimal DECIMAL(10, 2))"  # pylint: disable=line-too-long
-        .format(table_name))
+        "CREATE TABLE IF NOT EXISTS {}".format(table_name) + "(f_id INTEGER, " +
+        "f_float DOUBLE PRECISION, " + "f_char CHAR(10), " +
+        "f_varchar VARCHAR(10), " + f"f_bytes {binary_type[0]}, " +
+        f"f_varbytes {binary_type[1]}, " + "f_timestamp TIMESTAMP(3), " +
+        "f_decimal DECIMAL(10, 2))")
     inserted_rows = [
-        JdbcWriteTestRow(
+        JdbcTestRow(
             i,
             i + 0.1,
-            'Test{}'.format(i),
+            f'Test{i}',
+            f'Test{i}',
+            f'Test{i}'.encode(),
+            f'Test{i}'.encode(),
             # In alignment with Java Instant which supports milli precision.
             Timestamp.of(seconds=round(time.time(), 3)),
+            # Test both positive and negative numbers.
             Decimal(f'{i-1}.23')) for i in range(ROW_COUNT)
     ]
+    expected_row = []
+    for row in inserted_rows:
+      f_char = row.f_char + ' ' * (10 - len(row.f_char))
+      if database != 'postgres':
+        # padding expected results
+        f_bytes = row.f_bytes + b'\0' * (10 - len(row.f_bytes))
+      else:
+        f_bytes = row.f_bytes
+      expected_row.append(
+          JdbcTestRow(
+              row.f_id,
+              row.f_float,
+              f_char,
+              row.f_varchar,
+              f_bytes,
+              row.f_bytes,
+              row.f_timestamp,
+              row.f_decimal))
 
     with TestPipeline() as p:
       p.not_use_test_runner_api = True
       _ = (
           p
-          | beam.Create(inserted_rows).with_output_types(JdbcWriteTestRow)
+          | beam.Create(inserted_rows).with_output_types(JdbcTestRow)
           # TODO(https://github.com/apache/beam/issues/20446) Add test with
           # overridden write_statement
           | 'Write to jdbc' >> WriteToJdbc(
@@ -156,46 +180,6 @@ class CrossLanguageJdbcIOTest(unittest.TestCase):
               password=self.password,
               classpath=classpath,
           ))
-
-    fetched_data = self.engine.execute("SELECT * FROM {}".format(table_name))
-    fetched_rows = [
-        JdbcWriteTestRow(
-            int(row[0]),
-            float(row[1]),
-            str(row[2]),
-            Timestamp.from_utc_datetime(row[3].replace(tzinfo=pytz.UTC)),
-            Decimal(row[4])) for row in fetched_data
-    ]
-
-    self.assertEqual(
-        set(fetched_rows),
-        set(inserted_rows),
-        'Inserted data does not fit data fetched from table',
-    )
-
-  @parameterized.expand(['postgres', 'mysql'])
-  def test_xlang_jdbc_read(self, database):
-    container_init, classpath, db_string, driver = (
-        CrossLanguageJdbcIOTest.DB_CONTAINER_CLASSPATH_STRING[database])
-    self._setUpTestCase(container_init, db_string, driver)
-    table_name = 'jdbc_external_test_read'
-    self.engine.execute(
-        "CREATE TABLE {}(f_int INTEGER, f_timestamp TIMESTAMP, f_decimal DECIMAL(10,2))"  # pylint: disable=line-too-long
-        .format(table_name))
-
-    all_timestamps = []
-    for i in range(ROW_COUNT):
-      # prepare timestamp
-      strtime = Timestamp.now().to_utc_datetime().strftime('%Y-%m-%dT%H:%M:%S')
-      dttime = datetime.datetime.strptime(
-          strtime, '%Y-%m-%dT%H:%M:%S').replace(tzinfo=pytz.UTC)
-      all_timestamps.append(Timestamp.from_utc_datetime(dttime))
-      decimal_value = Decimal(f'{i-1}.23')
-
-      # write records using sqlalchemy engine
-      self.engine.execute(
-          "INSERT INTO {} VALUES({},'{}','{}')".format(
-              table_name, i, strtime, decimal_value))
 
     # Register MillisInstant logical type to override the mapping from Timestamp
     # originally handled by MicrosInstant.
@@ -215,12 +199,7 @@ class CrossLanguageJdbcIOTest(unittest.TestCase):
               password=self.password,
               classpath=classpath))
 
-      assert_that(
-          result,
-          equal_to([
-              JdbcReadTestRow(i, all_timestamps[i], Decimal(f'{i-1}.23'))
-              for i in range(ROW_COUNT)
-          ]))
+      assert_that(result, equal_to(expected_row))
 
   # Creating a container with testcontainers sometimes raises ReadTimeout
   # error. In java there are 2 retries set by default.

--- a/sdks/python/apache_beam/portability/common_urns.py
+++ b/sdks/python/apache_beam/portability/common_urns.py
@@ -83,3 +83,7 @@ decimal = LogicalTypes.Enum.DECIMAL
 micros_instant = LogicalTypes.Enum.MICROS_INSTANT
 millis_instant = LogicalTypes.Enum.MILLIS_INSTANT
 python_callable = LogicalTypes.Enum.PYTHON_CALLABLE
+fixed_bytes = LogicalTypes.Enum.FIXED_BYTES
+var_bytes = LogicalTypes.Enum.VAR_BYTES
+fixed_char = LogicalTypes.Enum.FIXED_CHAR
+var_char = LogicalTypes.Enum.VAR_CHAR

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -369,6 +369,7 @@ class SchemaTranslation(object):
       type_proto: schema_pb2.FieldType,
       value_proto: schema_pb2.FieldValue):
     if type_proto.WhichOneof("type_info") != "atomic_type":
+      # TODO: Allow other value types
       raise ValueError(
           "Encounterd option with unsupported type. Only "
           f"atomic_type options are supported: {type_proto}")
@@ -930,6 +931,7 @@ LogicalType.register_logical_type(DecimalLogicalType)
 
 @LogicalType.register_logical_type
 class FixedBytes(PassThroughLogicalType[bytes, np.int32]):
+  """A logical type for fixed-length bytes."""
   @classmethod
   def urn(cls):
     return common_urns.fixed_bytes.urn
@@ -962,6 +964,7 @@ class FixedBytes(PassThroughLogicalType[bytes, np.int32]):
 
 @LogicalType.register_logical_type
 class VariableBytes(PassThroughLogicalType[bytes, np.int32]):
+  """A logical type for variable-length bytes with specified maximum length."""
   @classmethod
   def urn(cls):
     return common_urns.var_bytes.urn
@@ -991,6 +994,7 @@ class VariableBytes(PassThroughLogicalType[bytes, np.int32]):
 
 @LogicalType.register_logical_type
 class FixedString(PassThroughLogicalType[str, np.int32]):
+  """A logical type for fixed-length string."""
   @classmethod
   def urn(cls):
     return common_urns.fixed_char.urn
@@ -1023,6 +1027,7 @@ class FixedString(PassThroughLogicalType[str, np.int32]):
 
 @LogicalType.register_logical_type
 class VariableString(PassThroughLogicalType[str, np.int32]):
+  """A logical type for variable-length string with specified maximum length."""
   @classmethod
   def urn(cls):
     return common_urns.var_char.urn

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -407,7 +407,7 @@ class SchemaTranslation(object):
 
     type_proto = self.typing_to_runner_api(type(value))
     value_proto = self.value_to_runner_api(type_proto, value)
-    return schema_pb2.Option(name=name, type=value_proto, value=value_proto)
+    return schema_pb2.Option(name=name, type=type_proto, value=value_proto)
 
   def typing_from_runner_api(
       self, fieldtype_proto: schema_pb2.FieldType) -> type:

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -171,6 +171,25 @@ def typing_from_runner_api(
       schema_registry=schema_registry).typing_from_runner_api(fieldtype_proto)
 
 
+def value_to_runner_api(
+    type_proto: schema_pb2.FieldType,
+    value,
+    schema_registry: SchemaTypeRegistry = SCHEMA_REGISTRY
+) -> schema_pb2.FieldValue:
+  return SchemaTranslation(schema_registry=schema_registry).value_to_runner_api(
+      type_proto, value)
+
+
+def value_from_runner_api(
+    type_proto: schema_pb2.FieldType,
+    value_proto: schema_pb2.FieldValue,
+    schema_registry: SchemaTypeRegistry = SCHEMA_REGISTRY
+) -> schema_pb2.FieldValue:
+  return SchemaTranslation(
+      schema_registry=schema_registry).value_from_runner_api(
+          type_proto, value_proto)
+
+
 def option_to_runner_api(
     option: Tuple[str, Any],
     schema_registry: SchemaTypeRegistry = SCHEMA_REGISTRY) -> schema_pb2.Option:
@@ -269,59 +288,113 @@ class SchemaTranslation(object):
           logical_type=schema_pb2.LogicalType(urn=PYTHON_ANY_URN),
           nullable=True)
     else:
-      if logical_type.argument_type() is None:
-        return schema_pb2.FieldType(
-            logical_type=schema_pb2.LogicalType(
-                urn=logical_type.urn(),
-                representation=self.typing_to_runner_api(
-                    logical_type.representation_type())))
-      else:
-        # TODO(https://github.com/apache/beam/issues/23373): Complete support
-        # for logical types that require arguments.
-        # This include implement SchemaTranslation.value_to_runner_api (see Java
-        # SDK's SchemaTranslation.fieldValueToProto)
-        return schema_pb2.FieldType(
-            logical_type=schema_pb2.LogicalType(
-                urn=logical_type.urn(),
-                representation=self.typing_to_runner_api(
-                    logical_type.representation_type()),
-                argument_type=self.typing_to_runner_api(
-                    logical_type.argument_type())))
+      argument_type = None
+      argument = None
+      if logical_type.argument_type() is not None:
+        argument_type = self.typing_to_runner_api(logical_type.argument_type())
+        try:
+          argument = self.value_to_runner_api(
+              argument_type, logical_type.argument())
+        except ValueError:
+          # TODO(https://github.com/apache/beam/issues/23373): Complete support
+          # for logical types that require arguments beyond atomic type.
+          # For now, skip arguments.
+          argument = None
+      return schema_pb2.FieldType(
+          logical_type=schema_pb2.LogicalType(
+              urn=logical_type.urn(),
+              representation=self.typing_to_runner_api(
+                  logical_type.representation_type()),
+              argument_type=argument_type,
+              argument=argument))
+
+  def atomic_value_from_runner_api(
+      self,
+      atomic_type: schema_pb2.AtomicType,
+      atomic_value: schema_pb2.AtomicTypeValue):
+    if atomic_type == schema_pb2.BYTE:
+      value = np.int8(atomic_value.byte)
+    elif atomic_type == schema_pb2.INT16:
+      value = np.int16(atomic_value.int16)
+    elif atomic_type == schema_pb2.INT32:
+      value = np.int32(atomic_value.int32)
+    elif atomic_type == schema_pb2.INT64:
+      value = np.int64(atomic_value.int64)
+    elif atomic_type == schema_pb2.FLOAT:
+      value = np.float32(atomic_value.float)
+    elif atomic_type == schema_pb2.DOUBLE:
+      value = np.float64(atomic_value.double)
+    elif atomic_type == schema_pb2.STRING:
+      value = atomic_value.string
+    elif atomic_type == schema_pb2.BOOLEAN:
+      value = atomic_value.boolean
+    elif atomic_type == schema_pb2.BYTES:
+      value = atomic_value.bytes
+    else:
+      raise ValueError(
+          f"Unrecognized atomic_type ({atomic_type}) "
+          f"when decoding value {atomic_value!r}")
+
+    return value
+
+  def atomic_value_to_runner_api(
+      self, atomic_type: schema_pb2.AtomicType,
+      value) -> schema_pb2.AtomicTypeValue:
+    if atomic_type == schema_pb2.BYTE:
+      atomic_value = schema_pb2.AtomicTypeValue(byte=value)
+    elif atomic_type == schema_pb2.INT16:
+      atomic_value = schema_pb2.AtomicTypeValue(int16=value)
+    elif atomic_type == schema_pb2.INT32:
+      atomic_value = schema_pb2.AtomicTypeValue(int32=value)
+    elif atomic_type == schema_pb2.INT64:
+      atomic_value = schema_pb2.AtomicTypeValue(int64=value)
+    elif atomic_type == schema_pb2.FLOAT:
+      atomic_value = schema_pb2.AtomicTypeValue(float=value)
+    elif atomic_type == schema_pb2.DOUBLE:
+      atomic_value = schema_pb2.AtomicTypeValue(double=value)
+    elif atomic_type == schema_pb2.STRING:
+      atomic_value = schema_pb2.AtomicTypeValue(string=value)
+    elif atomic_type == schema_pb2.BOOLEAN:
+      atomic_value = schema_pb2.AtomicTypeValue(boolean=value)
+    elif atomic_type == schema_pb2.BYTES:
+      atomic_value = schema_pb2.AtomicTypeValue(bytes=value)
+    else:
+      raise ValueError(
+          "Unrecognized atomic_type {atomic_type} when encoding value {value}")
+
+    return atomic_value
+
+  def value_from_runner_api(
+      self,
+      type_proto: schema_pb2.FieldType,
+      value_proto: schema_pb2.FieldValue):
+    if type_proto.WhichOneof("type_info") != "atomic_type":
+      raise ValueError(
+          "Encounterd option with unsupported type. Only "
+          f"atomic_type options are supported: {type_proto}")
+
+    value = self.atomic_value_from_runner_api(
+        type_proto.atomic_type, value_proto.atomic_value)
+    return value
+
+  def value_to_runner_api(self, typing_proto: schema_pb2.FieldType, value):
+    if typing_proto.WhichOneof("type_info") != "atomic_type":
+      # TODO: Allow other value types
+      raise ValueError(
+          "Only atomic_type option values are currently supported in Python. "
+          f"Got {value!r}, which maps to fieldtype {typing_proto!r}.")
+
+    atomic_value = self.atomic_value_to_runner_api(
+        typing_proto.atomic_type, value)
+    value_proto = schema_pb2.FieldValue(atomic_value=atomic_value)
+    return value_proto
 
   def option_from_runner_api(
       self, option_proto: schema_pb2.Option) -> Tuple[str, Any]:
     if not option_proto.HasField('type'):
       return option_proto.name, None
 
-    fieldtype_proto = option_proto.type
-    if fieldtype_proto.WhichOneof("type_info") != "atomic_type":
-      raise ValueError(
-          "Encounterd option with unsupported type. Only "
-          f"atomic_type options are supported: {option_proto}")
-
-    if fieldtype_proto.atomic_type == schema_pb2.BYTE:
-      value = np.int8(option_proto.value.atomic_value.byte)
-    elif fieldtype_proto.atomic_type == schema_pb2.INT16:
-      value = np.int16(option_proto.value.atomic_value.int16)
-    elif fieldtype_proto.atomic_type == schema_pb2.INT32:
-      value = np.int32(option_proto.value.atomic_value.int32)
-    elif fieldtype_proto.atomic_type == schema_pb2.INT64:
-      value = np.int64(option_proto.value.atomic_value.int64)
-    elif fieldtype_proto.atomic_type == schema_pb2.FLOAT:
-      value = np.float32(option_proto.value.atomic_value.float)
-    elif fieldtype_proto.atomic_type == schema_pb2.DOUBLE:
-      value = np.float64(option_proto.value.atomic_value.double)
-    elif fieldtype_proto.atomic_type == schema_pb2.STRING:
-      value = option_proto.value.atomic_value.string
-    elif fieldtype_proto.atomic_type == schema_pb2.BOOLEAN:
-      value = option_proto.value.atomic_value.boolean
-    elif fieldtype_proto.atomic_type == schema_pb2.BYTES:
-      value = option_proto.value.atomic_value.bytes
-    else:
-      raise ValueError(
-          f"Unrecognized atomic_type ({fieldtype_proto.atomic_type}) "
-          f"when decoding option {option_proto!r}")
-
+    value = self.value_from_runner_api(option_proto.type, option_proto.value)
     return option_proto.name, value
 
   def option_to_runner_api(self, option: Tuple[str, Any]) -> schema_pb2.Option:
@@ -332,41 +405,9 @@ class SchemaTranslation(object):
       # Don't set type, value
       return schema_pb2.Option(name=name)
 
-    fieldtype_proto = self.typing_to_runner_api(type(value))
-    if fieldtype_proto.WhichOneof("type_info") != "atomic_type":
-      # TODO: Allow other value types
-      raise ValueError(
-          "Only atomic_type option values are currently supported in Python. "
-          f"Got {value!r}, which maps to fieldtype {fieldtype_proto!r}.")
-
-    if fieldtype_proto.atomic_type == schema_pb2.BYTE:
-      atomictypevalue_proto = schema_pb2.AtomicTypeValue(byte=value)
-    elif fieldtype_proto.atomic_type == schema_pb2.INT16:
-      atomictypevalue_proto = schema_pb2.AtomicTypeValue(int16=value)
-    elif fieldtype_proto.atomic_type == schema_pb2.INT32:
-      atomictypevalue_proto = schema_pb2.AtomicTypeValue(int32=value)
-    elif fieldtype_proto.atomic_type == schema_pb2.INT64:
-      atomictypevalue_proto = schema_pb2.AtomicTypeValue(int64=value)
-    elif fieldtype_proto.atomic_type == schema_pb2.FLOAT:
-      atomictypevalue_proto = schema_pb2.AtomicTypeValue(float=value)
-    elif fieldtype_proto.atomic_type == schema_pb2.DOUBLE:
-      atomictypevalue_proto = schema_pb2.AtomicTypeValue(double=value)
-    elif fieldtype_proto.atomic_type == schema_pb2.STRING:
-      atomictypevalue_proto = schema_pb2.AtomicTypeValue(string=value)
-    elif fieldtype_proto.atomic_type == schema_pb2.BOOLEAN:
-      atomictypevalue_proto = schema_pb2.AtomicTypeValue(boolean=value)
-    elif fieldtype_proto.atomic_type == schema_pb2.BYTES:
-      atomictypevalue_proto = schema_pb2.AtomicTypeValue(bytes=value)
-    else:
-      raise ValueError(
-          "Unrecognized atomic_type in fieldtype_proto="
-          f"{fieldtype_proto!r} when encoding option {option!r}")
-
-    return schema_pb2.Option(
-        name=name,
-        type=fieldtype_proto,
-        value=schema_pb2.FieldValue(atomic_value=atomictypevalue_proto),
-    )
+    type_proto = self.typing_to_runner_api(type(value))
+    value_proto = self.value_to_runner_api(type_proto, value)
+    return schema_pb2.Option(name=name, type=value_proto, value=value_proto)
 
   def typing_from_runner_api(
       self, fieldtype_proto: schema_pb2.FieldType) -> type:
@@ -643,8 +684,20 @@ class LogicalType(Generic[LanguageT, RepresentationT, ArgT]):
     if logical_type is None:
       raise ValueError(
           "No logical type registered for URN '%s'" % logical_type_proto.urn)
-    # TODO(bhulette): Use argument
-    return logical_type()
+    if not logical_type_proto.HasField(
+        "argument_type") or not logical_type_proto.HasField("argument"):
+      # logical type_proto without argument
+      return logical_type()
+    else:
+      try:
+        argument = value_from_runner_api(
+            logical_type_proto.argument_type, logical_type_proto.argument)
+      except ValueError:
+        # TODO(https://github.com/apache/beam/issues/23373): Complete support
+        # for logical types that require arguments beyond atomic type.
+        # For now, skip arguments.
+        return logical_type()
+      return logical_type(argument)
 
 
 class NoArgumentLogicalType(LogicalType[LanguageT, RepresentationT, None]):
@@ -663,6 +716,28 @@ class NoArgumentLogicalType(LogicalType[LanguageT, RepresentationT, None]):
 
     # Since there's no argument, there can be no additional information encoded
     # in the typing. Just construct an instance.
+    return cls()
+
+
+class PassThroughLogicalType(LogicalType[LanguageT, LanguageT, ArgT]):
+  """A base class for LogicalTypes that use the same type as the underlying
+  representation type.
+  """
+  def to_language_type(self, value):
+    return value
+
+  @classmethod
+  def representation_type(cls):
+    # type: () -> type
+    return cls.language_type()
+
+  def to_representation_type(self, value):
+    return value
+
+  @classmethod
+  def _from_typing(cls, typ):
+    # type: (type) -> LogicalType
+    # TODO: enable argument
     return cls()
 
 
@@ -851,3 +926,125 @@ class FixedPrecisionDecimalLogicalType(
 # TODO(yathu,BEAM-10722): Investigate and resolve conflicts in logical type
 # registration when more than one logical types sharing the same language type
 LogicalType.register_logical_type(DecimalLogicalType)
+
+
+@LogicalType.register_logical_type
+class FixedBytes(PassThroughLogicalType[bytes, np.int32]):
+  @classmethod
+  def urn(cls):
+    return common_urns.fixed_bytes.urn
+
+  def __init__(self, length: np.int32):
+    self.length = length
+
+  @classmethod
+  def language_type(cls) -> type:
+    return bytes
+
+  def to_language_type(self, value: bytes):
+    length = len(value)
+    if length > self.length:
+      raise ValueError(
+          "value length {} > allowed length {}".format(length, self.length))
+    elif length < self.length:
+      # padding at the end
+      value = value + b'\0' * (self.length - length)
+
+    return value
+
+  @classmethod
+  def argument_type(cls):
+    return np.int32
+
+  def argument(self):
+    return self.length
+
+
+@LogicalType.register_logical_type
+class VariableBytes(PassThroughLogicalType[bytes, np.int32]):
+  @classmethod
+  def urn(cls):
+    return common_urns.var_bytes.urn
+
+  def __init__(self, max_length: np.int32 = np.iinfo(np.int32).max):
+    self.max_length = max_length
+
+  @classmethod
+  def language_type(cls) -> type:
+    return bytes
+
+  def to_language_type(self, value: bytes):
+    length = len(value)
+    if length > self.max_length:
+      raise ValueError(
+          "value length {} > allowed length {}".format(length, self.max_length))
+
+    return value
+
+  @classmethod
+  def argument_type(cls):
+    return np.int32
+
+  def argument(self):
+    return self.max_length
+
+
+@LogicalType.register_logical_type
+class FixedString(PassThroughLogicalType[str, np.int32]):
+  @classmethod
+  def urn(cls):
+    return common_urns.fixed_char.urn
+
+  def __init__(self, length: np.int32):
+    self.length = length
+
+  @classmethod
+  def language_type(cls) -> type:
+    return str
+
+  def to_language_type(self, value: str):
+    length = len(value)
+    if length > self.length:
+      raise ValueError(
+          "value length {} > allowed length {}".format(length, self.length))
+    elif length < self.length:
+      # padding at the end
+      value = value + ' ' * (self.length - length)
+
+    return value
+
+  @classmethod
+  def argument_type(cls):
+    return np.int32
+
+  def argument(self):
+    return self.length
+
+
+@LogicalType.register_logical_type
+class VariableString(PassThroughLogicalType[str, np.int32]):
+  @classmethod
+  def urn(cls):
+    return common_urns.var_char.urn
+
+  def __init__(self, max_length: np.int32 = np.iinfo(np.int32).max):
+    self.max_length = max_length
+
+  @classmethod
+  def language_type(cls) -> type:
+    return str
+
+  def to_language_type(self, value: str):
+    length = len(value)
+    if length > self.max_length:
+      raise ValueError(
+          "value length {} > allowed length {}".format(length, self.max_length))
+
+    return value
+
+  @classmethod
+  def argument_type(cls):
+    return np.int32
+
+  def argument(self):
+    return self.max_length


### PR DESCRIPTION
Fixes #23526

**Please** add a meaningful description for your change here

This enables cross-language jdbc ptransform write and read fixed/variable-length strings and bytes

* Move to portable logical types in Java

 * Create portable logical types in Python

Python cross-language JdbcIO can read/write rows with CHAR, VARCHAR, BINARY, VARBINARY types now.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
