### PR TITLE
Improve error message for unencodeable types

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/graphx/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/coder.go
@@ -448,7 +448,7 @@ func (b *CoderMarshaller) Add(c *coder.Coder) (string, error) {
 		if err != nil {
 			return "", errors.SetTopLevelMsgf(err, "failed to encode custom coder %s for TypeName %s. "+
 				"Make sure the type was registered before calling beam.Init. For example: "+
-				"beam.RegisterType(reflect.TypeOf((*TypeName)(nil)).Elem()). Some types can't be registered, see invalid registration types as below:(Link)", c, c.Custom.Type)
+				"beam.RegisterType(reflect.TypeOf((*TypeName)(nil)).Elem()). Some types, like maps, slices, arrays, channels, and functions cannot be registered as types.", c, c.Custom.Type)
 		}
 		data, err := protox.EncodeBase64(ref)
 		if err != nil {

--- a/sdks/go/pkg/beam/core/runtime/graphx/coder.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/coder.go
@@ -446,10 +446,9 @@ func (b *CoderMarshaller) Add(c *coder.Coder) (string, error) {
 	case coder.Custom:
 		ref, err := encodeCustomCoder(c.Custom)
 		if err != nil {
-			typeName := c.Custom.Name
-			return "", errors.SetTopLevelMsgf(err, "failed to encode custom coder for type %s. "+
+			return "", errors.SetTopLevelMsgf(err, "failed to encode custom coder %s for TypeName %s. "+
 				"Make sure the type was registered before calling beam.Init. For example: "+
-				"beam.RegisterType(reflect.TypeOf((*TypeName)(nil)).Elem())", typeName)
+				"beam.RegisterType(reflect.TypeOf((*TypeName)(nil)).Elem()). Some types can't be registered, see invalid registration types as below:(Link)", c, c.Custom.Type)
 		}
 		data, err := protox.EncodeBase64(ref)
 		if err != nil {

--- a/sdks/go/pkg/beam/core/runtime/graphx/serialize.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/serialize.go
@@ -498,8 +498,11 @@ func encodeType(t reflect.Type) (*v1pb.Type, error) {
 		}
 		return &v1pb.Type{Kind: v1pb.Type_PTR, Element: elm}, nil
 
+	case reflect.Map, reflect.Array:
+		return nil, errors.Errorf("unencodable type '%v', try to wrap the type as a field in a struct, see https://github.com/apache/beam/issues/23101 for details", t.Kind())
+
 	default:
-		return nil, errors.Errorf("unencodable type %v", t)
+		return nil, errors.Errorf("unencodable type '%v'", t.Kind())
 	}
 }
 

--- a/sdks/go/pkg/beam/core/runtime/graphx/serialize_test.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/serialize_test.go
@@ -68,4 +68,24 @@ func TestEncodeType(t *testing.T) {
 			t.Fatalf("got pbT.Kind == %v, want %v", got, want)
 		}
 	})
+	t.Run("FieldArrayWithoutWrapping", func(t *testing.T) {
+		rt := reflect.TypeOf((*[4]int)(nil)).Elem()
+		pbT, err := encodeType(rt)
+		if err == nil {
+			t.Fatalf("got type = %v, nil, want no wrap error", pbT)
+		}
+		if !strings.Contains(err.Error(), "try to wrap the type as a field in a struct") {
+			t.Errorf("expected error about wrapping in a struct, got %q", err.Error())
+		}
+	})
+	t.Run("FieldMapWithoutWrapping", func(t *testing.T) {
+		rt := reflect.TypeOf((*map[int]string)(nil)).Elem()
+		pbT, err := encodeType(rt)
+		if err == nil {
+			t.Fatalf("got type = %v, nil, want no wrap error", pbT)
+		}
+		if !strings.Contains(err.Error(), "try to wrap the type as a field in a struct") {
+			t.Errorf("expected error about wrapping in a struct, got %q", err.Error())
+		}
+	})
 }


### PR DESCRIPTION
Fix [#issue23101](https://github.com/apache/beam/issues/23101)
Now the error messages are like the below:

> Marshal([4]string[bar]) failed: failed to encode custom coder [4]string[bar] for TypeName [4]string. Make sure the type was registered before calling beam.Init. For example: beam.RegisterType(reflect.TypeOf((*TypeName)(nil)).Elem()). Some types can't be registered, see invalid registration types as below:(Link)
>         Full error:
>         failed to marshal the coder [4]string[bar].
>         	caused by:
>         	encoding custom coder [4]string[bar] for type [4]string
>         unencodable type 'array', try to wrap the type as a field in a struct, see https://github.com/apache/beam/issues/23101 for details

Changes are:
1. The top-level error msg contains the TypeName like "for TypeName [4]string", users can easily call "beam.RegisterType" to register that.
2. Give a "Link1"(WIP) to what registration types are invalid. 
3. The lowest-level error msg now uses a simple type name like "map" or "array", it could also give a "Link2"(WIP) for workarounds when the type is "map" or "array".
@lostluck Could u please help me with these two links? I can't find that on the beam website. Or I can help with the documentation if needed.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
