### PR TITLE
Reduce redundant Get API call when creating bq temp dataset

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_tools.py
@@ -873,29 +873,16 @@ class BigQueryWrapper(object):
       num_retries=MAX_RETRIES,
       retry_filter=retry.retry_on_server_errors_and_timeout_filter)
   def create_temporary_dataset(self, project_id, location, labels=None):
-    # Check if dataset exists to make sure that the temporary id is unique
-    try:
-      self.client.datasets.Get(
-          bigquery.BigqueryDatasetsGetRequest(
-              projectId=project_id, datasetId=self.temp_dataset_id))
-      if project_id is not None and not self.is_user_configured_dataset():
-        # Unittests don't pass projectIds so they can be run without error
-        # User configured datasets are allowed to pre-exist.
-        raise RuntimeError(
-            'Dataset %s:%s already exists so cannot be used as temporary.' %
-            (project_id, self.temp_dataset_id))
-    except HttpError as exn:
-      if exn.status_code == 404:
-        _LOGGER.warning(
-            'Dataset %s:%s does not exist so we will create it as temporary '
-            'with location=%s',
-            project_id,
-            self.temp_dataset_id,
-            location)
-        self.get_or_create_dataset(
-            project_id, self.temp_dataset_id, location=location, labels=labels)
-      else:
-        raise
+    self.get_or_create_dataset(
+        project_id, self.temp_dataset_id, location=location, labels=labels)
+
+    if project_id is not None and not self.is_user_configured_dataset() and \
+        not self.created_temp_dataset:
+      # Unittests don't pass projectIds so they can be run without error
+      # User configured datasets are allowed to pre-exist.
+      raise RuntimeError(
+          'Dataset %s:%s already exists so cannot be used as temporary.' %
+          (project_id, self.temp_dataset_id))
 
   @retry.with_exponential_backoff(
       num_retries=MAX_RETRIES,

--- a/sdks/python/apache_beam/io/gcp/bigquery_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_tools.py
@@ -882,8 +882,8 @@ class BigQueryWrapper(object):
     self.get_or_create_dataset(
         project_id, self.temp_dataset_id, location=location, labels=labels)
 
-    if project_id is not None and not self.is_user_configured_dataset() and \
-        not self.created_temp_dataset:
+    if (project_id is not None and not self.is_user_configured_dataset() and
+        not self.created_temp_dataset):
       # Unittests don't pass projectIds so they can be run without error
       # User configured datasets are allowed to pre-exist.
       raise RuntimeError(

--- a/sdks/python/apache_beam/io/gcp/bigquery_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_tools.py
@@ -794,6 +794,12 @@ class BigQueryWrapper(object):
       return dataset
     except HttpError as exn:
       if exn.status_code == 404:
+        _LOGGER.info(
+            'Dataset %s:%s does not exist so we will create it as temporary '
+            'with location=%s',
+            project_id,
+            dataset_id,
+            location)
         dataset_reference = bigquery.DatasetReference(
             projectId=project_id, datasetId=dataset_id)
         dataset = bigquery.Dataset(datasetReference=dataset_reference)


### PR DESCRIPTION
Found when investigating #20841
Currently `BigQueryWrapper.create_temporary_dataset()` will do 3 API calls when temp dataset gets created, including two exactly same GET call:
https://github.com/apache/beam/blob/3f28d55dbe1721b6fe403d53d73771b1456d0262/sdks/python/apache_beam/io/gcp/bigquery_tools.py#L878-L880
https://github.com/apache/beam/blob/3f28d55dbe1721b6fe403d53d73771b1456d0262/sdks/python/apache_beam/io/gcp/bigquery_tools.py#L790-L792

the first call is redundant as `get_or_create_dataset` will check for existence and set `created_temp_dataset` flag accordingly.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
