### PR TITLE
(BQ Java) Explicitly set coder for multi-partition batch load writes 

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -188,7 +188,8 @@ class BatchLoads<DestinationT, ElementT>
     this.rowWriterFactory = rowWriterFactory;
     schemaUpdateOptions = Collections.emptySet();
     this.tempDataset = tempDataset;
-    this.tableDestinationCoder = clusteringEnabled ? TableDestinationCoderV3.of(): TableDestinationCoderV2.of();
+    this.tableDestinationCoder =
+        clusteringEnabled ? TableDestinationCoderV3.of() : TableDestinationCoderV2.of();
   }
 
   void setSchemaUpdateOptions(Set<SchemaUpdateOption> schemaUpdateOptions) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -146,8 +146,8 @@ class BatchLoads<DestinationT, ElementT>
   private final Coder<ElementT> elementCoder;
   private final RowWriterFactory<ElementT, DestinationT> rowWriterFactory;
   private final @Nullable String kmsKey;
-  private final boolean clusteringEnabled;
   private final String tempDataset;
+  private Coder<TableDestination> tableDestinationCoder;
 
   // The maximum number of times to retry failed load or copy jobs.
   private int maxRetryJobs = DEFAULT_MAX_RETRY_JOBS;
@@ -186,9 +186,9 @@ class BatchLoads<DestinationT, ElementT>
     this.elementCoder = elementCoder;
     this.kmsKey = kmsKey;
     this.rowWriterFactory = rowWriterFactory;
-    this.clusteringEnabled = clusteringEnabled;
     schemaUpdateOptions = Collections.emptySet();
     this.tempDataset = tempDataset;
+    this.tableDestinationCoder = clusteringEnabled ? TableDestinationCoderV3.of(): TableDestinationCoderV2.of();
   }
 
   void setSchemaUpdateOptions(Set<SchemaUpdateOption> schemaUpdateOptions) {
@@ -493,7 +493,8 @@ class BatchLoads<DestinationT, ElementT>
                             maxRetryJobs,
                             kmsKey,
                             loadJobProjectId))
-                    .withSideInputs(copyJobIdPrefixView));
+                    .withSideInputs(copyJobIdPrefixView))
+            .setCoder(tableDestinationCoder);
 
     PCollectionList<TableDestination> allSuccessfulWrites =
         PCollectionList.of(successfulSinglePartitionWrites).and(successfulMultiPartitionWrites);
@@ -754,9 +755,6 @@ class BatchLoads<DestinationT, ElementT>
       PCollectionView<String> loadJobIdPrefixView) {
     List<PCollectionView<?>> sideInputs = Lists.newArrayList(loadJobIdPrefixView);
     sideInputs.addAll(dynamicDestinations.getSideInputs());
-
-    Coder<TableDestination> tableDestinationCoder =
-        clusteringEnabled ? TableDestinationCoderV3.of() : TableDestinationCoderV2.of();
 
     Coder<KV<ShardedKey<DestinationT>, WritePartition.Result>> partitionsCoder =
         KvCoder.of(


### PR DESCRIPTION
Fixes #23561 (once cherry picked into release-2.42.0)

Single partition writes set a coder `TableDestinationCoderV3` [here](https://github.com/ahmedabu98/beam/blob/ef85e6b948c4fd02b85f93e493e3dc50be2299c9/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java#L818) while multi partition writes doesn't set any coder explicitly, so it defaults to a serializable `TableDestination` coder. There is an attempt later to flatten the single and multi write PCollections [here](https://github.com/ahmedabu98/beam/blob/67d6e8aa1a7d8107e6fd84824364fc215269cc02/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java#L504-L505), but because the coder types are different, the following error is thrown: 

`
org.apache.flink.api.common.InvalidProgramException: Cannot union inputs of different types. Input1=CoderTypeInformation{coder=WindowedValue$FullWindowedValueCoder(TableDestinationCoderV2,GlobalWindow$Coder)}, input2=CoderTypeInformation{coder=WindowedValue$FullWindowedValueCoder(SerializableCoder(org.apache.beam.sdk.io.gcp.bigquery.TableDestination),GlobalWindow$Coder)}
`