### PR TITLE
[Spark Dataset runner] Reduce binary size of Java serialized task related for ParDo translation

### DIFF
--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/DoFnPartitionIteratorFactory.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/DoFnPartitionIteratorFactory.java
@@ -59,10 +59,10 @@ import scala.collection.Iterator;
  * Abstract factory to create a {@link DoFnPartitionIt DoFn partition iterator} using a customizable
  * {@link DoFnRunners.OutputManager}.
  */
-abstract class DoFnMapPartitionsFactory<InT, FnOutT, OutT extends @NonNull Object>
+abstract class DoFnPartitionIteratorFactory<InT, FnOutT, OutT extends @NonNull Object>
     implements Function1<Iterator<WindowedValue<InT>>, Iterator<OutT>>, Serializable {
   private final String stepName;
-  private final DoFn<? super InT, FnOutT> doFn;
+  private final DoFn<InT, FnOutT> doFn;
   private final DoFnSchemaInformation doFnSchema;
   private final Supplier<PipelineOptions> options;
   private final Coder<InT> coder;
@@ -73,7 +73,7 @@ abstract class DoFnMapPartitionsFactory<InT, FnOutT, OutT extends @NonNull Objec
   private final Map<String, PCollectionView<?>> sideInputs;
   private final SideInputReader sideInputReader;
 
-  private DoFnMapPartitionsFactory(
+  private DoFnPartitionIteratorFactory(
       AppliedPTransform<PCollection<? extends InT>, ?, MultiOutput<InT, FnOutT>> appliedPT,
       Supplier<PipelineOptions> options,
       PCollection<InT> input,
@@ -92,10 +92,10 @@ abstract class DoFnMapPartitionsFactory<InT, FnOutT, OutT extends @NonNull Objec
   }
 
   /**
-   * {@link DoFnMapPartitionsFactory} emitting a single output of type {@link WindowedValue} of
+   * {@link DoFnPartitionIteratorFactory} emitting a single output of type {@link WindowedValue} of
    * {@link OutT}.
    */
-  static <InT, OutT> DoFnMapPartitionsFactory<InT, ?, WindowedValue<OutT>> singleOutput(
+  static <InT, OutT> DoFnPartitionIteratorFactory<InT, ?, WindowedValue<OutT>> singleOutput(
       AppliedPTransform<PCollection<? extends InT>, ?, MultiOutput<InT, OutT>> appliedPT,
       Supplier<PipelineOptions> options,
       PCollection<InT> input,
@@ -104,12 +104,12 @@ abstract class DoFnMapPartitionsFactory<InT, FnOutT, OutT extends @NonNull Objec
   }
 
   /**
-   * {@link DoFnMapPartitionsFactory} emitting multiple outputs encoded as tuple of column index and
-   * {@link WindowedValue} of {@link OutT}, where column index corresponds to the index of a {@link
-   * TupleTag#getId()} in {@code tagColIdx}.
+   * {@link DoFnPartitionIteratorFactory} emitting multiple outputs encoded as tuple of column index
+   * and {@link WindowedValue} of {@link OutT}, where column index corresponds to the index of a
+   * {@link TupleTag#getId()} in {@code tagColIdx}.
    */
   static <InT, FnOutT, OutT>
-      DoFnMapPartitionsFactory<InT, ?, Tuple2<Integer, WindowedValue<OutT>>> multiOutput(
+      DoFnPartitionIteratorFactory<InT, ?, Tuple2<Integer, WindowedValue<OutT>>> multiOutput(
           AppliedPTransform<PCollection<? extends InT>, ?, MultiOutput<InT, FnOutT>> appliedPT,
           Supplier<PipelineOptions> options,
           PCollection<InT> input,
@@ -129,11 +129,11 @@ abstract class DoFnMapPartitionsFactory<InT, FnOutT, OutT extends @NonNull Objec
   abstract DoFnRunners.OutputManager outputManager(Deque<OutT> buffer);
 
   /**
-   * {@link DoFnMapPartitionsFactory} emitting a single output of type {@link WindowedValue} of
+   * {@link DoFnPartitionIteratorFactory} emitting a single output of type {@link WindowedValue} of
    * {@link OutT}.
    */
   private static class SingleOut<InT, OutT>
-      extends DoFnMapPartitionsFactory<InT, OutT, WindowedValue<OutT>> {
+      extends DoFnPartitionIteratorFactory<InT, OutT, WindowedValue<OutT>> {
     private SingleOut(
         AppliedPTransform<PCollection<? extends InT>, ?, MultiOutput<InT, OutT>> appliedPT,
         Supplier<PipelineOptions> options,
@@ -154,12 +154,12 @@ abstract class DoFnMapPartitionsFactory<InT, FnOutT, OutT extends @NonNull Objec
   }
 
   /**
-   * {@link DoFnMapPartitionsFactory} emitting multiple outputs encoded as tuple of column index and
-   * {@link WindowedValue} of {@link OutT}, where column index corresponds to the index of a {@link
-   * TupleTag#getId()} in {@link #tagColIdx}.
+   * {@link DoFnPartitionIteratorFactory} emitting multiple outputs encoded as tuple of column index
+   * and {@link WindowedValue} of {@link OutT}, where column index corresponds to the index of a
+   * {@link TupleTag#getId()} in {@link #tagColIdx}.
    */
   private static class MultiOut<InT, FnOutT, OutT>
-      extends DoFnMapPartitionsFactory<InT, FnOutT, Tuple2<Integer, WindowedValue<OutT>>> {
+      extends DoFnPartitionIteratorFactory<InT, FnOutT, Tuple2<Integer, WindowedValue<OutT>>> {
     private final Map<String, Integer> tagColIdx;
 
     public MultiOut(

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/ParDoTranslatorBatch.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/ParDoTranslatorBatch.java
@@ -122,8 +122,8 @@ class ParDoTranslatorBatch<InputT, OutputT>
       Map<String, Integer> tagColIdx = tagsColumnIndex((Collection<TupleTag<?>>) outputs.keySet());
       List<Encoder<WindowedValue<Object>>> encoders = createEncoders(outputs, tagColIdx, cxt);
 
-      DoFnMapPartitionsFactory<InputT, ?, Tuple2<Integer, WindowedValue<Object>>> doFnMapper =
-          DoFnMapPartitionsFactory.multiOutput(
+      DoFnPartitionIteratorFactory<InputT, ?, Tuple2<Integer, WindowedValue<Object>>> doFnMapper =
+          DoFnPartitionIteratorFactory.multiOutput(
               cxt.getCurrentTransform(),
               cxt.getOptionsSupplier(),
               input,
@@ -177,8 +177,8 @@ class ParDoTranslatorBatch<InputT, OutputT>
       }
     } else {
       PCollection<OutputT> output = cxt.getOutput(transform.getMainOutputTag());
-      DoFnMapPartitionsFactory<InputT, ?, WindowedValue<OutputT>> doFnMapper =
-          DoFnMapPartitionsFactory.singleOutput(
+      DoFnPartitionIteratorFactory<InputT, ?, WindowedValue<OutputT>> doFnMapper =
+          DoFnPartitionIteratorFactory.singleOutput(
               cxt.getCurrentTransform(), cxt.getOptionsSupplier(), input, sideInputReader);
 
       Dataset<WindowedValue<OutputT>> mainDS =


### PR DESCRIPTION
When investigating the performance of TPCDS query 83, I noticed that the query plan contains fairly heavy weight tasks. These trigger a Spark warning when the tasks get broadcasted because their serialized size (using Java serialization) is above 1MB. 

This is both a cleanup of the ParDo translation, but also reduces the serialized size of tasks that include many ParDos.

- Use subtypes of `DoFnMapPartitionsFactory` to handle the single output and multi-output case, rather than relying on a closure that has to be serialized.
- Use Java default collections rather than immutable Guava collections (Why does this matter for serialization???).
- Use `Collections.emptyList` and similar where applicable.




------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] [**Choose reviewer(s)**](https://beam.apache.org/contribute/#make-your-change) and mention them in a comment (`R: @username`).
 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
