### PR TITLE
[Spark Dataset runner] Trigger evaluation using write noop format

### DIFF
--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/SparkStructuredStreamingPipelineResult.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/SparkStructuredStreamingPipelineResult.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.spark.structuredstreaming;
 
 import static org.apache.beam.runners.core.metrics.MetricsContainerStepMap.asAttemptedOnlyMetricResults;
+import static org.sparkproject.guava.base.Objects.firstNonNull;
 
 import java.io.IOException;
 import java.util.concurrent.ExecutionException;
@@ -33,20 +34,15 @@ import org.apache.beam.sdk.util.UserCodeException;
 import org.apache.spark.SparkException;
 import org.joda.time.Duration;
 
-/** Represents a Spark pipeline execution result. */
-@SuppressWarnings({
-  "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
-  "nullness" // TODO(https://github.com/apache/beam/issues/20497)
-})
 public class SparkStructuredStreamingPipelineResult implements PipelineResult {
 
-  final Future pipelineExecution;
-  @Nullable final Runnable onTerminalState;
+  private final Future<?> pipelineExecution;
+  private @Nullable final Runnable onTerminalState;
 
-  PipelineResult.State state;
+  private PipelineResult.State state;
 
   SparkStructuredStreamingPipelineResult(
-      final Future<?> pipelineExecution, @Nullable final Runnable onTerminalState) {
+      Future<?> pipelineExecution, @Nullable Runnable onTerminalState) {
     this.pipelineExecution = pipelineExecution;
     this.onTerminalState = onTerminalState;
     // pipelineExecution is expected to have started executing eagerly.
@@ -57,21 +53,19 @@ public class SparkStructuredStreamingPipelineResult implements PipelineResult {
     return (e instanceof RuntimeException) ? (RuntimeException) e : new RuntimeException(e);
   }
 
-  private static RuntimeException beamExceptionFrom(final Throwable e) {
-    // Scala doesn't declare checked exceptions in the bytecode, and the Java compiler
-    // won't let you catch something that is not declared, so we can't catch
-    // SparkException directly, instead we do an instanceof check.
-
-    if (e instanceof SparkException) {
-      if (e.getCause() != null && e.getCause() instanceof UserCodeException) {
-        UserCodeException userException = (UserCodeException) e.getCause();
-        return new Pipeline.PipelineExecutionException(userException.getCause());
-      } else if (e.getCause() != null) {
-        return new Pipeline.PipelineExecutionException(e.getCause());
-      }
+  /**
+   * Unwrap cause of SparkException or UserCodeException as PipelineExecutionException. Otherwise,
+   * return {@code exception} as RuntimeException.
+   */
+  private static RuntimeException unwrapCause(Throwable exception) {
+    Throwable next = exception;
+    while (next != null && (next instanceof SparkException || next instanceof UserCodeException)) {
+      exception = next;
+      next = next.getCause();
     }
-
-    return runtimeExceptionFrom(e);
+    return exception == next
+        ? runtimeExceptionFrom(exception)
+        : new Pipeline.PipelineExecutionException(firstNonNull(next, exception));
   }
 
   private State awaitTermination(Duration duration)
@@ -96,15 +90,14 @@ public class SparkStructuredStreamingPipelineResult implements PipelineResult {
     try {
       State finishState = awaitTermination(duration);
       offerNewState(finishState);
-
     } catch (final TimeoutException e) {
       // ignore.
     } catch (final ExecutionException e) {
       offerNewState(PipelineResult.State.FAILED);
-      throw beamExceptionFrom(e.getCause());
+      throw unwrapCause(firstNonNull(e.getCause(), e));
     } catch (final Exception e) {
       offerNewState(PipelineResult.State.FAILED);
-      throw beamExceptionFrom(e);
+      throw unwrapCause(e);
     }
 
     return state;
@@ -128,7 +121,7 @@ public class SparkStructuredStreamingPipelineResult implements PipelineResult {
       try {
         onTerminalState.run();
       } catch (Exception e) {
-        throw beamExceptionFrom(e);
+        throw unwrapCause(e);
       }
     }
   }

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/EvaluationContext.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/EvaluationContext.java
@@ -22,7 +22,6 @@ import javax.annotation.Nullable;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Throwables;
-import org.apache.spark.api.java.function.ForeachFunction;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.execution.ExplainMode;
@@ -82,8 +81,8 @@ public final class EvaluationContext {
   public static <T> void evaluate(String name, Dataset<T> ds) {
     long startMs = System.currentTimeMillis();
     try {
-      // force evaluation using a dummy foreach action
-      ds.foreach(NOOP);
+      // force computation using noop format
+      ds.write().mode("overwrite").format("noop").save();
       LOG.info("Evaluated dataset {} in {}", name, durationSince(startMs));
     } catch (RuntimeException e) {
       LOG.error("Failed to evaluate dataset {}: {}", name, Throwables.getRootCause(e).getMessage());
@@ -114,7 +113,4 @@ public final class EvaluationContext {
   private static String durationSince(long startMs) {
     return Utils.msDurationToString(System.currentTimeMillis() - startMs);
   }
-
-  @SuppressWarnings("rawtypes")
-  private static final ForeachFunction NOOP = obj -> {};
 }

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/SparkSessionFactory.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/SparkSessionFactory.java
@@ -79,6 +79,7 @@ import org.apache.spark.serializer.KryoRegistrator;
 import org.apache.spark.serializer.KryoSerializer;
 import org.apache.spark.sql.SparkSession;
 import org.apache.spark.sql.catalyst.InternalRow;
+import org.apache.spark.sql.execution.datasources.v2.DataWritingSparkTaskResult;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -157,6 +158,9 @@ public class SparkSessionFactory {
       kryo.register(byte[][].class);
       kryo.register(HashMap.class);
       kryo.register(ArrayList.class);
+
+      // support writing noop format
+      kryo.register(DataWritingSparkTaskResult.class);
 
       // TODO find more efficient ways
       kryo.register(SerializablePipelineOptions.class, new JavaSerializer());


### PR DESCRIPTION
Spark 3 offers a build in way to force evaluation of a dataset, write using the `noop` format.
This implements this recommended way / best practice, see also https://holdenk.github.io/spark-flowchart/details/forced-computations/.

Using write noop seems to change how exceptions are propagated, the code to unwrap the respective cause is adjusted accordingly.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
