### PR TITLE
Performance test parameters followup fix

### DIFF
--- a/.test-infra/jenkins/job_PerformanceTests_FileBasedIO_Python.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_FileBasedIO_Python.groovy
@@ -60,8 +60,8 @@ private void createGCSFileBasedIOITTestJob(testJob) {
     common.setAutoJob(delegate, 'H H * * *')
     InfluxDBCredentialsHelper.useCredentials(delegate)
     additionalPipelineArgs = [
-      influxDatabase: InfluxDBCredentialsHelper.InfluxDBDatabaseName,
-      influxHost: InfluxDBCredentialsHelper.InfluxDBHostUrl,
+      influx_db_name: InfluxDBCredentialsHelper.InfluxDBDatabaseName,
+      influx_hostname: InfluxDBCredentialsHelper.InfluxDBHostUrl,
     ]
     testJob.pipelineOptions.putAll(additionalPipelineArgs)
 

--- a/.test-infra/jenkins/job_PerformanceTests_SingleStoreIO.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_SingleStoreIO.groovy
@@ -36,7 +36,7 @@ void waitFor(job, Kubernetes k8s, String resource) {
 
 job(jobName) {
   common.setTopLevelMainJobProperties(delegate)
-  common.setAutoJob(delegate,'H H/6 * * *')
+  common.setAutoJob(delegate,'H H/12 * * *')
   common.enablePhraseTriggeringFromPullRequest(
       delegate,
       'Java SingleStoreIO Performance Test',


### PR DESCRIPTION
Followup of #24211

* Fix FileBasedIO job parameter
  These parameters were copied from Java performance tests however Python has different naming and making the metrics not shown on grafana.

* Set cron job frequency to 12h for SingleStoreIO PerfTest
  This test is merged after #24211 was in. Also set its running frequency to every 12 h as jdbcio, cdapio, sparkreceiverio, etc.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
