### PR TITLE
Migrate nexmark to common config for cron jobs

### DIFF
--- a/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Dataflow.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Dataflow.groovy
@@ -31,163 +31,12 @@ import static NexmarkDatabaseProperties.nexmarkInfluxDBArgs
 // This job runs the suite of ValidatesRunner tests against the Dataflow runner.
 NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Dataflow',
     'Dataflow Runner Nexmark Tests', this) {
+
       description('Runs the Nexmark suite on the Dataflow runner.')
 
-      // Set common parameters.
       commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240)
-      InfluxDBCredentialsHelper.useCredentials(delegate)
 
-      // Gradle goals for this job.
-      steps {
-        shell('echo "*** RUN NEXMARK IN BATCH MODE USING DATAFLOW RUNNER ***"')
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches('-Pnexmark.runner=":runners:google-cloud-dataflow-java"' +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=DataflowRunner',
-                '--region=us-central1',
-                '--numWorkers=4',
-                '--maxNumWorkers=4',
-                '--autoscalingAlgorithm=NONE',
-                '--nexmarkParallel=16',
-                '--streaming=false',
-                '--suite=STRESS',
-                '--manageResources=false',
-                '--monitorJobs=true',
-                '--enforceEncodability=true',
-                '--enforceImmutability=true"'
-              ].join(' '))
-        }
-        shell('echo "*** RUN NEXMARK IN STREAMING MODE USING DATAFLOW RUNNER ***"')
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches('-Pnexmark.runner=":runners:google-cloud-dataflow-java"' +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=DataflowRunner',
-                '--region=us-central1',
-                '--numWorkers=4',
-                '--maxNumWorkers=4',
-                '--autoscalingAlgorithm=NONE',
-                '--nexmarkParallel=16',
-                '--streaming=true',
-                '--suite=STRESS',
-                '--manageResources=false',
-                '--monitorJobs=true',
-                '--enforceEncodability=true',
-                '--enforceImmutability=true"'
-              ].join(' '))
-        }
-        shell('echo "*** RUN NEXMARK IN SQL BATCH MODE USING DATAFLOW RUNNER ***"')
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches('-Pnexmark.runner=":runners:google-cloud-dataflow-java"' +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=DataflowRunner',
-                '--region=us-central1',
-                '--numWorkers=4',
-                '--maxNumWorkers=4',
-                '--autoscalingAlgorithm=NONE',
-                '--nexmarkParallel=16',
-                '--queryLanguage=sql',
-                '--streaming=false',
-                '--suite=STRESS',
-                '--manageResources=false',
-                '--monitorJobs=true',
-                '--enforceEncodability=true',
-                '--enforceImmutability=true"'
-              ].join(' '))
-        }
-        shell('echo "*** RUN NEXMARK IN SQL STREAMING MODE USING DATAFLOW RUNNER ***"')
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches('-Pnexmark.runner=":runners:google-cloud-dataflow-java"' +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=DataflowRunner',
-                '--region=us-central1',
-                '--numWorkers=4',
-                '--maxNumWorkers=4',
-                '--autoscalingAlgorithm=NONE',
-                '--nexmarkParallel=16',
-                '--queryLanguage=sql',
-                '--streaming=true',
-                '--suite=STRESS',
-                '--manageResources=false',
-                '--monitorJobs=true',
-                '--enforceEncodability=true',
-                '--enforceImmutability=true"'
-              ].join(' '))
-        }
-        shell('echo "*** RUN NEXMARK IN ZETASQL BATCH MODE USING DATAFLOW RUNNER ***"')
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches('-Pnexmark.runner=":runners:google-cloud-dataflow-java"' +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=DataflowRunner',
-                '--region=us-central1',
-                '--numWorkers=4',
-                '--maxNumWorkers=4',
-                '--autoscalingAlgorithm=NONE',
-                '--nexmarkParallel=16',
-                '--queryLanguage=zetasql',
-                '--streaming=false',
-                '--suite=STRESS',
-                '--manageResources=false',
-                '--monitorJobs=true',
-                '--enforceEncodability=true',
-                '--enforceImmutability=true"'
-              ].join(' '))
-        }
-        shell('echo "*** RUN NEXMARK IN ZETASQL STREAMING MODE USING DATAFLOW RUNNER ***"')
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches('-Pnexmark.runner=":runners:google-cloud-dataflow-java"' +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=DataflowRunner',
-                '--region=us-central1',
-                '--numWorkers=4',
-                '--maxNumWorkers=4',
-                '--autoscalingAlgorithm=NONE',
-                '--nexmarkParallel=16',
-                '--queryLanguage=zetasql',
-                '--streaming=true',
-                '--suite=STRESS',
-                '--manageResources=false',
-                '--monitorJobs=true',
-                '--enforceEncodability=true',
-                '--enforceImmutability=true"'
-              ].join(' '))
-        }
-      }
+      commonJob(delegate, TriggeringContext.POST_COMMIT)
     }
 
 PhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Dataflow',
@@ -197,15 +46,19 @@ PhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Da
 
       commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240)
 
-      def final JOB_SPECIFIC_OPTIONS = [
-        'region' : 'us-central1',
-        'suite' : 'STRESS',
-        'numWorkers' : 4,
-        'maxNumWorkers' : 4,
-        'autoscalingAlgorithm' : 'NONE',
-        'nexmarkParallel' : 16,
-        'enforceEncodability' : true,
-        'enforceImmutability' : true
-      ]
-      Nexmark.standardJob(delegate, Runner.DATAFLOW, SDK.JAVA, JOB_SPECIFIC_OPTIONS, TriggeringContext.PR)
+      commonJob(delegate, TriggeringContext.PR)
     }
+
+private void commonJob(delegate, TriggeringContext triggeringContext) {
+  def final JOB_SPECIFIC_OPTIONS = [
+    'region' : 'us-central1',
+    'suite' : 'STRESS',
+    'numWorkers' : 4,
+    'maxNumWorkers' : 4,
+    'autoscalingAlgorithm' : 'NONE',
+    'nexmarkParallel' : 16,
+    'enforceEncodability' : true,
+    'enforceImmutability' : true
+  ]
+  Nexmark.standardJob(delegate, Runner.DATAFLOW, SDK.JAVA, JOB_SPECIFIC_OPTIONS, triggeringContext)
+}

--- a/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Dataflow_V2.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Dataflow_V2.groovy
@@ -28,32 +28,15 @@ import InfluxDBCredentialsHelper
 import static NexmarkDatabaseProperties.nexmarkBigQueryArgs
 import static NexmarkDatabaseProperties.nexmarkInfluxDBArgs
 
-def final JOB_SPECIFIC_OPTIONS = [
-  'influxTags' : '{\\\"runnerVersion\\\":\\\"V2\\\",\\\"javaVersion\\\":\\\"8\\\"}',
-  'exportSummaryToBigQuery' : false,
-  'region' : 'us-central1',
-  'suite' : 'STRESS',
-  'numWorkers' : 4,
-  'maxNumWorkers' : 4,
-  'autoscalingAlgorithm' : 'NONE',
-  'nexmarkParallel' : 16,
-  'enforceEncodability' : true,
-  'enforceImmutability' : true
-]
-
-def final JOB_SPECIFIC_SWITCHES = [
-  '-Pnexmark.runner.version="V2"'
-]
-
 // This job runs the suite of Nexmark tests against the Dataflow runner V2.
 NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Dataflow_V2',
     'Dataflow Runner V2 Nexmark Tests', this) {
+
       description('Runs the Nexmark suite on the Dataflow runner V2.')
 
-      // Set common parameters.
       commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240)
 
-      Nexmark.nonQueryLanguageJobs(delegate, Runner.DATAFLOW, SDK.JAVA, JOB_SPECIFIC_OPTIONS, TriggeringContext.POST_COMMIT, JOB_SPECIFIC_SWITCHES, Nexmark.DEFAULT_JAVA_RUNTIME_VERSION)
+      commonJob(delegate, TriggeringContext.POST_COMMIT)
     }
 
 PhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_DataflowV2',
@@ -63,5 +46,26 @@ PhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Da
 
       commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240)
 
-      Nexmark.nonQueryLanguageJobs(delegate, Runner.DATAFLOW, SDK.JAVA, JOB_SPECIFIC_OPTIONS, TriggeringContext.PR, JOB_SPECIFIC_SWITCHES, Nexmark.DEFAULT_JAVA_RUNTIME_VERSION)
+      commonJob(delegate, TriggeringContext.PR)
     }
+
+private void commonJob(delegate, TriggeringContext triggeringContext) {
+  def final JOB_SPECIFIC_OPTIONS = [
+    'influxTags' : '{\\\"runnerVersion\\\":\\\"V2\\\",\\\"javaVersion\\\":\\\"8\\\"}',
+    'exportSummaryToBigQuery' : false,
+    'region' : 'us-central1',
+    'suite' : 'STRESS',
+    'numWorkers' : 4,
+    'maxNumWorkers' : 4,
+    'autoscalingAlgorithm' : 'NONE',
+    'nexmarkParallel' : 16,
+    'enforceEncodability' : true,
+    'enforceImmutability' : true
+  ]
+
+  def final JOB_SPECIFIC_SWITCHES = [
+    '-Pnexmark.runner.version="V2"'
+  ]
+
+  Nexmark.nonQueryLanguageJobs(delegate, Runner.DATAFLOW, SDK.JAVA, JOB_SPECIFIC_OPTIONS, triggeringContext, JOB_SPECIFIC_SWITCHES, Nexmark.DEFAULT_JAVA_RUNTIME_VERSION)
+}

--- a/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Dataflow_V2_Java11.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Dataflow_V2_Java11.groovy
@@ -28,32 +28,15 @@ import InfluxDBCredentialsHelper
 import static NexmarkDatabaseProperties.nexmarkBigQueryArgs
 import static NexmarkDatabaseProperties.nexmarkInfluxDBArgs
 
-def final JOB_SPECIFIC_OPTIONS = [
-  'influxTags' : '{\\\"runnerVersion\\\":\\\"V2\\\",\\\"javaVersion\\\":\\\"11\\\"}',
-  'exportSummaryToBigQuery' : false,
-  'region' : 'us-central1',
-  'suite' : 'STRESS',
-  'numWorkers' : 4,
-  'maxNumWorkers' : 4,
-  'autoscalingAlgorithm' : 'NONE',
-  'nexmarkParallel' : 16,
-  'enforceEncodability' : true,
-  'enforceImmutability' : true
-]
-
-def final JOB_SPECIFIC_SWITCHES = [
-  '-Pnexmark.runner.version="V2"'
-]
-
 // This job runs the suite of Nexmark tests against the Dataflow runner V2.
 NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Dataflow_V2_Java11',
     'Dataflow Runner V2 Java 11 Nexmark Tests', this) {
+
       description('Runs the Nexmark suite on the Dataflow runner V2 on Java 11.')
 
-      // Set common parameters.
       commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240)
 
-      Nexmark.nonQueryLanguageJobs(delegate, Runner.DATAFLOW, SDK.JAVA, JOB_SPECIFIC_OPTIONS, TriggeringContext.POST_COMMIT, JOB_SPECIFIC_SWITCHES, Nexmark.JAVA_11_RUNTIME_VERSION)
+      commonJob(delegate, TriggeringContext.POST_COMMIT)
     }
 
 PhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_DataflowV2_Java11',
@@ -63,5 +46,26 @@ PhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Da
 
       commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240)
 
-      Nexmark.nonQueryLanguageJobs(delegate, Runner.DATAFLOW, SDK.JAVA, JOB_SPECIFIC_OPTIONS, TriggeringContext.PR, JOB_SPECIFIC_SWITCHES, Nexmark.JAVA_11_RUNTIME_VERSION)
+      commonJob(delegate, TriggeringContext.PR)
     }
+
+private void commonJob(delegate, TriggeringContext triggeringContext) {
+  def final JOB_SPECIFIC_OPTIONS = [
+    'influxTags' : '{\\\"runnerVersion\\\":\\\"V2\\\",\\\"javaVersion\\\":\\\"11\\\"}',
+    'exportSummaryToBigQuery' : false,
+    'region' : 'us-central1',
+    'suite' : 'STRESS',
+    'numWorkers' : 4,
+    'maxNumWorkers' : 4,
+    'autoscalingAlgorithm' : 'NONE',
+    'nexmarkParallel' : 16,
+    'enforceEncodability' : true,
+    'enforceImmutability' : true
+  ]
+
+  def final JOB_SPECIFIC_SWITCHES = [
+    '-Pnexmark.runner.version="V2"'
+  ]
+
+  Nexmark.nonQueryLanguageJobs(delegate, Runner.DATAFLOW, SDK.JAVA, JOB_SPECIFIC_OPTIONS, triggeringContext, JOB_SPECIFIC_SWITCHES, Nexmark.JAVA_11_RUNTIME_VERSION)
+}

--- a/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Dataflow_V2_Java17.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Dataflow_V2_Java17.groovy
@@ -28,32 +28,15 @@ import InfluxDBCredentialsHelper
 import static NexmarkDatabaseProperties.nexmarkBigQueryArgs
 import static NexmarkDatabaseProperties.nexmarkInfluxDBArgs
 
-def final JOB_SPECIFIC_OPTIONS = [
-  'influxTags' : '{\\\"runnerVersion\\\":\\\"V2\\\",\\\"javaVersion\\\":\\\"17\\\"}',
-  'exportSummaryToBigQuery' : false,
-  'region' : 'us-central1',
-  'suite' : 'STRESS',
-  'numWorkers' : 4,
-  'maxNumWorkers' : 4,
-  'autoscalingAlgorithm' : 'NONE',
-  'nexmarkParallel' : 16,
-  'enforceEncodability' : true,
-  'enforceImmutability' : true
-]
-
-def final JOB_SPECIFIC_SWITCHES = [
-  '-Pnexmark.runner.version="V2"'
-]
-
 // This job runs the suite of Nexmark tests against the Dataflow runner V2.
 NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Dataflow_V2_Java17',
     'Dataflow Runner V2 Java 17 Nexmark Tests', this) {
+
       description('Runs the Nexmark suite on the Dataflow runner V2 on Java 17.')
 
-      // Set common parameters.
       commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240)
 
-      Nexmark.nonQueryLanguageJobs(delegate, Runner.DATAFLOW, SDK.JAVA, JOB_SPECIFIC_OPTIONS, TriggeringContext.POST_COMMIT, JOB_SPECIFIC_SWITCHES, Nexmark.JAVA_17_RUNTIME_VERSION)
+      commonJob(delegate, TriggeringContext.POST_COMMIT)
     }
 
 PhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_DataflowV2_Java17',
@@ -63,5 +46,26 @@ PhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Da
 
       commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240)
 
-      Nexmark.nonQueryLanguageJobs(delegate, Runner.DATAFLOW, SDK.JAVA, JOB_SPECIFIC_OPTIONS, TriggeringContext.PR, JOB_SPECIFIC_SWITCHES, Nexmark.JAVA_17_RUNTIME_VERSION)
+      commonJob(delegate, TriggeringContext.PR)
     }
+
+private void commonJob(delegate, TriggeringContext triggeringContext) {
+  def final JOB_SPECIFIC_OPTIONS = [
+    'influxTags' : '{\\\"runnerVersion\\\":\\\"V2\\\",\\\"javaVersion\\\":\\\"17\\\"}',
+    'exportSummaryToBigQuery' : false,
+    'region' : 'us-central1',
+    'suite' : 'STRESS',
+    'numWorkers' : 4,
+    'maxNumWorkers' : 4,
+    'autoscalingAlgorithm' : 'NONE',
+    'nexmarkParallel' : 16,
+    'enforceEncodability' : true,
+    'enforceImmutability' : true
+  ]
+
+  def final JOB_SPECIFIC_SWITCHES = [
+    '-Pnexmark.runner.version="V2"'
+  ]
+
+  Nexmark.nonQueryLanguageJobs(delegate, Runner.DATAFLOW, SDK.JAVA, JOB_SPECIFIC_OPTIONS, triggeringContext, JOB_SPECIFIC_SWITCHES, Nexmark.JAVA_17_RUNTIME_VERSION)
+}

--- a/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Direct.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Direct.groovy
@@ -30,133 +30,12 @@ import static NexmarkDatabaseProperties.nexmarkInfluxDBArgs
 
 NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Direct',
     'Direct Runner Nexmark Tests', this) {
+
       description('Runs the Nexmark suite on the Direct runner.')
 
-      // Set common parameters.
       commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240, true, 'beam-perf')
-      InfluxDBCredentialsHelper.useCredentials(delegate)
 
-      // Gradle goals for this job.
-      steps {
-        shell('echo "*** RUN NEXMARK IN BATCH MODE USING DIRECT RUNNER ***"')
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches('-Pnexmark.runner=":runners:direct-java"' +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=DirectRunner',
-                '--streaming=false',
-                '--suite=SMOKE',
-                '--manageResources=false',
-                '--monitorJobs=true',
-                '--enforceEncodability=true',
-                '--enforceImmutability=true"'
-              ].join(' '))
-        }
-        shell('echo "*** RUN NEXMARK IN STREAMING MODE USING DIRECT RUNNER ***"')
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches('-Pnexmark.runner=":runners:direct-java"' +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=DirectRunner',
-                '--streaming=true',
-                '--suite=SMOKE',
-                '--manageResources=false',
-                '--monitorJobs=true',
-                '--enforceEncodability=true',
-                '--enforceImmutability=true"'
-              ].join(' '))
-        }
-        shell('echo "*** RUN NEXMARK IN SQL BATCH MODE USING DIRECT RUNNER ***"')
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches('-Pnexmark.runner=":runners:direct-java"' +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=DirectRunner',
-                '--queryLanguage=sql',
-                '--streaming=false',
-                '--suite=SMOKE',
-                '--manageResources=false',
-                '--monitorJobs=true',
-                '--enforceEncodability=true',
-                '--enforceImmutability=true"'
-              ].join(' '))
-        }
-        shell('echo "*** RUN NEXMARK IN SQL STREAMING MODE USING DIRECT RUNNER ***"')
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches('-Pnexmark.runner=":runners:direct-java"' +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=DirectRunner',
-                '--queryLanguage=sql',
-                '--streaming=true',
-                '--suite=SMOKE',
-                '--manageResources=false',
-                '--monitorJobs=true',
-                '--enforceEncodability=true',
-                '--enforceImmutability=true"'
-              ].join(' '))
-        }
-        shell('echo "*** RUN NEXMARK IN ZETASQL BATCH MODE USING DIRECT RUNNER ***"')
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches('-Pnexmark.runner=":runners:direct-java"' +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=DirectRunner',
-                '--queryLanguage=zetasql',
-                '--streaming=false',
-                '--suite=SMOKE',
-                '--manageResources=false',
-                '--monitorJobs=true',
-                '--enforceEncodability=true',
-                '--enforceImmutability=true"'
-              ].join(' '))
-        }
-        shell('echo "*** RUN NEXMARK IN ZETASQL STREAMING MODE USING DIRECT RUNNER ***"')
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches('-Pnexmark.runner=":runners:direct-java"' +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=DirectRunner',
-                '--queryLanguage=zetasql',
-                '--streaming=true',
-                '--suite=SMOKE',
-                '--manageResources=false',
-                '--monitorJobs=true',
-                '--enforceEncodability=true',
-                '--enforceImmutability=true"'
-              ].join(' '))
-        }
-      }
+      commonJob(delegate, TriggeringContext.POST_COMMIT)
     }
 
 PhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Direct',
@@ -166,10 +45,14 @@ PhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Di
 
       commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240)
 
-      def final JOB_SPECIFIC_OPTIONS = [
-        'suite' : 'SMOKE',
-        'enforceEncodability' : true,
-        'enforceImmutability' : true
-      ]
-      Nexmark.standardJob(delegate, Runner.DIRECT, SDK.JAVA, JOB_SPECIFIC_OPTIONS, TriggeringContext.PR)
+      commonJob(delegate, TriggeringContext.PR)
     }
+
+private void commonJob(delegate, TriggeringContext triggeringContext) {
+  def final JOB_SPECIFIC_OPTIONS = [
+    'suite' : 'SMOKE',
+    'enforceEncodability' : true,
+    'enforceImmutability' : true
+  ]
+  Nexmark.standardJob(delegate, Runner.DIRECT, SDK.JAVA, JOB_SPECIFIC_OPTIONS, triggeringContext)
+}

--- a/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Flink.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Flink.groovy
@@ -32,125 +32,12 @@ import static NexmarkDatabaseProperties.nexmarkInfluxDBArgs
 // This job runs the suite of ValidatesRunner tests against the Flink runner.
 NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Flink',
     'Flink Runner Nexmark Tests', this) {
+
       description('Runs the Nexmark suite on the Flink runner.')
 
-      // Set common parameters.
       commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240, true, 'beam-perf')
-      InfluxDBCredentialsHelper.useCredentials(delegate)
 
-      // Gradle goals for this job.
-      steps {
-        shell('echo "*** RUN NEXMARK IN BATCH MODE USING FLINK RUNNER ***"')
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches("-Pnexmark.runner=\":runners:flink:${CommonTestProperties.getFlinkVersion()}\"" +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=FlinkRunner',
-                '--streaming=false',
-                '--suite=SMOKE',
-                '--streamTimeout=60' ,
-                '--manageResources=false',
-                '--monitorJobs=true"'
-              ].join(' '))
-        }
-        shell('echo "*** RUN NEXMARK IN STREAMING MODE USING FLINK RUNNER ***"')
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches("-Pnexmark.runner=\":runners:flink:${CommonTestProperties.getFlinkVersion()}\"" +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=FlinkRunner',
-                '--streaming=true',
-                '--suite=SMOKE',
-                '--streamTimeout=60' ,
-                '--manageResources=false',
-                '--monitorJobs=true"'
-              ].join(' '))
-        }
-        shell('echo "*** RUN NEXMARK IN SQL BATCH MODE USING FLINK RUNNER ***"')
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches("-Pnexmark.runner=\":runners:flink:${CommonTestProperties.getFlinkVersion()}\"" +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=FlinkRunner',
-                '--queryLanguage=sql',
-                '--streaming=false',
-                '--suite=SMOKE',
-                '--streamTimeout=60' ,
-                '--manageResources=false"'
-              ].join(' '))
-        }
-        shell('echo "*** RUN NEXMARK IN SQL STREAMING MODE USING FLINK RUNNER ***"')
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches("-Pnexmark.runner=\":runners:flink:${CommonTestProperties.getFlinkVersion()}\"" +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=FlinkRunner',
-                '--queryLanguage=sql',
-                '--streaming=true',
-                '--suite=SMOKE',
-                '--streamTimeout=60' ,
-                '--manageResources=false',
-                '--monitorJobs=true"'
-              ].join(' '))
-        }
-        shell('echo "*** RUN NEXMARK IN ZETASQL BATCH MODE USING FLINK RUNNER ***"')
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches("-Pnexmark.runner=\":runners:flink:${CommonTestProperties.getFlinkVersion()}\"" +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=FlinkRunner',
-                '--queryLanguage=zetasql',
-                '--streaming=false',
-                '--suite=SMOKE',
-                '--streamTimeout=60' ,
-                '--manageResources=false"'
-              ].join(' '))
-        }
-        shell('echo "*** RUN NEXMARK IN ZETASQL STREAMING MODE USING FLINK RUNNER ***"')
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches("-Pnexmark.runner=\":runners:flink:${CommonTestProperties.getFlinkVersion()}\"" +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=FlinkRunner',
-                '--queryLanguage=zetasql',
-                '--streaming=true',
-                '--suite=SMOKE',
-                '--streamTimeout=60' ,
-                '--manageResources=false',
-                '--monitorJobs=true"'
-              ].join(' '))
-        }
-      }
+      commonJob(delegate, TriggeringContext.POST_COMMIT)
     }
 
 PhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Flink',
@@ -160,10 +47,14 @@ PhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Fl
 
       commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240)
 
-      def final JOB_SPECIFIC_OPTIONS = [
-        'suite' : 'SMOKE',
-        'streamTimeout' : 60,
-      ]
-
-      Nexmark.standardJob(delegate, Runner.FLINK, SDK.JAVA, JOB_SPECIFIC_OPTIONS, TriggeringContext.PR)
+      commonJob(delegate, TriggeringContext.PR)
     }
+
+private void commonJob(delegate, TriggeringContext triggeringContext) {
+  def final JOB_SPECIFIC_OPTIONS = [
+    'suite' : 'SMOKE',
+    'streamTimeout' : 60,
+  ]
+
+  Nexmark.standardJob(delegate, Runner.FLINK, SDK.JAVA, JOB_SPECIFIC_OPTIONS, triggeringContext)
+}

--- a/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Spark.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Spark.groovy
@@ -23,99 +23,16 @@ import CommonTestProperties.TriggeringContext
 import NexmarkBuilder as Nexmark
 import NoPhraseTriggeringPostCommitBuilder
 import PhraseTriggeringPostCommitBuilder
-import InfluxDBCredentialsHelper
-
-import static NexmarkDatabaseProperties.nexmarkBigQueryArgs
-import static NexmarkDatabaseProperties.nexmarkInfluxDBArgs
 
 // This job runs the suite of ValidatesRunner tests against the Spark runner.
 NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Spark',
     'Spark Runner Nexmark Tests', this) {
+
       description('Runs the Nexmark suite on the Spark runner.')
 
-      // Set common parameters.
       commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240, true, 'beam-perf')
-      InfluxDBCredentialsHelper.useCredentials(delegate)
 
-      // Gradle goals for this job.
-      steps {
-        shell("echo \"*** RUN NEXMARK IN BATCH MODE USING SPARK ${CommonTestProperties.getSparkVersion()} RUNNER ***\"")
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches("-Pnexmark.runner=\":runners:spark:${CommonTestProperties.getSparkVersion()}\"" +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=SparkRunner',
-                '--streaming=false',
-                '--suite=SMOKE',
-                '--streamTimeout=60' ,
-                '--manageResources=false',
-                '--monitorJobs=true'
-              ].join(' ') + '"')
-        }
-        shell("echo \"*** RUN NEXMARK SQL IN BATCH MODE USING SPARK ${CommonTestProperties.getSparkVersion()} RUNNER ***\"")
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches("-Pnexmark.runner=\":runners:spark:${CommonTestProperties.getSparkVersion()}\"" +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=SparkRunner',
-                '--queryLanguage=sql',
-                '--streaming=false',
-                '--suite=SMOKE',
-                '--streamTimeout=60',
-                '--manageResources=false',
-                '--monitorJobs=true'
-              ].join(' ') + '"')
-        }
-        shell("echo \"*** RUN NEXMARK IN BATCH MODE USING SPARK ${CommonTestProperties.getSparkVersion()} STRUCTURED STREAMING RUNNER ***\"")
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches("-Pnexmark.runner=\":runners:spark:${CommonTestProperties.getSparkVersion()}\"" +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=SparkStructuredStreamingRunner',
-                '--streaming=false',
-                '--suite=SMOKE',
-                // Skip query 3 (SparkStructuredStreamingRunner does not support State/Timers yet)
-                '--skipQueries=3',
-                '--streamTimeout=60',
-                '--manageResources=false',
-                '--monitorJobs=true'
-              ].join(' ') + '"')
-        }
-        shell("echo \"*** RUN NEXMARK SQL IN BATCH MODE USING SPARK ${CommonTestProperties.getSparkVersion()} STRUCTURED STREAMING RUNNER ***\"")
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches("-Pnexmark.runner=\":runners:spark:${CommonTestProperties.getSparkVersion()}\"" +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=SparkStructuredStreamingRunner',
-                '--queryLanguage=sql',
-                '--streaming=false',
-                '--suite=SMOKE',
-                '--streamTimeout=60',
-                '--manageResources=false',
-                '--monitorJobs=true'
-              ].join(' ') + '"')
-        }
-      }
+      commonJob(delegate, TriggeringContext.POST_COMMIT)
     }
 
 PhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Spark',
@@ -125,18 +42,22 @@ PhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_Sp
 
       commonJobProperties.setTopLevelMainJobProperties(delegate, 'master', 240)
 
-      def final JOB_SPECIFIC_OPTIONS = [
-        'suite'        : 'SMOKE',
-        'streamTimeout': 60
-      ]
-      // Spark doesn't run streaming jobs, therefore run only batch variants.
-      Nexmark.batchOnlyJob(delegate, Runner.SPARK, SDK.JAVA, JOB_SPECIFIC_OPTIONS, TriggeringContext.PR)
-
-      def final SPARK_STRUCTURED_STREAMING_JOB_SPECIFIC_OPTIONS = [
-        'suite'        : 'SMOKE',
-        'streamTimeout': 60,
-        // Skip query 3 (SparkStructuredStreamingRunner does not support State/Timers yet)
-        'skipQueries'  : 3,
-      ]
-      Nexmark.batchOnlyJob(delegate, Runner.SPARK_STRUCTURED_STREAMING, SDK.JAVA, SPARK_STRUCTURED_STREAMING_JOB_SPECIFIC_OPTIONS, TriggeringContext.PR)
+      commonJob(delegate, TriggeringContext.PR)
     }
+
+private void commonJob(delegate, TriggeringContext triggeringContext) {
+  def final JOB_SPECIFIC_OPTIONS = [
+    'suite'        : 'SMOKE',
+    'streamTimeout': 60
+  ]
+  // Spark doesn't run streaming jobs, therefore run only batch variants.
+  Nexmark.batchOnlyJob(delegate, Runner.SPARK, SDK.JAVA, JOB_SPECIFIC_OPTIONS, triggeringContext)
+
+  def final SPARK_STRUCTURED_STREAMING_JOB_SPECIFIC_OPTIONS = [
+    'suite'        : 'SMOKE',
+    'streamTimeout': 60,
+    // Skip query 3 (SparkStructuredStreamingRunner does not support State/Timers yet)
+    'skipQueries'  : 3,
+  ]
+  Nexmark.batchOnlyJob(delegate, Runner.SPARK_STRUCTURED_STREAMING, SDK.JAVA, SPARK_STRUCTURED_STREAMING_JOB_SPECIFIC_OPTIONS, triggeringContext)
+}


### PR DESCRIPTION
This migrates all the nexmark jobs to use a common config for both the phrase and cron mode. This finishes the cleanup work started in #7021

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
