### PR TITLE
[Spark dataset runner] Add direct translation of Combine.GroupedValues

### DIFF
--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/TransformTranslator.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/TransformTranslator.java
@@ -69,6 +69,17 @@ public abstract class TransformTranslator<
     translate(transform, new Context(appliedTransform, cxt));
   }
 
+  /**
+   * Checks if a composite / primitive transform can be translated. Composites that cannot be
+   * translated as is, will be exploded further for translation of their parts.
+   *
+   * <p>This should be overridden where necessary. If a transform is know to be unsupported, this
+   * should throw a runtime exception to give early feedback before any part of the pipeline is run.
+   */
+  public boolean canTranslate(TransformT transform) {
+    return true;
+  }
+
   protected class Context {
     private final AppliedPTransform<InT, OutT, PTransform<InT, OutT>> transform;
     private final TranslationContext cxt;

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/CombineGroupedValuesTranslatorBatch.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/CombineGroupedValuesTranslatorBatch.java
@@ -1,0 +1,75 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.spark.structuredstreaming.translation.batch;
+
+import java.io.IOException;
+import org.apache.beam.runners.spark.structuredstreaming.translation.TransformTranslator;
+import org.apache.beam.runners.spark.structuredstreaming.translation.utils.ScalaInterop.Fun1;
+import org.apache.beam.sdk.transforms.Combine;
+import org.apache.beam.sdk.transforms.Combine.CombineFn;
+import org.apache.beam.sdk.transforms.CombineWithContext;
+import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.spark.sql.Dataset;
+import org.apache.spark.sql.Encoder;
+import org.apache.spark.sql.expressions.Aggregator;
+
+/**
+ * Translator for {@link Combine.GroupedValues} if the {@link CombineFn} doesn't require context /
+ * side-inputs.
+ *
+ * <p>This doesn't require a Spark {@link Aggregator}. Instead it can directly use the respective
+ * {@link CombineFn} to reduce each iterable of values into an aggregated output value.
+ */
+public class CombineGroupedValuesTranslatorBatch<K, InT, AccT, OutT>
+    extends TransformTranslator<
+        PCollection<? extends KV<K, ? extends Iterable<InT>>>,
+        PCollection<KV<K, OutT>>,
+        Combine.GroupedValues<K, InT, OutT>> {
+
+  @Override
+  protected void translate(Combine.GroupedValues<K, InT, OutT> transform, Context cxt)
+      throws IOException {
+    CombineFn<InT, AccT, OutT> combineFn = (CombineFn<InT, AccT, OutT>) transform.getFn();
+
+    Encoder<WindowedValue<KV<K, OutT>>> enc = cxt.windowedEncoder(cxt.getOutput().getCoder());
+    Dataset<WindowedValue<KV<K, Iterable<InT>>>> inputDs = (Dataset) cxt.getDataset(cxt.getInput());
+
+    cxt.putDataset(cxt.getOutput(), inputDs.map(reduce(combineFn), enc));
+  }
+
+  @Override
+  public boolean canTranslate(Combine.GroupedValues<K, InT, OutT> transform) {
+    return !(transform.getFn() instanceof CombineWithContext);
+  }
+
+  private static <K, InT, AccT, OutT>
+      Fun1<WindowedValue<KV<K, Iterable<InT>>>, WindowedValue<KV<K, OutT>>> reduce(
+          CombineFn<InT, AccT, OutT> fn) {
+    return wv -> {
+      KV<K, ? extends Iterable<InT>> kv = wv.getValue();
+      AccT acc = null;
+      for (InT in : kv.getValue()) {
+        acc = fn.addInput(acc != null ? acc : fn.createAccumulator(), in);
+      }
+      OutT res = acc != null ? fn.extractOutput(acc) : fn.defaultValue();
+      return wv.withValue(KV.of(kv.getKey(), res));
+    };
+  }
+}

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/PipelineTranslatorBatch.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/PipelineTranslatorBatch.java
@@ -65,6 +65,8 @@ public class PipelineTranslatorBatch extends PipelineTranslator {
     TRANSFORM_TRANSLATORS.put(Impulse.class, new ImpulseTranslatorBatch());
     TRANSFORM_TRANSLATORS.put(Combine.PerKey.class, new CombinePerKeyTranslatorBatch<>());
     TRANSFORM_TRANSLATORS.put(Combine.Globally.class, new CombineGloballyTranslatorBatch<>());
+    TRANSFORM_TRANSLATORS.put(
+        Combine.GroupedValues.class, new CombineGroupedValuesTranslatorBatch<>());
     TRANSFORM_TRANSLATORS.put(GroupByKey.class, new GroupByKeyTranslatorBatch<>());
 
     TRANSFORM_TRANSLATORS.put(Reshuffle.class, new ReshuffleTranslatorBatch<>());
@@ -98,6 +100,8 @@ public class PipelineTranslatorBatch extends PipelineTranslator {
     if (transform == null) {
       return null;
     }
-    return TRANSFORM_TRANSLATORS.get(transform.getClass());
+    TransformTranslator<InT, OutT, TransformT> translator =
+        TRANSFORM_TRANSLATORS.get(transform.getClass());
+    return translator != null && translator.canTranslate(transform) ? translator : null;
   }
 }

--- a/runners/spark/3/src/test/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/CombineGroupedValuesTest.java
+++ b/runners/spark/3/src/test/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/CombineGroupedValuesTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.spark.structuredstreaming.translation.batch;
+
+import java.io.Serializable;
+import org.apache.beam.runners.spark.structuredstreaming.SparkStructuredStreamingPipelineOptions;
+import org.apache.beam.runners.spark.structuredstreaming.SparkStructuredStreamingRunner;
+import org.apache.beam.sdk.coders.IterableCoder;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Combine;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.Sum;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Test class for beam to spark {@link Combine#groupedValues} translation. */
+@RunWith(JUnit4.class)
+public class CombineGroupedValuesTest implements Serializable {
+  @Rule public transient TestPipeline pipeline = TestPipeline.fromOptions(testOptions());
+
+  private static PipelineOptions testOptions() {
+    SparkStructuredStreamingPipelineOptions options =
+        PipelineOptionsFactory.create().as(SparkStructuredStreamingPipelineOptions.class);
+    options.setRunner(SparkStructuredStreamingRunner.class);
+    options.setTestMode(true);
+    return options;
+  }
+
+  @Test
+  public void testCombineGroupedValues() {
+    PCollection<KV<String, Integer>> input =
+        pipeline
+            .apply(
+                Create.<KV<String, Iterable<Integer>>>of(
+                        KV.of("a", ImmutableList.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)),
+                        KV.of("b", ImmutableList.of()))
+                    .withCoder(
+                        KvCoder.of(StringUtf8Coder.of(), IterableCoder.of(VarIntCoder.of()))))
+            .apply(Combine.groupedValues(Sum.ofIntegers()));
+
+    PAssert.that(input).containsInAnyOrder(KV.of("a", 55), KV.of("b", 0));
+    pipeline.run();
+  }
+}


### PR DESCRIPTION
Adding direct translation of Combine.GroupedValues.
This is a minor improvement to TPC-DS query 83, but by no means the issue for the big difference (related to #23845).

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
