### PR TITLE
Fix PR number in 2.43.0 changelog

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -147,7 +147,7 @@
 
 * Decreased TextSource CPU utilization by 2.3x (Java) ([#23193](https://github.com/apache/beam/issues/23193)).
 * Fixed bug when using SpannerIO with RuntimeValueProvider options (Java) ([#22146](https://github.com/apache/beam/issues/22146)).
-* Fixed issue for unicode rendering on WriteToBigQuery ([#10785](https://github.com/apache/beam/issues/10785))
+* Fixed issue for unicode rendering on WriteToBigQuery ([#22312](https://github.com/apache/beam/issues/22312))
 * Remove obsolete variants of BigQuery Read and Write, always using Beam-native variant
   ([#23564](https://github.com/apache/beam/issues/23564) and [#23559](https://github.com/apache/beam/issues/23559)).
 * Bumped google-cloud-spanner dependency version to 3.x for Python SDK ([#21198](https://github.com/apache/beam/issues/21198)).


### PR DESCRIPTION
The changelog entry for `Fixed issue for unicode rendering on WriteToBigQuery` in v2.43.0 cites PR #10785 which is unrelated to unicode rendering. That number actually seems to correspond to the Beam issue on Jira, rather than the GitHub PR: https://issues.apache.org/jira/projects/BEAM/issues/BEAM-10785?filter=allopenissues.

This PR updates the changelog entry to refer to the corresponding GitHub PR instead: #22312.