### PR TITLE
Fix Cassandra read bug when user query has no where clause

### DIFF
--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/ReadFn.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/ReadFn.java
@@ -137,10 +137,11 @@ class ReadFn<T> extends DoFn<Read<T>, T> {
     return combinedQuery;
   }
 
-  private static String buildInitialQuery(Read<?> spec, Boolean hasRingRange) {
+  private static String buildInitialQuery(CustomCassandraIO.Read<?> spec, Boolean hasRingRange) {
     return (spec.query() == null)
         ? String.format("SELECT * FROM %s.%s", spec.keyspace().get(), spec.table().get())
             + " WHERE "
-        : spec.query().get() + (hasRingRange ? " AND " : "");
+        : spec.query().get()
+            + (hasRingRange ? spec.query().get().toUpperCase().contains("WHERE") ? " AND " : " WHERE " :  "");
   }
 }


### PR DESCRIPTION
It would be very useful to be able to pass a user-defined query to CassandraIO for purposes of column selection only.

However, the current method for query parsing assumes such query necessarily comes with a 'where' clause, leading to an invalid resulting statement when this is not true.

Example of the current behavior:

Input query: "select partition_col, other_col from keyspace.table"

Resulting invalid query: "select partition_col, other_col from keyspace.table AND token(partition_col) >= ? and token(partition_col) < ?"

Resulting error:
SyntaxException: [...] mismatched input 'AND' expecting EOF (..., other_col from keyspace.table [AND]...)

The hereby proposed change fixes this by checking if the user given query contains a where clause, appending a "WHERE" to it when it doesn't, instead of a "AND".

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ N/A ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ N/A ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
