### PR TITLE
[BEAM-18065] Implement WithTimestamps.withWatermarkDelay

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithTimestamps.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithTimestamps.java
@@ -95,9 +95,9 @@ public class WithTimestamps<T> extends PTransform<PCollection<T>, PCollection<T>
   /**
    * DO NOT USE
    *
-   * <p>This method results in data within the allowed timestamp skew being late. Use {@link
-   * withWatermarkDelay} instead which results in data within the allowed timestamp skew being on
-   * time.
+   * <p>This method results in data within the allowed timestamp skew being late. Use
+   * {@link WithTimestamps#withWatermarkDelay} instead which results in data within the allowed
+   * timestamp skew being on time.
    *
    * <p>Return a new WithTimestamps like this one with updated allowed timestamp skew, which is the
    * maximum duration that timestamps can be shifted backward. Does not modify this object.
@@ -119,17 +119,18 @@ public class WithTimestamps<T> extends PTransform<PCollection<T>, PCollection<T>
   /**
    * DO NOT USE
    *
-   * <p>This method results in data within the allowed timestamp skew being late. Use {@link
-   * withWatermarkDelay} instead which results in data within the allowed timestamp skew being on
-   * time.
+   * <p>This method results in data within the allowed timestamp skew being late. Use
+   * {@link WithTimestamps#withWatermarkDelay} instead which results in data within the allowed
+   * timestamp skew being on time.
    *
    * <p>Returns the allowed timestamp skew duration, which is the maximum duration that timestamps
    * can be shifted backwards from the timestamp of the input element.
    *
    * @see DoFn#getAllowedTimestampSkew()
    * @deprecated This method permits elements to be emitted behind the watermark. These elements are
-   *     considered late, and if behind the {@link Window#withAllowedLateness(Duration) allowed
-   *     lateness} of a downstream {@link PCollection} may be silently dropped.
+   * considered late, and if behind the
+   * {@link Window#withAllowedLateness(Duration) allowed lateness} of a downstream
+   * {@link PCollection} may be silently dropped.
    */
   @Deprecated
   public Duration getAllowedTimestampSkew() {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithTimestamps.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithTimestamps.java
@@ -95,9 +95,9 @@ public class WithTimestamps<T> extends PTransform<PCollection<T>, PCollection<T>
   /**
    * DO NOT USE
    *
-   * <p>This method results in data within the allowed timestamp skew being late. Use
-   * {@link WithTimestamps#withWatermarkDelay} instead which results in data within the allowed
-   * timestamp skew being on time.
+   * <p>This method results in data within the allowed timestamp skew being late. Use {@link
+   * WithTimestamps#withWatermarkDelay} instead which results in data within the allowed timestamp
+   * skew being on time.
    *
    * <p>Return a new WithTimestamps like this one with updated allowed timestamp skew, which is the
    * maximum duration that timestamps can be shifted backward. Does not modify this object.
@@ -119,18 +119,17 @@ public class WithTimestamps<T> extends PTransform<PCollection<T>, PCollection<T>
   /**
    * DO NOT USE
    *
-   * <p>This method results in data within the allowed timestamp skew being late. Use
-   * {@link WithTimestamps#withWatermarkDelay} instead which results in data within the allowed
-   * timestamp skew being on time.
+   * <p>This method results in data within the allowed timestamp skew being late. Use {@link
+   * WithTimestamps#withWatermarkDelay} instead which results in data within the allowed timestamp
+   * skew being on time.
    *
    * <p>Returns the allowed timestamp skew duration, which is the maximum duration that timestamps
    * can be shifted backwards from the timestamp of the input element.
    *
    * @see DoFn#getAllowedTimestampSkew()
    * @deprecated This method permits elements to be emitted behind the watermark. These elements are
-   * considered late, and if behind the
-   * {@link Window#withAllowedLateness(Duration) allowed lateness} of a downstream
-   * {@link PCollection} may be silently dropped.
+   *     considered late, and if behind the {@link Window#withAllowedLateness(Duration) allowed
+   *     lateness} of a downstream {@link PCollection} may be silently dropped.
    */
   @Deprecated
   public Duration getAllowedTimestampSkew() {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithWatermarkDelayFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithWatermarkDelayFn.java
@@ -1,0 +1,105 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.transforms;
+
+import java.util.Arrays;
+import java.util.Collections;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.transforms.DoFn.BoundedPerElement;
+import org.apache.beam.sdk.transforms.splittabledofn.ManualWatermarkEstimator;
+import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
+import org.apache.beam.sdk.transforms.splittabledofn.SplitResult;
+import org.apache.beam.sdk.transforms.splittabledofn.WatermarkEstimators;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+
+@BoundedPerElement
+class WithWatermarkDelayFn<T> extends DoFn<T, T> {
+
+  private final SerializableFunction<T, Instant> fn;
+  private final Duration watermarkDelay;
+
+  WithWatermarkDelayFn(SerializableFunction<T, Instant> fn, Duration watermarkDelay) {
+    this.fn = fn;
+    this.watermarkDelay = watermarkDelay;
+  }
+
+  @ProcessElement
+  public void processElement(
+      @Element T input,
+      @Timestamp Instant inputTimestamp,
+      RestrictionTracker<Integer, Integer> restrictionTracker,
+      OutputReceiver<T> output,
+      ManualWatermarkEstimator<Instant> estimator) {
+    Instant ts = fn.apply(input);
+    output.outputWithTimestamp(input, ts);
+    Instant watermark = ts.minus(watermarkDelay);
+    // Don't advance the watermark past the input element timestamp.
+    watermark = Collections.min(Arrays.asList(watermark, inputTimestamp));
+    if (watermark.isAfter(estimator.currentWatermark())) {
+      estimator.setWatermark(watermark);
+    }
+  }
+
+  @GetInitialRestriction
+  public Integer getInitialRestriction() {
+    return 0;
+  }
+
+  @NewTracker
+  public RestrictionTracker<Integer, Integer> newTracker() {
+    // This is a noop restriction tracker that does nothing.
+    return new RestrictionTracker<Integer, Integer>() {
+
+      @Override
+      public boolean tryClaim(Integer newPosition) {
+        return true;
+      }
+
+      @Override
+      public Integer currentRestriction() {
+        return 0;
+      }
+
+      @Override
+      public @Nullable SplitResult<Integer> trySplit(double fractionOfRemainder) {
+        return null;
+      }
+
+      @Override
+      public void checkDone() {}
+
+      @Override
+      public IsBounded isBounded() {
+        return IsBounded.BOUNDED;
+      }
+    };
+  }
+
+  @GetInitialWatermarkEstimatorState
+  public Instant getInitialWatermarkEstimatorState() {
+    return BoundedWindow.TIMESTAMP_MIN_VALUE;
+  }
+
+  @NewWatermarkEstimator
+  public ManualWatermarkEstimator<Instant> newWatermarkEstimator(
+      @WatermarkEstimatorState Instant state) {
+    return new WatermarkEstimators.Manual(state);
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithWatermarkDelayFn.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/WithWatermarkDelayFn.java
@@ -29,6 +29,10 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 
+/**
+ * Adds a watermark a fixed delay behind the extracted timestamp of the source element. Does not
+ * allow the watermark to pass the timestamp of the source element.
+ */
 @BoundedPerElement
 class WithWatermarkDelayFn<T> extends DoFn<T, T> {
 


### PR DESCRIPTION
This implements in userland what KafkaIO implements inside the source with CustomTimestampPolicyWithLimitedDelay. It is a transform to properly remap timestamps between time domains by holding up the watermark a fixed amount, while still marking the data that arrives by that time as on time.

It does not implement predictive holdback time like PubSubIO does, however it provides a framework to implement that in userland.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
