### PR TITLE
Clean up portable runner test

### DIFF
--- a/sdks/python/apache_beam/runners/portability/portable_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/portable_runner_test.py
@@ -59,7 +59,7 @@ class PortableRunnerTest(fn_runner_test.FnApiRunnerTest):
 
   @staticmethod
   def _pick_unused_ports(num_ports):
-    """Not perfect, but we have to provide a port to the subprocess."""
+    """Returns a list of available ports for subprocesses."""
     # TODO(robertwb): Consider letting the subprocess communicate a choice of
     # port back.
     sockets = []
@@ -82,10 +82,9 @@ class PortableRunnerTest(fn_runner_test.FnApiRunnerTest):
     # TODO(robertwb): Consider letting the subprocess pick one and
     # communicate it back...
     # pylint: disable=unbalanced-tuple-unpacking
-    job_port, expansion_port = cls._pick_unused_ports(num_ports=2)
+    job_port = cls._pick_unused_port()
     _LOGGER.info('Starting server on port %d.', job_port)
-    cls._subprocess = subprocess.Popen(
-        cls._subprocess_command(job_port, expansion_port))
+    cls._subprocess = subprocess.Popen(cls._subprocess_command(job_port))
     address = 'localhost:%d' % job_port
     job_service = beam_job_api_pb2_grpc.JobServiceStub(
         GRPCChannelFactory.insecure_channel(address))
@@ -280,7 +279,7 @@ class PortableRunnerTestWithSubprocesses(PortableRunnerTest):
     return options
 
   @classmethod
-  def _subprocess_command(cls, job_port, _):
+  def _subprocess_command(cls, job_port):
     return [
         sys.executable,
         '-m',


### PR DESCRIPTION
Removes code that tries to allocate 2 ports when only one port is used in portable_runner_test.py.
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
