### PR TITLE
[#25070] Remove Kafka jars from Beam Java SDK Container

### DIFF
--- a/sdks/java/container/Dockerfile
+++ b/sdks/java/container/Dockerfile
@@ -28,11 +28,6 @@ ADD target/log4j-over-slf4j.jar /opt/apache/beam/jars/
 ADD target/log4j-to-slf4j.jar /opt/apache/beam/jars/
 ADD target/beam-sdks-java-harness.jar /opt/apache/beam/jars/
 
-# Required to run cross-language pipelines with KafkaIO
-# TODO May be removed once custom environments are supported
-ADD target/beam-sdks-java-io-kafka.jar /opt/apache/beam/jars/
-ADD target/kafka-clients.jar /opt/apache/beam/jars/
-
 # Required to use jamm as a javaagent to get accurate object size measuring
 # COPY fails if file is not found, so use a wildcard for open-module-agent.jar
 # since it is only included in Java 9+ containers

--- a/sdks/java/container/boot.go
+++ b/sdks/java/container/boot.go
@@ -141,8 +141,6 @@ func main() {
 		filepath.Join(jarsDir, "log4j-over-slf4j.jar"),
 		filepath.Join(jarsDir, "log4j-to-slf4j.jar"),
 		filepath.Join(jarsDir, "beam-sdks-java-harness.jar"),
-		filepath.Join(jarsDir, "beam-sdks-java-io-kafka.jar"),
-		filepath.Join(jarsDir, "kafka-clients.jar"),
 	}
 
 	var hasWorkerExperiment = strings.Contains(options, "use_staged_dataflow_worker_jar")

--- a/sdks/java/container/build.gradle
+++ b/sdks/java/container/build.gradle
@@ -25,7 +25,6 @@ applyGoNature()
 applyPythonNature()
 
 evaluationDependsOn(":sdks:java:harness")
-evaluationDependsOn(":sdks:java:io:kafka")
 evaluationDependsOn(":sdks:java:io:jdbc")
 
 description = "Apache Beam :: SDKs :: Java :: Container"
@@ -42,10 +41,6 @@ dependencies {
   dockerDependency library.java.log4j_over_slf4j
   dockerDependency library.java.log4j2_to_slf4j
   dockerDependency project(path: ":sdks:java:harness", configuration: "shadow")
-  // For executing KafkaIO, e.g. as an external transform
-  dockerDependency project(":sdks:java:io:kafka")
-  // This dependency is set to 'provided' scope in :sdks:java:io:kafka
-  dockerDependency library.java.kafka_clients
   dockerDependency library.java.jamm
 }
 
@@ -58,9 +53,7 @@ goBuild {
 import com.github.jk1.license.render.*
 licenseReport {
   projects = [project,
-              project.rootProject.findProject(':sdks:java:harness'),
-              project.rootProject.findProject(':sdks:java:io:kafka'),
-              project.rootProject.findProject(':sdks:java:io:jdbc')]
+              project.rootProject.findProject(':sdks:java:harness')]
   excludeOwnGroup = true
   excludeGroups = ["beam.*"] // project dependencies do not match their maven coords
   configurations = ALL

--- a/sdks/java/container/common.gradle
+++ b/sdks/java/container/common.gradle
@@ -55,8 +55,6 @@ task copyDockerfileDependencies(type: Copy) {
         rename 'beam-sdks-java-container-agent.*.jar', 'open-module-agent.jar'
     }
     rename 'beam-sdks-java-harness-.*.jar', 'beam-sdks-java-harness.jar'
-    rename 'beam-sdks-java-io-kafka.*.jar', 'beam-sdks-java-io-kafka.jar'
-    rename 'kafka-clients.*.jar', 'kafka-clients.jar'
     rename 'jamm.*.jar', 'jamm.jar'
 
     setDuplicatesStrategy(DuplicatesStrategy.INCLUDE)


### PR DESCRIPTION
This was added as a temporary work-around (https://github.com/apache/beam/pull/8322) when the XLang expansion service did not support returning additional dependencies. This removes that dependency prevent conflicts and allowing the user to control which Kafka dependency version they want to use.

For #25070

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
