### PR TITLE
Fix Cassandra read bug when user query has no where clause (fixes #24829)

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -80,7 +80,7 @@
 
 ## Bugfixes
 
-* Fixed X (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
+* Avoids Cassandra syntax error when user-defined query has no where clause in it (Java/Python) ([#24829](https://github.com/apache/beam/issues/24829)).
 
 ## Known Issues
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -80,7 +80,7 @@
 
 ## Bugfixes
 
-* Avoids Cassandra syntax error when user-defined query has no where clause in it (Java/Python) ([#24829](https://github.com/apache/beam/issues/24829)).
+* Avoids Cassandra syntax error when user-defined query has no where clause in it (Java) ([#24829](https://github.com/apache/beam/issues/24829)).
 
 ## Known Issues
 

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/ReadFn.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/ReadFn.java
@@ -142,6 +142,8 @@ class ReadFn<T> extends DoFn<Read<T>, T> {
         ? String.format("SELECT * FROM %s.%s", spec.keyspace().get(), spec.table().get())
             + " WHERE "
         : spec.query().get()
-            + (hasRingRange ? spec.query().get().toUpperCase().contains("WHERE") ? " AND " : " WHERE " :  "");
+            + (hasRingRange
+                ? spec.query().get().toUpperCase().contains("WHERE") ? " AND " : " WHERE "
+                :  "");
   }
 }

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/ReadFn.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/ReadFn.java
@@ -141,6 +141,7 @@ class ReadFn<T> extends DoFn<Read<T>, T> {
     return (spec.query() == null)
         ? String.format("SELECT * FROM %s.%s", spec.keyspace().get(), spec.table().get())
             + " WHERE "
-        : spec.query().get() + (hasRingRange ? " AND " : "");
+        : spec.query().get()
+            + (hasRingRange ? spec.query().get().toUpperCase().contains("WHERE") ? " AND " : " WHERE " :  "");
   }
 }

--- a/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/ReadFn.java
+++ b/sdks/java/io/cassandra/src/main/java/org/apache/beam/sdk/io/cassandra/ReadFn.java
@@ -144,6 +144,6 @@ class ReadFn<T> extends DoFn<Read<T>, T> {
         : spec.query().get()
             + (hasRingRange
                 ? spec.query().get().toUpperCase().contains("WHERE") ? " AND " : " WHERE "
-                :  "");
+                : "");
   }
 }

--- a/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOTest.java
+++ b/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOTest.java
@@ -458,6 +458,10 @@ public class CassandraIOTest implements Serializable {
 
   @Test
   public void testReadWithQuery() throws Exception {
+    String query = String.format(
+        "select person_id, writetime(person_name) from %s.%s where person_id=10 AND person_department='logic'",
+        CASSANDRA_KEYSPACE, CASSANDRA_TABLE);
+
     PCollection<Scientist> output =
         pipeline.apply(
             CassandraIO.<Scientist>read()
@@ -466,12 +470,43 @@ public class CassandraIOTest implements Serializable {
                 .withKeyspace(CASSANDRA_KEYSPACE)
                 .withTable(CASSANDRA_TABLE)
                 .withMinNumberOfSplits(20)
-                .withQuery(
-                    "select person_id, writetime(person_name) from beam_ks.scientist where person_id=10 AND person_department='logic'")
+                .withQuery(query)
                 .withCoder(SerializableCoder.of(Scientist.class))
                 .withEntity(Scientist.class));
 
     PAssert.thatSingleton(output.apply("Count", Count.globally())).isEqualTo(1L);
+    PAssert.that(output)
+        .satisfies(
+            input -> {
+              for (Scientist sci : input) {
+                assertNull(sci.name);
+                assertTrue(sci.nameTs != null && sci.nameTs > 0);
+              }
+              return null;
+            });
+
+    pipeline.run();
+  }
+
+  @Test
+  public void testReadWithUnfilteredQuery() throws Exception {
+    String query = String.format(
+        "select person_id, writetime(person_name) from %s.%s",
+        CASSANDRA_KEYSPACE, CASSANDRA_TABLE);
+
+    PCollection<Scientist> output =
+        pipeline.apply(
+            CassandraIO.<Scientist>read()
+                .withHosts(Collections.singletonList(CASSANDRA_HOST))
+                .withPort(cassandraPort)
+                .withKeyspace(CASSANDRA_KEYSPACE)
+                .withTable(CASSANDRA_TABLE)
+                .withMinNumberOfSplits(20)
+                .withQuery(query)
+                .withCoder(SerializableCoder.of(Scientist.class))
+                .withEntity(Scientist.class));
+
+    PAssert.thatSingleton(output.apply("Count", Count.globally())).isEqualTo(11L);
     PAssert.that(output)
         .satisfies(
             input -> {

--- a/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOTest.java
+++ b/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOTest.java
@@ -458,9 +458,10 @@ public class CassandraIOTest implements Serializable {
 
   @Test
   public void testReadWithQuery() throws Exception {
-    String query = String.format(
-        "select person_id, writetime(person_name) from %s.%s where person_id=10 AND person_department='logic'",
-        CASSANDRA_KEYSPACE, CASSANDRA_TABLE);
+    String query =
+        String.format(
+            "select person_id, writetime(person_name) from %s.%s where person_id=10 AND person_department='logic'",
+            CASSANDRA_KEYSPACE, CASSANDRA_TABLE);
 
     PCollection<Scientist> output =
         pipeline.apply(
@@ -490,9 +491,10 @@ public class CassandraIOTest implements Serializable {
 
   @Test
   public void testReadWithUnfilteredQuery() throws Exception {
-    String query = String.format(
-        "select person_id, writetime(person_name) from %s.%s",
-        CASSANDRA_KEYSPACE, CASSANDRA_TABLE);
+    String query =
+        String.format(
+            "select person_id, writetime(person_name) from %s.%s",
+            CASSANDRA_KEYSPACE, CASSANDRA_TABLE);
 
     PCollection<Scientist> output =
         pipeline.apply(
@@ -506,7 +508,7 @@ public class CassandraIOTest implements Serializable {
                 .withCoder(SerializableCoder.of(Scientist.class))
                 .withEntity(Scientist.class));
 
-    PAssert.thatSingleton(output.apply("Count", Count.globally())).isEqualTo(11L);
+    PAssert.thatSingleton(output.apply("Count", Count.globally())).isEqualTo(22L);
     PAssert.that(output)
         .satisfies(
             input -> {

--- a/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOTest.java
+++ b/sdks/java/io/cassandra/src/test/java/org/apache/beam/sdk/io/cassandra/CassandraIOTest.java
@@ -508,7 +508,7 @@ public class CassandraIOTest implements Serializable {
                 .withCoder(SerializableCoder.of(Scientist.class))
                 .withEntity(Scientist.class));
 
-    PAssert.thatSingleton(output.apply("Count", Count.globally())).isEqualTo(22L);
+    PAssert.thatSingleton(output.apply("Count", Count.globally())).isEqualTo(NUM_ROWS);
     PAssert.that(output)
         .satisfies(
             input -> {


### PR DESCRIPTION
It would be very useful to be able to pass a user-defined query to CassandraIO for purposes of column selection only.

However, the current method for query parsing assumes such query necessarily comes with a 'where' clause, which leads to an invalid resulting statement when this is not the case.

This behavior has been reported on issue #24829.

The hereby proposed change fixes #24829 by checking if the user given query contains a where clause, appending a "WHERE" to it when it doesn't, instead of a "AND".

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
