### PR TITLE
Add map_windows support to Go SDK

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,6 +73,7 @@
 * Pipeline Resource Hints now supported via `--resource_hints` flag (Go) ([#23990](https://github.com/apache/beam/pull/23990)).
 * Make Python SDK containers reusable on portable runners by installing dependencies to temporary venvs ([BEAM-12792](https://issues.apache.org/jira/browse/BEAM-12792)).
 * RunInference model handlers now support the specification of a custom inference function in Python ([#22572](https://github.com/apache/beam/issues/22572))
+* Support for `map_windows` urn added to Go SDK ([#24307](https://github.apache/beam/pull/24307)).
 
 ## Breaking Changes
 

--- a/sdks/go/pkg/beam/core/graph/coder/coder.go
+++ b/sdks/go/pkg/beam/core/graph/coder/coder.go
@@ -177,6 +177,7 @@ const (
 	Iterable           Kind = "I"
 	KV                 Kind = "KV"
 	LP                 Kind = "LP" // Explicitly length prefixed, likely at the runner's direction.
+	IWCValue           Kind = "IWCvalue"
 
 	Window Kind = "window" // A debug wrapper around a window coder.
 
@@ -292,6 +293,11 @@ func NewDouble() *Coder {
 // NewString returns a new string coder using the built-in scheme.
 func NewString() *Coder {
 	return &Coder{Kind: String, T: typex.New(reflectx.String)}
+}
+
+// NewIntervalWindowCoder returns a new IntervalWindow coder using the built-in scheme.
+func NewIntervalWindowCoder() *Coder {
+	return &Coder{Kind: IWCValue, T: typex.New(reflect.TypeOf((*struct{ Start, End int64 })(nil)).Elem())}
 }
 
 // IsW returns true iff the coder is for a WindowedValue.

--- a/sdks/go/pkg/beam/core/graph/coder/coder.go
+++ b/sdks/go/pkg/beam/core/graph/coder/coder.go
@@ -177,7 +177,11 @@ const (
 	Iterable           Kind = "I"
 	KV                 Kind = "KV"
 	LP                 Kind = "LP" // Explicitly length prefixed, likely at the runner's direction.
-	IWCValue           Kind = "IWCvalue"
+
+	// IW stands for IntervalWindow and uses the short name to avoid a collision with the
+	// WindowCoder kind. This Kind is used when the window is provided as a value instead
+	// of a window for the value.
+	IW Kind = "IW"
 
 	Window Kind = "window" // A debug wrapper around a window coder.
 
@@ -297,7 +301,7 @@ func NewString() *Coder {
 
 // NewIntervalWindowCoder returns a new IntervalWindow coder using the built-in scheme.
 func NewIntervalWindowCoder() *Coder {
-	return &Coder{Kind: IWCValue, T: typex.New(reflect.TypeOf((*struct{ Start, End int64 })(nil)).Elem())}
+	return &Coder{Kind: IW, T: typex.New(reflect.TypeOf((*struct{ Start, End int64 })(nil)).Elem())}
 }
 
 // IsW returns true iff the coder is for a WindowedValue.

--- a/sdks/go/pkg/beam/core/runtime/exec/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/coder.go
@@ -16,12 +16,11 @@
 package exec
 
 import (
+	"bytes"
 	"fmt"
 	"io"
 	"reflect"
 	"strings"
-
-	"bytes"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/coder"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/mtime"
@@ -116,6 +115,9 @@ func MakeElementEncoder(c *coder.Coder) ElementEncoder {
 			fst: MakeElementEncoder(c.Components[0]),
 			snd: MakeElementEncoder(c.Components[1]),
 		}
+
+	case coder.IWCValue:
+		return &intervalWindowValueEncoder{}
 
 	case coder.Window:
 		return &wrappedWindowEncoder{
@@ -228,6 +230,9 @@ func MakeElementDecoder(c *coder.Coder) ElementDecoder {
 			fst: MakeElementDecoder(c.Components[0]),
 			snd: MakeElementDecoder(c.Components[1]),
 		}
+
+	case coder.IWCValue:
+		return &intervalWindowValueDecoder{}
 
 	// The following cases are not expected to be executed in the normal
 	// course of a pipeline, however including them here enables simpler
@@ -1178,6 +1183,36 @@ func (*intervalWindowDecoder) DecodeSingle(r io.Reader) (typex.Window, error) {
 		return nil, err
 	}
 	return window.IntervalWindow{Start: mtime.FromMilliseconds(end.Milliseconds() - int64(duration)), End: end}, nil
+}
+
+type intervalWindowValueEncoder struct {
+	intervalWindowEncoder
+}
+
+func (e *intervalWindowValueEncoder) Encode(v *FullValue, w io.Writer) error {
+	return e.EncodeSingle(v.Elm.(window.IntervalWindow), w)
+}
+
+type intervalWindowValueDecoder struct {
+	intervalWindowDecoder
+}
+
+func (d *intervalWindowValueDecoder) Decode(r io.Reader) (*FullValue, error) {
+	fv := &FullValue{}
+	err := d.DecodeTo(r, fv)
+	if err != nil {
+		return nil, err
+	}
+	return fv, nil
+}
+
+func (d *intervalWindowValueDecoder) DecodeTo(r io.Reader, value *FullValue) error {
+	w, err := d.DecodeSingle(r)
+	if err != nil {
+		return err
+	}
+	value.Elm = w
+	return nil
 }
 
 // EncodeWindowedValueHeader serializes a windowed value header.

--- a/sdks/go/pkg/beam/core/runtime/exec/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/coder.go
@@ -116,7 +116,7 @@ func MakeElementEncoder(c *coder.Coder) ElementEncoder {
 			snd: MakeElementEncoder(c.Components[1]),
 		}
 
-	case coder.IWCValue:
+	case coder.IW:
 		return &intervalWindowValueEncoder{}
 
 	case coder.Window:
@@ -231,7 +231,7 @@ func MakeElementDecoder(c *coder.Coder) ElementDecoder {
 			snd: MakeElementDecoder(c.Components[1]),
 		}
 
-	case coder.IWCValue:
+	case coder.IW:
 		return &intervalWindowValueDecoder{}
 
 	// The following cases are not expected to be executed in the normal
@@ -594,7 +594,8 @@ func (c *kvDecoder) DecodeTo(r io.Reader, fv *FullValue) error {
 // Elm will be the decoded type.
 //
 // Example:
-//   KV<int, KV<...>> decodes to *FullValue{Elm: int, Elm2: *FullValue{...}}
+//
+//	KV<int, KV<...>> decodes to *FullValue{Elm: int, Elm2: *FullValue{...}}
 func (c *kvDecoder) Decode(r io.Reader) (*FullValue, error) {
 	fv := &FullValue{}
 	if err := c.DecodeTo(r, fv); err != nil {

--- a/sdks/go/pkg/beam/core/runtime/exec/coder_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/coder_test.go
@@ -89,6 +89,9 @@ func TestCoders(t *testing.T) {
 		}, {
 			coder: coder.NewN(coder.NewBytes()),
 			val:   &FullValue{Elm: []byte("myBytes")},
+		}, {
+			coder: coder.NewIntervalWindowCoder(),
+			val:   &FullValue{Elm: window.IntervalWindow{Start: 0, End: 100}},
 		},
 	} {
 		t.Run(fmt.Sprintf("%v", test.coder), func(t *testing.T) {

--- a/sdks/go/pkg/beam/core/runtime/exec/fullvalue.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/fullvalue.go
@@ -46,7 +46,7 @@ type FullValue struct {
 
 func (v *FullValue) String() string {
 	if v.Elm2 == nil {
-		return fmt.Sprintf("%v [@%v:%v:%v]", v.Elm, v.Timestamp, v.Windows, v.Pane)
+		return fmt.Sprintf("%v %T [@%v:%v:%v]", v.Elm, v.Elm, v.Timestamp, v.Windows, v.Pane)
 	}
 	return fmt.Sprintf("KV<%v,%v> [@%v:%v:%v]", v.Elm, v.Elm2, v.Timestamp, v.Windows, v.Pane)
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/fullvalue.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/fullvalue.go
@@ -46,7 +46,7 @@ type FullValue struct {
 
 func (v *FullValue) String() string {
 	if v.Elm2 == nil {
-		return fmt.Sprintf("%v %T [@%v:%v:%v]", v.Elm, v.Elm, v.Timestamp, v.Windows, v.Pane)
+		return fmt.Sprintf("%v [@%v:%v:%v]", v.Elm, v.Timestamp, v.Windows, v.Pane)
 	}
 	return fmt.Sprintf("KV<%v,%v> [@%v:%v:%v]", v.Elm, v.Elm2, v.Timestamp, v.Windows, v.Pane)
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/translate.go
@@ -762,6 +762,17 @@ func (b *builder) makeLink(from string, id linkID) (Node, error) {
 		}
 		u = &WindowInto{UID: b.idgen.New(), Fn: wfn, Out: out[0]}
 
+	case graphx.URNMapWindows:
+		var fn pipepb.FunctionSpec
+		if err := proto.Unmarshal(payload, &fn); err != nil {
+			return nil, errors.Wrapf(err, "invalid SideInput payload for %v", transform)
+		}
+		mapper, err := unmarshalAndMakeWindowMapping(&fn)
+		if err != nil {
+			return nil, err
+		}
+		u = &MapWindows{UID: b.idgen.New(), Fn: mapper, Out: out[0]}
+
 	case graphx.URNFlatten:
 		u = &Flatten{UID: b.idgen.New(), N: len(transform.Inputs), Out: out[0]}
 

--- a/sdks/go/pkg/beam/core/runtime/exec/window.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/window.go
@@ -23,6 +23,7 @@ import (
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/mtime"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/window"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/typex"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/log"
 )
 
 // WindowInto places each element in one or more windows.
@@ -95,6 +96,55 @@ func (w *WindowInto) Down(ctx context.Context) error {
 
 func (w *WindowInto) String() string {
 	return fmt.Sprintf("WindowInto[%v]. Out:%v", w.Fn, w.Out.ID())
+}
+
+type MapWindows struct {
+	UID UnitID
+	Fn  WindowMapper
+	Out Node
+}
+
+func (m *MapWindows) ID() UnitID {
+	return m.UID
+}
+
+func (m *MapWindows) Up(_ context.Context) error {
+	return nil
+}
+
+func (m *MapWindows) StartBundle(ctx context.Context, id string, data DataContext) error {
+	return m.Out.StartBundle(ctx, id, data)
+}
+
+func (m *MapWindows) ProcessElement(ctx context.Context, elm *FullValue, values ...ReStream) error {
+	w, ok := elm.Elm.(window.IntervalWindow)
+	if !ok {
+		return errors.Errorf("not an IntervalWindow, got %T", elm.Elm)
+	}
+	newW, err := m.Fn.MapWindow(w)
+	if err != nil {
+		return err
+	}
+	out := &FullValue{
+		Elm:       elm.Elm,
+		Elm2:      newW,
+		Timestamp: elm.Timestamp,
+		Windows:   elm.Windows,
+		Pane:      elm.Pane,
+	}
+	return m.Out.ProcessElement(ctx, out, values...)
+}
+
+func (m *MapWindows) FinishBundle(ctx context.Context) error {
+	return m.Out.FinishBundle(ctx)
+}
+
+func (m *MapWindows) Down(_ context.Context) error {
+	return nil
+}
+
+func (m *MapWindows) String() string {
+	return fmt.Sprintf("MapWindows[%v]. Out:%v", m.Fn, m.Out.ID())
 }
 
 // WindowMapper defines an interface maps windows from a main input window space

--- a/sdks/go/pkg/beam/core/runtime/exec/window.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/window.go
@@ -23,7 +23,7 @@ import (
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/mtime"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/window"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/typex"
-	"github.com/apache/beam/sdks/v2/go/pkg/beam/log"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/internal/errors"
 )
 
 // WindowInto places each element in one or more windows.

--- a/sdks/go/pkg/beam/core/runtime/exec/window.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/window.go
@@ -117,9 +117,9 @@ func (m *MapWindows) StartBundle(ctx context.Context, id string, data DataContex
 }
 
 func (m *MapWindows) ProcessElement(ctx context.Context, elm *FullValue, values ...ReStream) error {
-	w, ok := elm.Elm.(window.IntervalWindow)
+	w, ok := elm.Elm2.(window.IntervalWindow)
 	if !ok {
-		return errors.Errorf("not an IntervalWindow, got %T", elm.Elm)
+		return errors.Errorf("not an IntervalWindow, got %T", elm.Elm2)
 	}
 	newW, err := m.Fn.MapWindow(w)
 	if err != nil {

--- a/sdks/go/pkg/beam/core/runtime/graphx/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/coder.go
@@ -242,6 +242,8 @@ func (b *CoderUnmarshaller) makeCoder(id string, c *pipepb.Coder) (*coder.Coder,
 				t := typex.New(typex.CoGBKType, append([]typex.FullType{key.T}, coder.Types(values)...)...)
 				return &coder.Coder{Kind: coder.CoGBK, T: t, Components: append([]*coder.Coder{key}, values...)}, nil
 			}
+			// It's valid to have a KV<k,Iter<v>> without being a CoGBK, and validating if we need to change to
+			// a CoGBK is done at the DataSource, since that's when we can check against the downstream nodes.
 		}
 
 		value, err := b.Coder(id)

--- a/sdks/go/pkg/beam/core/runtime/graphx/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/coder.go
@@ -522,6 +522,9 @@ func (b *CoderMarshaller) Add(c *coder.Coder) (string, error) {
 	case coder.String:
 		return b.internBuiltInCoder(urnStringCoder), nil
 
+	case coder.IW:
+		return b.internBuiltInCoder(urnIntervalWindow), nil
+
 	case coder.Row:
 		rt := c.T.Type()
 		s, err := schema.FromType(rt)

--- a/sdks/go/pkg/beam/core/runtime/graphx/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/coder.go
@@ -244,6 +244,10 @@ func (b *CoderUnmarshaller) makeCoder(id string, c *pipepb.Coder) (*coder.Coder,
 			}
 			// It's valid to have a KV<k,Iter<v>> without being a CoGBK, and validating if we need to change to
 			// a CoGBK is done at the DataSource, since that's when we can check against the downstream nodes.
+		case urnIntervalWindow:
+			// If interval window in a KV, this may be a mapping function.
+			// Special case since windows are not normally used directly as FullValues.
+			return coder.NewIntervalWindowCoder(), nil
 		}
 
 		value, err := b.Coder(id)

--- a/sdks/go/pkg/beam/core/runtime/graphx/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/coder.go
@@ -247,7 +247,9 @@ func (b *CoderUnmarshaller) makeCoder(id string, c *pipepb.Coder) (*coder.Coder,
 		case urnIntervalWindow:
 			// If interval window in a KV, this may be a mapping function.
 			// Special case since windows are not normally used directly as FullValues.
-			return coder.NewIntervalWindowCoder(), nil
+			value := coder.NewIntervalWindowCoder()
+			t := typex.New(root, key.T, value.T)
+			return &coder.Coder{Kind: kind, T: t, Components: []*coder.Coder{key, value}}, nil
 		}
 
 		value, err := b.Coder(id)

--- a/sdks/go/pkg/beam/core/runtime/graphx/coder_test.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/coder_test.go
@@ -86,6 +86,10 @@ func TestMarshalUnmarshalCoders(t *testing.T) {
 			c:    baz,
 		},
 		{
+			name: "IW",
+			c:    coder.NewIntervalWindowCoder(),
+		},
+		{
 			name: "W<bytes>",
 			c:    coder.NewW(coder.NewBytes(), coder.NewGlobalWindow()),
 		},

--- a/sdks/go/pkg/beam/core/runtime/graphx/dataflow.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/dataflow.go
@@ -176,6 +176,9 @@ func EncodeCoderRef(c *coder.Coder) (*CoderRef, error) {
 		}
 		return &CoderRef{Type: windowedValueType, Components: []*CoderRef{elm, w}, IsWrapper: true}, nil
 
+	case coder.IW:
+		return &CoderRef{Type: intervalWindowType}, nil
+
 	case coder.Bytes:
 		return &CoderRef{Type: bytesType}, nil
 
@@ -304,6 +307,9 @@ func DecodeCoderRef(c *CoderRef) (*coder.Coder, error) {
 		default:
 			return decodeDataflowCustomCoder(subC.Type)
 		}
+
+	case intervalWindowType:
+		return coder.NewIntervalWindowCoder(), nil
 
 	case windowedValueType:
 		if len(c.Components) != 2 {

--- a/sdks/go/pkg/beam/core/runtime/graphx/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate.go
@@ -44,6 +44,7 @@ const (
 	URNReshuffle     = "beam:transform:reshuffle:v1"
 	URNCombinePerKey = "beam:transform:combine_per_key:v1"
 	URNWindow        = "beam:transform:window_into:v1"
+	URNMapWindows    = "beam:transform:map_windows:v1"
 
 	URNIterableSideInput = "beam:side_input:iterable:v1"
 	URNMultimapSideInput = "beam:side_input:multimap:v1"


### PR DESCRIPTION
Adds support to the Go SDK for the [map_windows][1] urn.

The existing type model does not allow `IntervalWindow` as a FullValue and the existing coders will throw away the window values when decoding the KV type [here][2] in `elideSingleElmFV`. This change updates coder construction to allow an IntervalWindow as a value coder.

Addresses #23106.

[1]: https://github.com/apache/beam/blob/master/model/pipeline/src/main/proto/org/apache/beam/model/pipeline/v1/beam_runner_api.proto#L296
[2]: https://github.com/camphillips22/beam/blob/8be4cdcaf65a1e53e3041ac3354e2e99c845e915/sdks/go/pkg/beam/core/runtime/exec/coder.go#L580-L580

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
