### PR TITLE
Reduce lock contention for metrics hashName hasher

### DIFF
--- a/sdks/go/pkg/beam/core/metrics/metrics_test.go
+++ b/sdks/go/pkg/beam/core/metrics/metrics_test.go
@@ -664,9 +664,11 @@ func BenchmarkMetrics(b *testing.B) {
 	}
 	for _, test := range tests {
 		b.Run(test.name, func(b *testing.B) {
-			for i := 0; i < b.N; i++ {
-				test.call()
-			}
+			b.RunParallel(func(pb *testing.PB) {
+				for pb.Next() {
+					test.call()
+				}
+			})
 		})
 	}
 }

--- a/sdks/go/pkg/beam/core/metrics/metrics_test.go
+++ b/sdks/go/pkg/beam/core/metrics/metrics_test.go
@@ -617,21 +617,23 @@ func TestPcolQueryResult(t *testing.T) {
 	}
 }
 
-// Run on @lostluck's desktop (2020/01/21) go1.13.4
+// Run on @shanemhansen's desktop (2022/01/03) go1.20 RC1 after changing hashName to use a pool of hashers
+// sync.Pool can return thread-local results eliminating the need for a lock and increasing throughput.
+// There are users in the wild who create an excessive number of Counters so a 4x improvement in throughput at the expense of
+// creating GOMAXPROCS hasher values seems reasonable.
 //
-// Allocs & bytes should be consistent within go versions, but ns/op is relative to the running machine.
-//
-// BenchmarkMetrics/counter_inplace-12              6054129               208 ns/op              48 B/op          1 allocs/op
-// BenchmarkMetrics/distribution_inplace-12         5707147               228 ns/op              48 B/op          1 allocs/op
-// BenchmarkMetrics/gauge_inplace-12                4742331               259 ns/op              48 B/op          1 allocs/op
-// BenchmarkMetrics/counter_predeclared-12         90147133                12.7 ns/op             0 B/op          0 allocs/op
-// BenchmarkMetrics/distribution_predeclared-12            55396678                21.6 ns/op             0 B/op          0 allocs/op
-// BenchmarkMetrics/gauge_predeclared-12                   18535839                60.5 ns/op             0 B/op          0 allocs/op
-// BenchmarkMetrics/counter_raw-12                         159581343                7.18 ns/op            0 B/op          0 allocs/op
-// BenchmarkMetrics/distribution_raw-12                    82724314                14.7 ns/op             0 B/op          0 allocs/op
-// BenchmarkMetrics/gauge_raw-12                           23292386                55.2 ns/op             0 B/op          0 allocs/op
-// BenchmarkMetrics/getStore-12                            309361303                3.78 ns/op            0 B/op          0 allocs/op
-// BenchmarkMetrics/getCounterSet-12                       287720998                3.98 ns/op            0 B/op          0 allocs/op
+// name                                 old time/op  new time/op  delta
+// Metrics/counter_inplace-12            376ns ±17%    88ns ± 7%  -76.66%  (p=0.008 n=5+5)
+// Metrics/distribution_inplace-12       394ns ± 3%   153ns ± 8%  -61.17%  (p=0.008 n=5+5)
+// Metrics/gauge_inplace-12              371ns ± 4%   258ns ± 1%  -30.37%  (p=0.008 n=5+5)
+// Metrics/counter_predeclared-12       16.9ns ± 6%  17.0ns ± 3%     ~     (p=0.595 n=5+5)
+// Metrics/distribution_predeclared-12  83.2ns ± 2%  84.9ns ± 1%     ~     (p=0.056 n=5+5)
+// Metrics/gauge_predeclared-12          105ns ± 6%   110ns ± 5%   +4.81%  (p=0.032 n=5+5)
+// Metrics/counter_raw-12               10.8ns ± 4%  12.0ns ±28%     ~     (p=0.151 n=5+5)
+// Metrics/distribution_raw-12          77.6ns ± 7%  78.8ns ± 5%     ~     (p=0.841 n=5+5)
+// Metrics/gauge_raw-12                 78.9ns ± 1%  77.3ns ± 4%     ~     (p=0.151 n=5+5)
+// Metrics/getStore-12                  0.27ns ± 3%  0.27ns ± 2%     ~     (p=0.841 n=5+5)
+// Metrics/getCounterSet-12             0.32ns ± 3%  0.31ns ± 0%   -1.28%  (p=0.048 n=5+4)
 func BenchmarkMetrics(b *testing.B) {
 	pt, c, d, g := "bench.bundle.data", "counter", "distribution", "gauge"
 	aBundleID := "benchBID"


### PR DESCRIPTION
The singleton hasher used by hashName can be highly contented and reduce overall multi-core throughput. This has been observed in applications that dynamically create lots of counters. This change adds a parallel benchmark to measure multi-core performance for applications. It also changes the singleton hasher to use sync.Pool and thus benefit from it's per-P cache:

- https://www.sobyte.net/post/2022-03/think-in-sync-pool/

In benchmarks this change can provide ~4x performance improvements in multicore situations.