### PR TITLE
Periodically check table schemas when using Storage write API

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryOptions.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryOptions.java
@@ -150,4 +150,12 @@ public interface BigQueryOptions
   Integer getStorageApiAppendThresholdRecordCount();
 
   void setStorageApiAppendThresholdRecordCount(Integer value);
+
+  @Description(
+      "Disable use of the storage API failed row collection; any failing rows will retry indefinitely if set."
+          + "For internal testing only.")
+  @Default.Boolean(false)
+  Boolean getDisableStorageApiFailedRowsCollection();
+
+  void setDisableStorageApiFailedRowsCollection(Boolean value);
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/DynamicDestinationsHelpers.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/DynamicDestinationsHelpers.java
@@ -317,7 +317,7 @@ class DynamicDestinationsHelpers {
     }
 
     @Override
-    public TableSchema getSchema(DestinationT destination) {
+    public @Nullable TableSchema getSchema(DestinationT destination) {
       List<TimestampedValue<Map<String, String>>> mapValues = sideInput(schemaView);
       Optional<Map<String, String>> mapValue =
           mapValues.stream()
@@ -368,7 +368,7 @@ class DynamicDestinationsHelpers {
     }
 
     @Override
-    public TableSchema getSchema(DestinationT destination) {
+    public @Nullable TableSchema getSchema(DestinationT destination) {
       Map<String, String> mapValue = sideInput(schemaView);
       TableDestination tableDestination = inner.getTable(destination);
       @Nullable String schema = mapValue.get(tableDestination.getTableSpec());

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/PeriodicallyRefreshTableSchema.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/PeriodicallyRefreshTableSchema.java
@@ -1,0 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.bigquery;
+
+import com.google.api.services.bigquery.model.Table;
+import com.google.api.services.bigquery.model.TableReference;
+import java.io.IOException;
+import java.util.Map;
+import java.util.Set;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.coders.InstantCoder;
+import org.apache.beam.sdk.coders.MapCoder;
+import org.apache.beam.sdk.coders.SnappyCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.state.StateSpec;
+import org.apache.beam.sdk.state.StateSpecs;
+import org.apache.beam.sdk.state.TimeDomain;
+import org.apache.beam.sdk.state.Timer;
+import org.apache.beam.sdk.state.TimerSpec;
+import org.apache.beam.sdk.state.TimerSpecs;
+import org.apache.beam.sdk.state.ValueState;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.windowing.AfterProcessingTime;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
+import org.apache.beam.sdk.transforms.windowing.Repeatedly;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TimestampedValue;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Sets;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+
+/** This transform periodically recalculates the schema for */
+@SuppressWarnings({"unused"})
+class PeriodicallyRefreshTableSchema<DestinationT, ElementT>
+    extends PTransform<
+        PCollection<KV<DestinationT, ElementT>>,
+        PCollection<TimestampedValue<Map<String, String>>>> {
+  private final Duration refreshDuration;
+  private final DynamicDestinations<?, DestinationT> dynamicDestinations;
+  private final BigQueryServices bqServices;
+
+  public PeriodicallyRefreshTableSchema(
+      Duration refreshDuration,
+      DynamicDestinations<?, DestinationT> dynamicDestinations,
+      BigQueryServices bqServices) {
+    this.refreshDuration = refreshDuration;
+    this.dynamicDestinations = dynamicDestinations;
+    this.bqServices = bqServices;
+  }
+
+  @Override
+  public PCollection<TimestampedValue<Map<String, String>>> expand(
+      PCollection<KV<DestinationT, ElementT>> input) {
+    PCollection<TimestampedValue<Map<String, String>>> tableSchemas =
+        input
+            .apply("rewindow", Window.into(new GlobalWindows()))
+            .apply("dedup", ParDo.of(new DedupDoFn()))
+            .apply("refresh schema", ParDo.of(new RefreshTableSchemaDoFn()))
+            .apply(
+                "addTrigger",
+                Window.<TimestampedValue<Map<String, String>>>configure()
+                    .triggering(Repeatedly.forever(AfterProcessingTime.pastFirstElementInPane()))
+                    .discardingFiredPanes());
+    tableSchemas.setCoder(
+        SnappyCoder.of(
+            TimestampedValue.TimestampedValueCoder.of(
+                MapCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()))));
+    return tableSchemas;
+  }
+
+  private class DedupDoFn extends DoFn<KV<DestinationT, ElementT>, KV<Void, DestinationT>> {
+    Set<DestinationT> destinations = Sets.newHashSet();
+
+    @StartBundle
+    public void startBundle() {
+      destinations.clear();
+    }
+
+    @ProcessElement
+    public void process(@Element KV<DestinationT, ElementT> element) {
+      destinations.add(element.getKey());
+    }
+
+    @FinishBundle
+    public void finishBundle(FinishBundleContext context) {
+      for (DestinationT destination : destinations) {
+        context.output(
+            KV.of(null, destination), GlobalWindow.INSTANCE.maxTimestamp(), GlobalWindow.INSTANCE);
+      }
+    }
+  }
+
+  private class RefreshTableSchemaDoFn
+      extends DoFn<KV<Void, DestinationT>, TimestampedValue<Map<String, String>>> {
+    private final String DESTINATIONS_TAG = "destinations";
+    private final String DESTINATIONS_TIMER_TIME = "dest_timer_time";
+    private final String DESTINATIONS_TIMER = "destinationsTimer";
+
+    @StateId(DESTINATIONS_TAG)
+    private final StateSpec<ValueState<Set<String>>> destinationsSpec = StateSpecs.value();
+
+    @StateId(DESTINATIONS_TIMER_TIME)
+    private final StateSpec<ValueState<Instant>> timerTimeSpec =
+        StateSpecs.value(InstantCoder.of());
+
+    @TimerId(DESTINATIONS_TIMER)
+    private final TimerSpec destinationsTimer = TimerSpecs.timer(TimeDomain.PROCESSING_TIME);
+
+    private Map<String, String> currentOutput;
+    private Instant currentOutputTs;
+
+    private transient @Nullable BigQueryServices.DatasetService datasetServiceInternal = null;
+
+    @StartBundle
+    public void startBundle() {
+      initOutputMap();
+    }
+
+    public void initOutputMap() {
+      if (currentOutput == null) {
+        currentOutput = Maps.newHashMap();
+      } else {
+        currentOutput.clear();
+      }
+    }
+
+    @ProcessElement
+    public void process(
+        @Element KV<Void, DestinationT> destination,
+        @AlwaysFetched @StateId(DESTINATIONS_TAG) ValueState<Set<String>> destinations,
+        @AlwaysFetched @StateId(DESTINATIONS_TIMER_TIME) ValueState<Instant> timerTime,
+        @TimerId(DESTINATIONS_TIMER) Timer destinationsTimer)
+        throws IOException, InterruptedException {
+      Set<String> newSet = destinations.read();
+      if (newSet == null) {
+        newSet = Sets.newHashSet();
+      }
+      if (newSet.add(dynamicDestinations.getTable(destination.getValue()).getTableSpec())) {
+        destinations.write(newSet);
+        if (timerTime.read() == null) {
+          timerTime.write(destinationsTimer.getCurrentRelativeTime().plus(refreshDuration));
+          destinationsTimer.set(timerTime.read());
+        }
+      }
+    }
+
+    @OnTimer(DESTINATIONS_TIMER)
+    public void onTimer(
+        @AlwaysFetched @StateId(DESTINATIONS_TAG) ValueState<Set<String>> destinations,
+        @AlwaysFetched @StateId(DESTINATIONS_TIMER_TIME) ValueState<Instant> timerTime,
+        @TimerId(DESTINATIONS_TIMER) Timer destinationsTimer,
+        OnTimerContext onTimerContext,
+        PipelineOptions pipelineOptions)
+        throws IOException, InterruptedException {
+      initOutputMap();
+      currentOutputTs = timerTime.read();
+
+      Set<String> allDestinations = destinations.read();
+      BigQueryServices.DatasetService datasetService = getDatasetService(pipelineOptions);
+      for (String tableSpec : allDestinations) {
+        TableReference tableReference = BigQueryHelpers.parseTableSpec(tableSpec);
+        Table table = datasetService.getTable(tableReference);
+        if (table != null) {
+          currentOutput.put(tableSpec, BigQueryHelpers.toJsonString(table.getSchema()));
+        }
+      }
+
+      timerTime.write(timerTime.read().plus(refreshDuration));
+      destinationsTimer.set(timerTime.read());
+    }
+
+    @FinishBundle
+    public void finishBundle(FinishBundleContext c) {
+      if (!currentOutput.isEmpty()) {
+        c.output(
+            TimestampedValue.of(currentOutput, currentOutputTs),
+            GlobalWindow.INSTANCE.maxTimestamp(),
+            GlobalWindow.INSTANCE);
+      }
+    }
+
+    private BigQueryServices.DatasetService getDatasetService(PipelineOptions pipelineOptions)
+        throws IOException {
+      if (datasetServiceInternal == null) {
+        datasetServiceInternal =
+            bqServices.getDatasetService(pipelineOptions.as(BigQueryOptions.class));
+      }
+      return datasetServiceInternal;
+    }
+
+    @Teardown
+    public void onTeardown() {
+      try {
+        if (datasetServiceInternal != null) {
+          datasetServiceInternal.close();
+          datasetServiceInternal = null;
+        }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
+    }
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/PeriodicallyRefreshTableSchema.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/PeriodicallyRefreshTableSchema.java
@@ -52,7 +52,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Sets;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 
-/** This transform periodically recalculates the schema for */
+/** This transform periodically recalculates the schema for each destination table. */
 @SuppressWarnings({"unused"})
 class PeriodicallyRefreshTableSchema<DestinationT, ElementT>
     extends PTransform<
@@ -115,9 +115,9 @@ class PeriodicallyRefreshTableSchema<DestinationT, ElementT>
 
   private class RefreshTableSchemaDoFn
       extends DoFn<KV<Void, DestinationT>, TimestampedValue<Map<String, String>>> {
-    private final String DESTINATIONS_TAG = "destinations";
-    private final String DESTINATIONS_TIMER_TIME = "dest_timer_time";
-    private final String DESTINATIONS_TIMER = "destinationsTimer";
+    private static final String DESTINATIONS_TAG = "destinations";
+    private static final String DESTINATIONS_TIMER_TIME = "dest_timer_time";
+    private static final String DESTINATIONS_TIMER = "destinationsTimer";
 
     @StateId(DESTINATIONS_TAG)
     private final StateSpec<ValueState<Set<String>>> destinationsSpec = StateSpecs.value();

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiLoads.java
@@ -230,8 +230,7 @@ public class StorageApiLoads<DestinationT, ElementT>
       PCollection<KV<DestinationT, ElementT>> input,
       Coder<KV<DestinationT, StorageApiWritePayload>> successCoder) {
     PCollection<KV<DestinationT, ElementT>> inputInGlobalWindow =
-        input.apply(
-            "rewindowIntoGlobal", Window.<KV<DestinationT, ElementT>>into(new GlobalWindows()));
+        input.apply("rewindowIntoGlobal", Window.into(new GlobalWindows()));
     PCollectionTuple convertedRecords =
         inputInGlobalWindow
             .apply(

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWritesShardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWritesShardedRecords.java
@@ -216,7 +216,7 @@ public class StorageApiWritesShardedRecords<DestinationT extends @NonNull Object
     private final Distribution appendSplitDistribution =
         Metrics.distribution(WriteRecordsDoFn.class, "appendSplitDistribution");
 
-    private TwoLevelMessageConverterCache<DestinationT, ElementT> messageConverters;
+    private TwoLevelMessageConverterCache<DestinationT> messageConverters;
 
     private Map<DestinationT, TableDestination> destinations = Maps.newHashMap();
 
@@ -315,7 +315,7 @@ public class StorageApiWritesShardedRecords<DestinationT extends @NonNull Object
               });
       final String tableId = tableDestination.getTableUrn();
       final DatasetService datasetService = getDatasetService(pipelineOptions);
-      MessageConverter<ElementT> messageConverter =
+      MessageConverter<?> messageConverter =
           messageConverters.get(element.getKey().getKey(), dynamicDestinations, datasetService);
       AtomicReference<DescriptorWrapper> descriptor =
           new AtomicReference<>(messageConverter.getSchemaDescriptor());


### PR DESCRIPTION
Add an option to periodically check for table schema refreshes. Once a new table schema is detected, any known fields will forwarded to the destination table. This is compatible with ignoreUnknownValues - unknown fields will be ignored until a schema containing the field is observed, at which point they will be included.