### PR TITLE
Strip FGAC database role from changestreams metadata requests

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dao/DaoFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/dao/DaoFactory.java
@@ -72,7 +72,7 @@ public class DaoFactory implements Serializable {
     }
     this.changeStreamSpannerConfig = changeStreamSpannerConfig;
     this.changeStreamName = changeStreamName;
-    this.metadataSpannerConfig = metadataSpannerConfig;
+    this.metadataSpannerConfig = metadataSpannerConfig.withDatabaseRole(null);
     this.partitionMetadataTableName = partitionMetadataTableName;
     this.rpcPriority = rpcPriority;
     this.jobName = jobName;


### PR DESCRIPTION
To support fine-grained access control (FGAC) for Spanner Change Streams, we've added a database role to the Spanner config.  When the user sets the database role, Spanner will verify that the role has appropriate permissions to, for example, read the change stream.  Since Spanner Change Streams are split into multiple partitions that are read independently, Beam stores partition read progress information into a metadata database table.  This table is created by the Beam framework and is transparent to the user.  However, the Spanner Config that the user creates is not only used to access the primary database that contains the change stream, but it is also used to access the metadata database.  This is problematic when the user specifies a database role because the role is used to access the metadata table and since it hasn't been granted access to the table, the operation fails with an error like the following:
```
PERMISSION_DENIED: Role test_role does not have required privileges on table CDC_Partitions_Metadata_testdbchangestreams_580294176_5b5541dd_ebd9_4b68_8053_7978b9448a02
```
This commit fixes the problem by stripping the database role from the metadata Spanner Config used to access the metadata tables.
R: @pabloem 
