### PR TITLE
[Python SDK] Re-enable PipelineOptionsTest.test_display_data

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -218,8 +218,6 @@ class PipelineOptionsTest(unittest.TestCase):
       parser.add_argument(
           '--fake_multi_option', action='append', help='fake multi option')
 
-#   @unittest.skip(
-    #   "TODO(https://github.com/apache/beam/issues/21116): Flaky test.")
   def test_display_data(self):
     for case in PipelineOptionsTest.TEST_CASES:
       options = PipelineOptions(flags=case['flags'])

--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -218,8 +218,8 @@ class PipelineOptionsTest(unittest.TestCase):
       parser.add_argument(
           '--fake_multi_option', action='append', help='fake multi option')
 
-  @unittest.skip(
-      "TODO(https://github.com/apache/beam/issues/21116): Flaky test.")
+#   @unittest.skip(
+    #   "TODO(https://github.com/apache/beam/issues/21116): Flaky test.")
   def test_display_data(self):
     for case in PipelineOptionsTest.TEST_CASES:
       options = PipelineOptions(flags=case['flags'])


### PR DESCRIPTION
Addresses #21116 by re-enabling non-flaky test.
