### PR TITLE
Fix incorrect parsing of None value parameters.

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -284,6 +284,10 @@ class PipelineOptions(HasDisplayData):
           flags.append('--%s=%s' % (k, i))
       elif isinstance(v, dict):
         flags.append('--%s=%s' % (k, json.dumps(v)))
+      elif v is None:
+        # Don't process None type args here, they will be treated
+        # as strings when parsed by BeamArgumentParser..
+        logging.warning('Not setting flag with value None: %s', k)
       else:
         flags.append('--%s=%s' % (k, v))
 

--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -317,7 +317,7 @@ class PipelineOptionsTest(unittest.TestCase):
         parser.add_argument('--test_arg_none', default=None, type=int)
         parser.add_argument('--test_arg_int', default=1, type=int)
 
-    options_dict = {'test_arg_none': None, 'test_arg_int' : 5}
+    options_dict = {'test_arg_none': None, 'test_arg_int': 5}
     options_from_dict = NoneDefaultOptions.from_dictionary(options_dict)
     result = options_from_dict.get_all_options()
     self.assertEqual(result['test_arg_int'], 5)

--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -310,6 +310,19 @@ class PipelineOptionsTest(unittest.TestCase):
           options.view_as(PipelineOptionsTest.MockOptions).mock_json_option,
           case['expected'].get('mock_json_option', {}))
 
+  def test_none_from_dictionary(self):
+    class NoneDefaultOptions(PipelineOptions):
+      @classmethod
+      def _add_argparse_args(cls, parser):
+        parser.add_argument('--test_arg_none', default=None, type=int)
+        parser.add_argument('--test_arg_int', default=1, type=int)
+
+    options_dict = {'test_arg_none': None, 'test_arg_int' : 5}
+    options_from_dict = NoneDefaultOptions.from_dictionary(options_dict)
+    result = options_from_dict.get_all_options()
+    self.assertEqual(result['test_arg_int'], 5)
+    self.assertEqual(result['test_arg_none'], None)
+
   def test_option_with_space(self):
     options = PipelineOptions(flags=['--option with space= value with space'])
     self.assertEqual(
@@ -523,7 +536,6 @@ class PipelineOptionsTest(unittest.TestCase):
             '--pot_vp_arg1', help='This flag is a value provider')
 
         parser.add_value_provider_argument('--pot_vp_arg2', default=1, type=int)
-
         parser.add_argument('--pot_non_vp_arg1', default=1, type=int)
 
     # Provide values: if not provided, the option becomes of the type runtime vp


### PR DESCRIPTION
When a parameter is set as None it gets parsed as the string "None". By not setting the flag in pipeline_options.py we allow it to be set to the default value, which correctly resolves to None.

R: @robertwb 
R: @lukecwik 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ n/a ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ n/a ] Update `CHANGES.md` with noteworthy changes.
 - [ n/a ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
