### PR TITLE
Fix compatibility with dill 0.3.6.

### DIFF
--- a/sdks/python/apache_beam/internal/dill_pickler.py
+++ b/sdks/python/apache_beam/internal/dill_pickler.py
@@ -70,6 +70,12 @@ if not getattr(dill, '_dill', None):
   dill._dill = dill.dill
   sys.modules['dill._dill'] = dill.dill
 
+dill_log = getattr(dill.dill, 'log', None)
+
+# dill v0.3.6 changed the attribute name from 'log' to 'logger'
+if not dill_log:
+  dill_log = getattr(dill.dill, 'logger')
+
 
 def _is_nested_class(cls):
   """Returns true if argument is a class object that appears to be nested."""
@@ -167,11 +173,11 @@ if 'save_module' in dir(dill.dill):
     if dill.dill.is_dill(pickler) and obj is pickler._main:
       return old_save_module(pickler, obj)
     else:
-      dill.dill.log.info('M2: %s' % obj)
+      dill_log.info('M2: %s' % obj)
       # pylint: disable=protected-access
       pickler.save_reduce(dill.dill._import_module, (obj.__name__, ), obj=obj)
       # pylint: enable=protected-access
-      dill.dill.log.info('# M2')
+      dill_log.info('# M2')
 
   # Pickle module dictionaries (commonly found in lambda's globals)
   # by referencing their module.
@@ -222,7 +228,7 @@ if 'save_module' in dir(dill.dill):
 
     Useful for debugging pickling of deeply nested structures.
     """
-    old_log_info = dill.dill.log.info
+    old_log_info = dill_log.info
 
     def new_log_info(msg, *args, **kwargs):
       old_log_info(
@@ -230,7 +236,7 @@ if 'save_module' in dir(dill.dill):
           *args,
           **kwargs)
 
-    dill.dill.log.info = new_log_info
+    dill_log.info = new_log_info
 
 
 # Turn off verbose logging from the dill pickler.


### PR DESCRIPTION
The "log" attribute changed to "logger". This partially addresses https://github.com/apache/beam/issues/22893.

There is a remaining issue I can see that is a side effect of the bug fix in https://github.com/uqfoundation/dill/issues/482. The tests in `window_test.py` fail with the following error:

```
TypeError: cannot pickle 'EncodedFile' object
```

This seems to be because dill 0.3.6 now is trying to pickle global variables, which includes instances from pytest that cannot be pickled (c.f. https://github.com/uqfoundation/dill/issues/482#issuecomment-1139017499). That comment suggests adding `recurse=True` to the `dumps` call, but I'm hesitant to do this myself because I don't fully understand the consequence.

I need this change ASAP to unblock beam in [nixpkgs](https://github.com/NixOS/nixpkgs) after I updated dill (reported in https://github.com/NixOS/nixpkgs/issues/200985). For context, nixpkgs only packages the latest version of each Python package. I will fetch this patch for now and disable the failing test until a more permanent solution is available.

Please feel free to incorporate this, or feel free to close it in favor of vendoring.

R: @ryanthompson591 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
