### PR TITLE
Fix multiple mutations affecting the same entity in Datastore write

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1Test.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1Test.java
@@ -553,7 +553,7 @@ public class DatastoreV1Test {
 
     /** Tests {@link DatastoreWriterFn} with entities less than one batch. */
     @Test
-    public void testDatatoreWriterFnWithOneBatch() throws Exception {
+    public void testDatastoreWriterFnWithOneBatch() throws Exception {
       datastoreWriterFnTest(100);
       verifyMetricWasSet("BatchDatastoreWrite", "ok", "", 2);
     }
@@ -562,7 +562,7 @@ public class DatastoreV1Test {
      * Tests {@link DatastoreWriterFn} with entities of more than one batches, but not a multiple.
      */
     @Test
-    public void testDatatoreWriterFnWithMultipleBatches() throws Exception {
+    public void testDatastoreWriterFnWithMultipleBatches() throws Exception {
       datastoreWriterFnTest(DatastoreV1.DATASTORE_BATCH_UPDATE_ENTITIES_START * 3 + 100);
       verifyMetricWasSet("BatchDatastoreWrite", "ok", "", 5);
     }
@@ -572,7 +572,7 @@ public class DatastoreV1Test {
      * write batch size.
      */
     @Test
-    public void testDatatoreWriterFnWithBatchesExactMultiple() throws Exception {
+    public void testDatastoreWriterFnWithBatchesExactMultiple() throws Exception {
       datastoreWriterFnTest(DatastoreV1.DATASTORE_BATCH_UPDATE_ENTITIES_START * 2);
       verifyMetricWasSet("BatchDatastoreWrite", "ok", "", 2);
     }
@@ -612,7 +612,7 @@ public class DatastoreV1Test {
      * Tests {@link DatastoreWriterFn} with large entities that need to be split into more batches.
      */
     @Test
-    public void testDatatoreWriterFnWithLargeEntities() throws Exception {
+    public void testDatastoreWriterFnWithLargeEntities() throws Exception {
       List<Mutation> mutations = new ArrayList<>();
       int entitySize = 0;
       for (int i = 0; i < 12; ++i) {
@@ -654,7 +654,7 @@ public class DatastoreV1Test {
 
     /** Tests {@link DatastoreWriterFn} correctly flushes batch upon receive same entity keys. */
     @Test
-    public void testDatatoreWriterFnWithDuplicateEntities() throws Exception {
+    public void testDatastoreWriterFnWithDuplicateEntities() throws Exception {
       List<Mutation> mutations = new ArrayList<>();
       for (int i : Arrays.asList(0, 1, 0, 2)) {
         // this will generate entities having key 0, 1, 0, 2 and random values
@@ -693,7 +693,7 @@ public class DatastoreV1Test {
 
     /** Tests {@link DatastoreWriterFn} with a failed request which is retried. */
     @Test
-    public void testDatatoreWriterFnRetriesErrors() throws Exception {
+    public void testDatastoreWriterFnRetriesErrors() throws Exception {
       List<Mutation> mutations = new ArrayList<>();
       int numRpcs = 2;
       for (int i = 0; i < DatastoreV1.DATASTORE_BATCH_UPDATE_ENTITIES_START * numRpcs; ++i) {

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/datastore/RampupThrottlingFnTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/datastore/RampupThrottlingFnTest.java
@@ -21,6 +21,7 @@ import static org.junit.Assert.assertThrows;
 import static org.mockito.Mockito.verify;
 
 import java.util.Map;
+import java.util.UUID;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
@@ -52,7 +53,7 @@ public class RampupThrottlingFnTest {
         verify(mockCounter).inc(millis);
         throw new RampupDelayException();
       };
-  private DoFnTester<Void, Void> rampupThrottlingFnTester;
+  private DoFnTester<String, String> rampupThrottlingFnTester;
 
   @Before
   public void setUp() throws Exception {
@@ -62,8 +63,8 @@ public class RampupThrottlingFnTest {
     TestPipeline pipeline = TestPipeline.create();
     PCollectionView<Instant> startTimeView =
         pipeline.apply(Create.of(Instant.now())).apply(View.asSingleton());
-    RampupThrottlingFn<Void> rampupThrottlingFn =
-        new RampupThrottlingFn<Void>(1, startTimeView) {
+    RampupThrottlingFn<String> rampupThrottlingFn =
+        new RampupThrottlingFn<String>(1, startTimeView) {
           @Override
           @Setup
           public void setup() {
@@ -101,7 +102,7 @@ public class RampupThrottlingFnTest {
     for (Map.Entry<Duration, Integer> entry : rampupSchedule.entrySet()) {
       DateTimeUtils.setCurrentMillisFixed(entry.getKey().getMillis());
       for (int i = 0; i < entry.getValue(); i++) {
-        rampupThrottlingFnTester.processElement(null);
+        rampupThrottlingFnTester.processElement(UUID.randomUUID().toString());
       }
       assertThrows(RampupDelayException.class, () -> rampupThrottlingFnTester.processElement(null));
     }


### PR DESCRIPTION
Fixes #18521

* Use entity key instead of mutation hash value to decide flush

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
