### PR TITLE
Ignoring BigQuery partitions with empty files

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -761,6 +761,11 @@ class PartitionFiles(beam.DoFn):
     files = element[1]
     partitions = []
 
+    if not files:
+      _LOGGER.warning(f'Ignoring a BigQuery batch load partition to {destination} '
+                      'that contains no source URIs.')
+      return
+
     latest_partition = PartitionFiles.Partition(
         self.max_partition_size, self.max_files_per_partition)
 

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
@@ -402,7 +402,7 @@ class TestPartitionFiles(unittest.TestCase):
 class TestBigQueryFileLoads(_TestCaseWithTempDirCleanUp):
   def test_trigger_load_jobs_with_empty_files(self):
     destination = "apache-beam-testing:python_load_job_empty_files_no_delete.empty"
-    empty_files = [("gs://ahmedabualsaud-wordcount/myfile", 50)]
+    empty_files = []
     load_job_prefix = "test_prefix"
 
     with beam.Pipeline() as p:


### PR DESCRIPTION
Fixes #20824


When a WriteToBigQuery Dataflow pipeline is moved into draining phase, we can sometimes get file load operations with empty files, resulting in an error code 400: `Load configuration must specify at least one source URI` from BigQuery. These changes do a sanity check on partitions and decide to ignore partitions that have an empty list of files. Instead of an error, a warning is logged.