### PR TITLE
Unify test parameters for certain IOs based on test row and grafana fixes

### DIFF
--- a/.test-infra/jenkins/job_PerformanceTests_CdapIO.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_CdapIO.groovy
@@ -24,7 +24,7 @@ String jobName = "beam_PerformanceTests_Cdap"
 
 job(jobName) {
   common.setTopLevelMainJobProperties(delegate)
-  common.setAutoJob(delegate, 'H H/6 * * *')
+  common.setAutoJob(delegate, 'H H/12 * * *')
   common.enablePhraseTriggeringFromPullRequest(
       delegate,
       'Java CdapIO Performance Test',
@@ -43,7 +43,7 @@ job(jobName) {
     tempRoot             : 'gs://temp-storage-for-perf-tests',
     project              : 'apache-beam-testing',
     runner               : 'DataflowRunner',
-    numberOfRecords      : '600000',
+    numberOfRecords      : '5000000',
     bigQueryDataset      : 'beam_performance',
     bigQueryTable        : 'cdapioit_results',
     influxMeasurement    : 'cdapioit_results',

--- a/.test-infra/jenkins/job_PerformanceTests_HadoopFormat.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_HadoopFormat.groovy
@@ -24,7 +24,7 @@ String jobName = "beam_PerformanceTests_HadoopFormat"
 
 job(jobName) {
   common.setTopLevelMainJobProperties(delegate)
-  common.setAutoJob(delegate, 'H H/6 * * *')
+  common.setAutoJob(delegate, 'H H/12 * * *')
   common.enablePhraseTriggeringFromPullRequest(
       delegate,
       'Java HadoopFormatIO Performance Test',
@@ -43,7 +43,7 @@ job(jobName) {
     tempRoot             : 'gs://temp-storage-for-perf-tests',
     project              : 'apache-beam-testing',
     runner               : 'DataflowRunner',
-    numberOfRecords      : '600000',
+    numberOfRecords      : '5000000',
     bigQueryDataset      : 'beam_performance',
     bigQueryTable        : 'hadoopformatioit_results',
     influxMeasurement    : 'hadoopformatioit_results',

--- a/.test-infra/jenkins/job_PerformanceTests_JDBC.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_JDBC.groovy
@@ -24,7 +24,7 @@ String jobName = "beam_PerformanceTests_JDBC"
 
 job(jobName) {
   common.setTopLevelMainJobProperties(delegate)
-  common.setAutoJob(delegate, 'H H/6 * * *')
+  common.setAutoJob(delegate, 'H H/12 * * *')
   common.enablePhraseTriggeringFromPullRequest(
       delegate,
       'Java JdbcIO Performance Test',

--- a/.test-infra/jenkins/job_PerformanceTests_SparkReceiverIO_IT.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_SparkReceiverIO_IT.groovy
@@ -33,7 +33,7 @@ String jobName = "beam_PerformanceTests_SparkReceiver_IO"
  */
 job(jobName) {
   common.setTopLevelMainJobProperties(delegate, 'master', 120)
-  common.setAutoJob(delegate, 'H H/6 * * *')
+  common.setAutoJob(delegate, 'H H/12 * * *')
   common.enablePhraseTriggeringFromPullRequest(
       delegate,
       'Java SparkReceiverIO Performance Test',
@@ -54,7 +54,7 @@ job(jobName) {
     runner                        : 'DataflowRunner',
     sourceOptions                 : """
                                      {
-                                       "numRecords": "600000",
+                                       "numRecords": "5000000",
                                        "keySizeBytes": "1",
                                        "valueSizeBytes": "90"
                                      }

--- a/.test-infra/metrics/grafana/dashboards/perftests_metrics/Java_IO_IT_Tests_Dataflow.json
+++ b/.test-infra/metrics/grafana/dashboards/perftests_metrics/Java_IO_IT_Tests_Dataflow.json
@@ -1874,7 +1874,7 @@
       },
       "hiddenSeries": false,
       "id": 19,
-      "interval": "6h",
+      "interval": "12h",
       "legend": {
         "avg": false,
         "current": false,
@@ -1997,7 +1997,7 @@
       },
       "hiddenSeries": false,
       "id": 20,
-      "interval": "6h",
+      "interval": "12h",
       "legend": {
         "avg": false,
         "current": false,
@@ -2062,7 +2062,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "HadoopFormatIO | 600k records",
+      "title": "HadoopFormatIO | 5M records",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2612,7 +2612,7 @@
       },
       "hiddenSeries": false,
       "id": 26,
-      "interval": "6h",
+      "interval": "12h",
       "legend": {
         "avg": false,
         "current": false,
@@ -2677,7 +2677,7 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "CdapIO | 600k records",
+      "title": "CdapIO | 5M records",
       "tooltip": {
         "shared": true,
         "sort": 0,
@@ -2735,7 +2735,7 @@
       },
       "hiddenSeries": false,
       "id": 27,
-      "interval": "6h",
+      "interval": "12h",
       "legend": {
         "avg": false,
         "current": false,
@@ -2800,7 +2800,130 @@
       "timeFrom": null,
       "timeRegions": [],
       "timeShift": null,
-      "title": "SparkReceiverIO | 600k Records",
+      "title": "SparkReceiverIO | 5M Records",
+      "tooltip": {
+        "shared": true,
+        "sort": 0,
+        "value_type": "individual"
+      },
+      "transparent": true,
+      "type": "graph",
+      "xaxis": {
+        "buckets": null,
+        "mode": "time",
+        "name": null,
+        "show": true,
+        "values": []
+      },
+      "yaxes": [
+        {
+          "$$hashKey": "object:403",
+          "format": "s",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        },
+        {
+          "$$hashKey": "object:404",
+          "format": "short",
+          "label": null,
+          "logBase": 1,
+          "max": null,
+          "min": null,
+          "show": true
+        }
+      ],
+      "yaxis": {
+        "align": false,
+        "alignLevel": null
+      }
+    },
+    {
+      "aliasColors": {},
+      "bars": false,
+      "cacheTimeout": null,
+      "dashLength": 10,
+      "dashes": false,
+      "datasource": "BeamInfluxDB",
+      "description": "",
+      "fill": 1,
+      "fillGradient": 0,
+      "gridPos": {
+        "h": 9,
+        "w": 12,
+        "x": 12,
+        "y": 106
+      },
+      "hiddenSeries": false,
+      "id": 28,
+      "interval": "6h",
+      "legend": {
+        "avg": false,
+        "current": false,
+        "max": false,
+        "min": false,
+        "show": false,
+        "total": false,
+        "values": false
+      },
+      "lines": true,
+      "linewidth": 2,
+      "links": [],
+      "nullPointMode": "connected",
+      "options": {
+        "dataLinks": []
+      },
+      "percentage": false,
+      "pluginVersion": "6.7.2",
+      "pointradius": 2,
+      "points": true,
+      "renderer": "flot",
+      "seriesOverrides": [],
+      "spaceLength": 10,
+      "stack": false,
+      "steppedLine": false,
+      "targets": [
+        {
+          "alias": "$tag_metric",
+          "groupBy": [
+            {
+              "params": [
+                "$__interval"
+              ],
+              "type": "time"
+            }
+          ],
+          "measurement": "",
+          "orderByTime": "ASC",
+          "policy": "default",
+          "query": "SELECT mean(\"value\") FROM \"singlestoreioit_results\" WHERE \"metric\" =~ /time/ AND $timeFilter GROUP BY time($__interval), \"metric\"",
+          "rawQuery": true,
+          "refId": "A",
+          "resultFormat": "time_series",
+          "select": [
+            [
+              {
+                "params": [
+                  "value"
+                ],
+                "type": "field"
+              },
+              {
+                "params": [],
+                "type": "mean"
+              }
+            ]
+          ],
+          "tags": []
+        }
+      ],
+      "thresholds": [],
+      "timeFrom": null,
+      "timeRegions": [],
+      "timeShift": null,
+      "title": "SingleStoreIO | 5M Records",
       "tooltip": {
         "shared": true,
         "sort": 0,

--- a/.test-infra/metrics/grafana/dashboards/perftests_metrics/Python_IO_IT_Tests_Dataflow.json
+++ b/.test-infra/metrics/grafana/dashboards/perftests_metrics/Python_IO_IT_Tests_Dataflow.json
@@ -189,7 +189,7 @@
         "y": 0
       },
       "hiddenSeries": false,
-      "id": 4,
+      "id": 3,
       "interval": "24h",
       "legend": {
         "avg": false,
@@ -344,7 +344,7 @@
         "y": 9
       },
       "hiddenSeries": false,
-      "id": 6,
+      "id": 4,
       "interval": "24h",
       "legend": {
         "avg": false,
@@ -499,7 +499,7 @@
         "y": 9
       },
       "hiddenSeries": false,
-      "id": 6,
+      "id": 5,
       "interval": "24h",
       "legend": {
         "avg": false,


### PR DESCRIPTION
Part of #18204

HadoopFormatIO, CdapIO, SparkReceiveIO are running performance tests on relatively small dataset (600k) which take only several seconds. The metrics obtained is thus barely meaningful to detect any regression / comparing performances. Bumping them to 5M, the same number used for JdbcIO performance tests. These tests all used the same TestRow so they are processing exactly same data and their metrics are now comparable.

Adjusted the run interval from 6 h to 12 h as they do not need to run that frequently.

Also add SingleStoreIO dashboard which is almost done; and some fixes on Python dashboard.

* CdapIO, SparkReceiver Performance test match data size for JDBC

* Set frequency to 12 h (performance tests not need to exercise very frequent)

* Add SingleStoreIO dashboard

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
