### PR TITLE
[#24801] ValueState.read() should specify returning null since it will if unset

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/state/ValueState.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/state/ValueState.java
@@ -37,7 +37,8 @@ public interface ValueState<T> extends ReadableState<@Nullable T>, State {
    * <p>Note that {@code null} will be returned if the value has never been written.
    */
   @Override
-  @Nullable T read();
+  @Nullable
+  T read();
 
   @Override
   ValueState<T> readLater();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/state/ValueState.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/state/ValueState.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.state;
 
 import org.apache.beam.sdk.annotations.Experimental;
 import org.apache.beam.sdk.annotations.Experimental.Kind;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
  * A {@link ReadableState} cell containing a single value.
@@ -26,9 +27,17 @@ import org.apache.beam.sdk.annotations.Experimental.Kind;
  * @param <T> The type of value being stored.
  */
 @Experimental(Kind.STATE)
-public interface ValueState<T> extends ReadableState<T>, State {
+public interface ValueState<T> extends ReadableState<@Nullable T>, State {
   /** Set the value. */
   void write(T input);
+
+  /**
+   * {@inheritDoc}
+   *
+   * <p>Note that {@code null} will be returned if the value has never been written.
+   */
+  @Override
+  @Nullable T read();
 
   @Override
   ValueState<T> readLater();


### PR DESCRIPTION
Also clarify documentation.

Fixes #24801

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
