### PR TITLE
[BigQuery] Extend timestamp precision to microseconds when writing with Beam Rows (Storage API)

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BeamRowToStorageApiProto.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BeamRowToStorageApiProto.java
@@ -24,9 +24,11 @@ import com.google.protobuf.Descriptors.Descriptor;
 import com.google.protobuf.Descriptors.FieldDescriptor;
 import com.google.protobuf.DynamicMessage;
 import java.math.BigDecimal;
+import java.time.Instant;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
 import java.util.List;
 import java.util.Map;
 import java.util.function.BiFunction;
@@ -119,7 +121,7 @@ public class BeamRowToStorageApiProto {
                   CivilTimeEncoder.encodePacked64DatetimeSeconds((LocalDateTime) value))
           .put(
               SqlTypes.TIMESTAMP.getIdentifier(),
-              (logicalType, value) -> ((java.time.Instant) value).toEpochMilli() * 1000)
+              (logicalType, value) -> (ChronoUnit.MICROS.between(Instant.EPOCH, (Instant) value)))
           .put(
               EnumerationType.IDENTIFIER,
               (logicalType, value) ->

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryUtils.java
@@ -263,6 +263,7 @@ public class BigQueryUtils {
           .put(SqlTypes.DATE.getIdentifier(), StandardSQLTypeName.DATE)
           .put(SqlTypes.TIME.getIdentifier(), StandardSQLTypeName.TIME)
           .put(SqlTypes.DATETIME.getIdentifier(), StandardSQLTypeName.DATETIME)
+          .put(SqlTypes.TIMESTAMP.getIdentifier(), StandardSQLTypeName.TIMESTAMP)
           .put("SqlTimeWithLocalTzType", StandardSQLTypeName.TIME)
           .put("Enum", StandardSQLTypeName.STRING)
           .build();

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BeamRowToStorageApiProtoTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BeamRowToStorageApiProtoTest.java
@@ -45,9 +45,12 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Functions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 import org.joda.time.Instant;
+import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @RunWith(JUnit4.class)
 @SuppressWarnings({
@@ -55,6 +58,8 @@ import org.junit.runners.JUnit4;
 })
 /** Unit tests form {@link BeamRowToStorageApiProto}. */
 public class BeamRowToStorageApiProtoTest {
+  private static final Logger LOG = LoggerFactory.getLogger(BeamRowToStorageApiProtoTest.class);
+
   private static final EnumerationType TEST_ENUM =
       EnumerationType.create("ONE", "TWO", "RED", "BLUE");
   private static final Schema BASE_SCHEMA =
@@ -78,7 +83,8 @@ public class BeamRowToStorageApiProtoTest {
           .addField(
               "sqlTimestampValue", FieldType.logicalType(SqlTypes.TIMESTAMP).withNullable(true))
           .addField(
-              "sqlTimestampMicrosValue", FieldType.logicalType(SqlTypes.TIMESTAMP).withNullable(true))
+              "sqlTimestampMicrosValue",
+              FieldType.logicalType(SqlTypes.TIMESTAMP).withNullable(true))
           .addField("enumValue", FieldType.logicalType(TEST_ENUM).withNullable(true))
           .build();
 
@@ -239,7 +245,8 @@ public class BeamRowToStorageApiProtoTest {
           .withFieldValue("sqlTimeValue", LocalTime.now())
           .withFieldValue("sqlDatetimeValue", LocalDateTime.now())
           .withFieldValue("sqlTimestampValue", java.time.Instant.now())
-          .withFieldValue("sqlTimestampMicrosValue", java.time.Instant.now().plus(123, ChronoUnit.MICROS))
+          .withFieldValue(
+              "sqlTimestampMicrosValue", java.time.Instant.now().plus(123, ChronoUnit.MICROS))
           .withFieldValue("enumValue", TEST_ENUM.valueOf("RED"))
           .build();
   private static final Map<String, Object> BASE_PROTO_EXPECTED_FIELDS =
@@ -280,8 +287,7 @@ public class BeamRowToStorageApiProtoTest {
               "sqltimestampmicrosvalue",
               ChronoUnit.MICROS.between(
                   java.time.Instant.EPOCH,
-                  BASE_ROW.getLogicalTypeValue("sqlTimestampMicrosValue", java.time.Instant.class)
-              ))
+                  BASE_ROW.getLogicalTypeValue("sqlTimestampMicrosValue", java.time.Instant.class)))
           .put("enumvalue", "RED")
           .build();
 
@@ -408,5 +414,12 @@ public class BeamRowToStorageApiProtoTest {
             .collect(Collectors.toMap(FieldDescriptor::getName, Functions.identity()));
     DynamicMessage nestedMsg = (DynamicMessage) msg.getField(fieldDescriptors.get("nested"));
     assertBaseRecord(nestedMsg);
+  }
+
+  @Test
+  public void testInstant() throws Exception {
+    java.time.Instant now = java.time.Instant.now();
+    LOG.info("Instant now: {}", now);
+    System.out.println(String.format("Instant:  %s", now));
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BeamRowToStorageApiProtoTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BeamRowToStorageApiProtoTest.java
@@ -32,6 +32,7 @@ import java.nio.charset.StandardCharsets;
 import java.time.LocalDate;
 import java.time.LocalDateTime;
 import java.time.LocalTime;
+import java.time.temporal.ChronoUnit;
 import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.schemas.Schema;
@@ -76,6 +77,8 @@ public class BeamRowToStorageApiProtoTest {
           .addField("sqlDatetimeValue", FieldType.logicalType(SqlTypes.DATETIME).withNullable(true))
           .addField(
               "sqlTimestampValue", FieldType.logicalType(SqlTypes.TIMESTAMP).withNullable(true))
+          .addField(
+              "sqlTimestampMicrosValue", FieldType.logicalType(SqlTypes.TIMESTAMP).withNullable(true))
           .addField("enumValue", FieldType.logicalType(TEST_ENUM).withNullable(true))
           .build();
 
@@ -202,8 +205,15 @@ public class BeamRowToStorageApiProtoTest {
                   .build())
           .addField(
               FieldDescriptorProto.newBuilder()
-                  .setName("enumvalue")
+                  .setName("sqltimestampmicrosvalue")
                   .setNumber(18)
+                  .setType(Type.TYPE_INT64)
+                  .setLabel(Label.LABEL_OPTIONAL)
+                  .build())
+          .addField(
+              FieldDescriptorProto.newBuilder()
+                  .setName("enumvalue")
+                  .setNumber(19)
                   .setType(Type.TYPE_STRING)
                   .setLabel(Label.LABEL_OPTIONAL)
                   .build())
@@ -229,6 +239,7 @@ public class BeamRowToStorageApiProtoTest {
           .withFieldValue("sqlTimeValue", LocalTime.now())
           .withFieldValue("sqlDatetimeValue", LocalDateTime.now())
           .withFieldValue("sqlTimestampValue", java.time.Instant.now())
+          .withFieldValue("sqlTimestampMicrosValue", java.time.Instant.now().plus(123, ChronoUnit.MICROS))
           .withFieldValue("enumValue", TEST_ENUM.valueOf("RED"))
           .build();
   private static final Map<String, Object> BASE_PROTO_EXPECTED_FIELDS =
@@ -265,6 +276,12 @@ public class BeamRowToStorageApiProtoTest {
                       .getLogicalTypeValue("sqlTimestampValue", java.time.Instant.class)
                       .toEpochMilli()
                   * 1000)
+          .put(
+              "sqltimestampmicrosvalue",
+              ChronoUnit.MICROS.between(
+                  java.time.Instant.EPOCH,
+                  BASE_ROW.getLogicalTypeValue("sqlTimestampMicrosValue", java.time.Instant.class)
+              ))
           .put("enumvalue", "RED")
           .build();
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BeamRowToStorageApiProtoTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BeamRowToStorageApiProtoTest.java
@@ -45,12 +45,9 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Functions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 import org.joda.time.Instant;
-import org.junit.Ignore;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 @RunWith(JUnit4.class)
 @SuppressWarnings({
@@ -58,8 +55,6 @@ import org.slf4j.LoggerFactory;
 })
 /** Unit tests form {@link BeamRowToStorageApiProto}. */
 public class BeamRowToStorageApiProtoTest {
-  private static final Logger LOG = LoggerFactory.getLogger(BeamRowToStorageApiProtoTest.class);
-
   private static final EnumerationType TEST_ENUM =
       EnumerationType.create("ONE", "TWO", "RED", "BLUE");
   private static final Schema BASE_SCHEMA =
@@ -82,9 +77,6 @@ public class BeamRowToStorageApiProtoTest {
           .addField("sqlDatetimeValue", FieldType.logicalType(SqlTypes.DATETIME).withNullable(true))
           .addField(
               "sqlTimestampValue", FieldType.logicalType(SqlTypes.TIMESTAMP).withNullable(true))
-          .addField(
-              "sqlTimestampMicrosValue",
-              FieldType.logicalType(SqlTypes.TIMESTAMP).withNullable(true))
           .addField("enumValue", FieldType.logicalType(TEST_ENUM).withNullable(true))
           .build();
 
@@ -211,15 +203,8 @@ public class BeamRowToStorageApiProtoTest {
                   .build())
           .addField(
               FieldDescriptorProto.newBuilder()
-                  .setName("sqltimestampmicrosvalue")
-                  .setNumber(18)
-                  .setType(Type.TYPE_INT64)
-                  .setLabel(Label.LABEL_OPTIONAL)
-                  .build())
-          .addField(
-              FieldDescriptorProto.newBuilder()
                   .setName("enumvalue")
-                  .setNumber(19)
+                  .setNumber(18)
                   .setType(Type.TYPE_STRING)
                   .setLabel(Label.LABEL_OPTIONAL)
                   .build())
@@ -244,9 +229,7 @@ public class BeamRowToStorageApiProtoTest {
           .withFieldValue("sqlDateValue", LocalDate.now())
           .withFieldValue("sqlTimeValue", LocalTime.now())
           .withFieldValue("sqlDatetimeValue", LocalDateTime.now())
-          .withFieldValue("sqlTimestampValue", java.time.Instant.now())
-          .withFieldValue(
-              "sqlTimestampMicrosValue", java.time.Instant.now().plus(123, ChronoUnit.MICROS))
+          .withFieldValue("sqlTimestampValue", java.time.Instant.now().plus(123, ChronoUnit.MICROS))
           .withFieldValue("enumValue", TEST_ENUM.valueOf("RED"))
           .build();
   private static final Map<String, Object> BASE_PROTO_EXPECTED_FIELDS =
@@ -279,15 +262,9 @@ public class BeamRowToStorageApiProtoTest {
                   BASE_ROW.getLogicalTypeValue("sqlDatetimeValue", LocalDateTime.class)))
           .put(
               "sqltimestampvalue",
-              BASE_ROW
-                      .getLogicalTypeValue("sqlTimestampValue", java.time.Instant.class)
-                      .toEpochMilli()
-                  * 1000)
-          .put(
-              "sqltimestampmicrosvalue",
               ChronoUnit.MICROS.between(
                   java.time.Instant.EPOCH,
-                  BASE_ROW.getLogicalTypeValue("sqlTimestampMicrosValue", java.time.Instant.class)))
+                  BASE_ROW.getLogicalTypeValue("sqlTimestampValue", java.time.Instant.class)))
           .put("enumvalue", "RED")
           .build();
 
@@ -414,12 +391,5 @@ public class BeamRowToStorageApiProtoTest {
             .collect(Collectors.toMap(FieldDescriptor::getName, Functions.identity()));
     DynamicMessage nestedMsg = (DynamicMessage) msg.getField(fieldDescriptors.get("nested"));
     assertBaseRecord(nestedMsg);
-  }
-
-  @Test
-  public void testInstant() throws Exception {
-    java.time.Instant now = java.time.Instant.now();
-    LOG.info("Instant now: {}", now);
-    System.out.println(String.format("Instant:  %s", now));
   }
 }


### PR DESCRIPTION
Fixes #24782

Timestamp logical type in Beam Row is being encoded in millisecond precision, see [here](https://github.com/apache/beam/blob/820839fe86b16c4600b0aab4ad8236456cd200a9/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BeamRowToStorageApiProto.java#L122). These changes update it to encode in microsecond precision.