### PR TITLE
[Python SDK] Re-enable FnRunnerTest.test_pardo_large_input

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -218,8 +218,6 @@ class PipelineOptionsTest(unittest.TestCase):
       parser.add_argument(
           '--fake_multi_option', action='append', help='fake multi option')
 
-#   @unittest.skip(
-    #   "TODO(https://github.com/apache/beam/issues/21116): Flaky test.")
   def test_display_data(self):
     for case in PipelineOptionsTest.TEST_CASES:
       options = PipelineOptions(flags=case['flags'])

--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -218,8 +218,8 @@ class PipelineOptionsTest(unittest.TestCase):
       parser.add_argument(
           '--fake_multi_option', action='append', help='fake multi option')
 
-  @unittest.skip(
-      "TODO(https://github.com/apache/beam/issues/21116): Flaky test.")
+#   @unittest.skip(
+    #   "TODO(https://github.com/apache/beam/issues/21116): Flaky test.")
   def test_display_data(self):
     for case in PipelineOptionsTest.TEST_CASES:
       options = PipelineOptions(flags=case['flags'])

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner_test.py
@@ -368,12 +368,6 @@ class FnApiRunnerTest(unittest.TestCase):
       assert_that(res, equal_to([6, 12, 12, 18, 18, 18]))
 
   def test_pardo_large_input(self):
-    try:
-      utils.check_compiled('apache_beam.coders.coder_impl')
-    except RuntimeError:
-      self.skipTest(
-          'https://github.com/apache/beam/issues/21643: FnRunnerTest with '
-          'non-trivial inputs flakes in non-cython environments')
     with self.create_pipeline() as p:
       res = (
           p


### PR DESCRIPTION
Addresses #21643 by enabling test for non-cython environments after reported flakes couldn't be reproduced.