### PR TITLE
[Spark dataset runner] Fix handling of exceptions during translation

### DIFF
--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/SparkStructuredStreamingPipelineResult.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/SparkStructuredStreamingPipelineResult.java
@@ -24,6 +24,7 @@ import java.util.concurrent.ExecutionException;
 import java.util.concurrent.Future;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
+import javax.annotation.Nullable;
 import org.apache.beam.runners.spark.structuredstreaming.metrics.MetricsAccumulator;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
@@ -40,12 +41,12 @@ import org.joda.time.Duration;
 public class SparkStructuredStreamingPipelineResult implements PipelineResult {
 
   final Future pipelineExecution;
-  final Runnable onTerminalState;
+  @Nullable final Runnable onTerminalState;
 
   PipelineResult.State state;
 
   SparkStructuredStreamingPipelineResult(
-      final Future<?> pipelineExecution, final Runnable onTerminalState) {
+      final Future<?> pipelineExecution, @Nullable final Runnable onTerminalState) {
     this.pipelineExecution = pipelineExecution;
     this.onTerminalState = onTerminalState;
     // pipelineExecution is expected to have started executing eagerly.
@@ -123,7 +124,7 @@ public class SparkStructuredStreamingPipelineResult implements PipelineResult {
   private void offerNewState(State newState) {
     State oldState = this.state;
     this.state = newState;
-    if (!oldState.isTerminal() && newState.isTerminal()) {
+    if (!oldState.isTerminal() && newState.isTerminal() && onTerminalState != null) {
       try {
         onTerminalState.run();
       } catch (Exception e) {

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/SparkStructuredStreamingRunner.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/SparkStructuredStreamingRunner.java
@@ -18,10 +18,13 @@
 package org.apache.beam.runners.spark.structuredstreaming;
 
 import static org.apache.beam.runners.spark.SparkCommonPipelineOptions.prepareFilesToStage;
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
 
 import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
+import java.util.concurrent.ThreadFactory;
+import javax.annotation.Nullable;
 import org.apache.beam.runners.core.construction.SplittableParDo;
 import org.apache.beam.runners.core.construction.graph.ProjectionPushdownOptimizer;
 import org.apache.beam.runners.core.metrics.MetricsPusher;
@@ -42,7 +45,6 @@ import org.apache.beam.sdk.options.ExperimentalOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.PipelineOptionsValidator;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.apache.spark.SparkContext;
 import org.apache.spark.SparkEnv$;
@@ -145,29 +147,22 @@ public final class SparkStructuredStreamingRunner
             + " https://spark.apache.org/docs/latest/structured-streaming-programming-guide.html\n"
             + " It is still experimental, its coverage of the Beam model is partial. ***");
 
+    PipelineTranslator.detectStreamingMode(pipeline, options);
+    checkArgument(!options.isStreaming(), "Streaming is not supported.");
+
     // clear state of Aggregators, Metrics and Watermarks if exists.
     AggregatorsAccumulator.clear();
     MetricsAccumulator.clear();
 
-    final EvaluationContext evaluationContext = translatePipeline(pipeline);
+    final SparkSession sparkSession = SparkSessionFactory.getOrCreateSession(options);
+    initAccumulators(sparkSession.sparkContext());
 
-    final ExecutorService executorService =
-        Executors.newSingleThreadExecutor(
-            new ThreadFactoryBuilder().setDaemon(true).setNameFormat("LocalSpark-thread").build());
     final Future<?> submissionFuture =
-        executorService.submit(
-            () -> {
-              // TODO initialise other services: checkpointing, metrics system, listeners, ...
-              evaluationContext.evaluate();
-            });
-    executorService.shutdown();
+        runAsync(() -> translatePipeline(sparkSession, pipeline).evaluate());
 
-    Runnable onTerminalState =
-        options.getUseActiveSparkSession()
-            ? () -> {}
-            : () -> evaluationContext.getSparkSession().stop();
-    SparkStructuredStreamingPipelineResult result =
-        new SparkStructuredStreamingPipelineResult(submissionFuture, onTerminalState);
+    final SparkStructuredStreamingPipelineResult result =
+        new SparkStructuredStreamingPipelineResult(
+            submissionFuture, stopSparkSession(sparkSession, options.getUseActiveSparkSession()));
 
     if (options.getEnableSparkMetricSinks()) {
       registerMetricsSource(options.getAppName());
@@ -185,11 +180,7 @@ public final class SparkStructuredStreamingRunner
     return result;
   }
 
-  private EvaluationContext translatePipeline(Pipeline pipeline) {
-    PipelineTranslator.detectStreamingMode(pipeline, options);
-    Preconditions.checkArgument(
-        !options.isStreaming(), "%s does not support streaming pipelines.", getClass().getName());
-
+  private EvaluationContext translatePipeline(SparkSession sparkSession, Pipeline pipeline) {
     // Default to using the primitive versions of Read.Bounded and Read.Unbounded for non-portable
     // execution.
     // TODO(https://github.com/apache/beam/issues/20530): Use SDF read as default when we address
@@ -204,9 +195,6 @@ public final class SparkStructuredStreamingRunner
 
     PipelineTranslator.replaceTransforms(pipeline, options);
     prepareFilesToStage(options);
-
-    final SparkSession sparkSession = SparkSessionFactory.getOrCreateSession(options);
-    initAccumulators(sparkSession.sparkContext());
 
     PipelineTranslator pipelineTranslator = new PipelineTranslatorBatch();
     return pipelineTranslator.translate(pipeline, sparkSession, options);
@@ -228,9 +216,25 @@ public final class SparkStructuredStreamingRunner
   }
 
   /** Init Metrics/Aggregators accumulators. This method is idempotent. */
-  public static void initAccumulators(SparkContext sparkContext) {
+  private static void initAccumulators(SparkContext sparkContext) {
     // Init metrics accumulators
     MetricsAccumulator.init(sparkContext);
     AggregatorsAccumulator.init(sparkContext);
+  }
+
+  private static Future<?> runAsync(Runnable task) {
+    ThreadFactory factory =
+        new ThreadFactoryBuilder()
+            .setDaemon(true)
+            .setNameFormat("SparkStructuredStreamingRunner-thread")
+            .build();
+    ExecutorService execService = Executors.newSingleThreadExecutor(factory);
+    Future<?> future = execService.submit(task);
+    execService.shutdown();
+    return future;
+  }
+
+  private static @Nullable Runnable stopSparkSession(SparkSession session, boolean isProvided) {
+    return !isProvided ? () -> session.stop() : null;
   }
 }


### PR DESCRIPTION
If pipeline translation fails with an exception, it bubbles all the way up to the caller of run without closing the SparkSession.

Considering that we're potentially already evaluating side-input datasets, translation should be done in the same thread as the evaluation. This way exceptions will result in a failed PipelineResult and close the session properly.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
