### PR TITLE
Support non-getter (POJO) AutoValues

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FieldValueTypeInformation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FieldValueTypeInformation.java
@@ -177,6 +177,14 @@ public abstract class FieldValueTypeInformation implements Serializable {
       throw new RuntimeException("Getter has wrong prefix " + method.getName());
     }
 
+    return forMethodWithName(method, index, name);
+  }
+
+  public static FieldValueTypeInformation forMethod(Method method, int index) {
+    return forMethodWithName(method, index, method.getName());
+  }
+
+  private static FieldValueTypeInformation forMethodWithName(Method method, int index, String name) {
     TypeDescriptor type = TypeDescriptor.of(method.getGenericReturnType());
     boolean nullable = hasNullableReturnType(method);
     return new AutoValue_FieldValueTypeInformation.Builder()

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AutoValueSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AutoValueSchemaTest.java
@@ -854,4 +854,86 @@ public class AutoValueSchemaTest {
     assertEquals(
         registry.getFromRowFunction(SimpleAutoValueWithRenamedFields.class).apply(row), autoValue);
   }
+
+  @AutoValue
+  @DefaultSchema(AutoValueSchema.class)
+  abstract static class NonGetterAutoValue {
+    public abstract String str();
+
+    public abstract byte aByte();
+
+    public abstract short aShort();
+
+    public abstract int getAnInt();
+
+    public abstract long aLong();
+
+    public abstract boolean aBoolean();
+
+    public abstract DateTime dateTime();
+
+    @SuppressWarnings("mutable")
+    public abstract byte[] bytes();
+
+    public abstract ByteBuffer byteBuffer();
+
+    public abstract Instant instant();
+
+    public abstract BigDecimal bigDecimal();
+
+    public abstract StringBuilder stringBuilder();
+  }
+  
+  @Test
+  public void testNonGetterAutoValue() throws NoSuchSchemaException {
+    SchemaRegistry registry = SchemaRegistry.createDefault();
+    Schema schema = registry.getSchema(NonGetterAutoValue.class);
+    SchemaTestUtils.assertSchemaEquivalent(SIMPLE_SCHEMA, schema);
+  }
+
+  static class SuperclassThatDefinesToString {
+    @Override
+    public String toString() {
+      return "Base class string representation";
+    }
+  }
+
+  @AutoValue
+  @DefaultSchema(AutoValueSchema.class)
+  abstract static class NonGetterAutoValueWithOverriddenObjectMethod extends SuperclassThatDefinesToString {
+    public abstract String str();
+
+    public abstract byte aByte();
+
+    public abstract short aShort();
+
+    public abstract int getAnInt();
+
+    public abstract long aLong();
+
+    public abstract boolean aBoolean();
+
+    public abstract DateTime dateTime();
+
+    @SuppressWarnings("mutable")
+    public abstract byte[] bytes();
+
+    public abstract ByteBuffer byteBuffer();
+
+    public abstract Instant instant();
+
+    public abstract BigDecimal bigDecimal();
+
+    public abstract StringBuilder stringBuilder();
+
+    // cause AutoValue to generate this even though the superclass has it
+    @Override public abstract String toString();
+  }
+
+  @Test
+  public void testNonGetterAutoValueWithOverriddenObjectMethod() throws NoSuchSchemaException {
+    SchemaRegistry registry = SchemaRegistry.createDefault();
+    Schema schema = registry.getSchema(NonGetterAutoValueWithOverriddenObjectMethod.class);
+    SchemaTestUtils.assertSchemaEquivalent(SIMPLE_SCHEMA, schema);
+  }
 }


### PR DESCRIPTION
The current `AuthValueSchema` class only supports `AutoValue` classes which are prefixed with `get` or `is`. This change adds support for methods which do not conform to the POJO standards.

For example:
```java
@AutoValue
@DefaultSchema(AutoValueSchema.class)
abstract class Example {
  public abstract long id();
  public abstract String str();
}
```

Issue: #20752