### PR TITLE
Remove datastore intersphinx_dependency to fix docs job.

### DIFF
--- a/sdks/python/scripts/generate_pydoc.sh
+++ b/sdks/python/scripts/generate_pydoc.sh
@@ -142,7 +142,6 @@ import apache_beam as beam
 intersphinx_mapping = {
   'python': ('https://docs.python.org/{}'.format(sys.version_info.major), None),
   'hamcrest': ('https://pyhamcrest.readthedocs.io/en/stable/', None),
-  'google-cloud-datastore': ('https://googleapis.dev/python/datastore/latest/', None),
   'numpy': ('https://numpy.org/doc/stable', None),
   'pandas': ('http://pandas.pydata.org/pandas-docs/dev', None),
 }


### PR DESCRIPTION
Right now, the datastore intersphinx_dependency is breaking our [docs job](https://ci-beam.apache.org/job/beam_PreCommit_PythonDocs_Cron/). This seems to be because the docs were migrated from `https://googleapis.dev/python/datastore/latest/` to `https://cloud.google.com/python/docs/reference/datastore/latest/` with a redirect, and the new url is not compatible with the sphinx tooling we're trying to use (I tried upgrading Sphinx and avoiding the redirect, but neither fixed the issue).

To fix the problem, I removed the datastore dependency. It has caused us trouble in the past multiple times ([example](https://issues.apache.org/jira/browse/BEAM-8286)), and doesn't provide a ton of value, plus I don't see a clear path around the current problems. Removing it will cause links like the one associated with `google.cloud.datastore.key.Key` in https://beam.apache.org/releases/pydoc/current/apache_beam.io.gcp.datastore.v1new.types.html#apache_beam.io.gcp.datastore.v1new.types.Key to no longer be automatically generated. We don't have many of those for datastore anyways, and they're trivial to lookup. Basically, this is a nice to have that is keeping our docs from functioning correctly, so cutting it seems like the right move to me.

Fixes #24976

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
