### PR TITLE
[Spark Dataset runner] Break linage of dataset to reduce Spark planning overhead in case of large query plans

### DIFF
--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/EvaluationContext.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/EvaluationContext.java
@@ -49,17 +49,17 @@ public final class EvaluationContext {
     Dataset<WindowedValue<T>> dataset();
   }
 
-  private final Collection<? extends NamedDataset<?>> leaveDatasets;
+  private final Collection<? extends NamedDataset<?>> leaves;
   private final SparkSession session;
 
-  EvaluationContext(Collection<? extends NamedDataset<?>> leaveDatasets, SparkSession session) {
-    this.leaveDatasets = leaveDatasets;
+  EvaluationContext(Collection<? extends NamedDataset<?>> leaves, SparkSession session) {
+    this.leaves = leaves;
     this.session = session;
   }
 
-  /** Trigger evaluation of all leave datasets. */
+  /** Trigger evaluation of all leaf datasets. */
   public void evaluate() {
-    for (NamedDataset<?> ds : leaveDatasets) {
+    for (NamedDataset<?> ds : leaves) {
       final Dataset<?> dataset = ds.dataset();
       if (dataset == null) {
         continue;

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/TransformTranslator.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/TransformTranslator.java
@@ -59,6 +59,15 @@ import scala.reflect.ClassTag;
 public abstract class TransformTranslator<
     InT extends PInput, OutT extends POutput, TransformT extends PTransform<InT, OutT>> {
 
+  // Factor to help estimate the complexity of the Spark execution plan. This is used to limit
+  // complexity by break linage where necessary to avoid overly large plans. Such plans can become
+  // very expensive during planning in the Catalyst optimizer.
+  protected final float complexityFactor;
+
+  protected TransformTranslator(float complexityFactor) {
+    this.complexityFactor = complexityFactor;
+  }
+
   protected abstract void translate(TransformT transform, Context cxt) throws IOException;
 
   final void translate(
@@ -150,8 +159,8 @@ public abstract class TransformTranslator<
     }
 
     @Override
-    public boolean isLeave(PCollection<?> pCollection) {
-      return state.isLeave(pCollection);
+    public boolean isLeaf(PCollection<?> pCollection) {
+      return state.isLeaf(pCollection);
     }
 
     @Override

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/CombineGloballyTranslatorBatch.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/CombineGloballyTranslatorBatch.java
@@ -51,6 +51,10 @@ import scala.collection.Iterator;
 class CombineGloballyTranslatorBatch<InT, AccT, OutT>
     extends TransformTranslator<PCollection<InT>, PCollection<OutT>, Combine.Globally<InT, OutT>> {
 
+  CombineGloballyTranslatorBatch() {
+    super(0.2f);
+  }
+
   @Override
   protected void translate(Combine.Globally<InT, OutT> transform, Context cxt) {
     WindowingStrategy<?, ?> windowing = cxt.getInput().getWindowingStrategy();

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/CombineGroupedValuesTranslatorBatch.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/CombineGroupedValuesTranslatorBatch.java
@@ -43,6 +43,10 @@ class CombineGroupedValuesTranslatorBatch<K, InT, AccT, OutT>
         PCollection<KV<K, OutT>>,
         Combine.GroupedValues<K, InT, OutT>> {
 
+  CombineGroupedValuesTranslatorBatch() {
+    super(0.2f);
+  }
+
   @Override
   protected void translate(Combine.GroupedValues<K, InT, OutT> transform, Context cxt)
       throws IOException {

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/CombinePerKeyTranslatorBatch.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/CombinePerKeyTranslatorBatch.java
@@ -69,6 +69,10 @@ class CombinePerKeyTranslatorBatch<K, InT, AccT, OutT>
     extends TransformTranslator<
         PCollection<KV<K, InT>>, PCollection<KV<K, OutT>>, Combine.PerKey<K, InT, OutT>> {
 
+  CombinePerKeyTranslatorBatch() {
+    super(0.2f);
+  }
+
   @Override
   public void translate(Combine.PerKey<K, InT, OutT> transform, Context cxt) {
     WindowingStrategy<?, ?> windowing = cxt.getInput().getWindowingStrategy();

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/FlattenTranslatorBatch.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/FlattenTranslatorBatch.java
@@ -34,6 +34,10 @@ import org.apache.spark.sql.Encoder;
 class FlattenTranslatorBatch<T>
     extends TransformTranslator<PCollectionList<T>, PCollection<T>, Flatten.PCollections<T>> {
 
+  FlattenTranslatorBatch() {
+    super(0.1f);
+  }
+
   @Override
   public void translate(Flatten.PCollections<T> transform, Context cxt) {
     Collection<PCollection<?>> pCollections = cxt.getInputs().values();

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/GroupByKeyTranslatorBatch.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/GroupByKeyTranslatorBatch.java
@@ -110,9 +110,12 @@ class GroupByKeyTranslatorBatch<K, V>
 
   private boolean useCollectList = true;
 
-  GroupByKeyTranslatorBatch() {}
+  GroupByKeyTranslatorBatch() {
+    super(0.2f);
+  }
 
   GroupByKeyTranslatorBatch(boolean useCollectList) {
+    super(0.2f);
     this.useCollectList = useCollectList;
   }
 

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/ImpulseTranslatorBatch.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/ImpulseTranslatorBatch.java
@@ -31,6 +31,10 @@ import org.apache.spark.sql.Dataset;
 
 class ImpulseTranslatorBatch extends TransformTranslator<PBegin, PCollection<byte[]>, Impulse> {
 
+  ImpulseTranslatorBatch() {
+    super(0);
+  }
+
   @Override
   public void translate(Impulse transform, Context cxt) {
     Dataset<WindowedValue<byte[]>> dataset =

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/ParDoTranslatorBatch.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/ParDoTranslatorBatch.java
@@ -79,6 +79,10 @@ class ParDoTranslatorBatch<InputT, OutputT>
   private static final ClassTag<Tuple2<Integer, WindowedValue<Object>>> TUPLE2_CTAG =
       ClassTag.apply(Tuple2.class);
 
+  ParDoTranslatorBatch() {
+    super(0.2f);
+  }
+
   @Override
   public boolean canTranslate(ParDo.MultiOutput<InputT, OutputT> transform) {
     DoFn<InputT, OutputT> doFn = transform.getFn();
@@ -123,7 +127,7 @@ class ParDoTranslatorBatch<InputT, OutputT>
     Map<TupleTag<?>, PCollection<?>> outputs =
         Maps.filterEntries(
             cxt.getOutputs(),
-            e -> e != null && (e.getKey().equals(mainOut) || !cxt.isLeave(e.getValue())));
+            e -> e != null && (e.getKey().equals(mainOut) || !cxt.isLeaf(e.getValue())));
 
     if (outputs.size() > 1) {
       // In case of multiple outputs / tags, map each tag to a column by index.

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/ReadSourceTranslatorBatch.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/ReadSourceTranslatorBatch.java
@@ -38,6 +38,10 @@ import org.apache.spark.sql.SparkSession;
 class ReadSourceTranslatorBatch<T>
     extends TransformTranslator<PBegin, PCollection<T>, SplittableParDo.PrimitiveBoundedRead<T>> {
 
+  ReadSourceTranslatorBatch() {
+    super(0.05f);
+  }
+
   @Override
   public void translate(SplittableParDo.PrimitiveBoundedRead<T> transform, Context cxt)
       throws IOException {
@@ -50,6 +54,7 @@ class ReadSourceTranslatorBatch<T>
 
     cxt.putDataset(
         cxt.getOutput(),
-        BoundedDatasetFactory.createDatasetFromRDD(session, source, options, encoder));
+        BoundedDatasetFactory.createDatasetFromRDD(session, source, options, encoder),
+        false);
   }
 }

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/ReshuffleTranslatorBatch.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/ReshuffleTranslatorBatch.java
@@ -31,6 +31,10 @@ import org.apache.spark.sql.internal.SQLConf;
 class ReshuffleTranslatorBatch<K, V>
     extends TransformTranslator<PCollection<KV<K, V>>, PCollection<KV<K, V>>, Reshuffle<K, V>> {
 
+  ReshuffleTranslatorBatch() {
+    super(0.1f);
+  }
+
   @Override
   protected void translate(Reshuffle<K, V> transform, Context cxt) throws IOException {
     Dataset<WindowedValue<KV<K, V>>> input = cxt.getDataset(cxt.getInput());
@@ -39,6 +43,10 @@ class ReshuffleTranslatorBatch<K, V>
 
   static class ViaRandomKey<V>
       extends TransformTranslator<PCollection<V>, PCollection<V>, Reshuffle.ViaRandomKey<V>> {
+
+    ViaRandomKey() {
+      super(0.1f);
+    }
 
     @Override
     protected void translate(Reshuffle.ViaRandomKey<V> transform, Context cxt) throws IOException {

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/WindowAssignTranslatorBatch.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/WindowAssignTranslatorBatch.java
@@ -34,6 +34,10 @@ import org.joda.time.Instant;
 class WindowAssignTranslatorBatch<T>
     extends TransformTranslator<PCollection<T>, PCollection<T>, Window.Assign<T>> {
 
+  WindowAssignTranslatorBatch() {
+    super(0.05f);
+  }
+
   @Override
   public void translate(Window.Assign<T> transform, Context cxt) {
     WindowFn<T, ?> windowFn = transform.getWindowFn();


### PR DESCRIPTION
#24711 removed some unnecessary caching when processing MultiParDos with additional but unconsumed outputs. With storage level "Memory Only" caching was done via RDDs. This also had a positive side effect as it breaks linage of the dataset. This is particularly beneficial with complex query plans as generated by TCPDS query 83 (due to #24314).

With caching removed, performance dropped for query 83. 
See http://metrics.beam.apache.org/d/tkqc0AdGk2/tpc-ds-spark-classic-new-sql?orgId=1&viewPanel=38&from=1670799600000&to=1673305199000

This change tracks a rough complexity estimate of the datasets and breaks linage where necessary by converting it to an RDD and back again.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
