### PR TITLE
[25119] Change test-infra Kafka outside service to NodePort

### DIFF
--- a/.test-infra/jenkins/Kubernetes.groovy
+++ b/.test-infra/jenkins/Kubernetes.groovy
@@ -117,6 +117,39 @@ class Kubernetes {
   }
 
   /**
+   * Specifies steps that will save specified address node ip address
+   * as an environment variable that can be used in later steps if needed.
+   *
+   * @param referenceName - name of the environment variable
+   */
+  void nodeIPAddress(String referenceName) {
+    jobs.steps {
+      String command = "${KUBERNETES_SCRIPT} nodeIPAddress"
+      shell("set -eo pipefail; eval ${command} | sed 's/^/${referenceName}=/' > job.properties")
+      environmentVariables {
+        propertiesFile('job.properties')
+      }
+    }
+  }
+
+  /**
+   * Specifies steps that will save the NodePort of the specified service
+   * as an environment variable that can be used in later steps if needed.
+   *
+   * @param serviceName - name of the load balancer Kubernetes service
+   * @param referenceName - name of the environment variable
+   */
+  void nodePort(String serviceName, String referenceName) {
+    job.steps {
+      String command = "${KUBERNETES_SCRIPT} nodePort ${serviceName}"
+      shell("set -eo pipefail; eval ${command} | sed 's/^/${referenceName}=/' > job.properties")
+      environmentVariables {
+        propertiesFile('job.properties')
+      }
+    }
+  }
+
+  /**
    * Specifies steps that will save specified load balancer serivce address
    * as an environment variable that can be used in later steps if needed.
    *

--- a/.test-infra/jenkins/Kubernetes.groovy
+++ b/.test-infra/jenkins/Kubernetes.groovy
@@ -123,7 +123,7 @@ class Kubernetes {
    * @param referenceName - name of the environment variable
    */
   void nodeIPAddress(String referenceName) {
-    jobs.steps {
+    job.steps {
       String command = "${KUBERNETES_SCRIPT} nodeIPAddress"
       shell("set -eo pipefail; eval ${command} | sed 's/^/${referenceName}=/' > job.properties")
       environmentVariables {

--- a/.test-infra/jenkins/Kubernetes.groovy
+++ b/.test-infra/jenkins/Kubernetes.groovy
@@ -117,7 +117,7 @@ class Kubernetes {
   }
 
   /**
-   * Specifies steps that will save specified address node ip address
+   * Specifies steps that will save specified node ip address
    * as an environment variable that can be used in later steps if needed.
    *
    * @param nodeIndex - index of node

--- a/.test-infra/jenkins/Kubernetes.groovy
+++ b/.test-infra/jenkins/Kubernetes.groovy
@@ -120,11 +120,12 @@ class Kubernetes {
    * Specifies steps that will save specified address node ip address
    * as an environment variable that can be used in later steps if needed.
    *
+   * @param nodeIndex - index of node
    * @param referenceName - name of the environment variable
    */
-  void nodeIPAddress(String referenceName) {
+  void nodeIPAddress(int nodeIndex, String referenceName) {
     job.steps {
-      String command = "${KUBERNETES_SCRIPT} nodeIPAddress"
+      String command = "${KUBERNETES_SCRIPT} nodeIPAddress ${nodeIndex}"
       shell("set -eo pipefail; eval ${command} | sed 's/^/${referenceName}=/' > job.properties")
       environmentVariables {
         propertiesFile('job.properties')

--- a/.test-infra/jenkins/job_PerformanceTests_KafkaIO_IT.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_KafkaIO_IT.groovy
@@ -67,7 +67,6 @@ job(jobName) {
   k8s.apply(kafkaDir)
   (0..2).each {
     k8s.nodeIPAddress(it, "KAFKA_BROKER_$it")
-    k8s.nodePort("outside-$it", "NODE_PORT_$it")
   }
   k8s.waitForJob(kafkaTopicJob,"40m")
 

--- a/.test-infra/jenkins/job_PerformanceTests_KafkaIO_IT.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_KafkaIO_IT.groovy
@@ -65,8 +65,10 @@ job(jobName) {
     }
   }
   k8s.apply(kafkaDir)
-  k8s.nodeIPAddress("NODE_IP")
-  (0..2).each { k8s.nodePort("outside-$it", "NODE_PORT_$it") }
+  (0..2).each {
+    k8s.nodeIPAddress(it, "NODE_IP_$it")
+    k8s.nodePort("outside-$it", "NODE_PORT_$it")
+  }
   k8s.waitForJob(kafkaTopicJob,"40m")
 
   Map pipelineOptions = [
@@ -86,7 +88,7 @@ job(jobName) {
     influxMeasurement            : 'kafkaioit_results',
     influxDatabase               : InfluxDBCredentialsHelper.InfluxDBDatabaseName,
     influxHost                   : InfluxDBCredentialsHelper.InfluxDBHostUrl,
-    kafkaBootstrapServerAddresses: "\$NODE_IP:\$NODE_PORT_0,\$NODE_IP:\$NODE_PORT_1,\$NODE_IP:\$NODE_PORT_2",
+    kafkaBootstrapServerAddresses: "\$NODE_IP_0:\$NODE_PORT_0,\$NODE_IP_1:\$NODE_PORT_1,\$NODE_IP_2:\$NODE_PORT_2",
     kafkaTopic                   : 'beam-batch',
     readTimeout                  : '1800',
     numWorkers                   : '5',

--- a/.test-infra/jenkins/job_PerformanceTests_KafkaIO_IT.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_KafkaIO_IT.groovy
@@ -87,7 +87,7 @@ job(jobName) {
     influxMeasurement            : 'kafkaioit_results',
     influxDatabase               : InfluxDBCredentialsHelper.InfluxDBDatabaseName,
     influxHost                   : InfluxDBCredentialsHelper.InfluxDBHostUrl,
-    kafkaBootstrapServerAddresses: "\$KAFKA_BROKER_0:\$NODE_PORT_0,\$KAFKA_BROKER_1:\$NODE_PORT_1,\$KAFKA_BROKER_2:\$NODE_PORT_2",
+    kafkaBootstrapServerAddresses: "\$KAFKA_BROKER_0:\$KAFKA_SERVICE_PORT_0,\$KAFKA_BROKER_1:\$KAFKA_SERVICE_PORT_1,\$KAFKA_BROKER_2:\$KAFKA_SERVICE_PORT_2",
     kafkaTopic                   : 'beam-batch',
     readTimeout                  : '1800',
     numWorkers                   : '5',

--- a/.test-infra/jenkins/job_PerformanceTests_KafkaIO_IT.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_KafkaIO_IT.groovy
@@ -75,7 +75,7 @@ job(jobName) {
     tempRoot                     : 'gs://temp-storage-for-perf-tests',
     project                      : 'apache-beam-testing',
     runner                       : 'DataflowRunner',
-    usePublicIPs                 : 'false', // See .test-infra/terraform/google-cloud-platform/networking
+    usePublicIps                 : 'false', // See .test-infra/terraform/google-cloud-platform/networking
     sourceOptions                : """
                                      {
                                        "numRecords": "100000000",

--- a/.test-infra/jenkins/job_PerformanceTests_KafkaIO_IT.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_KafkaIO_IT.groovy
@@ -75,7 +75,7 @@ job(jobName) {
     tempRoot                     : 'gs://temp-storage-for-perf-tests',
     project                      : 'apache-beam-testing',
     runner                       : 'DataflowRunner',
-    usePublicIPs                 : false, // See .test-infra/terraform/google-cloud-platform/networking
+    usePublicIPs                 : 'false', // See .test-infra/terraform/google-cloud-platform/networking
     sourceOptions                : """
                                      {
                                        "numRecords": "100000000",

--- a/.test-infra/jenkins/job_PerformanceTests_KafkaIO_IT.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_KafkaIO_IT.groovy
@@ -66,7 +66,7 @@ job(jobName) {
   }
   k8s.apply(kafkaDir)
   (0..2).each {
-    k8s.nodeIPAddress(it, "NODE_IP_$it")
+    k8s.nodeIPAddress(it, "KAFKA_BROKER_$it")
     k8s.nodePort("outside-$it", "NODE_PORT_$it")
   }
   k8s.waitForJob(kafkaTopicJob,"40m")
@@ -88,7 +88,7 @@ job(jobName) {
     influxMeasurement            : 'kafkaioit_results',
     influxDatabase               : InfluxDBCredentialsHelper.InfluxDBDatabaseName,
     influxHost                   : InfluxDBCredentialsHelper.InfluxDBHostUrl,
-    kafkaBootstrapServerAddresses: "\$NODE_IP_0:\$NODE_PORT_0,\$NODE_IP_1:\$NODE_PORT_1,\$NODE_IP_2:\$NODE_PORT_2",
+    kafkaBootstrapServerAddresses: "\$KAFKA_BROKER_0:\$NODE_PORT_0,\$KAFKA_BROKER_1:\$NODE_PORT_1,\$KAFKA_BROKER_2:\$NODE_PORT_2",
     kafkaTopic                   : 'beam-batch',
     readTimeout                  : '1800',
     numWorkers                   : '5',

--- a/.test-infra/jenkins/job_PerformanceTests_xlang_KafkaIO_Python.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_xlang_KafkaIO_Python.groovy
@@ -106,7 +106,7 @@ private void createKafkaIOTestJob(testJob) {
       project         : 'apache-beam-testing',
       region          : 'us-central1',
       temp_location   : 'gs://temp-storage-for-perf-tests/',
-      usePublicIPs    : false,
+      usePublicIPs    : false, // See .test-infra/terraform/google-cloud-platform/networking
       filename_prefix : "gs://temp-storage-for-perf-tests/${testJob.name}/\${BUILD_ID}/",
       sdk_harness_container_image_overrides: '.*java.*,gcr.io/apache-beam-testing/beam-sdk/beam_java8_sdk:latest'
     ]

--- a/.test-infra/jenkins/job_PerformanceTests_xlang_KafkaIO_Python.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_xlang_KafkaIO_Python.groovy
@@ -91,7 +91,7 @@ private void createKafkaIOTestJob(testJob) {
     }
     k8s.apply(kafkaDir)
     (0..2).each {
-      k8s.nodeIPAddress(it, "NODE_IP_$it")
+      k8s.nodeIPAddress(it, "KAFKA_BROKER_$it")
       k8s.nodePort("outside-$it", "NODE_PORT_$it")
     }
     k8s.waitForJob(kafkaTopicJob,"40m")
@@ -99,7 +99,7 @@ private void createKafkaIOTestJob(testJob) {
     additionalPipelineArgs = [
       influx_db_name: InfluxDBCredentialsHelper.InfluxDBDatabaseName,
       influx_hostname: InfluxDBCredentialsHelper.InfluxDBHostUrl,
-      bootstrap_servers: "\$NODE_IP_0:\$NODE_PORT_0,\$NODE_IP_1:\$NODE_PORT_1,\$NODE_IP_2:\$NODE_PORT_2",
+      bootstrap_servers: "\$KAFKA_BROKER_0:\$NODE_PORT_0,\$KAFKA_BROKER_1:\$NODE_PORT_1,\$KAFKA_BROKER_2:\$NODE_PORT_2",
     ]
     testJob.pipelineOptions.putAll(additionalPipelineArgs)
 

--- a/.test-infra/jenkins/job_PerformanceTests_xlang_KafkaIO_Python.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_xlang_KafkaIO_Python.groovy
@@ -98,7 +98,7 @@ private void createKafkaIOTestJob(testJob) {
     additionalPipelineArgs = [
       influx_db_name: InfluxDBCredentialsHelper.InfluxDBDatabaseName,
       influx_hostname: InfluxDBCredentialsHelper.InfluxDBHostUrl,
-      bootstrap_servers: "\$KAFKA_BROKER_0:\$NODE_PORT_0,\$KAFKA_BROKER_1:\$NODE_PORT_1,\$KAFKA_BROKER_2:\$NODE_PORT_2",
+      bootstrap_servers: "\$KAFKA_BROKER_0:\$KAFKA_SERVICE_PORT_0,\$KAFKA_BROKER_1:\$KAFKA_SERVICE_PORT_1,\$KAFKA_BROKER_2:\$KAFKA_SERVICE_PORT_2",
     ]
     testJob.pipelineOptions.putAll(additionalPipelineArgs)
 

--- a/.test-infra/jenkins/job_PerformanceTests_xlang_KafkaIO_Python.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_xlang_KafkaIO_Python.groovy
@@ -108,7 +108,7 @@ private void createKafkaIOTestJob(testJob) {
       project         : 'apache-beam-testing',
       region          : 'us-central1',
       temp_location   : 'gs://temp-storage-for-perf-tests/',
-      usePublicIPs    : 'false', // See .test-infra/terraform/google-cloud-platform/networking
+      usePublicIps    : 'false', // See .test-infra/terraform/google-cloud-platform/networking
       filename_prefix : "gs://temp-storage-for-perf-tests/${testJob.name}/\${BUILD_ID}/",
       sdk_harness_container_image_overrides: '.*java.*,gcr.io/apache-beam-testing/beam-sdk/beam_java8_sdk:latest'
     ]

--- a/.test-infra/jenkins/job_PerformanceTests_xlang_KafkaIO_Python.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_xlang_KafkaIO_Python.groovy
@@ -108,7 +108,7 @@ private void createKafkaIOTestJob(testJob) {
       project         : 'apache-beam-testing',
       region          : 'us-central1',
       temp_location   : 'gs://temp-storage-for-perf-tests/',
-      usePublicIPs    : false, // See .test-infra/terraform/google-cloud-platform/networking
+      usePublicIPs    : 'false', // See .test-infra/terraform/google-cloud-platform/networking
       filename_prefix : "gs://temp-storage-for-perf-tests/${testJob.name}/\${BUILD_ID}/",
       sdk_harness_container_image_overrides: '.*java.*,gcr.io/apache-beam-testing/beam-sdk/beam_java8_sdk:latest'
     ]

--- a/.test-infra/jenkins/job_PerformanceTests_xlang_KafkaIO_Python.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_xlang_KafkaIO_Python.groovy
@@ -92,7 +92,6 @@ private void createKafkaIOTestJob(testJob) {
     k8s.apply(kafkaDir)
     (0..2).each {
       k8s.nodeIPAddress(it, "KAFKA_BROKER_$it")
-      k8s.nodePort("outside-$it", "NODE_PORT_$it")
     }
     k8s.waitForJob(kafkaTopicJob,"40m")
 

--- a/.test-infra/jenkins/job_PerformanceTests_xlang_KafkaIO_Python.groovy
+++ b/.test-infra/jenkins/job_PerformanceTests_xlang_KafkaIO_Python.groovy
@@ -90,14 +90,16 @@ private void createKafkaIOTestJob(testJob) {
       }
     }
     k8s.apply(kafkaDir)
-    k8s.nodeIPAddress("NODE_IP")
-    (0..2).each { k8s.nodePort("outside-$it", "NODE_PORT_$it") }
+    (0..2).each {
+      k8s.nodeIPAddress(it, "NODE_IP_$it")
+      k8s.nodePort("outside-$it", "NODE_PORT_$it")
+    }
     k8s.waitForJob(kafkaTopicJob,"40m")
 
     additionalPipelineArgs = [
       influx_db_name: InfluxDBCredentialsHelper.InfluxDBDatabaseName,
       influx_hostname: InfluxDBCredentialsHelper.InfluxDBHostUrl,
-      bootstrap_servers: "\$NODE_IP:\$NODE_PORT_0,\$NODE_IP:\$NODE_PORT_1,\$NODE_IP:\$NODE_PORT_2",
+      bootstrap_servers: "\$NODE_IP_0:\$NODE_PORT_0,\$NODE_IP_1:\$NODE_PORT_1,\$NODE_IP_2:\$NODE_PORT_2",
     ]
     testJob.pipelineOptions.putAll(additionalPipelineArgs)
 

--- a/.test-infra/kubernetes/kafka-cluster/04-outside-services/outside-0.yml
+++ b/.test-infra/kubernetes/kafka-cluster/04-outside-services/outside-0.yml
@@ -26,4 +26,4 @@ spec:
     targetPort: 9094
     port: 32400
     nodePort: 32400
-  type: LoadBalancer
+  type: NodePort

--- a/.test-infra/kubernetes/kafka-cluster/04-outside-services/outside-1.yml
+++ b/.test-infra/kubernetes/kafka-cluster/04-outside-services/outside-1.yml
@@ -26,4 +26,4 @@ spec:
     targetPort: 9094
     port: 32401
     nodePort: 32401
-  type: LoadBalancer
+  type: NodePort

--- a/.test-infra/kubernetes/kafka-cluster/04-outside-services/outside-2.yml
+++ b/.test-infra/kubernetes/kafka-cluster/04-outside-services/outside-2.yml
@@ -26,4 +26,4 @@ spec:
     targetPort: 9094
     port: 32402
     nodePort: 32402
-  type: LoadBalancer
+  type: NodePort

--- a/.test-infra/kubernetes/kafka-cluster/05-kafka/10broker-config.yml
+++ b/.test-infra/kubernetes/kafka-cluster/05-kafka/10broker-config.yml
@@ -38,14 +38,8 @@ data:
         SEDS+=("s/#init#broker.rack=#init#/broker.rack=$ZONE/")
         LABELS="$LABELS kafka-broker-rack=$ZONE"
       fi
-      OUTSIDE_HOST=""
-      while [ -z $OUTSIDE_HOST ]; do
-        echo "Waiting for end point..."
-        OUTSIDE_HOST=$(kubectl get svc outside-${KAFKA_BROKER_ID} --template="{{range .status.loadBalancer.ingress}}{{.ip}}{{end}}")
-        [ -z "$OUTSIDE_HOST" ] && sleep 10
-      done
-      # OUTSIDE_HOST=$(kubectl get node "$NODE_NAME" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
-      OUTSIDE_PORT=$(kubectl get svc outside-${KAFKA_BROKER_ID} --template="{{range .spec.ports}}{{.port}}{{end}}")
+      OUTSIDE_HOST=$(kubectl get node "$NODE_NAME" -o jsonpath='{.status.addresses[?(@.type=="InternalIP")].address}')
+      OUTSIDE_PORT=$(kubectl get svc outside-${KAFKA_BROKER_ID} -o jsonpath='{.spec.ports[0].nodePort}')
       SEDS+=("s|#init#advertised.listeners=OUTSIDE://#init#|advertised.listeners=OUTSIDE://${OUTSIDE_HOST}:${OUTSIDE_PORT}|")
       ANNOTATIONS="$ANNOTATIONS kafka-listener-outside-host=$OUTSIDE_HOST kafka-listener-outside-port=$OUTSIDE_PORT"
 

--- a/.test-infra/kubernetes/kubernetes.sh
+++ b/.test-infra/kubernetes/kubernetes.sh
@@ -80,6 +80,22 @@ function deleteNamespace() {
   eval "kubectl --kubeconfig=${KUBECONFIG} delete namespace $1"
 }
 
+# Gets Node IP address of cluster
+# Usage: ./kubernetes.sh nodeIPAddress
+function nodeIPAddress() {
+  local command="$KUBECTL get node -ojsonpath='{.items[*].status.addresses[?(@.type==\"InternalIP\")].address}'"
+}
+
+# Gets NodePort of service
+# Blocks and retries until the IP is present or retry limit is exceeded.
+#
+# Usage: ./kubernetes.sh nodePort <name of the kubernetes service>
+function nodePort() {
+  local name=$1
+  local command="$KUBECTL get svc $name -ojsonpath='{.status.ports[0].nodePort}'"
+  retry "${command}" 36 10
+}
+
 # Gets Load Balancer Ingress IP address.
 # Blocks and retries until the IP is present or retry limit is exceeded.
 #

--- a/.test-infra/kubernetes/kubernetes.sh
+++ b/.test-infra/kubernetes/kubernetes.sh
@@ -81,9 +81,10 @@ function deleteNamespace() {
 }
 
 # Gets Node IP address of cluster
-# Usage: ./kubernetes.sh nodeIPAddress
+# Usage: ./kubernetes.sh nodeIPAddress nodeIndex
 function nodeIPAddress() {
-  local command="$KUBECTL get node -ojsonpath='{.items[*].status.addresses[?(@.type==\"InternalIP\")].address}'"
+  local nodeIndex=$1
+  local command="$KUBECTL get node -ojsonpath='{.items[${nodeIndex}].status.addresses[?(@.type==\"InternalIP\")].address}'"
 }
 
 # Gets NodePort of service
@@ -92,7 +93,7 @@ function nodeIPAddress() {
 # Usage: ./kubernetes.sh nodePort <name of the kubernetes service>
 function nodePort() {
   local name=$1
-  local command="$KUBECTL get svc $name -ojsonpath='{.status.ports[0].nodePort}'"
+  local command="$KUBECTL get svc $name -ojsonpath='{.spec.ports[0].nodePort}'"
   retry "${command}" 36 10
 }
 

--- a/.test-infra/terraform/OWNERS
+++ b/.test-infra/terraform/OWNERS
@@ -1,0 +1,4 @@
+# See the OWNERS docs at https://s.apache.org/beam-owners
+
+reviewers:
+  - damondouglas

--- a/.test-infra/terraform/README.md
+++ b/.test-infra/terraform/README.md
@@ -1,0 +1,30 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+# Overview
+
+This folder contains Infrastructure-as-Code implemented using
+[terraform](https://terraform.io) to provision resources for Apache Beam tests.
+Subfolders organize code according to the target environement.
+
+# Requirements
+
+Usage of this code minimally requires the terraform command-line interface.
+See [terraform](https://terraform.io) for further details. See individual
+subfolders for additional requirements for the target environment.

--- a/.test-infra/terraform/google-cloud-platform/README.md
+++ b/.test-infra/terraform/google-cloud-platform/README.md
@@ -1,0 +1,44 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+# Overview
+
+This folder contains Infrastructure-as-Code implemented using
+[terraform](https://terraform.io) to provision resources for Apache Beam tests
+requiring Google Cloud resources.
+
+# Requirements
+
+Usage of this code requires:
+
+- [terraform cli v1.2.0 and later](https://terraform.io)
+- [Google Cloud SDK](https://cloud.google.com/sdk); `gcloud init`
+  and `gcloud auth`
+- Google Cloud project with billing enabled
+- IntelliJ or VS Code terraform plugin (optional but **highly** recommended)
+
+# Usage
+
+Each folder contains all the code to achieve a category of
+provisioning. For example, the [networking](networking) folder contains
+all the necessary code to provision Google Cloud related networking resources.
+
+To provision resources in a chosen folder follow the conventional terraform
+workflow. See https://developer.hashicorp.com/terraform/intro/core-workflow
+for details.

--- a/.test-infra/terraform/google-cloud-platform/networking/README.md
+++ b/.test-infra/terraform/google-cloud-platform/networking/README.md
@@ -23,7 +23,8 @@ This folder contains Infrastructure-as-Code implemented using
 [terraform](https://terraform.io) to provision resources
 for Apache Beam tests requiring networking specific Google Cloud resources.
 
-Code in the folder:
+To support the [`usePublicIps=false`](https://beam.apache.org/releases/javadoc/current/org/apache/beam/runners/dataflow/options/DataflowPipelineWorkerPoolOptions.html#setUsePublicIps-java.lang.Boolean-)
+flag for Dataflow jobs, code in the folder:
 - Validates the Google Cloud Virtual Private Cloud (VPC) subnetwork has
 has [private Google Access](https://cloud.google.com/vpc/docs/private-google-access)
 turned on

--- a/.test-infra/terraform/google-cloud-platform/networking/README.md
+++ b/.test-infra/terraform/google-cloud-platform/networking/README.md
@@ -1,0 +1,47 @@
+<!--
+    Licensed to the Apache Software Foundation (ASF) under one
+    or more contributor license agreements.  See the NOTICE file
+    distributed with this work for additional information
+    regarding copyright ownership.  The ASF licenses this file
+    to you under the Apache License, Version 2.0 (the
+    "License"); you may not use this file except in compliance
+    with the License.  You may obtain a copy of the License at
+
+      http://www.apache.org/licenses/LICENSE-2.0
+
+    Unless required by applicable law or agreed to in writing,
+    software distributed under the License is distributed on an
+    "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+    KIND, either express or implied.  See the License for the
+    specific language governing permissions and limitations
+    under the License.
+-->
+
+# Overview
+
+This folder contains Infrastructure-as-Code implemented using
+[terraform](https://terraform.io) to provision resources
+for Apache Beam tests requiring networking specific Google Cloud resources.
+
+Code in the folder:
+- Validates the Google Cloud Virtual Private Cloud (VPC) subnetwork has
+has [private Google Access](https://cloud.google.com/vpc/docs/private-google-access)
+turned on
+- Provisions a [Cloud NAT](https://cloud.google.com/nat/docs/overview) and
+[Cloud Router](https://cloud.google.com/network-connectivity/docs/router/concepts/overview)
+
+# Requirements
+
+Usage of this code requires:
+
+- [terraform cli v1.2.0 and later](https://terraform.io)
+- [Google Cloud SDK](https://cloud.google.com/sdk); `gcloud init`
+  and `gcloud auth`
+- Google Cloud project with billing enabled
+- IntelliJ or VS Code terraform plugin (optional but **highly** recommended)
+
+# Usage
+
+To provision resources in a this folder follow the conventional terraform
+workflow. See https://developer.hashicorp.com/terraform/intro/core-workflow
+for details.

--- a/.test-infra/terraform/google-cloud-platform/networking/backend.tf
+++ b/.test-infra/terraform/google-cloud-platform/networking/backend.tf
@@ -1,0 +1,29 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+// Tells terraform to store state files in Google Cloud storage.
+// The Google Cloud storage bucket name must be hard coded.
+// See https://developer.hashicorp.com/terraform/language/settings/backends/configuration
+// for details.
+terraform {
+  backend "gcs" {
+    bucket = "b507e468-52e9-4e72-83e5-ecbf563eda12"
+    prefix = "terraform/projects/apache-beam-testing/networking"
+  }
+}

--- a/.test-infra/terraform/google-cloud-platform/networking/data.tf
+++ b/.test-infra/terraform/google-cloud-platform/networking/data.tf
@@ -1,0 +1,40 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+// Query the Virtual Private Cloud network
+data "google_compute_network" "default" {
+  name = var.network
+}
+
+// Query the Virtual Private Cloud subnetwork
+// Additionally checks whether Private Google Access is true
+data "google_compute_subnetwork" "default" {
+  name   = var.subnetwork
+  region = var.region
+  lifecycle {
+    postcondition {
+      condition     = self.private_ip_google_access
+      error_message = <<EOF
+Private Google Access is false, want: true, subnetwork: ${self.self_link}"
+Run the following command:
+gcloud compute networks subnets update --project=${self.project} ${self.name} --region=${self.region} --enable-private-ip-google-access
+EOF
+    }
+  }
+}

--- a/.test-infra/terraform/google-cloud-platform/networking/nat.tf
+++ b/.test-infra/terraform/google-cloud-platform/networking/nat.tf
@@ -1,0 +1,40 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+// Private IP-only Compute Engine instances require a Cloud NAT and router
+// to access public internet resources.
+resource "google_compute_router" "default" {
+  name    = "${data.google_compute_network.default.name}-${var.region}-router"
+  network = data.google_compute_network.default.id
+  region  = var.region
+}
+
+// Private IP-only Compute Engine instances require a Cloud NAT and router
+// to access public internet resources.
+resource "google_compute_router_nat" "default" {
+  name                               = "${data.google_compute_network.default.name}-${var.region}-router-nat"
+  nat_ip_allocate_option             = "AUTO_ONLY"
+  router                             = google_compute_router.default.name
+  region                             = google_compute_router.default.region
+  source_subnetwork_ip_ranges_to_nat = "ALL_SUBNETWORKS_ALL_IP_RANGES"
+  log_config {
+    enable = true
+    filter = "ERRORS_ONLY"
+  }
+}

--- a/.test-infra/terraform/google-cloud-platform/networking/provider.tf
+++ b/.test-infra/terraform/google-cloud-platform/networking/provider.tf
@@ -1,0 +1,22 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+provider "google" {
+  project = var.project
+}

--- a/.test-infra/terraform/google-cloud-platform/networking/variables.tf
+++ b/.test-infra/terraform/google-cloud-platform/networking/variables.tf
@@ -1,0 +1,38 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one
+# or more contributor license agreements.  See the NOTICE file
+# distributed with this work for additional information
+# regarding copyright ownership.  The ASF licenses this file
+# to you under the Apache License, Version 2.0 (the
+# "License"); you may not use this file except in compliance
+# with the License.  You may obtain a copy of the License at
+#
+#   http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing,
+# software distributed under the License is distributed on an
+# "AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+# KIND, either express or implied.  See the License for the
+# specific language governing permissions and limitations
+# under the License.
+#
+
+variable "project" {
+  type        = string
+  description = "The Google Cloud Platform project within which resources are provisioned"
+}
+
+variable "region" {
+  type        = string
+  description = "The Google Cloud Platform region in which to provision resources"
+}
+
+variable "network" {
+  type        = string
+  description = "The Google Cloud Platform Virtual Private Cloud network"
+}
+
+variable "subnetwork" {
+  type        = string
+  description = "The Google Cloud Platform Virtual Private Cloud subnetwork"
+}


### PR DESCRIPTION
This PR closes #25119 and addresses #19465 by:
1. Change .test-infra/kubernetes/kafka-cluster/04-outside-services from LoadBalancer to NodePort
2. Refactor .test-infra/kubernetes/kafka-cluster/05-kafka/10broker-config.yml to query `OUTSIDE_HOST` from k8s node `InternalIP` and `OUTSIDE_PORT` to query `outside-${KAFKA_BROKER_ID}`'s NodePort
3. Added `nodeIPAddress` and `nodePort` methods to .test-infra/jenkins/Kubernetes.groovy and cooresponding .test-infra/kubernetes/kubernetes.sh to enable Node InternalIP and NodePort querying within a jenkins job context
4. Refactor the following with `usePublicIps=false`
    - .test-infra/jenkins/job_PerformanceTests_xlang_KafkaIO_Python.groovy
    - .test-infra/jenkins/job_PerformanceTests_KafkaIO_IT.groovy
5. terraform code to validate and provision Google Cloud networking requirements to support `usePublicIps=false` (Note: I already executed the terraform code, per personal communication, on apache-beam-testing GCP project)

I was unable to test end-to-end the new workflow from jenkins job creation to seeing a Dataflow Job executing successfully in my own Google Cloud environment.  However, I was able to validate:
1. Using a private IP compute engine instance in the same GCP network, https://kafka.apache.org/quickstart worked using the kubernetes cluster's node InternalIP and NodePort as the `--bootstrap-server`
2. Spinning up .test-infra/dockerized-jenkins and seeding `job_PerformanceTests_xlang_KafkaIO_Python.groovy` from github.com/damondouglas/beam from branch `25119-fix-test-infra-kafka-service` built the test job using the queried kubernetes Node InternalIP and NodePort as the bootstrap_server arguments

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - ~Update `CHANGES.md` with noteworthy changes.~
 - ~If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).~

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
