### PR TITLE
[Playground] use JAVA SDK 2.43.0 in Examples CI

### DIFF
--- a/.github/workflows/playground_examples_ci_reusable.yml
+++ b/.github/workflows/playground_examples_ci_reusable.yml
@@ -34,7 +34,7 @@ on:
         type: string
         required: true
 env:
-  BEAM_VERSION: 2.42.0
+  BEAM_VERSION: 2.43.0
 jobs:
   check_has_examples:
     name: pre-check
@@ -140,6 +140,10 @@ jobs:
              opts=" -Pdocker-tag=$DOCKERTAG"
              if [ -n "$SDK_TAG" ]; then
                 opts="$opts -Psdk-tag=$SDK_TAG"
+             fi
+             if [ "$SDK" == "java" ]; then
+                # Java uses a fixed BEAM_VERSION
+                opts="$opts -Pbase-image=apache/beam_java8_sdk:$BEAM_VERSION"
              fi
 
              # by default (w/o -Psdk-tag) runner uses BEAM from local ./sdks

--- a/playground/backend/containers/java/Dockerfile
+++ b/playground/backend/containers/java/Dockerfile
@@ -15,7 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ###############################################################################
-ARG BEAM_VERSION=2.42.0
+ARG BEAM_VERSION=2.43.0
 ARG BASE_IMAGE=apache/beam_java8_sdk:${BEAM_VERSION}
 FROM golang:1.18-bullseye AS build
 


### PR DESCRIPTION
1. Bump BEAM_VERSION in java/Dockerfile
2. Make workflow and gradle task consistent: there was ambiguity when `-Pbase-image` is undefined, it uses the latest published SDK image which is now 2.43.0, and differs from BEAM_VERSION=2.42.0 in above Dockerfile

In future, we may want to rework Playground Java runner to use the SDK from local fs, as Go and Python runners do

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
