### PR TITLE
Add a portable runner that renders pipelines as a dot graph.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,8 @@
 
 ## New Features / Improvements
 
+* Beam now provides a portable "runner" that can render pipeline graphs with
+  graphviz.  See `python -m apache_beam.runners.render --help` for more details.
 * Local packages can now be used as dependencies in the requirements.txt file, rather
   than requiring them to be passed separately via the `--extra_package` option.
   ([#23684](https://github.com/apache/beam/pull/23684))

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -1285,7 +1285,8 @@ class AppliedPTransform(object):
           self.main_inputs, self.side_inputs)
       if not self.parts:
         for name, pc_out in self.outputs.items():
-          if pc_out.producer is not self:
+          if pc_out.producer is not self and pc_out not in named_inputs.values(
+          ):
             named_inputs[f'__implicit_input_{name}'] = pc_out
       return named_inputs
 

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
@@ -247,11 +247,7 @@ class Stage(object):
   def side_inputs(self):
     # type: () -> Iterator[str]
     for transform in self.transforms:
-      if transform.spec.urn in PAR_DO_URNS:
-        payload = proto_utils.parse_Bytes(
-            transform.spec.payload, beam_runner_api_pb2.ParDoPayload)
-        for side_input in payload.side_inputs:
-          yield transform.inputs[side_input]
+      yield from side_inputs(transform).values()
 
   def has_as_main_input(self, pcoll):
     for transform in self.transforms:
@@ -2052,6 +2048,16 @@ def union(a, b):
 
 
 _global_counter = 0
+
+
+def side_inputs(transform):
+  result = {}
+  if transform.spec.urn in PAR_DO_URNS:
+    payload = proto_utils.parse_Bytes(
+        transform.spec.payload, beam_runner_api_pb2.ParDoPayload)
+    for side_input in payload.side_inputs:
+      result[side_input] = transform.inputs[side_input]
+  return result
 
 
 def unique_name(existing, prefix):

--- a/sdks/python/apache_beam/runners/render.py
+++ b/sdks/python/apache_beam/runners/render.py
@@ -1,0 +1,465 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""A portable "runner" that renders a beam graph.
+
+This runner can either render the graph to a (set of) output path(s), as
+designated by (possibly repeated) --render_output, or serve the pipeline as
+an interactive graph, if --render_port is set.
+
+In Python, this runner can be passed directly at pipeline construction, e.g.::
+
+   with beam.Pipeline(runner=beam.runners.render.RenderRunner(), options=...)
+
+For other languages, start this service a by running::
+
+  python -m apache_beam.runners.render --job_port=PORT ...
+
+and then run your pipline with the PortableRunner setting the job endpoint
+to `localhost:PORT`.
+
+If any `--render_output=path.ext` flags are passed, each submitted job will
+get written to the given output (overwriting any previously existing file).
+
+If `--render_port` is set to a non-negative value, a local http server will
+be started which allows for interactive exploration of the pipeline graph.
+
+Requires the that graphviz dot executable be available in the path.
+"""
+
+import argparse
+import base64
+import collections
+import http.server
+import json
+import logging
+import os
+import re
+import subprocess
+import sys
+import tempfile
+import threading
+import time
+import urllib.parse
+
+from apache_beam.options import pipeline_options
+from apache_beam.runners import runner
+from apache_beam.runners.portability import local_job_service
+from apache_beam.runners.portability import local_job_service_main
+from apache_beam.runners.portability import portable_runner
+from apache_beam.runners.portability.fn_api_runner import translations
+
+# From the Beam site, circa November 2022.
+DEFAULT_EDGE_STYLE = 'color="#ff570b"'
+DEFAULT_TRANSFORM_STYLE = 'shape=rect style="rounded" color="#ff570b"'
+DEFAULT_HIGHLIGHT_STYLE = (
+    'shape=rect style="rounded, filled" color="#ff570b" fillcolor="#ffdb97"')
+
+
+class RenderOptions(pipeline_options.PipelineOptions):
+  """Rendering options."""
+  @classmethod
+  def _add_argparse_args(cls, parser):
+    parser.add_argument(
+        '--render_port',
+        type=int,
+        default=-1,
+        help='The port at which to serve the graph. '
+        'If 0, an unused port will be chosen. '
+        'If -1, the server will not be started.')
+    parser.add_argument(
+        '--render_output',
+        action='append',
+        help='A path or paths to which to write rendered output. '
+        'The output type will be deduced from the file extension.')
+    parser.add_argument(
+        '--render_leaf_composite_nodes',
+        action='append',
+        help='A set of regular expressions for transform names that should be '
+        'not be expanded.  For example, one could pass "\bRead.*" to indicate '
+        'the inner structure of read nodes should not be expanded. '
+        'If not give, defaults to the top-level nodes if interactively serving '
+        'the graph and expanding all nodes otherwise.')
+    parser.add_argument(
+        '--render_edge_attributes',
+        default='',
+        help='Graphviz attributes to add to all edges.')
+    parser.add_argument(
+        '--render_node_attributes',
+        default='',
+        help='Graphviz attributes to add to all nodes.')
+    parser.add_argument(
+        '--render_highlight_attributes',
+        default='',
+        help='Graphviz attributes to add to all highlighted nodes.')
+    return parser
+
+
+class PipelineRenderer:
+  def __init__(self, pipeline, options):
+    self.pipeline = pipeline
+    self.options = options
+
+    # Drill down into any uninteresting, top-level transforms that contain
+    # the whole pipeline (often added by the SDK).
+    roots = self.pipeline.root_transform_ids
+    while len(roots) == 1:
+      root = self.pipeline.components.transforms[roots[0]]
+      if not root.subtransforms:
+        break
+      roots = root.subtransforms
+    self.roots = roots
+
+    # Figure out at what point to stop rendering composite internals.
+    if options.render_leaf_composite_nodes:
+      is_leaf = lambda name: any(
+          re.match(pattern, name)
+          for patterns in options.render_leaf_composite_nodes
+          for pattern in pattern.split(','))
+      self.leaf_composites = set()
+
+      def mark_leaves(transform_ids):
+        for transform_id in transform_ids:
+          if is_leaf(transform_id):
+            self.leaf_composites.add(transform_id)
+          else:
+            mark_leaves(
+                self.pipeline.components.transforms[transform_id].subtransforms)
+
+    elif options.render_port >= 0:
+      # Start interactive with no unfolding.
+      self.leaf_composites = set(self.roots)
+    else:
+      # For non-interactive, expand fully.
+      self.leaf_composites = set()
+
+    # Useful for attempting graph layout consistency.
+    self.latest_positions = {}
+    self.highlighted = []
+
+  def update(self, toggle=None):
+    if toggle:
+      transform_id = toggle[0]
+      self.highlighted = [transform_id]
+      if transform_id in self.leaf_composites:
+        transform = self.pipeline.components.transforms[transform_id]
+        if transform.subtransforms:
+          self.leaf_composites.remove(transform_id)
+          for subtransform in transform.subtransforms:
+            self.leaf_composites.add(subtransform)
+            if transform_id in self.latest_positions:
+              self.latest_positions[subtransform] = self.latest_positions[
+                  transform_id]
+      else:
+        self.leaf_composites.add(transform_id)
+
+  def style(self, transform_id):
+    base = ' '.join(
+        [DEFAULT_TRANSFORM_STYLE, self.options.render_node_attributes])
+    if transform_id in self.highlighted:
+      return ' '.join([
+          base,
+          DEFAULT_HIGHLIGHT_STYLE,
+          self.options.render_highlight_attributes
+      ])
+    else:
+      return base
+
+  def to_dot(self):
+    return '\n'.join(self.to_dot_iter())
+
+  def to_dot_iter(self):
+    yield 'digraph G {'
+    # Defer drawing any edges until the end lest we declare nodes too early.
+    edges_out = []
+    for transform_id in self.roots:
+      yield from self.transform_to_dot(
+          transform_id, self.pcoll_leaf_consumers(), edges_out)
+    yield from edges_out
+    yield '}'
+
+  def transform_to_dot(self, transform_id, pcoll_leaf_consumers, edges_out):
+    transform = self.pipeline.components.transforms[transform_id]
+    if self.is_leaf(transform_id):
+      yield self.transform_node(transform_id)
+      transform_inputs = set(transform.inputs.values())
+      for name, output in transform.outputs.items():
+        # For outputs that are also inputs, it's ambiguous whether the are
+        # consumed as the outputs of this transform, or of the upstream
+        # transform. Render the latter.
+        if output in transform_inputs:
+          continue
+        output_label = name if len(transform.outputs) > 1 else ''
+        for consumer, is_side_input in pcoll_leaf_consumers[output]:
+          # Can't yield this here as the consumer might not be in this cluster.
+          edge_style = 'dotted' if is_side_input else 'solid'
+          edge_attributes = ' '.join([
+              f'label="{output_label}" style={edge_style}',
+              DEFAULT_EDGE_STYLE,
+              self.options.render_edge_attributes
+          ])
+          edges_out.append(
+              f'"{transform_id}" -> "{consumer}" [{edge_attributes}]')
+    else:
+      yield f'subgraph "cluster_{transform_id}" {{'
+      yield self.transform_attributes(transform_id)
+      for subtransform in transform.subtransforms:
+        yield from self.transform_to_dot(
+            subtransform, pcoll_leaf_consumers, edges_out)
+      yield '}'
+
+  def transform_node(self, transform_id):
+    return f'"{transform_id}" [{self.transform_attributes(transform_id)}]'
+
+  def transform_attributes(self, transform_id):
+    transform = self.pipeline.components.transforms[transform_id]
+    local_name = transform.unique_name.split('/')[-1]
+    if transform_id in self.latest_positions:
+      pos_str = f'pos="{self.latest_positions[transform_id]}"'
+    else:
+      pos_str = ''
+    return (
+        f'label="{local_name}" {self.style(transform_id)} '
+        f'URL="javascript:click(\'{transform_id}\')" {pos_str}')
+
+  def pcoll_leaf_consumers_iter(self, transform_id):
+    transform = self.pipeline.components.transforms[transform_id]
+    transform_inputs = set(transform.inputs.values())
+    side_inputs = set(translations.side_inputs(transform).values())
+    if self.is_leaf(transform_id):
+      for pcoll in transform.inputs.values():
+        yield pcoll, (transform_id, pcoll in side_inputs)
+    for subtransform in transform.subtransforms:
+      for pcoll, (consumer,
+                  annotation) in self.pcoll_leaf_consumers_iter(subtransform):
+        if self.is_leaf(transform_id):
+          if pcoll not in transform_inputs:
+            yield pcoll, (transform_id, annotation)
+        else:
+          yield pcoll, (consumer, annotation)
+
+  def pcoll_leaf_consumers(self):
+    result = collections.defaultdict(list)
+    for transform_id in self.roots:
+      for pcoll, consumer_info in self.pcoll_leaf_consumers_iter(transform_id):
+        result[pcoll].append(consumer_info)
+    return result
+
+  def is_leaf(self, transform_id):
+    return (
+        transform_id in self.leaf_composites or
+        not self.pipeline.components.transforms[transform_id].subtransforms)
+
+  def info(self):
+    if len(self.highlighted) != 1:
+      return ''
+    transform_id, = self.highlighted
+    return f'<pre>{self.pipeline.components.transforms[transform_id]}</pre>'
+
+  def layout_dot(self):
+    with open('out.dot', 'w') as fout:
+      fout.write(self.to_dot())
+    layout = subprocess.run(['dot', '-Tdot'],
+                            input=self.to_dot().encode('utf-8'),
+                            capture_output=True,
+                            check=True).stdout
+
+    # Try to capture the positions for layout consistency.
+    json_out = json.loads(
+        subprocess.run(['dot', '-n2', '-Kneato', '-Tjson'],
+                       input=layout,
+                       capture_output=True,
+                       check=True).stdout)
+    for box in json_out['objects']:
+      name = box.get('name', None)
+      if box.get('name', None) in self.pipeline.components.transforms:
+        if 'pos' in box:
+          self.latest_positions[name] = box['pos']
+        elif 'bb' in box:
+          x0, y0, x1, y1 = [float(r) for r in box['bb'].split(',')]
+          pos = '{(x0+x1)/2},{(y0+y1)/2}'
+
+    return layout
+
+  def page_callback_data(self, layout):
+    svg = subprocess.run(['dot', '-Kneato', '-n2', '-Tsvg'],
+                         input=layout,
+                         capture_output=True,
+                         check=True).stdout
+    cmapx = subprocess.run(['dot', '-Kneato', '-n2', '-Tcmapx'],
+                           input=layout,
+                           capture_output=True,
+                           check=True).stdout
+
+    return {
+        'src': 'data:image/svg+xml;base64,' +
+        base64.b64encode(svg).decode('utf-8'),
+        'cmapx': cmapx.decode('utf-8'),
+        'info': self.info(),
+    }
+
+  def render_data(self):
+    logging.info("Re-rendering pipeline...")
+    layout = self.layout_dot()
+    if self.options.render_output:
+      for path in self.options.render_output:
+        format = os.path.splitext(path)[-1][1:]
+        result = subprocess.run(
+            ['dot', '-Kneato', '-n2', '-T' + format, '-o', path], input=layout)
+        if result.returncode:
+          logging.error(
+              "Failed render pipeline as %r: exit %s", path, result.returncode)
+        else:
+          logging.info("Rendered pipeline as %r", path)
+    return self.page_callback_data(layout)
+
+  def render_json(self):
+    return json.dumps(self.render_data())
+
+  def page(self):
+    data = self.render_data()
+    src = data['src']
+    cmapx = data['cmapx']
+    return """
+        <html>
+          <head>
+          <script>
+            function click(transform_id) {
+              var xhttp = new XMLHttpRequest();
+              xhttp.onreadystatechange = function() {
+                render_data = JSON.parse(this.responseText);
+                document.getElementById('image_map_holder').innerHTML =
+                    render_data.cmapx;
+                document.getElementById('image_tag').src = render_data.src
+                document.getElementById('info').innerHTML = render_data.info
+              };
+              xhttp.open("GET", "render?toggle=" + transform_id, true);
+              xhttp.send();
+            }
+
+          </script>
+          </head>
+          """ + f"""
+          <body>
+            Click on a composite transform to expand.
+            <br>
+            <img id='image_tag' src='{src}' usemap='#G'>
+            <hr>
+            <div id='info'></div>
+            <div id='image_map_holder'>
+            {cmapx}
+            </div>
+          </body>
+        </html>
+    """
+
+
+class RenderRunner(runner.PipelineRunner):
+  # TODO(robertwb): Consider making this a runner wrapper, where live status
+  # (such as counters, stage completion status, or possibly even PCollection
+  # samples) queryable and/or displayed.  This could evolve into a full Beam
+  # UI.
+  def run_pipeline(self, pipeline_object, options, pipeline_proto=None):
+    if not pipeline_proto:
+      pipeline_proto = pipeline_object.to_runner_api()
+    render_options = options.view_as(RenderOptions)
+    renderer = PipelineRenderer(pipeline_proto, render_options)
+    renderer.page()
+
+    if render_options.render_port >= 0:
+      # TODO: If this gets more complex, we could consider taking on a
+      # framework like Flask as a dependency.
+      class RequestHandler(http.server.BaseHTTPRequestHandler):
+        def do_GET(self):
+          parts = urllib.parse.urlparse(self.path)
+          args = urllib.parse.parse_qs(parts.query)
+          renderer.update(**args)
+
+          if parts.path == '/':
+            response = renderer.page()
+          elif parts.path == '/render':
+            response = renderer.render_json()
+          else:
+            self.send_response(400)
+            return
+
+          self.send_response(200)
+          self.send_header("Content-type", "text/html")
+          self.end_headers()
+          self.wfile.write(response.encode('utf-8'))
+
+      server = http.server.HTTPServer(('localhost', render_options.render_port),
+                                      RequestHandler)
+      server_thread = threading.Thread(target=server.serve_forever, daemon=True)
+      server_thread.start()
+      print('Serving at http://%s:%s' % server.server_address)
+      return RenderPipelineResult(server)
+
+    else:
+      return RenderPipelineResult(None)
+
+
+class RenderPipelineResult(runner.PipelineResult):
+  def __init__(self, server):
+    super().__init__(runner.PipelineState.RUNNING)
+    self.server = server
+
+  def wait_until_finish(self, duration=None):
+    if self.server:
+      time.sleep(duration or 1e8)
+      self.server.shutdown()
+    self._state = runner.PipelineState.DONE
+
+  def monitoring_infos(self):
+    return []
+
+
+def run(argv):
+  if argv[0] == __file__:
+    argv = argv[1:]
+  parser = argparse.ArgumentParser(
+      description=__doc__, formatter_class=argparse.RawDescriptionHelpFormatter)
+  parser.add_argument(
+      '--job_port',
+      type=int,
+      default=0,
+      help='port on which to serve the job api')
+  RenderOptions._add_argparse_args(parser)
+  options = parser.parse_args(argv)
+
+  class RenderBeamJob(local_job_service.BeamJob):
+    def _invoke_runner(self):
+      return RenderRunner().run_pipeline(
+          None,
+          pipeline_options.PipelineOptions(**vars(options)),
+          self._pipeline_proto)
+
+  with tempfile.TemporaryDirectory() as staging_dir:
+    job_servicer = local_job_service.LocalJobServicer(
+        staging_dir, beam_job_type=RenderBeamJob)
+    port = job_servicer.start_grpc_server(options.job_port)
+    try:
+      local_job_service_main.serve(
+          "Listening for beam jobs on port %d." % port, job_servicer)
+    finally:
+      job_servicer.stop()
+
+
+if __name__ == '__main__':
+  logging.basicConfig()
+  logging.getLogger().setLevel(logging.INFO)
+  run(sys.argv)

--- a/sdks/python/apache_beam/runners/render.py
+++ b/sdks/python/apache_beam/runners/render.py
@@ -60,7 +60,7 @@ import time
 import urllib.parse
 
 from google.protobuf import json_format
-from google.protobuf import text_format
+from google.protobuf import text_format  # pylint: disable=attr-defined
 
 from apache_beam.options import pipeline_options
 from apache_beam.portability.api import beam_runner_api_pb2

--- a/sdks/python/apache_beam/runners/render.py
+++ b/sdks/python/apache_beam/runners/render.py
@@ -100,8 +100,8 @@ class RenderOptions(pipeline_options.PipelineOptions):
         help='A set of regular expressions for transform names that should be '
         'not be expanded.  For example, one could pass "\bRead.*" to indicate '
         'the inner structure of read nodes should not be expanded. '
-        'If not give, defaults to the top-level nodes if interactively serving '
-        'the graph and expanding all nodes otherwise.')
+        'If not given, defaults to the top-level nodes if interactively '
+        'serving the graph and expanding all nodes otherwise.')
     parser.add_argument(
         '--render_edge_attributes',
         default='',

--- a/sdks/python/apache_beam/runners/render.py
+++ b/sdks/python/apache_beam/runners/render.py
@@ -452,8 +452,11 @@ def run(argv):
 
   if options.pipeline_proto:
     render_one(options)
-  else:
-    run_server(options)
+
+    if options.render_output:
+        sys.exit()
+
+  run_server(options)
 
 
 def render_one(options):

--- a/sdks/python/apache_beam/runners/render.py
+++ b/sdks/python/apache_beam/runners/render.py
@@ -60,7 +60,7 @@ import time
 import urllib.parse
 
 from google.protobuf import json_format
-from google.protobuf import text_format
+from google.protobuf import text_format  # pylint: disable=attr-defined
 
 from apache_beam.options import pipeline_options
 from apache_beam.portability.api import beam_runner_api_pb2
@@ -72,7 +72,7 @@ from apache_beam.runners.portability.fn_api_runner import translations
 try:
   from apache_beam.io.gcp import gcsio
 except ImportError:
-  gcsio = None
+  gcsio = None  # type: ignore
 
 # From the Beam site, circa November 2022.
 DEFAULT_EDGE_STYLE = 'color="#ff570b"'

--- a/sdks/python/apache_beam/runners/render.py
+++ b/sdks/python/apache_beam/runners/render.py
@@ -483,7 +483,8 @@ def render_one(options):
   elif ext == '.json':
     pipeline_proto = json_format.Parse(content, beam_runner_api_pb2.Pipeline())
   else:
-    pipeline_proto = beam_runner_api_pb2.Pipeline.ParseFromString(content)
+    pipeline_proto = beam_runner_api_pb2.Pipeline()
+    pipeline_proto.ParseFromString(content)
 
   RenderRunner().run_pipeline(
       None,

--- a/sdks/python/apache_beam/runners/render.py
+++ b/sdks/python/apache_beam/runners/render.py
@@ -64,11 +64,15 @@ from google.protobuf import text_format
 
 from apache_beam.options import pipeline_options
 from apache_beam.portability.api import beam_runner_api_pb2
-from apache_beam.io.gcp import gcsio
 from apache_beam.runners import runner
 from apache_beam.runners.portability import local_job_service
 from apache_beam.runners.portability import local_job_service_main
 from apache_beam.runners.portability.fn_api_runner import translations
+
+try:
+  from apache_beam.io.gcp import gcsio
+except ImportError:
+  gcsio = None
 
 # From the Beam site, circa November 2022.
 DEFAULT_EDGE_STYLE = 'color="#ff570b"'
@@ -484,6 +488,8 @@ def render_one(options):
         ext = '.pb'
   else:
     if options.pipeline_proto.startswith('gs://'):
+      if gcsio is None:
+        raise ImportError('GCS not available; please install apache_beam[gcp]')
       open_fn = gcsio.GcsIO().open
     else:
       open_fn = open

--- a/sdks/python/apache_beam/runners/render.py
+++ b/sdks/python/apache_beam/runners/render.py
@@ -303,7 +303,7 @@ class PipelineRenderer:
           self.latest_positions[name] = box['pos']
         elif 'bb' in box:
           x0, y0, x1, y1 = [float(r) for r in box['bb'].split(',')]
-          pos = '{(x0+x1)/2},{(y0+y1)/2}'
+          self.latest_positions[name] = '{(x0+x1)/2},{(y0+y1)/2}'
 
     return layout
 

--- a/sdks/python/apache_beam/runners/render.py
+++ b/sdks/python/apache_beam/runners/render.py
@@ -470,7 +470,7 @@ def run(argv):
     render_one(options)
 
     if options.render_output:
-      sys.exit()
+      return
 
   run_server(options)
 

--- a/sdks/python/apache_beam/runners/render.py
+++ b/sdks/python/apache_beam/runners/render.py
@@ -114,6 +114,11 @@ class RenderOptions(pipeline_options.PipelineOptions):
         '--render_highlight_attributes',
         default='',
         help='Graphviz attributes to add to all highlighted nodes.')
+    parser.add_argument(
+        '--log_proto',
+        default=False,
+        action='store_true',
+        help='Set to also log input pipeline proto to stdout.')
     return parser
 
 
@@ -385,6 +390,8 @@ class RenderRunner(runner.PipelineRunner):
     if not pipeline_proto:
       pipeline_proto = pipeline_object.to_runner_api()
     render_options = options.view_as(RenderOptions)
+    if render_options.log_proto:
+      logging.info(pipeline_proto)
     renderer = PipelineRenderer(pipeline_proto, render_options)
     renderer.page()
 

--- a/sdks/python/apache_beam/runners/render.py
+++ b/sdks/python/apache_beam/runners/render.py
@@ -60,7 +60,7 @@ import time
 import urllib.parse
 
 from google.protobuf import json_format
-from google.protobuf import text_format  # pylint: disable=attr-defined
+from google.protobuf import text_format
 
 from apache_beam.options import pipeline_options
 from apache_beam.portability.api import beam_runner_api_pb2
@@ -68,7 +68,6 @@ from apache_beam.io.gcp import gcsio
 from apache_beam.runners import runner
 from apache_beam.runners.portability import local_job_service
 from apache_beam.runners.portability import local_job_service_main
-from apache_beam.runners.portability import portable_runner
 from apache_beam.runners.portability.fn_api_runner import translations
 
 # From the Beam site, circa November 2022.
@@ -280,7 +279,7 @@ class PipelineRenderer:
   def info(self):
     if len(self.highlighted) != 1:
       return ''
-    transform_id, = self.highlighted
+    transform_id = self.highlighted[0]
     return f'<pre>{self.pipeline.components.transforms[transform_id]}</pre>'
 
   def layout_dot(self):
@@ -332,7 +331,9 @@ class PipelineRenderer:
       for path in self.options.render_output:
         format = os.path.splitext(path)[-1][1:]
         result = subprocess.run(
-            ['dot', '-Kneato', '-n2', '-T' + format, '-o', path], input=layout)
+            ['dot', '-Kneato', '-n2', '-T' + format, '-o', path],
+            input=layout,
+            check=False)
         if result.returncode:
           logging.error(
               "Failed render pipeline as %r: exit %s", path, result.returncode)
@@ -460,12 +461,12 @@ def run(argv):
 
   if options.pipeline_proto:
     if not options.render_output and options.render_port < 0:
-        options.render_port = 0
+      options.render_port = 0
 
     render_one(options)
 
     if options.render_output:
-        sys.exit()
+      sys.exit()
 
   run_server(options)
 
@@ -500,9 +501,7 @@ def render_one(options):
     pipeline_proto.ParseFromString(content)
 
   RenderRunner().run_pipeline(
-      None,
-      pipeline_options.PipelineOptions(**vars(options)),
-      pipeline_proto)
+      None, pipeline_options.PipelineOptions(**vars(options)), pipeline_proto)
 
 
 def run_server(options):

--- a/sdks/python/apache_beam/runners/render.py
+++ b/sdks/python/apache_beam/runners/render.py
@@ -41,7 +41,7 @@ be started which allows for interactive exploration of the pipeline graph.
 As an alternative to starting a job server, a single pipeline can be rendered
 by passing a pipeline proto file to `--pipeline_proto`.
 
-Requires the that graphviz dot executable be available in the path.
+Requires the graphviz dot executable to be available in the path.
 """
 
 import argparse
@@ -100,7 +100,7 @@ class RenderOptions(pipeline_options.PipelineOptions):
     parser.add_argument(
         '--render_leaf_composite_nodes',
         action='append',
-        help='A set of regular expressions for transform names that should be '
+        help='A set of regular expressions for transform names that should '
         'not be expanded.  For example, one could pass "\bRead.*" to indicate '
         'the inner structure of read nodes should not be expanded. '
         'If not given, defaults to the top-level nodes if interactively '
@@ -214,7 +214,7 @@ class PipelineRenderer:
       yield self.transform_node(transform_id)
       transform_inputs = set(transform.inputs.values())
       for name, output in transform.outputs.items():
-        # For outputs that are also inputs, it's ambiguous whether the are
+        # For outputs that are also inputs, it's ambiguous whether they are
         # consumed as the outputs of this transform, or of the upstream
         # transform. Render the latter.
         if output in transform_inputs:
@@ -302,7 +302,7 @@ class PipelineRenderer:
                        check=True).stdout)
     for box in json_out['objects']:
       name = box.get('name', None)
-      if box.get('name', None) in self.pipeline.components.transforms:
+      if name in self.pipeline.components.transforms:
         if 'pos' in box:
           self.latest_positions[name] = box['pos']
         elif 'bb' in box:

--- a/sdks/python/apache_beam/runners/render.py
+++ b/sdks/python/apache_beam/runners/render.py
@@ -64,6 +64,7 @@ from google.protobuf import text_format  # pylint: disable=attr-defined
 
 from apache_beam.options import pipeline_options
 from apache_beam.portability.api import beam_runner_api_pb2
+from apache_beam.io.gcp import gcsio
 from apache_beam.runners import runner
 from apache_beam.runners.portability import local_job_service
 from apache_beam.runners.portability import local_job_service_main
@@ -474,7 +475,12 @@ def render_one(options):
       except UnicodeDecodeError:
         ext = '.pb'
   else:
-    with open(options.pipeline_proto, 'rb') as fin:
+    if options.pipeline_proto.startswith('gs://'):
+      open_fn = gcsio.GcsIO().open
+    else:
+      open_fn = open
+
+    with open_fn(options.pipeline_proto, 'rb') as fin:
       content = fin.read()
     ext = os.path.splitext(options.pipeline_proto)[-1]
 

--- a/sdks/python/apache_beam/runners/render.py
+++ b/sdks/python/apache_beam/runners/render.py
@@ -482,7 +482,7 @@ def render_one(options):
   RenderRunner().run_pipeline(
       None,
       pipeline_options.PipelineOptions(**vars(options)),
-      self._pipeline_proto)
+      pipeline_proto)
 
 
 def run_server(options):

--- a/sdks/python/apache_beam/runners/render.py
+++ b/sdks/python/apache_beam/runners/render.py
@@ -451,6 +451,9 @@ def run(argv):
   options = parser.parse_args(argv)
 
   if options.pipeline_proto:
+    if not options.render_output and options.render_port < 0:
+        options.render_port = 0
+
     render_one(options)
 
     if options.render_output:

--- a/sdks/python/apache_beam/runners/render.py
+++ b/sdks/python/apache_beam/runners/render.py
@@ -149,7 +149,7 @@ class PipelineRenderer:
       is_leaf = lambda name: any(
           re.match(pattern, name)
           for patterns in options.render_leaf_composite_nodes
-          for pattern in pattern.split(','))
+          for pattern in patterns.split(','))
       self.leaf_composites = set()
 
       def mark_leaves(transform_ids):

--- a/sdks/python/apache_beam/runners/render_test.py
+++ b/sdks/python/apache_beam/runners/render_test.py
@@ -1,0 +1,85 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+# pytype: skip-file
+
+import argparse
+import logging
+import subprocess
+import unittest
+
+import apache_beam as beam
+from apache_beam.runners import render
+
+default_options = render.RenderOptions._add_argparse_args(
+    argparse.ArgumentParser()).parse_args([])
+
+
+class RenderRunnerTest(unittest.TestCase):
+  def test_basic_graph(self):
+    p = beam.Pipeline()
+    pcoll = (
+        p | beam.Impulse() | beam.Map(lambda _: 2)
+        | 'CustomName' >> beam.Map(lambda x: x * x))
+    dot = render.PipelineRenderer(p.to_runner_api(), default_options).to_dot()
+    self.assertIn('digraph', dot)
+    self.assertIn('CustomName', dot)
+    self.assertEqual(dot.count('->'), 2)
+
+  def test_side_input(self):
+    p = beam.Pipeline()
+    pcoll = p | beam.Impulse() | beam.FlatMap(lambda x: [1, 2, 3])
+    dot = renderer = render.PipelineRenderer(
+        p.to_runner_api(), default_options).to_dot()
+    self.assertEqual(dot.count('->'), 1)
+    self.assertNotIn('dotted', dot)
+
+    pcoll | beam.Map(lambda x, side: x * side, side=beam.pvalue.AsList(pcoll))
+    dot = renderer = render.PipelineRenderer(
+        p.to_runner_api(), default_options).to_dot()
+    self.assertEqual(dot.count('->'), 3)
+    self.assertIn('dotted', dot)
+
+  def test_composite_collapse(self):
+    p = beam.Pipeline()
+    _ = p | beam.Create([1, 2, 3]) | beam.Map(lambda x: x * x)
+    pipeline_proto = p.to_runner_api()
+    renderer = render.PipelineRenderer(pipeline_proto, default_options)
+    self.assertEqual(renderer.to_dot().count('->'), 8)
+    create_transform_id, = [
+        id
+        for (id, transform) in pipeline_proto.components.transforms.items()
+        if transform.unique_name == 'Create']
+    renderer.update(toggle=[create_transform_id])
+    self.assertEqual(renderer.to_dot().count('->'), 1)
+
+  def test_dot_well_formed(self):
+    try:
+      subprocess.run(['dot', '--version'], capture_output=True)
+    except FileNotFoundError:
+      self.skipTest('dot executable not installed')
+    p = beam.Pipeline()
+    _ = p | beam.Create([1, 2, 3]) | beam.Map(lambda x: x * x)
+    pipeline_proto = p.to_runner_api()
+    renderer = render.PipelineRenderer(pipeline_proto, default_options)
+    # This doesn't actually look at the output, but ensures dot executes correctly.
+    renderer.render_data()
+    create_transform_id, = [
+        id
+        for (id, transform) in pipeline_proto.components.transforms.items()
+        if transform.unique_name == 'Create']
+    renderer.update(toggle=[create_transform_id])
+    renderer.render_data()

--- a/sdks/python/apache_beam/runners/render_test.py
+++ b/sdks/python/apache_beam/runners/render_test.py
@@ -17,6 +17,7 @@
 # pytype: skip-file
 
 import argparse
+import logging
 import subprocess
 import unittest
 
@@ -81,3 +82,8 @@ class RenderRunnerTest(unittest.TestCase):
         if transform.unique_name == 'Create']
     renderer.update(toggle=[create_transform_id])
     renderer.render_data()
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()

--- a/sdks/python/apache_beam/runners/render_test.py
+++ b/sdks/python/apache_beam/runners/render_test.py
@@ -66,7 +66,7 @@ class RenderRunnerTest(unittest.TestCase):
 
   def test_dot_well_formed(self):
     try:
-      subprocess.run(['dot', '--version'], capture_output=True, check=True)
+      subprocess.run(['dot', '-V'], capture_output=True, check=True)
     except FileNotFoundError:
       self.skipTest('dot executable not installed')
     p = beam.Pipeline()

--- a/sdks/python/apache_beam/runners/render_test.py
+++ b/sdks/python/apache_beam/runners/render_test.py
@@ -17,7 +17,6 @@
 # pytype: skip-file
 
 import argparse
-import logging
 import subprocess
 import unittest
 
@@ -31,7 +30,7 @@ default_options = render.RenderOptions._add_argparse_args(
 class RenderRunnerTest(unittest.TestCase):
   def test_basic_graph(self):
     p = beam.Pipeline()
-    pcoll = (
+    _ = (
         p | beam.Impulse() | beam.Map(lambda _: 2)
         | 'CustomName' >> beam.Map(lambda x: x * x))
     dot = render.PipelineRenderer(p.to_runner_api(), default_options).to_dot()
@@ -42,14 +41,13 @@ class RenderRunnerTest(unittest.TestCase):
   def test_side_input(self):
     p = beam.Pipeline()
     pcoll = p | beam.Impulse() | beam.FlatMap(lambda x: [1, 2, 3])
-    dot = renderer = render.PipelineRenderer(
-        p.to_runner_api(), default_options).to_dot()
+    dot = render.PipelineRenderer(p.to_runner_api(), default_options).to_dot()
     self.assertEqual(dot.count('->'), 1)
     self.assertNotIn('dotted', dot)
 
-    pcoll | beam.Map(lambda x, side: x * side, side=beam.pvalue.AsList(pcoll))
-    dot = renderer = render.PipelineRenderer(
-        p.to_runner_api(), default_options).to_dot()
+    _ = pcoll | beam.Map(
+        lambda x, side: x * side, side=beam.pvalue.AsList(pcoll))
+    dot = render.PipelineRenderer(p.to_runner_api(), default_options).to_dot()
     self.assertEqual(dot.count('->'), 3)
     self.assertIn('dotted', dot)
 
@@ -68,14 +66,14 @@ class RenderRunnerTest(unittest.TestCase):
 
   def test_dot_well_formed(self):
     try:
-      subprocess.run(['dot', '--version'], capture_output=True)
+      subprocess.run(['dot', '--version'], capture_output=True, check=True)
     except FileNotFoundError:
       self.skipTest('dot executable not installed')
     p = beam.Pipeline()
     _ = p | beam.Create([1, 2, 3]) | beam.Map(lambda x: x * x)
     pipeline_proto = p.to_runner_api()
     renderer = render.PipelineRenderer(pipeline_proto, default_options)
-    # This doesn't actually look at the output, but ensures dot executes correctly.
+    # Doesn't actually look at the output, but ensures dot executes correctly.
     renderer.render_data()
     create_transform_id, = [
         id

--- a/sdks/python/scripts/run_pylint.sh
+++ b/sdks/python/scripts/run_pylint.sh
@@ -98,6 +98,7 @@ ISORT_EXCLUDED=(
   "taxi.py"
   "process_tfma.py"
   "doctests_test.py"
+  "render_test.py"
 )
 SKIP_PARAM=""
 for file in "${ISORT_EXCLUDED[@]}"; do


### PR DESCRIPTION
This runner can either render the graph to a (set of) output path(s), as
designated by (possibly repeated) --render_output, or serve the pipeline as
an interactive graph, if --render_port is set.

In Python, this runner can be passed directly at pipeline construction, e.g.::

   with beam.Pipeline(runner=beam.runners.render.RenderRunner(), options=...)

For other languages, start this service a by running::

  python -m apache_beam.runners.render --job_port=PORT ...

and then run your pipline with the PortableRunner setting the job endpoint
to `localhost:PORT`.

If any `--render_output=path.ext` flags are passed, each submitted job will
get written to the given output (overwriting any previously existing file).

If `--render_port` is set to a non-negative value, a local http server will
be started which allows for interactive exploration of the pipeline graph.

Requires the that graphviz dot executable be available in the path.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
