### PR TITLE
[Go] Pipeline Resource Hints

### DIFF
--- a/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/beam_runner_api.proto
+++ b/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/beam_runner_api.proto
@@ -1959,12 +1959,18 @@ message ExecutableStagePayload {
   }
 }
 
+// See https://beam.apache.org/documentation/runtime/resource-hints/ for additional documentation
+// on the behavior of StandardResourceHint.
 message StandardResourceHints {
   enum Enum {
     // Describes hardware accelerators that are desired to have in the execution environment.
+    // Payload: ASCII encoded string with the following format: "type:<type>;count:<n>;<options>" where type
+    // is an accelerator sku, count is the number of accelerators per worker, and options are
+    // related options flags.
     ACCELERATOR = 0 [(beam_urn) = "beam:resources:accelerator:v1"];
     // Describes desired minimal available RAM size in transform's execution environment.
     // SDKs should convert the size to bytes, but can allow users to specify human-friendly units (e.g. GiB).
+    // Payload: ASCII encoded string of the base 10 representation of an integer number of bytes.
     MIN_RAM_BYTES = 1 [(beam_urn) = "beam:resources:min_ram_bytes:v1"];
   }
 }

--- a/sdks/go.mod
+++ b/sdks/go.mod
@@ -29,6 +29,7 @@ require (
 	cloud.google.com/go/pubsub v1.26.0
 	cloud.google.com/go/storage v1.27.0
 	github.com/docker/go-connections v0.4.0
+	github.com/dustin/go-humanize v1.0.0
 	github.com/go-sql-driver/mysql v1.6.0
 	github.com/golang/protobuf v1.5.2 // TODO(danoliveira): Fully replace this with google.golang.org/protobuf
 	github.com/google/go-cmp v0.5.9

--- a/sdks/go.sum
+++ b/sdks/go.sum
@@ -392,6 +392,7 @@ github.com/docker/libtrust v0.0.0-20150114040149-fa567046d9b1/go.mod h1:cyGadeNE
 github.com/docker/spdystream v0.0.0-20160310174837-449fdfce4d96/go.mod h1:Qh8CwZgvJUkLughtfhJv5dyTYa91l1fOUCrgjqmcifM=
 github.com/docopt/docopt-go v0.0.0-20180111231733-ee0de3bc6815/go.mod h1:WwZ+bS3ebgob9U8Nd0kOddGdZWjyMGR8Wziv+TBNwSE=
 github.com/dustin/go-humanize v0.0.0-20171111073723-bb3d318650d4/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
+github.com/dustin/go-humanize v1.0.0 h1:VSnTsYCnlFHaM2/igO1h6X3HA71jcobQuxemgkq4zYo=
 github.com/dustin/go-humanize v1.0.0/go.mod h1:HtrtbFcZ19U5GC7JDqmcUSB87Iq5E25KnS6fMYU6eOk=
 github.com/elazarl/goproxy v0.0.0-20180725130230-947c36da3153/go.mod h1:/Zj4wYkgs4iZTTu3o/KG3Itv/qCCa8VVMlb3i9OVuzc=
 github.com/emicklei/go-restful v0.0.0-20170410110728-ff4f55a20633/go.mod h1:otzb+WCGbkyDHkqmQmT5YD2WR4BBwUdeQoFo8l/7tVs=

--- a/sdks/go/pkg/beam/core/runtime/graphx/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate.go
@@ -31,12 +31,12 @@ import (
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/util/protox"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/internal/errors"
 	pipepb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/pipeline_v1"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/options/resource"
 	"github.com/golang/protobuf/proto"
 	"google.golang.org/protobuf/types/known/durationpb"
 )
 
 // Model constants for interfacing with a Beam runner.
-// TODO(lostluck): 2018/05/28 Extract these from their enum descriptors in the pipeline_v1 proto
 const (
 	URNImpulse       = "beam:transform:impulse:v1"
 	URNParDo         = "beam:transform:pardo:v1"
@@ -137,12 +137,16 @@ func CreateEnvironment(ctx context.Context, urn string, extractEnvironmentConfig
 	}, nil
 }
 
-// TODO(herohde) 11/6/2017: move some of the configuration into the graph during construction.
+// TODO(https://github.com/apache/beam/issues/23893): Along with scoped resource hints,
+// move some of the configuration into the graph during construction.
 
 // Options for marshalling a graph into a model pipeline.
 type Options struct {
 	// Environment used to run the user code.
 	Environment *pipepb.Environment
+
+	// PipelineResourceHints for setting defaults across the whole pipeline.
+	PipelineResourceHints resource.Hints
 }
 
 // Marshal converts a graph to a model pipeline.
@@ -871,11 +875,11 @@ func (m *marshaller) expandCoGBK(edge NamedEdge) (string, error) {
 //
 // In particular, the "backup plan" needs to:
 //
-//  * Encode the windowed element, preserving timestamps.
-//  * Add random keys to the encoded windowed element []bytes
-//  * GroupByKey (in the global window).
-//  * Explode the resulting elements list.
-//  * Decode the windowed element []bytes.
+//   - Encode the windowed element, preserving timestamps.
+//   - Add random keys to the encoded windowed element []bytes
+//   - GroupByKey (in the global window).
+//   - Explode the resulting elements list.
+//   - Decode the windowed element []bytes.
 //
 // While a simple reshard can be written in user terms, (timestamps and windows
 // are accessible to user functions) there are some framework internal
@@ -1122,7 +1126,12 @@ const defaultEnvId = "go"
 
 func (m *marshaller) addDefaultEnv() string {
 	if _, exists := m.environments[defaultEnvId]; !exists {
-		m.environments[defaultEnvId] = m.opt.Environment
+		env := proto.Clone(m.opt.Environment).(*pipepb.Environment)
+		// Add the pipeline level resource hints here for now.
+		// TODO(https://github.com/apache/beam/issues/23893) move to a better place for
+		// scoped hints in next pass, which affect number of environments set by Go pipelines.
+		env.ResourceHints = m.opt.PipelineResourceHints.Payloads()
+		m.environments[defaultEnvId] = env
 	}
 	return defaultEnvId
 }

--- a/sdks/go/pkg/beam/core/runtime/graphx/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate.go
@@ -1127,6 +1127,10 @@ const defaultEnvId = "go"
 func (m *marshaller) addDefaultEnv() string {
 	if _, exists := m.environments[defaultEnvId]; !exists {
 		env := proto.Clone(m.opt.Environment).(*pipepb.Environment)
+		// If there's no environment set, we need to ignore
+		if env == nil {
+			return defaultEnvId
+		}
 		// Add the pipeline level resource hints here for now.
 		// TODO(https://github.com/apache/beam/issues/23893) move to a better place for
 		// scoped hints in next pass, which affect number of environments set by Go pipelines.

--- a/sdks/go/pkg/beam/core/runtime/options.go
+++ b/sdks/go/pkg/beam/core/runtime/options.go
@@ -119,7 +119,7 @@ func (o *Options) Export() RawOptions {
 }
 
 // LoadOptionsFromFlags adds any flags not defined in excludeFlags to the options.
-// If the key is already defnined, it ignores that flag
+// If the key is already defined, it ignores that flag.
 func (o *Options) LoadOptionsFromFlags(excludeFlags map[string]bool) {
 	o.mu.Lock()
 	defer o.mu.Unlock()

--- a/sdks/go/pkg/beam/options/jobopts/options.go
+++ b/sdks/go/pkg/beam/options/jobopts/options.go
@@ -49,7 +49,7 @@ func init() {
 	flag.Var(&ResourceHints,
 		"resource_hints",
 		"Set whole pipeline level resource hints, accepting values of the format '<urn>=<value>'. "+
-			"Supports 'min_ram' and 'accelerator' hints. "+
+			"eg.'min_ram=12GB', 'beam:resources:accelerator:v1='runner_specific' "+
 			"In case of duplicate hint URNs, the last value specified will be used. "+
 			"See https://beam.apache.org/documentation/runtime/resource-hints/ for more information.")
 }
@@ -191,9 +191,9 @@ func GetPipelineResourceHints() resource.Hints {
 		}
 		var h resource.Hint
 		switch name {
-		case "min_ram":
+		case "min_ram", "beam:resources:min_ram_bytes:v1":
 			h = resource.ParseMinRam(val)
-		case "accelerator":
+		case "accelerator", "beam:resources:accelerator:v1":
 			h = resource.Accelerator(val)
 		default:
 			if strings.HasPrefix(name, "beam:resources:") {
@@ -222,6 +222,6 @@ func (h stringHint) Payload() []byte {
 	return []byte(h.value)
 }
 
-func (h stringHint) MergeWith(outer resource.Hint) resource.Hint {
+func (h stringHint) MergeWithOuter(outer resource.Hint) resource.Hint {
 	return h
 }

--- a/sdks/go/pkg/beam/options/jobopts/options.go
+++ b/sdks/go/pkg/beam/options/jobopts/options.go
@@ -30,6 +30,7 @@ import (
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/internal/errors"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/log"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/options/resource"
 )
 
 func init() {
@@ -45,6 +46,12 @@ func init() {
 			"have no more than 1 override applied to it. If multiple "+
 			"overrides match a container image it is arbitrary which "+
 			"will be applied.")
+	flag.Var(&ResourceHints,
+		"resource_hints",
+		"Set whole pipeline level resource hints, accepting values of the format '<urn>=<value>'. "+
+			"Supports 'min_ram' and 'accelerator' hints. "+
+			"In case of duplicate hint URNs, the last value specified will be used. "+
+			"See https://beam.apache.org/documentation/runtime/resource-hints/ for more information.")
 }
 
 var (
@@ -92,6 +99,9 @@ var (
 
 	// Flag to set the degree of parallelism. If not set, the configured Flink default is used, or 1 if none can be found.
 	Parallelism = flag.Int("parallelism", -1, "The degree of parallelism to be used when distributing operations onto Flink workers.")
+
+	// ResourceHints flag takes whole pipeline hints for resources.
+	ResourceHints stringSlice
 )
 
 type missingFlagError error
@@ -168,4 +178,50 @@ func GetExperiments() []string {
 		return nil
 	}
 	return strings.Split(*Experiments, ",")
+}
+
+// GetPipelineResourceHints parses known standard hints and returns the flag set hints for the pipeline.
+// In case of duplicate hint URNs, the last value specified will be used.
+func GetPipelineResourceHints() resource.Hints {
+	hints := make([]resource.Hint, 0, len(ResourceHints))
+	for _, hint := range ResourceHints {
+		name, val, ok := strings.Cut(hint, "=")
+		if !ok {
+			panic(fmt.Sprintf("unparsable resource hint: %q", hint))
+		}
+		var h resource.Hint
+		switch name {
+		case "min_ram":
+			h = resource.ParseMinRam(val)
+		case "accelerator":
+			h = resource.Accelerator(val)
+		default:
+			if strings.HasPrefix(name, "beam:resources:") {
+				h = stringHint{urn: name, value: val}
+			} else {
+				panic(fmt.Sprintf("unknown resource hint: %v", hint))
+			}
+		}
+		hints = append(hints, h)
+	}
+	return resource.NewHints(hints...)
+}
+
+// stringHint is a backup implementation of hint for new standard hints.
+type stringHint struct {
+	urn, value string
+}
+
+func (h stringHint) URN() string {
+	return h.urn
+}
+
+func (h stringHint) Payload() []byte {
+	// Go strings are utf8, and if the string is ascii,
+	// byte conversion handles that directly.
+	return []byte(h.value)
+}
+
+func (h stringHint) MergeWith(outer resource.Hint) resource.Hint {
+	return h
 }

--- a/sdks/go/pkg/beam/options/jobopts/options_test.go
+++ b/sdks/go/pkg/beam/options/jobopts/options_test.go
@@ -69,32 +69,41 @@ func TestGetJobName(t *testing.T) {
 	}
 }
 
+// Also tests IsLoopback because it uses the same flag.
 func TestGetEnvironmentUrn(t *testing.T) {
 	tests := []struct {
-		env string
-		urn string
+		env        string
+		urn        string
+		isLoopback bool
 	}{
 		{
 			"PROCESS",
 			"beam:env:process:v1",
+			false,
 		},
 		{
 			"DOCKER",
 			"beam:env:docker:v1",
+			false,
 		},
 		{
 			"LOOPBACK",
 			"beam:env:external:v1",
+			true,
 		},
 		{
 			"",
 			"beam:env:docker:v1",
+			false,
 		},
 	}
 	for _, test := range tests {
 		EnvironmentType = &test.env
-		if gotUrn := GetEnvironmentUrn(context.Background()); gotUrn != test.urn {
-			t.Errorf("GetEnvironmentUrn(ctx) = %v, want %v", gotUrn, test.urn)
+		if got, want := GetEnvironmentUrn(context.Background()), test.urn; got != want {
+			t.Errorf("GetEnvironmentUrn(%v) = %v, want %v", test.env, got, want)
+		}
+		if got, want := IsLoopback(), test.isLoopback; got != want {
+			t.Errorf("IsLoopback(%v) = %v, want %v", test.env, got, want)
 		}
 	}
 }
@@ -145,5 +154,16 @@ func TestGetPipelineResourceHints(t *testing.T) {
 	})
 	if got := GetPipelineResourceHints(); !got.Equal(want) {
 		t.Errorf("GetPipelineResourceHints() = %v, want %v", got, want)
+	}
+}
+
+func TestGetExperiements(t *testing.T) {
+	*Experiments = ""
+	if got, want := GetExperiments(), []string(nil); !reflect.DeepEqual(got, want) {
+		t.Errorf("GetExperiments(\"\") = %v, want %v", got, want)
+	}
+	*Experiments = "better,faster,stronger"
+	if got, want := GetExperiments(), []string{"better", "faster", "stronger"}; !reflect.DeepEqual(got, want) {
+		t.Errorf("GetExperiments(\"\") = %v, want %v", got, want)
 	}
 }

--- a/sdks/go/pkg/beam/options/jobopts/options_test.go
+++ b/sdks/go/pkg/beam/options/jobopts/options_test.go
@@ -69,7 +69,7 @@ func TestGetJobName(t *testing.T) {
 	}
 }
 
-func TestGetEnvironamentUrn(t *testing.T) {
+func TestGetEnvironmentUrn(t *testing.T) {
 	tests := []struct {
 		env string
 		urn string

--- a/sdks/go/pkg/beam/options/jobopts/options_test.go
+++ b/sdks/go/pkg/beam/options/jobopts/options_test.go
@@ -143,6 +143,8 @@ func TestGetSdkImageOverrides(t *testing.T) {
 func TestGetPipelineResourceHints(t *testing.T) {
 	var hints stringSlice
 	hints.Set("min_ram=2GB")
+	hints.Set("beam:resources:min_ram_bytes:v1=16GB")
+	hints.Set("beam:resources:accelerator:v1=cheetah")
 	hints.Set("accelerator=pedal_to_the_metal")
 	hints.Set("beam:resources:novel_execution:v1=jaguar")
 	hints.Set("min_ram=1GB")

--- a/sdks/go/pkg/beam/options/jobopts/options_test.go
+++ b/sdks/go/pkg/beam/options/jobopts/options_test.go
@@ -22,6 +22,7 @@ import (
 	"testing"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/options/resource"
 )
 
 func TestGetEndpoint(t *testing.T) {
@@ -127,5 +128,22 @@ func TestGetSdkImageOverrides(t *testing.T) {
 	want := map[string]string{".*beam_go_sdk.*": "apache/beam_go_sdk:testing"}
 	if got := GetSdkImageOverrides(); reflect.DeepEqual(got, want) {
 		t.Errorf("GetSdkImageOverrides() = %v, want %v", got, want)
+	}
+}
+
+func TestGetPipelineResourceHints(t *testing.T) {
+	var hints stringSlice
+	hints.Set("min_ram=2GB")
+	hints.Set("accelerator=pedal_to_the_metal")
+	hints.Set("beam:resources:novel_execution:v1=jaguar")
+	hints.Set("min_ram=1GB")
+	ResourceHints = hints
+
+	want := resource.NewHints(resource.ParseMinRam("1GB"), resource.Accelerator("pedal_to_the_metal"), stringHint{
+		urn:   "beam:resources:novel_execution:v1",
+		value: "jaguar",
+	})
+	if got := GetPipelineResourceHints(); !got.Equal(want) {
+		t.Errorf("GetPipelineResourceHints() = %v, want %v", got, want)
 	}
 }

--- a/sdks/go/pkg/beam/options/jobopts/stringSlice.go
+++ b/sdks/go/pkg/beam/options/jobopts/stringSlice.go
@@ -24,10 +24,12 @@ import (
 // of the flag.
 //
 // Example:
-//    var myFlags stringSlice
-//    flag.Var(&myFlags, "my_flag", "A list of flags")
+//
+//	var myFlags stringSlice
+//	flag.Var(&myFlags, "my_flag", "A list of flags")
+//	$cmd -my_flag foo -my_flag bar
+//
 // With the example above, the slice can be set to contain ["foo", "bar"]:
-//    cmd -my_flag foo -my_flag bar
 type stringSlice []string
 
 // String implements the String method of flag.Value. This outputs the value

--- a/sdks/go/pkg/beam/options/resource/hint.go
+++ b/sdks/go/pkg/beam/options/resource/hint.go
@@ -23,6 +23,8 @@ import (
 	"bytes"
 	"fmt"
 	"strconv"
+
+	"github.com/dustin/go-humanize"
 )
 
 // Hints contains a list of hints for a given scope.
@@ -99,11 +101,23 @@ type Hint interface {
 //
 // See https://beam.apache.org/documentation/runtime/resource-hints/ for more information about
 // resource hints.
-func MinRamBytes(v int64) Hint {
-	if v < 0 {
-		panic(fmt.Sprintf("negative min ram hint: %v", v))
+func MinRamBytes(v uint64) Hint {
+	return minRamHint{value: int64(v)}
+}
+
+// ParseMinRam converts various byte units, including MB, GB, MiB, and GiB into a hint.
+// An invalid byte size format will cause ParseMinRam to panic.
+//
+// Hints are advisory only and runners may not respect them.
+//
+// See https://beam.apache.org/documentation/runtime/resource-hints/ for more information about
+// resource hints.
+func ParseMinRam(v string) Hint {
+	b, err := humanize.ParseBytes(v)
+	if err != nil {
+		panic(fmt.Sprintf("resource.ParseMinRam: unable to parse %q: %v", v, err))
 	}
-	return minRamHint{value: v}
+	return MinRamBytes(b)
 }
 
 type minRamHint struct {

--- a/sdks/go/pkg/beam/options/resource/hint.go
+++ b/sdks/go/pkg/beam/options/resource/hint.go
@@ -143,6 +143,10 @@ func (h minRamHint) MergeWith(outer Hint) Hint {
 	return h
 }
 
+func (h minRamHint) String() string {
+	return fmt.Sprintf("min_ram=%v", humanize.Bytes(uint64(h.value)))
+}
+
 // Accelerator hints that this scope should be put in a machine with a given accelerator.
 //
 // Hints for accelerators will have formats that are runner specific.
@@ -175,4 +179,8 @@ func (h acceleratorHint) Payload() []byte {
 // MergeWith an outer acceleratorHint by keeping this hint.
 func (h acceleratorHint) MergeWith(outer Hint) Hint {
 	return h
+}
+
+func (h acceleratorHint) String() string {
+	return fmt.Sprintf("accelerator=%v", h.value)
 }

--- a/sdks/go/pkg/beam/options/resource/hint.go
+++ b/sdks/go/pkg/beam/options/resource/hint.go
@@ -76,6 +76,14 @@ func (hs Hints) Equal(other Hints) bool {
 	return true
 }
 
+func (hs Hints) Payloads() map[string][]byte {
+	p := map[string][]byte{}
+	for k, h := range hs.h {
+		p[k] = h.Payload()
+	}
+	return p
+}
+
 // NewHints produces a hints map from a list of hints. If there are multiple hints
 // with the same URN, the last one in the list is used.
 func NewHints(hs ...Hint) Hints {

--- a/sdks/go/pkg/beam/options/resource/hint.go
+++ b/sdks/go/pkg/beam/options/resource/hint.go
@@ -1,0 +1,164 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package resource supports Beam resource hints to specify scoped hints or annotations
+// to pipelines.
+//
+// See https://beam.apache.org/documentation/runtime/resource-hints/ for more information.
+package resource
+
+import (
+	"bytes"
+	"fmt"
+	"strconv"
+)
+
+// NewHints produces a hints map from a list of hints. If there are multiple hints
+// with the same URN, the last one in the list is used.
+func NewHints(hs ...Hint) Hints {
+	hints := Hints{}
+	for _, h := range hs {
+		hints[h.URN()] = h
+	}
+	return hints
+}
+
+// Hints contains a list of hints for a given scope.
+type Hints map[string]Hint
+
+// MergeWithOuter produces a new list of Hints from this Hints, and the Hints from the outer scope.
+func (hs Hints) MergeWithOuter(outer Hints) Hints {
+	if len(outer) == 0 {
+		return hs
+	}
+	if len(hs) == 0 {
+		return outer
+	}
+	merged := Hints{}
+	for k, o := range outer {
+		if h, ok := hs[k]; ok {
+			merged[k] = h.MergeWith(o)
+		} else {
+			merged[k] = o
+		}
+	}
+	// Always include any from the base, not already merged from outer.
+	for k, h := range hs {
+		if _, ok := outer[k]; !ok {
+			merged[k] = h
+		}
+	}
+	return merged
+}
+
+// Equal checks if two sets of hints are identical. A hint is identical to another if their payloads
+// are the same for a given URN.
+func (hs Hints) Equal(other Hints) bool {
+	if len(hs) != len(other) {
+		return false
+	}
+	for k, h := range hs {
+		o, ok := other[k]
+		if !ok {
+			return false
+		}
+		hp := h.Payload()
+		op := o.Payload()
+		if !bytes.Equal(hp, op) {
+			return false
+		}
+	}
+
+	return true
+}
+
+type Hint interface {
+	// URN returns the name for this hint.
+	URN() string
+	// Payload returns the serialized version of this payload.
+	Payload() []byte
+	// MergeWith an outer scope hint.
+	MergeWith(outer Hint) Hint
+}
+
+// MinRamBytes hints that this scope should be put in a machine with at least this many bytes of memory.
+//
+// Hints are advisory only and runners may not respect them.
+//
+// See https://beam.apache.org/documentation/runtime/resource-hints/ for more information about
+// resource hints.
+func MinRamBytes(v int64) Hint {
+	if v < 0 {
+		panic(fmt.Sprintf("negative min ram hint: %v", v))
+	}
+	return minRamHint{value: v}
+}
+
+type minRamHint struct {
+	value int64
+}
+
+func (minRamHint) URN() string {
+	return "beam:resources:min_ram_bytes:v1"
+}
+
+func (a minRamHint) Payload() []byte {
+	// Go strings are utf8, and if the string is ascii,
+	// byte conversion handles that directly.
+	return []byte(strconv.FormatInt(a.value, 10))
+}
+
+// MergeWith an outer minRamHints by keeping the maximum of the two byte amounts.
+func (h minRamHint) MergeWith(outer Hint) Hint {
+	// Intentional runtime panic from type assertion to catch hint merge errors.
+	if outer.(minRamHint).value > h.value {
+		return outer
+	}
+	return h
+}
+
+// Accelerator hints that this scope should be put in a machine with a given accelerator.
+//
+// Hints for accelerators will have formats that are runner specific.
+// For example, the following is valid accelerator syntax for the Dataflow runner:
+//
+//	accelerator="type:<type>;count:<n>;<options>"
+//
+// Hints are advisory only and runners may not respect them.
+//
+// See https://beam.apache.org/documentation/runtime/resource-hints/ for more information about
+// resource hints.
+func Accelerator(v string) Hint {
+	return acceleratorHint{value: v}
+}
+
+type acceleratorHint struct {
+	value string
+}
+
+func (acceleratorHint) URN() string {
+	return "beam:resources:accelerator:v1"
+}
+
+func (h acceleratorHint) Payload() []byte {
+	// Go strings are utf8, and if the string is ascii,
+	// byte conversion handles that directly.
+	return []byte(h.value)
+}
+
+// MergeWith an outer acceleratorHint by keeping this hint.
+func (h acceleratorHint) MergeWith(outer Hint) Hint {
+	return h
+}

--- a/sdks/go/pkg/beam/options/resource/hint_test.go
+++ b/sdks/go/pkg/beam/options/resource/hint_test.go
@@ -77,15 +77,38 @@ func TestMinRamBytesHint_Payload(t *testing.T) {
 	}
 }
 
-func TestMinRamBytes_Panic(t *testing.T) {
-	defer func() {
-		if r := recover(); r == nil {
-			t.Error("expected panic, but didn't get one.")
+func TestParseMinRamHint(t *testing.T) {
+	tests := []struct {
+		value   string
+		payload string
+	}{
+		{"0", "0"},
+		{"2", "2"},
+		{"11", "11"},
+		{"2003", "2003"},
+		{"1.23MB", "1230000"},
+		{"1.23MiB", "1289748"},
+		{"4GB", "4000000000"},
+		{"2GiB", "2147483648"},
+		{"1.4KiB", "1433"},
+	}
+
+	for _, test := range tests {
+		h := ParseMinRam(test.value)
+		if got, want := h.Payload(), []byte(test.payload); !bytes.Equal(got, want) {
+			t.Errorf("%v.Payload() = %v, want %v", h, string(got), string(want))
 		}
-	}()
-	MinRamBytes(-1)
+	}
 }
 
+func TestParseMinRamHint_panic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("want ParseMinRam to panic")
+		}
+	}()
+	ParseMinRam("a bad byte string")
+}
 // We copy the URN from the proto for use as a constant rather than perform a direct look up
 // each time, or increase initialization time. However we do need to validate that they are
 // correct, and match the standard hint urns, so that's done here.

--- a/sdks/go/pkg/beam/options/resource/hint_test.go
+++ b/sdks/go/pkg/beam/options/resource/hint_test.go
@@ -30,7 +30,7 @@ import (
 func TestAcceleratorHint_MergeWith(t *testing.T) {
 	inner := acceleratorHint{value: "inner"}
 	outer := acceleratorHint{value: "outer"}
-	if got, want := inner.MergeWith(outer), inner; got != want {
+	if got, want := inner.MergeWithOuter(outer), inner; got != want {
 		t.Errorf("%v.MergeWith(%v) = %v, want %v", inner, outer, got, want)
 	}
 }
@@ -47,10 +47,10 @@ func TestMinRamBytesHint_MergeWith(t *testing.T) {
 	low := minRamHint{value: 2}
 	high := minRamHint{value: 12e7}
 
-	if got, want := low.MergeWith(high), high; got != want {
+	if got, want := low.MergeWithOuter(high), high; got != want {
 		t.Errorf("%v.MergeWith(%v) = %v, want %v", low, high, got, want)
 	}
-	if got, want := high.MergeWith(low), high; got != want {
+	if got, want := high.MergeWithOuter(low), high; got != want {
 		t.Errorf("%v.MergeWith(%v) = %v, want %v", high, low, got, want)
 	}
 }
@@ -149,7 +149,7 @@ func (customHint) Payload() []byte {
 	return []byte("custom")
 }
 
-func (h customHint) MergeWith(outer Hint) Hint {
+func (h customHint) MergeWithOuter(outer Hint) Hint {
 	return h
 }
 

--- a/sdks/go/pkg/beam/options/resource/hint_test.go
+++ b/sdks/go/pkg/beam/options/resource/hint_test.go
@@ -1,0 +1,223 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package resource
+
+import (
+	"bytes"
+	"fmt"
+	"math"
+	"testing"
+
+	pipepb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/pipeline_v1"
+	"google.golang.org/protobuf/proto"
+	"google.golang.org/protobuf/reflect/protoreflect"
+)
+
+func TestAcceleratorHint_MergeWith(t *testing.T) {
+	inner := acceleratorHint{value: "inner"}
+	outer := acceleratorHint{value: "outer"}
+	if got, want := inner.MergeWith(outer), inner; got != want {
+		t.Errorf("%v.MergeWith(%v) = %v, want %v", inner, outer, got, want)
+	}
+}
+
+func TestAcceleratorHint_Payload(t *testing.T) {
+	want := []byte("want")
+	h := acceleratorHint{value: "want"}
+	if got := h.Payload(); !bytes.Equal(got, want) {
+		t.Errorf("%v.Payload() = %v, want %v", h, got, want)
+	}
+}
+
+func TestMinRamBytesHint_MergeWith(t *testing.T) {
+	low := minRamHint{value: 2}
+	high := minRamHint{value: 12e7}
+
+	if got, want := low.MergeWith(high), high; got != want {
+		t.Errorf("%v.MergeWith(%v) = %v, want %v", low, high, got, want)
+	}
+	if got, want := high.MergeWith(low), high; got != want {
+		t.Errorf("%v.MergeWith(%v) = %v, want %v", high, low, got, want)
+	}
+}
+
+func TestMinRamBytesHint_Payload(t *testing.T) {
+	tests := []struct {
+		value   int64
+		payload string
+	}{
+		{math.MinInt64, "-9223372036854775808"},
+		{-1, "-1"},
+		{0, "0"},
+		{2, "2"},
+		{11, "11"},
+		{2003, "2003"},
+		{1.2e7, "12000000"},
+		{math.MaxInt64, "9223372036854775807"},
+	}
+
+	for _, test := range tests {
+		h := minRamHint{value: test.value}
+		if got, want := h.Payload(), []byte(test.payload); !bytes.Equal(got, want) {
+			t.Errorf("%v.Payload() = %v, want %v", h, got, want)
+		}
+	}
+}
+
+func TestMinRamBytes_Panic(t *testing.T) {
+	defer func() {
+		if r := recover(); r == nil {
+			t.Error("expected panic, but didn't get one.")
+		}
+	}()
+	MinRamBytes(-1)
+}
+
+// We copy the URN from the proto for use as a constant rather than perform a direct look up
+// each time, or increase initialization time. However we do need to validate that they are
+// correct, and match the standard hint urns, so that's done here.
+func TestStandardHintUrns(t *testing.T) {
+	var props = (pipepb.StandardResourceHints_Enum)(0).Descriptor().Values()
+
+	getStandardURN := func(e pipepb.StandardResourceHints_Enum) string {
+		return proto.GetExtension(props.ByNumber(protoreflect.EnumNumber(e)).Options(), pipepb.E_BeamUrn).(string)
+	}
+
+	tests := []struct {
+		h   Hint
+		urn string
+	}{{
+		h:   Accelerator("type:foo;count:bar;optional_option"),
+		urn: getStandardURN(pipepb.StandardResourceHints_ACCELERATOR),
+	}, {
+		h:   MinRamBytes(2e9),
+		urn: getStandardURN(pipepb.StandardResourceHints_MIN_RAM_BYTES),
+	}}
+	for _, test := range tests {
+		if got, want := test.h.URN(), test.urn; got != want {
+			t.Errorf("Checked urn for %T, got %q, want %q", test.h, got, want)
+		}
+	}
+}
+
+type customHint struct {
+}
+
+func (customHint) URN() string {
+	return "top:secret:custom:urn"
+}
+
+func (customHint) Payload() []byte {
+	return []byte("custom")
+}
+
+func (h customHint) MergeWith(outer Hint) Hint {
+	return h
+}
+
+func TestHints_Equal(t *testing.T) {
+	hs := NewHints(MinRamBytes(2e9), Accelerator("type:pants;count1;install-pajamas"))
+
+	if got, want := hs.Equal(hs), true; got != want {
+		t.Errorf("Self equal test: hs.Equal(hs) = %v, want %v", got, want)
+	}
+	eq := NewHints(MinRamBytes(2e9), Accelerator("type:pants;count1;install-pajamas"))
+	if got, want := hs.Equal(eq), true; got != want {
+		t.Errorf("identical equal test: hs.Equal(eq) = %v, want %v", got, want)
+	}
+	neqLenShort := NewHints(MinRamBytes(2e9))
+	if got, want := hs.Equal(neqLenShort), false; got != want {
+		t.Errorf("too short equal test: hs.Equal(neqLenShort) = %v, want %v", got, want)
+	}
+	ch := customHint{}
+	neqLenLong := NewHints(MinRamBytes(2e9), Accelerator("type:pants;count1;install-pajamas"), ch)
+	if got, want := hs.Equal(neqLenLong), false; got != want {
+		t.Errorf("too long equal test: hs.Equal(neqLenLong) = %v, want %v", got, want)
+	}
+	neqSameHintTypes := NewHints(MinRamBytes(2e10), Accelerator("type:pants;count1;install-pajamas"))
+	if got, want := hs.Equal(neqSameHintTypes), false; got != want {
+		t.Errorf("sameHintTypes equal test: hs.Equal(neqLenSameHintTypes) = %v, want %v", got, want)
+	}
+	neqSameHintTypes2 := NewHints(MinRamBytes(2e9), Accelerator("type:pants;count1;install-pajama"))
+	if got, want := hs.Equal(neqSameHintTypes2), false; got != want {
+		t.Errorf("sameHintTypes2 equal test: hs.Equal(neqLenSameHintTypes2) = %v, want %v", got, want)
+	}
+	neqDiffHintTypes2 := NewHints(MinRamBytes(2e9), ch)
+	if got, want := hs.Equal(neqDiffHintTypes2), false; got != want {
+		t.Errorf("diffHintTypes equal test: hs.Equal(neqDiffHintTypes2) = %v, want %v", got, want)
+	}
+}
+
+func TestHints_MergeWithOuter(t *testing.T) {
+
+	lowRam, medRam, highRam := MinRamBytes(2e7), MinRamBytes(2e9), MinRamBytes(2e10)
+
+	pantsAcc := Accelerator("type:pants;count1;install-pajamas")
+	jeansAcc := Accelerator("type:jeans;count1;")
+	custom := customHint{}
+
+	hsA := NewHints(medRam, pantsAcc)
+	hsB := NewHints(highRam, jeansAcc)
+	hsC := NewHints(lowRam, custom)
+
+	tests := []struct {
+		inner, outer, want Hints
+	}{
+		{hsA, hsA, hsA},
+		{hsB, hsB, hsB},
+		{hsC, hsC, hsC},
+		{hsA, hsB, NewHints(highRam, pantsAcc)},
+		{hsB, hsA, NewHints(highRam, jeansAcc)},
+		{hsA, hsC, NewHints(medRam, pantsAcc, custom)},
+		{hsC, hsA, NewHints(medRam, pantsAcc, custom)},
+		{hsB, hsC, NewHints(highRam, jeansAcc, custom)},
+		{hsC, hsB, NewHints(highRam, jeansAcc, custom)},
+	}
+
+	for i, test := range tests {
+		t.Run(fmt.Sprintf("%v", i), func(t *testing.T) {
+			if got, want := test.inner.MergeWithOuter(test.outer), test.want; !got.Equal(want) {
+				t.Errorf("%v.MergeWithOuter(%v) = %v, want %v", test.inner, test.outer, got, want)
+			}
+		})
+	}
+}
+
+func TestHints_NilHints(t *testing.T) {
+	var hs1, hs2 Hints
+
+	hs := NewHints(MinRamBytes(2e9), Accelerator("type:pants;count1;install-pajamas"))
+
+	if got, want := hs1.Equal(hs2), true; got != want {
+		t.Errorf("nils equal test: (nil).Equal(nil) = %v, want %v", got, want)
+	}
+	if got, want := hs.Equal(hs2), false; got != want {
+		t.Errorf("nil equal test: hs.Equal(nil) = %v, want %v", got, want)
+	}
+	if got, want := hs1.Equal(hs), false; got != want {
+		t.Errorf("nil equal test: (nil).Equal(hs) = %v, want %v", got, want)
+	}
+
+	if got, want := hs1.MergeWithOuter(hs2), Hints(nil); !got.Equal(want) {
+		t.Errorf("nils equal test: (nil).Equal(nil) = %v, want %v", got, want)
+	}
+	if got, want := hs.MergeWithOuter(hs2), hs; !got.Equal(want) {
+		t.Errorf("nil equal test: hs.Equal(nil) = %v, want %v", got, want)
+	}
+	if got, want := hs1.MergeWithOuter(hs), hs; !got.Equal(want) {
+		t.Errorf("nil equal test: (nil).Equal(hs) = %v, want %v", got, want)
+	}
+}

--- a/sdks/go/pkg/beam/options/resource/hint_test.go
+++ b/sdks/go/pkg/beam/options/resource/hint_test.go
@@ -222,15 +222,26 @@ func TestHints_MergeWithOuter(t *testing.T) {
 }
 
 func TestHints_Payloads(t *testing.T) {
-	hs := NewHints(MinRamBytes(2e9), Accelerator("type:jeans;count1;"))
+	{
+		hs := NewHints(MinRamBytes(2e9), Accelerator("type:jeans;count1;"))
 
-	got := hs.Payloads()
-	want := map[string][]byte{
-		"beam:resources:min_ram_bytes:v1": []byte("2000000000"),
-		"beam:resources:accelerator:v1":   []byte("type:jeans;count1;"),
+		got := hs.Payloads()
+		want := map[string][]byte{
+			"beam:resources:min_ram_bytes:v1": []byte("2000000000"),
+			"beam:resources:accelerator:v1":   []byte("type:jeans;count1;"),
+		}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("hs.Payloads() = %v, want %v", got, want)
+		}
 	}
-	if !reflect.DeepEqual(got, want) {
-		t.Errorf("hs.Payloads() = %v, want %v", got, want)
+
+	{
+		var emptyHints Hints
+		got := emptyHints.Payloads()
+		want := map[string][]byte{}
+		if !reflect.DeepEqual(got, want) {
+			t.Errorf("emptyHints.Payloads() = %v, want %v", got, want)
+		}
 	}
 }
 

--- a/sdks/go/pkg/beam/options/resource/hint_test.go
+++ b/sdks/go/pkg/beam/options/resource/hint_test.go
@@ -19,6 +19,7 @@ import (
 	"bytes"
 	"fmt"
 	"math"
+	"reflect"
 	"testing"
 
 	pipepb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/pipeline_v1"
@@ -109,6 +110,7 @@ func TestParseMinRamHint_panic(t *testing.T) {
 	}()
 	ParseMinRam("a bad byte string")
 }
+
 // We copy the URN from the proto for use as a constant rather than perform a direct look up
 // each time, or increase initialization time. However we do need to validate that they are
 // correct, and match the standard hint urns, so that's done here.
@@ -216,6 +218,19 @@ func TestHints_MergeWithOuter(t *testing.T) {
 				t.Errorf("%v.MergeWithOuter(%v) = %v, want %v", test.inner, test.outer, got, want)
 			}
 		})
+	}
+}
+
+func TestHints_Payloads(t *testing.T) {
+	hs := NewHints(MinRamBytes(2e9), Accelerator("type:jeans;count1;"))
+
+	got := hs.Payloads()
+	want := map[string][]byte{
+		"beam:resources:min_ram_bytes:v1": []byte("2000000000"),
+		"beam:resources:accelerator:v1":   []byte("type:jeans;count1;"),
+	}
+	if !reflect.DeepEqual(got, want) {
+		t.Errorf("hs.Payloads() = %v, want %v", got, want)
 	}
 }
 

--- a/sdks/go/pkg/beam/options/resource/hint_test.go
+++ b/sdks/go/pkg/beam/options/resource/hint_test.go
@@ -211,7 +211,7 @@ func TestHints_NilHints(t *testing.T) {
 		t.Errorf("nil equal test: (nil).Equal(hs) = %v, want %v", got, want)
 	}
 
-	if got, want := hs1.MergeWithOuter(hs2), Hints(nil); !got.Equal(want) {
+	if got, want := hs1.MergeWithOuter(hs2), (Hints{}); !got.Equal(want) {
 		t.Errorf("nils equal test: (nil).Equal(nil) = %v, want %v", got, want)
 	}
 	if got, want := hs.MergeWithOuter(hs2), hs; !got.Equal(want) {

--- a/sdks/go/pkg/beam/runners/dataflow/dataflow.go
+++ b/sdks/go/pkg/beam/runners/dataflow/dataflow.go
@@ -205,7 +205,10 @@ func Execute(ctx context.Context, p *beam.Pipeline) (beam.PipelineResult, error)
 	if err != nil {
 		return nil, errors.WithContext(err, "creating environment for model pipeline")
 	}
-	model, err := graphx.Marshal(edges, &graphx.Options{Environment: environment})
+	model, err := graphx.Marshal(edges, &graphx.Options{
+		Environment:           environment,
+		PipelineResourceHints: jobopts.GetPipelineResourceHints(),
+	})
 	if err != nil {
 		return nil, errors.WithContext(err, "generating model pipeline")
 	}

--- a/sdks/go/pkg/beam/runners/universal/universal.go
+++ b/sdks/go/pkg/beam/runners/universal/universal.go
@@ -85,7 +85,10 @@ func Execute(ctx context.Context, p *beam.Pipeline) (beam.PipelineResult, error)
 	if err != nil {
 		return nil, errors.WithContextf(err, "generating model pipeline")
 	}
-	pipeline, err := graphx.Marshal(edges, &graphx.Options{Environment: environment})
+	pipeline, err := graphx.Marshal(edges, &graphx.Options{
+		Environment:           environment,
+		PipelineResourceHints: jobopts.GetPipelineResourceHints(),
+	})
 	if err != nil {
 		return nil, errors.WithContextf(err, "generating model pipeline")
 	}


### PR DESCRIPTION
Does the v0 pass to add resource hints as mentioned in #23893.  

* Adds resource package to manage hints, while enabling custom hints.
* Adds --resource_hints flag with the same behavior as Beam Java and Python (tolerant of "unknown" hints)
* Sets the hints on the default environment fields.
* Minor improvements to test coverage.
* Document the payload spec for the standard known resource hint urns in the proto.

Validated that runners do respect the hints if desired, by having Dataflow Prime use a higher minimum bound of ram than default.

At this stage a user can use the flag from the command line, or manually set the flag to programatically change the pipeline level hints. However, this doesn't enable custom types that aren't in the "beam:resources:" URN namespace at this time. Once scoped resource hints are added, and multiple Go environments supported, the user will be able to derive custom hints as needed on whatever scoped side mechanism exists.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
