### PR TITLE
[CI] Use quotes to avoid python-version 3.10 be interpreted as 3.1

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -73,7 +73,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: '3.7'
       - name: Get build dependencies
         working-directory: ./sdks/python
         run: python -m pip install -r build-requirements.txt
@@ -235,7 +235,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v4
       with:
-        python-version: 3.7
+        python-version: '3.7'
     - uses: docker/setup-qemu-action@v1
       if: ${{matrix.arch == 'aarch64'}}
       name: Set up QEMU

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -77,7 +77,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.7
+          python-version: '3.7'
       - name: Get build dependencies
         working-directory: ./sdks/python
         run: pip install pip setuptools --upgrade && pip install -r build-requirements.txt
@@ -111,7 +111,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.params.py_ver }}
+          python-version: '${{ matrix.params.py_ver }}'
       - name: Get build dependencies
         working-directory: ./sdks/python
         run: pip install -r build-requirements.txt
@@ -139,14 +139,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [3.7, 3.8, 3.9]
+        python: ['3.7', '3.8', '3.9']
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Install python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python }}
+          python-version: '${{ matrix.python }}'
       - name: Get build dependencies
         working-directory: ./sdks/python
         run: pip install -r build-requirements.txt
@@ -167,14 +167,14 @@ jobs:
       fail-fast: false
       matrix:
         os: [ubuntu-latest, macos-latest, windows-latest]
-        python: [3.7, 3.8, 3.9]
+        python: ['3.7', '3.8', '3.9']
     steps:
       - name: Checkout code
         uses: actions/checkout@v3
       - name: Install python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{ matrix.python }}
+          python-version: '${{ matrix.python }}'
       - name: Install go
         uses: actions/setup-go@v3
         with:

--- a/.github/workflows/run_rc_validation.yml
+++ b/.github/workflows/run_rc_validation.yml
@@ -107,7 +107,7 @@ jobs:
     if: ${{github.event.inputs.RUN_SQL_TAXI_WITH_DATAFLOW == 'true'}}
     strategy:
       matrix: 
-        py_version: [3.8]
+        py_version: ["3.8"]
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -117,7 +117,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v4
       with:
-        python-version: ${{matrix.py_version}}
+        python-version: "${{matrix.py_version}}"
         
 
     - name: Setup Java JDK
@@ -172,7 +172,7 @@ jobs:
     if: ${{github.event.inputs.RUN_PYTHON_CROSS_VALIDATION == 'true'}} 
     strategy:
       matrix: 
-        py_version: [3.8]
+        py_version: ['3.8']
     steps:
     - name: Checkout code
       uses: actions/checkout@v3
@@ -196,7 +196,7 @@ jobs:
     - name: Install Python
       uses: actions/setup-python@v4
       with:
-        python-version: ${{matrix.py_version}}
+        python-version: "${{matrix.py_version}}"
    
 
     - name: Setting python env
@@ -363,7 +363,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{matrix.py_version}}
+          python-version: "${{matrix.py_version}}"
       
       - name: Setting python env
         uses: ./.github/actions/common-rc-validation
@@ -411,7 +411,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{matrix.py_version}}
+          python-version: "${{matrix.py_version}}"
       
       - name: Setting python env
         uses: ./.github/actions/common-rc-validation
@@ -463,7 +463,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{matrix.py_version}}
+          python-version: "${{matrix.py_version}}"
    
       - name: Setting python env
         uses: ./.github/actions/common-rc-validation
@@ -512,7 +512,7 @@ jobs:
       - name: Install Python
         uses: actions/setup-python@v4
         with:
-          python-version: ${{matrix.py_version}}
+          python-version: "${{matrix.py_version}}"
       
       - name: Setting python env
         uses: ./.github/actions/common-rc-validation

--- a/.github/workflows/typescript_tests.yml
+++ b/.github/workflows/typescript_tests.yml
@@ -87,7 +87,7 @@ jobs:
       - name: Install python
         uses: actions/setup-python@v4
         with:
-          python-version: 3.8
+          python-version: '3.8'
       - name: Setup Beam Python
         working-directory: ./sdks/python
         run: |


### PR DESCRIPTION
This is a fix to an issue that isn't yet an issue, but could become one in #23587 unless fixed there. The issue is that when YAML is parsing 3.10 the number, it becomes 3.1 when translated back to a string.

```yaml
  some-github-workflows-job:
    strategy:
      matrix:
        # WARNING: Quotes needed for 3.10
        python-version: [3.9, 3.10]
    steps:
      - uses: actions/setup-python@v4
        with:
          # WARNING: Quotes needed for 3.10, which is what
          # ${{ matrix.python-version }} would resolve to if set to a string "3.10"
          python-version: ${{ matrix.python-version }}
```

Note that I think the YAML is parsed twice making us need to quote both the `3.10` when we declare the `python-version` variable, and then once again after it is used in a text templating way to declare the input passed to the `actions/setup-python` action. Due to this, we need quotes in two places above, not just one.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
    _Comment: I'll ask the author of #23587 to review who may be impacted by this: @AnandInguva_
 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
   _Comment: I have not opened an issue to describe this issue beforehand._
 - [x] Update `CHANGES.md` with noteworthy changes.
   _Comment: I don't consider this change noteworthy._
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).
   _Comment: it isn't large._

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
