### PR TITLE
[Go SDK] skip output coder field in expansion request

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/graphx/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate.go
@@ -19,7 +19,6 @@ import (
 	"context"
 	"fmt"
 	"sort"
-	"strings"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/coder"
@@ -685,19 +684,6 @@ func (m *marshaller) expandCrossLanguage(namedEdge NamedEdge) (string, error) {
 		Spec:          spec,
 		Inputs:        inputs,
 		EnvironmentId: m.addDefaultEnv(),
-	}
-
-	// Add the coders for output types in the marshaller even if expanded is nil
-	// to set the output coder request field in expansion request for python external transforms.
-	names := strings.Split(spec.Urn, ":")
-	if len(names) > 2 && names[2] == "python" {
-		for _, out := range edge.Output {
-			cID, err := m.coders.Add(out.To.Coder)
-			if err != nil {
-				return "", errors.Wrapf(err, "failed to add output coder to coder registry: %v", m.coders)
-			}
-			out.To.Coder.ID = cID
-		}
 	}
 
 	if edge.External.Expanded != nil {

--- a/sdks/go/pkg/beam/core/runtime/xlangx/expand.go
+++ b/sdks/go/pkg/beam/core/runtime/xlangx/expand.go
@@ -111,18 +111,12 @@ func expand(
 		ext.ExpansionAddr = config
 	}
 
-	outputCoderID := make(map[string]string)
-	for tag, id := range edge.External.OutputsMap {
-		outputCoderID[tag] = edge.Output[id].To.Coder.ID
-	}
-
 	return h(ctx, &HandlerParams{
 		Config: config,
 		Req: &jobpb.ExpansionRequest{
-			Components:          comps,
-			Transform:           transform,
-			Namespace:           ext.Namespace,
-			OutputCoderRequests: outputCoderID,
+			Components: comps,
+			Transform:  transform,
+			Namespace:  ext.Namespace,
 		},
 		edge: edge,
 		ext:  ext,


### PR DESCRIPTION
Skipping the output coder field since the dataframe wrapper doesn't need it. This should be handled separately when merging RunInference wrapper.

Fixes #24065 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
