### PR TITLE
Remove slow review label after processing commands to avoid race

### DIFF
--- a/scripts/ci/pr-bot/processPrUpdate.ts
+++ b/scripts/ci/pr-bot/processPrUpdate.ts
@@ -75,20 +75,19 @@ async function processPrComment(
   const commentContents = payload.comment.body;
   const commentAuthor = payload.sender.login;
   const pullAuthor = getPullAuthorFromPayload(payload);
+  console.log(commentContents);
+  const processedCommand = await processCommand(
+    payload,
+    commentAuthor,
+    commentContents,
+    stateClient,
+    reviewerConfig
+  );
   // If there's been a comment by a non-author, we can remove the slow review label
   if (commentAuthor !== pullAuthor && commentAuthor !== BOT_NAME) {
     await removeSlowReviewLabel(payload);
   }
-  console.log(commentContents);
-  if (
-    await processCommand(
-      payload,
-      commentAuthor,
-      commentContents,
-      stateClient,
-      reviewerConfig
-    )
-  ) {
+  if (processedCommand) {
     // If we've processed a command, don't worry about trying to change the attention set.
     // This is not a meaningful push or comment from the author.
     console.log("Processed command");

--- a/scripts/ci/pr-bot/shared/persistentState.ts
+++ b/scripts/ci/pr-bot/shared/persistentState.ts
@@ -40,14 +40,20 @@ async function commitStateToRepo() {
     );
   }
   // Print changes for observability
-  await exec.exec("git status", [], {ignoreReturnCode: true});
+  await exec.exec("git status", [], { ignoreReturnCode: true });
   await exec.exec("git add state/*");
-  const changes = await exec.exec("git diff --quiet --cached origin/pr-bot-state state", [], {ignoreReturnCode: true});
+  const changes = await exec.exec(
+    "git diff --quiet --cached origin/pr-bot-state state",
+    [],
+    { ignoreReturnCode: true }
+  );
   if (changes == 1) {
     await exec.exec(`git commit -m "Updating config from bot" --allow-empty`);
     await exec.exec("git push origin pr-bot-state");
   } else {
-    console.log("Skipping updating state branch since there are no changes to commit");
+    console.log(
+      "Skipping updating state branch since there are no changes to commit"
+    );
   }
 }
 


### PR DESCRIPTION
Right now, when we process a command, if that command changes the label set we have the potential to overwrite earlier label changes. This is generally not a problem, but when we've already removed the slow-review label it can add it back. This can lead to cases like https://github.com/apache/beam/pull/23984#issuecomment-1362984438 where we assign new reviewers by mistake.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
