### PR TITLE
adding azure IO

### DIFF
--- a/runners/flink/job-server/flink_job_server.gradle
+++ b/runners/flink/job-server/flink_job_server.gradle
@@ -96,6 +96,8 @@ dependencies {
   runtimeOnly project(":sdks:java:io:google-cloud-platform")
   // SqlTransform
   runtimeOnly project(":sdks:java:extensions:sql:expansion-service")
+  // Azure IO
+  runtimeOnly project(":sdks:java:io:azure")
 }
 
 // NOTE: runShadow must be used in order to run the job server. The standard run


### PR DESCRIPTION
Flink job-server does not include Azure Blob Storage filesystem. This change adds it.

R: @phoerious @kennknowles 
fixes #24367 
