### PR TITLE
Remove artificial timeout in FirestoreV1IT, Dataflow runner is very slow

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/firestore/it/BaseFirestoreIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/firestore/it/BaseFirestoreIT.java
@@ -62,7 +62,6 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.TestName;
-import org.junit.rules.Timeout;
 
 @SuppressWarnings({
   "initialization.fields.uninitialized",
@@ -76,19 +75,13 @@ abstract class BaseFirestoreIT {
   @Rule(order = 1)
   public final TestName testName = new TestName();
 
-  @Rule(
-      order =
-          2) // ensure our helper is "outer" to the timeout so we are allowed to cleanup even if a
-  // test times out
+  @Rule(order = 2)
   public final FirestoreTestingHelper helper = new FirestoreTestingHelper(CleanupMode.ALWAYS);
 
   @Rule(order = 3)
-  public final Timeout timeout = new Timeout(10, TimeUnit.MINUTES);
-
-  @Rule(order = 4)
   public final TestPipeline testPipeline = TestPipeline.create();
 
-  @Rule(order = 5)
+  @Rule(order = 4)
   public final TestPipeline testPipeline2 = TestPipeline.create();
 
   protected static final RpcQosOptions RPC_QOS_OPTIONS =


### PR DESCRIPTION
Dataflow runner takes much longer to run any IT test, the artificial timeout added in FirestoreV1IT makes the test flaky, other IT tests don't set this timeout and many of them can run >10 minutes on Dataflow runner.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
