### PR TITLE
Allow avro block size to be configurable in AvroIO.write

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
@@ -573,7 +573,7 @@ public class AvroIO {
         .setMetadata(ImmutableMap.of())
         .setWindowedWrites(false)
         .setNoSpilling(false)
-        .setBlockSize(DataFileConstants.DEFAULT_SYNC_INTERVAL);
+        .setSyncInterval(DataFileConstants.DEFAULT_SYNC_INTERVAL);
   }
 
   @Experimental(Kind.SCHEMAS)
@@ -1320,7 +1320,7 @@ public class AvroIO {
 
     abstract boolean getGenericRecords();
 
-    abstract int getBlockSize();
+    abstract int getSyncInterval();
 
     abstract @Nullable Schema getSchema();
 
@@ -1366,7 +1366,7 @@ public class AvroIO {
 
       abstract Builder<UserT, DestinationT, OutputT> setGenericRecords(boolean genericRecords);
 
-      abstract Builder<UserT, DestinationT, OutputT> setBlockSize(int blockSize);
+      abstract Builder<UserT, DestinationT, OutputT> setSyncInterval(int syncInterval);
 
       abstract Builder<UserT, DestinationT, OutputT> setSchema(Schema schema);
 
@@ -1483,8 +1483,8 @@ public class AvroIO {
      * Sets the approximate number of uncompressed bytes to write in each block for the AVRO
      * container format.
      */
-    public TypedWrite<UserT, DestinationT, OutputT> withBlockSize(int blockSize) {
-      return toBuilder().setBlockSize(blockSize).build();
+    public TypedWrite<UserT, DestinationT, OutputT> withSyncInterval(int syncInterval) {
+      return toBuilder().setSyncInterval(syncInterval).build();
     }
 
     /**
@@ -1677,7 +1677,7 @@ public class AvroIO {
                   tempDirectory,
                   resolveDynamicDestinations(),
                   getGenericRecords(),
-                  getBlockSize()));
+                  getSyncInterval()));
       if (getNumShards() > 0) {
         write = write.withNumShards(getNumShards());
       }
@@ -1760,9 +1760,9 @@ public class AvroIO {
       return new Write<>(inner.to(dynamicDestinations).withFormatFunction(null));
     }
 
-    /** See {@link TypedWrite#withBlockSize}. */
-    public Write<T> withBlockSize(int blockSize) {
-      return new Write<>(inner.withBlockSize(blockSize));
+    /** See {@link TypedWrite#withSyncInterval}. */
+    public Write<T> withSyncInterval(int syncInterval) {
+      return new Write<>(inner.withSyncInterval(syncInterval));
     }
 
     /** See {@link TypedWrite#withSchema}. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroIO.java
@@ -30,6 +30,7 @@ import java.nio.channels.WritableByteChannel;
 import java.util.Map;
 import org.apache.avro.Schema;
 import org.apache.avro.file.CodecFactory;
+import org.apache.avro.file.DataFileConstants;
 import org.apache.avro.file.DataFileWriter;
 import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
@@ -571,7 +572,8 @@ public class AvroIO {
         .setCodec(TypedWrite.DEFAULT_SERIALIZABLE_CODEC)
         .setMetadata(ImmutableMap.of())
         .setWindowedWrites(false)
-        .setNoSpilling(false);
+        .setNoSpilling(false)
+        .setBlockSize(DataFileConstants.DEFAULT_SYNC_INTERVAL);
   }
 
   @Experimental(Kind.SCHEMAS)
@@ -1318,6 +1320,8 @@ public class AvroIO {
 
     abstract boolean getGenericRecords();
 
+    abstract int getBlockSize();
+
     abstract @Nullable Schema getSchema();
 
     abstract boolean getWindowedWrites();
@@ -1361,6 +1365,8 @@ public class AvroIO {
           @Nullable String shardTemplate);
 
       abstract Builder<UserT, DestinationT, OutputT> setGenericRecords(boolean genericRecords);
+
+      abstract Builder<UserT, DestinationT, OutputT> setBlockSize(int blockSize);
 
       abstract Builder<UserT, DestinationT, OutputT> setSchema(Schema schema);
 
@@ -1471,6 +1477,14 @@ public class AvroIO {
       return toBuilder()
           .setDynamicDestinations((DynamicAvroDestinations) dynamicDestinations)
           .build();
+    }
+
+    /**
+     * Sets the approximate number of uncompressed bytes to write in each block for the AVRO
+     * container format.
+     */
+    public TypedWrite<UserT, DestinationT, OutputT> withBlockSize(int blockSize) {
+      return toBuilder().setBlockSize(blockSize).build();
     }
 
     /**
@@ -1659,7 +1673,11 @@ public class AvroIO {
       }
       WriteFiles<UserT, DestinationT, OutputT> write =
           WriteFiles.to(
-              new AvroSink<>(tempDirectory, resolveDynamicDestinations(), getGenericRecords()));
+              new AvroSink<>(
+                  tempDirectory,
+                  resolveDynamicDestinations(),
+                  getGenericRecords(),
+                  getBlockSize()));
       if (getNumShards() > 0) {
         write = write.withNumShards(getNumShards());
       }
@@ -1742,10 +1760,16 @@ public class AvroIO {
       return new Write<>(inner.to(dynamicDestinations).withFormatFunction(null));
     }
 
+    /** See {@link TypedWrite#withBlockSize}. */
+    public Write<T> withBlockSize(int blockSize) {
+      return new Write<>(inner.withBlockSize(blockSize));
+    }
+
     /** See {@link TypedWrite#withSchema}. */
     public Write<T> withSchema(Schema schema) {
       return new Write<>(inner.withSchema(schema));
     }
+
     /** See {@link TypedWrite#withTempDirectory(ValueProvider)}. */
     @Experimental(Kind.FILESYSTEM)
     public Write<T> withTempDirectory(ValueProvider<ResourceId> tempDirectory) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSink.java
@@ -39,6 +39,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class AvroSink<UserT, DestinationT, OutputT>
     extends FileBasedSink<UserT, DestinationT, OutputT> {
   private final boolean genericRecords;
+  private final int blockSize;
 
   @FunctionalInterface
   public interface DatumWriterFactory<T> extends Serializable {
@@ -48,10 +49,12 @@ public class AvroSink<UserT, DestinationT, OutputT>
   AvroSink(
       ValueProvider<ResourceId> outputPrefix,
       DynamicAvroDestinations<UserT, DestinationT, OutputT> dynamicDestinations,
-      boolean genericRecords) {
+      boolean genericRecords,
+      int blockSize) {
     // Avro handles compression internally using the codec.
     super(outputPrefix, dynamicDestinations, Compression.UNCOMPRESSED);
     this.genericRecords = genericRecords;
+    this.blockSize = blockSize;
   }
 
   @Override
@@ -61,7 +64,7 @@ public class AvroSink<UserT, DestinationT, OutputT>
 
   @Override
   public WriteOperation<DestinationT, OutputT> createWriteOperation() {
-    return new AvroWriteOperation<>(this, genericRecords);
+    return new AvroWriteOperation<>(this, genericRecords, blockSize);
   }
 
   /** A {@link WriteOperation WriteOperation} for Avro files. */
@@ -69,16 +72,19 @@ public class AvroSink<UserT, DestinationT, OutputT>
       extends WriteOperation<DestinationT, OutputT> {
     private final DynamicAvroDestinations<?, DestinationT, OutputT> dynamicDestinations;
     private final boolean genericRecords;
+    private final int blockSize;
 
-    private AvroWriteOperation(AvroSink<?, DestinationT, OutputT> sink, boolean genericRecords) {
+    private AvroWriteOperation(
+        AvroSink<?, DestinationT, OutputT> sink, boolean genericRecords, int blockSize) {
       super(sink);
       this.dynamicDestinations = sink.getDynamicDestinations();
       this.genericRecords = genericRecords;
+      this.blockSize = blockSize;
     }
 
     @Override
     public Writer<DestinationT, OutputT> createWriter() throws Exception {
-      return new AvroWriter<>(this, dynamicDestinations, genericRecords);
+      return new AvroWriter<>(this, dynamicDestinations, genericRecords, blockSize);
     }
   }
 
@@ -90,14 +96,17 @@ public class AvroSink<UserT, DestinationT, OutputT>
 
     private final DynamicAvroDestinations<?, DestinationT, OutputT> dynamicDestinations;
     private final boolean genericRecords;
+    private final int blockSize;
 
     public AvroWriter(
         WriteOperation<DestinationT, OutputT> writeOperation,
         DynamicAvroDestinations<?, DestinationT, OutputT> dynamicDestinations,
-        boolean genericRecords) {
+        boolean genericRecords,
+        int blockSize) {
       super(writeOperation, MimeTypes.BINARY);
       this.dynamicDestinations = dynamicDestinations;
       this.genericRecords = genericRecords;
+      this.blockSize = blockSize;
     }
 
     @SuppressWarnings("deprecation") // uses internal test functionality.
@@ -133,6 +142,7 @@ public class AvroSink<UserT, DestinationT, OutputT>
                   + v.getClass().getSimpleName());
         }
       }
+      dataFileWriter.setSyncInterval(blockSize);
       dataFileWriter.create(schema, Channels.newOutputStream(channel));
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSink.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/AvroSink.java
@@ -39,7 +39,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class AvroSink<UserT, DestinationT, OutputT>
     extends FileBasedSink<UserT, DestinationT, OutputT> {
   private final boolean genericRecords;
-  private final int blockSize;
+  private final int syncInterval;
 
   @FunctionalInterface
   public interface DatumWriterFactory<T> extends Serializable {
@@ -50,11 +50,11 @@ public class AvroSink<UserT, DestinationT, OutputT>
       ValueProvider<ResourceId> outputPrefix,
       DynamicAvroDestinations<UserT, DestinationT, OutputT> dynamicDestinations,
       boolean genericRecords,
-      int blockSize) {
+      int syncInterval) {
     // Avro handles compression internally using the codec.
     super(outputPrefix, dynamicDestinations, Compression.UNCOMPRESSED);
     this.genericRecords = genericRecords;
-    this.blockSize = blockSize;
+    this.syncInterval = syncInterval;
   }
 
   @Override
@@ -64,7 +64,7 @@ public class AvroSink<UserT, DestinationT, OutputT>
 
   @Override
   public WriteOperation<DestinationT, OutputT> createWriteOperation() {
-    return new AvroWriteOperation<>(this, genericRecords, blockSize);
+    return new AvroWriteOperation<>(this, genericRecords, syncInterval);
   }
 
   /** A {@link WriteOperation WriteOperation} for Avro files. */
@@ -72,19 +72,19 @@ public class AvroSink<UserT, DestinationT, OutputT>
       extends WriteOperation<DestinationT, OutputT> {
     private final DynamicAvroDestinations<?, DestinationT, OutputT> dynamicDestinations;
     private final boolean genericRecords;
-    private final int blockSize;
+    private final int syncInterval;
 
     private AvroWriteOperation(
-        AvroSink<?, DestinationT, OutputT> sink, boolean genericRecords, int blockSize) {
+        AvroSink<?, DestinationT, OutputT> sink, boolean genericRecords, int syncInterval) {
       super(sink);
       this.dynamicDestinations = sink.getDynamicDestinations();
       this.genericRecords = genericRecords;
-      this.blockSize = blockSize;
+      this.syncInterval = syncInterval;
     }
 
     @Override
     public Writer<DestinationT, OutputT> createWriter() throws Exception {
-      return new AvroWriter<>(this, dynamicDestinations, genericRecords, blockSize);
+      return new AvroWriter<>(this, dynamicDestinations, genericRecords, syncInterval);
     }
   }
 
@@ -96,17 +96,17 @@ public class AvroSink<UserT, DestinationT, OutputT>
 
     private final DynamicAvroDestinations<?, DestinationT, OutputT> dynamicDestinations;
     private final boolean genericRecords;
-    private final int blockSize;
+    private final int syncInterval;
 
     public AvroWriter(
         WriteOperation<DestinationT, OutputT> writeOperation,
         DynamicAvroDestinations<?, DestinationT, OutputT> dynamicDestinations,
         boolean genericRecords,
-        int blockSize) {
+        int syncInterval) {
       super(writeOperation, MimeTypes.BINARY);
       this.dynamicDestinations = dynamicDestinations;
       this.genericRecords = genericRecords;
-      this.blockSize = blockSize;
+      this.syncInterval = syncInterval;
     }
 
     @SuppressWarnings("deprecation") // uses internal test functionality.
@@ -142,7 +142,7 @@ public class AvroSink<UserT, DestinationT, OutputT>
                   + v.getClass().getSimpleName());
         }
       }
-      dataFileWriter.setSyncInterval(blockSize);
+      dataFileWriter.setSyncInterval(syncInterval);
       dataFileWriter.create(schema, Channels.newOutputStream(channel));
     }
 


### PR DESCRIPTION
Adding support for making block size configurable for AvroIO.write operation. Setting a higher block size generally helps in achieving better compression ratio and is beneficial for persisting large datasets (in terms of storage cost).

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
