### PR TITLE
Add record_metrics argument to utils.BatchElements

### DIFF
--- a/sdks/python/apache_beam/transforms/util.py
+++ b/sdks/python/apache_beam/transforms/util.py
@@ -647,8 +647,8 @@ class BatchElements(PTransform):
         linear interpolation
     clock: (optional) an alternative to time.time for measuring the cost of
         donwstream operations (mostly for testing)
-    record_metrics: (optional) if given, record beam metrics on distributions
-        of the batch size.
+    record_metrics: (optional) whether or not to record beam metrics on distributions
+        of the batch size. Defaults to True.
   """
   def __init__(
       self,

--- a/sdks/python/apache_beam/transforms/util.py
+++ b/sdks/python/apache_beam/transforms/util.py
@@ -350,6 +350,7 @@ class _BatchSizeEstimator(object):
         ignore_first_n_seen_per_batch_size)
     self._batch_size_num_seen = {}
     self._replay_last_batch_size = None
+    self._record_metrics = record_metrics
 
     if record_metrics:
       self._size_distribution = Metrics.distribution(
@@ -378,9 +379,8 @@ class _BatchSizeEstimator(object):
     yield
     elapsed = self._clock() - start
     elapsed_msec = 1e3 * elapsed + self._remainder_msecs
-    if self._size_distribution is not None:
+    if self._record_metrics:
       self._size_distribution.update(batch_size)
-    if self._time_distribution is not None:
       self._time_distribution.update(int(elapsed_msec))
     self._remainder_msecs = elapsed_msec - int(elapsed_msec)
     # If we ignore the next timing, replay the batch size to get accurate

--- a/sdks/python/apache_beam/transforms/util.py
+++ b/sdks/python/apache_beam/transforms/util.py
@@ -668,8 +668,7 @@ class BatchElements(PTransform):
         target_batch_duration_secs=target_batch_duration_secs,
         variance=variance,
         clock=clock,
-        record_metrics=record_metrics,
-    )
+        record_metrics=record_metrics)
     self._element_size_fn = element_size_fn
 
   def expand(self, pcoll):

--- a/sdks/python/apache_beam/transforms/util.py
+++ b/sdks/python/apache_beam/transforms/util.py
@@ -647,8 +647,8 @@ class BatchElements(PTransform):
         linear interpolation
     clock: (optional) an alternative to time.time for measuring the cost of
         donwstream operations (mostly for testing)
-    record_metrics: (optional) whether or not to record beam metrics on distributions
-        of the batch size. Defaults to True.
+    record_metrics: (optional) whether or not to record beam metrics on 
+        distributions of the batch size. Defaults to True.
   """
   def __init__(
       self,

--- a/sdks/python/apache_beam/transforms/util.py
+++ b/sdks/python/apache_beam/transforms/util.py
@@ -647,7 +647,7 @@ class BatchElements(PTransform):
         linear interpolation
     clock: (optional) an alternative to time.time for measuring the cost of
         donwstream operations (mostly for testing)
-    record_metrics: (optional) whether or not to record beam metrics on 
+    record_metrics: (optional) whether or not to record beam metrics on
         distributions of the batch size. Defaults to True.
   """
   def __init__(

--- a/sdks/python/apache_beam/transforms/util.py
+++ b/sdks/python/apache_beam/transforms/util.py
@@ -316,7 +316,8 @@ class _BatchSizeEstimator(object):
       target_batch_duration_secs=1,
       variance=0.25,
       clock=time.time,
-      ignore_first_n_seen_per_batch_size=0):
+      ignore_first_n_seen_per_batch_size=0,
+      record_metrics=True):
     if min_batch_size > max_batch_size:
       raise ValueError(
           "Minimum (%s) must not be greater than maximum (%s)" %
@@ -350,10 +351,13 @@ class _BatchSizeEstimator(object):
     self._batch_size_num_seen = {}
     self._replay_last_batch_size = None
 
-    self._size_distribution = Metrics.distribution(
-        'BatchElements', 'batch_size')
-    self._time_distribution = Metrics.distribution(
-        'BatchElements', 'msec_per_batch')
+    if record_metrics:
+      self._size_distribution = Metrics.distribution(
+          'BatchElements', 'batch_size')
+      self._time_distribution = Metrics.distribution(
+          'BatchElements', 'msec_per_batch')
+    else:
+      self._size_distribution = self._time_distribution = None
     # Beam distributions only accept integer values, so we use this to
     # accumulate under-reported values until they add up to whole milliseconds.
     # (Milliseconds are chosen because that's conventionally used elsewhere in
@@ -374,8 +378,10 @@ class _BatchSizeEstimator(object):
     yield
     elapsed = self._clock() - start
     elapsed_msec = 1e3 * elapsed + self._remainder_msecs
-    self._size_distribution.update(batch_size)
-    self._time_distribution.update(int(elapsed_msec))
+    if self._size_distribution is not None:
+      self._size_distribution.update(batch_size)
+    if self._time_distribution is not None:
+      self._time_distribution.update(int(elapsed_msec))
     self._remainder_msecs = elapsed_msec - int(elapsed_msec)
     # If we ignore the next timing, replay the batch size to get accurate
     # timing.
@@ -641,6 +647,8 @@ class BatchElements(PTransform):
         linear interpolation
     clock: (optional) an alternative to time.time for measuring the cost of
         donwstream operations (mostly for testing)
+    record_metrics: (optional) if given, record beam metrics on distributions
+        of the batch size.
   """
   def __init__(
       self,
@@ -651,14 +659,17 @@ class BatchElements(PTransform):
       *,
       element_size_fn=lambda x: 1,
       variance=0.25,
-      clock=time.time):
+      clock=time.time,
+      record_metrics=True):
     self._batch_size_estimator = _BatchSizeEstimator(
         min_batch_size=min_batch_size,
         max_batch_size=max_batch_size,
         target_batch_overhead=target_batch_overhead,
         target_batch_duration_secs=target_batch_duration_secs,
         variance=variance,
-        clock=clock)
+        clock=clock,
+        record_metrics=record_metrics,
+    )
     self._element_size_fn = element_size_fn
 
   def expand(self, pcoll):

--- a/sdks/python/apache_beam/transforms/util_test.py
+++ b/sdks/python/apache_beam/transforms/util_test.py
@@ -19,7 +19,6 @@
 
 # pytype: skip-file
 
-from apache_beam.metrics import MetricsFilter
 import logging
 import math
 import random
@@ -35,6 +34,7 @@ from apache_beam import GroupByKey
 from apache_beam import Map
 from apache_beam import WindowInto
 from apache_beam.coders import coders
+from apache_beam.metrics import MetricsFilter
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.portability import common_urns

--- a/sdks/python/apache_beam/transforms/util_test.py
+++ b/sdks/python/apache_beam/transforms/util_test.py
@@ -20,7 +20,6 @@
 # pytype: skip-file
 
 from apache_beam.metrics import MetricsFilter
-from apache_beam.metrics.metric import MetricName
 import logging
 import math
 import random

--- a/sdks/python/apache_beam/transforms/util_test.py
+++ b/sdks/python/apache_beam/transforms/util_test.py
@@ -195,6 +195,17 @@ class BatchElementsTest(unittest.TestCase):
           | beam.Map(len))
       assert_that(res, equal_to([10, 10, 10, 5]))
 
+  def test_constant_batch_no_metrics(self):
+    # Assumes a single bundle...
+    with TestPipeline() as p:
+      res = (
+          p
+          | beam.Create(range(35))
+          | util.BatchElements(min_batch_size=10, max_batch_size=10,
+                               record_metrics=False)
+          | beam.Map(len))
+      assert_that(res, equal_to([10, 10, 10, 5]))
+
   def test_grows_to_max_batch(self):
     # Assumes a single bundle...
     with TestPipeline() as p:


### PR DESCRIPTION
Fixes #24012 

utils.BatchElements creates a lot of metrics (since it uses distribution metrics) and we use a lot of these transforms in our pipeline, causing the overall number of counters to blow up.

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
