### PR TITLE
Remove TheNeuralBit from the pool of Python reviewers

### DIFF
--- a/.github/REVIEWERS.yml
+++ b/.github/REVIEWERS.yml
@@ -29,7 +29,6 @@ labels:
   - name: Python
     reviewers:
       - AnandInguva
-      - TheNeuralBit
       - ryanthompson591
       - tvalentyn
       - pabloem


### PR DESCRIPTION
I am switching teams within Google, and will no longer have the bandwidth to do arbitrary Python reviews :cry: :wave: 
Please do ping me if my attention would be particularly helpful.

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
