### PR TITLE
[Dockerized Jenkins] Update README how to use local repo

### DIFF
--- a/.test-infra/dockerized-jenkins/README.md
+++ b/.test-infra/dockerized-jenkins/README.md
@@ -156,9 +156,13 @@ have to git push every time changes were made.
 1. Build Jenkins image using provided scripts.
 1. Provide an environment variable *BEAM_HOME* pointing to the beam root
    directory, for example: `export BEAM_HOME=~/my/beam/directory`.
-1. Run image using the following command: `docker run -d -p 127.0.0.1:8080:8080
-   -v $BEAM_HOME:/var/jenkins_real_home/beam:ro beamjenkins`. The only difference is
-   the *-v* option which sets up a bind mount.
+1. Run the image using the command below that adds the bind mount option *-v*.
+   Additionally you have to permit doing a local checkout.
+   ```bash
+   docker run -d -p 127.0.0.1:8080:8080 \
+     -e _JAVA_OPTIONS=-Dhudson.plugins.git.GitSCM.ALLOW_LOCAL_CHECKOUT=true \
+     -v $BEAM_HOME:/var/jenkins_real_home/beam:ro beamjenkins
+   ```
 1. Sign in to Jenkins.
     1. Go to the *sample_seed_job* and open its configuration. Scroll down to
        the **Source Code Management** section.


### PR DESCRIPTION
A vulnerability fix prevents using local repos in Jenkins in the most recent versions.

> Command line git and JGit can fetch a repository using a local URL (like file:/my/repo.git) or a path (like /my/repo.git). [SECURITY-2478](https://www.jenkins.io/security/advisory/2022-05-17/#SECURITY-2478) notes that fetching from a local URL or a path creates a security vulnerability on the Jenkins controller. Current releases of the git plugin disallow fetch from a local URL and from a path. If a local URL or a path is required and administrators accept the risk of disabling this security safeguard, the Java property `hudson.plugins.git.GitSCM.ALLOW_LOCAL_CHECKOUT=true` can be set from the command line that starts the Jenkins controller.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
