### PR TITLE
[Spark Dataset runner] Fix SparkSessionFactory to better support running on a cluster.

### DIFF
--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/SparkStructuredStreamingRunner.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/SparkStructuredStreamingRunner.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.runners.spark.structuredstreaming;
 
-import static org.apache.beam.runners.spark.SparkCommonPipelineOptions.prepareFilesToStage;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
 
 import java.util.concurrent.ExecutorService;
@@ -188,7 +187,6 @@ public final class SparkStructuredStreamingRunner
     }
 
     PipelineTranslator.replaceTransforms(pipeline, options);
-    prepareFilesToStage(options);
 
     PipelineTranslator pipelineTranslator = new PipelineTranslatorBatch();
     return pipelineTranslator.translate(pipeline, sparkSession, options);

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/SparkSessionFactory.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/SparkSessionFactory.java
@@ -17,14 +17,12 @@
  */
 package org.apache.beam.runners.spark.structuredstreaming.translation;
 
-import static org.apache.commons.lang.ArrayUtils.EMPTY_STRING_ARRAY;
+import static org.apache.commons.lang3.ArrayUtils.EMPTY_STRING_ARRAY;
 import static org.apache.commons.lang3.StringUtils.substringBetween;
 import static org.apache.commons.lang3.math.NumberUtils.toInt;
 
 import com.esotericsoftware.kryo.Kryo;
 import com.esotericsoftware.kryo.serializers.JavaSerializer;
-import com.google.common.collect.Collections2;
-import com.google.common.collect.Lists;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.Collections;
@@ -83,6 +81,8 @@ import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.PCollectionViews;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TupleTagList;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Collections2;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 import org.apache.spark.SparkConf;
 import org.apache.spark.serializer.KryoRegistrator;
 import org.apache.spark.serializer.KryoSerializer;
@@ -97,7 +97,7 @@ public class SparkSessionFactory {
   private static final Logger LOG = LoggerFactory.getLogger(SparkSessionFactory.class);
 
   // Patterns to exclude local JRE and certain artifact (groups) in Maven and Gradle cache.
-  private static Collection<String> SPARK_JAR_EXCLUDES =
+  private static final Collection<String> SPARK_JAR_EXCLUDES =
       Lists.newArrayList(
           "jre/lib/ext/",
           "/org/slf4j/",
@@ -178,7 +178,7 @@ public class SparkSessionFactory {
     return SparkSession.builder().config(sparkConf);
   }
 
-  @SuppressWarnings({"return", "toarray.nullable.elements.not.newarray"})
+  @SuppressWarnings({"return", "toarray.nullable.elements", "methodref.receiver"}) // safe to ignore
   private static String[] filesToStage(
       SparkStructuredStreamingPipelineOptions opts, Collection<String> excludes) {
     Collection<String> files = opts.getFilesToStage();

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/SparkSessionFactory.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/SparkSessionFactory.java
@@ -137,7 +137,9 @@ public class SparkSessionFactory {
     master = sparkConf.get("spark.master"); // update to effective master
 
     if (options != null) {
-      sparkConf.setAppName(options.getAppName());
+      if (options.getAppName() != null) {
+        sparkConf.setAppName(options.getAppName());
+      }
 
       if (options.getFilesToStage() != null && !options.getFilesToStage().isEmpty()) {
         // Append the files to stage provided by the user to `spark.jars`.

--- a/runners/spark/spark_runner.gradle
+++ b/runners/spark/spark_runner.gradle
@@ -164,6 +164,7 @@ dependencies {
   implementation library.java.jackson_annotations
   implementation library.java.slf4j_api
   implementation library.java.joda_time
+  implementation library.java.commons_lang3
   implementation library.java.args4j
   implementation project(path: ":model:fn-execution", configuration: "shadow")
   implementation project(path: ":model:job-management", configuration: "shadow")


### PR DESCRIPTION
The most common way to submit jobs to a Spark cluster is to use `spark-submit`. `SparkSessionFactory` doesn't handle that well. Despite `spark.master` being set by `spark-submit`, it's overwritten by the respective `PipelineOption` which defaults to `local[*]`.

- Fix factory to not overwrite `spark.master` if configured already, use the effective Spark master going forward.

Staging of classpath artifacts is necessary when running on a cluster using a local driver. This is required to populate `spark.jars` as it would be done by `spark-submit` otherwise. Unfortunately this is broken as staging is done after the session was already created.

- Enable `userClassPathFirst` to deal with conflicting dependency versions. For Spark & Beam that's usually the case for Jackson and Guava, but potentially also others.

- Correctly stage classpath if not in local mode and if `spark.jars` is not set. Exclude Spark jars and similar that are already available on the cluster and that cause conflicts if enabling `userClassPathFirst`.

(fixes #24861).

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
