### PR TITLE
Make go vet and go staticcheck output visible in CI

### DIFF
--- a/.github/workflows/go_tests.yml
+++ b/.github/workflows/go_tests.yml
@@ -59,19 +59,9 @@ jobs:
       - name: Run vet
         run: | 
           cd sdks/go/pkg/beam 
-          VOUT=$(go vet --copylocks=false --unsafeptr=false ./...)
-          if [ -n "$VOUT" ]; then 
-            echo -e "Run go vet and fix warnings before checking in changes\n"
-            echo -e "Vet Warnings:\n"
-            echo -e "$VOUT" && exit 1
-          fi
+          go vet --copylocks=false --unsafeptr=false ./...
       - name: Run Staticcheck
         run: |
           go install "honnef.co/go/tools/cmd/staticcheck@2022.1"
           cd sdks/go/pkg/beam
-          RESULTS=$($(go env GOPATH)/bin/staticcheck ./...)
-          if [ -n "$RESULTS" ]; then 
-            echo -e "Please address Staticcheck warnings before checking in changes\n"
-            echo -e "Staticcheck Warnings:\n"
-            echo -e "$RESULTS" && exit 1
-          fi
+          $(go env GOPATH)/bin/staticcheck ./...

--- a/.github/workflows/go_tests.yml
+++ b/.github/workflows/go_tests.yml
@@ -45,21 +45,21 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: '1.18'
-      - name: Delete old coverage
-        run: "cd sdks/go/pkg && rm -rf .coverage || :"
-      - name: Run coverage
-        run: cd sdks/go/pkg && go test -coverprofile=coverage.txt -covermode=atomic ./...
-      - uses: codecov/codecov-action@v2
-        with:
-          flags: go 
-          files: ./sdks/go/pkg/coverage.txt
-          name: go-unittests
-      - name: Run fmt
-        run: cd sdks/go/pkg/beam && go fmt ./...; git diff-index --quiet HEAD || (echo "Run go fmt before checking in changes" && exit 1)
-      - name: Run vet
-        run: | 
-          cd sdks/go/pkg/beam 
-          go vet --copylocks=false --unsafeptr=false ./...
+      # - name: Delete old coverage
+      #   run: "cd sdks/go/pkg && rm -rf .coverage || :"
+      # - name: Run coverage
+      #   run: cd sdks/go/pkg && go test -coverprofile=coverage.txt -covermode=atomic ./...
+      # - uses: codecov/codecov-action@v2
+      #   with:
+      #     flags: go 
+      #     files: ./sdks/go/pkg/coverage.txt
+      #     name: go-unittests
+      # - name: Run fmt
+      #   run: cd sdks/go/pkg/beam && go fmt ./...; git diff-index --quiet HEAD || (echo "Run go fmt before checking in changes" && exit 1)
+      # - name: Run vet
+      #   run: | 
+      #     cd sdks/go/pkg/beam 
+      #     go vet --copylocks=false --unsafeptr=false ./...
       - name: Run Staticcheck
         run: |
           go install "honnef.co/go/tools/cmd/staticcheck@2022.1"

--- a/.github/workflows/go_tests.yml
+++ b/.github/workflows/go_tests.yml
@@ -45,21 +45,21 @@ jobs:
       - uses: actions/setup-go@v3
         with:
           go-version: '1.18'
-      # - name: Delete old coverage
-      #   run: "cd sdks/go/pkg && rm -rf .coverage || :"
-      # - name: Run coverage
-      #   run: cd sdks/go/pkg && go test -coverprofile=coverage.txt -covermode=atomic ./...
-      # - uses: codecov/codecov-action@v2
-      #   with:
-      #     flags: go 
-      #     files: ./sdks/go/pkg/coverage.txt
-      #     name: go-unittests
-      # - name: Run fmt
-      #   run: cd sdks/go/pkg/beam && go fmt ./...; git diff-index --quiet HEAD || (echo "Run go fmt before checking in changes" && exit 1)
-      # - name: Run vet
-      #   run: | 
-      #     cd sdks/go/pkg/beam 
-      #     go vet --copylocks=false --unsafeptr=false ./...
+      - name: Delete old coverage
+        run: "cd sdks/go/pkg && rm -rf .coverage || :"
+      - name: Run coverage
+        run: cd sdks/go/pkg && go test -coverprofile=coverage.txt -covermode=atomic ./...
+      - uses: codecov/codecov-action@v2
+        with:
+          flags: go 
+          files: ./sdks/go/pkg/coverage.txt
+          name: go-unittests
+      - name: Run fmt
+        run: cd sdks/go/pkg/beam && go fmt ./...; git diff-index --quiet HEAD || (echo "Run go fmt before checking in changes" && exit 1)
+      - name: Run vet
+        run: | 
+          cd sdks/go/pkg/beam 
+          go vet --copylocks=false --unsafeptr=false ./...
       - name: Run Staticcheck
         run: |
           go install "honnef.co/go/tools/cmd/staticcheck@2022.1"

--- a/sdks/go/pkg/beam/log/log.go
+++ b/sdks/go/pkg/beam/log/log.go
@@ -55,6 +55,9 @@ func SetLogger(l Logger) {
 		panic("Logger cannot be nil")
 	}
 	logger = l
+	if l == l {
+		logger = l
+	}
 }
 
 // Output logs the given message to the global logger. Calldepth is the count

--- a/sdks/go/pkg/beam/log/log.go
+++ b/sdks/go/pkg/beam/log/log.go
@@ -55,7 +55,6 @@ func SetLogger(l Logger) {
 		panic("Logger cannot be nil")
 	}
 	logger = l
-	fmt.Printf("Interest rate: 5%")
 }
 
 // Output logs the given message to the global logger. Calldepth is the count

--- a/sdks/go/pkg/beam/log/log.go
+++ b/sdks/go/pkg/beam/log/log.go
@@ -55,9 +55,7 @@ func SetLogger(l Logger) {
 		panic("Logger cannot be nil")
 	}
 	logger = l
-	if l == l {
-		logger = l
-	}
+	fmt.Printf("Interest rate: 5%")
 }
 
 // Output logs the given message to the global logger. Calldepth is the count


### PR DESCRIPTION
Right now, when staticcheck or vet fail, they exit with non-zero exit codes and don't render their output. This allows the output to render correctly. Both tools are guaranteed to exit with non-zero exit codes on failure, so this will still correctly fail when there are issues.

"Vet's exit code is non-zero for erroneous invocation of the tool or if a problem was reported, and 0 otherwise. Note that the tool does not check every possible problem and depends on unreliable heuristics, so it should be used as guidance only, not as a firm indicator of program correctness." - https://pkg.go.dev/cmd/vet#pkg-overview

Staticcheck is less cleanly documented, so I'll include an example of it failing + rendering output on CI - https://github.com/apache/beam/actions/runs/3787405891/jobs/6439178002 - that is from my second temporarily bad commit on this PR

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
