### PR TITLE
[#20287][Go SDK] Make base_sdk URN versioned on default docker container.

### DIFF
--- a/sdks/go/pkg/beam/core/core.go
+++ b/sdks/go/pkg/beam/core/core.go
@@ -28,4 +28,7 @@ const (
 	SdkName = "Apache Beam SDK for Go"
 	// SdkVersion is the current version of the SDK.
 	SdkVersion = "2.45.0.dev"
+
+	// DefaultDockerImage represents the associated image for this release.
+	DefaultDockerImage = "apache/beam_go_sdk:" + SdkVersion
 )

--- a/sdks/go/pkg/beam/core/runtime/graphx/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate.go
@@ -21,6 +21,7 @@ import (
 	"sort"
 	"strings"
 
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/coder"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/window"
@@ -83,14 +84,18 @@ const (
 	URNArtifactURLType      = "beam:artifact:type:url:v1"
 	URNArtifactGoWorkerRole = "beam:artifact:role:go_worker_binary:v1"
 
-	// Environment Urns.
+	// Environment URNs.
 	URNEnvProcess  = "beam:env:process:v1"
 	URNEnvExternal = "beam:env:external:v1"
 	URNEnvDocker   = "beam:env:docker:v1"
 
-	// Userstate Urns.
+	// Userstate URNs.
 	URNBagUserState      = "beam:user_state:bag:v1"
 	URNMultiMapUserState = "beam:user_state:multimap:v1"
+
+	// Base version URNs are to allow runners to make distinctions between different releases
+	// in a way that won't change based on actual releases, in particular for FnAPI behaviors.
+	URNBaseVersionGo = "beam:version:sdk_base:go:" + core.DefaultDockerImage
 )
 
 func goCapabilities() []string {
@@ -100,8 +105,7 @@ func goCapabilities() []string {
 		URNTruncate,
 		URNWorkerStatus,
 		URNMonitoringInfoShortID,
-		// TOOD(https://github.com/apache/beam/issues/20287): Make this versioned.
-		"beam:version:sdk_base:go",
+		URNBaseVersionGo,
 	}
 	return append(capabilities, knownStandardCoders()...)
 }

--- a/sdks/go/pkg/beam/options/jobopts/options.go
+++ b/sdks/go/pkg/beam/options/jobopts/options.go
@@ -21,7 +21,6 @@ import (
 	"context"
 	"flag"
 	"fmt"
-	"os"
 	"strings"
 	"time"
 
@@ -154,7 +153,7 @@ func IsLoopback() bool {
 // Convenience function.
 func GetEnvironmentConfig(ctx context.Context) string {
 	if *EnvironmentConfig == "" {
-		*EnvironmentConfig = os.ExpandEnv("apache/beam_go_sdk:" + core.SdkVersion)
+		*EnvironmentConfig = core.DefaultDockerImage
 		log.Infof(ctx, "No environment config specified. Using default config: '%v'", *EnvironmentConfig)
 	}
 	return *EnvironmentConfig

--- a/sdks/go/pkg/beam/options/jobopts/options_test.go
+++ b/sdks/go/pkg/beam/options/jobopts/options_test.go
@@ -119,7 +119,7 @@ func TestGetEnvironmentConfig(t *testing.T) {
 		},
 		{
 			"",
-			"apache/beam_go_sdk:" + core.SdkVersion,
+			core.DefaultDockerImage,
 		},
 	}
 	for _, test := range tests {


### PR DESCRIPTION
The Go SDK is fairly stable WRT it's FnAPI behavior, but prior to 2.45.0 the SDK would return errors on benign split failures. This has been determined to be incorrect behavior (the failures, if they don't cause dataloss or corruption, should have returned empty splits).

However, to support variable behavior on these split failures and become intolerant of them in the future, we need to finally have a versioned base SDK capability. 

This change builds off of the automatically incrementing SDK version on releases, and makes the default image constant clearer in the core.

Fixes #20287

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
