### PR TITLE
Update grouping table to sample window size as well

### DIFF
--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/PrecombineGroupingTable.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/PrecombineGroupingTable.java
@@ -21,7 +21,6 @@ import java.util.Collection;
 import java.util.Collections;
 import java.util.Iterator;
 import java.util.LinkedHashMap;
-import java.util.Objects;
 import java.util.Random;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nullable;
@@ -72,7 +71,6 @@ public class PrecombineGroupingTable<K, InputT, AccumT>
         keyCoder,
         GlobalCombineFnRunners.create(combineFn),
         Caches::weigh,
-        Caches::weigh,
         isGloballyWindowed);
   }
 
@@ -93,8 +91,7 @@ public class PrecombineGroupingTable<K, InputT, AccumT>
         cache,
         keyCoder,
         GlobalCombineFnRunners.create(combineFn),
-        new SamplingSizeEstimator<>(Caches::weigh, sizeEstimatorSampleRate, 1.0),
-        new SamplingSizeEstimator<>(Caches::weigh, sizeEstimatorSampleRate, 1.0),
+        new SamplingSizeEstimator(Caches::weigh, sizeEstimatorSampleRate, 1.0),
         isGloballyWindowed);
   }
 
@@ -118,20 +115,19 @@ public class PrecombineGroupingTable<K, InputT, AccumT>
 
   /** Provides client-specific operations for size estimates. */
   @FunctionalInterface
-  public interface SizeEstimator<T> {
-    long estimateSize(T element);
+  public interface SizeEstimator {
+    long estimateSize(Object element);
   }
 
   private final Coder<K> keyCoder;
   private final GlobalCombineFnRunner<InputT, AccumT, ?> combineFn;
   private final PipelineOptions options;
-  private final SizeEstimator<K> keySizer;
-  private final SizeEstimator<AccumT> accumulatorSizer;
+  private final SizeEstimator sizer;
   private final Cache<Key, PrecombineGroupingTable<K, InputT, AccumT>> cache;
   private final LinkedHashMap<GroupingTableKey, GroupingTableEntry> lruMap;
   private final AtomicLong maxWeight;
   private long weight;
-  private boolean isGloballyWindowed;
+  private final boolean isGloballyWindowed;
   private long checkFlushCounter;
   private long checkFlushLimit = -5;
 
@@ -152,15 +148,13 @@ public class PrecombineGroupingTable<K, InputT, AccumT>
       Cache<?, ?> cache,
       Coder<K> keyCoder,
       GlobalCombineFnRunner<InputT, AccumT, ?> combineFn,
-      SizeEstimator<K> keySizer,
-      SizeEstimator<AccumT> accumulatorSizer,
+      SizeEstimator sizer,
       boolean isGloballyWindowed) {
     this.options = options;
     this.cache = (Cache<Key, PrecombineGroupingTable<K, InputT, AccumT>>) cache;
     this.keyCoder = keyCoder;
     this.combineFn = combineFn;
-    this.keySizer = keySizer;
-    this.accumulatorSizer = accumulatorSizer;
+    this.sizer = sizer;
     this.isGloballyWindowed = isGloballyWindowed;
     this.lruMap = new LinkedHashMap<>(16, 0.75f, true);
     this.maxWeight = new AtomicLong();
@@ -180,7 +174,8 @@ public class PrecombineGroupingTable<K, InputT, AccumT>
     int hashCode();
   }
 
-  private static class WindowedGroupingTableKey implements GroupingTableKey {
+  @VisibleForTesting
+  static class WindowedGroupingTableKey implements GroupingTableKey {
     private final Object structuralKey;
     private final Collection<? extends BoundedWindow> windows;
     private final long weight;
@@ -189,16 +184,10 @@ public class PrecombineGroupingTable<K, InputT, AccumT>
         K key,
         Collection<? extends BoundedWindow> windows,
         Coder<K> keyCoder,
-        SizeEstimator<K> keySizer) {
+        SizeEstimator sizer) {
       this.structuralKey = keyCoder.structuralValue(key);
       this.windows = windows;
-      // We account for the weight of the key using the keySizer if the coder's structural value
-      // is the same as its value.
-      if (structuralKey == key) {
-        weight = keySizer.estimateSize(key) + Caches.weigh(windows);
-      } else {
-        weight = Caches.weigh(this);
-      }
+      this.weight = sizer.estimateSize(this);
     }
 
     @Override
@@ -225,12 +214,12 @@ public class PrecombineGroupingTable<K, InputT, AccumT>
         return false;
       }
       WindowedGroupingTableKey that = (WindowedGroupingTableKey) o;
-      return Objects.equals(structuralKey, that.structuralKey) && windows.equals(that.windows);
+      return structuralKey.equals(that.structuralKey) && windows.equals(that.windows);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hash(structuralKey, windows);
+      return structuralKey.hashCode() * 31 + windows.hashCode();
     }
 
     @Override
@@ -246,21 +235,17 @@ public class PrecombineGroupingTable<K, InputT, AccumT>
     }
   }
 
-  private static class GloballyWindowedTableGroupingKey implements GroupingTableKey {
+  @VisibleForTesting
+  static class GloballyWindowedTableGroupingKey implements GroupingTableKey {
     private static final Collection<? extends BoundedWindow> GLOBAL_WINDOWS =
         Collections.singletonList(GlobalWindow.INSTANCE);
 
     private final Object structuralKey;
     private final long weight;
 
-    private <K> GloballyWindowedTableGroupingKey(
-        K key, Coder<K> keyCoder, SizeEstimator<K> keySizer) {
-      structuralKey = keyCoder.structuralValue(key);
-      if (structuralKey == key) {
-        weight = keySizer.estimateSize(key);
-      } else {
-        weight = Caches.weigh(this);
-      }
+    private <K> GloballyWindowedTableGroupingKey(K key, Coder<K> keyCoder, SizeEstimator sizer) {
+      this.structuralKey = keyCoder.structuralValue(key);
+      this.weight = sizer.estimateSize(this);
     }
 
     @Override
@@ -287,16 +272,17 @@ public class PrecombineGroupingTable<K, InputT, AccumT>
         return false;
       }
       GloballyWindowedTableGroupingKey that = (GloballyWindowedTableGroupingKey) o;
-      return Objects.equals(structuralKey, that.structuralKey);
+      return structuralKey.equals(that.structuralKey);
     }
 
     @Override
     public int hashCode() {
-      return Objects.hashCode(structuralKey);
+      return structuralKey.hashCode();
     }
   }
 
-  private class GroupingTableEntry implements Weighted {
+  @VisibleForTesting
+  class GroupingTableEntry implements Weighted {
     private final GroupingTableKey groupingKey;
     private final K userKey;
     // The PGBK output will inherit the timestamp of one of its inputs.
@@ -319,13 +305,13 @@ public class PrecombineGroupingTable<K, InputT, AccumT>
         // by the cache so the accounting of the size of the key is occurring already.
         this.keySize = Caches.REFERENCE_SIZE * 2;
       } else {
-        this.keySize = Caches.REFERENCE_SIZE + keySizer.estimateSize(userKey);
+        this.keySize = Caches.REFERENCE_SIZE + sizer.estimateSize(userKey);
       }
       this.accumulator =
           combineFn.createAccumulator(
               options, NullSideInputReader.empty(), groupingKey.getWindows());
       add(initialInputValue);
-      this.accumulatorSize = accumulatorSizer.estimateSize(accumulator);
+      this.accumulatorSize = sizer.estimateSize(accumulator);
     }
 
     public GroupingTableKey getGroupingKey() {
@@ -354,7 +340,7 @@ public class PrecombineGroupingTable<K, InputT, AccumT>
         accumulator =
             combineFn.compact(
                 accumulator, options, NullSideInputReader.empty(), groupingKey.getWindows());
-        accumulatorSize = accumulatorSizer.estimateSize(accumulator);
+        accumulatorSize = sizer.estimateSize(accumulator);
         dirty = false;
       }
     }
@@ -364,7 +350,7 @@ public class PrecombineGroupingTable<K, InputT, AccumT>
       accumulator =
           combineFn.addInput(
               accumulator, value, options, NullSideInputReader.empty(), groupingKey.getWindows());
-      accumulatorSize = accumulatorSizer.estimateSize(accumulator);
+      accumulatorSize = sizer.estimateSize(accumulator);
     }
 
     @Override
@@ -398,9 +384,9 @@ public class PrecombineGroupingTable<K, InputT, AccumT>
     // The Pre-combine output will inherit the timestamp of one of its inputs.
     GroupingTableKey groupingKey =
         isGloballyWindowed
-            ? new GloballyWindowedTableGroupingKey(value.getValue().getKey(), keyCoder, keySizer)
+            ? new GloballyWindowedTableGroupingKey(value.getValue().getKey(), keyCoder, sizer)
             : new WindowedGroupingTableKey(
-                value.getValue().getKey(), value.getWindows(), keyCoder, keySizer);
+                value.getValue().getKey(), value.getWindows(), keyCoder, sizer);
 
     lruMap.compute(
         groupingKey,
@@ -483,7 +469,7 @@ public class PrecombineGroupingTable<K, InputT, AccumT>
                 KV.of(entry.getKey(), entry.getAccumulator()),
                 entry.getOutputTimestamp(),
                 entry.getGroupingKey().getWindows(),
-                // The PaneInfow will always be overwritten by the GBK.
+                // The PaneInfo will always be overwritten by the GBK.
                 PaneInfo.NO_FIRING));
   }
 
@@ -505,7 +491,7 @@ public class PrecombineGroupingTable<K, InputT, AccumT>
    * expensive) estimator for some elements and returning the average value for others.
    */
   @VisibleForTesting
-  static class SamplingSizeEstimator<T> implements SizeEstimator<T> {
+  static class SamplingSizeEstimator implements SizeEstimator {
 
     /**
      * The degree of confidence required in our expected value predictions before we allow
@@ -526,7 +512,7 @@ public class PrecombineGroupingTable<K, InputT, AccumT>
     /** Default number of elements that must be measured before elements are skipped. */
     static final long DEFAULT_MIN_SAMPLED = 20;
 
-    private final SizeEstimator<T> underlying;
+    private final SizeEstimator underlying;
     private final double minSampleRate;
     private final double maxSampleRate;
     private final long minSampled;
@@ -541,13 +527,13 @@ public class PrecombineGroupingTable<K, InputT, AccumT>
     private long nextSample = 0;
 
     private SamplingSizeEstimator(
-        SizeEstimator<T> underlying, double minSampleRate, double maxSampleRate) {
+        SizeEstimator underlying, double minSampleRate, double maxSampleRate) {
       this(underlying, minSampleRate, maxSampleRate, DEFAULT_MIN_SAMPLED, new Random());
     }
 
     @VisibleForTesting
     SamplingSizeEstimator(
-        SizeEstimator<T> underlying,
+        SizeEstimator underlying,
         double minSampleRate,
         double maxSampleRate,
         long minSampled,
@@ -560,7 +546,7 @@ public class PrecombineGroupingTable<K, InputT, AccumT>
     }
 
     @Override
-    public long estimateSize(T element) {
+    public long estimateSize(Object element) {
       if (sampleNow()) {
         return recordSample(underlying.estimateSize(element));
       } else {


### PR DESCRIPTION
The existing implementation only sampled the key/accumulator size but always measured the size of the window. Note the 50-75% improvement for non-globally windowed accumulation.

There are also some trivial reductions hashCode/equality since we know that certain types are always non-null.

Before
```
Benchmark                                                 (distribution)  (globallyWindowed)   Mode  Cnt   Score   Error  Units 
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine         uniform                true  thrpt   15  12.775 ± 0.640  ops/s 
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine         uniform               false  thrpt   15   6.047 ± 0.535  ops/s 
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine          normal                true  thrpt   15   7.148 ± 0.473  ops/s 
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine          normal               false  thrpt   15   4.233 ± 0.239  ops/s 
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine          hotKey                true  thrpt   15  13.894 ± 0.649  ops/s 
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine          hotKey               false  thrpt   15   6.708 ± 0.375  ops/s 
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine      uniqueKeys                true  thrpt   15   2.286 ± 0.115  ops/s 
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine      uniqueKeys               false  thrpt   15   1.765 ± 0.064  ops/s
```

After
```
Benchmark                                                 (distribution)  (globallyWindowed)   Mode  Cnt   Score   Error  Units 
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine         uniform                true  thrpt   15  13.399 ± 0.241  ops/s 
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine         uniform               false  thrpt   15  11.522 ± 1.120  ops/s 
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine          normal                true  thrpt   15   7.186 ± 0.123  ops/s 
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine          normal               false  thrpt   15   6.578 ± 0.161  ops/s 
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine          hotKey                true  thrpt   15  13.467 ± 0.562  ops/s 
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine          hotKey               false  thrpt   15   9.704 ± 0.866  ops/s 
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine      uniqueKeys                true  thrpt   15   2.264 ± 0.110  ops/s 
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine      uniqueKeys               false  thrpt   15   2.255 ± 0.190  ops/s
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
