### PR TITLE
[Go SDK]: Infer field names from struct tags

### DIFF
--- a/sdks/go/pkg/beam/io/spannerio/spanner_test.go
+++ b/sdks/go/pkg/beam/io/spannerio/spanner_test.go
@@ -35,17 +35,6 @@ type TestDto struct {
 	Two int64  `spanner:"Two"`
 }
 
-func TestColumnsFromStructReturnsColumns(t *testing.T) {
-	// arrange
-	// act
-	cols := columnsFromStruct(reflect.TypeOf(TestDto{}))
-
-	// assert
-	if len(cols) != 2 {
-		t.Fatalf("got %v columns, expected 2", len(cols))
-	}
-}
-
 func TestRead(t *testing.T) {
 	testCases := []struct {
 		name          string

--- a/sdks/go/pkg/beam/util/structx/struct.go
+++ b/sdks/go/pkg/beam/util/structx/struct.go
@@ -1,0 +1,58 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+// Package structx provides utilities for working with structs.
+package structx
+
+import (
+	"fmt"
+	"reflect"
+	"strings"
+)
+
+// InferFieldNames returns the field names of the given struct type and tag key. Includes only
+// exported fields. If a field's tag key is empty or not set, uses the field's name. If a field's
+// tag key is set to '-', omits the field. Panics if the type's kind is not a struct.
+func InferFieldNames(t reflect.Type, key string) []string {
+	if t.Kind() != reflect.Struct {
+		panic(fmt.Sprintf("structx: InferFieldNames of non-struct type %s", t))
+	}
+
+	var names []string
+
+	for i := 0; i < t.NumField(); i++ {
+		field := t.Field(i)
+
+		if field.Anonymous {
+			names = append(names, InferFieldNames(field.Type, key)...)
+			continue
+		}
+
+		if !field.IsExported() {
+			continue
+		}
+
+		value := field.Tag.Get(key)
+		name := strings.Split(value, ",")[0]
+
+		if name == "" {
+			names = append(names, field.Name)
+		} else if name != "-" {
+			names = append(names, name)
+		}
+	}
+
+	return names
+}

--- a/sdks/go/pkg/beam/util/structx/struct_test.go
+++ b/sdks/go/pkg/beam/util/structx/struct_test.go
@@ -1,0 +1,144 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package structx
+
+import (
+	"reflect"
+	"testing"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestInferFieldNames(t *testing.T) {
+	type embedded struct {
+		Embedded1 string `key:"embedded1"`
+		Embedded2 string
+	}
+
+	tests := []struct {
+		name string
+		t    reflect.Type
+		key  string
+		want []string
+	}{
+		{
+			name: "Return slice of field names from tagged struct fields",
+			t: reflect.TypeOf(struct {
+				Field1 string `key:"field1"`
+				Field2 string `key:"field2"`
+			}{}),
+			key:  "key",
+			want: []string{"field1", "field2"},
+		},
+		{
+			name: "Return nil slice from struct with no fields",
+			t:    reflect.TypeOf(struct{}{}),
+			key:  "key",
+			want: nil,
+		},
+		{
+			name: "Use struct field name for field without tag",
+			t: reflect.TypeOf(struct {
+				Field1 string `key:"field1"`
+				Field2 string
+			}{}),
+			key:  "key",
+			want: []string{"field1", "Field2"},
+		},
+		{
+			name: "Use struct field name for field with empty tag",
+			t: reflect.TypeOf(struct {
+				Field1 string `key:"field1"`
+				Field2 string `key:""`
+			}{}),
+			key:  "key",
+			want: []string{"field1", "Field2"},
+		},
+		{
+			name: "Use struct field name for field with other tag key",
+			t: reflect.TypeOf(struct {
+				Field1 string `key:"field1"`
+				Field2 string `other:"field2"`
+			}{}),
+			key:  "key",
+			want: []string{"field1", "Field2"},
+		},
+		{
+			name: "Omit field with '-' tag",
+			t: reflect.TypeOf(struct {
+				Field1 string `key:"field1"`
+				Field2 string `key:"-"`
+			}{}),
+			key:  "key",
+			want: []string{"field1"},
+		},
+		{
+			name: "Omit unexported field",
+			t: reflect.TypeOf(struct {
+				Field1 string `key:"field1"`
+				field2 string
+			}{}),
+			key:  "key",
+			want: []string{"field1"},
+		},
+		{
+			name: "Omit unexported field with tag",
+			t: reflect.TypeOf(struct {
+				Field1 string `key:"field1"`
+				field2 string `key:"field2"`
+			}{}),
+			key:  "key",
+			want: []string{"field1"},
+		},
+		{
+			name: "Extract the first comma separated value",
+			t: reflect.TypeOf(struct {
+				Field1 string `key:"field1,omitempty"`
+				Field2 string `key:",omitempty"`
+			}{}),
+			key:  "key",
+			want: []string{"field1", "Field2"},
+		},
+		{
+			name: "Include fields from embedded struct",
+			t: reflect.TypeOf(struct {
+				Field1 string `key:"field1"`
+				embedded
+			}{}),
+			key:  "key",
+			want: []string{"field1", "embedded1", "Embedded2"},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.name, func(t *testing.T) {
+			if got := InferFieldNames(tt.t, tt.key); !cmp.Equal(got, tt.want) {
+				t.Errorf("InferFieldNames() = %v, want %v", got, tt.want)
+			}
+		})
+	}
+}
+
+func TestInferFieldNamesPanic(t *testing.T) {
+	t.Run("Panic for non-struct type", func(t *testing.T) {
+		defer func() {
+			if r := recover(); r == nil {
+				t.Errorf("InferFieldNames() does not panic")
+			}
+		}()
+
+		InferFieldNames(reflect.TypeOf(""), "key")
+	})
+}


### PR DESCRIPTION
Implements a function `structx.InferFieldNames` which takes a struct type and a tag key, and returns a slice of field names based on this. Fixes #24465.

Updates `bigqueryio.Read` and `spannerio.Read` to make use of `structx.InferFieldNames` when constructing select statements.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
