### PR TITLE
perf: improve bigtableio.WriteBatch performance by approx. 20% due to non blocking batch

### DIFF
--- a/sdks/go/pkg/beam/io/bigtableio/bigtable_test.go
+++ b/sdks/go/pkg/beam/io/bigtableio/bigtable_test.go
@@ -156,11 +156,11 @@ func TestValidateMutationFailsWhenGreaterThanHundredKOps(t *testing.T) {
 
 // Examples:
 
-func ExampleWriteBatch() {
+func ExampleWrite() {
 	pipeline := beam.NewPipeline()
 	s := pipeline.Root()
 
-	//sample PBCollection<bigtableio.Mutation>
+	// sample PBCollection<bigtableio.Mutation>
 	bigtableioMutationCol := beam.CreateList(s, func() []Mutation {
 		columnFamilyName := "stats_summary"
 		timestamp := bigtable.Now()
@@ -172,7 +172,7 @@ func ExampleWriteBatch() {
 		rowKeyA := deviceA + "#a0b81f74#20190501"
 
 		// bigtableio.NewMutation(rowKeyA).WithGroupKey(deviceA)
-		mutA := NewMutation(rowKeyA).WithGroupKey(deviceA) // this groups bundles by device identifiers
+		mutA := NewMutation(rowKeyA).WithGroupKey(deviceA)
 		mutA.Set(columnFamilyName, "connected_wifi", timestamp, []byte("1"))
 		mutA.Set(columnFamilyName, "os_build", timestamp, []byte("12155.0.0-rc1"))
 
@@ -182,6 +182,42 @@ func ExampleWriteBatch() {
 		rowKeyB := deviceB + "#a0b81f74#20190502"
 
 		mutB := NewMutation(rowKeyB).WithGroupKey(deviceB)
+		mutB.Set(columnFamilyName, "connected_wifi", timestamp, []byte("1"))
+		mutB.Set(columnFamilyName, "os_build", timestamp, []byte("12145.0.0-rc6"))
+
+		muts = append(muts, *mutB)
+
+		return muts
+	}())
+
+	// bigtableio.Write(...)
+	Write(s, "project", "instanceId", "tableName", bigtableioMutationCol)
+}
+
+func ExampleWriteBatch() {
+	pipeline := beam.NewPipeline()
+	s := pipeline.Root()
+
+	// sample PBCollection<bigtableio.Mutation>
+	bigtableioMutationCol := beam.CreateList(s, func() []Mutation {
+		columnFamilyName := "stats_summary"
+		timestamp := bigtable.Now()
+
+		// var muts []bigtableio.Mutation
+		var muts []Mutation
+
+		rowKeyA := "tablet#a0b81f74#20190501"
+
+		// bigtableio.NewMutation(rowKeyA)
+		mutA := NewMutation(rowKeyA)
+		mutA.Set(columnFamilyName, "connected_wifi", timestamp, []byte("1"))
+		mutA.Set(columnFamilyName, "os_build", timestamp, []byte("12155.0.0-rc1"))
+
+		muts = append(muts, *mutA)
+
+		rowKeyB := "phone#a0b81f74#20190502"
+
+		mutB := NewMutation(rowKeyB)
 		mutB.Set(columnFamilyName, "connected_wifi", timestamp, []byte("1"))
 		mutB.Set(columnFamilyName, "os_build", timestamp, []byte("12145.0.0-rc6"))
 


### PR DESCRIPTION
Further testing with the changes from #23324 showed that especially for larger batch-processed datasets (tested with datasets with sizes of around 110 million rows) profited from removing the GroupByKey step and therefore making the actual WriteBatch process non-blocking and about 20% faster. This was due to the bounded nature of batch-processed PBCollection. Changes been fully tested. By chance they can still make release-2.44.0

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
