### PR TITLE
Remove obsolete sparkRunner task from hadoop-format

### DIFF
--- a/sdks/java/io/hadoop-format/build.gradle
+++ b/sdks/java/io/hadoop-format/build.gradle
@@ -40,14 +40,6 @@ hadoopVersions.each {kv -> configurations.create("hadoopVersion$kv.key")}
 
 def elastic_search_version = "7.12.0"
 
-configurations.create("sparkRunner")
-configurations.sparkRunner {
-  // Ban certain dependencies to prevent a StackOverflow within Spark
-  // because JUL -> SLF4J -> JUL, and similarly JDK14 -> SLF4J -> JDK14
-  exclude group: "org.slf4j", module: "jul-to-slf4j"
-  exclude group: "org.slf4j", module: "slf4j-jdk14"
-}
-
 // Ban dependencies from the test runtime classpath
 configurations.testRuntimeClasspath {
   // Prevent a StackOverflow because of wiring LOG4J -> SLF4J -> LOG4J
@@ -115,15 +107,6 @@ dependencies {
   testRuntimeOnly library.java.slf4j_jdk14
   testRuntimeOnly project(path: ":runners:direct-java", configuration: "shadow")
 
-  delegate.add("sparkRunner", project(path: ":sdks:java:io:hadoop-format", configuration: "testRuntimeMigration"))
-
-  sparkRunner project(path: ":examples:java", configuration: "testRuntimeMigration")
-  sparkRunner project(path: ":examples:java:twitter", configuration: "testRuntimeMigration")
-  sparkRunner project(":runners:spark:2")
-  sparkRunner project(":sdks:java:io:hadoop-file-system")
-  sparkRunner library.java.spark_streaming
-  sparkRunner library.java.spark_core
-
   hadoopVersions.each {kv ->
     "hadoopVersion$kv.key" "org.apache.hadoop:hadoop-common:$kv.value"
     "hadoopVersion$kv.key" "org.apache.hadoop:hadoop-mapreduce-client-core:$kv.value"
@@ -168,29 +151,6 @@ task createTargetDirectoryForCassandra() {
   }
 }
 test.dependsOn createTargetDirectoryForCassandra
-
-def runnerClass = "org.apache.beam.runners.spark.TestSparkRunner"
-task sparkRunner(type: Test) {
-  group = "Verification"
-  def beamTestPipelineOptions = [
-          "--project=hadoop-format",
-          "--tempRoot=/tmp/hadoop-format/",
-          "--streaming=false",
-          "--runner=" + runnerClass,
-          "--enableSparkMetricSinks=false",
-  ]
-  classpath = configurations.sparkRunner
-  include "**/HadoopFormatIOSequenceFileTest.class"
-  useJUnit {
-    includeCategories 'org.apache.beam.sdk.testing.ValidatesRunner'
-  }
-  forkEvery 1
-  maxParallelForks 4
-  systemProperty "spark.ui.enabled", "false"
-  systemProperty "spark.ui.showConsoleProgress", "false"
-  systemProperty "beam.spark.test.reuseSparkContext", "true"
-  systemProperty "beamTestPipelineOptions", JsonOutput.toJson(beamTestPipelineOptions)
-}
 
 task hadoopVersionsTest(group: "Verification") {
   description = "Runs Hadoop format tests with different Hadoop versions"


### PR DESCRIPTION
The `sparkRunner` task is far outdated and can be removed (addresses #23728):
- It's not triggered anymore.
- The filters, as is, don't match any existing test case.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
