### PR TITLE
Support usage of custom profileName with AWS ProfileCredentialsProvider

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -546,6 +546,7 @@ class BeamModulePlugin implements Plugin<Project> {
         aws_java_sdk2_http_client_spi               : "software.amazon.awssdk:http-client-spi:$aws_java_sdk2_version",
         aws_java_sdk2_regions                       : "software.amazon.awssdk:regions:$aws_java_sdk2_version",
         aws_java_sdk2_utils                         : "software.amazon.awssdk:utils:$aws_java_sdk2_version",
+        aws_java_sdk2_profiles                      : "software.amazon.awssdk:profiles:$aws_java_sdk2_version",
         bigdataoss_gcsio                            : "com.google.cloud.bigdataoss:gcsio:$google_cloud_bigdataoss_version",
         bigdataoss_util                             : "com.google.cloud.bigdataoss:util:$google_cloud_bigdataoss_version",
         byte_buddy                                  : "net.bytebuddy:byte-buddy:1.12.14",

--- a/sdks/java/io/amazon-web-services2/build.gradle
+++ b/sdks/java/io/amazon-web-services2/build.gradle
@@ -48,6 +48,7 @@ dependencies {
   implementation library.java.aws_java_sdk2_auth, excludeNetty
   implementation library.java.aws_java_sdk2_regions, excludeNetty
   implementation library.java.aws_java_sdk2_utils, excludeNetty
+  implementation library.java.aws_java_sdk2_profiles, excludeNetty
   implementation library.java.aws_java_sdk2_http_client_spi, excludeNetty
   implementation library.java.aws_java_sdk2_apache_client, excludeNetty
   implementation library.java.aws_java_sdk2_netty_client, excludeNetty

--- a/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/options/AwsOptions.java
+++ b/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/options/AwsOptions.java
@@ -78,21 +78,20 @@ public interface AwsOptions extends PipelineOptions {
    * <p>The class name of the provider must be set in the {@code @type} field. Note: Not all
    * available providers are supported and some configuration options might be ignored.
    *
-   * <p>Most providers rely on system's environment to follow AWS conventions, there's no further
-   * configuration:
+   * <p>Most providers must use the system environment following AWS conventions. Programmatic
+   * configuration for these providers is NOT supported:
    * <li>{@link DefaultCredentialsProvider}
    * <li>{@link EnvironmentVariableCredentialsProvider}
    * <li>{@link SystemPropertyCredentialsProvider}
-   * <li>{@link ProfileCredentialsProvider}
    * <li>{@link ContainerCredentialsProvider}
    *
    *     <p>Example:
    *
-   *     <pre>{@code --awsCredentialsProvider={"@type": "ProfileCredentialsProvider"}}</pre>
+   *     <pre>{@code --awsCredentialsProvider={"@type": "EnvironmentVariableCredentialsProvider"}}
+   *     </pre>
    *
-   *     <p>Some other providers require additional configuration:
+   *     <p>Some other providers support additional configuration:
    * <li>{@link StaticCredentialsProvider}
-   * <li>{@link StsAssumeRoleCredentialsProvider}
    *
    *     <p>Examples:
    *
@@ -107,9 +106,27 @@ public interface AwsOptions extends PipelineOptions {
    *   "awsAccessKeyId": "key_id_value",
    *   "awsSecretKey": "secret_value",
    *   "sessionToken": "token_value"
+   * }}</pre>
+   *
+   * <li>{@link ProfileCredentialsProvider}
+   *
+   *     <p>{@code profileName} is optional, if not set the environment default is used. Be careful
+   *     if using this provider programmatically, it can behave unexpectedly.
+   *
+   *     <p>Examples:
+   *
+   *     <pre>{@code --awsCredentialsProvider={
+   *   "@type": "ProfileCredentialsProvider"
    * }
    *
    * --awsCredentialsProvider={
+   *   "@type": "ProfileCredentialsProvider",
+   *   "profileName": "my_profile"
+   * }}</pre>
+   *
+   * <li>{@link StsAssumeRoleCredentialsProvider}
+   *
+   *     <pre>{@code --awsCredentialsProvider={
    *   "@type": "StsAssumeRoleCredentialsProvider",
    *   "roleArn": "role_arn_Value",
    *   "roleSessionName": "session_name_value",

--- a/sdks/java/io/amazon-web-services2/src/test/java/org/apache/beam/sdk/io/aws2/options/SerializationTestUtil.java
+++ b/sdks/java/io/amazon-web-services2/src/test/java/org/apache/beam/sdk/io/aws2/options/SerializationTestUtil.java
@@ -28,11 +28,22 @@ public class SerializationTestUtil {
           .registerModules(ObjectMapper.findModules(ReflectHelpers.findClassLoader()));
 
   public static <T> T serializeDeserialize(Class<T> clazz, T obj) {
+    return deserialize(serialize(obj), clazz);
+  }
+
+  public static <T> String serialize(T obj) {
     try {
-      String jsonString = MAPPER.writeValueAsString(obj);
+      return MAPPER.writeValueAsString(obj);
+    } catch (JsonProcessingException e) {
+      throw new RuntimeException("Failed to serialize " + obj.getClass().getSimpleName(), e);
+    }
+  }
+
+  public static <T> T deserialize(String jsonString, Class<T> clazz) {
+    try {
       return MAPPER.readValue(jsonString, clazz);
     } catch (JsonProcessingException e) {
-      throw new RuntimeException("Failed to serialize/deserialize " + clazz.getSimpleName(), e);
+      throw new RuntimeException("Failed to deserialize " + clazz.getSimpleName(), e);
     }
   }
 }


### PR DESCRIPTION
Support usage of custom `profileName` with AWS `ProfileCredentialsProvider` (aws2) (closes #23206)

`profileName` is optional, if not set the environment default is used. Be careful if using this provider programmatically, it can behave unexpectedly (see tests).

Examples:

```
 --awsCredentialsProvider={    
  "@type": "ProfileCredentialsProvider"
} 
```
```
--awsCredentialsProvider={
    "@type": "ProfileCredentialsProvider",
    "profileName": "my_profile" 
}
```
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
