### PR TITLE
Revert "Remove google-cloud-platform-core dependency from harness"

### DIFF
--- a/sdks/java/harness/build.gradle
+++ b/sdks/java/harness/build.gradle
@@ -23,6 +23,7 @@ plugins { id 'org.apache.beam.module' }
 // and also the set of project level dependencies.
 def dependOnShadedProjects = [":model:pipeline", ":model:fn-execution", ":sdks:java:core"]
 def dependOnProjects = [":sdks:java:fn-execution",
+                        ":sdks:java:extensions:google-cloud-platform-core",
                         ":runners:core-java", ":runners:core-construction-java"]
 
 applyJavaNature(

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnHarness.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnHarness.java
@@ -41,6 +41,7 @@ import org.apache.beam.model.pipeline.v1.Endpoints;
 import org.apache.beam.runners.core.construction.PipelineOptionsTranslation;
 import org.apache.beam.runners.core.metrics.MetricsContainerImpl;
 import org.apache.beam.runners.core.metrics.ShortIdMap;
+import org.apache.beam.sdk.extensions.gcp.options.GcsOptions;
 import org.apache.beam.sdk.fn.IdGenerator;
 import org.apache.beam.sdk.fn.IdGenerators;
 import org.apache.beam.sdk.fn.JvmInitializers;
@@ -50,7 +51,6 @@ import org.apache.beam.sdk.fn.stream.OutboundObserverFactory;
 import org.apache.beam.sdk.function.ThrowingFunction;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.metrics.MetricsEnvironment;
-import org.apache.beam.sdk.options.ExecutorOptions;
 import org.apache.beam.sdk.options.ExperimentalOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.vendor.grpc.v1p48p1.com.google.protobuf.TextFormat;
@@ -217,8 +217,7 @@ public class FnHarness {
 
     IdGenerator idGenerator = IdGenerators.decrementingLongs();
     ShortIdMap metricsShortIds = new ShortIdMap();
-    ExecutorService executorService =
-        options.as(ExecutorOptions.class).getScheduledExecutorService();
+    ExecutorService executorService = options.as(GcsOptions.class).getExecutorService();
     ExecutionStateSampler executionStateSampler =
         new ExecutionStateSampler(options, System::currentTimeMillis);
 
@@ -246,7 +245,8 @@ public class FnHarness {
       BeamFnStateGrpcClientCache beamFnStateGrpcClientCache =
           new BeamFnStateGrpcClientCache(idGenerator, channelFactory, outboundObserverFactory);
 
-      FinalizeBundleHandler finalizeBundleHandler = new FinalizeBundleHandler(executorService);
+      FinalizeBundleHandler finalizeBundleHandler =
+          new FinalizeBundleHandler(options.as(GcsOptions.class).getExecutorService());
 
       Function<String, BeamFnApi.ProcessBundleDescriptor> getProcessBundleDescriptor =
           new Function<String, ProcessBundleDescriptor>() {

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ExecutionStateSampler.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ExecutionStateSampler.java
@@ -33,7 +33,7 @@ import java.util.concurrent.atomic.AtomicReference;
 import javax.annotation.concurrent.GuardedBy;
 import org.apache.beam.fn.harness.control.ProcessBundleHandler.BundleProcessor;
 import org.apache.beam.runners.core.metrics.MonitoringInfoEncodings;
-import org.apache.beam.sdk.options.ExecutorOptions;
+import org.apache.beam.sdk.extensions.gcp.options.GcsOptions;
 import org.apache.beam.sdk.options.ExperimentalOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.vendor.grpc.v1p48p1.com.google.protobuf.ByteString;
@@ -89,10 +89,7 @@ public class ExecutionStateSampler {
     // being published before the state sampler thread starts.
     synchronized (this) {
       this.stateSamplingThread =
-          options
-              .as(ExecutorOptions.class)
-              .getScheduledExecutorService()
-              .submit(this::stateSampler);
+          options.as(GcsOptions.class).getExecutorService().submit(this::stateSampler);
     }
   }
 

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/logging/BeamFnLoggingClient.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/logging/BeamFnLoggingClient.java
@@ -46,7 +46,7 @@ import org.apache.beam.model.fnexecution.v1.BeamFnApi;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.LogEntry;
 import org.apache.beam.model.fnexecution.v1.BeamFnLoggingGrpc;
 import org.apache.beam.model.pipeline.v1.Endpoints;
-import org.apache.beam.sdk.options.ExecutorOptions;
+import org.apache.beam.sdk.extensions.gcp.options.GcsOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.SdkHarnessOptions;
 import org.apache.beam.vendor.grpc.v1p48p1.com.google.protobuf.Timestamp;
@@ -121,7 +121,7 @@ public class BeamFnLoggingClient implements AutoCloseable {
     logRecordHandler = new LogRecordHandler();
     logRecordHandler.setLevel(Level.ALL);
     logRecordHandler.setFormatter(DEFAULT_FORMATTER);
-    logRecordHandler.executeOn(options.as(ExecutorOptions.class).getScheduledExecutorService());
+    logRecordHandler.executeOn(options.as(GcsOptions.class).getExecutorService());
     outboundObserver = (CallStreamObserver<BeamFnApi.LogEntry.List>) stub.logging(inboundObserver);
     rootLogger.addHandler(logRecordHandler);
   }

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/stream/HarnessStreamObserverFactories.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/stream/HarnessStreamObserverFactories.java
@@ -18,8 +18,8 @@
 package org.apache.beam.fn.harness.stream;
 
 import java.util.List;
+import org.apache.beam.sdk.extensions.gcp.options.GcsOptions;
 import org.apache.beam.sdk.fn.stream.OutboundObserverFactory;
-import org.apache.beam.sdk.options.ExecutorOptions;
 import org.apache.beam.sdk.options.ExperimentalOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.vendor.grpc.v1p48p1.io.grpc.stub.StreamObserver;
@@ -40,10 +40,10 @@ public abstract class HarnessStreamObserverFactories {
       int bufferSize = getBufferSize(experiments);
       if (bufferSize > 0) {
         return OutboundObserverFactory.clientBuffered(
-            options.as(ExecutorOptions.class).getScheduledExecutorService(), bufferSize);
+            options.as(GcsOptions.class).getExecutorService(), bufferSize);
       }
       return OutboundObserverFactory.clientBuffered(
-          options.as(ExecutorOptions.class).getScheduledExecutorService());
+          options.as(GcsOptions.class).getExecutorService());
     }
     return OutboundObserverFactory.clientDirect();
   }

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnHarnessTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnHarnessTest.java
@@ -38,9 +38,9 @@ import org.apache.beam.model.fnexecution.v1.BeamFnControlGrpc;
 import org.apache.beam.model.fnexecution.v1.BeamFnLoggingGrpc;
 import org.apache.beam.model.pipeline.v1.Endpoints;
 import org.apache.beam.runners.core.construction.PipelineOptionsTranslation;
+import org.apache.beam.sdk.extensions.gcp.options.GcsOptions;
 import org.apache.beam.sdk.fn.test.TestStreams;
 import org.apache.beam.sdk.harness.JvmInitializer;
-import org.apache.beam.sdk.options.ExecutorOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.vendor.grpc.v1p48p1.com.google.protobuf.TextFormat;
@@ -128,8 +128,8 @@ public class FnHarnessTest {
             CountDownLatch waitForResponses =
                 new CountDownLatch(1 /* number of responses expected */);
             options
-                .as(ExecutorOptions.class)
-                .getScheduledExecutorService()
+                .as(GcsOptions.class)
+                .getExecutorService()
                 .submit(
                     () -> {
                       responseObserver.onNext(INSTRUCTION_REQUEST);


### PR DESCRIPTION
Reverts apache/beam#24235

It seems like this may have broken some x-lang scenarios where google-cloud-platform-core is required to be present in the container image (specifically x-lang use cases that rely on parsing the `gs` file system). Trying a revert to see if that fixes the problem.