### PR TITLE
Remove databaseRole from metadata DB requests in SpannerIO.ReadChange…

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -1629,6 +1629,7 @@ public class SpannerIO {
               .toBuilder()
               .setInstanceId(StaticValueProvider.of(partitionMetadataInstanceId))
               .setDatabaseId(StaticValueProvider.of(partitionMetadataDatabaseId))
+              .setDatabaseRole(null)
               .build();
       Dialect changeStreamDatabaseDialect = getDialect(changeStreamSpannerConfig);
       Dialect metadataDatabaseDialect = getDialect(partitionMetadataSpannerConfig);


### PR DESCRIPTION
This change removes the database role from the SpannerConfig that is used to access the Spanner Change Stream metadata database.  The role shouldn't be passed to the Change Stream metadata database because there are no roles defined on that database.  Addresses #25105.