### PR TITLE
Use writer schema only for BigQueryIO Read API

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -595,20 +595,17 @@ public class BigQueryIO {
     private final Supplier<TableSchema> tableSchema;
     private GenericDatumReader<T> reader;
     private org.apache.avro.Schema writerSchema;
-    private org.apache.avro.Schema readerSchema;
 
     public GenericDatumTransformer(
         SerializableFunction<SchemaAndRecord, T> parseFn,
         String tableSchema,
-        org.apache.avro.Schema writer,
-        org.apache.avro.Schema reader) {
+        org.apache.avro.Schema writer) {
       this.parseFn = parseFn;
       this.tableSchema =
           Suppliers.memoize(
               Suppliers.compose(new TableSchemaFunction(), Suppliers.ofInstance(tableSchema)));
       this.writerSchema = writer;
-      this.readerSchema = reader;
-      this.reader = new GenericDatumReader<>(this.writerSchema, this.readerSchema);
+      this.reader = new GenericDatumReader<>(this.writerSchema);
     }
 
     @Override
@@ -618,11 +615,7 @@ public class BigQueryIO {
       }
 
       this.writerSchema = schema;
-      if (this.readerSchema == null) {
-        this.readerSchema = schema;
-      }
-
-      this.reader = new GenericDatumReader<>(this.writerSchema, this.readerSchema);
+      this.reader = new GenericDatumReader<>(this.writerSchema);
     }
 
     @Override
@@ -664,7 +657,7 @@ public class BigQueryIO {
                     String jsonTableSchema = BigQueryIO.JSON_FACTORY.toString(input);
                     return (AvroSource.DatumReaderFactory<T>)
                         (writer, reader) ->
-                            new GenericDatumTransformer<>(parseFn, jsonTableSchema, writer, reader);
+                            new GenericDatumTransformer<>(parseFn, jsonTableSchema, writer);
                   } catch (IOException e) {
                     LOG.warn(
                         String.format("Error while converting table schema %s to JSON!", input), e);

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOReadTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOReadTest.java
@@ -143,7 +143,7 @@ public class BigQueryIOReadTest implements Serializable {
                   return (AvroSource.DatumReaderFactory<TableRow>)
                       (writer, reader) ->
                           new BigQueryIO.GenericDatumTransformer<>(
-                              BigQueryIO.TableRowParser.INSTANCE, jsonSchema, writer, reader);
+                              BigQueryIO.TableRowParser.INSTANCE, jsonSchema, writer);
                 } catch (IOException e) {
                   return null;
                 }


### PR DESCRIPTION
This PR fixes #23541
 
PR [22718](https://github.com/apache/beam/pull/22718) updated the behavior of BigQueryIO **read** and **readTableRows** API where it uses both the Avro writer and reader schema to decode BigQuery elements. However, before this change, these APIs only relied on the writer schema to deserialize elements. The issue with using reader schema is that its derived via the `BigQueryAvroUtils.toGenericAvroSchema` function that does not correctly handle _TableFieldSchema -> Avro schema_ conversion for Avro schemas containing LogicalTypes.

R: @steveniemitz 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [X] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
