### PR TITLE
Make MonotonicWatermarkEstimator work like its Java SDK equivalent

### DIFF
--- a/sdks/python/apache_beam/io/watermark_estimators.py
+++ b/sdks/python/apache_beam/io/watermark_estimators.py
@@ -41,7 +41,8 @@ class MonotonicWatermarkEstimator(WatermarkEstimator):
     self._last_observed_timestamp = timestamp
 
   def current_watermark(self):
-    if self._last_observed_timestamp is not None and self._last_observed_timestamp >= self._watermark:
+    if self._last_observed_timestamp is not None \
+        and self._last_observed_timestamp >= self._watermark:
       self._watermark = self._last_observed_timestamp
     return self._watermark
 

--- a/sdks/python/apache_beam/io/watermark_estimators.py
+++ b/sdks/python/apache_beam/io/watermark_estimators.py
@@ -35,20 +35,14 @@ class MonotonicWatermarkEstimator(WatermarkEstimator):
     watermark.
     """
     self._watermark = timestamp
+    self._last_observed_timestamp = timestamp
 
   def observe_timestamp(self, timestamp):
-    if self._watermark is None:
-      self._watermark = timestamp
-    else:
-      # TODO(https://github.com/apache/beam/issues/20041): Consider making it
-      # configurable to deal with late timestamp.
-      if timestamp < self._watermark:
-        raise ValueError(
-            'A MonotonicWatermarkEstimator expects output '
-            'timestamp to be increasing monotonically.')
-      self._watermark = timestamp
+    self._last_observed_timestamp = timestamp
 
   def current_watermark(self):
+    if self._last_observed_timestamp is not None and self._last_observed_timestamp >= self._watermark:
+      self._watermark = self._last_observed_timestamp
     return self._watermark
 
   def get_estimator_state(self):

--- a/sdks/python/apache_beam/io/watermark_estimators_test.py
+++ b/sdks/python/apache_beam/io/watermark_estimators_test.py
@@ -46,12 +46,16 @@ class MonotonicWatermarkEstimatorTest(unittest.TestCase):
     self.assertEqual(watermark_estimator.current_watermark(), Timestamp(20))
     watermark_estimator.observe_timestamp(Timestamp(20))
     self.assertEqual(watermark_estimator.current_watermark(), Timestamp(20))
-    with self.assertRaises(ValueError):
-      watermark_estimator.observe_timestamp(Timestamp(10))
+    watermark_estimator.observe_timestamp(Timestamp(10))
+    self.assertEqual(watermark_estimator.current_watermark(), Timestamp(20))
 
   def test_get_estimator_state(self):
     watermark_estimator = MonotonicWatermarkEstimator(Timestamp(10))
+    self.assertEqual(watermark_estimator.get_estimator_state(), Timestamp(10))
     watermark_estimator.observe_timestamp(Timestamp(15))
+    # State only progresses when we request a new watermark
+    self.assertEqual(watermark_estimator.get_estimator_state(), Timestamp(10))
+    self.assertEqual(watermark_estimator.current_watermark(), Timestamp(15))
     self.assertEqual(watermark_estimator.get_estimator_state(), Timestamp(15))
 
 


### PR DESCRIPTION
The current implementation of MonotonicWatermarkEstimator raises an exception with late messages, which makes the watermark estimator barely usable in real world scenarios (a late message should not cause a DoFn to raise an exception).

This PR fixes #20041 by making this watermark estimator work like [its Java SDK equivalent (`WatermarkEstimators.MonotonicallyIncreasing`)](https://github.com/apache/beam/blob/243128a8fc52798e1b58b0cf1a271d95ee7aa241/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/splittabledofn/WatermarkEstimators.java#L120-L127).


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
