### PR TITLE
[Task]: PR Bot will push commits only if they are non-empty

### DIFF
--- a/scripts/ci/pr-bot/shared/persistentState.ts
+++ b/scripts/ci/pr-bot/shared/persistentState.ts
@@ -39,9 +39,7 @@ async function commitStateToRepo() {
       `Unable to get most recent repo contents, commit may fail: ${err}`
     );
   }
-  await exec.exec("git add state/*");
-  await exec.exec(`git commit -m "Updating config from bot" --allow-empty`);
-  await exec.exec("git push origin pr-bot-state");
+  await exec.exec("git diff-index --quiet HEAD || (git add * && git commit -m 'Updating config from' && git push)");
 }
 
 export class PersistentState {

--- a/scripts/ci/pr-bot/shared/persistentState.ts
+++ b/scripts/ci/pr-bot/shared/persistentState.ts
@@ -39,7 +39,7 @@ async function commitStateToRepo() {
       `Unable to get most recent repo contents, commit may fail: ${err}`
     );
   }
-  await exec.exec("git diff-index --quiet HEAD || (git add * && git commit -m 'Updating config from' && git push)");
+  await exec.exec("git diff-index --quiet HEAD || (git add state/* && git commit -m 'Updating config from bot' && git push origin pr-bot-state)");
 }
 
 export class PersistentState {


### PR DESCRIPTION
fixes #23851 

Currently a number of non-empty commits are pushed for the PR bot.

This pr provides for modifying the bot such that it _commits & pushes_  only if there are any changes made.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
