### PR TITLE
Add ZstdCoder to wrap coders with Zstandard compression

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -731,7 +731,7 @@ class BeamModulePlugin implements Plugin<Project> {
         vendored_guava_26_0_jre                     : "org.apache.beam:beam-vendor-guava-26_0-jre:0.1",
         vendored_calcite_1_28_0                     : "org.apache.beam:beam-vendor-calcite-1_28_0:0.2",
         woodstox_core_asl                           : "org.codehaus.woodstox:woodstox-core-asl:4.4.1",
-        zstd_jni                                    : "com.github.luben:zstd-jni:1.5.2-1",
+        zstd_jni                                    : "com.github.luben:zstd-jni:1.5.2-5",
         quickcheck_core                             : "com.pholser:junit-quickcheck-core:$quickcheck_version",
         quickcheck_generators                       : "com.pholser:junit-quickcheck-generators:$quickcheck_version",
         arrow_vector                                : "org.apache.arrow:arrow-vector:$arrow_version",

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -986,8 +986,12 @@ class BeamModulePlugin implements Plugin<Project> {
       skipDefRegexes += configuration.classesTriggerCheckerBugs.keySet()
       String skipDefCombinedRegex = skipDefRegexes.collect({ regex -> "(${regex})"}).join("|")
 
+      List<String> skipUsesRegexes = []
+      // zstd-jni is not annotated, handles Zstd(De)CompressCtx.loadDict(null) just fine
+      skipUsesRegexes << "^com\\.github\\.luben\\.zstd\\..*"
       // SLF4J logger handles null log message parameters
-      String skipUsesRegex = "^org\\.slf4j\\.Logger.*"
+      skipUsesRegexes << "^org\\.slf4j\\.Logger.*"
+      String skipUsesCombinedRegex = skipUsesRegexes.collect({ regex -> "(${regex})"}).join("|")
 
       project.apply plugin: 'org.checkerframework'
       project.checkerFramework {
@@ -1010,7 +1014,7 @@ class BeamModulePlugin implements Plugin<Project> {
 
         extraJavacArgs = [
           "-AskipDefs=${skipDefCombinedRegex}",
-          "-AskipUses=${skipUsesRegex}",
+          "-AskipUses=${skipUsesCombinedRegex}",
           "-AsuppressWarnings=annotation.not.completed",
         ]
 

--- a/sdks/java/core/build.gradle
+++ b/sdks/java/core/build.gradle
@@ -95,6 +95,7 @@ dependencies {
   provided library.java.hamcrest
   provided 'io.airlift:aircompressor:0.18'
   provided 'com.facebook.presto.hadoop:hadoop-apache2:3.2.0-1'
+  provided library.java.zstd_jni
   permitUnusedDeclared 'com.facebook.presto.hadoop:hadoop-apache2:3.2.0-1'
   shadowTest library.java.jackson_dataformat_yaml
   shadowTest library.java.guava_testlib

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/ZstdCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/ZstdCoder.java
@@ -74,7 +74,6 @@ public class ZstdCoder<T> extends StructuredCoder<T> {
       ctx.loadDict(dict);
 
       byte[] encoded = CoderUtils.encodeToByteArray(innerCoder, value);
-      ctx.setPledgedSrcSize(encoded.length);
       byte[] compressed = ctx.compress(encoded);
       ByteArrayCoder.of().encode(compressed, os);
     } finally {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/ZstdCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/ZstdCoder.java
@@ -24,6 +24,7 @@ import java.io.IOException;
 import java.io.InputStream;
 import java.io.OutputStream;
 import java.util.List;
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 
@@ -34,7 +35,7 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Immutabl
  */
 public class ZstdCoder<T> extends StructuredCoder<T> {
   private final Coder<T> innerCoder;
-  private final byte[] dict;
+  private final @Nullable byte[] dict;
   private final int level;
 
   /** Wraps the given coder into a {@link ZstdCoder}. */
@@ -57,7 +58,7 @@ public class ZstdCoder<T> extends StructuredCoder<T> {
     return new ZstdCoder<>(innerCoder, null, Zstd.defaultCompressionLevel());
   }
 
-  private ZstdCoder(Coder<T> innerCoder, byte[] dict, int level) {
+  private ZstdCoder(Coder<T> innerCoder, @Nullable byte[] dict, int level) {
     this.innerCoder = innerCoder;
     this.dict = dict;
     this.level = level;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/ZstdCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/ZstdCoder.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.coders;
+
+import com.github.luben.zstd.Zstd;
+import com.github.luben.zstd.ZstdCompressCtx;
+import com.github.luben.zstd.ZstdDecompressCtx;
+import java.io.IOException;
+import java.io.InputStream;
+import java.io.OutputStream;
+import java.util.List;
+import org.apache.beam.sdk.util.CoderUtils;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
+
+/**
+ * Wraps an existing coder with Zstandard compression. It makes sense to use this coder when it's
+ * likely that the encoded value is quite large and compressible or when a dictionary is available
+ * to improve compression performance.
+ */
+public class ZstdCoder<T> extends StructuredCoder<T> {
+  private final Coder<T> innerCoder;
+  private final byte[] dict;
+  private final int level;
+
+  /** Wraps the given coder into a {@link ZstdCoder}. */
+  public static <T> ZstdCoder<T> of(Coder<T> innerCoder, byte[] dict, int level) {
+    return new ZstdCoder<>(innerCoder, dict, level);
+  }
+
+  /** Wraps the given coder into a {@link ZstdCoder}. */
+  public static <T> ZstdCoder<T> of(Coder<T> innerCoder, byte[] dict) {
+    return new ZstdCoder<>(innerCoder, dict, Zstd.defaultCompressionLevel());
+  }
+
+  /** Wraps the given coder into a {@link ZstdCoder}. */
+  public static <T> ZstdCoder<T> of(Coder<T> innerCoder, int level) {
+    return new ZstdCoder<>(innerCoder, null, level);
+  }
+
+  /** Wraps the given coder into a {@link ZstdCoder}. */
+  public static <T> ZstdCoder<T> of(Coder<T> innerCoder) {
+    return new ZstdCoder<>(innerCoder, null, Zstd.defaultCompressionLevel());
+  }
+
+  private ZstdCoder(Coder<T> innerCoder, byte[] dict, int level) {
+    this.innerCoder = innerCoder;
+    this.dict = dict;
+    this.level = level;
+  }
+
+  @Override
+  public void encode(T value, OutputStream os) throws IOException {
+    ZstdCompressCtx ctx = new ZstdCompressCtx();
+    try {
+      ctx.setLevel(level);
+      ctx.setMagicless(true); // No magic since we know this will be compressed data on decode.
+      ctx.setDictID(false); // No dict ID since we initialize the coder with the expected dict.
+      ctx.loadDict(dict);
+
+      byte[] encoded = CoderUtils.encodeToByteArray(innerCoder, value);
+      ctx.setPledgedSrcSize(encoded.length);
+      byte[] compressed = ctx.compress(encoded);
+      ByteArrayCoder.of().encode(compressed, os);
+    } finally {
+      ctx.close();
+    }
+  }
+
+  @Override
+  public T decode(InputStream is) throws IOException {
+    ZstdDecompressCtx ctx = new ZstdDecompressCtx();
+    try {
+      ctx.setMagicless(true);
+      ctx.loadDict(dict);
+
+      byte[] compressed = ByteArrayCoder.of().decode(is);
+      int decompressedSize = (int) Zstd.decompressedSize(compressed, 0, compressed.length, true);
+      byte[] encoded = ctx.decompress(compressed, decompressedSize);
+      return CoderUtils.decodeFromByteArray(innerCoder, encoded);
+    } finally {
+      ctx.close();
+    }
+  }
+
+  @Override
+  public List<? extends Coder<?>> getCoderArguments() {
+    return ImmutableList.of(innerCoder);
+  }
+
+  @Override
+  public void verifyDeterministic() throws NonDeterministicException {
+    innerCoder.verifyDeterministic();
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/ZstdCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/ZstdCoderTest.java
@@ -1,0 +1,137 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.coders;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNotEquals;
+
+import java.util.Arrays;
+import java.util.List;
+import org.apache.beam.sdk.testing.CoderProperties;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
+import org.apache.beam.sdk.values.KV;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Test case for {@link ZstdCoder}. */
+@RunWith(JUnit4.class)
+public class ZstdCoderTest {
+  private static final ZstdCoder<String> TEST_CODER = ZstdCoder.of(StringUtf8Coder.of());
+
+  private static final List<String> TEST_VALUES =
+      Arrays.asList(
+          "",
+          "a",
+          "aaabbbccc",
+          "Hello world!",
+          "I am Groot. I am Groot. I am Groot.",
+          "{\"foo\":32417897,\"bar\":true}",
+          "<html><head></head><body></body></html>");
+
+  @Test
+  public void testDecodeEncodeEquals() throws Exception {
+    for (String value : TEST_VALUES) {
+      CoderProperties.coderDecodeEncodeEqual(TEST_CODER, value);
+    }
+  }
+
+  @Test
+  public void testEncodingNotBuffered() throws Exception {
+    // This test ensures that the coder does not buffer any data from the inner stream.
+    // This is not of much importance today, since the coder relies on direct compression and uses
+    // ByteArrayCoder to encode the resulting byte[], but this may change if the coder switches to
+    // stream based compression in which case the stream must not buffer input from the inner
+    // stream.
+    for (String value : TEST_VALUES) {
+      CoderProperties.coderDecodeEncodeEqual(
+          KvCoder.of(TEST_CODER, StringUtf8Coder.of()), KV.of(value, value));
+    }
+  }
+
+  @Test
+  public void testCoderSerializable() throws Exception {
+    CoderProperties.coderSerializable(TEST_CODER);
+  }
+
+  @Test
+  public void testCoderIsSerializableWithWellKnownCoderType() throws Exception {
+    CoderProperties.coderSerializable(ZstdCoder.of(GlobalWindow.Coder.INSTANCE));
+  }
+
+  @Test
+  public void testCoderEquals() throws Exception {
+    // True if coder, dict and level are equal.
+    assertEquals(
+        ZstdCoder.of(ListCoder.of(StringUtf8Coder.of()), null, 0),
+        ZstdCoder.of(ListCoder.of(StringUtf8Coder.of()), null, 0));
+    assertEquals(
+        ZstdCoder.of(ListCoder.of(ByteArrayCoder.of()), new byte[0], 1),
+        ZstdCoder.of(ListCoder.of(ByteArrayCoder.of()), new byte[0], 1));
+    // False if coder, dict or level differs.
+    assertNotEquals(
+        ZstdCoder.of(ListCoder.of(StringUtf8Coder.of()), null, 0),
+        ZstdCoder.of(ListCoder.of(ByteArrayCoder.of()), null, 0));
+    assertNotEquals(
+        ZstdCoder.of(ListCoder.of(StringUtf8Coder.of()), null, 0),
+        ZstdCoder.of(ListCoder.of(StringUtf8Coder.of()), new byte[0], 0));
+    assertNotEquals(
+        ZstdCoder.of(ListCoder.of(StringUtf8Coder.of()), null, 0),
+        ZstdCoder.of(ListCoder.of(StringUtf8Coder.of()), null, 1));
+    assertNotEquals(
+        ZstdCoder.of(ListCoder.of(StringUtf8Coder.of()), null, 0),
+        ZstdCoder.of(ListCoder.of(ByteArrayCoder.of()), new byte[0], 1));
+  }
+
+  @Test
+  public void testCoderHashCode() throws Exception {
+    // Equal if coder, dict and level are equal.
+    assertEquals(
+        ZstdCoder.of(ListCoder.of(StringUtf8Coder.of()), null, 0).hashCode(),
+        ZstdCoder.of(ListCoder.of(StringUtf8Coder.of()), null, 0).hashCode());
+    assertEquals(
+        ZstdCoder.of(ListCoder.of(ByteArrayCoder.of()), new byte[0], 1).hashCode(),
+        ZstdCoder.of(ListCoder.of(ByteArrayCoder.of()), new byte[0], 1).hashCode());
+    // Not equal if coder, dict or level differs.
+    assertNotEquals(
+        ZstdCoder.of(ListCoder.of(StringUtf8Coder.of()), null, 0).hashCode(),
+        ZstdCoder.of(ListCoder.of(ByteArrayCoder.of()), null, 0).hashCode());
+    assertNotEquals(
+        ZstdCoder.of(ListCoder.of(StringUtf8Coder.of()), null, 0).hashCode(),
+        ZstdCoder.of(ListCoder.of(StringUtf8Coder.of()), new byte[0], 0).hashCode());
+    assertNotEquals(
+        ZstdCoder.of(ListCoder.of(StringUtf8Coder.of()), null, 0).hashCode(),
+        ZstdCoder.of(ListCoder.of(StringUtf8Coder.of()), null, 1).hashCode());
+    assertNotEquals(
+        ZstdCoder.of(ListCoder.of(StringUtf8Coder.of()), null, 0).hashCode(),
+        ZstdCoder.of(ListCoder.of(ByteArrayCoder.of()), new byte[0], 1).hashCode());
+  }
+
+  @Test
+  public void testToString() throws Exception {
+    assertEquals(
+        "ZstdCoder{innerCoder=StringUtf8Coder, dict=null, level=0}",
+        ZstdCoder.of(StringUtf8Coder.of(), null, 0).toString());
+    assertEquals(
+        "ZstdCoder{innerCoder=ByteArrayCoder, dict=base64:, level=1}",
+        ZstdCoder.of(ByteArrayCoder.of(), new byte[0], 1).toString());
+    assertEquals(
+        "ZstdCoder{innerCoder=TextualIntegerCoder, dict=base64:AA==, level=2}",
+        ZstdCoder.of(TextualIntegerCoder.of(), new byte[1], 2).toString());
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CompressedSourceTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/io/CompressedSourceTest.java
@@ -806,7 +806,7 @@ public class CompressedSourceTest {
     byte[] input = generateInput(1000);
     File tmpFile = tmpFolder.newFile("test.zst");
     Files.write(input, tmpFile);
-    thrown.expectMessage("Decompression error: Unknown frame descriptor");
+    thrown.expectMessage("Unknown frame descriptor");
     verifyReadContents(input, tmpFile, Compression.ZSTD);
   }
 


### PR DESCRIPTION
This adds a Zstandard compressing coder, enabling users to modify the compression level (trading off compression ratio for compression speed) and use a custom dictionary to further compress hard to compress data.

I've previously used SnappyCoder to reduce shuffle data volume when writing data to storage using FileIO, which helps reduce overall pipeline cost when running on Dataflow with Streaming Engine enabled. However, Snappy doesn't perform well on workloads which have small encoded payloads per element. Replacing Snappy with Zstandard and a custom dictionary helped me reduce a high volume workload with small elements from 350 bytes per element to 95 bytes per element.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
