### PR TITLE
Update typehint code to allow primitive composite types in python 3.9+

### DIFF
--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -123,6 +123,10 @@ class NativeTypeCompatibilityTest(unittest.TestCase):
               'nested builtin',
               dict[str, list[tuple[float]]],
               typehints.Dict[str, typehints.List[typehints.Tuple[float]]]),
+          (
+              'builtin nested tuple',
+              tuple[str, list],
+              typehints.Tuple[str, typehints.List[typehints.Any]],)
       ]
 
       for test_case in test_cases:

--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -114,20 +114,20 @@ class NativeTypeCompatibilityTest(unittest.TestCase):
 
   def test_convert_to_beam_type_with_builtin_types(self):
     if sys.version_info >= (3, 9):
-      test_cases = [
-          ('builtin dict', dict[str, int], typehints.Dict[str, int]),
-          ('builtin list', list[str], typehints.List[str]),
-          ('builtin tuple', tuple[str], typehints.Tuple[str]),
-          ('builtin set', set[str], typehints.Set[str]),
-          (
-              'nested builtin',
-              dict[str, list[tuple[float]]],
-              typehints.Dict[str, typehints.List[typehints.Tuple[float]]]),
-          (
-              'builtin nested tuple',
-              tuple[str, list],
-              typehints.Tuple[str, typehints.List[typehints.Any]],)
-      ]
+      test_cases = [('builtin dict', dict[str, int], typehints.Dict[str, int]),
+                    ('builtin list', list[str], typehints.List[str]),
+                    ('builtin tuple', tuple[str], typehints.Tuple[str]),
+                    ('builtin set', set[str], typehints.Set[str]),
+                    (
+                        'nested builtin',
+                        dict[str, list[tuple[float]]],
+                        typehints.Dict[str,
+                                       typehints.List[typehints.Tuple[float]]]),
+                    (
+                        'builtin nested tuple',
+                        tuple[str, list],
+                        typehints.Tuple[str, typehints.List[typehints.Any]],
+                    )]
 
       for test_case in test_cases:
         description = test_case[0]

--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -391,7 +391,8 @@ def validate_composite_type_param(type_param, error_msg_prefix):
       is_not_type_constraint = False
   if sys.version_info.major == 3 and sys.version_info.minor < 9:
     is_not_type_constraint = is_not_type_constraint or (
-      isinstance(type_param, type) and type_param in DISALLOWED_PRIMITIVE_TYPES)
+        isinstance(type_param, type) and
+        type_param in DISALLOWED_PRIMITIVE_TYPES)
 
   if is_not_type_constraint:
     raise TypeError(

--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -389,10 +389,11 @@ def validate_composite_type_param(type_param, error_msg_prefix):
   if sys.version_info.major == 3 and sys.version_info.minor >= 10:
     if isinstance(type_param, types.UnionType):
       is_not_type_constraint = False
-  is_forbidden_type = (
+  if sys.version_info.major == 3 and sys.version_info.minor < 9:
+    is_not_type_constraint = is_not_type_constraint or (
       isinstance(type_param, type) and type_param in DISALLOWED_PRIMITIVE_TYPES)
 
-  if is_not_type_constraint or is_forbidden_type:
+  if is_not_type_constraint:
     raise TypeError(
         '%s must be a non-sequence, a type, or a TypeConstraint. %s'
         ' is an instance of %s.' %

--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -389,6 +389,8 @@ def validate_composite_type_param(type_param, error_msg_prefix):
   if sys.version_info.major == 3 and sys.version_info.minor >= 10:
     if isinstance(type_param, types.UnionType):
       is_not_type_constraint = False
+  # Pre-Python 3.9 compositve type-hinting with built-in types was not
+  # supported, the typing module equivalents should be used instead.
   if sys.version_info.major == 3 and sys.version_info.minor < 9:
     is_not_type_constraint = is_not_type_constraint or (
         isinstance(type_param, type) and

--- a/sdks/python/apache_beam/typehints/typehints_test.py
+++ b/sdks/python/apache_beam/typehints/typehints_test.py
@@ -379,9 +379,10 @@ class TupleHintTestCase(TypeHintTestCase):
       typehints.Tuple[5, [1, 3]]
     self.assertTrue(e.exception.args[0].startswith(expected_error_prefix))
 
-    with self.assertRaises(TypeError) as e:
-      typehints.Tuple[list, dict]
-    self.assertTrue(e.exception.args[0].startswith(expected_error_prefix))
+    if sys.version_info < (3, 9):
+      with self.assertRaises(TypeError) as e:
+        typehints.Tuple[list, dict]
+      self.assertTrue(e.exception.args[0].startswith(expected_error_prefix))
 
   def test_compatibility_arbitrary_length(self):
     self.assertNotCompatible(
@@ -665,8 +666,9 @@ class DictHintTestCase(TypeHintTestCase):
         e.exception.args[0])
 
   def test_key_type_must_be_valid_composite_param(self):
-    with self.assertRaises(TypeError):
-      typehints.Dict[list, int]
+    if sys.version_info < (3, 9):
+      with self.assertRaises(TypeError):
+        typehints.Dict[list, int]
 
   def test_value_type_must_be_valid_composite_param(self):
     with self.assertRaises(TypeError):
@@ -765,13 +767,14 @@ class DictHintTestCase(TypeHintTestCase):
 class BaseSetHintTest:
   class CommonTests(TypeHintTestCase):
     def test_getitem_invalid_composite_type_param(self):
-      with self.assertRaises(TypeError) as e:
-        self.beam_type[list]
-      self.assertEqual(
-          "Parameter to a {} hint must be a non-sequence, a "
-          "type, or a TypeConstraint. {} is an instance of "
-          "type.".format(self.string_type, list),
-          e.exception.args[0])
+      if sys.version_info < (3, 9):
+        with self.assertRaises(TypeError) as e:
+          self.beam_type[list]
+        self.assertEqual(
+            "Parameter to a {} hint must be a non-sequence, a "
+            "type, or a TypeConstraint. {} is an instance of "
+            "type.".format(self.string_type, list),
+            e.exception.args[0])
 
     def test_compatibility(self):
       hint1 = self.beam_type[typehints.List[str]]

--- a/sdks/python/apache_beam/typehints/typehints_test.py
+++ b/sdks/python/apache_beam/typehints/typehints_test.py
@@ -383,6 +383,11 @@ class TupleHintTestCase(TypeHintTestCase):
       with self.assertRaises(TypeError) as e:
         typehints.Tuple[list, dict]
       self.assertTrue(e.exception.args[0].startswith(expected_error_prefix))
+    else:
+      try:
+        typehints.Tuple[list, dict]
+      except TypeError:
+        self.fail("built-in composite raised TypeError unexpectedly")
 
   def test_compatibility_arbitrary_length(self):
     self.assertNotCompatible(
@@ -669,6 +674,11 @@ class DictHintTestCase(TypeHintTestCase):
     if sys.version_info < (3, 9):
       with self.assertRaises(TypeError):
         typehints.Dict[list, int]
+    else:
+      try:
+        typehints.Tuple[list, int]
+      except TypeError:
+        self.fail("built-in composite raised TypeError unexpectedly")
 
   def test_value_type_must_be_valid_composite_param(self):
     with self.assertRaises(TypeError):
@@ -775,6 +785,11 @@ class BaseSetHintTest:
             "type, or a TypeConstraint. {} is an instance of "
             "type.".format(self.string_type, list),
             e.exception.args[0])
+      else:
+        try:
+          self.beam_type[list]
+        except TypeError:
+          self.fail("built-in composite raised TypeError unexpectedly")
 
     def test_compatibility(self):
       hint1 = self.beam_type[typehints.List[str]]


### PR DESCRIPTION
Updates python typehinting code to allow primitive containers in composite type hints, allowing statements like `tuple[str, list]` to work since their typing module equivalent also worked. 

Fixes #25146 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
