### PR TITLE
[Playground] Return only Playground examples in GetCatalog()

### DIFF
--- a/playground/backend/internal/db/datastore/datastore_db.go
+++ b/playground/backend/internal/db/datastore/datastore_db.go
@@ -212,7 +212,7 @@ func (d *Datastore) GetSDKs(ctx context.Context) ([]*entity.SDKEntity, error) {
 //GetCatalog returns all examples
 func (d *Datastore) GetCatalog(ctx context.Context, sdkCatalog []*entity.SDKEntity) ([]*pb.Categories, error) {
 	//Retrieving examples
-	exampleQuery := datastore.NewQuery(constants.ExampleKind).Namespace(utils.GetNamespace(ctx))
+	exampleQuery := datastore.NewQuery(constants.ExampleKind).Namespace(utils.GetNamespace(ctx)).FilterField("origin", "=", constants.ExampleOrigin)
 	var examples []*entity.ExampleEntity
 	exampleKeys, err := d.Client.GetAll(ctx, exampleQuery, &examples)
 	if err != nil {

--- a/playground/backend/internal/db/datastore/datastore_db_test.go
+++ b/playground/backend/internal/db/datastore/datastore_db_test.go
@@ -403,9 +403,13 @@ func TestDatastore_GetCatalog(t *testing.T) {
 			name: "Getting catalog in the usual case",
 			prepare: func() {
 				exampleId := utils.GetIDWithDelimiter(pb.Sdk_SDK_JAVA.String(), "MOCK_EXAMPLE")
-				saveExample("MOCK_EXAMPLE", pb.Sdk_SDK_JAVA.String())
+				saveExample("MOCK_EXAMPLE", pb.Sdk_SDK_JAVA.String(), constants.ExampleOrigin)
 				saveSnippet(exampleId, pb.Sdk_SDK_JAVA.String(), false)
 				savePCObjs(exampleId)
+				exampleIdDifferentOrigin := utils.GetIDWithDelimiter(pb.Sdk_SDK_GO.String(), "MOCK_EXAMPLE_DIFFERENT_ORIGIN")
+				saveExample("MOCK_EXAMPLE_DIFFERENT_ORIGIN", pb.Sdk_SDK_GO.String(), "MOCK_ORIGIN")
+				saveSnippet(exampleIdDifferentOrigin, pb.Sdk_SDK_GO.String(), false)
+				savePCObjs(exampleIdDifferentOrigin)
 			},
 			args: args{
 				ctx: ctx,
@@ -427,6 +431,11 @@ func TestDatastore_GetCatalog(t *testing.T) {
 				test_cleaner.CleanFiles(ctx, t, exampleId, 1)
 				test_cleaner.CleanSnippet(ctx, t, exampleId)
 				test_cleaner.CleanExample(ctx, t, exampleId)
+				exampleIdDifferentOrigin := utils.GetIDWithDelimiter(pb.Sdk_SDK_JAVA.String(), "MOCK_EXAMPLE_DIFFERENT_ORIGIN")
+				test_cleaner.CleanPCObjs(ctx, t, exampleIdDifferentOrigin)
+				test_cleaner.CleanFiles(ctx, t, exampleIdDifferentOrigin, 1)
+				test_cleaner.CleanSnippet(ctx, t, exampleIdDifferentOrigin)
+				test_cleaner.CleanExample(ctx, t, exampleIdDifferentOrigin)
 			},
 		},
 	}
@@ -439,6 +448,9 @@ func TestDatastore_GetCatalog(t *testing.T) {
 				t.Errorf("GetCatalog() error = %v, wantErr %v", err, tt.wantErr)
 			}
 			if err == nil {
+				if len(catalog) != 1 {
+					t.Error("GetCatalog() unexpected result: query returned too many objects")
+				}
 				if catalog[0].GetSdk() != pb.Sdk_SDK_JAVA {
 					t.Error("GetCatalog() unexpected result: wrong sdk")
 				}
@@ -482,7 +494,7 @@ func TestDatastore_GetDefaultExamples(t *testing.T) {
 			prepare: func() {
 				for sdk := range pb.Sdk_value {
 					exampleId := utils.GetIDWithDelimiter(sdk, "MOCK_DEFAULT_EXAMPLE")
-					saveExample("MOCK_DEFAULT_EXAMPLE", sdk)
+					saveExample("MOCK_DEFAULT_EXAMPLE", sdk, constants.ExampleOrigin)
 					saveSnippet(exampleId, sdk, false)
 					savePCObjs(exampleId)
 				}
@@ -551,7 +563,7 @@ func TestDatastore_GetExample(t *testing.T) {
 			name: "Getting an example in the usual case",
 			prepare: func() {
 				exampleId := utils.GetIDWithDelimiter(pb.Sdk_SDK_JAVA.String(), "MOCK_EXAMPLE")
-				saveExample("MOCK_EXAMPLE", pb.Sdk_SDK_JAVA.String())
+				saveExample("MOCK_EXAMPLE", pb.Sdk_SDK_JAVA.String(), constants.ExampleOrigin)
 				saveSnippet(exampleId, pb.Sdk_SDK_JAVA.String(), false)
 				savePCObjs(exampleId)
 			},
@@ -613,7 +625,7 @@ func TestDatastore_GetExampleCode(t *testing.T) {
 			name: "Getting multifile example code",
 			prepare: func() {
 				exampleId := utils.GetIDWithDelimiter(pb.Sdk_SDK_JAVA.String(), "MOCK_EXAMPLE")
-				saveExample("MOCK_EXAMPLE", pb.Sdk_SDK_JAVA.String())
+				saveExample("MOCK_EXAMPLE", pb.Sdk_SDK_JAVA.String(), constants.ExampleOrigin)
 				saveSnippet(exampleId, pb.Sdk_SDK_JAVA.String(), true /* multifile */)
 				savePCObjs(exampleId)
 			},
@@ -667,7 +679,7 @@ func TestDatastore_GetExampleOutput(t *testing.T) {
 			name: "Getting an example output in the usual case",
 			prepare: func() {
 				exampleId := utils.GetIDWithDelimiter(pb.Sdk_SDK_JAVA.String(), "MOCK_EXAMPLE")
-				saveExample("MOCK_EXAMPLE", pb.Sdk_SDK_JAVA.String())
+				saveExample("MOCK_EXAMPLE", pb.Sdk_SDK_JAVA.String(), constants.ExampleOrigin)
 				saveSnippet(exampleId, pb.Sdk_SDK_JAVA.String(), false)
 				savePCObjs(exampleId)
 			},
@@ -719,7 +731,7 @@ func TestDatastore_GetExampleLogs(t *testing.T) {
 			name: "Getting an example logs in the usual case",
 			prepare: func() {
 				exampleId := utils.GetIDWithDelimiter(pb.Sdk_SDK_JAVA.String(), "MOCK_EXAMPLE")
-				saveExample("MOCK_EXAMPLE", pb.Sdk_SDK_JAVA.String())
+				saveExample("MOCK_EXAMPLE", pb.Sdk_SDK_JAVA.String(), constants.ExampleOrigin)
 				saveSnippet(exampleId, pb.Sdk_SDK_JAVA.String(), false)
 				savePCObjs(exampleId)
 			},
@@ -771,7 +783,7 @@ func TestDatastore_GetExampleGraph(t *testing.T) {
 			name: "Getting an example graph in the usual case",
 			prepare: func() {
 				exampleId := utils.GetIDWithDelimiter(pb.Sdk_SDK_JAVA.String(), "MOCK_EXAMPLE")
-				saveExample("MOCK_EXAMPLE", pb.Sdk_SDK_JAVA.String())
+				saveExample("MOCK_EXAMPLE", pb.Sdk_SDK_JAVA.String(), constants.ExampleOrigin)
 				saveSnippet(exampleId, pb.Sdk_SDK_JAVA.String(), false)
 				savePCObjs(exampleId)
 			},
@@ -940,7 +952,7 @@ func TestNew(t *testing.T) {
 	}
 }
 
-func saveExample(name, sdk string) {
+func saveExample(name, sdk string, origin string) {
 	_, _ = datastoreDb.Client.Put(ctx, utils.GetExampleKey(ctx, sdk, name), &entity.ExampleEntity{
 		Name:   name,
 		Sdk:    utils.GetSdkKey(ctx, sdk),
@@ -948,7 +960,7 @@ func saveExample(name, sdk string) {
 		Cats:   []string{"MOCK_CATEGORY"},
 		Path:   "MOCK_PATH",
 		Type:   pb.PrecompiledObjectType_PRECOMPILED_OBJECT_TYPE_EXAMPLE.String(),
-		Origin: constants.ExampleOrigin,
+		Origin: origin,
 		SchVer: utils.GetSchemaVerKey(ctx, "MOCK_VERSION"),
 	})
 }


### PR DESCRIPTION
`GetCatalog()` function's current behavior is to return all examples from the datastore. This causes the examples catalog in Playground to show all examples instead of only showing examples with `PG_EXAMPLES` origin.

This PR addresses this issues and makes `GetCatalog()` to only return examples intended for the Playground

fixes #22352

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
