### PR TITLE
Sort SchemaTransform configuration schema fields by name to establish consistency

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -264,6 +264,18 @@ public class Schema implements Serializable {
     return Schema.builder().addFields(fields).build();
   }
 
+  /** Returns an identical Schema with sorted fields. */
+  public Schema sorted() {
+    Schema sortedSchema = this.fields.stream()
+        .sorted(Comparator.comparing(Field::getName))
+        .collect(Schema.toSchema())
+        .withOptions(getOptions());
+    sortedSchema.setUUID(getUUID());
+    sortedSchema.setEncodingPositions(getEncodingPositions());
+
+    return sortedSchema;
+  }
+
   /** Returns a copy of the Schema with the options set. */
   public Schema withOptions(Options options) {
     return new Schema(fields, getOptions().toBuilder().addOptions(options).build());

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -266,6 +266,8 @@ public class Schema implements Serializable {
 
   /** Returns an identical Schema with sorted fields. */
   public Schema sorted() {
+    // Create a new schema and copy over the appropriate Schema object attributes:
+    // {fields, uuid, encodingPositions, options}
     Schema sortedSchema =
         this.fields.stream()
             .sorted(Comparator.comparing(Field::getName))

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -266,10 +266,11 @@ public class Schema implements Serializable {
 
   /** Returns an identical Schema with sorted fields. */
   public Schema sorted() {
-    Schema sortedSchema = this.fields.stream()
-        .sorted(Comparator.comparing(Field::getName))
-        .collect(Schema.toSchema())
-        .withOptions(getOptions());
+    Schema sortedSchema =
+        this.fields.stream()
+            .sorted(Comparator.comparing(Field::getName))
+            .collect(Schema.toSchema())
+            .withOptions(getOptions());
     sortedSchema.setUUID(getUUID());
     sortedSchema.setEncodingPositions(getEncodingPositions());
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/TypedSchemaTransformProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/TypedSchemaTransformProvider.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.sdk.schemas.transforms;
 
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import org.apache.beam.sdk.annotations.Experimental;
@@ -26,7 +25,6 @@ import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.schemas.NoSuchSchemaException;
 import org.apache.beam.sdk.schemas.Schema;
-import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.SchemaRegistry;
 import org.apache.beam.sdk.values.Row;
 
@@ -43,7 +41,7 @@ import org.apache.beam.sdk.values.Row;
 @Internal
 @Experimental(Kind.SCHEMAS)
 @SuppressWarnings({
-    "nullness" // TODO(https://github.com/apache/beam/issues/20506)
+  "nullness" // TODO(https://github.com/apache/beam/issues/20506)
 })
 public abstract class TypedSchemaTransformProvider<ConfigT> implements SchemaTransformProvider {
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/TypedSchemaTransformProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/TypedSchemaTransformProvider.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.sdk.schemas.transforms;
 
+import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import org.apache.beam.sdk.annotations.Experimental;
@@ -25,6 +26,7 @@ import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.schemas.NoSuchSchemaException;
 import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.SchemaRegistry;
 import org.apache.beam.sdk.values.Row;
 
@@ -40,6 +42,9 @@ import org.apache.beam.sdk.values.Row;
  */
 @Internal
 @Experimental(Kind.SCHEMAS)
+@SuppressWarnings({
+    "nullness" // TODO(https://github.com/apache/beam/issues/20506)
+})
 public abstract class TypedSchemaTransformProvider<ConfigT> implements SchemaTransformProvider {
 
   protected abstract Class<ConfigT> configurationClass();
@@ -61,7 +66,8 @@ public abstract class TypedSchemaTransformProvider<ConfigT> implements SchemaTra
   @Override
   public final Schema configurationSchema() {
     try {
-      return SchemaRegistry.createDefault().getSchema(configurationClass());
+      // Sort the fields by name to ensure a consistent schema is produced
+      return SchemaRegistry.createDefault().getSchema(configurationClass()).sorted();
     } catch (NoSuchSchemaException e) {
       throw new RuntimeException(
           "Unable to find schema for "

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/TypedSchemaTransformProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/TypedSchemaTransformProvider.java
@@ -40,9 +40,6 @@ import org.apache.beam.sdk.values.Row;
  */
 @Internal
 @Experimental(Kind.SCHEMAS)
-@SuppressWarnings({
-  "nullness" // TODO(https://github.com/apache/beam/issues/20506)
-})
 public abstract class TypedSchemaTransformProvider<ConfigT> implements SchemaTransformProvider {
 
   protected abstract Class<ConfigT> configurationClass();

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaTest.java
@@ -23,9 +23,12 @@ import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
+import java.util.Objects;
+import java.util.UUID;
 import java.util.stream.Stream;
 import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
+import org.apache.beam.sdk.schemas.Schema.Options;
 import org.apache.beam.sdk.schemas.logicaltypes.PassThroughLogicalType;
 import org.junit.Rule;
 import org.junit.Test;
@@ -186,6 +189,29 @@ public class SchemaTest {
     assertEquals(FieldType.INT32, schema.getField(0).getType());
     assertEquals("f_string", schema.getField(1).getName());
     assertEquals(FieldType.STRING, schema.getField(1).getType());
+  }
+
+  @Test
+  public void testSorted() {
+    Options testOptions = Options.builder().setOption("test_str_option", FieldType.STRING, "test_str")
+        .setOption("test_bool_option", FieldType.BOOLEAN, true).build();
+
+    Schema schema1 =
+        Schema.builder().addStringField("d").addInt32Field("c").addStringField("b").addByteField("a").build()
+            .withOptions(testOptions);
+
+    Schema sortedSchema1 = schema1.sorted();
+
+    Schema schema2 =
+        Schema.builder().addByteField("a").addStringField("b").addInt32Field("c").addStringField("d").build()
+            .withOptions(testOptions);
+    schema2.setEncodingPositions(schema1.getEncodingPositions());
+
+    assertEquals(true, schema1.equivalent(sortedSchema1));
+    assertEquals(true,
+        Objects.equals(sortedSchema1.getFields(), schema2.getFields())
+            && Objects.equals(sortedSchema1.getOptions(), schema2.getOptions())
+            && Objects.equals(sortedSchema1.getEncodingPositions(), schema2.getEncodingPositions()));
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaTest.java
@@ -198,7 +198,7 @@ public class SchemaTest {
             .setOption("test_bool_option", FieldType.BOOLEAN, true)
             .build();
 
-    Schema schema1 =
+    Schema unorderedSchema =
         Schema.builder()
             .addStringField("d")
             .addInt32Field("c")
@@ -207,9 +207,9 @@ public class SchemaTest {
             .build()
             .withOptions(testOptions);
 
-    Schema sortedSchema1 = schema1.sorted();
+    Schema unorderedSchemaAfterSorting = unorderedSchema.sorted();
 
-    Schema schema2 =
+    Schema sortedSchema =
         Schema.builder()
             .addByteField("a")
             .addStringField("b")
@@ -217,15 +217,15 @@ public class SchemaTest {
             .addStringField("d")
             .build()
             .withOptions(testOptions);
-    schema2.setEncodingPositions(schema1.getEncodingPositions());
+    sortedSchema.setEncodingPositions(unorderedSchema.getEncodingPositions());
 
-    assertEquals(true, schema1.equivalent(sortedSchema1));
+    assertEquals(true, unorderedSchema.equivalent(unorderedSchemaAfterSorting));
     assertEquals(
         true,
-        Objects.equals(sortedSchema1.getFields(), schema2.getFields())
-            && Objects.equals(sortedSchema1.getOptions(), schema2.getOptions())
+        Objects.equals(unorderedSchemaAfterSorting.getFields(), sortedSchema.getFields())
+            && Objects.equals(unorderedSchemaAfterSorting.getOptions(), sortedSchema.getOptions())
             && Objects.equals(
-                sortedSchema1.getEncodingPositions(), schema2.getEncodingPositions()));
+            unorderedSchemaAfterSorting.getEncodingPositions(), sortedSchema.getEncodingPositions()));
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaTest.java
@@ -24,7 +24,6 @@ import static org.junit.Assert.assertNotEquals;
 import static org.junit.Assert.assertTrue;
 
 import java.util.Objects;
-import java.util.UUID;
 import java.util.stream.Stream;
 import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
@@ -193,25 +192,40 @@ public class SchemaTest {
 
   @Test
   public void testSorted() {
-    Options testOptions = Options.builder().setOption("test_str_option", FieldType.STRING, "test_str")
-        .setOption("test_bool_option", FieldType.BOOLEAN, true).build();
+    Options testOptions =
+        Options.builder()
+            .setOption("test_str_option", FieldType.STRING, "test_str")
+            .setOption("test_bool_option", FieldType.BOOLEAN, true)
+            .build();
 
     Schema schema1 =
-        Schema.builder().addStringField("d").addInt32Field("c").addStringField("b").addByteField("a").build()
+        Schema.builder()
+            .addStringField("d")
+            .addInt32Field("c")
+            .addStringField("b")
+            .addByteField("a")
+            .build()
             .withOptions(testOptions);
 
     Schema sortedSchema1 = schema1.sorted();
 
     Schema schema2 =
-        Schema.builder().addByteField("a").addStringField("b").addInt32Field("c").addStringField("d").build()
+        Schema.builder()
+            .addByteField("a")
+            .addStringField("b")
+            .addInt32Field("c")
+            .addStringField("d")
+            .build()
             .withOptions(testOptions);
     schema2.setEncodingPositions(schema1.getEncodingPositions());
 
     assertEquals(true, schema1.equivalent(sortedSchema1));
-    assertEquals(true,
+    assertEquals(
+        true,
         Objects.equals(sortedSchema1.getFields(), schema2.getFields())
             && Objects.equals(sortedSchema1.getOptions(), schema2.getOptions())
-            && Objects.equals(sortedSchema1.getEncodingPositions(), schema2.getEncodingPositions()));
+            && Objects.equals(
+                sortedSchema1.getEncodingPositions(), schema2.getEncodingPositions()));
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaTest.java
@@ -254,6 +254,7 @@ public class SchemaTest {
     // Current attributes in Schema object.
     List<String> currentAttributes =
         Arrays.stream(Schema.class.getDeclaredFields())
+            .filter(field -> !field.isSynthetic())
             .map(java.lang.reflect.Field::getName)
             .collect(Collectors.toList());
 


### PR DESCRIPTION
`TypedSchemaTransformProvider::configurationSchema` returns an inconsistently ordered Schema object. A consistent Schema is needed to use configuration Row objects to instantiate and build SchemaTransforms. The solution in this PR is to sort the fields by name.

Fixes #24361