### PR TITLE
Keep Spark version in a single place only (BeamModulePlugin)

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -499,6 +499,10 @@ class BeamModulePlugin implements Plugin<Project> {
     def arrow_version = "5.0.0"
     def jmh_version = "1.34"
 
+    // Export Spark versions, so they are defined in a single place only
+    project.ext.spark2_version = spark2_version
+    project.ext.spark3_version = spark3_version
+
     // A map of maps containing common libraries used per language. To use:
     // dependencies {
     //   compile library.java.slf4j_api

--- a/runners/spark/2/build.gradle
+++ b/runners/spark/2/build.gradle
@@ -19,8 +19,8 @@
 def basePath = '..'
 /* All properties required for loading the Spark build script */
 project.ext {
-  // Set the version of all Spark-related dependencies here.
-  spark_version = '2.4.8'
+  // Spark 2 version as defined in BeamModulePlugin
+  spark_version = spark2_version
   spark_scala_version = '2.11'
   // Copy shared sources for Spark 2 to use Spark 3 as primary version in place
   copySourceBase = true

--- a/runners/spark/3/build.gradle
+++ b/runners/spark/3/build.gradle
@@ -19,8 +19,8 @@
 def basePath = '..'
 /* All properties required for loading the Spark build script */
 project.ext {
-  // Set the version of all Spark-related dependencies here.
-  spark_version = '3.1.2'
+  // Spark 3 version as defined in BeamModulePlugin
+  spark_version = spark3_version
   spark_scala_version = '2.12'
   copySourceBase = false // disabled to use Spark 3 as primary dev version
   archives_base_name = 'beam-runners-spark-3'
@@ -29,7 +29,7 @@ project.ext {
 // Load the main build script which contains all build logic.
 apply from: "$basePath/spark_runner.gradle"
 
-
+// Additional supported Spark versions (used in compatibility tests)
 def sparkVersions = [
     "330": "3.3.0",
     "321": "3.2.1"


### PR DESCRIPTION
It's a bit of a trap to have the Spark version in two places.

Especially because it's most obvious to change the one in the Spark build.gradle. But that one is always overruled by the one used in the artifact library in BeamModulePlugin.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
