### PR TITLE
Use --release 8 for builds targeting Java 8

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -914,6 +914,10 @@ class BeamModulePlugin implements Plugin<Project> {
       project.tasks.withType(JavaCompile).configureEach {
         options.encoding = "UTF-8"
         // Use --release 8 when targeting Java 8 and running on JDK > 8
+        //
+        // Consider migrating compilation and testing to use JDK 9+ and setting '--release=8' as
+        // the default allowing 'applyJavaNature' to override it for the few modules that need JDK 9+
+        // artifacts. See https://stackoverflow.com/a/43103038/4368200 for additional details.
         if (JavaVersion.VERSION_1_8.compareTo(JavaVersion.toVersion(project.javaVersion)) == 0
         && JavaVersion.VERSION_1_8.compareTo(JavaVersion.current()) < 0) {
           options.compilerArgs.addAll(['--release', '8'])

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -920,7 +920,7 @@ class BeamModulePlugin implements Plugin<Project> {
         // artifacts. See https://stackoverflow.com/a/43103038/4368200 for additional details.
         if (JavaVersion.VERSION_1_8.compareTo(JavaVersion.toVersion(project.javaVersion)) == 0
         && JavaVersion.VERSION_1_8.compareTo(JavaVersion.current()) < 0) {
-          options.compilerArgs.addAll(['--release', '8'])
+          options.compilerArgs += ['--release', '8']
         }
         // As we want to add '-Xlint:-deprecation' we intentionally remove '-Xlint:deprecation' from compilerArgs here,
         // as intellij is adding this, see https://youtrack.jetbrains.com/issue/IDEA-196615

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -913,6 +913,11 @@ class BeamModulePlugin implements Plugin<Project> {
 
       project.tasks.withType(JavaCompile).configureEach {
         options.encoding = "UTF-8"
+        // Use --release 8 when targeting Java 8 and running on JDK > 8
+        if (JavaVersion.VERSION_1_8.compareTo(JavaVersion.toVersion(project.javaVersion)) == 0
+        && JavaVersion.VERSION_1_8.compareTo(JavaVersion.current()) < 0) {
+          options.compilerArgs.addAll(['--release', '8'])
+        }
         // As we want to add '-Xlint:-deprecation' we intentionally remove '-Xlint:deprecation' from compilerArgs here,
         // as intellij is adding this, see https://youtrack.jetbrains.com/issue/IDEA-196615
         options.compilerArgs -= [

--- a/sdks/java/container/agent/build.gradle
+++ b/sdks/java/container/agent/build.gradle
@@ -22,21 +22,8 @@ plugins {
 
 if (project.hasProperty('java11Home')) {
     javaVersion = "1.11"
-    def java11Home = project.findProperty('java11Home')
-    project.tasks.withType(JavaCompile) {
-        options.fork = true
-        options.forkOptions.javaHome = java11Home as File
-        options.compilerArgs += ['-Xlint:-path']
-    }
 } else if (project.hasProperty('java17Home')) {
     javaVersion = "1.17"
-    project.tasks.withType(JavaCompile) {
-        setJava17Options(options)
-
-        checkerFramework {
-            skipCheckerFramework = true
-        }
-    }
 }
 
 applyJavaNature(
@@ -52,6 +39,23 @@ jar {
                 "Can-Redefine-Classes": true,
                 "Can-Retransform-Classes": true,
                 "Premain-Class": "org.apache.beam.agent.OpenModuleAgent")
+    }
+}
+
+if (project.hasProperty('java11Home')) {
+    def java11Home = project.findProperty('java11Home')
+    project.tasks.withType(JavaCompile) {
+        options.fork = true
+        options.forkOptions.javaHome = java11Home as File
+        options.compilerArgs += ['-Xlint:-path']
+    }
+} else if (project.hasProperty('java17Home')) {
+    project.tasks.withType(JavaCompile) {
+        setJava17Options(options)
+
+        checkerFramework {
+            skipCheckerFramework = true
+        }
     }
 }
 

--- a/sdks/java/container/agent/build.gradle
+++ b/sdks/java/container/agent/build.gradle
@@ -59,6 +59,7 @@ if (project.hasProperty('java11Home')) {
 project.tasks.each {
     it.onlyIf {
         project.hasProperty('java11Home') || project.hasProperty('java17Home')
-                || JavaVersion.VERSION_1_8.compareTo(JavaVersion.current()) < 0
+                || (JavaVersion.VERSION_1_8.compareTo(JavaVersion.current()) < 0
+                && JavaVersion.VERSION_1_8.compareTo(JavaVersion.toVersion(project.javaVersion)) < 0)
     }
 }

--- a/sdks/java/container/agent/build.gradle
+++ b/sdks/java/container/agent/build.gradle
@@ -19,22 +19,6 @@
 plugins {
     id 'org.apache.beam.module'
 }
-applyJavaNature(
-    exportJavadoc: false,
-    publish: false
-)
-
-description = "Apache Beam :: SDKs :: Java :: Container :: Agent"
-
-jar {
-    manifest {
-        attributes("Agent-Class": "org.apache.beam.agent.OpenModuleAgent",
-                "Can-Redefine-Classes": true,
-                "Can-Retransform-Classes": true,
-                "Premain-Class": "org.apache.beam.agent.OpenModuleAgent")
-    }
-}
-
 
 if (project.hasProperty('java11Home')) {
     javaVersion = "1.11"
@@ -55,11 +39,26 @@ if (project.hasProperty('java11Home')) {
     }
 }
 
+applyJavaNature(
+    exportJavadoc: false,
+    publish: false
+)
+
+description = "Apache Beam :: SDKs :: Java :: Container :: Agent"
+
+jar {
+    manifest {
+        attributes("Agent-Class": "org.apache.beam.agent.OpenModuleAgent",
+                "Can-Redefine-Classes": true,
+                "Can-Retransform-Classes": true,
+                "Premain-Class": "org.apache.beam.agent.OpenModuleAgent")
+    }
+}
+
 // Module classes requires JDK > 8
 project.tasks.each {
     it.onlyIf {
         project.hasProperty('java11Home') || project.hasProperty('java17Home')
-                || (JavaVersion.VERSION_1_8.compareTo(JavaVersion.current()) < 0
-                && JavaVersion.VERSION_1_8.compareTo(JavaVersion.toVersion(project.javaVersion)) < 0)
+                || JavaVersion.VERSION_1_8.compareTo(JavaVersion.current()) < 0
     }
 }

--- a/sdks/java/testing/jpms-tests/build.gradle
+++ b/sdks/java/testing/jpms-tests/build.gradle
@@ -134,7 +134,6 @@ plugins.withType(JavaPlugin).configureEach{
 project.tasks.each {
   it.onlyIf {
     project.hasProperty("compileAndRunTestsWithJava17")
-            || (JavaVersion.VERSION_1_8.compareTo(JavaVersion.current()) < 0
-            && JavaVersion.VERSION_1_8.compareTo(JavaVersion.toVersion(project.javaVersion)) < 0)
+            || JavaVersion.VERSION_1_8.compareTo(JavaVersion.current()) < 0
   }
 }

--- a/sdks/java/testing/jpms-tests/build.gradle
+++ b/sdks/java/testing/jpms-tests/build.gradle
@@ -134,6 +134,7 @@ plugins.withType(JavaPlugin).configureEach{
 project.tasks.each {
   it.onlyIf {
     project.hasProperty("compileAndRunTestsWithJava17")
-            || JavaVersion.VERSION_1_8.compareTo(JavaVersion.current()) < 0
+            || (JavaVersion.VERSION_1_8.compareTo(JavaVersion.current()) < 0
+            && JavaVersion.VERSION_1_8.compareTo(JavaVersion.toVersion(project.javaVersion)) < 0)
   }
 }


### PR DESCRIPTION
Setting `--release 8` ensures the compilation uses the JDK 8 versions of APIs.

For example, `java.nio.ByteBuffer` added an override of `clear()` in JDK 9. Compiling on JDK 9 or newer and
targeting Java 8, without also setting `--release` (or `-bootclasspath`), will result in references to the new method
which will then fail at runtime with a `NoSuchMethodError`.

This change also updates some version detection to use the target language level of the build
(`JavaVersion.toVersion(project.javaVersion)`) instead of the JVM version the build is using
(`JavaVersion.current()`).

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
