### PR TITLE
Re-enable WatchTest.testMultiplePollsWithManyResults on DirectRunner (#19734)

### DIFF
--- a/runners/direct-java/build.gradle
+++ b/runners/direct-java/build.gradle
@@ -118,8 +118,6 @@ static def pipelineOptionsStringCrossPlatformHandling(String[] options) {
 def disabledTests = [
         // https://github.com/apache/beam/issues/18499
         'org.apache.beam.sdk.testing.UsesLoopingTimer',
-        // https://github.com/apache/beam/issues/19734
-        'org.apache.beam.sdk.transforms.WatchTest.testMultiplePollsWithManyResults',
         // https://github.com/apache/beam/issues/19344
         'org.apache.beam.sdk.io.BoundedReadFromUnboundedSourceTest.testTimeBound',
 ]

--- a/runners/direct-java/build.gradle
+++ b/runners/direct-java/build.gradle
@@ -115,7 +115,7 @@ static def pipelineOptionsStringCrossPlatformHandling(String[] options) {
   }
 }
 
-def sickbayTests = [
+def disabledTests = [
         // https://github.com/apache/beam/issues/18499
         'org.apache.beam.sdk.testing.UsesLoopingTimer',
         // https://github.com/apache/beam/issues/19734
@@ -142,7 +142,7 @@ task needsRunnerTests(type: Test) {
   useJUnit {
 
     filter {
-      for (String test : sickbayTests) {
+      for (String test : disabledTests) {
         excludeTestsMatching test
       }
     }
@@ -203,7 +203,7 @@ tasks.register("validatesRunnerSickbay", Test) {
   testClassesDirs = files(project(":sdks:java:core").sourceSets.test.output.classesDirs)
 
   filter {
-    for (String test : sickbayTests) {
+    for (String test : disabledTests) {
       includeTestsMatching test
     }
 


### PR DESCRIPTION
Context: in #11614 this was disabled in `WatchTest` instead of per-runner and then in #17471 that was moved to just the DirectRunner. The original flake was a DirectRunner flake on precommit so this particular variation is the one that would be expected to fail.

Verified that it is working or less than 1% flaky for the DirectRunner today, via the following (plus a few ad hoc runs):

```
for i in `seq 1 100` ; do (
  echo "RUN $i" ;
   ./gradlew :runners:direct-java:cleanTest --quiet
   ./gradlew :runners:direct-java:needsRunnerTests --quiet --tests WatchTest.testMultiplePollsWithManyResults
)
done
```

This fixes #19734

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
