### PR TITLE
Ensure SDK suffix to avoid mis-labels of Go.

### DIFF
--- a/.github/ISSUE_TEMPLATE/failing_test.yml
+++ b/.github/ISSUE_TEMPLATE/failing_test.yml
@@ -64,10 +64,10 @@ body:
       label: Issue Components
       description: Which languages, SDKs, or features are related to your report? (check all that apply)
       options:
-       - label: "Component: Python"
-       - label: "Component: Java"
-       - label: "Component: Go"
-       - label: "Component: Typescript"
+       - label: "Component: Python SDK"
+       - label: "Component: Java SDK"
+       - label: "Component: Go SDK"
+       - label: "Component: Typescript SDK"
        - label: "Component: IO connector"
        - label: "Component: Beam examples"
        - label: "Component: Beam playground"

--- a/.github/issue-rules.yml
+++ b/.github/issue-rules.yml
@@ -26,13 +26,13 @@ rules:
 - valueFor: 'Priority'
   contains: '3'
   addLabels: ['P3']
-- contains: '[x] Component: Java'
+- contains: '[x] Component: Java SDK'
   addLabels: ['java']
-- contains: '[x] Component: Python'
+- contains: '[x] Component: Python SDK'
   addLabels: ['python']
-- contains: '[x] Component: Go'
+- contains: '[x] Component: Go SDK'
   addLabels: ['go']
-- contains: '[x] Component: Typescript'
+- contains: '[x] Component: Typescript SDK'
   addLabels: ['typescript']
 - contains: '[x] Component: IO'
   addLabels: ['io']


### PR DESCRIPTION
Fixes #24697.

I check for issues to triage for the Go label, and a few python issues snuck in. All but one of the templates and the issue labeler itself had "SDK" as part of the suffixes, so the fix is just ensuring SDK suffix consistency.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
