### PR TITLE
Fix OrderedListState for Dataflow Streaming pipelines on SE.

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WindmillStateInternals.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WindmillStateInternals.java
@@ -653,8 +653,11 @@ class WindmillStateInternals<K> implements StateInternals {
     static final String IDS_AVAILABLE_STR = "IdsAvailable";
     static final String DELETIONS_STR = "Deletions";
 
-    static final long MIN_ID = Long.MIN_VALUE;
-    static final long MAX_ID = Long.MAX_VALUE;
+    // Note that this previously was Long.MIN_VALUE but ids are unsigned when
+    // sending to windmill for Streaming Engine. For updated appliance
+    // pipelines with existing state, there may be negative ids.
+    static final long NEW_RANGE_MIN_ID = 0;
+    static final long NEW_RANGE_MAX_ID = Long.MAX_VALUE;
 
     // We track ids on five-minute boundaries.
     private static final Duration RESOLUTION = Duration.standardMinutes(5);
@@ -755,7 +758,9 @@ class WindmillStateInternals<K> implements StateInternals {
           availableIdsForTsRange =
               idsAvailable.computeIfAbsent(
                   currentTsRange,
-                  r -> TreeRangeSet.create(ImmutableList.of(Range.closedOpen(MIN_ID, MAX_ID))));
+                  r ->
+                      TreeRangeSet.create(
+                          ImmutableList.of(Range.closedOpen(NEW_RANGE_MIN_ID, NEW_RANGE_MAX_ID))));
           idRangeIter = availableIdsForTsRange.asRanges().iterator();
           currentIdRange = null;
           currentTsRangeDeletions = subRangeDeletions.get(currentTsRange);

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WindmillStateInternalsTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WindmillStateInternalsTest.java
@@ -800,7 +800,7 @@ public class WindmillStateInternalsTest {
 
     assertEquals("hello", updates.getInserts(0).getEntries(0).getValue().toStringUtf8());
     assertEquals(1000, updates.getInserts(0).getEntries(0).getSortKey());
-    assertEquals(IdTracker.MIN_ID, updates.getInserts(0).getEntries(0).getId());
+    assertEquals(IdTracker.NEW_RANGE_MIN_ID, updates.getInserts(0).getEntries(0).getId());
   }
 
   @Test
@@ -829,8 +829,8 @@ public class WindmillStateInternalsTest {
     assertEquals("world", updates.getInserts(0).getEntries(1).getValue().toStringUtf8());
     assertEquals(2000, updates.getInserts(0).getEntries(0).getSortKey());
     assertEquals(2000, updates.getInserts(0).getEntries(1).getSortKey());
-    assertEquals(IdTracker.MIN_ID, updates.getInserts(0).getEntries(0).getId());
-    assertEquals(IdTracker.MIN_ID + 1, updates.getInserts(0).getEntries(1).getId());
+    assertEquals(IdTracker.NEW_RANGE_MIN_ID, updates.getInserts(0).getEntries(0).getId());
+    assertEquals(IdTracker.NEW_RANGE_MIN_ID + 1, updates.getInserts(0).getEntries(1).getId());
     Mockito.verifyNoMoreInteractions(mockReader);
   }
 
@@ -877,8 +877,8 @@ public class WindmillStateInternalsTest {
     assertEquals("world", updates.getInserts(0).getEntries(1).getValue().toStringUtf8());
     assertEquals(1000, updates.getInserts(0).getEntries(0).getSortKey());
     assertEquals(4000, updates.getInserts(0).getEntries(1).getSortKey());
-    assertEquals(IdTracker.MIN_ID, updates.getInserts(0).getEntries(0).getId());
-    assertEquals(IdTracker.MIN_ID + 1, updates.getInserts(0).getEntries(1).getId());
+    assertEquals(IdTracker.NEW_RANGE_MIN_ID, updates.getInserts(0).getEntries(0).getId());
+    assertEquals(IdTracker.NEW_RANGE_MIN_ID + 1, updates.getInserts(0).getEntries(1).getId());
   }
 
   @Test


### PR DESCRIPTION
The id field is unsigned so setting LONG.MIN resulted in a larger id than supported in SE.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
