### PR TITLE
Add error reporting for BatchConverter match failure

### DIFF
--- a/sdks/python/apache_beam/typehints/arrow_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/arrow_type_compatibility.py
@@ -303,13 +303,19 @@ class PyarrowBatchConverter(BatchConverter):
     self._arrow_schema = arrow_schema
 
   @staticmethod
-  @BatchConverter.register
   def from_typehints(element_type,
                      batch_type) -> Optional['PyarrowBatchConverter']:
-    if isinstance(element_type, RowTypeConstraint) and batch_type == pa.Table:
-      return PyarrowBatchConverter(element_type)
+    assert batch_type == pa.Table
 
-    return None
+    if not isinstance(element_type, RowTypeConstraint):
+      element_type = RowTypeConstraint.from_user_type(element_type)
+      if element_type is None:
+        raise TypeError(
+            "Element type must be compatible with Beam Schemas "
+            "(https://beam.apache.org/documentation/programming-guide/#schemas) "
+            "for batch type pa.Table.")
+
+    return PyarrowBatchConverter(element_type)
 
   def produce_batch(self, elements):
     arrays = [
@@ -358,13 +364,11 @@ class PyarrowArrayBatchConverter(BatchConverter):
     self._arrow_type = _arrow_type_from_beam_fieldtype(beam_fieldtype)
 
   @staticmethod
-  @BatchConverter.register
   def from_typehints(element_type,
                      batch_type) -> Optional['PyarrowArrayBatchConverter']:
-    if batch_type == pa.Array:
-      return PyarrowArrayBatchConverter(element_type)
+    assert batch_type == pa.Array
 
-    return None
+    return PyarrowArrayBatchConverter(element_type)
 
   def produce_batch(self, elements):
     return pa.array(list(elements), type=self._arrow_type)
@@ -382,3 +386,16 @@ class PyarrowArrayBatchConverter(BatchConverter):
 
   def estimate_byte_size(self, batch: pa.Array):
     return batch.nbytes
+
+
+@BatchConverter.register(name="pyarrow")
+def create_pyarrow_batch_converter(
+    element_type: type, batch_type: type) -> BatchConverter:
+  if batch_type == pa.Table:
+    return PyarrowBatchConverter.from_typehints(
+        element_type=element_type, batch_type=batch_type)
+  elif batch_type == pa.Array:
+    return PyarrowArrayBatchConverter.from_typehints(
+        element_type=element_type, batch_type=batch_type)
+
+  raise TypeError("batch type must be pa.Table or pa.Array")

--- a/sdks/python/apache_beam/typehints/arrow_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/arrow_type_compatibility.py
@@ -311,8 +311,8 @@ class PyarrowBatchConverter(BatchConverter):
       element_type = RowTypeConstraint.from_user_type(element_type)
       if element_type is None:
         raise TypeError(
-            "Element type must be compatible with Beam Schemas "
-            "(https://beam.apache.org/documentation/programming-guide/#schemas) "
+            "Element type must be compatible with Beam Schemas ("
+            "https://beam.apache.org/documentation/programming-guide/#schemas) "
             "for batch type pa.Table.")
 
     return PyarrowBatchConverter(element_type)

--- a/sdks/python/apache_beam/typehints/batch.py
+++ b/sdks/python/apache_beam/typehints/batch.py
@@ -197,7 +197,8 @@ class NumpyBatchConverter(BatchConverter):
     if not isinstance(batch_type, NumpyTypeHint.NumpyTypeConstraint):
       if not batch_type == np.ndarray:
         raise TypeError(
-            "batch type must be np.ndarray or beam.typehints.batch.NumpyArray[..]"
+            "batch type must be np.ndarray or "
+            "beam.typehints.batch.NumpyArray[..]"
         )
       batch_type = NumpyArray[element_type.dtype, (N, )]
 

--- a/sdks/python/apache_beam/typehints/batch.py
+++ b/sdks/python/apache_beam/typehints/batch.py
@@ -198,8 +198,7 @@ class NumpyBatchConverter(BatchConverter):
       if not batch_type == np.ndarray:
         raise TypeError(
             "batch type must be np.ndarray or "
-            "beam.typehints.batch.NumpyArray[..]"
-        )
+            "beam.typehints.batch.NumpyArray[..]")
       batch_type = NumpyArray[element_type.dtype, (N, )]
 
     if not batch_type.dtype == element_type.dtype:

--- a/sdks/python/apache_beam/typehints/batch.py
+++ b/sdks/python/apache_beam/typehints/batch.py
@@ -30,6 +30,7 @@ from typing import Callable
 from typing import Generic
 from typing import Iterator
 from typing import List
+from typing import Mapping
 from typing import Optional
 from typing import Sequence
 from typing import TypeVar
@@ -44,7 +45,8 @@ __all__ = ['BatchConverter']
 B = TypeVar('B')
 E = TypeVar('E')
 
-BATCH_CONVERTER_REGISTRY: List[Callable[[type, type], 'BatchConverter']] = []
+BatchConverterConstructor = Callable[[type, type], 'BatchConverter']
+BATCH_CONVERTER_REGISTRY: Mapping[str, BatchConverterConstructor] = {}
 
 __all__ = ['BatchConverter']
 
@@ -72,26 +74,36 @@ class BatchConverter(Generic[B, E]):
     raise NotImplementedError
 
   @staticmethod
-  def register(
-      batch_converter_constructor: Callable[[type, type], 'BatchConverter']):
-    BATCH_CONVERTER_REGISTRY.append(batch_converter_constructor)
-    return batch_converter_constructor
+  def register(*, name: str):
+    def do_registration(
+        batch_converter_constructor: Callable[[type, type], 'BatchConverter']):
+      if name in BATCH_CONVERTER_REGISTRY:
+        raise AssertionError(
+            f"Attempted to register two batch converters with name {name}")
+
+      BATCH_CONVERTER_REGISTRY[name] = batch_converter_constructor
+      return batch_converter_constructor
+
+    return do_registration
 
   @staticmethod
   def from_typehints(*, element_type, batch_type) -> 'BatchConverter':
     element_type = typehints.normalize(element_type)
     batch_type = typehints.normalize(batch_type)
-    for constructor in BATCH_CONVERTER_REGISTRY:
-      result = constructor(element_type, batch_type)
-      if result is not None:
+    errors = {}
+    for name, constructor in BATCH_CONVERTER_REGISTRY.items():
+      try:
+        result = constructor(element_type, batch_type)
+      except TypeError as e:
+        errors[name] = e.args[0]
+      else:
         return result
 
-    # TODO(https://github.com/apache/beam/issues/21654): Aggregate error
-    # information from the failed BatchConverter matches instead of this
-    # generic error.
+    error_summaries = '\n\n'.join(
+        f"{name}:\n\t{msg}" for name, msg in errors.items())
     raise TypeError(
-        f"Unable to find BatchConverter for element_type {element_type!r} and "
-        f"batch_type {batch_type!r}")
+        f"Unable to find BatchConverter for element_type={element_type!r} and "
+        f"batch_type={batch_type!r}. Error summaries:\n\n{error_summaries}")
 
   @property
   def batch_type(self):
@@ -124,13 +136,13 @@ class ListBatchConverter(BatchConverter):
     self.element_coder = coders.registry.get_coder(element_type)
 
   @staticmethod
-  @BatchConverter.register
+  @BatchConverter.register(name="list")
   def from_typehints(element_type, batch_type):
-    if (isinstance(batch_type, typehints.ListConstraint) and
-        batch_type.inner_type == element_type):
-      return ListBatchConverter(batch_type, element_type)
-    else:
-      return None
+    if (not isinstance(batch_type, typehints.ListConstraint) or
+        batch_type.inner_type != element_type):
+      raise TypeError("batch type must be List[T] for element type T")
+
+    return ListBatchConverter(batch_type, element_type)
 
   def produce_batch(self, elements):
     return list(elements)
@@ -173,29 +185,35 @@ class NumpyBatchConverter(BatchConverter):
     self.partition_dimension = partition_dimension
 
   @staticmethod
-  @BatchConverter.register
+  @BatchConverter.register(name="numpy")
   def from_typehints(element_type,
                      batch_type) -> Optional['NumpyBatchConverter']:
     if not isinstance(element_type, NumpyTypeHint.NumpyTypeConstraint):
       try:
         element_type = NumpyArray[element_type, ()]
-      except TypeError:
-        # TODO: Is there a better way to detect if element_type is a dtype?
-        return None
+      except TypeError as e:
+        raise TypeError("Element type is not a dtype") from e
 
     if not isinstance(batch_type, NumpyTypeHint.NumpyTypeConstraint):
       if not batch_type == np.ndarray:
-        # TODO: Include explanation for mismatch?
-        return None
+        raise TypeError(
+            "batch type must be np.ndarray or beam.typehints.batch.NumpyArray[..]"
+        )
       batch_type = NumpyArray[element_type.dtype, (N, )]
 
     if not batch_type.dtype == element_type.dtype:
-      return None
-    batch_shape = list(batch_type.shape)
-    partition_dimension = batch_shape.index(N)
-    batch_shape.pop(partition_dimension)
-    if not tuple(batch_shape) == element_type.shape:
-      return None
+      raise TypeError(
+          "batch type and element type must have equivalent dtypes "
+          f"(batch={batch_type.dtype}, element={element_type.dtype})")
+
+    computed_element_shape = list(batch_type.shape)
+    partition_dimension = computed_element_shape.index(N)
+    computed_element_shape.pop(partition_dimension)
+    if not tuple(computed_element_shape) == element_type.shape:
+      raise TypeError(
+          "Failed to align batch type's batch dimension with element type. "
+          f"(batch type dimensions: {batch_type.shape}, element type "
+          f"dimenstions: {element_type.shape}")
 
     return NumpyBatchConverter(
         batch_type,

--- a/sdks/python/apache_beam/typehints/batch.py
+++ b/sdks/python/apache_beam/typehints/batch.py
@@ -93,11 +93,9 @@ class BatchConverter(Generic[B, E]):
     errors = {}
     for name, constructor in BATCH_CONVERTER_REGISTRY.items():
       try:
-        result = constructor(element_type, batch_type)
+        return constructor(element_type, batch_type)
       except TypeError as e:
         errors[name] = e.args[0]
-      else:
-        return result
 
     error_summaries = '\n\n'.join(
         f"{name}:\n\t{msg}" for name, msg in errors.items())

--- a/sdks/python/apache_beam/typehints/batch_test.py
+++ b/sdks/python/apache_beam/typehints/batch_test.py
@@ -149,6 +149,36 @@ class BatchConverterTest(unittest.TestCase):
     self.assertEqual(hash(self.create_batch_converter()), hash(self.converter))
 
 
+class BatchConverterErrorsTest(unittest.TestCase):
+  @parameterized.expand([
+      (
+          typing.List[int],
+          str,
+          r'batch type must be List\[T\] for element type T',
+      ),
+      (
+          np.ndarray,
+          typing.Any,
+          r'Element type is not a dtype',
+      ),
+      (
+          np.array,
+          np.int64,
+          r'batch type must be np\.ndarray or beam\.typehints\.batch\.NumpyArray\[\.\.\]',
+      ),
+      (
+          NumpyArray[np.int64, (3, N, 2)],
+          NumpyArray[np.int64, (3, 7)],
+          r'Failed to align batch type\'s batch dimension',
+      ),
+  ])
+  def test_construction_errors(
+      self, batch_typehint, element_typehint, error_regex):
+    with self.assertRaisesRegex(TypeError, error_regex):
+      BatchConverter.from_typehints(
+          element_type=element_typehint, batch_type=batch_typehint)
+
+
 @contextlib.contextmanager
 def temp_seed(seed):
   state = random.getstate()

--- a/sdks/python/apache_beam/typehints/batch_test.py
+++ b/sdks/python/apache_beam/typehints/batch_test.py
@@ -164,8 +164,9 @@ class BatchConverterErrorsTest(unittest.TestCase):
       (
           np.array,
           np.int64,
-          (r'batch type must be np\.ndarray or '
-           r'beam\.typehints\.batch\.NumpyArray\[\.\.\]'),
+          (
+              r'batch type must be np\.ndarray or '
+              r'beam\.typehints\.batch\.NumpyArray\[\.\.\]'),
       ),
       (
           NumpyArray[np.int64, (3, N, 2)],

--- a/sdks/python/apache_beam/typehints/batch_test.py
+++ b/sdks/python/apache_beam/typehints/batch_test.py
@@ -164,7 +164,8 @@ class BatchConverterErrorsTest(unittest.TestCase):
       (
           np.array,
           np.int64,
-          r'batch type must be np\.ndarray or beam\.typehints\.batch\.NumpyArray\[\.\.\]',
+          (r'batch type must be np\.ndarray or '
+           r'beam\.typehints\.batch\.NumpyArray\[\.\.\]'),
       ),
       (
           NumpyArray[np.int64, (3, N, 2)],

--- a/sdks/python/apache_beam/typehints/pandas_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/pandas_type_compatibility.py
@@ -136,7 +136,7 @@ def dtype_to_fieldtype(dtype):
     return Any
 
 
-@BatchConverter.register
+@BatchConverter.register(name="pandas")
 def create_pandas_batch_converter(
     element_type: type, batch_type: type) -> BatchConverter:
   if batch_type == pd.DataFrame:
@@ -146,7 +146,7 @@ def create_pandas_batch_converter(
     return SeriesBatchConverter.from_typehints(
         element_type=element_type, batch_type=batch_type)
 
-  return None
+  raise TypeError("batch type must be pd.Series or pd.DataFrame")
 
 
 class DataFrameBatchConverter(BatchConverter):
@@ -160,13 +160,15 @@ class DataFrameBatchConverter(BatchConverter):
   @staticmethod
   def from_typehints(element_type,
                      batch_type) -> Optional['DataFrameBatchConverter']:
-    if not batch_type == pd.DataFrame:
-      return None
+    assert batch_type == pd.DataFrame
 
     if not isinstance(element_type, RowTypeConstraint):
       element_type = RowTypeConstraint.from_user_type(element_type)
       if element_type is None:
-        return None
+        raise TypeError(
+            "Element type must be compatible with Beam Schemas "
+            "(https://beam.apache.org/documentation/programming-guide/#schemas) "
+            "for batch type pd.DataFrame")
 
     index_columns = [
         field_name
@@ -275,8 +277,7 @@ class SeriesBatchConverter(BatchConverter):
   @staticmethod
   def from_typehints(element_type,
                      batch_type) -> Optional['SeriesBatchConverter']:
-    if not batch_type == pd.Series:
-      return None
+    assert batch_type == pd.Series
 
     dtype = dtype_from_typehint(element_type)
 

--- a/sdks/python/apache_beam/typehints/pandas_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/pandas_type_compatibility.py
@@ -166,8 +166,8 @@ class DataFrameBatchConverter(BatchConverter):
       element_type = RowTypeConstraint.from_user_type(element_type)
       if element_type is None:
         raise TypeError(
-            "Element type must be compatible with Beam Schemas "
-            "(https://beam.apache.org/documentation/programming-guide/#schemas) "
+            "Element type must be compatible with Beam Schemas ("
+            "https://beam.apache.org/documentation/programming-guide/#schemas) "
             "for batch type pd.DataFrame")
 
     index_columns = [

--- a/sdks/python/apache_beam/typehints/pytorch_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/pytorch_type_compatibility.py
@@ -42,27 +42,26 @@ class PytorchBatchConverter(BatchConverter):
                      batch_type) -> Optional['PytorchBatchConverter']:
     if not isinstance(element_type, PytorchTypeHint.PytorchTypeConstraint):
       element_type = PytorchTensor[element_type, ()]
-      # TODO: Validate element_type is a pytorch dtype
 
     if not isinstance(batch_type, PytorchTypeHint.PytorchTypeConstraint):
       if not batch_type == torch.Tensor:
         raise TypeError(
-          "batch type must torch.Tensor or "
-          "beam.typehints.pytorch_type_compatibility.PytorchTensor[..]")
+            "batch type must be torch.Tensor or "
+            "beam.typehints.pytorch_type_compatibility.PytorchTensor[..]")
       batch_type = PytorchTensor[element_type.dtype, (N, )]
 
     if not batch_type.dtype == element_type.dtype:
       raise TypeError(
-        "batch type and element type must have equivalent dtypes "
-        f"(batch={batch_type.dtype}, element={element_type.dtype})")
+          "batch type and element type must have equivalent dtypes "
+          f"(batch={batch_type.dtype}, element={element_type.dtype})")
     computed_element_shape = list(batch_type.shape)
     partition_dimension = computed_element_shape.index(N)
     computed_element_shape.pop(partition_dimension)
     if not tuple(computed_element_shape) == element_type.shape:
       raise TypeError(
-        "Could not align batch type's batch dimension with element type. "
-        f"(batch type dimensions: {batch_type.shape}, element type "
-        f"dimenstions: {element_type.shape}")
+          "Could not align batch type's batch dimension with element type. "
+          f"(batch type dimensions: {batch_type.shape}, element type "
+          f"dimenstions: {element_type.shape}")
 
     return PytorchBatchConverter(
         batch_type,

--- a/sdks/python/apache_beam/typehints/pytorch_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/pytorch_type_compatibility.py
@@ -37,29 +37,32 @@ class PytorchBatchConverter(BatchConverter):
     self.partition_dimension = partition_dimension
 
   @staticmethod
-  @BatchConverter.register
+  @BatchConverter.register(name="pytorch")
   def from_typehints(element_type,
                      batch_type) -> Optional['PytorchBatchConverter']:
     if not isinstance(element_type, PytorchTypeHint.PytorchTypeConstraint):
-      try:
-        element_type = PytorchTensor[element_type, ()]
-      except TypeError:
-        # TODO: Is there a better way to detect if element_type is a dtype?
-        return None
+      element_type = PytorchTensor[element_type, ()]
+      # TODO: Validate element_type is a pytorch dtype
 
     if not isinstance(batch_type, PytorchTypeHint.PytorchTypeConstraint):
       if not batch_type == torch.Tensor:
-        # TODO: Include explanation for mismatch?
-        return None
+        raise TypeError(
+          "batch type must torch.Tensor or "
+          "beam.typehints.pytorch_type_compatibility.PytorchTensor[..]")
       batch_type = PytorchTensor[element_type.dtype, (N, )]
 
     if not batch_type.dtype == element_type.dtype:
-      return None
-    batch_shape = list(batch_type.shape)
-    partition_dimension = batch_shape.index(N)
-    batch_shape.pop(partition_dimension)
-    if not tuple(batch_shape) == element_type.shape:
-      return None
+      raise TypeError(
+        "batch type and element type must have equivalent dtypes "
+        f"(batch={batch_type.dtype}, element={element_type.dtype})")
+    computed_element_shape = list(batch_type.shape)
+    partition_dimension = computed_element_shape.index(N)
+    computed_element_shape.pop(partition_dimension)
+    if not tuple(computed_element_shape) == element_type.shape:
+      raise TypeError(
+        "Could not align batch type's batch dimension with element type. "
+        f"(batch type dimensions: {batch_type.shape}, element type "
+        f"dimenstions: {element_type.shape}")
 
     return PytorchBatchConverter(
         batch_type,


### PR DESCRIPTION
Fixes #21654

This PR changes the contract for registered BatchConverter constructors (internal API). Previously a mismatched constructor should return `None` - now it should raise a `TypeError` with an explanation of why it is mismatched. When we fail to match any BatchConverters, an exception is raised that includes a summary of all the mismatch reasons.

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
