### PR TITLE
[#24931][Go SDK] Make element checkpoints independant

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/datasource.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasource.go
@@ -157,13 +157,13 @@ func (n *DataSource) Process(ctx context.Context) ([]*Checkpoint, error) {
 	var checkpoints []*Checkpoint
 	for {
 		if n.incrementIndexAndCheckSplit() {
-			return checkpoints, nil
+			break
 		}
 		// TODO(lostluck) 2020/02/22: Should we include window headers or just count the element sizes?
 		ws, t, pn, err := DecodeWindowedValueHeader(wc, r)
 		if err != nil {
 			if err == io.EOF {
-				return nil, nil
+				break
 			}
 			return nil, errors.Wrap(err, "source failed")
 		}
@@ -206,6 +206,7 @@ func (n *DataSource) Process(ctx context.Context) ([]*Checkpoint, error) {
 			}
 		}
 	}
+	return checkpoints, nil
 }
 
 func (n *DataSource) makeReStream(ctx context.Context, cv ElementDecoder, bcr *byteCountReader, onlyStream bool) (ReStream, error) {

--- a/sdks/go/pkg/beam/core/runtime/exec/datasource.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasource.go
@@ -127,10 +127,10 @@ func (r *byteCountReader) reset() int {
 }
 
 // Process opens the data source, reads and decodes data, kicking off element processing.
-func (n *DataSource) Process(ctx context.Context) error {
+func (n *DataSource) Process(ctx context.Context) ([]*Checkpoint, error) {
 	r, err := n.source.OpenRead(ctx, n.SID)
 	if err != nil {
-		return err
+		return nil, err
 	}
 	defer r.Close()
 	n.PCol.resetSize() // initialize the size distribution for this bundle.
@@ -154,23 +154,24 @@ func (n *DataSource) Process(ctx context.Context) error {
 		cp = MakeElementDecoder(c)
 	}
 
+	var checkpoints []*Checkpoint
 	for {
 		if n.incrementIndexAndCheckSplit() {
-			return nil
+			return checkpoints, nil
 		}
 		// TODO(lostluck) 2020/02/22: Should we include window headers or just count the element sizes?
 		ws, t, pn, err := DecodeWindowedValueHeader(wc, r)
 		if err != nil {
 			if err == io.EOF {
-				return nil
+				return nil, nil
 			}
-			return errors.Wrap(err, "source failed")
+			return nil, errors.Wrap(err, "source failed")
 		}
 
 		// Decode key or parallel element.
 		pe, err := cp.Decode(&bcr)
 		if err != nil {
-			return errors.Wrap(err, "source decode failed")
+			return nil, errors.Wrap(err, "source decode failed")
 		}
 		pe.Timestamp = t
 		pe.Windows = ws
@@ -180,17 +181,30 @@ func (n *DataSource) Process(ctx context.Context) error {
 		for _, cv := range cvs {
 			values, err := n.makeReStream(ctx, cv, &bcr, len(cvs) == 1 && n.singleIterate)
 			if err != nil {
-				return err
+				return nil, err
 			}
 			valReStreams = append(valReStreams, values)
 		}
 
 		if err := n.Out.ProcessElement(ctx, pe, valReStreams...); err != nil {
-			return err
+			return nil, err
 		}
 		// Collect the actual size of the element, and reset the bytecounter reader.
 		n.PCol.addSize(int64(bcr.reset()))
 		bcr.reader = r
+
+		// Check if there's a continuation and return residuals
+		// Needs to be done immeadiately after processing to not lose the element.
+		if c := n.getProcessContinuation(); c != nil {
+			cp, err := n.checkpointThis(c)
+			if err != nil {
+				// Errors during checkpointing should fail a bundle.
+				return nil, err
+			}
+			if cp != nil {
+				checkpoints = append(checkpoints, cp)
+			}
+		}
 	}
 }
 
@@ -397,18 +411,22 @@ func (n *DataSource) makeEncodeElms() func([]*FullValue) ([][]byte, error) {
 	return encodeElms
 }
 
+type Checkpoint struct {
+	SR      SplitResult
+	Reapply time.Duration
+}
+
 // Checkpoint attempts to split an SDF that has self-checkpointed (e.g. returned a
 // ProcessContinuation) and needs to be resumed later. If the underlying DoFn is not
 // splittable or has not returned a resuming continuation, the function returns an empty
 // SplitResult, a negative resumption time, and a false boolean to indicate that no split
 // occurred.
-func (n *DataSource) Checkpoint() (SplitResult, time.Duration, bool, error) {
+func (n *DataSource) checkpointThis(pc sdf.ProcessContinuation) (*Checkpoint, error) {
 	n.mu.Lock()
 	defer n.mu.Unlock()
 
-	pc := n.getProcessContinuation()
 	if pc == nil || !pc.ShouldResume() {
-		return SplitResult{}, -1 * time.Minute, false, nil
+		return nil, nil
 	}
 
 	su := SplittableUnit(n.Out.(*ProcessSizedElementsAndRestrictions))
@@ -418,17 +436,17 @@ func (n *DataSource) Checkpoint() (SplitResult, time.Duration, bool, error) {
 	// Checkpointing is functionally a split at fraction 0.0
 	rs, err := su.Checkpoint()
 	if err != nil {
-		return SplitResult{}, -1 * time.Minute, false, err
+		return nil, err
 	}
 	if len(rs) == 0 {
-		return SplitResult{}, -1 * time.Minute, false, nil
+		return nil, nil
 	}
 
 	encodeElms := n.makeEncodeElms()
 
 	rsEnc, err := encodeElms(rs)
 	if err != nil {
-		return SplitResult{}, -1 * time.Minute, false, err
+		return nil, err
 	}
 
 	res := SplitResult{
@@ -437,7 +455,7 @@ func (n *DataSource) Checkpoint() (SplitResult, time.Duration, bool, error) {
 		InId: su.GetInputId(),
 		OW:   ow,
 	}
-	return res, pc.ResumeDelay(), true, nil
+	return &Checkpoint{SR: res, Reapply: pc.ResumeDelay()}, nil
 }
 
 // Split takes a sorted set of potential split indices and a fraction of the

--- a/sdks/go/pkg/beam/core/runtime/exec/datasource_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasource_test.go
@@ -20,14 +20,20 @@ import (
 	"fmt"
 	"io"
 	"math"
+	"reflect"
 	"testing"
 	"time"
 
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/coder"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/mtime"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/window"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime/coderx"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/sdf"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/typex"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/util/reflectx"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/internal/errors"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/io/rtrackers/offsetrange"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
@@ -314,7 +320,10 @@ func TestDataSource_Split(t *testing.T) {
 				t.Fatalf("error in Split: got primary index = %v, want %v ", got, want)
 			}
 
-			runOnRoots(ctx, t, p, "Process", Root.Process)
+			runOnRoots(ctx, t, p, "Process", func(root Root, ctx context.Context) error {
+				_, err := root.Process(ctx)
+				return err
+			})
 			runOnRoots(ctx, t, p, "FinishBundle", Root.FinishBundle)
 
 			validateSource(t, out, source, makeValues(test.expected...))
@@ -449,7 +458,10 @@ func TestDataSource_Split(t *testing.T) {
 		if got, want := splitRes.PI, test.splitIdx-1; got != want {
 			t.Fatalf("error in Split: got primary index = %v, want %v ", got, want)
 		}
-		runOnRoots(ctx, t, p, "Process", Root.Process)
+		runOnRoots(ctx, t, p, "Process", func(root Root, ctx context.Context) error {
+			_, err := root.Process(ctx)
+			return err
+		})
 		runOnRoots(ctx, t, p, "FinishBundle", Root.FinishBundle)
 
 		validateSource(t, out, source, makeValues(test.expected...))
@@ -582,7 +594,10 @@ func TestDataSource_Split(t *testing.T) {
 		if sr, err := p.Split(ctx, SplitPoints{Splits: []int64{0}, Frac: -1}); err != nil || !sr.Unsuccessful {
 			t.Fatalf("p.Split(active) = %v,%v want unsuccessful split & nil err", sr, err)
 		}
-		runOnRoots(ctx, t, p, "Process", Root.Process)
+		runOnRoots(ctx, t, p, "Process", func(root Root, ctx context.Context) error {
+			_, err := root.Process(ctx)
+			return err
+		})
 		if sr, err := p.Split(ctx, SplitPoints{Splits: []int64{0}, Frac: -1}); err != nil || !sr.Unsuccessful {
 			t.Fatalf("p.Split(active, unable to get desired split) = %v,%v want unsuccessful split & nil err", sr, err)
 		}
@@ -854,6 +869,100 @@ func TestSplitHelper(t *testing.T) {
 					t.Errorf("incorrect split fraction: got: %v, want: %v", gotFrac, test.wantFrac)
 				}
 			})
+		}
+	})
+}
+
+func TestCheckpointing(t *testing.T) {
+	t.Run("nil", func(t *testing.T) {
+		cps, err := (&DataSource{}).checkpointThis(nil)
+		if err != nil {
+			t.Fatalf("checkpointThis() = %v, %v", cps, err)
+		}
+	})
+	t.Run("Stop", func(t *testing.T) {
+		cps, err := (&DataSource{}).checkpointThis(sdf.StopProcessing())
+		if err != nil {
+			t.Fatalf("checkpointThis() = %v, %v", cps, err)
+		}
+	})
+	t.Run("Delay_no_residuals", func(t *testing.T) {
+		wesInv, _ := newWatermarkEstimatorStateInvoker(nil)
+		root := &DataSource{
+			Out: &ProcessSizedElementsAndRestrictions{
+				PDo:    &ParDo{},
+				wesInv: wesInv,
+				rt:     offsetrange.NewTracker(offsetrange.Restriction{}),
+				elm: &FullValue{
+					Windows: window.SingleGlobalWindow,
+				},
+			},
+		}
+		cp, err := root.checkpointThis(sdf.ResumeProcessingIn(time.Second * 13))
+		if err != nil {
+			t.Fatalf("checkpointThis() = %v, %v, want nil", cp, err)
+		}
+		if cp != nil {
+			t.Fatalf("checkpointThis() = %v, want nil", cp)
+		}
+	})
+	dfn, err := graph.NewDoFn(&WindowBlockingSdf{claim: -1}, graph.NumMainInputs(graph.MainSingle))
+	if err != nil {
+		t.Fatalf("invalid function: %v", err)
+	}
+	t.Run("Delay_residuals", func(t *testing.T) {
+		wesInv, _ := newWatermarkEstimatorStateInvoker(nil)
+		rest := offsetrange.Restriction{Start: 1, End: 10}
+		intCoder, _ := coderx.NewVarIntZ(reflectx.Int)
+		root := &DataSource{
+			Coder: coder.NewW(
+				coder.NewKV([]*coder.Coder{
+					coder.NewKV([]*coder.Coder{
+						coder.CoderFrom(intCoder),                   // Element
+						coder.NewR(typex.New(reflect.TypeOf(rest))), // Restriction
+					}),
+					coder.NewDouble(), // Size
+				}),
+				coder.NewGlobalWindow(),
+			),
+			Out: &ProcessSizedElementsAndRestrictions{
+				PDo: &ParDo{
+					Fn: dfn,
+				},
+				TfId:   "testTransformID",
+				wesInv: wesInv,
+				rt:     offsetrange.NewTracker(rest),
+				elm: &FullValue{
+					Windows: window.SingleGlobalWindow,
+					Elm: &FullValue{
+						Elm:  42,
+						Elm2: rest,
+					},
+				},
+			},
+		}
+		if err := root.Up(context.Background()); err != nil {
+			t.Fatalf("invalid function: %v", err)
+		}
+		if err := root.Out.Up(context.Background()); err != nil {
+			t.Fatalf("invalid function: %v", err)
+		}
+		wantDelay := time.Second * 13
+		cp, err := root.checkpointThis(sdf.ResumeProcessingIn(wantDelay))
+		if err != nil {
+			t.Fatalf("checkpointThis() = %v, %v, want nil", cp, err)
+		}
+		if cp == nil {
+			t.Fatalf("checkpointThis() = %v, want not nil", cp)
+		}
+		if got, want := cp.Reapply, wantDelay; got != want {
+			t.Errorf("checkpointThis(delay(%v)) delay = %v, want %v", want, got, want)
+		}
+		if got, want := cp.SR.TId, root.Out.(*ProcessSizedElementsAndRestrictions).TfId; got != want {
+			t.Errorf("checkpointThis() transformID = %v, want %v", got, want)
+		}
+		if got, want := cp.SR.InId, "i0"; got != want {
+			t.Errorf("checkpointThis() transformID = %v, want %v", got, want)
 		}
 	})
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/plan_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/plan_test.go
@@ -1,0 +1,35 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package exec
+
+import (
+	"testing"
+	"time"
+
+	"github.com/google/go-cmp/cmp"
+)
+
+func TestPlan_Checkpoints(t *testing.T) {
+	var p Plan
+	want := []*Checkpoint{{Reapply: time.Hour}}
+	p.checkpoints = want
+	if got := p.Checkpoint(); !cmp.Equal(got, want) {
+		t.Errorf("p.Checkpoint() = %v, want %v", got, want)
+	}
+	if p.checkpoints != nil {
+		t.Errorf("p.Checkpoint() didn't nil checkpoints field")
+	}
+}

--- a/sdks/go/pkg/beam/core/runtime/exec/plan_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/plan_test.go
@@ -16,13 +16,14 @@
 package exec
 
 import (
+	"fmt"
 	"testing"
 	"time"
 
 	"github.com/google/go-cmp/cmp"
 )
 
-func TestPlan_Checkpoints(t *testing.T) {
+func TestPlan_Checkpoint(t *testing.T) {
 	var p Plan
 	want := []*Checkpoint{{Reapply: time.Hour}}
 	p.checkpoints = want
@@ -32,4 +33,109 @@ func TestPlan_Checkpoints(t *testing.T) {
 	if p.checkpoints != nil {
 		t.Errorf("p.Checkpoint() didn't nil checkpoints field")
 	}
+}
+
+func TestPlan_BundleFinalizers(t *testing.T) {
+	newPlan := func() Plan {
+		var p Plan
+		p.status = Up
+		return p
+	}
+	t.Run("NoCallbacks", func(t *testing.T) {
+		p := newPlan()
+		p.bf = &bundleFinalizer{}
+		if err := p.Finalize(); err != nil {
+			t.Errorf("p.Finalize() = %v, want nil", err)
+		}
+		// Expiration time is no longer set to default
+		if got, want := p.GetExpirationTime(), (time.Time{}); want.Equal(got) {
+			t.Errorf("p.GetExpirationTime() = %v, want %v", got, want)
+		}
+	})
+
+	t.Run("Callbacks", func(t *testing.T) {
+		p := newPlan()
+		initialDeadline := time.Now().Add(time.Hour)
+
+		var callCount int
+		inc := func() error {
+			callCount++
+			return nil
+		}
+		p.bf = &bundleFinalizer{
+			callbacks: []bundleFinalizationCallback{
+				{callback: inc, validUntil: initialDeadline},
+				{callback: inc, validUntil: initialDeadline},
+				{callback: inc, validUntil: initialDeadline},
+			},
+		}
+		if err := p.Finalize(); err != nil {
+			t.Errorf("p.Finalize() = %v, want nil", err)
+		}
+		// Expiration time is no longer set to default
+		if got, want := p.GetExpirationTime(), (time.Time{}); want.Equal(got) {
+			t.Errorf("p.GetExpirationTime() = %v, want %v", got, want)
+		}
+		if got, want := callCount, 3; got != want {
+			t.Errorf("p.Finalize() didn't call all finalizers, got %v, want %v", got, want)
+		}
+	})
+	t.Run("Callbacks_expired", func(t *testing.T) {
+		p := newPlan()
+		initialDeadline := time.Now().Add(-time.Hour)
+
+		var callCount int
+		inc := func() error {
+			callCount++
+			return nil
+		}
+		p.bf = &bundleFinalizer{
+			callbacks: []bundleFinalizationCallback{
+				{callback: inc, validUntil: initialDeadline},
+				{callback: inc, validUntil: initialDeadline},
+				{callback: inc, validUntil: initialDeadline},
+			},
+		}
+		if err := p.Finalize(); err != nil {
+			t.Errorf("p.Finalize() = %v, want nil", err)
+		}
+		// Expiration time is no longer set to default
+		if got, want := p.GetExpirationTime(), (time.Time{}); want.Equal(got) {
+			t.Errorf("p.GetExpirationTime() = %v, want %v", got, want)
+		}
+		if got, want := callCount, 0; got != want {
+			t.Errorf("p.Finalize() didn't call all finalizers, got %v, want %v", got, want)
+		}
+	})
+
+	t.Run("Callbacks_failures", func(t *testing.T) {
+		p := newPlan()
+		initialDeadline := time.Now().Add(time.Hour)
+
+		var callCount int
+		inc := func() error {
+			callCount++
+			if callCount == 1 {
+				return fmt.Errorf("unable to call")
+			}
+			return nil
+		}
+		p.bf = &bundleFinalizer{
+			callbacks: []bundleFinalizationCallback{
+				{callback: inc, validUntil: initialDeadline},
+				{callback: inc, validUntil: initialDeadline},
+				{callback: inc, validUntil: initialDeadline},
+			},
+		}
+		if err := p.Finalize(); err == nil {
+			t.Errorf("p.Finalize() = %v, want an error", err)
+		}
+		if got, want := callCount, 3; got != want {
+			t.Errorf("p.Finalize() didn't call all finalizers, got %v, want %v", got, want)
+		}
+		if len(p.bf.callbacks) != 1 {
+			t.Errorf("p.Finalize() didn't preserve failed callbacks")
+		}
+	})
+
 }

--- a/sdks/go/pkg/beam/core/runtime/exec/sdf.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/sdf.go
@@ -459,18 +459,18 @@ func (n *ProcessSizedElementsAndRestrictions) StartBundle(ctx context.Context, i
 //
 // Input Diagram:
 //
-//	  *FullValue {
-//	    Elm: *FullValue {
-//	      Elm:  *FullValue (KV input) or InputType (single-element input)
-//			 Elm2: *FullValue {
-//			   Elm: Restriction
-//	        Elm2: Watermark estimator state
-//			 }
-//	    }
-//	    Elm2: float64 (size)
-//	    Windows
-//	    Timestamps
-//	  }
+//	*FullValue {
+//		Elm: *FullValue {
+//			Elm:  *FullValue (KV input) or InputType (single-element input)
+//			Elm2: *FullValue {
+//				Elm: Restriction
+//				Elm2: Watermark estimator state
+//		 	}
+//		}
+//		Elm2: float64 (size)
+//		Windows
+//		Timestamps
+//	}
 //
 // ProcessElement then creates a restriction tracker from the stored restriction
 // and processes each element using the underlying ParDo and adding the

--- a/sdks/go/pkg/beam/core/runtime/exec/unit.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/unit.go
@@ -57,7 +57,7 @@ type Root interface {
 
 	// Process processes the entire source, notably emitting elements to
 	// downstream nodes.
-	Process(ctx context.Context) error
+	Process(ctx context.Context) ([]*Checkpoint, error)
 }
 
 // ElementProcessor presents a component that can process an element.

--- a/sdks/go/pkg/beam/core/runtime/exec/unit_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/unit_test.go
@@ -125,6 +125,8 @@ type FixedRoot struct {
 	Out      Node
 }
 
+var _ Root = (*FixedRoot)(nil)
+
 func (n *FixedRoot) ID() UnitID {
 	return n.UID
 }
@@ -137,13 +139,13 @@ func (n *FixedRoot) StartBundle(ctx context.Context, id string, data DataContext
 	return n.Out.StartBundle(ctx, id, data)
 }
 
-func (n *FixedRoot) Process(ctx context.Context) error {
+func (n *FixedRoot) Process(ctx context.Context) ([]*Checkpoint, error) {
 	for _, elm := range n.Elements {
 		if err := n.Out.ProcessElement(ctx, &elm.Key, elm.Values...); err != nil {
-			return err
+			return nil, err
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 func (n *FixedRoot) FinishBundle(ctx context.Context) error {
@@ -186,13 +188,13 @@ func (n *BenchRoot) StartBundle(ctx context.Context, id string, data DataContext
 	return n.Out.StartBundle(ctx, id, data)
 }
 
-func (n *BenchRoot) Process(ctx context.Context) error {
+func (n *BenchRoot) Process(ctx context.Context) ([]*Checkpoint, error) {
 	for elm := range n.Elements {
 		if err := n.Out.ProcessElement(ctx, &elm.Key, elm.Values...); err != nil {
-			return err
+			return nil, err
 		}
 	}
-	return nil
+	return nil, nil
 }
 
 func (n *BenchRoot) FinishBundle(ctx context.Context) error {

--- a/sdks/go/pkg/beam/core/sdf/lock.go
+++ b/sdks/go/pkg/beam/core/sdf/lock.go
@@ -15,7 +15,10 @@
 
 package sdf
 
-import "sync"
+import (
+	"fmt"
+	"sync"
+)
 
 // NewLockRTracker creates a LockRTracker initialized with the specified
 // restriction tracker as its underlying restriction tracker.
@@ -91,4 +94,8 @@ func (rt *LockRTracker) IsBounded() bool {
 		return tracker.IsBounded()
 	}
 	return true
+}
+
+func (rt *LockRTracker) String() string {
+	return fmt.Sprintf("LockRTracker(%v)", rt.Rt)
 }

--- a/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange.go
+++ b/sdks/go/pkg/beam/io/rtrackers/offsetrange/offsetrange.go
@@ -131,6 +131,10 @@ type Tracker struct {
 	err       error
 }
 
+func (tracker *Tracker) String() string {
+	return fmt.Sprintf("[%v,%v) c: %v, a.: %v, stopped: %v, err: %v", tracker.rest.Start, tracker.rest.End, tracker.claimed, tracker.attempted, tracker.stopped, tracker.err)
+}
+
 // NewTracker is a constructor for an Tracker given a start and end range.
 func NewTracker(rest Restriction) *Tracker {
 	return &Tracker{

--- a/sdks/go/pkg/beam/runners/direct/impulse.go
+++ b/sdks/go/pkg/beam/runners/direct/impulse.go
@@ -43,13 +43,13 @@ func (n *Impulse) StartBundle(ctx context.Context, id string, data exec.DataCont
 	return n.Out.StartBundle(ctx, id, data)
 }
 
-func (n *Impulse) Process(ctx context.Context) error {
+func (n *Impulse) Process(ctx context.Context) ([]*exec.Checkpoint, error) {
 	value := &exec.FullValue{
 		Windows:   window.SingleGlobalWindow,
 		Timestamp: mtime.Now(),
 		Elm:       n.Value,
 	}
-	return n.Out.ProcessElement(ctx, value)
+	return nil, n.Out.ProcessElement(ctx, value)
 }
 
 func (n *Impulse) FinishBundle(ctx context.Context) error {

--- a/sdks/go/test/integration/integration.go
+++ b/sdks/go/test/integration/integration.go
@@ -236,6 +236,9 @@ var dataflowFilters = []string{
 	// Dataflow doesn't support any test that requires loopback.
 	// Eg. For FileIO examples.
 	".*Loopback.*",
+	// Dataflow does not automatically terminate the TestCheckpointing pipeline when
+	// complete.
+	"TestCheckpointing",
 	// TODO(21761): This test needs to provide GCP project to expansion service.
 	"TestBigQueryIO_BasicWriteQueryRead",
 	// Dataflow does not drain jobs by itself.

--- a/sdks/go/test/integration/integration.go
+++ b/sdks/go/test/integration/integration.go
@@ -236,9 +236,6 @@ var dataflowFilters = []string{
 	// Dataflow doesn't support any test that requires loopback.
 	// Eg. For FileIO examples.
 	".*Loopback.*",
-	// Dataflow does not automatically terminate the TestCheckpointing pipeline when
-	// complete.
-	"TestCheckpointing",
 	// TODO(21761): This test needs to provide GCP project to expansion service.
 	"TestBigQueryIO_BasicWriteQueryRead",
 	// Dataflow does not drain jobs by itself.

--- a/sdks/go/test/integration/primitives/checkpointing.go
+++ b/sdks/go/test/integration/primitives/checkpointing.go
@@ -97,8 +97,6 @@ func (fn *selfCheckpointingDoFn) ProcessElement(rt *sdf.LockRTracker, _ []byte, 
 
 // Checkpoints is a small test pipeline to establish the correctness of the simple test case.
 func Checkpoints(s beam.Scope) {
-	beam.Init()
-
 	s.Scope("checkpoint")
 	out := beam.ParDo(s, &selfCheckpointingDoFn{}, beam.Impulse(s))
 	passert.Count(s, out, "num ints", 10)


### PR DESCRIPTION
Resolves #24931, which discovered that if there are multiple elements in the data buffer, then only the checkpoint for the last one can be used, previous ones are being overwritten.

The solution is to build up a list of checkpointed elements in processing, and return them.

Typically streaming execution has only one element anyway, which hides the error, but this is only at the runner's discretion. If the runner batches elements, then delayed elements will no longer process.

Discovered in working on #24789, which isn't yet a clever runner at all.

This change is smaller than it looks due to complexities in testing the execution harness, which requires ample set up. However, this change covers the core DataSource side changes.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
