### PR TITLE
[BigQueryIO] Pick provided schema if existing table has null schema

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/DynamicDestinationsHelpers.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/DynamicDestinationsHelpers.java
@@ -426,7 +426,7 @@ class DynamicDestinationsHelpers {
     public @Nullable TableSchema getSchema(DestinationT destination) {
       TableDestination wrappedDestination = super.getTable(destination);
       @Nullable Table existingTable = getBigQueryTable(wrappedDestination.getTableReference());
-      if (existingTable == null) {
+      if (existingTable == null || existingTable.getSchema() == null) {
         return super.getSchema(destination);
       } else {
         return existingTable.getSchema();

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/UpdateSchemaDestination.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/UpdateSchemaDestination.java
@@ -254,7 +254,7 @@ public class UpdateSchemaDestination<DestinationT>
       LOG.warn("Failed to get table {} with {}", tableReference, e.toString());
       throw new RuntimeException(e);
     }
-    if (destinationTable.getSchema().equals(schema)) {
+    if (destinationTable.getSchema() == null || destinationTable.getSchema().equals(schema)) {
       return null; // no need to update schema ahead if schema is already the same
     }
     if (timePartitioning != null) {

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
@@ -727,10 +727,14 @@ public class BigQueryIOWriteTest implements Serializable {
     testTriggeredFileLoadsWithTempTables("project-id:dataset-id.table-id");
   }
 
-    @Test
+  @Test
   public void testTriggeredFileLoadsWithTempTablesToExistingNullSchemaTable() throws Exception {
     Table fakeTable = new Table();
-    TableReference ref = new TableReference().setProjectId("project-id").setDatasetId("dataset-id").setTableId("table-id");
+    TableReference ref =
+        new TableReference()
+            .setProjectId("project-id")
+            .setDatasetId("dataset-id")
+            .setTableId("table-id");
     fakeTable.setTableReference(ref);
     fakeDatasetService.createTable(fakeTable);
     testTriggeredFileLoadsWithTempTables("project-id:dataset-id.table-id");

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java
@@ -727,6 +727,15 @@ public class BigQueryIOWriteTest implements Serializable {
     testTriggeredFileLoadsWithTempTables("project-id:dataset-id.table-id");
   }
 
+    @Test
+  public void testTriggeredFileLoadsWithTempTablesToExistingNullSchemaTable() throws Exception {
+    Table fakeTable = new Table();
+    TableReference ref = new TableReference().setProjectId("project-id").setDatasetId("dataset-id").setTableId("table-id");
+    fakeTable.setTableReference(ref);
+    fakeDatasetService.createTable(fakeTable);
+    testTriggeredFileLoadsWithTempTables("project-id:dataset-id.table-id");
+  }
+
   @Test
   public void testUntriggeredFileLoadsWithTempTables() throws Exception {
     // Test only non-streaming inserts.


### PR DESCRIPTION
During temp table writes, we always pick the existing table's schema if the table exists. This is a problem when the existing table has a null schema. If it's null, we should pick the provided schema.