### PR TITLE
fix(sec): upgrade torch to 1.13.1

### DIFF
--- a/sdks/python/apache_beam/examples/ml-orchestration/kfp/components/preprocessing/requirements.txt
+++ b/sdks/python/apache_beam/examples/ml-orchestration/kfp/components/preprocessing/requirements.txt
@@ -15,7 +15,7 @@
 
 apache_beam[gcp]==2.40.0
 requests==2.28.1
-torch==1.12.0
+torch==1.13.1
 torchvision==0.13.0
 numpy==1.22.4
 Pillow==9.3.0

--- a/sdks/python/apache_beam/examples/ml-orchestration/kfp/components/train/requirements.txt
+++ b/sdks/python/apache_beam/examples/ml-orchestration/kfp/components/train/requirements.txt
@@ -13,6 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-torch==1.12.0
+torch==1.13.1
 numpy==1.22.4
 Pillow==9.2.0


### PR DESCRIPTION
### What happened？
There are 1 security vulnerabilities found in torch 1.12.0.
- [CVE-2022-45907](https://www.oscs1024.com/hd/CVE-2022-45907)


### What did I do？
Upgrade torch from 1.12.0 to 1.13.1 for vulnerability fix.

### What did you expect to happen？
Clean out the insecure libs to used.

### The specification of the pull request
[PR Specification](https://www.oscs1024.com/docs/pr-specification/) from OSCS