### PR TITLE
[Jenkins,Spark] Stop running Nexmark suite for deprecated Spark 2 runners

### DIFF
--- a/.test-infra/jenkins/CommonTestProperties.groovy
+++ b/.test-infra/jenkins/CommonTestProperties.groovy
@@ -29,6 +29,10 @@ class CommonTestProperties {
     return "1.13"
   }
 
+  static String getSparkVersion() {
+    return "3"
+  }
+
   enum Runner {
     DATAFLOW("DataflowRunner"),
     TEST_DATAFLOW("TestDataflowRunner"),
@@ -42,8 +46,8 @@ class CommonTestProperties {
       JAVA: [
         DATAFLOW: ":runners:google-cloud-dataflow-java",
         TEST_DATAFLOW: ":runners:google-cloud-dataflow-java",
-        SPARK: ":runners:spark:2",
-        SPARK_STRUCTURED_STREAMING: ":runners:spark:2",
+        SPARK: ":runners:spark:${CommonTestProperties.getSparkVersion()}",
+        SPARK_STRUCTURED_STREAMING: ":runners:spark:${CommonTestProperties.getSparkVersion()}",
         FLINK: ":runners:flink:${CommonTestProperties.getFlinkVersion()}",
         DIRECT: ":runners:direct-java"
       ],

--- a/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Spark.groovy
+++ b/.test-infra/jenkins/job_PostCommit_Java_Nexmark_Spark.groovy
@@ -39,12 +39,12 @@ NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_
 
       // Gradle goals for this job.
       steps {
-        shell('echo "*** RUN NEXMARK IN BATCH MODE USING SPARK 2 RUNNER ***"')
+        shell("echo \"*** RUN NEXMARK IN BATCH MODE USING SPARK ${CommonTestProperties.getSparkVersion()} RUNNER ***\"")
         gradle {
           rootBuildScriptDir(commonJobProperties.checkoutDir)
           tasks(':sdks:java:testing:nexmark:run')
           commonJobProperties.setGradleSwitches(delegate)
-          switches('-Pnexmark.runner=":runners:spark:2"' +
+          switches("-Pnexmark.runner=\":runners:spark:${CommonTestProperties.getSparkVersion()}\"" +
               ' -Pnexmark.args="' +
               [
                 commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
@@ -55,51 +55,14 @@ NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_
                 '--streamTimeout=60' ,
                 '--manageResources=false',
                 '--monitorJobs=true'
-              ].join(' '))
+              ].join(' ') + '"')
         }
-        shell('echo "*** RUN NEXMARK SQL IN BATCH MODE USING SPARK 2 RUNNER ***"')
+        shell("echo \"*** RUN NEXMARK SQL IN BATCH MODE USING SPARK ${CommonTestProperties.getSparkVersion()} RUNNER ***\"")
         gradle {
           rootBuildScriptDir(commonJobProperties.checkoutDir)
           tasks(':sdks:java:testing:nexmark:run')
           commonJobProperties.setGradleSwitches(delegate)
-          switches('-Pnexmark.runner=":runners:spark:2"' +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=SparkRunner',
-                '--queryLanguage=sql',
-                '--streaming=false',
-                '--suite=SMOKE',
-                '--streamTimeout=60' ,
-                '--manageResources=false',
-                '--monitorJobs=true'
-              ].join(' '))
-        }
-        shell('echo "*** RUN NEXMARK IN BATCH MODE USING SPARK 3 RUNNER ***"')
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches('-Pnexmark.runner=":runners:spark:3"' +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=SparkRunner',
-                '--streaming=false',
-                '--suite=SMOKE',
-                '--streamTimeout=60' ,
-                '--manageResources=false',
-                '--monitorJobs=true'
-              ].join(' '))
-        }
-        shell('echo "*** RUN NEXMARK SQL IN BATCH MODE USING SPARK 3 RUNNER ***"')
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches('-Pnexmark.runner=":runners:spark:3"' +
+          switches("-Pnexmark.runner=\":runners:spark:${CommonTestProperties.getSparkVersion()}\"" +
               ' -Pnexmark.args="' +
               [
                 commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
@@ -108,17 +71,17 @@ NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_
                 '--queryLanguage=sql',
                 '--streaming=false',
                 '--suite=SMOKE',
-                '--streamTimeout=60' ,
+                '--streamTimeout=60',
                 '--manageResources=false',
                 '--monitorJobs=true'
-              ].join(' '))
+              ].join(' ') + '"')
         }
-        shell('echo "*** RUN NEXMARK IN BATCH MODE USING SPARK 2 STRUCTURED STREAMING RUNNER ***"')
+        shell("echo \"*** RUN NEXMARK IN BATCH MODE USING SPARK ${CommonTestProperties.getSparkVersion()} STRUCTURED STREAMING RUNNER ***\"")
         gradle {
           rootBuildScriptDir(commonJobProperties.checkoutDir)
           tasks(':sdks:java:testing:nexmark:run')
           commonJobProperties.setGradleSwitches(delegate)
-          switches('-Pnexmark.runner=":runners:spark:2"' +
+          switches("-Pnexmark.runner=\":runners:spark:${CommonTestProperties.getSparkVersion()}\"" +
               ' -Pnexmark.args="' +
               [
                 commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
@@ -128,17 +91,17 @@ NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_
                 '--suite=SMOKE',
                 // Skip query 3 (SparkStructuredStreamingRunner does not support State/Timers yet)
                 '--skipQueries=3',
-                '--streamTimeout=60' ,
+                '--streamTimeout=60',
                 '--manageResources=false',
                 '--monitorJobs=true'
-              ].join(' '))
+              ].join(' ') + '"')
         }
-        shell('echo "*** RUN NEXMARK SQL IN BATCH MODE USING SPARK 2 STRUCTURED STREAMING RUNNER ***"')
+        shell("echo \"*** RUN NEXMARK SQL IN BATCH MODE USING SPARK ${CommonTestProperties.getSparkVersion()} STRUCTURED STREAMING RUNNER ***\"")
         gradle {
           rootBuildScriptDir(commonJobProperties.checkoutDir)
           tasks(':sdks:java:testing:nexmark:run')
           commonJobProperties.setGradleSwitches(delegate)
-          switches('-Pnexmark.runner=":runners:spark:2"' +
+          switches("-Pnexmark.runner=\":runners:spark:${CommonTestProperties.getSparkVersion()}\"" +
               ' -Pnexmark.args="' +
               [
                 commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
@@ -147,49 +110,10 @@ NoPhraseTriggeringPostCommitBuilder.postCommitJob('beam_PostCommit_Java_Nexmark_
                 '--queryLanguage=sql',
                 '--streaming=false',
                 '--suite=SMOKE',
-                '--streamTimeout=60' ,
+                '--streamTimeout=60',
                 '--manageResources=false',
                 '--monitorJobs=true'
-              ].join(' '))
-        }
-        shell('echo "*** RUN NEXMARK IN BATCH MODE USING SPARK 3 STRUCTURED STREAMING RUNNER ***"')
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches('-Pnexmark.runner=":runners:spark:3"' +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=SparkStructuredStreamingRunner',
-                '--streaming=false',
-                '--suite=SMOKE',
-                // Skip query 3 (SparkStructuredStreamingRunner does not support State/Timers yet)
-                '--skipQueries=3',
-                '--streamTimeout=60' ,
-                '--manageResources=false',
-                '--monitorJobs=true'
-              ].join(' '))
-        }
-        shell('echo "*** RUN NEXMARK SQL IN BATCH MODE USING SPARK 3 STRUCTURED STREAMING RUNNER ***"')
-        gradle {
-          rootBuildScriptDir(commonJobProperties.checkoutDir)
-          tasks(':sdks:java:testing:nexmark:run')
-          commonJobProperties.setGradleSwitches(delegate)
-          switches('-Pnexmark.runner=":runners:spark:3"' +
-              ' -Pnexmark.args="' +
-              [
-                commonJobProperties.mapToArgString(nexmarkBigQueryArgs),
-                commonJobProperties.mapToArgString(nexmarkInfluxDBArgs),
-                '--runner=SparkStructuredStreamingRunner',
-                '--queryLanguage=sql',
-                '--streaming=false',
-                '--suite=SMOKE',
-                '--streamTimeout=60' ,
-                '--manageResources=false',
-                '--monitorJobs=true'
-              ].join(' '))
+              ].join(' ') + '"')
         }
       }
     }


### PR DESCRIPTION
The Nexmark SparkStructuredStreamingRunner v2 and v3 tests are currently both publishing results to the same metric, the same issue applies to the "normal" SparkRunner.

Stop running Nexmark suite for deprecated Spark 2 runners. 
Additionally,  following the approach taken for Flink, this ensures a consistent version of Spark is used for Nexmark tests (fixes #23634).

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
