### PR TITLE
Add ability to configure ArtifactService gRPC Channel

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ArtifactServiceClient.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ArtifactServiceClient.java
@@ -1,0 +1,9 @@
+package org.apache.beam.runners.core.construction;
+
+import java.util.Iterator;
+import org.apache.beam.model.jobmanagement.v1.ArtifactApi;
+
+public interface ArtifactServiceClient extends AutoCloseable {
+    ArtifactApi.ResolveArtifactsResponse resolveArtifacts(ArtifactApi.ResolveArtifactsRequest request);
+    Iterator<ArtifactApi.GetArtifactResponse> getArtifact(ArtifactApi.GetArtifactRequest request);
+}

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/DefaultExpansionServiceClientFactory.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/DefaultExpansionServiceClientFactory.java
@@ -37,6 +37,7 @@ public class DefaultExpansionServiceClientFactory implements ExpansionServiceCli
       Function<Endpoints.ApiServiceDescriptor, ManagedChannel> expansionChannelFactory,
       Function<Endpoints.ApiServiceDescriptor, ManagedChannel> artifactChannelFactory) {
     this.expansionServiceMap = new ConcurrentHashMap<>();
+    this.artifactServiceMap = new ConcurrentHashMap<>();
     this.expansionChannelFactory = expansionChannelFactory;
     this.artifactChannelFactory = artifactChannelFactory;
   }
@@ -85,7 +86,7 @@ public class DefaultExpansionServiceClientFactory implements ExpansionServiceCli
   }
 
   @Override
-  public ExpansionServiceClient getArtifServiceClient(Endpoints.ApiServiceDescriptor endpoint) {
+  public ArtifactServiceClient getArtifactServiceClient(Endpoints.ApiServiceDescriptor endpoint) {
     return artifactServiceMap.computeIfAbsent(
         endpoint,
         e ->

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/DefaultExpansionServiceClientFactory.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/DefaultExpansionServiceClientFactory.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.core.construction;
 
+import java.util.Iterator;
 import java.util.Map;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.function.Function;
@@ -24,6 +25,8 @@ import org.apache.beam.model.expansion.v1.ExpansionApi;
 import org.apache.beam.model.expansion.v1.ExpansionServiceGrpc;
 import org.apache.beam.model.pipeline.v1.Endpoints;
 import org.apache.beam.vendor.grpc.v1p48p1.io.grpc.ManagedChannel;
+import org.apache.beam.model.jobmanagement.v1.ArtifactApi;
+import org.apache.beam.model.jobmanagement.v1.ArtifactRetrievalServiceGrpc;
 
 /** Default factory for ExpansionServiceClient used by External transform. */
 public class DefaultExpansionServiceClientFactory implements ExpansionServiceClientFactory {
@@ -96,12 +99,12 @@ public class DefaultExpansionServiceClientFactory implements ExpansionServiceCli
               ArtifactRetrievalServiceGrpc.newBlockingStub(channel);
 
               @Override
-              ArtifactApi.ResolveArtifactsResponse resolveArtifacts(ArtifactApi.ResolveArtifactsRequest request) {
+              public ArtifactApi.ResolveArtifactsResponse resolveArtifacts(ArtifactApi.ResolveArtifactsRequest request) {
                 return service.resolveArtifacts(request);
               }
 
               @Override
-              Iterator<ArtifactApi.GetArtifactResponse> getArtifact(ArtifactApi.GetArtifactRequest request) {
+              public Iterator<ArtifactApi.GetArtifactResponse> getArtifact(ArtifactApi.GetArtifactRequest request) {
                 return service.getArtifact(request);
               }
 

--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ExpansionServiceClientFactory.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/ExpansionServiceClientFactory.java
@@ -25,4 +25,6 @@ import org.apache.beam.model.pipeline.v1.Endpoints;
  */
 public interface ExpansionServiceClientFactory extends AutoCloseable {
   ExpansionServiceClient getExpansionServiceClient(Endpoints.ApiServiceDescriptor endpoint);
+
+  ArtifactServiceClient getArtifactServiceClient(Endpoints.ApiServiceDescriptor endpoint);
 }

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/ExternalTranslationTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/ExternalTranslationTest.java
@@ -22,16 +22,20 @@ import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItems;
 
 import org.apache.beam.model.expansion.v1.ExpansionApi;
+import org.apache.beam.model.jobmanagement.v1.ArtifactApi;
 import org.apache.beam.model.pipeline.v1.Endpoints;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.vendor.grpc.v1p48p1.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+
+import java.util.Iterator;
 
 /** Tests for {@link org.apache.beam.runners.core.construction.ExternalTranslation}. */
 @RunWith(JUnit4.class)
@@ -56,6 +60,7 @@ public class ExternalTranslationTest {
                 .getTransformsMap()
                 .keySet()
                 .toArray(new String[0])));
+
   }
 
   static class TestExpansionServiceClientFactory implements ExpansionServiceClientFactory {
@@ -93,6 +98,26 @@ public class ExternalTranslationTest {
         @Override
         public void close() throws Exception {
           // do nothing
+        }
+      };
+    }
+
+    @Override
+    public ArtifactServiceClient getArtifactServiceClient(Endpoints.ApiServiceDescriptor endpoint) {
+      return new ArtifactServiceClient() {
+        @Override
+        public ArtifactApi.ResolveArtifactsResponse resolveArtifacts(ArtifactApi.ResolveArtifactsRequest request) {
+          return ArtifactApi.ResolveArtifactsResponse.getDefaultInstance();
+        }
+
+        @Override
+        public Iterator<ArtifactApi.GetArtifactResponse> getArtifact(ArtifactApi.GetArtifactRequest request) {
+          return ImmutableList.of(ArtifactApi.GetArtifactResponse.newBuilder().setData(ByteString.EMPTY).build()).iterator();
+        }
+
+        @Override
+        public void close() throws Exception {
+
         }
       };
     }


### PR DESCRIPTION
The purpose of this PR is to support configurable gRPC channels for ArtifactService. We have use cases where we run the ExpansionService in different environments. One example environment is in Google Cloud Run. This requires authenticated gRPC calls with the google cloud token in the gRPC header and transport security enabled vs plaint text. With the current public methods, we can do this for the expand stub with no problem, but not for the artifact stub which would need the same channel configuration.  We ended up monkey patching this to get our use case to work. I am contributing the monkey patch back to beam. 

address #25840 
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
