### PR TITLE
[Dockerized Jenkins] Fix build of dockerized jenkins (fixes #24053)

### DIFF
--- a/.test-infra/dockerized-jenkins/Dockerfile
+++ b/.test-infra/dockerized-jenkins/Dockerfile
@@ -26,7 +26,7 @@ ENV JENKINS_HOME=/var/jenkins_real_home/
 
 # Pre-install plugins specified in plugins.txt
 COPY --chown=root:jenkins plugins.txt /usr/share/jenkins/ref/plugins.txt
-RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt
+RUN jenkins-plugin-cli -f /usr/share/jenkins/ref/plugins.txt
 
 # Copy default configuration and sample seed job.
 COPY --chown=jenkins basic-security.groovy /usr/share/jenkins/ref/init.groovy.d/


### PR DESCRIPTION
Most recent Jenkins images (`jenkins/jenkins:lts`) do not contain `install-plugins.sh` anymore, causing the build to fail.

```
 > [3/9] RUN /usr/local/bin/install-plugins.sh < /usr/share/jenkins/ref/plugins.txt:
#5 0.195 WARN: install-plugins.sh has been removed, please switch to jenkins-plugin-cli
```

The lastest image I was able to use without changing the Dockerfile is `jenkins/jenkins:2.346.1-lts`


See https://github.com/jenkinsci/docker/blob/master/README.md#usage-1 for how to use `jenkins-plugin-cli`:
```
RUN jenkins-plugin-cli -f /usr/share/jenkins/ref/plugins.txt
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
