### PR TITLE
Further increase transient expansion service timeout

### DIFF
--- a/sdks/java/extensions/python/src/main/java/org/apache/beam/sdk/extensions/python/PythonExternalTransform.java
+++ b/sdks/java/extensions/python/src/main/java/org/apache/beam/sdk/extensions/python/PythonExternalTransform.java
@@ -65,14 +65,10 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Immutabl
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
-import org.slf4j.Logger;
-import org.slf4j.LoggerFactory;
 
 /** Wrapper for invoking external Python transforms. */
 public class PythonExternalTransform<InputT extends PInput, OutputT extends POutput>
     extends PTransform<InputT, OutputT> {
-
-  private static final Logger LOG = LoggerFactory.getLogger(PythonExternalTransform.class);
 
   private static final SchemaRegistry SCHEMA_REGISTRY = SchemaRegistry.createDefault();
   private String fullyQualifiedName;

--- a/sdks/java/extensions/python/src/main/java/org/apache/beam/sdk/extensions/python/PythonExternalTransform.java
+++ b/sdks/java/extensions/python/src/main/java/org/apache/beam/sdk/extensions/python/PythonExternalTransform.java
@@ -448,7 +448,7 @@ public class PythonExternalTransform<InputT extends PInput, OutputT extends POut
         PythonService.waitForPort(
             Iterables.get(Splitter.on(':').split(expansionService), 0),
             Integer.parseInt(Iterables.get(Splitter.on(':').split(expansionService), 1)),
-            60000);
+            15000);
         return apply(input, expansionService, payload);
       } else {
         int port = PythonService.findAvailablePort();
@@ -472,13 +472,8 @@ public class PythonExternalTransform<InputT extends PInput, OutputT extends POut
                     "apache_beam.runners.portability.expansion_service_main", args.build())
                 .withExtraPackages(extraPackages);
         try (AutoCloseable p = service.start()) {
-          // allow more time for service with extra packages to response.
-          int timeoutSeconds = extraPackages.isEmpty() ? 15 : 30;
-          LOG.info(
-              "Expanding Python external transform {} using default transient expansion service with timeout {}s.",
-              fullyQualifiedName,
-              timeoutSeconds);
-          PythonService.waitForPort("localhost", port, timeoutSeconds * 1000);
+          // allow more time waiting for the port ready for transient expansion service setup.
+          PythonService.waitForPort("localhost", port, 60000);
           return apply(input, String.format("localhost:%s", port), payload);
         }
       }


### PR DESCRIPTION
Fixes #25110

reverting much of #25111 and #25169 and direct to the actual code path

In #25111 I assumed the cause is that the expansion service needs more time up when there is extra dependency. This is not true. The expansion service is a python interpreter call. It is markedly faster at the second time, which is why there is almost always one test (but not more) fail.

This is also a followup of a paralllel effort #25169

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
