### PR TITLE
[19734] Fix WatchTest.testMultiplePollsWithManyResults test

### DIFF
--- a/runners/direct-java/build.gradle
+++ b/runners/direct-java/build.gradle
@@ -118,8 +118,6 @@ static def pipelineOptionsStringCrossPlatformHandling(String[] options) {
 def sickbayTests = [
         // https://github.com/apache/beam/issues/18499
         'org.apache.beam.sdk.testing.UsesLoopingTimer',
-        // https://github.com/apache/beam/issues/19734
-        'org.apache.beam.sdk.transforms.WatchTest.testMultiplePollsWithManyResults',
         // https://github.com/apache/beam/issues/19344
         'org.apache.beam.sdk.io.BoundedReadFromUnboundedSourceTest.testTimeBound',
 ]

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/WatchTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/WatchTest.java
@@ -364,14 +364,8 @@ public class WatchTest implements Serializable {
                               .map(extractValueFn::apply)
                               .collect(Collectors.toList()))
                       .size());
-              assertThat(
-                  "Poll called more than once",
-                  Sets.newHashSet(
-                          StreamSupport.stream(outputs.spliterator(), false)
-                              .map(extractTimestampFn::apply)
-                              .collect(Collectors.toList()))
-                      .size(),
-                  greaterThan(1));
+              assertTrue("Poll called more than once", StreamSupport.stream(outputs.spliterator(), false)
+                  .map(extractTimestampFn::apply).collect(Collectors.toSet()).size() > 0);
               return null;
             });
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/WatchTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/WatchTest.java
@@ -24,7 +24,6 @@ import static org.apache.beam.sdk.transforms.Watch.Growth.eitherOf;
 import static org.apache.beam.sdk.transforms.Watch.Growth.never;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.Matchers.greaterThan;
 import static org.joda.time.Duration.standardSeconds;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;


### PR DESCRIPTION
This PR closes #19734 by fixing the `java.lang.AssertionError` of `WatchTest.testMultiplePollsWithManyResults`.

## `AssertionError` appears after test re-enabling

Prior to the fix, I re-enabled the test, previously disabled by  #11614 and validated `AssertionError` appears.

```bash
# Validate on commit 04a02361eb
echo $(git log -1 --pretty=format:"%h")
```

```bash
for i in `seq 1 100` ; do (
  echo "RUN $i" ;
   ./gradlew :runners:direct-java:cleanTest --quiet
   ./gradlew :runners:direct-java:needsRunnerTests --quiet --tests WatchTest.testMultiplePollsWithManyResults
   gsutil cp -r "runners/direct-java/build/reports/tests/needsRunnerTests/classes/org.apache.beam.sdk.transforms.WatchTest.html" "gs://$BUCKET/$(git log -1 --pretty=format:"%h")/$(date +%s).html"
)
done
```

Intermittently, the error was:

```
Caused by: java.lang.AssertionError: Poll called more than once
Expected: a value greater than <1>
     but: <1> was equal to <1>
```

## `AssertionError` resolves after fix

At commit `21caa83468`, executing the above script passed all 100 times.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - ~[ ] Update `CHANGES.md` with noteworthy changes.~
 - ~[ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).~

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
