### PR TITLE
Caching DebeziumIO SourceTask instances to reduce the number of outstanding connections

### DIFF
--- a/sdks/java/io/debezium/src/main/java/org/apache/beam/io/debezium/KafkaSourceConsumerFn.java
+++ b/sdks/java/io/debezium/src/main/java/org/apache/beam/io/debezium/KafkaSourceConsumerFn.java
@@ -275,7 +275,7 @@ public class KafkaSourceConsumerFn<T> extends DoFn<Map<String, String>, T> {
     }
 
     long elapsedTime = System.currentTimeMillis() - KafkaSourceConsumerFn.startTime.getMillis();
-    if (milisecondsToRun != null && elapsedTime >= milisecondsToRun) {
+    if (milisecondsToRun != null && milisecondsToRun > 0 && elapsedTime >= milisecondsToRun) {
       return ProcessContinuation.stop();
     } else {
       return ProcessContinuation.resume().withResumeDelay(Duration.standardSeconds(1));

--- a/sdks/java/io/debezium/src/main/java/org/apache/beam/io/debezium/KafkaSourceConsumerFn.java
+++ b/sdks/java/io/debezium/src/main/java/org/apache/beam/io/debezium/KafkaSourceConsumerFn.java
@@ -275,7 +275,7 @@ public class KafkaSourceConsumerFn<T> extends DoFn<Map<String, String>, T> {
     }
 
     long elapsedTime = System.currentTimeMillis() - KafkaSourceConsumerFn.startTime.getMillis();
-    if (milisecondsToRun != null && milisecondsToRun > 0 && elapsedTime >= milisecondsToRun) {
+    if (milisecondsToRun != null && elapsedTime >= milisecondsToRun) {
       return ProcessContinuation.stop();
     } else {
       return ProcessContinuation.resume().withResumeDelay(Duration.standardSeconds(1));

--- a/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumIOMySqlConnectorIT.java
+++ b/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumIOMySqlConnectorIT.java
@@ -80,8 +80,8 @@ public class DebeziumIOMySqlConnectorIT {
   public static DataSource getMysqlDatasource(Void unused) {
     HikariConfig hikariConfig = new HikariConfig();
     hikariConfig.setJdbcUrl(MY_SQL_CONTAINER.getJdbcUrl());
-    hikariConfig.setUsername(MY_SQL_CONTAINER.getUsername());
-    hikariConfig.setPassword(MY_SQL_CONTAINER.getPassword());
+    hikariConfig.setUsername("debezium");
+    hikariConfig.setPassword("dbz");
     hikariConfig.setDriverClassName(MY_SQL_CONTAINER.getDriverClassName());
     return new HikariDataSource(hikariConfig);
   }

--- a/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumIOMySqlConnectorIT.java
+++ b/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumIOMySqlConnectorIT.java
@@ -80,8 +80,8 @@ public class DebeziumIOMySqlConnectorIT {
   public static DataSource getMysqlDatasource(Void unused) {
     HikariConfig hikariConfig = new HikariConfig();
     hikariConfig.setJdbcUrl(MY_SQL_CONTAINER.getJdbcUrl());
-    hikariConfig.setUsername("debezium");
-    hikariConfig.setPassword("dbz");
+    hikariConfig.setUsername(MY_SQL_CONTAINER.getUsername());
+    hikariConfig.setPassword(MY_SQL_CONTAINER.getPassword());
     hikariConfig.setDriverClassName(MY_SQL_CONTAINER.getDriverClassName());
     return new HikariDataSource(hikariConfig);
   }

--- a/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumIOMySqlConnectorIT.java
+++ b/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumIOMySqlConnectorIT.java
@@ -110,8 +110,8 @@ public class DebeziumIOMySqlConnectorIT {
 
   @Test
   public void testDebeziumSchemaTransformMysqlRead() throws InterruptedException {
-    long writeSize = 10000L;
-    long testTime = writeSize * 200L;
+    long writeSize = 1000L;
+    long testTime = writeSize * 300L;
     MY_SQL_CONTAINER.start();
 
     PipelineOptions options = PipelineOptionsFactory.create();

--- a/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumIOPostgresSqlConnectorIT.java
+++ b/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumIOPostgresSqlConnectorIT.java
@@ -22,8 +22,6 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 
 import io.debezium.connector.postgresql.PostgresConnector;
-import java.util.stream.Collectors;
-import java.util.stream.IntStream;
 import javax.sql.DataSource;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.StringUtf8Coder;

--- a/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumIOPostgresSqlConnectorIT.java
+++ b/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumIOPostgresSqlConnectorIT.java
@@ -24,6 +24,7 @@ import static org.hamcrest.Matchers.hasItem;
 import io.debezium.connector.postgresql.PostgresConnector;
 import javax.sql.DataSource;
 import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.GenerateSequence;
 import org.apache.beam.sdk.io.jdbc.JdbcIO;

--- a/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumIOPostgresSqlConnectorIT.java
+++ b/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumIOPostgresSqlConnectorIT.java
@@ -22,9 +22,10 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
 
 import io.debezium.connector.postgresql.PostgresConnector;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
 import javax.sql.DataSource;
 import org.apache.beam.sdk.Pipeline;
-import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.GenerateSequence;
 import org.apache.beam.sdk.io.jdbc.JdbcIO;

--- a/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumIOPostgresSqlConnectorIT.java
+++ b/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumIOPostgresSqlConnectorIT.java
@@ -83,8 +83,8 @@ public class DebeziumIOPostgresSqlConnectorIT {
 
   @Test
   public void testDebeziumSchemaTransformPostgresRead() throws InterruptedException {
-    long writeSize = 500L;
-    long testTime = writeSize * 200L;
+    long writeSize = 1000L;
+    long testTime = writeSize * 300L;
     POSTGRES_SQL_CONTAINER.start();
 
     PipelineOptions options = PipelineOptionsFactory.create();

--- a/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/KafkaSourceConsumerFnTest.java
+++ b/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/KafkaSourceConsumerFnTest.java
@@ -43,7 +43,6 @@ import org.apache.kafka.connect.source.SourceRecord;
 import org.apache.kafka.connect.source.SourceTask;
 import org.apache.kafka.connect.source.SourceTaskContext;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.junit.Assert;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -77,34 +76,6 @@ public class KafkaSourceConsumerFnTest implements Serializable {
 
     PAssert.that(counts).containsInAnyOrder(1, 2, 3, 4, 5, 6, 7, 8, 9, 10);
     pipeline.run().waitUntilFinish();
-  }
-
-  @Test
-  public void testStoppableKafkaSourceConsumerFn() {
-    Map<String, String> config =
-        ImmutableMap.of(
-            "from", "1",
-            "to", "3",
-            "delay", "0.2",
-            "topic", "any");
-
-    Pipeline pipeline = Pipeline.create();
-
-    pipeline
-        .apply(
-            Create.of(Lists.newArrayList(config))
-                .withCoder(MapCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of())))
-        .apply(
-            ParDo.of(
-                new KafkaSourceConsumerFn<>(
-                    CounterSourceConnector.class,
-                    sourceRecord -> ((Struct) sourceRecord.value()).getInt64("value").intValue(),
-                    1)))
-        .setCoder(VarIntCoder.of());
-
-    pipeline.run().waitUntilFinish();
-    // Since we're now caching calls
-    Assert.assertEquals(1, CounterTask.getCountTasks());
   }
 }
 

--- a/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/KafkaSourceConsumerFnTest.java
+++ b/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/KafkaSourceConsumerFnTest.java
@@ -103,6 +103,7 @@ public class KafkaSourceConsumerFnTest implements Serializable {
         .setCoder(VarIntCoder.of());
 
     pipeline.run().waitUntilFinish();
+    // Since we're now caching calls
     Assert.assertEquals(1, CounterTask.getCountTasks());
   }
 }

--- a/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/OffsetTrackerTest.java
+++ b/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/OffsetTrackerTest.java
@@ -65,7 +65,7 @@ public class OffsetTrackerTest implements Serializable {
 
     assertTrue(tracker.tryClaim(position));
 
-    Thread.sleep(1000); // Sleep for a whole second
+    Thread.sleep(2000); // Sleep for a whole 2 seconds
 
     assertFalse(tracker.tryClaim(position));
   }

--- a/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/OffsetTrackerTest.java
+++ b/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/OffsetTrackerTest.java
@@ -65,7 +65,7 @@ public class OffsetTrackerTest implements Serializable {
 
     assertTrue(tracker.tryClaim(position));
 
-    Thread.sleep(1000); // Sleep for a whole 2 seconds
+    Thread.sleep(1000); // Sleep for a whole second
 
     assertFalse(tracker.tryClaim(position));
   }

--- a/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/OffsetTrackerTest.java
+++ b/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/OffsetTrackerTest.java
@@ -65,7 +65,7 @@ public class OffsetTrackerTest implements Serializable {
 
     assertTrue(tracker.tryClaim(position));
 
-    Thread.sleep(2000); // Sleep for a whole 2 seconds
+    Thread.sleep(1000); // Sleep for a whole 2 seconds
 
     assertFalse(tracker.tryClaim(position));
   }


### PR DESCRIPTION
I've tested this in the Direct Runner and I feel good about it. However, I've not tested this on distributed runners. 

Once we can stand up JDBC databases that can be tested on Dataflow, we can run a more extensive test against this code, and try to force an eviction of the owrk item to a different worker to see the behavior when we create separate instances of the SourceTask.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
