### PR TITLE
Sets PubsubMessageWithAttributesAndMessageIdAndOrderingKeyCoder as default coder for all PubsubMessage

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -73,6 +73,13 @@
   `disable_runner_v2_until_2023`, `disable_prime_runner_v2` experiments will raise an error during
   pipeline construction. You can no longer specify the Dataflow worker jar override. Note that
   non-portable Java jobs and non-portable Python batch jobs are not impacted. ([#24515](https://github.com/apache/beam/issues/24515)).
+* The default Coder for `PubsubMessage` objects in Java SDK has been changed
+  from `PubsubMessageWithAttributesCoder` to
+  `PubsubMessageWithAttributesAndMessageIdAndOrderingKeyCoder` to allow support
+  for publishing messages with an ordering key. Pipelines with the
+  requirement to be updated will need to explicitly set the coder to the
+  previous default of `PubsubMessageWithAttributesCoder` to avoid pipeline
+  update errors. (Java) ([#24887](https://github.com/apache/beam/pull/24887))
 
 ## Deprecations
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubCoderProviderRegistrar.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubCoderProviderRegistrar.java
@@ -32,14 +32,14 @@ public class PubsubCoderProviderRegistrar implements CoderProviderRegistrar {
   public List<CoderProvider> getCoderProviders() {
     return ImmutableList.of(
         CoderProviders.forCoder(
+            TypeDescriptor.of(PubsubMessage.class),
+            PubsubMessageWithAttributesAndMessageIdAndOrderingKeyCoder.of()),
+        CoderProviders.forCoder(
             TypeDescriptor.of(PubsubMessage.class), PubsubMessageWithAttributesCoder.of()),
         CoderProviders.forCoder(
             TypeDescriptor.of(PubsubMessage.class), PubsubMessageWithMessageIdCoder.of()),
         CoderProviders.forCoder(
             TypeDescriptor.of(PubsubMessage.class),
-            PubsubMessageWithAttributesAndMessageIdCoder.of()),
-        CoderProviders.forCoder(
-            TypeDescriptor.of(PubsubMessage.class),
-            PubsubMessageWithAttributesAndMessageIdAndOrderingKeyCoder.of()));
+            PubsubMessageWithAttributesAndMessageIdCoder.of()));
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubMessageWithAttributesAndMessageIdAndOrderingKeyCoder.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubMessageWithAttributesAndMessageIdAndOrderingKeyCoder.java
@@ -42,8 +42,9 @@ public class PubsubMessageWithAttributesAndMessageIdAndOrderingKeyCoder
   // A message's attributes can be null.
   private static final Coder<Map<String, String>> ATTRIBUTES_CODER =
       NullableCoder.of(MapCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()));
-  // A message's messageId cannot be null
-  private static final Coder<String> MESSAGE_ID_CODER = StringUtf8Coder.of();
+  // A message's messageId can only be null when the message is an outgoing message (i.e. to be
+  // published). Incoming messages will always have a non-null messageId
+  private static final Coder<String> MESSAGE_ID_CODER = NullableCoder.of(StringUtf8Coder.of());
   // A message's publish time, populated by server
   private static final Coder<Timestamp> PUBLISH_TIME_CODER = ProtoCoder.of(Timestamp.class);
   // A message's ordering key can be null


### PR DESCRIPTION
This PR alters the default Coder for pubsub message objects from `PubsubMessageWithAttributesCoder` to `PubsubMessageWithAttributesAndMessageIdAndOrderingKeyCoder` as default coder for all `PubsubMessage.class`.  Note that there was a previous dev@ thread[1] on this subject where there was no opposition to this change.

The one important detail to call out is that pipeline authors may need to explicitly set the coder to the value which was previously the default, `PubsubMessageWithAttributesCoder`, in cases where pipeline update is required.  I do have some concern over whether that's completely sufficient/possible based on the behaviour observed in https://github.com/apache/beam/issues/21162#issuecomment-1371259467.  

**I'm not sure this should be merged until further testing can be done to validate whether a running pipeline can be successfully updated.**


Fixes #23525 

[1] https://lists.apache.org/thread/c3qk0cp3rbhk2wh8m0z8gqxqy931dbwc
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
