### PR TITLE
ElasticsearchIO: Lower log level in flushBatch to avoid noisy log

### DIFF
--- a/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
+++ b/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
@@ -2460,7 +2460,7 @@ public class ElasticsearchIO {
           return new ArrayList<>();
         }
 
-        LOG.info(
+        LOG.debug(
             "ElasticsearchIO batch size: {}, batch size bytes: {}",
             batch.size(),
             currentBatchSizeBytes);


### PR DESCRIPTION
Hi,

Found this logline not particularly helpful. It logs an info-level log line every time flushBatch() is called. Quite noisy when I browse through the info log. Debug makes more sense IMO.

Thank you!