### PR TITLE
[Playground] parse url_notebook example tag

### DIFF
--- a/playground/infrastructure/cd_helper.py
+++ b/playground/infrastructure/cd_helper.py
@@ -88,7 +88,7 @@ class CDHelper:
                 if example.sdk in [SDK_JAVA, SDK_PYTHON]:
                     example.graph = await client.get_graph(example.pipeline_id, example.filepath)
             except Exception as e:
-                logging.error(example.link)
+                logging.error(example.url_vcs)
                 logging.error(example.compile_output)
                 raise RuntimeError(f"error in {example.name}") from e
 

--- a/playground/infrastructure/config.py
+++ b/playground/infrastructure/config.py
@@ -61,7 +61,7 @@ class Config:
     CI_STEP_NAME = "CI"
     CD_STEP_NAME = "CD"
     CI_CD_LITERAL = Literal["CI", "CD"]
-    LINK_PREFIX = "https://github.com/apache/beam/blob/master"
+    URL_VCS_PREFIX = "https://github.com/apache/beam/blob/master"
     GOOGLE_CLOUD_PROJECT = os.getenv("GOOGLE_CLOUD_PROJECT")
     SDK_CONFIG = os.getenv("SDK_CONFIG", "../../playground/sdks.yaml")
 
@@ -74,11 +74,12 @@ class TagFields:
     categories: str = "categories"
     pipeline_options: str = "pipeline_options"
     default_example: str = "default_example"
-    context_line: int = "context_line"
+    context_line: str = "context_line"
     complexity: str = "complexity"
     tags: str = "tags"
     emulators: str = "emulators"
     datasets: str = "datasets"
+    url_notebook: str = "url_notebook"
 
 
 @dataclass(frozen=True)
@@ -103,6 +104,7 @@ class OptionalTagFields:
     default_example: str = "default_example"
     emulators: str = "emulators"
     datasets: str = "datasets"
+    url_notebook: str = "url_notebook"
 
 
 @dataclass(frozen=True)

--- a/playground/infrastructure/datastore_client.py
+++ b/playground/infrastructure/datastore_client.py
@@ -295,10 +295,12 @@ class DatastoreClient:
                 "descr": example.tag.description,
                 "tags": example.tag.tags,
                 "cats": example.tag.categories,
-                "path": example.link,
+                "path": example.url_vcs, # keep for backward-compatibity, to be removed
                 "type": PrecompiledObjectType.Name(example.type),
                 "origin": origin,
                 "schVer": schema_key,
+                "urlVCS": example.url_vcs,
+                "urlNotebook": example.url_notebook,
             }
         )
         return example_entity

--- a/playground/infrastructure/helper.py
+++ b/playground/infrastructure/helper.py
@@ -21,6 +21,7 @@ import logging
 import os
 from collections import namedtuple
 from dataclasses import dataclass, fields, field
+import urllib3
 from pathlib import PurePath
 from typing import List, Optional, Dict
 from api.v1 import api_pb2
@@ -280,12 +281,9 @@ def _get_url_vcs(filepath: str):
     """
     Construct VCS URL from example's filepath
     """
-    root_dir = os.getenv("BEAM_ROOT_DIR", "")
-    file_path_without_root = filepath.replace(root_dir, "", 1)
-    if file_path_without_root.startswith("/"):
-        return "{}{}".format(Config.URL_VCS_PREFIX, file_path_without_root)
-    else:
-        return "{}/{}".format(Config.URL_VCS_PREFIX, file_path_without_root)
+    root_dir = os.getenv("BEAM_ROOT_DIR", "../..")
+    rel_path = os.path.relpath(filepath, root_dir)
+    return "{}/{}".format(Config.URL_VCS_PREFIX, rel_path)
 
 def _get_example(filepath: str, filename: str, tag: ExampleTag) -> Example:
     """

--- a/playground/infrastructure/test_ci_helper.py
+++ b/playground/infrastructure/test_ci_helper.py
@@ -62,7 +62,7 @@ async def test__verify_examples():
         output="output_of_example",
         status=STATUS_FINISHED,
         tag=Tag(**object_meta_def_ex),
-        link="link")
+        url_vcs="link")
     finished_example = Example(
         name="name",
         complexity="MEDIUM",
@@ -73,7 +73,8 @@ async def test__verify_examples():
         output="output_of_example",
         status=STATUS_FINISHED,
         tag=Tag(**object_meta),
-        link="link")
+        url_vcs="link",
+        url_notebook="notebook_link")
     examples_without_def_ex = [
         finished_example,
         finished_example,
@@ -97,7 +98,7 @@ async def test__verify_examples():
             output="output_of_example",
             status=STATUS_VALIDATION_ERROR,
             tag=Tag(**object_meta_def_ex),
-            link="link"),
+            url_vcs="link"),
         Example(
             name="name",
             complexity="MEDIUM",
@@ -108,7 +109,7 @@ async def test__verify_examples():
             output="output_of_example",
             status=STATUS_ERROR,
             tag=Tag(**object_meta),
-            link="link"),
+            url_vcs="link"),
         Example(
             name="name",
             complexity="MEDIUM",
@@ -119,7 +120,7 @@ async def test__verify_examples():
             output="output_of_example",
             status=STATUS_COMPILE_ERROR,
             tag=Tag(**object_meta),
-            link="link"),
+            url_vcs="link"),
         Example(
             name="name",
             complexity="MEDIUM",
@@ -130,7 +131,7 @@ async def test__verify_examples():
             output="output_of_example",
             status=STATUS_PREPARATION_ERROR,
             tag=Tag(**object_meta),
-            link="link"),
+            url_vcs="link"),
         Example(
             name="name",
             complexity="MEDIUM",
@@ -141,7 +142,7 @@ async def test__verify_examples():
             output="output_of_example",
             status=STATUS_RUN_TIMEOUT,
             tag=Tag(**object_meta),
-            link="link"),
+            url_vcs="link"),
         Example(
             name="name",
             complexity="MEDIUM",
@@ -152,7 +153,7 @@ async def test__verify_examples():
             output="output_of_example",
             status=STATUS_VALIDATION_ERROR,
             tag=Tag(**object_meta),
-            link="link"),
+            url_vcs="link"),
         Example(
             name="name",
             complexity="MEDIUM",
@@ -163,7 +164,7 @@ async def test__verify_examples():
             output="output_of_example",
             status=STATUS_RUN_ERROR,
             tag=Tag(**object_meta),
-            link="link"),
+            url_vcs="link"),
     ]
     client = mock.AsyncMock()
     with pytest.raises(VerifyException):

--- a/playground/infrastructure/test_helper.py
+++ b/playground/infrastructure/test_helper.py
@@ -128,7 +128,7 @@ async def test_get_statuses(mock_update_example_status):
         output="output",
         status=STATUS_UNSPECIFIED,
         tag={"name": "Name"},
-        link="link",
+        url_vcs="link"
     )
     client = mock.sentinel
     await get_statuses(client, [example])
@@ -167,7 +167,7 @@ def test__check_file_with_correct_tag(mock_get_tag, mock_validate, mock_get_exam
         code="data",
         status=STATUS_UNSPECIFIED,
         tag=Tag("Name", "Description", False, [], "--option option"),
-        link="link",
+        url_vcs="link",
     )
     examples = []
 
@@ -225,6 +225,7 @@ def test__get_example():
             "pipeline_options": "--option option",
             "context_line": 1,
             "complexity": "MEDIUM",
+            "url_notebook": "https://some_url/py-name.ipynb",
             "emulators": {"kafka": {"topic": {"id": "dataset", "dataset": "dataset"}}},
             "datasets": {"dataset": {"location": "local", "format": "json"}},
         },
@@ -250,8 +251,11 @@ def test__get_example():
             "--option option",
             False,
             1,
+            None,
+            "https://some_url/py-name.ipynb",
         ),
-        link="https://github.com/apache/beam/blob/master/root/filepath.java",
+        url_vcs="https://github.com/apache/beam/blob/master/root/filepath.java",
+        url_notebook="https://some_url/py-name.ipynb",
         complexity="MEDIUM",
         emulators=[
             Emulator(topic=Topic(id="dataset", dataset="dataset"), name="kafka")
@@ -340,8 +344,14 @@ async def test__update_example_status(mock_grpc_client_run_code, mock_grpc_clien
         code="code",
         output="output",
         status=STATUS_UNSPECIFIED,
-        tag=Tag(**{"pipeline_options": "--key value"}),
-        link="link",
+        tag=Tag(
+            name="MOCK_NAME",
+            description="MOCK_DESCR",
+            context_line=333,
+            pipeline_options="--key value",
+            complexity="MEDIUM",
+            ),
+        url_vcs="link",
     )
 
     mock_grpc_client_run_code.return_value = "pipeline_id"
@@ -432,11 +442,8 @@ def test_validate_example_fields_when_code_is_invalid():
 
 def test_validate_example_fields_when_link_is_invalid():
     example = _create_example("MOCK_NAME")
-    example.link = ""
-    with pytest.raises(
-          ValidationException,
-          match="Example doesn't have a link field. Path: MOCK_FILEPATH",
-    ):
+    example.url_vcs = ""
+    with pytest.raises(ValidationException, match="Example doesn't have a url_vcs field. Path: MOCK_FILEPATH"):
         validate_example_fields(example)
 
 
@@ -558,7 +565,7 @@ def _create_example_with_meta(name: str, object_meta: Dict[str, Union[str, bool,
         output="MOCK_OUTPUT",
         status=STATUS_UNSPECIFIED,
         tag=Tag(**object_meta),
-        link="MOCK_LINK",
+        url_vcs="MOCK_LINK",
         complexity="MOCK_COMPLEXITY",
     )
     return example

--- a/playground/infrastructure/test_helper.py
+++ b/playground/infrastructure/test_helper.py
@@ -232,13 +232,14 @@ def test__get_example():
         "",
     )
 
-    result = _get_example("/root/filepath.java", "filepath.java", tag)
+    result = _get_example("../../examples/dir/filepath.java", "filepath.java", tag)
 
     assert result == Example(
         name="Name",
         sdk=SDK_JAVA,
-        filepath="/root/filepath.java",
+        filepath="../../examples/dir/filepath.java",
         code="data",
+        type=PRECOMPILED_OBJECT_TYPE_EXAMPLE,
         status=STATUS_UNSPECIFIED,
         tag=Tag(
             "Name",
@@ -254,7 +255,7 @@ def test__get_example():
             None,
             "https://some_url/py-name.ipynb",
         ),
-        url_vcs="https://github.com/apache/beam/blob/master/root/filepath.java",
+        url_vcs="https://github.com/apache/beam/blob/master/examples/dir/filepath.java",
         url_notebook="https://some_url/py-name.ipynb",
         complexity="MEDIUM",
         emulators=[

--- a/playground/infrastructure/test_utils.py
+++ b/playground/infrastructure/test_utils.py
@@ -39,6 +39,6 @@ def _get_examples(number_of_examples: int) -> List[Example]:
             output=f"MOCK_OUTPUT_{number}",
             status=STATUS_UNSPECIFIED,
             tag=Tag(**object_meta),
-            link=f"MOCK_LINK_{number}")
+            url_vcs=f"MOCK_LINK_{number}")
         examples.append(example)
     return examples


### PR DESCRIPTION
resolves #24225
follow-up PR which uses new fields: #24425

example tag:
```
# beam-playground:
#   name: setting-pipeline
#   description: Setting pipeline example.
#   url_notebook: https://some-url/py-file.ipynb
#   multifile: false
#   context_line: 35
```

Resulting pg_examples entity has an old `path` field along with new ones: `urlVCS`(==`path`) and `urlNotebook`

Proposed update sequence:
- infrastructure merged, examples CD step is run. Both backend versions, old and new consume different pg_examples fields
- backend merged, deployed. New backend API provides all fields: `link`, `url_vcs`, and `url_notebook` to not break old frontend client
- frontend merged, deployed. New frontend consumes only `url_vcs` and `url_notebook`, ignores `link`
Optional steps:
- `path` is removed from pg_examples, infrastructure merged, examples CD step applied
- `link` field removed from proto and marked reserved
- backend, frontend deployed


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
