### PR TITLE
Fix error message (add proper spacing)

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -264,8 +264,8 @@ class BatchLoads<DestinationT, ElementT>
     }
     checkArgument(
         !Strings.isNullOrEmpty(tempLocation),
-        "BigQueryIO.Write needs a GCS temp location to store temp files."
-            + "This can be set by withCustomGcsTempLocation() in the Builder"
+        "BigQueryIO.Write needs a GCS temp location to store temp files. "
+            + "This can be set by withCustomGcsTempLocation() in the Builder "
             + "or through the fallback pipeline option --tempLocation.");
     if (bigQueryServices == null) {
       try {


### PR DESCRIPTION
Minor string fix, as I've got the exception with two inconsistencies:

> BigQueryIO.Write needs a GCS temp location to store temp **files.This** can be set by withCustomGcsTempLocation() in the **Builderor** through the fallback pipeline option --tempLocation.

