### PR TITLE
Fix beam.Row.__eq__ for rows with trailing columns

### DIFF
--- a/sdks/python/apache_beam/pvalue.py
+++ b/sdks/python/apache_beam/pvalue.py
@@ -684,8 +684,8 @@ class Row(object):
     return hash(self.__dict__.items())
 
   def __eq__(self, other):
-    return type(self) == type(other) and all(
-        s == o for s, o in zip(self.__dict__.items(), other.__dict__.items()))
+    return (type(self) == type(other) and
+            self.__dict__.items() == other.__dict__.items())
 
   def __reduce__(self):
     return _make_Row, tuple(self.__dict__.items())

--- a/sdks/python/apache_beam/pvalue.py
+++ b/sdks/python/apache_beam/pvalue.py
@@ -684,8 +684,11 @@ class Row(object):
     return hash(self.__dict__.items())
 
   def __eq__(self, other):
-    return (type(self) == type(other) and
-            self.__dict__.items() == other.__dict__.items())
+    return (
+        type(self) == type(other) and
+        len(self.__dict__) == len(other.__dict__) and all(
+            s == o for s,
+            o in zip(self.__dict__.items(), other.__dict__.items())))
 
   def __reduce__(self):
     return _make_Row, tuple(self.__dict__.items())

--- a/sdks/python/apache_beam/pvalue_test.py
+++ b/sdks/python/apache_beam/pvalue_test.py
@@ -55,11 +55,16 @@ class RowTest(unittest.TestCase):
     row = Row(a=1, b=2)
     same = Row(a=1, b=2)
     self.assertEqual(row, same)
-  
+
   def test_trailing_column_row_neq(self):
     row = Row(a=1, b=2)
     trail = Row(a=1, b=2, c=3)
     self.assertNotEqual(row, trail)
+
+  def test_row_comparison_respects_element_order(self):
+    row = Row(a=1, b=2)
+    different = Row(b=2, a=1)
+    self.assertNotEqual(row, different)
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/pvalue_test.py
+++ b/sdks/python/apache_beam/pvalue_test.py
@@ -23,6 +23,7 @@ import unittest
 
 from apache_beam.pvalue import AsSingleton
 from apache_beam.pvalue import PValue
+from apache_beam.pvalue import Row
 from apache_beam.pvalue import TaggedOutput
 from apache_beam.testing.test_pipeline import TestPipeline
 
@@ -47,6 +48,18 @@ class TaggedValueTest(unittest.TestCase):
         TypeError,
         r'Attempting to create a TaggedOutput with non-string tag \(1, 2, 3\)'):
       TaggedOutput((1, 2, 3), 'value')
+
+
+class RowTest(unittest.TestCase):
+  def test_row_eq(self):
+    row = Row(a=1, b=2)
+    same = Row(a=1, b=2)
+    self.assertEqual(row, same)
+  
+  def test_trailing_column_row_neq(self):
+    row = Row(a=1, b=2)
+    trail = Row(a=1, b=2, c=3)
+    self.assertNotEqual(row, trail)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
The `beam.Row.__eq__` operator had unexpected behavior when the rows had a different number of columns. 

Specifically the case:

`beam.Row(x=1, y=2) == beam.Row(x=1, y=2, z=3)` returns true.

This is because zip() drops the trailing columns from the row that has more columns. When all rows are equal trailing rows are ignored and a `__eq__` call returns true.

Fix was to replace zip with comparison of the lists of dict items.

cc @robertwb

