### PR TITLE
[#24789][Go SDK] Fix Minor race conditions

### DIFF
--- a/sdks/go/pkg/beam/runners/universal/extworker/extworker.go
+++ b/sdks/go/pkg/beam/runners/universal/extworker/extworker.go
@@ -109,7 +109,6 @@ func (s *Loopback) Stop(ctx context.Context) error {
 
 	log.Infof(ctx, "stopping Loopback, and %d workers", len(s.workers))
 	s.workers = map[string]context.CancelFunc{}
-	s.lis.Close()
 	s.rootCancel()
 
 	// There can be a deadlock between the StopWorker RPC and GracefulStop

--- a/sdks/go/pkg/beam/runners/universal/extworker/extworker.go
+++ b/sdks/go/pkg/beam/runners/universal/extworker/extworker.go
@@ -67,7 +67,7 @@ func (s *Loopback) StartWorker(ctx context.Context, req *fnpb.StartWorkerRequest
 	defer s.mu.Unlock()
 	if s.workers == nil {
 		return &fnpb.StartWorkerResponse{
-			Error: fmt.Sprintf("worker pool shutting down"),
+			Error: "worker pool shutting down",
 		}, nil
 	}
 

--- a/sdks/go/pkg/beam/runners/universal/extworker/extworker.go
+++ b/sdks/go/pkg/beam/runners/universal/extworker/extworker.go
@@ -65,6 +65,12 @@ func (s *Loopback) StartWorker(ctx context.Context, req *fnpb.StartWorkerRequest
 	log.Infof(ctx, "starting worker %v", req.GetWorkerId())
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.workers == nil {
+		return &fnpb.StartWorkerResponse{
+			Error: fmt.Sprintf("worker pool shutting down"),
+		}, nil
+	}
+
 	if _, ok := s.workers[req.GetWorkerId()]; ok {
 		return &fnpb.StartWorkerResponse{
 			Error: fmt.Sprintf("worker with ID %q already exists", req.GetWorkerId()),
@@ -92,6 +98,10 @@ func (s *Loopback) StopWorker(ctx context.Context, req *fnpb.StopWorkerRequest) 
 	log.Infof(ctx, "stopping worker %v", req.GetWorkerId())
 	s.mu.Lock()
 	defer s.mu.Unlock()
+	if s.workers == nil {
+		// Worker pool is already shutting down, so no action is needed.
+		return &fnpb.StopWorkerResponse{}, nil
+	}
 	if cancelfn, ok := s.workers[req.GetWorkerId()]; ok {
 		cancelfn()
 		delete(s.workers, req.GetWorkerId())
@@ -108,7 +118,7 @@ func (s *Loopback) Stop(ctx context.Context) error {
 	s.mu.Lock()
 
 	log.Infof(ctx, "stopping Loopback, and %d workers", len(s.workers))
-	s.workers = map[string]context.CancelFunc{}
+	s.workers = nil
 	s.rootCancel()
 
 	// There can be a deadlock between the StopWorker RPC and GracefulStop


### PR DESCRIPTION
Resolving SDK side race conditions that lead to flaky or hung unit tests while I've been iterating on #24789 These can cause the unit test runs to hand or fail spuriously.

* Logger can sometimes be set at the same time as output being called on it. Holding the logger with an atomic, and loading from it, resolves this.
* In loopback mode, the worker server can get deadlocked while shutting down, with an RPC waiting on the lock, while the graceful shutdown goroutine holds the lock, waiting for all connections to terminate. Moving the grpc server shutdown out of the critical section resolves the deadlock.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
