### PR TITLE
Improves StorageWrite API error logging

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
@@ -30,7 +30,6 @@ import com.google.cloud.bigquery.storage.v1.WriteStream.Type;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.InvalidProtocolBufferException;
-import io.grpc.StatusRuntimeException;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Arrays;
@@ -512,17 +511,12 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
             .<@Nullable Throwable>map(AppendRowsContext::getError)
             .filter(err -> err != null)
             .map(
-                thrw -> {
-                  String errorDesc = "Description: ";
-                  if (thrw instanceof StatusRuntimeException) {
-                    errorDesc += ((StatusRuntimeException) thrw).getStatus().getDescription();
-                  }
-                  return errorDesc
-                      + "\n"
-                      + Arrays.stream(Preconditions.checkStateNotNull(thrw).getStackTrace())
-                          .map(StackTraceElement::toString)
-                          .collect(Collectors.joining("\n"));
-                })
+                thrw ->
+                    Preconditions.checkStateNotNull(thrw).toString()
+                        + "\n"
+                        + Arrays.stream(Preconditions.checkStateNotNull(thrw).getStackTrace())
+                            .map(StackTraceElement::toString)
+                            .collect(Collectors.joining("\n")))
             .collect(Collectors.joining("\n"));
       }
     }


### PR DESCRIPTION
In case the error returned is a StatusRuntimeException it includes the inner description, this description usually include valuable information like quota related messages. 

Example:
```
Append to stream projects/xxx/datasets/yyy/tables/zzz/streams/_default by client #7 failed with error, operations will be retried.
io.grpc.StatusRuntimeException: RESOURCE_EXHAUSTED: Exceeds 'AppendRows throughput' quota, user_id: project000000TTTTT_us (status: INSUFFICIENT_TOKENS), you can issue a raise quota request through Google Cloud Console. Be sure to include this full error message in the request description.  Entity: projects/pabs-pso-lab/datasets/pinstall/tables/streaming_pinstall_sub/streams/_default
Details:

com.google.cloud.bigquery.storage.v1.ConnectionWorker.requestCallback(ConnectionWorker.java:676)
com.google.cloud.bigquery.storage.v1.ConnectionWorker.access$100(ConnectionWorker.java:62)
com.google.cloud.bigquery.storage.v1.ConnectionWorker$2.run(ConnectionWorker.java:251)
com.google.cloud.bigquery.storage.v1.StreamConnection$1.onResponse(StreamConnection.java:63)
com.google.cloud.bigquery.storage.v1.StreamConnection$1.onResponse(StreamConnection.java:54)
com.google.api.gax.tracing.TracedResponseObserver.onResponse(TracedResponseObserver.java:91)
com.google.api.gax.grpc.ExceptionResponseObserver.onResponseImpl(ExceptionResponseObserver.java:74)
com.google.api.gax.rpc.StateCheckingResponseObserver.onResponse(StateCheckingResponseObserver.java:60)
com.google.api.gax.grpc.GrpcDirectStreamController$ResponseObserverAdapter.onMessage(GrpcDirectStreamController.java:134)
io.grpc.ForwardingClientCallListener.onMessage(ForwardingClientCallListener.java:33)
io.grpc.ForwardingClientCallListener.onMessage(ForwardingClientCallListener.java:33)
io.grpc.ForwardingClientCallListener.onMessage(ForwardingClientCallListener.java:33)
io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1MessagesAvailable.runInternal(ClientCallImpl.java:662)
io.grpc.internal.ClientCallImpl$ClientStreamListenerImpl$1MessagesAvailable.runInContext(ClientCallImpl.java:647)
io.grpc.internal.ContextRunnable.run(ContextRunnable.java:37)
io.grpc.internal.SerializingExecutor.run(SerializingExecutor.java:133)
java.base/java.util.concurrent.ThreadPoolExecutor.runWorker(ThreadPoolExecutor.java:1128)
java.base/java.util.concurrent.ThreadPoolExecutor$Worker.run(ThreadPoolExecutor.java:628)
java.base/java.lang.Thread.run(Thread.java:834)```

