### PR TITLE
Attempt deserialize all non-standard portable logical types from proto

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java
@@ -439,9 +439,8 @@ public class SchemaTranslation {
                         logicalType.getPayload().toByteArray(), "logicalType"));
           } catch (IllegalArgumentException e) {
             LOG.warn(
-                String.format(
-                    "Unable to deserialize the logical type %s from proto. Mark as UnknownLogicalType",
-                    urn));
+                "Unable to deserialize the logical type {} from proto. Mark as UnknownLogicalType.",
+                urn);
           }
         }
         // assemble an UnknownLogicalType

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java
@@ -56,6 +56,7 @@ import org.apache.beam.sdk.schemas.logicaltypes.VariableString;
 import org.apache.beam.sdk.util.SerializableUtils;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.grpc.v1p48p1.com.google.protobuf.ByteString;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
@@ -63,6 +64,8 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.io.ByteStreams;
 import org.apache.commons.lang3.ClassUtils;
 import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Utility methods for translating schemas. */
 @Experimental(Kind.SCHEMAS)
@@ -71,6 +74,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
   "rawtypes"
 })
 public class SchemaTranslation {
+  private static final Logger LOG = LoggerFactory.getLogger(SchemaTranslation.class);
 
   private static final String URN_BEAM_LOGICAL_DECIMAL = FixedPrecisionNumeric.BASE_IDENTIFIER;
   private static final String URN_BEAM_LOGICAL_JAVASDK = "beam:logical_type:javasdk:v1";
@@ -124,8 +128,8 @@ public class SchemaTranslation {
         .build();
   }
 
-  private static SchemaApi.FieldType fieldTypeToProto(
-      FieldType fieldType, boolean serializeLogicalType) {
+  @VisibleForTesting
+  static SchemaApi.FieldType fieldTypeToProto(FieldType fieldType, boolean serializeLogicalType) {
     SchemaApi.FieldType.Builder builder = SchemaApi.FieldType.newBuilder();
     switch (fieldType.getTypeName()) {
       case ROW:
@@ -297,7 +301,8 @@ public class SchemaTranslation {
         .withDescription(protoField.getDescription());
   }
 
-  private static FieldType fieldTypeFromProto(SchemaApi.FieldType protoFieldType) {
+  @VisibleForTesting
+  static FieldType fieldTypeFromProto(SchemaApi.FieldType protoFieldType) {
     FieldType fieldType = fieldTypeFromProtoWithoutNullable(protoFieldType);
 
     if (protoFieldType.getNullable()) {
@@ -426,26 +431,33 @@ public class SchemaTranslation {
           return FieldType.DATETIME;
         } else if (urn.equals(URN_BEAM_LOGICAL_DECIMAL)) {
           return FieldType.DECIMAL;
-        } else if (urn.equals(URN_BEAM_LOGICAL_JAVASDK)) {
-          return FieldType.logicalType(
-              (LogicalType)
-                  SerializableUtils.deserializeFromByteArray(
-                      logicalType.getPayload().toByteArray(), "logicalType"));
-        } else {
-          @Nullable FieldType argumentType = null;
-          @Nullable Object argumentValue = null;
-          if (logicalType.hasArgumentType()) {
-            argumentType = fieldTypeFromProto(logicalType.getArgumentType());
-            argumentValue = fieldValueFromProto(argumentType, logicalType.getArgument());
+        } else if (urn.startsWith("beam:logical_type:")) {
+          try {
+            return FieldType.logicalType(
+                (LogicalType)
+                    SerializableUtils.deserializeFromByteArray(
+                        logicalType.getPayload().toByteArray(), "logicalType"));
+          } catch (IllegalArgumentException e) {
+            LOG.warn(
+                String.format(
+                    "Unable to deserialize the logical type %s from proto. Mark as UnknownLogicalType",
+                    urn));
           }
-          return FieldType.logicalType(
-              new UnknownLogicalType(
-                  urn,
-                  logicalType.getPayload().toByteArray(),
-                  argumentType,
-                  argumentValue,
-                  fieldTypeFromProto(logicalType.getRepresentation())));
         }
+        // assemble an UnknownLogicalType
+        @Nullable FieldType argumentType = null;
+        @Nullable Object argumentValue = null;
+        if (logicalType.hasArgumentType()) {
+          argumentType = fieldTypeFromProto(logicalType.getArgumentType());
+          argumentValue = fieldValueFromProto(argumentType, logicalType.getArgument());
+        }
+        return FieldType.logicalType(
+            new UnknownLogicalType(
+                urn,
+                logicalType.getPayload().toByteArray(),
+                argumentType,
+                argumentValue,
+                fieldTypeFromProto(logicalType.getRepresentation())));
       default:
         throw new IllegalArgumentException(
             "Unexpected type_info: " + protoFieldType.getTypeInfoCase());

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaTranslationTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/SchemaTranslationTest.java
@@ -402,38 +402,42 @@ public class SchemaTranslationTest {
     }
   }
 
-  @RunWith(JUnit4.class)
+  /** Test schema translation of logical types. */
+  @RunWith(Parameterized.class)
   public static class LogicalTypesTest {
+    @Parameters(name = "{index}: {0}")
+    public static Iterable<Schema.FieldType> data() {
+      return ImmutableList.<Schema.FieldType>builder()
+          .add(FieldType.logicalType(SqlTypes.DATE))
+          .add(FieldType.logicalType(SqlTypes.TIME))
+          .add(FieldType.logicalType(SqlTypes.DATETIME))
+          .add(FieldType.logicalType(SqlTypes.TIMESTAMP))
+          .add(FieldType.logicalType(new NanosInstant()))
+          .add(FieldType.logicalType(new NanosDuration()))
+          .add(FieldType.logicalType(FixedBytes.of(10)))
+          .add(FieldType.logicalType(VariableBytes.of(10)))
+          .add(FieldType.logicalType(FixedString.of(10)))
+          .add(FieldType.logicalType(VariableString.of(10)))
+          .add(FieldType.logicalType(FixedPrecisionNumeric.of(10)))
+          .build();
+    }
+
+    @Parameter(0)
+    public Schema.FieldType fieldType;
+
     @Test
     public void testPortableLogicalTypeSerializeDeserilizeCorrectly() {
-      List<Schema.FieldType> testCases =
-          ImmutableList.<Schema.FieldType>builder()
-              .add(FieldType.logicalType(SqlTypes.DATE))
-              .add(FieldType.logicalType(SqlTypes.TIME))
-              .add(FieldType.logicalType(SqlTypes.DATETIME))
-              .add(FieldType.logicalType(SqlTypes.TIMESTAMP))
-              .add(FieldType.logicalType(new NanosInstant()))
-              .add(FieldType.logicalType(new NanosDuration()))
-              .add(FieldType.logicalType(FixedBytes.of(10)))
-              .add(FieldType.logicalType(VariableBytes.of(10)))
-              .add(FieldType.logicalType(FixedString.of(10)))
-              .add(FieldType.logicalType(VariableString.of(10)))
-              .add(FieldType.logicalType(FixedPrecisionNumeric.of(10)))
-              .build();
+      SchemaApi.FieldType proto = SchemaTranslation.fieldTypeToProto(fieldType, true);
+      Schema.FieldType translated = SchemaTranslation.fieldTypeFromProto(proto);
 
-      for (Schema.FieldType fieldType : testCases) {
-        SchemaApi.FieldType proto = SchemaTranslation.fieldTypeToProto(fieldType, true);
-        Schema.FieldType translated = SchemaTranslation.fieldTypeFromProto(proto);
-
-        assertThat(
-            translated.getLogicalType().getClass(), equalTo(fieldType.getLogicalType().getClass()));
-        assertThat(
-            translated.getLogicalType().getArgumentType(),
-            equalTo(fieldType.getLogicalType().getArgumentType()));
-        assertThat(
-            translated.getLogicalType().getArgument(),
-            equalTo(fieldType.getLogicalType().getArgument()));
-      }
+      assertThat(
+          translated.getLogicalType().getClass(), equalTo(fieldType.getLogicalType().getClass()));
+      assertThat(
+          translated.getLogicalType().getArgumentType(),
+          equalTo(fieldType.getLogicalType().getArgumentType()));
+      assertThat(
+          translated.getLogicalType().getArgument(),
+          equalTo(fieldType.getLogicalType().getArgument()));
     }
   }
 


### PR DESCRIPTION
Fixes #24870

* Fixes portable and not-yet-standard logical type get deserialized to UnknownLogicalType

**Please** add a meaningful description for your change here

This was broken by #23014 in particular, prior to the change, SchemaTransform sets the identifier of all  not-yet-STANDARD logical types as "beam:logical_type:java_sdk:v1" when translating to proto

https://github.com/apache/beam/blob/release-2.42.0/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java#L183

after the change, it keeps URNs of portable logical types (identifier is a URN starts with  "beam:logical_type:"). This enables translating them from another SDK.

https://github.com/apache/beam/blob/release-2.43.0/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java#L176

But, when translating back, the code here did not change accordingly:

https://github.com/apache/beam/blob/f9a86e5e2e3bbb345dad0953d7fe6a6b8ffe7a68/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java#L417

Causing the deserialization not attempted and reduced to UnknownLogicalType.

Unfortunately Schema containing logical type with same identifier but different class is not considered equal, and is not caught by the unit test SchemaTranslationTest.FromProtoToProtoTest <- this could be a followup fix

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
