### PR TITLE
Implement PubsubRowToMessage transform

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubRowToMessage.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubRowToMessage.java
@@ -1,0 +1,290 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.pubsub;
+
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+
+import com.google.auto.value.AutoValue;
+import java.util.Arrays;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.Optional;
+import java.util.stream.Collectors;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.Field;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.schemas.Schema.TypeName;
+import org.apache.beam.sdk.schemas.io.payloads.PayloadSerializer;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionTuple;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
+
+/** Write side {@link Row} to {@link PubsubMessage} converter. */
+@Internal
+@Experimental
+@AutoValue
+@SuppressWarnings({
+  "nullness" // TODO(https://github.com/apache/beam/issues/20497)
+})
+abstract class PubsubRowToMessage extends PTransform<PCollection<Row>, PCollectionTuple> {
+  static TupleTag<PubsubMessage> OUTPUT = new TupleTag<PubsubMessage>() {};
+  static TupleTag<Row> ERROR = new TupleTag<Row>() {};
+
+  private static final String DEFAULT_KEY_PREFIX = "$";
+  private static final String ATTRIBUTES_KEY_NAME = "pubsub_attributes";
+  private static final FieldType ATTRIBUTES_FIELD_TYPE =
+      FieldType.map(FieldType.STRING, FieldType.STRING);
+
+  private static final String EVENT_TIMESTAMP_KEY_NAME = "pubsub_event_timestamp";
+  private static final FieldType EVENT_TIMESTAMP_FIELD_TYPE = FieldType.DATETIME;
+
+  private static final String PAYLOAD_KEY_NAME = "pubsub_payload";
+  private static final TypeName PAYLOAD_BYTES_TYPE_NAME = TypeName.BYTES;
+  private static final TypeName PAYLOAD_ROW_TYPE_NAME = TypeName.ROW;
+
+  abstract String getKeyPrefix();
+
+  @Nullable
+  abstract PayloadSerializer getPayloadSerializer();
+
+  @Nullable
+  abstract String getTimestampAttributeName();
+
+  @Override
+  public PCollectionTuple expand(PCollection<Row> input) {
+    return null;
+  }
+
+  String getAttributesKeyName() {
+    return getKeyPrefix() + ATTRIBUTES_KEY_NAME;
+  }
+
+  String getEventTimestampKeyName() {
+    return getKeyPrefix() + EVENT_TIMESTAMP_KEY_NAME;
+  }
+
+  String getPayloadKeyName() {
+    return getKeyPrefix() + PAYLOAD_KEY_NAME;
+  }
+
+  void validate(Schema schema) {
+    validateAttributesField(schema);
+    validateEventTimeStampField(schema);
+    validatePayloadField(schema);
+  }
+
+  void validateAttributesField(Schema schema) {
+    String attributesKeyName = getAttributesKeyName();
+    if (!schema.hasField(attributesKeyName)) {
+      return;
+    }
+    checkArgument(SchemaReflection.of(schema).matchesAll(FieldMatcher.of(attributesKeyName, ATTRIBUTES_FIELD_TYPE)));
+  }
+
+  void validateEventTimeStampField(Schema schema) {
+    String eventTimestampKeyName = getEventTimestampKeyName();
+    if (!schema.hasField(eventTimestampKeyName)) {
+      return;
+    }
+    checkArgument(SchemaReflection.of(schema).matchesAll(FieldMatcher.of(eventTimestampKeyName, EVENT_TIMESTAMP_FIELD_TYPE)));
+  }
+
+  void validatePayloadField(Schema schema) {
+    String attributesKeyName = getAttributesKeyName();
+    String eventTimestampKeyName = getEventTimestampKeyName();
+    String payloadKeyName = getPayloadKeyName();
+    Schema withUserFieldsOnly = removeFields(schema, attributesKeyName, eventTimestampKeyName, payloadKeyName);
+    boolean hasUserFields = withUserFieldsOnly.getFieldCount() > 0;
+    String withUserFieldsList = String.join(", ", withUserFieldsOnly.getFieldNames());
+    SchemaReflection schemaReflection = SchemaReflection.of(schema);
+    boolean hasPayloadField = schemaReflection.matchesAll(FieldMatcher.of(name));
+    boolean hasPayloadRowField = schemaReflection.matchesAll(FieldMatcher.of(payloadKeyName,
+        PAYLOAD_ROW_TYPE_NAME));
+    boolean hasBothUserFieldsAndPayloadField = hasUserFields && hasPayloadField;
+
+    checkArgument(!hasBothUserFieldsAndPayloadField,
+        String.format("schema field: %s incompatible with %s fields", payloadKeyName, withUserFieldsList)
+    );
+    checkArgument(hasPayloadRowField && getPayloadSerializer() != null, String.format("schema field: %s of type: %s requires a %s", payloadKeyName, PAYLOAD_ROW_TYPE_NAME, PayloadSerializer.class.getName()));
+    checkArgument(hasUserFields && getPayloadSerializer() != null, String.format("specifying schema fields: %s requires a %s", withUserFieldsList, PayloadSerializer.class.getName()));
+  }
+
+  @AutoValue.Builder
+  abstract static class Builder {
+    abstract Builder setKeyPrefix(String value);
+
+    abstract Optional<String> getKeyPrefix();
+
+    abstract Builder setPayloadSerializer(PayloadSerializer value);
+
+    abstract Builder setTimestampAttributeName(String value);
+
+    abstract PubsubRowToMessage autoBuild();
+
+    final PubsubRowToMessage build() {
+      if (!getKeyPrefix().isPresent()) {
+        setKeyPrefix(DEFAULT_KEY_PREFIX);
+      }
+      return autoBuild();
+    }
+  }
+
+  static class SchemaReflection {
+    static SchemaReflection of(Schema schema) {
+      return new SchemaReflection(schema);
+    }
+    private final Schema schema;
+
+    private SchemaReflection(Schema schema) {
+      this.schema = schema;
+    }
+
+    boolean matchesAll(FieldMatcher ...fieldMatchers) {
+      for (FieldMatcher fieldMatcher : fieldMatchers) {
+        if (!fieldMatcher.match(schema)) {
+          return false;
+        }
+      }
+      return true;
+    }
+  }
+
+  static class FieldMatcher {
+    static FieldMatcher of(String name) {
+      return new FieldMatcher(name);
+    }
+    static FieldMatcher of(String name, TypeName typeName) {
+      return new FieldMatcher(name, typeName);
+    }
+    static FieldMatcher of(String name, FieldType fieldType) {
+      return new FieldMatcher(name, fieldType);
+    }
+    private final String name;
+
+    @Nullable
+    private final TypeName typeName;
+
+    @Nullable
+    private final FieldType fieldType;
+
+    private FieldMatcher(String name, @Nullable TypeName typeName,
+        @Nullable FieldType fieldType) {
+      this.name = name;
+      this.typeName = typeName;
+      this.fieldType = fieldType;
+    }
+
+    private FieldMatcher(String name) {
+      this(name, null, null);
+    }
+
+    private FieldMatcher(String name, TypeName typeName) {
+      this(name, typeName, null);
+    }
+
+    private FieldMatcher(String name, FieldType fieldType) {
+      this(name, null, fieldType);
+    }
+
+    boolean match(Schema schema) {
+      if (typeName == null && fieldType == null) {
+        return schema.hasField(name);
+      }
+      Field field = schema.getField(name);
+      if (typeName != null) {
+        return field.getType().getTypeName().equals(typeName);
+      }
+      return fieldType.equals(field.getType());
+    }
+  }
+
+  static Schema removeFields(Schema schema, String ...fields) {
+    List<String> exclude = Arrays.stream(fields).collect(Collectors.toList());
+    Schema.Builder builder = Schema.builder();
+    for (Field field : schema.getFields()) {
+      if (exclude.contains(field.getName())) {
+        continue;
+      }
+      builder.addField(field);
+    }
+    return builder.build();
+  }
+
+  static class PubsubRowToMessageDoFn extends DoFn<Row, PubsubMessage> {
+    PubsubRowToMessageDoFn from(PubsubRowToMessage spec) {
+      return new PubsubRowToMessageDoFn(spec.getAttributesKeyName(), spec.getEventTimestampKeyName(), spec.getPayloadKeyName(), spec.getPayloadSerializer());
+    }
+    private final String attributesKeyName;
+    private final String eventTimestampKeyName;
+    private final String payloadKeyName;
+
+    @Nullable
+    private PayloadSerializer payloadSerializer;
+
+    PubsubRowToMessageDoFn(String attributesKeyName, String eventTimestampKeyName,
+        String payloadKeyName,
+        @Nullable PayloadSerializer payloadSerializer) {
+      this.attributesKeyName = attributesKeyName;
+      this.eventTimestampKeyName = eventTimestampKeyName;
+      this.payloadKeyName = payloadKeyName;
+      this.payloadSerializer = payloadSerializer;
+    }
+
+    @ProcessElement
+    public void process(@Element Row row, MultiOutputReceiver receiver) {
+
+    }
+
+    Map<String, String> attributes(Row row) {
+      if (!row.getSchema().hasField(attributesKeyName)) {
+        return ImmutableMap.of();
+      }
+      return row.getMap(attributesKeyName);
+    }
+
+    byte[] payload(Row row) {
+      if (SchemaReflection.of(row.getSchema()).matchesAll(FieldMatcher.of(payloadKeyName,
+          PAYLOAD_BYTES_TYPE_NAME))) {
+        return row.getBytes(payloadKeyName);
+      }
+      return Objects.requireNonNull(payloadSerializer).serialize(serializableRow(row));
+    }
+
+    Row serializableRow(Row row) {
+      SchemaReflection schemaReflection = SchemaReflection.of(row.getSchema());
+      if (schemaReflection.matchesAll(FieldMatcher.of(payloadKeyName, PAYLOAD_ROW_TYPE_NAME))) {
+        return row.getRow(payloadKeyName);
+      }
+      Schema withUserFieldsOnly = removeFields(row.getSchema(), attributesKeyName, eventTimestampKeyName);
+      Map<String, Object> values = new HashMap<>();
+      for (String name : withUserFieldsOnly.getFieldNames()) {
+        values.put(name, row.getValue(name));
+      }
+      return Row.withSchema(withUserFieldsOnly).withFieldValues(values).build();
+    }
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubRowToMessage.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubRowToMessage.java
@@ -37,11 +37,15 @@ import org.apache.beam.sdk.schemas.Schema.TypeName;
 import org.apache.beam.sdk.schemas.io.payloads.PayloadSerializer;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TupleTag;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
+import org.apache.beam.sdk.values.TupleTagList;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Throwables;
+import org.joda.time.Instant;
+import org.joda.time.ReadableDateTime;
 
 /** Write side {@link Row} to {@link PubsubMessage} converter. */
 @Internal
@@ -53,18 +57,21 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Immutabl
 abstract class PubsubRowToMessage extends PTransform<PCollection<Row>, PCollectionTuple> {
   static TupleTag<PubsubMessage> OUTPUT = new TupleTag<PubsubMessage>() {};
   static TupleTag<Row> ERROR = new TupleTag<Row>() {};
+  static final String ERROR_DATA_FIELD_NAME = "data";
+  static final Field ERROR_MESSAGE_FIELD = Field.of("error_message", FieldType.STRING);
+  static final Field ERROR_STACK_TRACE_FIELD = Field.of("error_stack_trace", FieldType.STRING);
 
-  private static final String DEFAULT_KEY_PREFIX = "$";
-  private static final String ATTRIBUTES_KEY_NAME = "pubsub_attributes";
-  private static final FieldType ATTRIBUTES_FIELD_TYPE =
+  static final String DEFAULT_KEY_PREFIX = "$";
+  static final String ATTRIBUTES_KEY_NAME = "pubsub_attributes";
+  static final FieldType ATTRIBUTES_FIELD_TYPE =
       FieldType.map(FieldType.STRING, FieldType.STRING);
 
-  private static final String EVENT_TIMESTAMP_KEY_NAME = "pubsub_event_timestamp";
-  private static final FieldType EVENT_TIMESTAMP_FIELD_TYPE = FieldType.DATETIME;
+  static final String EVENT_TIMESTAMP_KEY_NAME = "pubsub_event_timestamp";
+  static final FieldType EVENT_TIMESTAMP_FIELD_TYPE = FieldType.DATETIME;
 
-  private static final String PAYLOAD_KEY_NAME = "pubsub_payload";
-  private static final TypeName PAYLOAD_BYTES_TYPE_NAME = TypeName.BYTES;
-  private static final TypeName PAYLOAD_ROW_TYPE_NAME = TypeName.ROW;
+  static final String PAYLOAD_KEY_NAME = "pubsub_payload";
+  static final TypeName PAYLOAD_BYTES_TYPE_NAME = TypeName.BYTES;
+  static final TypeName PAYLOAD_ROW_TYPE_NAME = TypeName.ROW;
 
   abstract String getKeyPrefix();
 
@@ -72,11 +79,24 @@ abstract class PubsubRowToMessage extends PTransform<PCollection<Row>, PCollecti
   abstract PayloadSerializer getPayloadSerializer();
 
   @Nullable
-  abstract String getTimestampAttributeName();
+  abstract String getTargetTimestampAttributeName();
 
   @Override
   public PCollectionTuple expand(PCollection<Row> input) {
-    return null;
+    Schema schema = input.getSchema();
+    validate(schema);
+    Field dataField = Field.of(ERROR_DATA_FIELD_NAME, FieldType.row(schema));
+    Schema errorSchema = Schema.of(dataField, ERROR_MESSAGE_FIELD, ERROR_STACK_TRACE_FIELD);
+    return input.apply(
+        PubsubRowToMessage.class.getSimpleName(),
+        ParDo.of(
+                new PubsubRowToMessageDoFn(
+                    getAttributesKeyName(),
+                    getEventTimestampKeyName(),
+                    getPayloadKeyName(),
+                    errorSchema,
+                    getPayloadSerializer()))
+            .withOutputTags(OUTPUT, TupleTagList.of(ERROR)));
   }
 
   String getAttributesKeyName() {
@@ -102,7 +122,9 @@ abstract class PubsubRowToMessage extends PTransform<PCollection<Row>, PCollecti
     if (!schema.hasField(attributesKeyName)) {
       return;
     }
-    checkArgument(SchemaReflection.of(schema).matchesAll(FieldMatcher.of(attributesKeyName, ATTRIBUTES_FIELD_TYPE)));
+    checkArgument(
+        SchemaReflection.of(schema)
+            .matchesAll(FieldMatcher.of(attributesKeyName, ATTRIBUTES_FIELD_TYPE)));
   }
 
   void validateEventTimeStampField(Schema schema) {
@@ -110,27 +132,39 @@ abstract class PubsubRowToMessage extends PTransform<PCollection<Row>, PCollecti
     if (!schema.hasField(eventTimestampKeyName)) {
       return;
     }
-    checkArgument(SchemaReflection.of(schema).matchesAll(FieldMatcher.of(eventTimestampKeyName, EVENT_TIMESTAMP_FIELD_TYPE)));
+    checkArgument(
+        SchemaReflection.of(schema)
+            .matchesAll(FieldMatcher.of(eventTimestampKeyName, EVENT_TIMESTAMP_FIELD_TYPE)));
   }
 
   void validatePayloadField(Schema schema) {
     String attributesKeyName = getAttributesKeyName();
     String eventTimestampKeyName = getEventTimestampKeyName();
     String payloadKeyName = getPayloadKeyName();
-    Schema withUserFieldsOnly = removeFields(schema, attributesKeyName, eventTimestampKeyName, payloadKeyName);
+    Schema withUserFieldsOnly =
+        removeFields(schema, attributesKeyName, eventTimestampKeyName, payloadKeyName);
     boolean hasUserFields = withUserFieldsOnly.getFieldCount() > 0;
     String withUserFieldsList = String.join(", ", withUserFieldsOnly.getFieldNames());
     SchemaReflection schemaReflection = SchemaReflection.of(schema);
     boolean hasPayloadField = schemaReflection.matchesAll(FieldMatcher.of(name));
-    boolean hasPayloadRowField = schemaReflection.matchesAll(FieldMatcher.of(payloadKeyName,
-        PAYLOAD_ROW_TYPE_NAME));
+    boolean hasPayloadRowField =
+        schemaReflection.matchesAll(FieldMatcher.of(payloadKeyName, PAYLOAD_ROW_TYPE_NAME));
     boolean hasBothUserFieldsAndPayloadField = hasUserFields && hasPayloadField;
 
-    checkArgument(!hasBothUserFieldsAndPayloadField,
-        String.format("schema field: %s incompatible with %s fields", payloadKeyName, withUserFieldsList)
-    );
-    checkArgument(hasPayloadRowField && getPayloadSerializer() != null, String.format("schema field: %s of type: %s requires a %s", payloadKeyName, PAYLOAD_ROW_TYPE_NAME, PayloadSerializer.class.getName()));
-    checkArgument(hasUserFields && getPayloadSerializer() != null, String.format("specifying schema fields: %s requires a %s", withUserFieldsList, PayloadSerializer.class.getName()));
+    checkArgument(
+        !hasBothUserFieldsAndPayloadField,
+        String.format(
+            "schema field: %s incompatible with %s fields", payloadKeyName, withUserFieldsList));
+    checkArgument(
+        hasPayloadRowField && getPayloadSerializer() != null,
+        String.format(
+            "schema field: %s of type: %s requires a %s",
+            payloadKeyName, PAYLOAD_ROW_TYPE_NAME, PayloadSerializer.class.getName()));
+    checkArgument(
+        hasUserFields && getPayloadSerializer() != null,
+        String.format(
+            "specifying schema fields: %s requires a %s",
+            withUserFieldsList, PayloadSerializer.class.getName()));
   }
 
   @AutoValue.Builder
@@ -141,7 +175,7 @@ abstract class PubsubRowToMessage extends PTransform<PCollection<Row>, PCollecti
 
     abstract Builder setPayloadSerializer(PayloadSerializer value);
 
-    abstract Builder setTimestampAttributeName(String value);
+    abstract Builder setTargetTimestampAttributeName(String value);
 
     abstract PubsubRowToMessage autoBuild();
 
@@ -157,13 +191,14 @@ abstract class PubsubRowToMessage extends PTransform<PCollection<Row>, PCollecti
     static SchemaReflection of(Schema schema) {
       return new SchemaReflection(schema);
     }
+
     private final Schema schema;
 
     private SchemaReflection(Schema schema) {
       this.schema = schema;
     }
 
-    boolean matchesAll(FieldMatcher ...fieldMatchers) {
+    boolean matchesAll(FieldMatcher... fieldMatchers) {
       for (FieldMatcher fieldMatcher : fieldMatchers) {
         if (!fieldMatcher.match(schema)) {
           return false;
@@ -177,22 +212,22 @@ abstract class PubsubRowToMessage extends PTransform<PCollection<Row>, PCollecti
     static FieldMatcher of(String name) {
       return new FieldMatcher(name);
     }
+
     static FieldMatcher of(String name, TypeName typeName) {
       return new FieldMatcher(name, typeName);
     }
+
     static FieldMatcher of(String name, FieldType fieldType) {
       return new FieldMatcher(name, fieldType);
     }
+
     private final String name;
 
-    @Nullable
-    private final TypeName typeName;
+    @Nullable private final TypeName typeName;
 
-    @Nullable
-    private final FieldType fieldType;
+    @Nullable private final FieldType fieldType;
 
-    private FieldMatcher(String name, @Nullable TypeName typeName,
-        @Nullable FieldType fieldType) {
+    private FieldMatcher(String name, @Nullable TypeName typeName, @Nullable FieldType fieldType) {
       this.name = name;
       this.typeName = typeName;
       this.fieldType = fieldType;
@@ -222,7 +257,7 @@ abstract class PubsubRowToMessage extends PTransform<PCollection<Row>, PCollecti
     }
   }
 
-  static Schema removeFields(Schema schema, String ...fields) {
+  static Schema removeFields(Schema schema, String... fields) {
     List<String> exclude = Arrays.stream(fields).collect(Collectors.toList());
     Schema.Builder builder = Schema.builder();
     for (Field field : schema.getFields()) {
@@ -236,39 +271,86 @@ abstract class PubsubRowToMessage extends PTransform<PCollection<Row>, PCollecti
 
   static class PubsubRowToMessageDoFn extends DoFn<Row, PubsubMessage> {
     PubsubRowToMessageDoFn from(PubsubRowToMessage spec) {
-      return new PubsubRowToMessageDoFn(spec.getAttributesKeyName(), spec.getEventTimestampKeyName(), spec.getPayloadKeyName(), spec.getPayloadSerializer());
+      return new PubsubRowToMessageDoFn(
+          spec.getAttributesKeyName(),
+          spec.getEventTimestampKeyName(),
+          spec.getPayloadKeyName(),
+          errorSchema,
+          spec.getPayloadSerializer());
     }
+
     private final String attributesKeyName;
     private final String eventTimestampKeyName;
     private final String payloadKeyName;
+    private final Schema errorSchema;
 
-    @Nullable
-    private PayloadSerializer payloadSerializer;
+    @Nullable private PayloadSerializer payloadSerializer;
 
-    PubsubRowToMessageDoFn(String attributesKeyName, String eventTimestampKeyName,
+    PubsubRowToMessageDoFn(
+        String attributesKeyName,
+        String eventTimestampKeyName,
         String payloadKeyName,
+        Schema errorSchema,
         @Nullable PayloadSerializer payloadSerializer) {
       this.attributesKeyName = attributesKeyName;
       this.eventTimestampKeyName = eventTimestampKeyName;
       this.payloadKeyName = payloadKeyName;
+      this.errorSchema = errorSchema;
       this.payloadSerializer = payloadSerializer;
     }
 
     @ProcessElement
     public void process(@Element Row row, MultiOutputReceiver receiver) {
+      try {
 
+        Map<String, String> attributesWithoutTimestamp = this.attributesWithoutTimestamp(row);
+        String timestampAsString = this.timestampAsString(row);
+        byte[] payload = this.payload(row);
+        HashMap<String, String> attributes = new HashMap<>(attributesWithoutTimestamp);
+        attributes.put(eventTimestampKeyName, timestampAsString);
+        PubsubMessage message = new PubsubMessage(payload, attributes);
+        receiver.get(OUTPUT).output(message);
+
+      } catch (Exception e) {
+
+        String message = e.getMessage();
+        String stackTrace = Throwables.getStackTraceAsString(e);
+        Row error =
+            Row.withSchema(errorSchema)
+                .withFieldValue(ERROR_DATA_FIELD_NAME, row)
+                .withFieldValue(ERROR_MESSAGE_FIELD.getName(), message)
+                .withFieldValue(ERROR_STACK_TRACE_FIELD.getName(), stackTrace)
+                .build();
+
+        receiver.get(ERROR).output(error);
+      }
     }
 
-    Map<String, String> attributes(Row row) {
+    Map<String, String> attributesWithoutTimestamp(Row row) {
       if (!row.getSchema().hasField(attributesKeyName)) {
-        return ImmutableMap.of();
+        return new HashMap<>();
       }
       return row.getMap(attributesKeyName);
     }
 
+    /**
+     * Outputs the {@link #timestamp(Row)} as a String in RFC 3339 format. For example, {@code
+     * 2015-10-29T23:41:41.123Z}.
+     */
+    String timestampAsString(Row row) {
+      return timestamp(row).toString();
+    }
+
+    ReadableDateTime timestamp(Row row) {
+      if (!row.getSchema().hasField(eventTimestampKeyName)) {
+        return Instant.now().toDateTime();
+      }
+      return row.getDateTime(eventTimestampKeyName);
+    }
+
     byte[] payload(Row row) {
-      if (SchemaReflection.of(row.getSchema()).matchesAll(FieldMatcher.of(payloadKeyName,
-          PAYLOAD_BYTES_TYPE_NAME))) {
+      if (SchemaReflection.of(row.getSchema())
+          .matchesAll(FieldMatcher.of(payloadKeyName, PAYLOAD_BYTES_TYPE_NAME))) {
         return row.getBytes(payloadKeyName);
       }
       return Objects.requireNonNull(payloadSerializer).serialize(serializableRow(row));
@@ -279,7 +361,8 @@ abstract class PubsubRowToMessage extends PTransform<PCollection<Row>, PCollecti
       if (schemaReflection.matchesAll(FieldMatcher.of(payloadKeyName, PAYLOAD_ROW_TYPE_NAME))) {
         return row.getRow(payloadKeyName);
       }
-      Schema withUserFieldsOnly = removeFields(row.getSchema(), attributesKeyName, eventTimestampKeyName);
+      Schema withUserFieldsOnly =
+          removeFields(row.getSchema(), attributesKeyName, eventTimestampKeyName);
       Map<String, Object> values = new HashMap<>();
       for (String name : withUserFieldsOnly.getFieldNames()) {
         values.put(name, row.getValue(name));

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubRowToMessage.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubRowToMessage.java
@@ -449,7 +449,7 @@ abstract class PubsubRowToMessage extends PTransform<PCollection<Row>, PCollecti
 
     /**
      * Extracts a {@code byte[]} payload from a {@link Row}, from either of the following mutually
-     * exclusive sources: <br>
+     * exclusive sources. <br>
      * - {@link #payloadKeyName} {@link Field} with {@link FieldType#BYTES} <br>
      * - serialized {@link #payloadKeyName} {@link Field} with {@link TypeName#ROW} using the {@link
      * #payloadSerializer} <br>
@@ -466,7 +466,7 @@ abstract class PubsubRowToMessage extends PTransform<PCollection<Row>, PCollecti
 
     /**
      * Extracts the serializable part of a {@link Row} from the following mutually exclusive
-     * sources: <br>
+     * sources. <br>
      * - serialized {@link #payloadKeyName} {@link Field} with {@link TypeName#ROW} using the {@link
      * #payloadSerializer} <br>
      * - serialized user fields provided that are not {@link #attributesKeyName} and {@link

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubRowToMessage.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubRowToMessage.java
@@ -60,16 +60,15 @@ abstract class PubsubRowToMessage extends PTransform<PCollection<Row>, PCollecti
     return new AutoValue_PubsubRowToMessage.Builder();
   }
 
-  static TupleTag<PubsubMessage> OUTPUT = new TupleTag<PubsubMessage>() {};
-  static TupleTag<Row> ERROR = new TupleTag<Row>() {};
+  static final TupleTag<PubsubMessage> OUTPUT = new TupleTag<PubsubMessage>() {};
+  static final TupleTag<Row> ERROR = new TupleTag<Row>() {};
   static final String ERROR_DATA_FIELD_NAME = "data";
   static final Field ERROR_MESSAGE_FIELD = Field.of("error_message", FieldType.STRING);
   static final Field ERROR_STACK_TRACE_FIELD = Field.of("error_stack_trace", FieldType.STRING);
 
   static final String DEFAULT_KEY_PREFIX = "$";
   static final String ATTRIBUTES_KEY_NAME = "pubsub_attributes";
-  static final FieldType ATTRIBUTES_FIELD_TYPE =
-      FieldType.map(FieldType.STRING, FieldType.STRING);
+  static final FieldType ATTRIBUTES_FIELD_TYPE = FieldType.map(FieldType.STRING, FieldType.STRING);
 
   static final String EVENT_TIMESTAMP_KEY_NAME = "pubsub_event_timestamp";
   static final FieldType EVENT_TIMESTAMP_FIELD_TYPE = FieldType.DATETIME;
@@ -172,8 +171,7 @@ abstract class PubsubRowToMessage extends PTransform<PCollection<Row>, PCollecti
           getPayloadSerializer() == null,
           String.format(
               "schema field: %s of type: %s with a %s is incompatible",
-              payloadKeyName, PAYLOAD_BYTES_TYPE_NAME, PayloadSerializer.class.getName())
-      );
+              payloadKeyName, PAYLOAD_BYTES_TYPE_NAME, PayloadSerializer.class.getName()));
     }
 
     if (hasPayloadRowField) {
@@ -395,6 +393,14 @@ abstract class PubsubRowToMessage extends PTransform<PCollection<Row>, PCollecti
 
     Row serializableRow(Row row) {
       SchemaReflection schemaReflection = SchemaReflection.of(row.getSchema());
+
+      if (schemaReflection.matchesAll(FieldMatcher.of(payloadKeyName, PAYLOAD_BYTES_TYPE_NAME))) {
+        throw new IllegalArgumentException(
+            String.format(
+                "serializable Row does not exist for payload of type: %s",
+                PAYLOAD_BYTES_TYPE_NAME));
+      }
+
       if (schemaReflection.matchesAll(FieldMatcher.of(payloadKeyName, PAYLOAD_ROW_TYPE_NAME))) {
         return row.getRow(payloadKeyName);
       }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubRowToMessage.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubRowToMessage.java
@@ -118,7 +118,7 @@ abstract class PubsubRowToMessage extends PTransform<PCollection<Row>, PCollecti
    * As a convenience method, generates {@link InputSchemaFactory} for expected {@link Schema} for
    * {@link Row} input into {@link PubsubRowToMessage}. The {@link Field} for {@link
    * #getPayloadKeyName()} is excluded for null {@param payloadFieldType}. See {@link
-   * InputSchemaFactory#buildSchema(Field...)} for details on how to * add additional fields.
+   * InputSchemaFactory#buildSchema(Field...)} for details on how to add additional fields.
    */
   InputSchemaFactory inputSchemaFactory(@Nullable FieldType payloadFieldType) {
     InputSchemaFactory.Builder builder =

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubRowToMessageTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubRowToMessageTest.java
@@ -549,14 +549,14 @@ public class PubsubRowToMessageTest {
             .serializableRow(nonUserWithRowPayload));
 
     Row withAttributesAndTimestamp =
-            Row.withSchema(NON_USER_WITHOUT_PAYLOAD).addValues(attributes, Instant.now()).build();
+        Row.withSchema(NON_USER_WITHOUT_PAYLOAD).addValues(attributes, Instant.now()).build();
 
     Row withUserFieldsAttributesAndTimestamp = merge(withAttributesAndTimestamp, withAllDataTypes);
 
     assertEquals(
-            withAllDataTypes,
-            doFn(withUserFieldsAttributesAndTimestamp.getSchema(), jsonPayloadSerializer)
-                    .serializableRow(withUserFieldsAttributesAndTimestamp));
+        withAllDataTypes,
+        doFn(withUserFieldsAttributesAndTimestamp.getSchema(), jsonPayloadSerializer)
+            .serializableRow(withUserFieldsAttributesAndTimestamp));
   }
 
   private static PubsubRowToMessageDoFn doFn(Schema schema, PayloadSerializer payloadSerializer) {
@@ -570,18 +570,18 @@ public class PubsubRowToMessageTest {
   }
 
   private static Row rowWithAllDataTypes(
-      boolean _boolean,
-      byte _byte,
+      boolean boolean0,
+      byte byte0,
       ReadableDateTime datetime,
       BigDecimal decimal,
-      Double _double,
-      Float _float,
+      Double double0,
+      Float float0,
       Short int16,
       Integer int32,
       Long int64,
       String string) {
     return Row.withSchema(ALL_DATA_TYPES_SCHEMA)
-        .addValues(_boolean, _byte, datetime, decimal, _double, _float, int16, int32, int64, string)
+        .addValues(boolean0, byte0, datetime, decimal, double0, float0, int16, int32, int64, string)
         .build();
   }
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubRowToMessageTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubRowToMessageTest.java
@@ -22,11 +22,7 @@ import static org.junit.Assert.*;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
-import java.util.ArrayList;
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-
+import java.util.*;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptions.CheckEnabled;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
@@ -42,6 +38,7 @@ import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 import org.joda.time.Instant;
 import org.joda.time.ReadableDateTime;
 import org.junit.Rule;
@@ -49,812 +46,901 @@ import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
-/**
- * Tests for {@link PubsubRowToMessage}.
- */
+/** Tests for {@link PubsubRowToMessage}. */
 @RunWith(JUnit4.class)
 public class PubsubRowToMessageTest {
 
-    private static final PipelineOptions PIPELINE_OPTIONS = PipelineOptionsFactory.create();
-    private static final String DEFAULT_ATTRIBUTES_KEY_NAME =
-            DEFAULT_KEY_PREFIX + ATTRIBUTES_KEY_NAME;
-    private static final String DEFAULT_EVENT_TIMESTAMP_KEY_NAME =
-            DEFAULT_KEY_PREFIX + EVENT_TIMESTAMP_KEY_NAME;
-    private static final String DEFAULT_PAYLOAD_KEY_NAME = DEFAULT_KEY_PREFIX + PAYLOAD_KEY_NAME;
-    private static final Field BOOLEAN_FIELD = Field.of("boolean", FieldType.BOOLEAN);
-    private static final Field BYTE_FIELD = Field.of("byte", FieldType.BYTE);
-    private static final Field DATETIME_FIELD = Field.of("datetime", FieldType.DATETIME);
-    private static final Field DECIMAL_FIELD = Field.of("decimal", FieldType.DECIMAL);
-    private static final Field DOUBLE_FIELD = Field.of("double", FieldType.DOUBLE);
-    private static final Field FLOAT_FIELD = Field.of("float", FieldType.FLOAT);
-    private static final Field INT16_FIELD = Field.of("int16", FieldType.INT16);
-    private static final Field INT32_FIELD = Field.of("int32", FieldType.INT32);
-    private static final Field INT64_FIELD = Field.of("int64", FieldType.INT64);
-    private static final Field STRING_FIELD = Field.of("string", FieldType.STRING);
-    private static final Schema ALL_DATA_TYPES_SCHEMA =
-            Schema.of(
-                    BOOLEAN_FIELD,
-                    BYTE_FIELD,
-                    DATETIME_FIELD,
-                    DECIMAL_FIELD,
-                    DOUBLE_FIELD,
-                    FLOAT_FIELD,
-                    INT16_FIELD,
-                    INT32_FIELD,
-                    INT64_FIELD,
-                    STRING_FIELD);
+  private static final PipelineOptions PIPELINE_OPTIONS = PipelineOptionsFactory.create();
+  private static final String DEFAULT_ATTRIBUTES_KEY_NAME =
+      DEFAULT_KEY_PREFIX + ATTRIBUTES_KEY_NAME;
+  private static final String DEFAULT_EVENT_TIMESTAMP_KEY_NAME =
+      DEFAULT_KEY_PREFIX + EVENT_TIMESTAMP_KEY_NAME;
+  private static final String DEFAULT_PAYLOAD_KEY_NAME = DEFAULT_KEY_PREFIX + PAYLOAD_KEY_NAME;
+  private static final Field BOOLEAN_FIELD = Field.of("boolean", FieldType.BOOLEAN);
+  private static final Field BYTE_FIELD = Field.of("byte", FieldType.BYTE);
+  private static final Field DATETIME_FIELD = Field.of("datetime", FieldType.DATETIME);
+  private static final Field DECIMAL_FIELD = Field.of("decimal", FieldType.DECIMAL);
+  private static final Field DOUBLE_FIELD = Field.of("double", FieldType.DOUBLE);
+  private static final Field FLOAT_FIELD = Field.of("float", FieldType.FLOAT);
+  private static final Field INT16_FIELD = Field.of("int16", FieldType.INT16);
+  private static final Field INT32_FIELD = Field.of("int32", FieldType.INT32);
+  private static final Field INT64_FIELD = Field.of("int64", FieldType.INT64);
+  private static final Field STRING_FIELD = Field.of("string", FieldType.STRING);
+  private static final Schema ALL_DATA_TYPES_SCHEMA =
+      Schema.of(
+          BOOLEAN_FIELD,
+          BYTE_FIELD,
+          DATETIME_FIELD,
+          DECIMAL_FIELD,
+          DOUBLE_FIELD,
+          FLOAT_FIELD,
+          INT16_FIELD,
+          INT32_FIELD,
+          INT64_FIELD,
+          STRING_FIELD);
 
-    private static final Schema NON_USER_WITH_BYTES_PAYLOAD =
-            Schema.of(
-                    Field.of(DEFAULT_ATTRIBUTES_KEY_NAME, ATTRIBUTES_FIELD_TYPE),
-                    Field.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, EVENT_TIMESTAMP_FIELD_TYPE),
-                    Field.of(DEFAULT_PAYLOAD_KEY_NAME, FieldType.BYTES));
+  private static final Schema NON_USER_WITH_BYTES_PAYLOAD =
+      Schema.of(
+          Field.of(DEFAULT_ATTRIBUTES_KEY_NAME, ATTRIBUTES_FIELD_TYPE),
+          Field.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, EVENT_TIMESTAMP_FIELD_TYPE),
+          Field.of(DEFAULT_PAYLOAD_KEY_NAME, FieldType.BYTES));
 
-    private static final Schema NON_USER_WITH_ROW_PAYLOAD =
-            Schema.of(
-                    Field.of(DEFAULT_ATTRIBUTES_KEY_NAME, ATTRIBUTES_FIELD_TYPE),
-                    Field.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, EVENT_TIMESTAMP_FIELD_TYPE),
-                    Field.of(DEFAULT_PAYLOAD_KEY_NAME, FieldType.row(ALL_DATA_TYPES_SCHEMA)));
+  private static final Schema NON_USER_WITH_ROW_PAYLOAD =
+      Schema.of(
+          Field.of(DEFAULT_ATTRIBUTES_KEY_NAME, ATTRIBUTES_FIELD_TYPE),
+          Field.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, EVENT_TIMESTAMP_FIELD_TYPE),
+          Field.of(DEFAULT_PAYLOAD_KEY_NAME, FieldType.row(ALL_DATA_TYPES_SCHEMA)));
 
-    private static final Schema NON_USER_WITHOUT_PAYLOAD =
-            Schema.of(
-                    Field.of(DEFAULT_ATTRIBUTES_KEY_NAME, ATTRIBUTES_FIELD_TYPE),
-                    Field.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, EVENT_TIMESTAMP_FIELD_TYPE));
+  private static final Schema NON_USER_WITHOUT_PAYLOAD =
+      Schema.of(
+          Field.of(DEFAULT_ATTRIBUTES_KEY_NAME, ATTRIBUTES_FIELD_TYPE),
+          Field.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, EVENT_TIMESTAMP_FIELD_TYPE));
 
-    static {
-        PIPELINE_OPTIONS.setStableUniqueNames(CheckEnabled.OFF);
-    }
+  static {
+    PIPELINE_OPTIONS.setStableUniqueNames(CheckEnabled.OFF);
+  }
 
-    @Rule
-    public TestPipeline pipeline = TestPipeline.create();
+  @Rule public TestPipeline pipeline = TestPipeline.create();
 
-    @Test
-    public void testExpand() {
-        PayloadSerializer jsonPayloadSerializer =
-                new JsonPayloadSerializerProvider().getSerializer(ALL_DATA_TYPES_SCHEMA, new HashMap<>());
+  @Rule
+  public TestPipeline errorsTestPipeline =
+      TestPipeline.create().enableAbandonedNodeEnforcement(false);
 
-        Instant embeddedTimestamp = Instant.now();
-        Instant mockTimestamp = Instant.ofEpochMilli(embeddedTimestamp.getMillis() + 1000000L);
+  @Test(expected = IllegalArgumentException.class)
+  public void testExpandThrowsExceptions() {
+    PayloadSerializer jsonPayloadSerializer =
+        new JsonPayloadSerializerProvider().getSerializer(ALL_DATA_TYPES_SCHEMA, new HashMap<>());
 
-        Map<String, String> attributesWithMockTimestampOnly = new HashMap<>();
-        attributesWithMockTimestampOnly.put(
-                DEFAULT_EVENT_TIMESTAMP_KEY_NAME, mockTimestamp.toDateTime().toString());
+    Instant embeddedTimestamp = Instant.now();
+    Instant mockTimestamp = Instant.ofEpochMilli(embeddedTimestamp.getMillis() + 1000000L);
 
-        Map<String, String> attributesWithoutAnyTimestamp = new HashMap<>();
-        attributesWithoutAnyTimestamp.put("aaa", "111");
-        attributesWithoutAnyTimestamp.put("bbb", "222");
-        attributesWithoutAnyTimestamp.put("ccc", "333");
+    Field attributesField = Field.of(DEFAULT_ATTRIBUTES_KEY_NAME, ATTRIBUTES_FIELD_TYPE);
+    Schema withAttributesSchema = Schema.of(attributesField);
+    Row withAttributes =
+        Row.withSchema(withAttributesSchema).attachValues(ImmutableMap.of("aaa", "111"));
 
-        Map<String, String> attributesWithMockTimestamp = new HashMap<>(attributesWithoutAnyTimestamp);
-        attributesWithMockTimestamp.putAll(attributesWithMockTimestampOnly);
+    Field timestampField = Field.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, EVENT_TIMESTAMP_FIELD_TYPE);
+    Schema withTimestampSchema = Schema.of(timestampField);
+    Row withEmbeddedTimestamp = Row.withSchema(withTimestampSchema).attachValues(embeddedTimestamp);
 
-        Map<String, String> attributesWithEmbeddedTimestampOnly = new HashMap<>();
-        attributesWithEmbeddedTimestampOnly.put(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, embeddedTimestamp.toDateTime().toString());
+    Field payloadBytesField = Field.of(DEFAULT_PAYLOAD_KEY_NAME, FieldType.BYTES);
+    Schema withPayloadBytesSchema = Schema.of(payloadBytesField);
+    Row withPayloadBytes =
+        Row.withSchema(withPayloadBytesSchema).attachValues(new byte[] {1, 2, 3, 4});
 
-        //    Map<String, String> attributesWithTimestamp = new HashMap<>(attributes);
-        //    attributesWithTimestamp.putAll(timestampOnlyAttributes);
+    Row withAllDataTypes =
+        rowWithAllDataTypes(
+            true,
+            (byte) 0,
+            Instant.now().toDateTime(),
+            BigDecimal.valueOf(1L),
+            3.12345,
+            4.1f,
+            (short) 5,
+            2,
+            7L,
+            "asdfjkl;");
 
-        //    byte[] bytes =
-        //        "All the 🌎's a 🎦, and all the 🚹 and 🚺 merely players. They 🈷️their 🚪and their
-        // 🎟️and 1️⃣🚹in his time ▶️many🤺🪂🏆"
-        //            .getBytes(StandardCharsets.UTF_8);
-        //
-        Field attributesField = Field.of(DEFAULT_ATTRIBUTES_KEY_NAME, ATTRIBUTES_FIELD_TYPE);
-        Field timestampField = Field.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME,
-                EVENT_TIMESTAMP_FIELD_TYPE);
-        //    Field payloadBytesField = Field.of(DEFAULT_PAYLOAD_KEY_NAME, FieldType.BYTES);
-        //    Field payloadRowField =
-        //        Field.of(DEFAULT_PAYLOAD_KEY_NAME, FieldType.row(ALL_DATA_TYPES_SCHEMA));
+    Field payloadRowField =
+        Field.of(DEFAULT_PAYLOAD_KEY_NAME, FieldType.row(ALL_DATA_TYPES_SCHEMA));
+    Schema withPayloadRowSchema = Schema.of(payloadRowField);
+    Row withPayloadRow = Row.withSchema(withPayloadRowSchema).attachValues(withAllDataTypes);
 
-        Row withAllDataTypes =
-                rowWithAllDataTypes(
-                        true,
-                        (byte) 0,
-                        Instant.now().toDateTime(),
-                        BigDecimal.valueOf(1L),
-                        3.12345,
-                        4.1f,
-                        (short) 5,
-                        2,
-                        7L,
-                        "asdfjkl;");
+    PubsubRowToMessage transformWithoutSerializer =
+        PubsubRowToMessage.builder().setMockInstant(mockTimestamp).build();
 
-        byte[] serializedWithAllDataTypes = jsonPayloadSerializer.serialize(withAllDataTypes);
+    PubsubRowToMessage transformWithSerializer =
+        PubsubRowToMessage.builder().setPayloadSerializer(jsonPayloadSerializer).build();
 
-        Schema withAttributesSchema = Schema.of(attributesField);
-        Row withAttributes =
-                Row.withSchema(withAttributesSchema).attachValues(attributesWithoutAnyTimestamp);
+    // requires either payload or user fields
+    errorsTestPipeline
+        .apply(Create.of(withAttributes))
+        .setRowSchema(withAttributesSchema)
+        .apply(transformWithoutSerializer);
 
-        Schema withTimestampSchema = Schema.of(timestampField);
-        Row withEmbeddedTimestamp = Row.withSchema(withTimestampSchema).attachValues(embeddedTimestamp);
+    // requires either payload or user fields
+    errorsTestPipeline
+        .apply(Create.of(withEmbeddedTimestamp))
+        .setRowSchema(withTimestampSchema)
+        .apply(transformWithoutSerializer);
 
-        //    Schema withPayloadBytesSchema = Schema.of(payloadBytesField);
-        //    Row withPayloadBytes = Row.withSchema(withPayloadBytesSchema).attachValues(bytes);
+    // payload bytes incompatible with non-null payload serializer
+    errorsTestPipeline
+        .apply(Create.of(withPayloadBytes))
+        .setRowSchema(withPayloadBytesSchema)
+        .apply(transformWithSerializer);
 
-        //    Schema withPayloadRowSchema = Schema.of(payloadRowField);
-        //    Row withPayloadRow = Row.withSchema(withPayloadRowSchema).attachValues(withAllDataTypes);
+    // payload row requires payload serializer
+    errorsTestPipeline
+        .apply(Create.of(withPayloadRow))
+        .setRowSchema(withPayloadRowSchema)
+        .apply(transformWithoutSerializer);
 
-        //    PubsubRowToMessage transformWithoutSerializer = PubsubRowToMessage.builder().build();
-        PubsubRowToMessage transformWithSerializer =
-                PubsubRowToMessage.builder()
-                        .setMockInstant(mockTimestamp)
-                        .setPayloadSerializer(jsonPayloadSerializer)
-                        .build();
+    // user fields row requires payload serializer
+    errorsTestPipeline
+        .apply(Create.of(withAllDataTypes))
+        .setRowSchema(ALL_DATA_TYPES_SCHEMA)
+        .apply(transformWithoutSerializer);
 
-        PCollection<Row> a0t0p0u1 =
-                pipeline.apply(Create.of(withAllDataTypes)).setRowSchema(ALL_DATA_TYPES_SCHEMA);
-        PubsubMessage a0t0p0u1Message =
-                new PubsubMessage(serializedWithAllDataTypes, attributesWithMockTimestampOnly);
-        PAssert.that(
-                        "expected: payload: user serialized row, attributes: ParDo mocked generated timestamp only",
-                        a0t0p0u1.apply(transformWithSerializer).get(OUTPUT))
-                .containsInAnyOrder(a0t0p0u1Message);
+    // input with both payload row and user fields incompatible
+    errorsTestPipeline
+        .apply(Create.of(merge(withPayloadRow, withAllDataTypes)))
+        .setRowSchema(merge(withPayloadRowSchema, ALL_DATA_TYPES_SCHEMA))
+        .apply(transformWithSerializer);
+  }
 
-        PCollection<Row> a1t0p0u1 =
-                pipeline
-                        .apply(Create.of(merge(withAttributes, withAllDataTypes)))
-                        .setRowSchema(merge(withAttributesSchema, ALL_DATA_TYPES_SCHEMA));
-        PubsubMessage a1t0p0u1Message =
-                new PubsubMessage(serializedWithAllDataTypes, attributesWithMockTimestamp);
-        PAssert.that("expected: payload: user serialized row, attributes: input attributes and ParDo generated timestamp",
-                        a1t0p0u1.apply(transformWithSerializer).get(OUTPUT))
-                .containsInAnyOrder(a1t0p0u1Message);
+  @Test
+  public void testExpand() {
+    PayloadSerializer jsonPayloadSerializer =
+        new JsonPayloadSerializerProvider().getSerializer(ALL_DATA_TYPES_SCHEMA, new HashMap<>());
 
-        PCollection<Row> a0t1p0u1 = pipeline.apply(Create.of(merge(withEmbeddedTimestamp,
-                        withAllDataTypes)))
-                .setRowSchema(merge(withTimestampSchema, ALL_DATA_TYPES_SCHEMA));
-        PubsubMessage a0t1p0u1Message =
-                new PubsubMessage(serializedWithAllDataTypes, attributesWithEmbeddedTimestampOnly);
-        PAssert.that("expected: payload: user serialized row, attributes: only embedded timestamp",
-                        a0t1p0u1.apply(transformWithSerializer).get(OUTPUT))
-                .containsInAnyOrder(a0t1p0u1Message);
+    Instant embeddedTimestamp = Instant.now();
+    Instant mockTimestamp = Instant.ofEpochMilli(embeddedTimestamp.getMillis() + 1000000L);
+    String embeddedTimestampString = embeddedTimestamp.toString();
+    String mockTimestampString = mockTimestamp.toString();
 
-        //    PCollection<Row> a0t0p1bu0 = pipeline.apply(Create.of(withPayloadBytes))
-        //            .setRowSchema(withPayloadBytesSchema);
-        //    PubsubMessage a0t0p1bu0Message = new PubsubMessage(bytes, emptyAttributes);
-        //    PAssert.that(a0t0p1bu0.apply(transformWithoutSerializer).get(OUTPUT))
-        //        .containsInAnyOrder(a0t0p1bu0Message);
-        //
-        //    PCollection<Row> a0t0p1ru0 = pipeline.apply(Create.of(withPayloadRow))
-        //            .setRowSchema(withPayloadRowSchema);
-        //    PubsubMessage a0t0p1ru0Message = new PubsubMessage(serializedWithAllDataTypes,
-        // emptyAttributes);
-        //    PAssert.that(a0t0p1ru0.apply(transformWithSerializer).get(OUTPUT))
-        //        .containsInAnyOrder(a0t0p1ru0Message);
-        //
-        //    PCollection<Row> a1t0p1bu0 = pipeline.apply(Create.of(merge(withAttributes,
-        // withPayloadBytes)))
-        //            .setRowSchema(merge(withAttributesSchema, withPayloadBytesSchema));
-        //    PubsubMessage a1t0p1bu0Message = new PubsubMessage(bytes, attributes);
-        //    PAssert.that(a1t0p1bu0.apply(transformWithoutSerializer).get(OUTPUT))
-        //        .containsInAnyOrder(a1t0p1bu0Message);
-        //
-        //    PCollection<Row> a0t1p1bu0 = pipeline.apply(Create.of(merge(withTimestamp,
-        // withPayloadBytes)))
-        //            .setRowSchema(merge(withTimestampSchema, withPayloadBytesSchema));
-        //    PubsubMessage a0t1p1bu0Message = new PubsubMessage(bytes, timestampOnlyAttributes);
-        //    PAssert.that(a0t1p1bu0.apply(transformWithoutSerializer).get(OUTPUT))
-        //        .containsInAnyOrder(a0t1p1bu0Message);
-        //
-        //    PCollection<Row> a1t1p1bu0 =
-        //        pipeline.apply(Create.of(merge(withAttributes, withTimestamp, withPayloadBytes)))
-        //                .setRowSchema(merge(withAttributesSchema, withTimestampSchema,
-        // withPayloadBytesSchema));
-        //    PubsubMessage a1t1p1bu0Message = new PubsubMessage(bytes, attributesWithTimestamp);
-        //    PAssert.that(a1t1p1bu0.apply(transformWithoutSerializer).get(OUTPUT))
-        //        .containsInAnyOrder(a1t1p1bu0Message);
-        //
-        //    PCollection<Row> a1t1p1ru0 =
-        //        pipeline.apply(Create.of(merge(withAttributes, withTimestamp, withPayloadRow)))
-        //                .setRowSchema(merge(withAttributesSchema, withTimestampSchema,
-        // withPayloadRowSchema));
-        //    PubsubMessage a1t1p1ru0Message =
-        //        new PubsubMessage(serializedWithAllDataTypes, attributesWithTimestamp);
-        //    PAssert.that(a1t1p1ru0.apply(transformWithSerializer).get(OUTPUT))
-        //        .containsInAnyOrder(a1t1p1ru0Message);
-        //
-        //    PCollection<Row> a1t1p0u1 =
-        //        pipeline.apply(Create.of(merge(withAttributes, withTimestamp, withAllDataTypes)))
-        //                .setRowSchema(merge(withAttributesSchema, withTimestampSchema,
-        // ALL_DATA_TYPES_SCHEMA));
-        //    PubsubMessage a1t1p0u1Message =
-        //        new PubsubMessage(serializedWithAllDataTypes, attributesWithTimestamp);
-        //    PAssert.that(a1t1p0u1.apply(transformWithSerializer).get(OUTPUT))
-        //        .containsInAnyOrder(a1t1p0u1Message);
+    byte[] bytes =
+        "All the 🌎's a 🎦, and all the 🚹 and 🚺 merely players. They 🈷️their 🚪and their 🎟️and 1️⃣🚹in his time ▶️many🤺🪂🏆"
+            .getBytes(StandardCharsets.UTF_8);
 
-        pipeline.run(PIPELINE_OPTIONS);
-    }
+    Field attributesField = Field.of(DEFAULT_ATTRIBUTES_KEY_NAME, ATTRIBUTES_FIELD_TYPE);
+    Field timestampField = Field.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, EVENT_TIMESTAMP_FIELD_TYPE);
+    Field payloadBytesField = Field.of(DEFAULT_PAYLOAD_KEY_NAME, FieldType.BYTES);
+    Field payloadRowField =
+        Field.of(DEFAULT_PAYLOAD_KEY_NAME, FieldType.row(ALL_DATA_TYPES_SCHEMA));
 
-    @Test
-    public void testKeyPrefix() {
-        PubsubRowToMessage withDefaultKeyPrefix = PubsubRowToMessage.builder().build();
-        assertEquals(DEFAULT_ATTRIBUTES_KEY_NAME, withDefaultKeyPrefix.getAttributesKeyName());
-        assertEquals(
-                DEFAULT_EVENT_TIMESTAMP_KEY_NAME, withDefaultKeyPrefix.getSourceEventTimestampKeyName());
-        assertEquals(DEFAULT_PAYLOAD_KEY_NAME, withDefaultKeyPrefix.getPayloadKeyName());
+    Row withAllDataTypes =
+        rowWithAllDataTypes(
+            true,
+            (byte) 0,
+            Instant.now().toDateTime(),
+            BigDecimal.valueOf(1L),
+            3.12345,
+            4.1f,
+            (short) 5,
+            2,
+            7L,
+            "asdfjkl;");
 
-        PubsubRowToMessage withKeyPrefixOverride =
-                PubsubRowToMessage.builder().setKeyPrefix("_").build();
-        assertEquals("_" + ATTRIBUTES_KEY_NAME, withKeyPrefixOverride.getAttributesKeyName());
-        assertEquals(
-                "_" + EVENT_TIMESTAMP_KEY_NAME, withKeyPrefixOverride.getSourceEventTimestampKeyName());
-        assertEquals("_" + PAYLOAD_KEY_NAME, withKeyPrefixOverride.getPayloadKeyName());
-    }
+    byte[] serializedWithAllDataTypes = jsonPayloadSerializer.serialize(withAllDataTypes);
 
-    @Test
-    public void testValidate() {
-        PubsubRowToMessage pubsubRowToMessage = PubsubRowToMessage.builder().build();
-        PayloadSerializer jsonPayloadSerializer =
-                new JsonPayloadSerializerProvider().getSerializer(ALL_DATA_TYPES_SCHEMA, new HashMap<>());
+    Schema withAttributesSchema = Schema.of(attributesField);
+    Row withAttributes =
+        Row.withSchema(withAttributesSchema).attachValues(ImmutableMap.of("aaa", "111"));
 
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> pubsubRowToMessage.validate(Schema.builder().build()));
+    Schema withTimestampSchema = Schema.of(timestampField);
+    Row withEmbeddedTimestamp = Row.withSchema(withTimestampSchema).attachValues(embeddedTimestamp);
 
-        assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                        pubsubRowToMessage.validate(
-                                Schema.of(Field.of(DEFAULT_ATTRIBUTES_KEY_NAME, FieldType.STRING))));
+    Schema withPayloadBytesSchema = Schema.of(payloadBytesField);
+    Row withPayloadBytes = Row.withSchema(withPayloadBytesSchema).attachValues(bytes);
 
-        assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                        pubsubRowToMessage.validate(
-                                Schema.of(
-                                        Field.of(
-                                                DEFAULT_ATTRIBUTES_KEY_NAME,
-                                                FieldType.map(FieldType.STRING, FieldType.BYTES)))));
+    Schema withPayloadRowSchema = Schema.of(payloadRowField);
+    Row withPayloadRow = Row.withSchema(withPayloadRowSchema).attachValues(withAllDataTypes);
 
-        assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                        pubsubRowToMessage.validate(
-                                Schema.of(
-                                        Field.of(
-                                                DEFAULT_ATTRIBUTES_KEY_NAME,
-                                                FieldType.map(FieldType.BYTES, FieldType.STRING)))));
-        assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                        pubsubRowToMessage.validate(
-                                Schema.of(Field.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, FieldType.STRING))));
+    PubsubRowToMessage transformWithoutSerializer =
+        PubsubRowToMessage.builder().setMockInstant(mockTimestamp).build();
 
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> PubsubRowToMessage.builder().build().validate(ALL_DATA_TYPES_SCHEMA));
-
-        assertThrows(
-                IllegalArgumentException.class,
-                () -> PubsubRowToMessage.builder().build().validate(NON_USER_WITH_ROW_PAYLOAD));
-
-        assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                        PubsubRowToMessage.builder()
-                                .setPayloadSerializer(jsonPayloadSerializer)
-                                .build()
-                                .validate(NON_USER_WITH_BYTES_PAYLOAD));
-
-        assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                        PubsubRowToMessage.builder()
-                                .build()
-                                .validate(merge(ALL_DATA_TYPES_SCHEMA, NON_USER_WITH_BYTES_PAYLOAD)));
-
-        assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                        PubsubRowToMessage.builder()
-                                .build()
-                                .validate(merge(ALL_DATA_TYPES_SCHEMA, NON_USER_WITH_ROW_PAYLOAD)));
-    }
-
-    @Test
-    public void testValidateAttributesField() {
-        PubsubRowToMessage pubsubRowToMessage = PubsubRowToMessage.builder().build();
-        pubsubRowToMessage.validateAttributesField(ALL_DATA_TYPES_SCHEMA);
-        pubsubRowToMessage.validateAttributesField(
-                Schema.of(Field.of(DEFAULT_ATTRIBUTES_KEY_NAME, ATTRIBUTES_FIELD_TYPE)));
-
-        assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                        pubsubRowToMessage.validateAttributesField(
-                                Schema.of(Field.of(DEFAULT_ATTRIBUTES_KEY_NAME, FieldType.STRING))));
-
-        assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                        pubsubRowToMessage.validateAttributesField(
-                                Schema.of(
-                                        Field.of(
-                                                DEFAULT_ATTRIBUTES_KEY_NAME,
-                                                FieldType.map(FieldType.STRING, FieldType.BYTES)))));
-
-        assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                        pubsubRowToMessage.validateAttributesField(
-                                Schema.of(
-                                        Field.of(
-                                                DEFAULT_ATTRIBUTES_KEY_NAME,
-                                                FieldType.map(FieldType.BYTES, FieldType.STRING)))));
-
-        assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                        PubsubRowToMessage.builder().build().validateSerializableFields(ALL_DATA_TYPES_SCHEMA));
-    }
-
-    @Test
-    public void testValidateSourceEventTimeStampField() {
-        PubsubRowToMessage pubsubRowToMessage = PubsubRowToMessage.builder().build();
-        pubsubRowToMessage.validateSourceEventTimeStampField(ALL_DATA_TYPES_SCHEMA);
-        pubsubRowToMessage.validateSourceEventTimeStampField(
-                Schema.of(Field.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, EVENT_TIMESTAMP_FIELD_TYPE)));
-        assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                        pubsubRowToMessage.validateSourceEventTimeStampField(
-                                Schema.of(Field.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, FieldType.STRING))));
-    }
-
-    @Test
-    public void testShouldValidatePayloadSerializerNullState() {
-        PayloadSerializer jsonPayloadSerializer =
-                new JsonPayloadSerializerProvider().getSerializer(ALL_DATA_TYPES_SCHEMA, new HashMap<>());
-        PayloadSerializer avroPayloadSerializer =
-                new AvroPayloadSerializerProvider().getSerializer(ALL_DATA_TYPES_SCHEMA, new HashMap<>());
-
+    PubsubRowToMessage transformWithSerializer =
         PubsubRowToMessage.builder()
+            .setMockInstant(mockTimestamp)
+            .setPayloadSerializer(jsonPayloadSerializer)
+            .build();
+
+    PCollection<Row> a0t0p0u1 =
+        pipeline.apply(Create.of(withAllDataTypes)).setRowSchema(ALL_DATA_TYPES_SCHEMA);
+    PubsubMessage a0t0p0u1Message =
+        new PubsubMessage(
+            serializedWithAllDataTypes,
+            ImmutableMap.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, mockTimestampString));
+    PAssert.that(
+            "expected: payload: user serialized row, attributes: ParDo mocked generated timestamp only",
+            a0t0p0u1.apply(transformWithSerializer).get(OUTPUT))
+        .containsInAnyOrder(a0t0p0u1Message);
+
+    PCollection<Row> a1t0p0u1 =
+        pipeline
+            .apply(Create.of(merge(withAttributes, withAllDataTypes)))
+            .setRowSchema(merge(withAttributesSchema, ALL_DATA_TYPES_SCHEMA));
+    PubsubMessage a1t0p0u1Message =
+        new PubsubMessage(
+            serializedWithAllDataTypes,
+            ImmutableMap.of("aaa", "111", DEFAULT_EVENT_TIMESTAMP_KEY_NAME, mockTimestampString));
+    PAssert.that(
+            "expected: payload: user serialized row, attributes: input attributes and ParDo generated timestamp",
+            a1t0p0u1.apply(transformWithSerializer).get(OUTPUT))
+        .containsInAnyOrder(a1t0p0u1Message);
+
+    PCollection<Row> a0t1p0u1 =
+        pipeline
+            .apply(Create.of(merge(withEmbeddedTimestamp, withAllDataTypes)))
+            .setRowSchema(merge(withTimestampSchema, ALL_DATA_TYPES_SCHEMA));
+    PubsubMessage a0t1p0u1Message =
+        new PubsubMessage(
+            serializedWithAllDataTypes,
+            ImmutableMap.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, embeddedTimestampString));
+    PAssert.that(
+            "expected: payload: user serialized row, attributes: timestamp from row input",
+            a0t1p0u1.apply(transformWithSerializer).get(OUTPUT))
+        .containsInAnyOrder(a0t1p0u1Message);
+
+    PCollection<Row> a0t0p1bu0 =
+        pipeline.apply(Create.of(withPayloadBytes)).setRowSchema(withPayloadBytesSchema);
+    PubsubMessage a0t0p1bu0Message =
+        new PubsubMessage(
+            bytes, ImmutableMap.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, mockTimestampString));
+    PAssert.that(
+            "expected: payload: raw bytes, attributes: ParDo generated timestamp",
+            a0t0p1bu0.apply(transformWithoutSerializer).get(OUTPUT))
+        .containsInAnyOrder(a0t0p1bu0Message);
+
+    PCollection<Row> a0t0p1ru0 =
+        pipeline.apply(Create.of(withPayloadRow)).setRowSchema(withPayloadRowSchema);
+    PubsubMessage a0t0p1ru0Message =
+        new PubsubMessage(
+            serializedWithAllDataTypes,
+            ImmutableMap.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, mockTimestampString));
+    PAssert.that(
+            "expected: payload: non-user row, attributes: ParDo generated timestamp",
+            a0t0p1ru0.apply(transformWithSerializer).get(OUTPUT))
+        .containsInAnyOrder(a0t0p1ru0Message);
+
+    PCollection<Row> a1t0p1bu0 =
+        pipeline
+            .apply(Create.of(merge(withAttributes, withPayloadBytes)))
+            .setRowSchema(merge(withAttributesSchema, withPayloadBytesSchema));
+    PubsubMessage a1t0p1bu0Message =
+        new PubsubMessage(
+            bytes,
+            ImmutableMap.of("aaa", "111", DEFAULT_EVENT_TIMESTAMP_KEY_NAME, mockTimestampString));
+    PAssert.that(
+            "expected: raw bytes, attributes: embedded attributes and ParDo generated timestamp",
+            a1t0p1bu0.apply(transformWithoutSerializer).get(OUTPUT))
+        .containsInAnyOrder(a1t0p1bu0Message);
+
+    PCollection<Row> a0t1p1bu0 =
+        pipeline
+            .apply(Create.of(merge(withEmbeddedTimestamp, withPayloadBytes)))
+            .setRowSchema(merge(withTimestampSchema, withPayloadBytesSchema));
+    PubsubMessage a0t1p1bu0Message =
+        new PubsubMessage(
+            bytes, ImmutableMap.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, embeddedTimestampString));
+    PAssert.that(
+            "expected: payload: raw bytes, attributes: timestamp from row input",
+            a0t1p1bu0.apply(transformWithoutSerializer).get(OUTPUT))
+        .containsInAnyOrder(a0t1p1bu0Message);
+
+    PCollection<Row> a1t1p1bu0 =
+        pipeline
+            .apply(Create.of(merge(merge(withAttributes, withEmbeddedTimestamp), withPayloadBytes)))
+            .setRowSchema(
+                merge(merge(withAttributesSchema, withTimestampSchema), withPayloadBytesSchema));
+    PubsubMessage a1t1p1bu0Message =
+        new PubsubMessage(
+            bytes,
+            ImmutableMap.of(
+                "aaa", "111", DEFAULT_EVENT_TIMESTAMP_KEY_NAME, embeddedTimestampString));
+    PAssert.that(
+            "expected: payload: raw bytes, attributes: from row input including its embedded timestamp",
+            a1t1p1bu0.apply(transformWithoutSerializer).get(OUTPUT))
+        .containsInAnyOrder(a1t1p1bu0Message);
+
+    PCollection<Row> a1t1p1ru0 =
+        pipeline
+            .apply(Create.of(merge(merge(withAttributes, withEmbeddedTimestamp), withPayloadRow)))
+            .setRowSchema(
+                merge(merge(withAttributesSchema, withTimestampSchema), withPayloadRowSchema));
+    PubsubMessage a1t1p1ru0Message =
+        new PubsubMessage(
+            serializedWithAllDataTypes,
+            ImmutableMap.of(
+                "aaa", "111", DEFAULT_EVENT_TIMESTAMP_KEY_NAME, embeddedTimestampString));
+    PAssert.that(
+            "expected: payload: serialized row payload input, attributes: from row input including its embedded timestamp",
+            a1t1p1ru0.apply(transformWithSerializer).get(OUTPUT))
+        .containsInAnyOrder(a1t1p1ru0Message);
+
+    PCollection<Row> a1t1p0u1 =
+        pipeline
+            .apply(Create.of(merge(merge(withAttributes, withEmbeddedTimestamp), withAllDataTypes)))
+            .setRowSchema(
+                merge(merge(withAttributesSchema, withTimestampSchema), ALL_DATA_TYPES_SCHEMA));
+    PubsubMessage a1t1p0u1Message =
+        new PubsubMessage(
+            serializedWithAllDataTypes,
+            ImmutableMap.of(
+                "aaa", "111", DEFAULT_EVENT_TIMESTAMP_KEY_NAME, embeddedTimestampString));
+    PAssert.that(
+            "expected: payload: serialized user fields, attributes: from row input including embedded timestamp",
+            a1t1p0u1.apply(transformWithSerializer).get(OUTPUT))
+        .containsInAnyOrder(a1t1p0u1Message);
+
+    pipeline.run(PIPELINE_OPTIONS);
+  }
+
+  @Test
+  public void testKeyPrefix() {
+    PubsubRowToMessage withDefaultKeyPrefix = PubsubRowToMessage.builder().build();
+    assertEquals(DEFAULT_ATTRIBUTES_KEY_NAME, withDefaultKeyPrefix.getAttributesKeyName());
+    assertEquals(
+        DEFAULT_EVENT_TIMESTAMP_KEY_NAME, withDefaultKeyPrefix.getSourceEventTimestampKeyName());
+    assertEquals(DEFAULT_PAYLOAD_KEY_NAME, withDefaultKeyPrefix.getPayloadKeyName());
+
+    PubsubRowToMessage withKeyPrefixOverride =
+        PubsubRowToMessage.builder().setKeyPrefix("_").build();
+    assertEquals("_" + ATTRIBUTES_KEY_NAME, withKeyPrefixOverride.getAttributesKeyName());
+    assertEquals(
+        "_" + EVENT_TIMESTAMP_KEY_NAME, withKeyPrefixOverride.getSourceEventTimestampKeyName());
+    assertEquals("_" + PAYLOAD_KEY_NAME, withKeyPrefixOverride.getPayloadKeyName());
+  }
+
+  @Test
+  public void testValidate() {
+    PubsubRowToMessage pubsubRowToMessage = PubsubRowToMessage.builder().build();
+    PayloadSerializer jsonPayloadSerializer =
+        new JsonPayloadSerializerProvider().getSerializer(ALL_DATA_TYPES_SCHEMA, new HashMap<>());
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> pubsubRowToMessage.validate(Schema.builder().build()));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            pubsubRowToMessage.validate(
+                Schema.of(Field.of(DEFAULT_ATTRIBUTES_KEY_NAME, FieldType.STRING))));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            pubsubRowToMessage.validate(
+                Schema.of(
+                    Field.of(
+                        DEFAULT_ATTRIBUTES_KEY_NAME,
+                        FieldType.map(FieldType.STRING, FieldType.BYTES)))));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            pubsubRowToMessage.validate(
+                Schema.of(
+                    Field.of(
+                        DEFAULT_ATTRIBUTES_KEY_NAME,
+                        FieldType.map(FieldType.BYTES, FieldType.STRING)))));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            pubsubRowToMessage.validate(
+                Schema.of(Field.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, FieldType.STRING))));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PubsubRowToMessage.builder().build().validate(ALL_DATA_TYPES_SCHEMA));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> PubsubRowToMessage.builder().build().validate(NON_USER_WITH_ROW_PAYLOAD));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PubsubRowToMessage.builder()
                 .setPayloadSerializer(jsonPayloadSerializer)
                 .build()
-                .validateSerializableFields(ALL_DATA_TYPES_SCHEMA);
+                .validate(NON_USER_WITH_BYTES_PAYLOAD));
 
-        PubsubRowToMessage.builder()
-                .setPayloadSerializer(avroPayloadSerializer)
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PubsubRowToMessage.builder()
                 .build()
-                .validateSerializableFields(ALL_DATA_TYPES_SCHEMA);
+                .validate(merge(ALL_DATA_TYPES_SCHEMA, NON_USER_WITH_BYTES_PAYLOAD)));
 
-        PubsubRowToMessage.builder()
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PubsubRowToMessage.builder()
+                .build()
+                .validate(merge(ALL_DATA_TYPES_SCHEMA, NON_USER_WITH_ROW_PAYLOAD)));
+  }
+
+  @Test
+  public void testValidateAttributesField() {
+    PubsubRowToMessage pubsubRowToMessage = PubsubRowToMessage.builder().build();
+    pubsubRowToMessage.validateAttributesField(ALL_DATA_TYPES_SCHEMA);
+    pubsubRowToMessage.validateAttributesField(
+        Schema.of(Field.of(DEFAULT_ATTRIBUTES_KEY_NAME, ATTRIBUTES_FIELD_TYPE)));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            pubsubRowToMessage.validateAttributesField(
+                Schema.of(Field.of(DEFAULT_ATTRIBUTES_KEY_NAME, FieldType.STRING))));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            pubsubRowToMessage.validateAttributesField(
+                Schema.of(
+                    Field.of(
+                        DEFAULT_ATTRIBUTES_KEY_NAME,
+                        FieldType.map(FieldType.STRING, FieldType.BYTES)))));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            pubsubRowToMessage.validateAttributesField(
+                Schema.of(
+                    Field.of(
+                        DEFAULT_ATTRIBUTES_KEY_NAME,
+                        FieldType.map(FieldType.BYTES, FieldType.STRING)))));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PubsubRowToMessage.builder().build().validateSerializableFields(ALL_DATA_TYPES_SCHEMA));
+  }
+
+  @Test
+  public void testValidateSourceEventTimeStampField() {
+    PubsubRowToMessage pubsubRowToMessage = PubsubRowToMessage.builder().build();
+    pubsubRowToMessage.validateSourceEventTimeStampField(ALL_DATA_TYPES_SCHEMA);
+    pubsubRowToMessage.validateSourceEventTimeStampField(
+        Schema.of(Field.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, EVENT_TIMESTAMP_FIELD_TYPE)));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            pubsubRowToMessage.validateSourceEventTimeStampField(
+                Schema.of(Field.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, FieldType.STRING))));
+  }
+
+  @Test
+  public void testShouldValidatePayloadSerializerNullState() {
+    PayloadSerializer jsonPayloadSerializer =
+        new JsonPayloadSerializerProvider().getSerializer(ALL_DATA_TYPES_SCHEMA, new HashMap<>());
+    PayloadSerializer avroPayloadSerializer =
+        new AvroPayloadSerializerProvider().getSerializer(ALL_DATA_TYPES_SCHEMA, new HashMap<>());
+
+    PubsubRowToMessage.builder()
+        .setPayloadSerializer(jsonPayloadSerializer)
+        .build()
+        .validateSerializableFields(ALL_DATA_TYPES_SCHEMA);
+
+    PubsubRowToMessage.builder()
+        .setPayloadSerializer(avroPayloadSerializer)
+        .build()
+        .validateSerializableFields(ALL_DATA_TYPES_SCHEMA);
+
+    PubsubRowToMessage.builder()
+        .setPayloadSerializer(jsonPayloadSerializer)
+        .build()
+        .validateSerializableFields(NON_USER_WITH_ROW_PAYLOAD);
+
+    PubsubRowToMessage.builder()
+        .setPayloadSerializer(avroPayloadSerializer)
+        .build()
+        .validateSerializableFields(NON_USER_WITH_ROW_PAYLOAD);
+
+    PubsubRowToMessage.builder().build().validateSerializableFields(NON_USER_WITH_BYTES_PAYLOAD);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PubsubRowToMessage.builder().build().validateSerializableFields(ALL_DATA_TYPES_SCHEMA));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PubsubRowToMessage.builder()
+                .build()
+                .validateSerializableFields(NON_USER_WITH_ROW_PAYLOAD));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PubsubRowToMessage.builder()
                 .setPayloadSerializer(jsonPayloadSerializer)
                 .build()
-                .validateSerializableFields(NON_USER_WITH_ROW_PAYLOAD);
+                .validateSerializableFields(NON_USER_WITH_BYTES_PAYLOAD));
+  }
 
-        PubsubRowToMessage.builder()
-                .setPayloadSerializer(avroPayloadSerializer)
+  @Test
+  public void testShouldEitherHavePayloadOrUserFields() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PubsubRowToMessage.builder()
                 .build()
-                .validateSerializableFields(NON_USER_WITH_ROW_PAYLOAD);
+                .validateSerializableFields(
+                    Schema.of(
+                        Field.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, EVENT_TIMESTAMP_FIELD_TYPE))));
+  }
 
-        PubsubRowToMessage.builder().build().validateSerializableFields(NON_USER_WITH_BYTES_PAYLOAD);
+  @Test
+  public void testShouldNotAllowPayloadFieldWithUserFields() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PubsubRowToMessage.builder()
+                .build()
+                .validateSerializableFields(
+                    merge(ALL_DATA_TYPES_SCHEMA, NON_USER_WITH_BYTES_PAYLOAD)));
 
-        assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                        PubsubRowToMessage.builder().build().validateSerializableFields(ALL_DATA_TYPES_SCHEMA));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PubsubRowToMessage.builder()
+                .build()
+                .validateSerializableFields(
+                    merge(ALL_DATA_TYPES_SCHEMA, NON_USER_WITH_ROW_PAYLOAD)));
+  }
 
-        assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                        PubsubRowToMessage.builder()
-                                .build()
-                                .validateSerializableFields(NON_USER_WITH_ROW_PAYLOAD));
+  @Test
+  public void testSchemaReflection_matchesAll() {
+    SchemaReflection schemaReflection = SchemaReflection.of(ALL_DATA_TYPES_SCHEMA);
 
-        assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                        PubsubRowToMessage.builder()
-                                .setPayloadSerializer(jsonPayloadSerializer)
-                                .build()
-                                .validateSerializableFields(NON_USER_WITH_BYTES_PAYLOAD));
-    }
+    assertTrue(
+        schemaReflection.matchesAll(
+            FieldMatcher.of(BOOLEAN_FIELD.getName()),
+            FieldMatcher.of(BYTE_FIELD.getName()),
+            FieldMatcher.of(DATETIME_FIELD.getName()),
+            FieldMatcher.of(DECIMAL_FIELD.getName()),
+            FieldMatcher.of(DOUBLE_FIELD.getName()),
+            FieldMatcher.of(FLOAT_FIELD.getName()),
+            FieldMatcher.of(INT16_FIELD.getName()),
+            FieldMatcher.of(INT32_FIELD.getName()),
+            FieldMatcher.of(INT64_FIELD.getName()),
+            FieldMatcher.of(STRING_FIELD.getName())));
 
-    @Test
-    public void testShouldEitherHavePayloadOrUserFields() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                        PubsubRowToMessage.builder()
-                                .build()
-                                .validateSerializableFields(
-                                        Schema.of(
-                                                Field.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, EVENT_TIMESTAMP_FIELD_TYPE))));
-    }
+    assertTrue(
+        schemaReflection.matchesAll(
+            FieldMatcher.of(BOOLEAN_FIELD.getName(), FieldType.BOOLEAN),
+            FieldMatcher.of(BYTE_FIELD.getName(), FieldType.BYTE),
+            FieldMatcher.of(DATETIME_FIELD.getName(), FieldType.DATETIME),
+            FieldMatcher.of(DECIMAL_FIELD.getName(), FieldType.DECIMAL),
+            FieldMatcher.of(DOUBLE_FIELD.getName(), FieldType.DOUBLE),
+            FieldMatcher.of(FLOAT_FIELD.getName(), FieldType.FLOAT),
+            FieldMatcher.of(INT16_FIELD.getName(), FieldType.INT16),
+            FieldMatcher.of(INT32_FIELD.getName(), FieldType.INT32),
+            FieldMatcher.of(INT64_FIELD.getName(), FieldType.INT64),
+            FieldMatcher.of(STRING_FIELD.getName(), FieldType.STRING)));
 
-    @Test
-    public void testShouldNotAllowPayloadFieldWithUserFields() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                        PubsubRowToMessage.builder()
-                                .build()
-                                .validateSerializableFields(
-                                        merge(ALL_DATA_TYPES_SCHEMA, NON_USER_WITH_BYTES_PAYLOAD)));
+    assertTrue(
+        schemaReflection.matchesAll(
+            FieldMatcher.of(BOOLEAN_FIELD.getName(), TypeName.BOOLEAN),
+            FieldMatcher.of(BYTE_FIELD.getName(), TypeName.BYTE),
+            FieldMatcher.of(DATETIME_FIELD.getName(), TypeName.DATETIME),
+            FieldMatcher.of(DECIMAL_FIELD.getName(), TypeName.DECIMAL),
+            FieldMatcher.of(DOUBLE_FIELD.getName(), TypeName.DOUBLE),
+            FieldMatcher.of(FLOAT_FIELD.getName(), TypeName.FLOAT),
+            FieldMatcher.of(INT16_FIELD.getName(), TypeName.INT16),
+            FieldMatcher.of(INT32_FIELD.getName(), TypeName.INT32),
+            FieldMatcher.of(INT64_FIELD.getName(), TypeName.INT64),
+            FieldMatcher.of(STRING_FIELD.getName(), TypeName.STRING)));
 
-        assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                        PubsubRowToMessage.builder()
-                                .build()
-                                .validateSerializableFields(
-                                        merge(ALL_DATA_TYPES_SCHEMA, NON_USER_WITH_ROW_PAYLOAD)));
-    }
+    assertFalse(
+        schemaReflection.matchesAll(
+            FieldMatcher.of("idontexist"),
+            FieldMatcher.of(BOOLEAN_FIELD.getName()),
+            FieldMatcher.of(BYTE_FIELD.getName()),
+            FieldMatcher.of(DATETIME_FIELD.getName()),
+            FieldMatcher.of(DECIMAL_FIELD.getName()),
+            FieldMatcher.of(DOUBLE_FIELD.getName()),
+            FieldMatcher.of(FLOAT_FIELD.getName()),
+            FieldMatcher.of(INT16_FIELD.getName()),
+            FieldMatcher.of(INT32_FIELD.getName()),
+            FieldMatcher.of(INT64_FIELD.getName()),
+            FieldMatcher.of(STRING_FIELD.getName())));
 
-    @Test
-    public void testSchemaReflection_matchesAll() {
-        SchemaReflection schemaReflection = SchemaReflection.of(ALL_DATA_TYPES_SCHEMA);
+    assertFalse(
+        schemaReflection.matchesAll(
+            FieldMatcher.of(BOOLEAN_FIELD.getName(), FieldType.BOOLEAN),
+            FieldMatcher.of(BYTE_FIELD.getName(), FieldType.BYTE),
+            FieldMatcher.of(DATETIME_FIELD.getName(), FieldType.DATETIME),
+            FieldMatcher.of(DECIMAL_FIELD.getName(), FieldType.DECIMAL),
+            FieldMatcher.of(DOUBLE_FIELD.getName(), FieldType.DOUBLE),
+            FieldMatcher.of(FLOAT_FIELD.getName(), FieldType.FLOAT),
+            FieldMatcher.of(INT16_FIELD.getName(), FieldType.INT16),
+            FieldMatcher.of(INT32_FIELD.getName(), FieldType.INT32),
+            FieldMatcher.of(INT64_FIELD.getName(), FieldType.INT64),
+            // should not match type:
+            FieldMatcher.of(STRING_FIELD.getName(), FieldType.BYTE)));
 
-        assertTrue(
-                schemaReflection.matchesAll(
-                        FieldMatcher.of(BOOLEAN_FIELD.getName()),
-                        FieldMatcher.of(BYTE_FIELD.getName()),
-                        FieldMatcher.of(DATETIME_FIELD.getName()),
-                        FieldMatcher.of(DECIMAL_FIELD.getName()),
-                        FieldMatcher.of(DOUBLE_FIELD.getName()),
-                        FieldMatcher.of(FLOAT_FIELD.getName()),
-                        FieldMatcher.of(INT16_FIELD.getName()),
-                        FieldMatcher.of(INT32_FIELD.getName()),
-                        FieldMatcher.of(INT64_FIELD.getName()),
-                        FieldMatcher.of(STRING_FIELD.getName())));
+    assertFalse(
+        schemaReflection.matchesAll(
+            FieldMatcher.of(BOOLEAN_FIELD.getName(), TypeName.BOOLEAN),
+            FieldMatcher.of(BYTE_FIELD.getName(), TypeName.BYTE),
+            FieldMatcher.of(DATETIME_FIELD.getName(), TypeName.DATETIME),
+            FieldMatcher.of(DECIMAL_FIELD.getName(), TypeName.DECIMAL),
+            FieldMatcher.of(DOUBLE_FIELD.getName(), TypeName.DOUBLE),
+            FieldMatcher.of(FLOAT_FIELD.getName(), TypeName.FLOAT),
+            FieldMatcher.of(INT16_FIELD.getName(), TypeName.INT16),
+            FieldMatcher.of(INT32_FIELD.getName(), TypeName.INT32),
+            FieldMatcher.of(INT64_FIELD.getName(), TypeName.INT64),
+            // should not match TypeName:
+            FieldMatcher.of(STRING_FIELD.getName(), TypeName.INT16)));
+  }
 
-        assertTrue(
-                schemaReflection.matchesAll(
-                        FieldMatcher.of(BOOLEAN_FIELD.getName(), FieldType.BOOLEAN),
-                        FieldMatcher.of(BYTE_FIELD.getName(), FieldType.BYTE),
-                        FieldMatcher.of(DATETIME_FIELD.getName(), FieldType.DATETIME),
-                        FieldMatcher.of(DECIMAL_FIELD.getName(), FieldType.DECIMAL),
-                        FieldMatcher.of(DOUBLE_FIELD.getName(), FieldType.DOUBLE),
-                        FieldMatcher.of(FLOAT_FIELD.getName(), FieldType.FLOAT),
-                        FieldMatcher.of(INT16_FIELD.getName(), FieldType.INT16),
-                        FieldMatcher.of(INT32_FIELD.getName(), FieldType.INT32),
-                        FieldMatcher.of(INT64_FIELD.getName(), FieldType.INT64),
-                        FieldMatcher.of(STRING_FIELD.getName(), FieldType.STRING)));
+  @Test
+  public void testFieldMatcher_match_NameOnly() {
+    FieldMatcher fieldMatcher = FieldMatcher.of(DEFAULT_PAYLOAD_KEY_NAME);
+    assertTrue(fieldMatcher.match(NON_USER_WITH_ROW_PAYLOAD));
+    assertTrue(fieldMatcher.match(NON_USER_WITH_BYTES_PAYLOAD));
+    assertFalse(fieldMatcher.match(ALL_DATA_TYPES_SCHEMA));
+  }
 
-        assertTrue(
-                schemaReflection.matchesAll(
-                        FieldMatcher.of(BOOLEAN_FIELD.getName(), TypeName.BOOLEAN),
-                        FieldMatcher.of(BYTE_FIELD.getName(), TypeName.BYTE),
-                        FieldMatcher.of(DATETIME_FIELD.getName(), TypeName.DATETIME),
-                        FieldMatcher.of(DECIMAL_FIELD.getName(), TypeName.DECIMAL),
-                        FieldMatcher.of(DOUBLE_FIELD.getName(), TypeName.DOUBLE),
-                        FieldMatcher.of(FLOAT_FIELD.getName(), TypeName.FLOAT),
-                        FieldMatcher.of(INT16_FIELD.getName(), TypeName.INT16),
-                        FieldMatcher.of(INT32_FIELD.getName(), TypeName.INT32),
-                        FieldMatcher.of(INT64_FIELD.getName(), TypeName.INT64),
-                        FieldMatcher.of(STRING_FIELD.getName(), TypeName.STRING)));
+  @Test
+  public void testFieldMatcher_match_TypeName() {
+    assertTrue(
+        FieldMatcher.of(DEFAULT_PAYLOAD_KEY_NAME, TypeName.ROW).match(NON_USER_WITH_ROW_PAYLOAD));
+    assertTrue(
+        FieldMatcher.of(DEFAULT_PAYLOAD_KEY_NAME, TypeName.BYTES)
+            .match(NON_USER_WITH_BYTES_PAYLOAD));
+    assertFalse(
+        FieldMatcher.of(DEFAULT_PAYLOAD_KEY_NAME, TypeName.ROW).match(NON_USER_WITH_BYTES_PAYLOAD));
+    assertFalse(
+        FieldMatcher.of(DEFAULT_PAYLOAD_KEY_NAME, TypeName.BYTES).match(NON_USER_WITH_ROW_PAYLOAD));
+  }
 
-        assertFalse(
-                schemaReflection.matchesAll(
-                        FieldMatcher.of("idontexist"),
-                        FieldMatcher.of(BOOLEAN_FIELD.getName()),
-                        FieldMatcher.of(BYTE_FIELD.getName()),
-                        FieldMatcher.of(DATETIME_FIELD.getName()),
-                        FieldMatcher.of(DECIMAL_FIELD.getName()),
-                        FieldMatcher.of(DOUBLE_FIELD.getName()),
-                        FieldMatcher.of(FLOAT_FIELD.getName()),
-                        FieldMatcher.of(INT16_FIELD.getName()),
-                        FieldMatcher.of(INT32_FIELD.getName()),
-                        FieldMatcher.of(INT64_FIELD.getName()),
-                        FieldMatcher.of(STRING_FIELD.getName())));
+  @Test
+  public void testFieldMatcher_match_FieldType() {
+    assertTrue(
+        FieldMatcher.of(
+                DEFAULT_ATTRIBUTES_KEY_NAME, FieldType.map(FieldType.STRING, FieldType.STRING))
+            .match(NON_USER_WITH_BYTES_PAYLOAD));
+    assertFalse(
+        FieldMatcher.of(
+                DEFAULT_ATTRIBUTES_KEY_NAME, FieldType.map(FieldType.STRING, FieldType.BYTES))
+            .match(NON_USER_WITH_BYTES_PAYLOAD));
+  }
 
-        assertFalse(
-                schemaReflection.matchesAll(
-                        FieldMatcher.of(BOOLEAN_FIELD.getName(), FieldType.BOOLEAN),
-                        FieldMatcher.of(BYTE_FIELD.getName(), FieldType.BYTE),
-                        FieldMatcher.of(DATETIME_FIELD.getName(), FieldType.DATETIME),
-                        FieldMatcher.of(DECIMAL_FIELD.getName(), FieldType.DECIMAL),
-                        FieldMatcher.of(DOUBLE_FIELD.getName(), FieldType.DOUBLE),
-                        FieldMatcher.of(FLOAT_FIELD.getName(), FieldType.FLOAT),
-                        FieldMatcher.of(INT16_FIELD.getName(), FieldType.INT16),
-                        FieldMatcher.of(INT32_FIELD.getName(), FieldType.INT32),
-                        FieldMatcher.of(INT64_FIELD.getName(), FieldType.INT64),
-                        // should not match type:
-                        FieldMatcher.of(STRING_FIELD.getName(), FieldType.BYTE)));
+  @Test
+  public void testRemoveFields() {
+    Schema input = Schema.of(STRING_FIELD, BOOLEAN_FIELD, INT64_FIELD);
+    Schema expected = Schema.builder().build();
+    Schema actual =
+        removeFields(input, STRING_FIELD.getName(), BOOLEAN_FIELD.getName(), INT64_FIELD.getName());
+    assertEquals(expected, actual);
+  }
 
-        assertFalse(
-                schemaReflection.matchesAll(
-                        FieldMatcher.of(BOOLEAN_FIELD.getName(), TypeName.BOOLEAN),
-                        FieldMatcher.of(BYTE_FIELD.getName(), TypeName.BYTE),
-                        FieldMatcher.of(DATETIME_FIELD.getName(), TypeName.DATETIME),
-                        FieldMatcher.of(DECIMAL_FIELD.getName(), TypeName.DECIMAL),
-                        FieldMatcher.of(DOUBLE_FIELD.getName(), TypeName.DOUBLE),
-                        FieldMatcher.of(FLOAT_FIELD.getName(), TypeName.FLOAT),
-                        FieldMatcher.of(INT16_FIELD.getName(), TypeName.INT16),
-                        FieldMatcher.of(INT32_FIELD.getName(), TypeName.INT32),
-                        FieldMatcher.of(INT64_FIELD.getName(), TypeName.INT64),
-                        // should not match TypeName:
-                        FieldMatcher.of(STRING_FIELD.getName(), TypeName.INT16)));
-    }
+  @Test
+  public void testPubsubRowToMessageParDo_attributesWithoutTimestamp() {
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put("a", "1");
+    attributes.put("b", "2");
+    attributes.put("c", "3");
 
-    @Test
-    public void testFieldMatcher_match_NameOnly() {
-        FieldMatcher fieldMatcher = FieldMatcher.of(DEFAULT_PAYLOAD_KEY_NAME);
-        assertTrue(fieldMatcher.match(NON_USER_WITH_ROW_PAYLOAD));
-        assertTrue(fieldMatcher.match(NON_USER_WITH_BYTES_PAYLOAD));
-        assertFalse(fieldMatcher.match(ALL_DATA_TYPES_SCHEMA));
-    }
+    Row withAttributes =
+        Row.withSchema(NON_USER_WITH_BYTES_PAYLOAD)
+            .addValues(attributes, Instant.now(), new byte[] {})
+            .build();
 
-    @Test
-    public void testFieldMatcher_match_TypeName() {
-        assertTrue(
-                FieldMatcher.of(DEFAULT_PAYLOAD_KEY_NAME, TypeName.ROW).match(NON_USER_WITH_ROW_PAYLOAD));
-        assertTrue(
-                FieldMatcher.of(DEFAULT_PAYLOAD_KEY_NAME, TypeName.BYTES)
-                        .match(NON_USER_WITH_BYTES_PAYLOAD));
-        assertFalse(
-                FieldMatcher.of(DEFAULT_PAYLOAD_KEY_NAME, TypeName.ROW).match(NON_USER_WITH_BYTES_PAYLOAD));
-        assertFalse(
-                FieldMatcher.of(DEFAULT_PAYLOAD_KEY_NAME, TypeName.BYTES).match(NON_USER_WITH_ROW_PAYLOAD));
-    }
+    assertEquals(
+        attributes,
+        doFn(NON_USER_WITH_BYTES_PAYLOAD, null).attributesWithoutTimestamp(withAttributes));
 
-    @Test
-    public void testFieldMatcher_match_FieldType() {
-        assertTrue(
-                FieldMatcher.of(
-                                DEFAULT_ATTRIBUTES_KEY_NAME, FieldType.map(FieldType.STRING, FieldType.STRING))
-                        .match(NON_USER_WITH_BYTES_PAYLOAD));
-        assertFalse(
-                FieldMatcher.of(
-                                DEFAULT_ATTRIBUTES_KEY_NAME, FieldType.map(FieldType.STRING, FieldType.BYTES))
-                        .match(NON_USER_WITH_BYTES_PAYLOAD));
-    }
+    Schema withoutAttributesSchema =
+        removeFields(NON_USER_WITH_BYTES_PAYLOAD, DEFAULT_ATTRIBUTES_KEY_NAME);
+    Row withoutAttributes =
+        Row.withSchema(withoutAttributesSchema).addValues(Instant.now(), new byte[] {}).build();
 
-    @Test
-    public void testRemoveFields() {
-        Schema input = Schema.of(STRING_FIELD, BOOLEAN_FIELD, INT64_FIELD);
-        Schema expected = Schema.builder().build();
-        Schema actual =
-                removeFields(input, STRING_FIELD.getName(), BOOLEAN_FIELD.getName(), INT64_FIELD.getName());
-        assertEquals(expected, actual);
-    }
+    assertEquals(
+        new HashMap<>(),
+        doFn(withoutAttributesSchema, null).attributesWithoutTimestamp(withoutAttributes));
+  }
 
-    @Test
-    public void testPubsubRowToMessageParDo_attributesWithoutTimestamp() {
-        Map<String, String> attributes = new HashMap<>();
-        attributes.put("a", "1");
-        attributes.put("b", "2");
-        attributes.put("c", "3");
+  @Test
+  public void testPubsubRowToMessageParDo_timestamp() {
+    Instant timestamp = Instant.now();
+    Row withTimestamp =
+        Row.withSchema(NON_USER_WITH_BYTES_PAYLOAD)
+            .addValues(new HashMap<>(), timestamp, new byte[] {})
+            .build();
+    assertEquals(
+        timestamp.toString(),
+        doFn(NON_USER_WITH_BYTES_PAYLOAD, null).timestamp(withTimestamp).toString());
 
-        Row withAttributes =
+    Schema withoutTimestampSchema =
+        removeFields(NON_USER_WITH_BYTES_PAYLOAD, DEFAULT_EVENT_TIMESTAMP_KEY_NAME);
+    Row withoutTimestamp =
+        Row.withSchema(withoutTimestampSchema).addValues(new HashMap<>(), new byte[] {}).build();
+    ReadableDateTime actual = doFn(withoutTimestampSchema, null).timestamp(withoutTimestamp);
+    assertNotNull(actual);
+    assertTrue(actual.isAfter(timestamp));
+  }
+
+  @Test
+  public void testPubsubRowToMessageParDo_payload() {
+    PayloadSerializer jsonPayloadSerializer =
+        new JsonPayloadSerializerProvider().getSerializer(ALL_DATA_TYPES_SCHEMA, new HashMap<>());
+    PayloadSerializer avroPayloadSerializer =
+        new JsonPayloadSerializerProvider().getSerializer(ALL_DATA_TYPES_SCHEMA, new HashMap<>());
+
+    byte[] bytes = "abcdefg".getBytes(StandardCharsets.UTF_8);
+    assertArrayEquals(
+        bytes,
+        doFn(NON_USER_WITH_BYTES_PAYLOAD, null)
+            .payload(
                 Row.withSchema(NON_USER_WITH_BYTES_PAYLOAD)
-                        .addValues(attributes, Instant.now(), new byte[]{})
-                        .build();
+                    .addValues(new HashMap<>(), Instant.now(), bytes)
+                    .build()));
 
-        assertEquals(
-                attributes,
-                doFn(NON_USER_WITH_BYTES_PAYLOAD, null).attributesWithoutTimestamp(withAttributes));
-
-        Schema withoutAttributesSchema =
-                removeFields(NON_USER_WITH_BYTES_PAYLOAD, DEFAULT_ATTRIBUTES_KEY_NAME);
-        Row withoutAttributes =
-                Row.withSchema(withoutAttributesSchema).addValues(Instant.now(), new byte[]{}).build();
-
-        assertEquals(
+    Row withoutUserFields =
+        Row.withSchema(NON_USER_WITH_ROW_PAYLOAD)
+            .addValues(
                 new HashMap<>(),
-                doFn(withoutAttributesSchema, null).attributesWithoutTimestamp(withoutAttributes));
-    }
-
-    @Test
-    public void testPubsubRowToMessageParDo_timestamp() {
-        Instant timestamp = Instant.now();
-        Row withTimestamp =
-                Row.withSchema(NON_USER_WITH_BYTES_PAYLOAD)
-                        .addValues(new HashMap<>(), timestamp, new byte[]{})
-                        .build();
-        assertEquals(
-                timestamp.toString(),
-                doFn(NON_USER_WITH_BYTES_PAYLOAD, null).timestamp(withTimestamp).toString());
-
-        Schema withoutTimestampSchema =
-                removeFields(NON_USER_WITH_BYTES_PAYLOAD, DEFAULT_EVENT_TIMESTAMP_KEY_NAME);
-        Row withoutTimestamp =
-                Row.withSchema(withoutTimestampSchema).addValues(new HashMap<>(), new byte[]{}).build();
-        ReadableDateTime actual = doFn(withoutTimestampSchema, null).timestamp(withoutTimestamp);
-        assertNotNull(actual);
-        assertTrue(actual.isAfter(timestamp));
-
-        Instant mockTimestamp = Instant.ofEpochMilli(timestamp.getMillis() + 1000000L);
-        actual = doFn(withoutTimestampSchema, null, mockTimestamp).timestamp(withoutTimestamp);
-        assertNotNull(actual);
-        assertEquals(actual.toString(), mockTimestamp.toDateTime().toString());
-    }
-
-    @Test
-    public void testPubsubRowToMessageParDo_payload() {
-        PayloadSerializer jsonPayloadSerializer =
-                new JsonPayloadSerializerProvider().getSerializer(ALL_DATA_TYPES_SCHEMA, new HashMap<>());
-        PayloadSerializer avroPayloadSerializer =
-                new JsonPayloadSerializerProvider().getSerializer(ALL_DATA_TYPES_SCHEMA, new HashMap<>());
-
-        byte[] bytes = "abcdefg".getBytes(StandardCharsets.UTF_8);
-        assertArrayEquals(
-                bytes,
-                doFn(NON_USER_WITH_BYTES_PAYLOAD, null)
-                        .payload(
-                                Row.withSchema(NON_USER_WITH_BYTES_PAYLOAD)
-                                        .addValues(new HashMap<>(), Instant.now(), bytes)
-                                        .build()));
-
-        Row withoutUserFields =
-                Row.withSchema(NON_USER_WITH_ROW_PAYLOAD)
-                        .addValues(
-                                new HashMap<>(),
-                                Instant.now(),
-                                rowWithAllDataTypes(
-                                        true,
-                                        (byte) 1,
-                                        Instant.now().toDateTime(),
-                                        BigDecimal.valueOf(100L),
-                                        1.12345,
-                                        1.1f,
-                                        (short) 1,
-                                        1,
-                                        1L,
-                                        "abcdefg"))
-                        .build();
-
-        assertArrayEquals(
-                jsonPayloadSerializer.serialize(withoutUserFields.getRow(DEFAULT_PAYLOAD_KEY_NAME)),
-                doFn(NON_USER_WITH_ROW_PAYLOAD, jsonPayloadSerializer).payload(withoutUserFields));
-
-        assertArrayEquals(
-                avroPayloadSerializer.serialize(withoutUserFields.getRow(DEFAULT_PAYLOAD_KEY_NAME)),
-                doFn(NON_USER_WITH_ROW_PAYLOAD, avroPayloadSerializer).payload(withoutUserFields));
-
-        Map<String, String> attributes = new HashMap<>();
-        attributes.put("a", "1");
-        attributes.put("b", "2");
-        attributes.put("c", "3");
-
-        Row withAttributesAndTimestamp =
-                Row.withSchema(NON_USER_WITHOUT_PAYLOAD).addValues(attributes, Instant.now()).build();
-
-        Row withUserFields =
+                Instant.now(),
                 rowWithAllDataTypes(
-                        false,
-                        (byte) 0,
-                        Instant.now().toDateTime(),
-                        BigDecimal.valueOf(200L),
-                        2.12345,
-                        2.1f,
-                        (short) 2,
-                        2,
-                        2L,
-                        "1234567");
+                    true,
+                    (byte) 1,
+                    Instant.now().toDateTime(),
+                    BigDecimal.valueOf(100L),
+                    1.12345,
+                    1.1f,
+                    (short) 1,
+                    1,
+                    1L,
+                    "abcdefg"))
+            .build();
 
-        Row withUserFieldsAndAttributesTimestamp = merge(withAttributesAndTimestamp, withUserFields);
+    assertArrayEquals(
+        jsonPayloadSerializer.serialize(withoutUserFields.getRow(DEFAULT_PAYLOAD_KEY_NAME)),
+        doFn(NON_USER_WITH_ROW_PAYLOAD, jsonPayloadSerializer).payload(withoutUserFields));
 
-        assertArrayEquals(
-                jsonPayloadSerializer.serialize(withUserFields),
-                doFn(withUserFieldsAndAttributesTimestamp.getSchema(), jsonPayloadSerializer)
-                        .payload(withUserFieldsAndAttributesTimestamp));
+    assertArrayEquals(
+        avroPayloadSerializer.serialize(withoutUserFields.getRow(DEFAULT_PAYLOAD_KEY_NAME)),
+        doFn(NON_USER_WITH_ROW_PAYLOAD, avroPayloadSerializer).payload(withoutUserFields));
 
-        assertArrayEquals(
-                avroPayloadSerializer.serialize(withUserFields),
-                doFn(withUserFieldsAndAttributesTimestamp.getSchema(), avroPayloadSerializer)
-                        .payload(withUserFieldsAndAttributesTimestamp));
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put("a", "1");
+    attributes.put("b", "2");
+    attributes.put("c", "3");
+
+    Row withAttributesAndTimestamp =
+        Row.withSchema(NON_USER_WITHOUT_PAYLOAD).addValues(attributes, Instant.now()).build();
+
+    Row withUserFields =
+        rowWithAllDataTypes(
+            false,
+            (byte) 0,
+            Instant.now().toDateTime(),
+            BigDecimal.valueOf(200L),
+            2.12345,
+            2.1f,
+            (short) 2,
+            2,
+            2L,
+            "1234567");
+
+    Row withUserFieldsAndAttributesTimestamp = merge(withAttributesAndTimestamp, withUserFields);
+
+    assertArrayEquals(
+        jsonPayloadSerializer.serialize(withUserFields),
+        doFn(withUserFieldsAndAttributesTimestamp.getSchema(), jsonPayloadSerializer)
+            .payload(withUserFieldsAndAttributesTimestamp));
+
+    assertArrayEquals(
+        avroPayloadSerializer.serialize(withUserFields),
+        doFn(withUserFieldsAndAttributesTimestamp.getSchema(), avroPayloadSerializer)
+            .payload(withUserFieldsAndAttributesTimestamp));
+  }
+
+  @Test
+  public void testPubsubRowToMessageParDo_serializableRow() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            doFn(NON_USER_WITH_BYTES_PAYLOAD, null)
+                .serializableRow(
+                    Row.withSchema(NON_USER_WITH_BYTES_PAYLOAD)
+                        .attachValues(new HashMap<>(), Instant.now(), new byte[] {})));
+
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put("a", "1");
+    attributes.put("b", "2");
+    attributes.put("c", "3");
+
+    Row withAllDataTypes =
+        rowWithAllDataTypes(
+            true,
+            (byte) 0,
+            Instant.now().toDateTime(),
+            BigDecimal.valueOf(1L),
+            3.12345,
+            4.1f,
+            (short) 5,
+            2,
+            7L,
+            "asdfjkl;");
+
+    Row nonUserWithRowPayload =
+        Row.withSchema(NON_USER_WITH_ROW_PAYLOAD)
+            .attachValues(attributes, Instant.now(), withAllDataTypes);
+
+    PayloadSerializer jsonPayloadSerializer =
+        new JsonPayloadSerializerProvider().getSerializer(ALL_DATA_TYPES_SCHEMA, new HashMap<>());
+
+    assertEquals(
+        withAllDataTypes,
+        doFn(NON_USER_WITH_ROW_PAYLOAD, jsonPayloadSerializer)
+            .serializableRow(nonUserWithRowPayload));
+
+    Row withAttributesAndTimestamp =
+        Row.withSchema(NON_USER_WITHOUT_PAYLOAD).addValues(attributes, Instant.now()).build();
+
+    Row withUserFieldsAttributesAndTimestamp = merge(withAttributesAndTimestamp, withAllDataTypes);
+
+    assertEquals(
+        withAllDataTypes,
+        doFn(withUserFieldsAttributesAndTimestamp.getSchema(), jsonPayloadSerializer)
+            .serializableRow(withUserFieldsAttributesAndTimestamp));
+  }
+
+  private static PubsubRowToMessageDoFn doFn(Schema schema, PayloadSerializer payloadSerializer) {
+    return new PubsubRowToMessageDoFn(
+        DEFAULT_ATTRIBUTES_KEY_NAME,
+        DEFAULT_EVENT_TIMESTAMP_KEY_NAME,
+        DEFAULT_PAYLOAD_KEY_NAME,
+        errorSchema(schema),
+        DEFAULT_EVENT_TIMESTAMP_KEY_NAME,
+        null,
+        payloadSerializer);
+  }
+
+  private static Row rowWithAllDataTypes(
+      boolean boolean0,
+      byte byte0,
+      ReadableDateTime datetime,
+      BigDecimal decimal,
+      Double double0,
+      Float float0,
+      Short int16,
+      Integer int32,
+      Long int64,
+      String string) {
+    return Row.withSchema(ALL_DATA_TYPES_SCHEMA)
+        .addValues(boolean0, byte0, datetime, decimal, double0, float0, int16, int32, int64, string)
+        .build();
+  }
+
+  private static Schema merge(Schema a, Schema b) {
+    List<Field> fields = new ArrayList<>(a.getFields());
+    fields.addAll(b.getFields());
+    Schema.Builder builder = Schema.builder();
+    for (Field field : fields) {
+      builder = builder.addField(field);
     }
+    return builder.build();
+  }
 
-    @Test
-    public void testPubsubRowToMessageParDo_serializableRow() {
-        assertThrows(
-                IllegalArgumentException.class,
-                () ->
-                        doFn(NON_USER_WITH_BYTES_PAYLOAD, null)
-                                .serializableRow(
-                                        Row.withSchema(NON_USER_WITH_BYTES_PAYLOAD)
-                                                .attachValues(new HashMap<>(), Instant.now(), new byte[]{})));
-
-        Map<String, String> attributes = new HashMap<>();
-        attributes.put("a", "1");
-        attributes.put("b", "2");
-        attributes.put("c", "3");
-
-        Row withAllDataTypes =
-                rowWithAllDataTypes(
-                        true,
-                        (byte) 0,
-                        Instant.now().toDateTime(),
-                        BigDecimal.valueOf(1L),
-                        3.12345,
-                        4.1f,
-                        (short) 5,
-                        2,
-                        7L,
-                        "asdfjkl;");
-
-        Row nonUserWithRowPayload =
-                Row.withSchema(NON_USER_WITH_ROW_PAYLOAD)
-                        .attachValues(attributes, Instant.now(), withAllDataTypes);
-
-        PayloadSerializer jsonPayloadSerializer =
-                new JsonPayloadSerializerProvider().getSerializer(ALL_DATA_TYPES_SCHEMA, new HashMap<>());
-
-        assertEquals(
-                withAllDataTypes,
-                doFn(NON_USER_WITH_ROW_PAYLOAD, jsonPayloadSerializer)
-                        .serializableRow(nonUserWithRowPayload));
-
-        Row withAttributesAndTimestamp =
-                Row.withSchema(NON_USER_WITHOUT_PAYLOAD).addValues(attributes, Instant.now()).build();
-
-        Row withUserFieldsAttributesAndTimestamp = merge(withAttributesAndTimestamp, withAllDataTypes);
-
-        assertEquals(
-                withAllDataTypes,
-                doFn(withUserFieldsAttributesAndTimestamp.getSchema(), jsonPayloadSerializer)
-                        .serializableRow(withUserFieldsAttributesAndTimestamp));
+  private static Row merge(Row a, Row b) {
+    Schema schema = merge(a.getSchema(), b.getSchema());
+    Map<String, Object> values = new HashMap<>();
+    for (String name : a.getSchema().getFieldNames()) {
+      values.put(name, a.getValue(name));
     }
-
-    private static PubsubRowToMessageDoFn doFn(Schema schema, PayloadSerializer payloadSerializer) {
-        return doFn(schema, payloadSerializer, null);
+    for (String name : b.getSchema().getFieldNames()) {
+      values.put(name, b.getValue(name));
     }
-
-    private static PubsubRowToMessageDoFn doFn(
-            Schema schema, PayloadSerializer payloadSerializer, Instant testInstant) {
-        return new PubsubRowToMessageDoFn(
-                DEFAULT_ATTRIBUTES_KEY_NAME,
-                DEFAULT_EVENT_TIMESTAMP_KEY_NAME,
-                DEFAULT_PAYLOAD_KEY_NAME,
-                errorSchema(schema),
-                DEFAULT_EVENT_TIMESTAMP_KEY_NAME,
-                testInstant,
-                payloadSerializer);
-    }
-
-    private static Row rowWithAllDataTypes(
-            boolean boolean0,
-            byte byte0,
-            ReadableDateTime datetime,
-            BigDecimal decimal,
-            Double double0,
-            Float float0,
-            Short int16,
-            Integer int32,
-            Long int64,
-            String string) {
-        return Row.withSchema(ALL_DATA_TYPES_SCHEMA)
-                .addValues(boolean0, byte0, datetime, decimal, double0, float0, int16, int32, int64, string)
-                .build();
-    }
-
-    private static Schema merge(Schema a, Schema b) {
-        List<Field> fields = new ArrayList<>(a.getFields());
-        fields.addAll(b.getFields());
-        Schema.Builder builder = Schema.builder();
-        for (Field field : fields) {
-            builder = builder.addField(field);
-        }
-        return builder.build();
-    }
-
-    //  private static Schema merge(Schema schema, Schema ...additional) {
-    //    Schema result = schema;
-    //    for (Schema additionalSchema : additional) {
-    //      result = merge(result, additionalSchema);
-    //    }
-    //    return result;
-    //  }
-
-    private static Row merge(Row a, Row b) {
-        Schema schema = merge(a.getSchema(), b.getSchema());
-        Map<String, Object> values = new HashMap<>();
-        for (String name : a.getSchema().getFieldNames()) {
-            values.put(name, a.getValue(name));
-        }
-        for (String name : b.getSchema().getFieldNames()) {
-            values.put(name, b.getValue(name));
-        }
-        return Row.withSchema(schema).withFieldValues(values).build();
-    }
-
-    //  private static Row merge(Row row, Row... additional) {
-    //    Row result = row;
-    //    for (Row additionalRow : additional) {
-    //      row = merge(row, additionalRow);
-    //    }
-    //    return result;
-    //  }
+    return Row.withSchema(schema).withFieldValues(values).build();
+  }
 }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubRowToMessageTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubRowToMessageTest.java
@@ -17,12 +17,31 @@
  */
 package org.apache.beam.sdk.io.gcp.pubsub;
 
-import static org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.*;
-import static org.junit.Assert.*;
+import static org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.ATTRIBUTES_FIELD_TYPE;
+import static org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.ATTRIBUTES_KEY_NAME;
+import static org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.DEFAULT_KEY_PREFIX;
+import static org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.EVENT_TIMESTAMP_FIELD_TYPE;
+import static org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.EVENT_TIMESTAMP_KEY_NAME;
+import static org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.OUTPUT;
+import static org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.PAYLOAD_KEY_NAME;
+import static org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.errorSchema;
+import static org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.removeFields;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
 
 import java.math.BigDecimal;
 import java.nio.charset.StandardCharsets;
-import java.util.*;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.FieldMatcher;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.PubsubRowToMessageDoFn;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.SchemaReflection;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptions.CheckEnabled;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubRowToMessageTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubRowToMessageTest.java
@@ -1,0 +1,484 @@
+package org.apache.beam.sdk.io.gcp.pubsub;
+
+import static org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.ATTRIBUTES_FIELD_TYPE;
+import static org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.ATTRIBUTES_KEY_NAME;
+import static org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.DEFAULT_KEY_PREFIX;
+import static org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.EVENT_TIMESTAMP_FIELD_TYPE;
+import static org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.EVENT_TIMESTAMP_KEY_NAME;
+import static org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.PAYLOAD_KEY_NAME;
+import static org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.errorSchema;
+import static org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.removeFields;
+import static org.junit.Assert.assertArrayEquals;
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
+import java.util.ArrayList;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.FieldMatcher;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.PubsubRowToMessageDoFn;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubRowToMessage.SchemaReflection;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptions.CheckEnabled;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.Field;
+import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.schemas.Schema.TypeName;
+import org.apache.beam.sdk.schemas.io.payloads.AvroPayloadSerializerProvider;
+import org.apache.beam.sdk.schemas.io.payloads.JsonPayloadSerializerProvider;
+import org.apache.beam.sdk.schemas.io.payloads.PayloadSerializer;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.values.Row;
+import org.joda.time.Instant;
+import org.joda.time.ReadableDateTime;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link PubsubRowToMessage}. */
+@RunWith(JUnit4.class)
+public class PubsubRowToMessageTest {
+
+  private static final PipelineOptions PIPELINE_OPTIONS = PipelineOptionsFactory.create();
+  private static final String DEFAULT_ATTRIBUTES_KEY_NAME =
+      DEFAULT_KEY_PREFIX + ATTRIBUTES_KEY_NAME;
+  private static final String DEFAULT_EVENT_TIMESTAMP_KEY_NAME =
+      DEFAULT_KEY_PREFIX + EVENT_TIMESTAMP_KEY_NAME;
+  private static final String DEFAULT_PAYLOAD_KEY_NAME = DEFAULT_KEY_PREFIX + PAYLOAD_KEY_NAME;
+  private static final Field BOOLEAN_FIELD = Field.of("boolean", FieldType.BOOLEAN);
+  private static final Field BYTE_FIELD = Field.of("byte", FieldType.BYTE);
+  private static final Field DATETIME_FIELD = Field.of("datetime", FieldType.DATETIME);
+  private static final Field DECIMAL_FIELD = Field.of("decimal", FieldType.DECIMAL);
+  private static final Field DOUBLE_FIELD = Field.of("double", FieldType.DOUBLE);
+  private static final Field FLOAT_FIELD = Field.of("float", FieldType.FLOAT);
+  private static final Field INT16_FIELD = Field.of("int16", FieldType.INT16);
+  private static final Field INT32_FIELD = Field.of("int32", FieldType.INT32);
+  private static final Field INT64_FIELD = Field.of("int64", FieldType.INT64);
+  private static final Field STRING_FIELD = Field.of("string", FieldType.STRING);
+  private static final Schema ALL_DATA_TYPES_SCHEMA =
+      Schema.of(
+          BOOLEAN_FIELD,
+          BYTE_FIELD,
+          DATETIME_FIELD,
+          DECIMAL_FIELD,
+          DOUBLE_FIELD,
+          FLOAT_FIELD,
+          INT16_FIELD,
+          INT32_FIELD,
+          INT64_FIELD,
+          STRING_FIELD);
+
+  private static final Schema NON_USER_WITH_BYTES_PAYLOAD =
+      Schema.of(
+          Field.of(DEFAULT_ATTRIBUTES_KEY_NAME, ATTRIBUTES_FIELD_TYPE),
+          Field.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, EVENT_TIMESTAMP_FIELD_TYPE),
+          Field.of(DEFAULT_PAYLOAD_KEY_NAME, FieldType.BYTES));
+
+  private static final Schema NON_USER_WITH_ROW_PAYLOAD =
+      Schema.of(
+          Field.of(DEFAULT_ATTRIBUTES_KEY_NAME, ATTRIBUTES_FIELD_TYPE),
+          Field.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, EVENT_TIMESTAMP_FIELD_TYPE),
+          Field.of(DEFAULT_PAYLOAD_KEY_NAME, FieldType.row(ALL_DATA_TYPES_SCHEMA)));
+
+  // private static final Field ROW_FIELD = Field.of("row", FieldType.row(ALL_DATA_TYPES_SCHEMA));
+
+  static {
+    PIPELINE_OPTIONS.setStableUniqueNames(CheckEnabled.OFF);
+  }
+
+  @Rule public TestPipeline pipeline = TestPipeline.create();
+
+  @Test
+  public void testExpand() {
+    pipeline.run(PIPELINE_OPTIONS);
+  }
+
+  @Test
+  public void testPubsubRowToMessageParDo_Process() {
+    pipeline.run(PIPELINE_OPTIONS);
+  }
+
+  @Test
+  public void testKeyPrefix() {
+    PubsubRowToMessage withDefaultKeyPrefix = PubsubRowToMessage.builder().build();
+    assertEquals(DEFAULT_ATTRIBUTES_KEY_NAME, withDefaultKeyPrefix.getAttributesKeyName());
+    assertEquals(
+        DEFAULT_EVENT_TIMESTAMP_KEY_NAME, withDefaultKeyPrefix.getSourceEventTimestampKeyName());
+    assertEquals(DEFAULT_PAYLOAD_KEY_NAME, withDefaultKeyPrefix.getPayloadKeyName());
+
+    PubsubRowToMessage withKeyPrefixOverride =
+        PubsubRowToMessage.builder().setKeyPrefix("_").build();
+    assertEquals("_" + ATTRIBUTES_KEY_NAME, withKeyPrefixOverride.getAttributesKeyName());
+    assertEquals(
+        "_" + EVENT_TIMESTAMP_KEY_NAME, withKeyPrefixOverride.getSourceEventTimestampKeyName());
+    assertEquals("_" + PAYLOAD_KEY_NAME, withKeyPrefixOverride.getPayloadKeyName());
+  }
+
+  @Test
+  public void testValidate() {}
+
+  @Test
+  public void testValidateAttributesField() {
+    PubsubRowToMessage pubsubRowToMessage = PubsubRowToMessage.builder().build();
+    pubsubRowToMessage.validateAttributesField(ALL_DATA_TYPES_SCHEMA);
+    pubsubRowToMessage.validateAttributesField(
+        Schema.of(Field.of(DEFAULT_ATTRIBUTES_KEY_NAME, ATTRIBUTES_FIELD_TYPE)));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            pubsubRowToMessage.validateAttributesField(
+                Schema.of(Field.of(DEFAULT_ATTRIBUTES_KEY_NAME, FieldType.STRING))));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            pubsubRowToMessage.validateAttributesField(
+                Schema.of(
+                    Field.of(
+                        DEFAULT_ATTRIBUTES_KEY_NAME,
+                        FieldType.map(FieldType.STRING, FieldType.BYTES)))));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            pubsubRowToMessage.validateAttributesField(
+                Schema.of(
+                    Field.of(
+                        DEFAULT_ATTRIBUTES_KEY_NAME,
+                        FieldType.map(FieldType.BYTES, FieldType.STRING)))));
+  }
+
+  @Test
+  public void testValidateSourceEventTimeStampField() {
+    PubsubRowToMessage pubsubRowToMessage = PubsubRowToMessage.builder().build();
+    pubsubRowToMessage.validateSourceEventTimeStampField(ALL_DATA_TYPES_SCHEMA);
+    pubsubRowToMessage.validateSourceEventTimeStampField(
+        Schema.of(Field.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, EVENT_TIMESTAMP_FIELD_TYPE)));
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            pubsubRowToMessage.validateSourceEventTimeStampField(
+                Schema.of(Field.of(DEFAULT_EVENT_TIMESTAMP_KEY_NAME, FieldType.STRING))));
+  }
+
+  @Test
+  public void testShouldValidatePayloadSerializerNullState() {
+    PayloadSerializer jsonPayloadSerializer =
+        new JsonPayloadSerializerProvider().getSerializer(ALL_DATA_TYPES_SCHEMA, new HashMap<>());
+    PayloadSerializer avroPayloadSerializer =
+        new AvroPayloadSerializerProvider().getSerializer(ALL_DATA_TYPES_SCHEMA, new HashMap<>());
+
+    PubsubRowToMessage.builder()
+        .setPayloadSerializer(jsonPayloadSerializer)
+        .build()
+        .validateSerializableFields(ALL_DATA_TYPES_SCHEMA);
+
+    PubsubRowToMessage.builder()
+        .setPayloadSerializer(avroPayloadSerializer)
+        .build()
+        .validateSerializableFields(ALL_DATA_TYPES_SCHEMA);
+
+    PubsubRowToMessage.builder()
+        .setPayloadSerializer(jsonPayloadSerializer)
+        .build()
+        .validateSerializableFields(NON_USER_WITH_ROW_PAYLOAD);
+
+    PubsubRowToMessage.builder()
+        .setPayloadSerializer(avroPayloadSerializer)
+        .build()
+        .validateSerializableFields(NON_USER_WITH_ROW_PAYLOAD);
+
+    PubsubRowToMessage.builder().build().validateSerializableFields(NON_USER_WITH_BYTES_PAYLOAD);
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PubsubRowToMessage.builder().build().validateSerializableFields(ALL_DATA_TYPES_SCHEMA));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PubsubRowToMessage.builder()
+                .build()
+                .validateSerializableFields(NON_USER_WITH_ROW_PAYLOAD));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PubsubRowToMessage.builder()
+                .setPayloadSerializer(jsonPayloadSerializer)
+                .build()
+                .validateSerializableFields(NON_USER_WITH_BYTES_PAYLOAD));
+  }
+
+  @Test
+  public void testShouldNotAllowPayloadFieldWithUserFields() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PubsubRowToMessage.builder()
+                .build()
+                .validateSerializableFields(
+                    merge(ALL_DATA_TYPES_SCHEMA, NON_USER_WITH_BYTES_PAYLOAD)));
+
+    assertThrows(
+        IllegalArgumentException.class,
+        () ->
+            PubsubRowToMessage.builder()
+                .build()
+                .validateSerializableFields(
+                    merge(ALL_DATA_TYPES_SCHEMA, NON_USER_WITH_ROW_PAYLOAD)));
+  }
+
+  @Test
+  public void testSchemaReflection_matchesAll() {
+    SchemaReflection schemaReflection = SchemaReflection.of(ALL_DATA_TYPES_SCHEMA);
+
+    assertTrue(
+        schemaReflection.matchesAll(
+            FieldMatcher.of(BOOLEAN_FIELD.getName()),
+            FieldMatcher.of(BYTE_FIELD.getName()),
+            FieldMatcher.of(DATETIME_FIELD.getName()),
+            FieldMatcher.of(DECIMAL_FIELD.getName()),
+            FieldMatcher.of(DOUBLE_FIELD.getName()),
+            FieldMatcher.of(FLOAT_FIELD.getName()),
+            FieldMatcher.of(INT16_FIELD.getName()),
+            FieldMatcher.of(INT32_FIELD.getName()),
+            FieldMatcher.of(INT64_FIELD.getName()),
+            FieldMatcher.of(STRING_FIELD.getName())));
+
+    assertTrue(
+        schemaReflection.matchesAll(
+            FieldMatcher.of(BOOLEAN_FIELD.getName(), FieldType.BOOLEAN),
+            FieldMatcher.of(BYTE_FIELD.getName(), FieldType.BYTE),
+            FieldMatcher.of(DATETIME_FIELD.getName(), FieldType.DATETIME),
+            FieldMatcher.of(DECIMAL_FIELD.getName(), FieldType.DECIMAL),
+            FieldMatcher.of(DOUBLE_FIELD.getName(), FieldType.DOUBLE),
+            FieldMatcher.of(FLOAT_FIELD.getName(), FieldType.FLOAT),
+            FieldMatcher.of(INT16_FIELD.getName(), FieldType.INT16),
+            FieldMatcher.of(INT32_FIELD.getName(), FieldType.INT32),
+            FieldMatcher.of(INT64_FIELD.getName(), FieldType.INT64),
+            FieldMatcher.of(STRING_FIELD.getName(), FieldType.STRING)));
+
+    assertTrue(
+        schemaReflection.matchesAll(
+            FieldMatcher.of(BOOLEAN_FIELD.getName(), TypeName.BOOLEAN),
+            FieldMatcher.of(BYTE_FIELD.getName(), TypeName.BYTE),
+            FieldMatcher.of(DATETIME_FIELD.getName(), TypeName.DATETIME),
+            FieldMatcher.of(DECIMAL_FIELD.getName(), TypeName.DECIMAL),
+            FieldMatcher.of(DOUBLE_FIELD.getName(), TypeName.DOUBLE),
+            FieldMatcher.of(FLOAT_FIELD.getName(), TypeName.FLOAT),
+            FieldMatcher.of(INT16_FIELD.getName(), TypeName.INT16),
+            FieldMatcher.of(INT32_FIELD.getName(), TypeName.INT32),
+            FieldMatcher.of(INT64_FIELD.getName(), TypeName.INT64),
+            FieldMatcher.of(STRING_FIELD.getName(), TypeName.STRING)));
+
+    assertFalse(
+        schemaReflection.matchesAll(
+            FieldMatcher.of("idontexist"),
+            FieldMatcher.of(BOOLEAN_FIELD.getName()),
+            FieldMatcher.of(BYTE_FIELD.getName()),
+            FieldMatcher.of(DATETIME_FIELD.getName()),
+            FieldMatcher.of(DECIMAL_FIELD.getName()),
+            FieldMatcher.of(DOUBLE_FIELD.getName()),
+            FieldMatcher.of(FLOAT_FIELD.getName()),
+            FieldMatcher.of(INT16_FIELD.getName()),
+            FieldMatcher.of(INT32_FIELD.getName()),
+            FieldMatcher.of(INT64_FIELD.getName()),
+            FieldMatcher.of(STRING_FIELD.getName())));
+
+    assertFalse(
+        schemaReflection.matchesAll(
+            FieldMatcher.of(BOOLEAN_FIELD.getName(), FieldType.BOOLEAN),
+            FieldMatcher.of(BYTE_FIELD.getName(), FieldType.BYTE),
+            FieldMatcher.of(DATETIME_FIELD.getName(), FieldType.DATETIME),
+            FieldMatcher.of(DECIMAL_FIELD.getName(), FieldType.DECIMAL),
+            FieldMatcher.of(DOUBLE_FIELD.getName(), FieldType.DOUBLE),
+            FieldMatcher.of(FLOAT_FIELD.getName(), FieldType.FLOAT),
+            FieldMatcher.of(INT16_FIELD.getName(), FieldType.INT16),
+            FieldMatcher.of(INT32_FIELD.getName(), FieldType.INT32),
+            FieldMatcher.of(INT64_FIELD.getName(), FieldType.INT64),
+            // should not match type:
+            FieldMatcher.of(STRING_FIELD.getName(), FieldType.BYTE)));
+
+    assertFalse(
+        schemaReflection.matchesAll(
+            FieldMatcher.of(BOOLEAN_FIELD.getName(), TypeName.BOOLEAN),
+            FieldMatcher.of(BYTE_FIELD.getName(), TypeName.BYTE),
+            FieldMatcher.of(DATETIME_FIELD.getName(), TypeName.DATETIME),
+            FieldMatcher.of(DECIMAL_FIELD.getName(), TypeName.DECIMAL),
+            FieldMatcher.of(DOUBLE_FIELD.getName(), TypeName.DOUBLE),
+            FieldMatcher.of(FLOAT_FIELD.getName(), TypeName.FLOAT),
+            FieldMatcher.of(INT16_FIELD.getName(), TypeName.INT16),
+            FieldMatcher.of(INT32_FIELD.getName(), TypeName.INT32),
+            FieldMatcher.of(INT64_FIELD.getName(), TypeName.INT64),
+            // should not match TypeName:
+            FieldMatcher.of(STRING_FIELD.getName(), TypeName.INT16)));
+  }
+
+  @Test
+  public void testFieldMatcher_match_NameOnly() {
+    FieldMatcher fieldMatcher = FieldMatcher.of(DEFAULT_PAYLOAD_KEY_NAME);
+    assertTrue(fieldMatcher.match(NON_USER_WITH_ROW_PAYLOAD));
+    assertTrue(fieldMatcher.match(NON_USER_WITH_BYTES_PAYLOAD));
+    assertFalse(fieldMatcher.match(ALL_DATA_TYPES_SCHEMA));
+  }
+
+  @Test
+  public void testFieldMatcher_match_TypeName() {
+    assertTrue(FieldMatcher.of(DEFAULT_PAYLOAD_KEY_NAME, TypeName.ROW).match(NON_USER_WITH_ROW_PAYLOAD));
+    assertTrue(FieldMatcher.of(DEFAULT_PAYLOAD_KEY_NAME, TypeName.BYTES).match(NON_USER_WITH_BYTES_PAYLOAD));
+    assertFalse(FieldMatcher.of(DEFAULT_PAYLOAD_KEY_NAME, TypeName.ROW).match(NON_USER_WITH_BYTES_PAYLOAD));
+    assertFalse(FieldMatcher.of(DEFAULT_PAYLOAD_KEY_NAME, TypeName.BYTES).match(NON_USER_WITH_ROW_PAYLOAD));
+  }
+
+  @Test
+  public void testFieldMatcher_match_FieldType() {
+    assertTrue(FieldMatcher.of(DEFAULT_ATTRIBUTES_KEY_NAME, FieldType.map(FieldType.STRING, FieldType.STRING)).match(NON_USER_WITH_BYTES_PAYLOAD));
+    assertFalse(FieldMatcher.of(DEFAULT_ATTRIBUTES_KEY_NAME, FieldType.map(FieldType.STRING, FieldType.BYTES)).match(NON_USER_WITH_BYTES_PAYLOAD));
+  }
+
+  @Test
+  public void testRemoveFields() {
+    Schema input = Schema.of(STRING_FIELD, BOOLEAN_FIELD, INT64_FIELD);
+    Schema expected = Schema.builder().build();
+    Schema actual = removeFields(input, STRING_FIELD.getName(), BOOLEAN_FIELD.getName(), INT64_FIELD.getName());
+    assertEquals(expected, actual);
+  }
+
+  @Test
+  public void testPubsubRowToMessageParDo_attributesWithoutTimestamp() {
+    Map<String, String> attributes = new HashMap<>();
+    attributes.put("a", "1");
+    attributes.put("b", "2");
+    attributes.put("c", "3");
+
+    Row withAttributes = Row.withSchema(NON_USER_WITH_BYTES_PAYLOAD)
+        .addValues(attributes, Instant.now(), new byte[]{})
+        .build();
+
+    assertEquals(attributes, doFn(NON_USER_WITH_BYTES_PAYLOAD, null).attributesWithoutTimestamp(withAttributes));
+
+    Schema withoutAttributesSchema = removeFields(NON_USER_WITH_BYTES_PAYLOAD, DEFAULT_ATTRIBUTES_KEY_NAME);
+    Row withoutAttributes = Row.withSchema(withoutAttributesSchema)
+        .addValues(Instant.now(), new byte[]{})
+        .build();
+
+    assertEquals(new HashMap<>(), doFn(withoutAttributesSchema, null).attributesWithoutTimestamp(withoutAttributes));
+  }
+
+  @Test
+  public void testPubsubRowToMessageParDo_timestamp() {
+    Instant timestamp = Instant.now();
+    Row withTimestamp = Row.withSchema(NON_USER_WITH_BYTES_PAYLOAD)
+        .addValues(new HashMap<>(), timestamp, new byte[]{})
+        .build();
+    assertEquals(timestamp.toString(), doFn(NON_USER_WITH_BYTES_PAYLOAD, null).timestamp(withTimestamp).toString());
+
+    Schema withoutTimestampSchema = removeFields(NON_USER_WITH_BYTES_PAYLOAD, DEFAULT_EVENT_TIMESTAMP_KEY_NAME);
+    Row withoutTimestamp = Row.withSchema(withoutTimestampSchema)
+        .addValues(new HashMap<>(), new byte[]{})
+        .build();
+    ReadableDateTime actual = doFn(withoutTimestampSchema, null).timestamp(withoutTimestamp);
+    assertNotNull(actual);
+    assertTrue(actual.isAfter(timestamp));
+  }
+
+  @Test
+  public void testPubsubRowToMessageParDo_payload() {
+    PayloadSerializer jsonPayloadSerializer = new JsonPayloadSerializerProvider().getSerializer(ALL_DATA_TYPES_SCHEMA, new HashMap<>());
+    PayloadSerializer avroPayloadSerializer = new JsonPayloadSerializerProvider().getSerializer(ALL_DATA_TYPES_SCHEMA, new HashMap<>());
+
+    byte[] bytes = "abcdefg".getBytes(StandardCharsets.UTF_8);
+    assertArrayEquals(bytes, doFn(NON_USER_WITH_BYTES_PAYLOAD, null).payload(Row.withSchema(NON_USER_WITH_BYTES_PAYLOAD)
+            .addValues(new HashMap<>(), Instant.now(), bytes)
+        .build()));
+
+    Row withoutUserFields = Row.withSchema(NON_USER_WITH_ROW_PAYLOAD)
+        .addValues(
+            new HashMap<>(), Instant.now(),
+            rowWithAllDataTypes(
+                true,
+                (byte) 1,
+                (ReadableDateTime) Instant.now().toDateTime(),
+                BigDecimal.valueOf(100L),
+                1.12345,
+                1.1f,
+                (short) 1,
+                1,
+                1L,
+                "abcdefg"
+            )
+        )
+        .build();
+
+    assertArrayEquals(jsonPayloadSerializer.serialize( withoutUserFields.getRow(DEFAULT_PAYLOAD_KEY_NAME)), doFn(NON_USER_WITH_ROW_PAYLOAD, jsonPayloadSerializer).payload( withoutUserFields));
+    assertArrayEquals(avroPayloadSerializer.serialize( withoutUserFields.getRow(DEFAULT_PAYLOAD_KEY_NAME)), doFn(NON_USER_WITH_ROW_PAYLOAD, avroPayloadSerializer).payload( withoutUserFields));
+  }
+
+  @Test
+  public void testPubsubRowToMessageParDo_serializableRow() {}
+
+  private static PubsubRowToMessageDoFn doFn(Schema schema, PayloadSerializer payloadSerializer) {
+    return new PubsubRowToMessageDoFn(DEFAULT_ATTRIBUTES_KEY_NAME, DEFAULT_EVENT_TIMESTAMP_KEY_NAME, DEFAULT_PAYLOAD_KEY_NAME, errorSchema(schema), DEFAULT_EVENT_TIMESTAMP_KEY_NAME, payloadSerializer);
+  }
+
+  private static Row rowWithAllDataTypes(
+      boolean _boolean,
+      byte _byte,
+      ReadableDateTime datetime,
+      BigDecimal decimal,
+      Double _double,
+      Float _float,
+      Short int16,
+      Integer int32,
+      Long int64,
+      String string
+  ) {
+    return Row.withSchema(ALL_DATA_TYPES_SCHEMA)
+        .addValues(_boolean, _byte, datetime, decimal, _double, _float, int16, int32,
+  int64, string)
+        .build();
+  }
+
+  // private static Row nest(String name, Row row) {
+  //   Field field = Field.of(name, FieldType.row(row.getSchema()));
+  //   return Row.withSchema(Schema.of(field)).addValues(row).build();
+  // }
+  //
+  // private static Schema asArrays(Schema schema) {
+  //   Schema.Builder builder = Schema.builder();
+  //   for (Field field : schema.getFields()) {
+  //     String name = field.getName();
+  //     FieldType fieldType = field.getType();
+  //     builder = builder.addField(Field.of(name, FieldType.array(fieldType)));
+  //   }
+  //   return builder.build();
+  // }
+  //
+  private static Schema merge(Schema a, Schema b) {
+    List<Field> fields = new ArrayList<>(a.getFields());
+    fields.addAll(b.getFields());
+    Schema.Builder builder = Schema.builder();
+    for (Field field : fields) {
+      builder = builder.addField(field);
+    }
+    return builder.build();
+  }
+  //
+  // private static Row merge(Row a, Row b) {
+  //   Schema schema = merge(a.getSchema(), b.getSchema());
+  //   Row.Builder builder = Row.withSchema(schema);
+  //   for (String name : schema.getFieldNames()) {
+  //     builder.addValue(getValue(name, a, b));
+  //   }
+  //   return builder.build();
+  // }
+}


### PR DESCRIPTION
This PR addresses #21412 with a PubsubRowToMessage transform.

## Validation logic

Prior to processing `Row` inputs, it throws errors from `Schema` validation according to the following fields, where in the `Row` input:

`attributes` - refers to the expected `Map<String, String>`
`timestamp` - refers to the expected `ReadableDateTime`
`payload` - refers to either the expected `FieldType.BYTES` or `TypeName.ROW`
`user fields` - refers to any fields that are present in the `Row` input that are not `attributes`, `timestamp`, or `payload` fields
`PayloadSerializer` - refers to the interface responsible for serializing a `Row` to `byte[]`

_NOTE: `...` in the table below indicates that the value in the cell is irrelevant for the case_

| attributes | timestamp | payload | user fields | PayloadSerializer | reason |
| --- | --- | --- | --- | --- | --- |
| not Map<String, String> | ... | ... | ... | ... | attributes are expected to match the same type as a `PubsubMessage` |
| ... | not DATETIME | ... | ... | ... | the timestamp is expected to be derived from the Schema type |
| ... | ... | not BYTES or ROW | ... | ... | we expect no other type but BYTES or ROW |
| ... | ... | exists | exists | ... | providing the payload and user fields is incompatible |
| ... | ... | BYTES | ... | not null | providing a PayloadSerializer in the context of payload BYTES is incompatible |
| ... | ... | ROW | ... | null | PayloadSerializer is required to serialize payload ROW input |
| ... | ... | ... | exist | null | PayloadSerializer is required to serialize a Row with user fields |

## Timestamp logic

The following summarizes the logic when populating the stringified timestamp of the resulting `PubsubMessage`'s attributes, where in the `Row` input:

`attributes` - refers to the expected `Map<String, String>`
`timestamp` - refers to the expected `ReadableDateTime`
`targetTimestampKey` - refers to the optional configuration parameter
`sourceTimestampKey` - refers to the expected timestamp field name of the `Row` input

_NOTE: `...` in the table below indicates that the value in the cell is irrelevant for the case_

| user provided timestamp in attributes | timestamp | targetTimestampKey | result PubsubMessage attributes key | result PubsubMessage attributes value | reason |
| --- | --- | --- | --- | --- | --- |
| exists | ... | ... | sourceTimestampKey | value from Instant.now() | we only use the Row's timestamp field as input |
| ... | exists | ... | sourceTimestampKey | value from Row input | we apply the stringified timestamp value to the PubsubMessage attributes using the sourceTimestampKey as its key |
| ... | ... | exists | targetTimestampKey | ... | we use the configured key instead of the default sourceTimestampKey |
| ... | absent | ... | ... | value from Instant.now() | when Row input lacks the timestamp we generate from Instant.now() |

## Payload logic

The following summarizes the logic when populating the `byte[]` payload to a `PubsubMessage`, where in the `Row` input:

`payload` - refers to either the expected `FieldType.BYTES` or `TypeName.ROW`
`user fields` - refers to any fields that are present in the `Row` input that are not `attributes`, `timestamp`, or `payload` fields

| payload | user fields | PubsubMessage byte[] | reason |
| --- | --- | --- | --- |
| BYTES | absent | raw byte[] value from payload Field | no serialization is needed since the Row input already has the byte[] payload |
| ROW | absent | serialized Row output from payload Field | serialization is applied using the PayloadSerializer |
| absent | present | serialized Row output from user fields | serialization is applied to the Row using the PayloadSerializer resulting from user fields after removing the timestamp and attributes fields |



GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
