### PR TITLE
[Spark Dataset runner] Skip unconsumed additional outputs of ParDo.MultiOutput to avoid caching if not necessary

### DIFF
--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/PipelineTranslator.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/PipelineTranslator.java
@@ -152,6 +152,8 @@ public abstract class PipelineTranslator {
   public interface TranslationState extends EncoderProvider {
     <T> Dataset<WindowedValue<T>> getDataset(PCollection<T> pCollection);
 
+    boolean isLeave(PCollection<?> pCollection);
+
     <T> void putDataset(
         PCollection<T> pCollection, Dataset<WindowedValue<T>> dataset, boolean cache);
 
@@ -254,6 +256,11 @@ public abstract class PipelineTranslator {
           leaves.add(result);
         }
       }
+    }
+
+    @Override
+    public boolean isLeave(PCollection<?> pCollection) {
+      return getResult(pCollection).dependentTransforms.isEmpty();
     }
 
     @Override

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/TransformTranslator.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/TransformTranslator.java
@@ -150,6 +150,11 @@ public abstract class TransformTranslator<
     }
 
     @Override
+    public boolean isLeave(PCollection<?> pCollection) {
+      return state.isLeave(pCollection);
+    }
+
+    @Override
     public Supplier<PipelineOptions> getOptionsSupplier() {
       return state.getOptionsSupplier();
     }

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/DoFnPartitionIteratorFactory.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/DoFnPartitionIteratorFactory.java
@@ -146,6 +146,8 @@ abstract class DoFnPartitionIteratorFactory<InT, FnOutT, OutT extends @NonNull O
       return new DoFnRunners.OutputManager() {
         @Override
         public <T> void output(TupleTag<T> tag, WindowedValue<T> output) {
+          // SingleOut will only ever emmit the mainOutput. Though, there might be additional
+          // outputs which are skipped if unused to avoid caching.
           if (mainOutput.equals(tag)) {
             buffer.add((WindowedValue<OutT>) output);
           }
@@ -178,6 +180,7 @@ abstract class DoFnPartitionIteratorFactory<InT, FnOutT, OutT extends @NonNull O
       return new DoFnRunners.OutputManager() {
         @Override
         public <T> void output(TupleTag<T> tag, WindowedValue<T> output) {
+          // Additional unused outputs can be skipped here. In that case columnIdx is null.
           Integer columnIdx = tagColIdx.get(tag.getId());
           if (columnIdx != null) {
             buffer.add(tuple(columnIdx, (WindowedValue<OutT>) output));

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/DoFnPartitionIteratorFactory.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/DoFnPartitionIteratorFactory.java
@@ -19,7 +19,6 @@ package org.apache.beam.runners.spark.structuredstreaming.translation.batch;
 
 import static org.apache.beam.runners.spark.structuredstreaming.translation.utils.ScalaInterop.scalaIterator;
 import static org.apache.beam.runners.spark.structuredstreaming.translation.utils.ScalaInterop.tuple;
-import static org.apache.beam.sdk.util.Preconditions.checkStateNotNull;
 
 import java.io.Serializable;
 import java.util.ArrayDeque;
@@ -61,17 +60,17 @@ import scala.collection.Iterator;
  */
 abstract class DoFnPartitionIteratorFactory<InT, FnOutT, OutT extends @NonNull Object>
     implements Function1<Iterator<WindowedValue<InT>>, Iterator<OutT>>, Serializable {
-  private final String stepName;
-  private final DoFn<InT, FnOutT> doFn;
-  private final DoFnSchemaInformation doFnSchema;
-  private final Supplier<PipelineOptions> options;
-  private final Coder<InT> coder;
-  private final WindowingStrategy<?, ?> windowingStrategy;
-  private final TupleTag<FnOutT> mainOutput;
-  private final List<TupleTag<?>> additionalOutputs;
-  private final Map<TupleTag<?>, Coder<?>> outputCoders;
-  private final Map<String, PCollectionView<?>> sideInputs;
-  private final SideInputReader sideInputReader;
+  protected final String stepName;
+  protected final DoFn<InT, FnOutT> doFn;
+  protected final DoFnSchemaInformation doFnSchema;
+  protected final Supplier<PipelineOptions> options;
+  protected final Coder<InT> coder;
+  protected final WindowingStrategy<?, ?> windowingStrategy;
+  protected final TupleTag<FnOutT> mainOutput;
+  protected final List<TupleTag<?>> additionalOutputs;
+  protected final Map<TupleTag<?>, Coder<?>> outputCoders;
+  protected final Map<String, PCollectionView<?>> sideInputs;
+  protected final SideInputReader sideInputReader;
 
   private DoFnPartitionIteratorFactory(
       AppliedPTransform<PCollection<? extends InT>, ?, MultiOutput<InT, FnOutT>> appliedPT,
@@ -147,7 +146,9 @@ abstract class DoFnPartitionIteratorFactory<InT, FnOutT, OutT extends @NonNull O
       return new DoFnRunners.OutputManager() {
         @Override
         public <T> void output(TupleTag<T> tag, WindowedValue<T> output) {
-          buffer.add((WindowedValue<OutT>) output);
+          if (mainOutput.equals(tag)) {
+            buffer.add((WindowedValue<OutT>) output);
+          }
         }
       };
     }
@@ -177,8 +178,10 @@ abstract class DoFnPartitionIteratorFactory<InT, FnOutT, OutT extends @NonNull O
       return new DoFnRunners.OutputManager() {
         @Override
         public <T> void output(TupleTag<T> tag, WindowedValue<T> output) {
-          Integer columnIdx = checkStateNotNull(tagColIdx.get(tag.getId()), "Unknown tag %s", tag);
-          buffer.add(tuple(columnIdx, (WindowedValue<OutT>) output));
+          Integer columnIdx = tagColIdx.get(tag.getId());
+          if (columnIdx != null) {
+            buffer.add(tuple(columnIdx, (WindowedValue<OutT>) output));
+          }
         }
       };
     }

--- a/runners/spark/3/src/test/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/ParDoTest.java
+++ b/runners/spark/3/src/test/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/ParDoTest.java
@@ -17,14 +17,13 @@
  */
 package org.apache.beam.runners.spark.structuredstreaming.translation.batch;
 
+import static org.junit.Assert.assertTrue;
+
 import java.io.Serializable;
 import java.util.List;
 import java.util.Map;
 import org.apache.beam.runners.spark.SparkCommonPipelineOptions;
-import org.apache.beam.runners.spark.structuredstreaming.SparkStructuredStreamingPipelineOptions;
-import org.apache.beam.runners.spark.structuredstreaming.SparkStructuredStreamingRunner;
-import org.apache.beam.sdk.options.PipelineOptions;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.runners.spark.structuredstreaming.SparkSessionRule;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
@@ -37,23 +36,23 @@ import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
+import org.junit.ClassRule;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.rules.TestRule;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Test class for beam to spark {@link ParDo} translation. */
 @RunWith(JUnit4.class)
 public class ParDoTest implements Serializable {
-  @Rule public transient TestPipeline pipeline = TestPipeline.fromOptions(testOptions());
+  @ClassRule public static final SparkSessionRule SESSION = new SparkSessionRule();
 
-  private static PipelineOptions testOptions() {
-    SparkStructuredStreamingPipelineOptions options =
-        PipelineOptionsFactory.create().as(SparkStructuredStreamingPipelineOptions.class);
-    options.setRunner(SparkStructuredStreamingRunner.class);
-    options.setTestMode(true);
-    return options;
-  }
+  @Rule
+  public transient TestPipeline pipeline =
+      TestPipeline.fromOptions(SESSION.createPipelineOptions());
+
+  @Rule public transient TestRule clearCache = SESSION.clearCache();
 
   @Test
   public void testPardo() {
@@ -61,32 +60,42 @@ public class ParDoTest implements Serializable {
         pipeline.apply(Create.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10)).apply(ParDo.of(PLUS_ONE_DOFN));
     PAssert.that(input).containsInAnyOrder(2, 3, 4, 5, 6, 7, 8, 9, 10, 11);
     pipeline.run();
+
+    assertTrue("No usage of cache expected", !SESSION.hasCachedData());
   }
 
   @Test
   public void testPardoWithOutputTagsCachedRDD() {
-    pardoWithOutputTags("MEMORY_ONLY");
+    pardoWithOutputTags("MEMORY_ONLY", true);
+    assertTrue("Expected cached data", SESSION.hasCachedData());
   }
 
   @Test
   public void testPardoWithOutputTagsCachedDataset() {
-    pardoWithOutputTags("MEMORY_AND_DISK");
+    pardoWithOutputTags("MEMORY_AND_DISK", true);
+    assertTrue("Expected cached data", SESSION.hasCachedData());
   }
 
-  private void pardoWithOutputTags(String storageLevel) {
+  @Test
+  public void testPardoWithUnusedOutputTags() {
+    pardoWithOutputTags("MEMORY_AND_DISK", false);
+    assertTrue("No usage of cache expected", !SESSION.hasCachedData());
+  }
+
+  private void pardoWithOutputTags(String storageLevel, boolean evaluateAdditionalOutputs) {
     pipeline.getOptions().as(SparkCommonPipelineOptions.class).setStorageLevel(storageLevel);
 
-    TupleTag<Integer> even = new TupleTag<Integer>() {};
-    TupleTag<String> unevenAsString = new TupleTag<String>() {};
+    TupleTag<Integer> mainTag = new TupleTag<Integer>() {};
+    TupleTag<String> additionalUnevenTag = new TupleTag<String>() {};
 
     DoFn<Integer, Integer> doFn =
         new DoFn<Integer, Integer>() {
           @ProcessElement
           public void processElement(@Element Integer i, MultiOutputReceiver out) {
             if (i % 2 == 0) {
-              out.get(even).output(i);
+              out.get(mainTag).output(i);
             } else {
-              out.get(unevenAsString).output(i.toString());
+              out.get(additionalUnevenTag).output(i.toString());
             }
           }
         };
@@ -94,10 +103,12 @@ public class ParDoTest implements Serializable {
     PCollectionTuple outputs =
         pipeline
             .apply(Create.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
-            .apply(ParDo.of(doFn).withOutputTags(even, TupleTagList.of(unevenAsString)));
+            .apply(ParDo.of(doFn).withOutputTags(mainTag, TupleTagList.of(additionalUnevenTag)));
 
-    PAssert.that(outputs.get(even)).containsInAnyOrder(2, 4, 6, 8, 10);
-    PAssert.that(outputs.get(unevenAsString)).containsInAnyOrder("1", "3", "5", "7", "9");
+    PAssert.that(outputs.get(mainTag)).containsInAnyOrder(2, 4, 6, 8, 10);
+    if (evaluateAdditionalOutputs) {
+      PAssert.that(outputs.get(additionalUnevenTag)).containsInAnyOrder("1", "3", "5", "7", "9");
+    }
     pipeline.run();
   }
 
@@ -106,10 +117,12 @@ public class ParDoTest implements Serializable {
     PCollection<Integer> input =
         pipeline
             .apply(Create.of(1, 2, 3, 4, 5, 6, 7, 8, 9, 10))
-            .apply(ParDo.of(PLUS_ONE_DOFN))
-            .apply(ParDo.of(PLUS_ONE_DOFN));
+            .apply("Plus 1 (1st)", ParDo.of(PLUS_ONE_DOFN))
+            .apply("Plus 1 (2nd)", ParDo.of(PLUS_ONE_DOFN));
     PAssert.that(input).containsInAnyOrder(3, 4, 5, 6, 7, 8, 9, 10, 11, 12);
     pipeline.run();
+
+    assertTrue("No usage of cache expected", !SESSION.hasCachedData());
   }
 
   @Test
@@ -133,6 +146,8 @@ public class ParDoTest implements Serializable {
                     .withSideInputs(sideInputView));
     PAssert.that(input).containsInAnyOrder(4, 5, 6, 7, 8, 9, 10);
     pipeline.run();
+
+    assertTrue("No usage of cache expected", !SESSION.hasCachedData());
   }
 
   @Test
@@ -158,6 +173,8 @@ public class ParDoTest implements Serializable {
 
     PAssert.that(input).containsInAnyOrder(2, 3, 4, 5, 6, 7, 8, 9, 10);
     pipeline.run();
+
+    assertTrue("No usage of cache expected", !SESSION.hasCachedData());
   }
 
   @Test
@@ -183,6 +200,8 @@ public class ParDoTest implements Serializable {
                     .withSideInputs(sideInputView));
     PAssert.that(input).containsInAnyOrder(3, 4, 5, 6, 7, 8, 9, 10);
     pipeline.run();
+
+    assertTrue("No usage of cache expected", !SESSION.hasCachedData());
   }
 
   private static final DoFn<Integer, Integer> PLUS_ONE_DOFN =


### PR DESCRIPTION
If there's multiple tupled outputs in a `ParDo.MultiOutput`, it's necessary to cache the result to not trigger the evaluation multiple times once the dataset is split into separate datasets per output `TupleTag` (and these datasets are eventually lazily evaluated).

However, in some cases these outputs might just be ignored. Using the pipeline graph we can know that during translation time, allowing us to skip unused outputs. This can free us from having to cache the result of `ParDo.Multioutput` and then splitting it into respective datasets.

The main output is always kept as it's required to force the evaluation of the lazily evaluated datasets.

Closes #24710

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
