### PR TITLE
Optimize PGBK table to only update cache when there is a large enough size change. #21250

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -1553,7 +1553,7 @@ class BeamModulePlugin implements Plugin<Project> {
             if (project.file("/opt/cprof/profiler_java_agent.so").exists()) {
               def gcpProject = project.findProperty('gcpProject') ?: 'apache-beam-testing'
               def userName = System.getProperty("user.name").toLowerCase().replaceAll(" ", "_")
-              jvmArgs '-agentpath:/opt/cprof/profiler_java_agent.so=-cprof_service=' + userName + "_" + project.getProperty("benchmark").toLowerCase() + '_' + String.format('%1$tm%1$td%1$tY_%1$tH%1$tM%1$tS%1$tL', System.currentTimeMillis()) + ',-cprof_project_id=' + gcpProject + ',-cprof_zone_name=us-central1-a'
+              jvmArgs '-agentpath:/opt/cprof/profiler_java_agent.so=-cprof_service=' + userName + "_" + project.getProperty("benchmark").toLowerCase() + '_' + String.format('%1$tY%1$tm%1$td_%1$tH%1$tM%1$tS_%1$tL', System.currentTimeMillis()) + ',-cprof_project_id=' + gcpProject + ',-cprof_zone_name=us-central1-a'
             }
           } else {
             // We filter for only Apache Beam benchmarks to ensure that we aren't

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -1553,7 +1553,7 @@ class BeamModulePlugin implements Plugin<Project> {
             if (project.file("/opt/cprof/profiler_java_agent.so").exists()) {
               def gcpProject = project.findProperty('gcpProject') ?: 'apache-beam-testing'
               def userName = System.getProperty("user.name").toLowerCase().replaceAll(" ", "_")
-              jvmArgs '-agentpath:/opt/cprof/profiler_java_agent.so=-cprof_service=' + userName + "_" + project.getProperty("benchmark").toLowerCase() + '_' + System.currentTimeMillis() + ',-cprof_project_id=' + gcpProject + ',-cprof_zone_name=us-central1-a'
+              jvmArgs '-agentpath:/opt/cprof/profiler_java_agent.so=-cprof_service=' + userName + "_" + project.getProperty("benchmark").toLowerCase() + '_' + String.format('%1$tm%1$td%1$tY_%1$tH%1$tM%1$tS%1$tL', System.currentTimeMillis()) + ',-cprof_project_id=' + gcpProject + ',-cprof_zone_name=us-central1-a'
             }
           } else {
             // We filter for only Apache Beam benchmarks to ensure that we aren't

--- a/sdks/java/harness/jmh/src/main/java/org/apache/beam/fn/harness/jmh/PrecombineGroupingTableBenchmark.java
+++ b/sdks/java/harness/jmh/src/main/java/org/apache/beam/fn/harness/jmh/PrecombineGroupingTableBenchmark.java
@@ -19,9 +19,15 @@ package org.apache.beam.fn.harness.jmh;
 
 import java.util.ArrayList;
 import java.util.Collections;
+import java.util.HashSet;
+import java.util.LinkedHashMap;
 import java.util.List;
+import java.util.Map;
 import java.util.Random;
+import java.util.Set;
+import org.apache.beam.fn.harness.Cache;
 import org.apache.beam.fn.harness.Caches;
+import org.apache.beam.fn.harness.Caches.ClearableCache;
 import org.apache.beam.fn.harness.PrecombineGroupingTable;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -36,15 +42,20 @@ import org.openjdk.jmh.annotations.Param;
 import org.openjdk.jmh.annotations.Scope;
 import org.openjdk.jmh.annotations.Setup;
 import org.openjdk.jmh.annotations.State;
+import org.openjdk.jmh.annotations.Threads;
 import org.openjdk.jmh.infra.Blackhole;
 
 public class PrecombineGroupingTableBenchmark {
   private static final int TOTAL_VALUES = 1_000_000;
+  private static final int KEY_SPACE = 1_000;
 
   @State(Scope.Benchmark)
   public static class SumIntegerBinaryCombine {
     final Combine.BinaryCombineIntegerFn sumInts = Sum.ofIntegers();
     final PipelineOptions options = PipelineOptionsFactory.create();
+
+    final Cache<Object, Object> cache = Caches.fromOptions(options);
+
     List<WindowedValue<KV<String, Integer>>> elements;
 
     @Param({"true", "false"})
@@ -55,51 +66,60 @@ public class PrecombineGroupingTableBenchmark {
 
     @Setup(Level.Trial)
     public void setUp() {
-      // Use a stable seed to ensure consistency across benchmark runs
-      Random random = new Random(-2134890234);
-      elements = new ArrayList<>();
-      switch (distribution) {
-        case "uniform":
-          for (int i = 0; i < TOTAL_VALUES; ++i) {
-            int key = random.nextInt(1000);
-            elements.add(WindowedValue.valueInGlobalWindow(KV.of(Integer.toString(key), key)));
-          }
-          break;
-        case "normal":
-          for (int i = 0; i < TOTAL_VALUES; ++i) {
-            int key = (int) (random.nextGaussian() * 1000);
-            elements.add(WindowedValue.valueInGlobalWindow(KV.of(Integer.toString(key), key)));
-          }
-          break;
-        case "hotKey":
-          for (int i = 0; i < TOTAL_VALUES; ++i) {
-            int key;
-            if (random.nextBoolean()) {
-              key = 0;
-            } else {
-              key = random.nextInt(1000);
-            }
-            elements.add(WindowedValue.valueInGlobalWindow(KV.of(Integer.toString(key), key)));
-          }
-          break;
-        case "uniqueKeys":
-          for (int i = 0; i < TOTAL_VALUES; ++i) {
-            elements.add(WindowedValue.valueInGlobalWindow(KV.of(Integer.toString(i), i)));
-          }
-          Collections.shuffle(elements, random);
-          break;
-        default:
-      }
+      this.elements = generateTestData(distribution);
     }
   }
 
+  private static List<WindowedValue<KV<String, Integer>>> generateTestData(String distribution) {
+    // Use a stable seed to ensure consistency across benchmark runs
+    Random random = new Random(-2134890234);
+    List<WindowedValue<KV<String, Integer>>> elements = new ArrayList<>();
+    switch (distribution) {
+      case "uniform":
+        for (int i = 0; i < TOTAL_VALUES; ++i) {
+          int key = random.nextInt(KEY_SPACE);
+          elements.add(WindowedValue.valueInGlobalWindow(KV.of(Integer.toString(key), key)));
+        }
+        break;
+      case "normal":
+        for (int i = 0; i < TOTAL_VALUES; ++i) {
+          int key = (int) (random.nextGaussian() * KEY_SPACE);
+          elements.add(WindowedValue.valueInGlobalWindow(KV.of(Integer.toString(key), key)));
+        }
+        break;
+      case "hotKey":
+        for (int i = 0; i < TOTAL_VALUES; ++i) {
+          int key;
+          if (random.nextBoolean()) {
+            key = -123814201;
+          } else {
+            key = random.nextInt(KEY_SPACE);
+          }
+          elements.add(WindowedValue.valueInGlobalWindow(KV.of(Integer.toString(key), key)));
+        }
+        break;
+      case "uniqueKeys":
+        for (int i = 0; i < TOTAL_VALUES; ++i) {
+          elements.add(WindowedValue.valueInGlobalWindow(KV.of(Integer.toString(i), i)));
+        }
+        Collections.shuffle(elements, random);
+        break;
+      default:
+        throw new IllegalArgumentException("Unknown distribution: " + distribution);
+    }
+    return elements;
+  }
+
   @Benchmark
+  @Threads(16)
   public void sumIntegerBinaryCombine(SumIntegerBinaryCombine table, Blackhole blackhole)
       throws Exception {
+    ClearableCache<Object, Object> cache =
+        new ClearableCache<>(Caches.subCache(table.cache, Thread.currentThread().getName()));
     PrecombineGroupingTable<String, Integer, int[]> groupingTable =
         PrecombineGroupingTable.combiningAndSampling(
             table.options,
-            Caches.eternal(),
+            cache,
             table.sumInts,
             StringUtf8Coder.of(),
             .001,
@@ -108,5 +128,6 @@ public class PrecombineGroupingTableBenchmark {
       groupingTable.put(table.elements.get(i), blackhole::consume);
     }
     groupingTable.flush(blackhole::consume);
+    cache.clear();
   }
 }

--- a/sdks/java/harness/jmh/src/main/java/org/apache/beam/fn/harness/jmh/PrecombineGroupingTableBenchmark.java
+++ b/sdks/java/harness/jmh/src/main/java/org/apache/beam/fn/harness/jmh/PrecombineGroupingTableBenchmark.java
@@ -19,12 +19,8 @@ package org.apache.beam.fn.harness.jmh;
 
 import java.util.ArrayList;
 import java.util.Collections;
-import java.util.HashSet;
-import java.util.LinkedHashMap;
 import java.util.List;
-import java.util.Map;
 import java.util.Random;
-import java.util.Set;
 import org.apache.beam.fn.harness.Cache;
 import org.apache.beam.fn.harness.Caches;
 import org.apache.beam.fn.harness.Caches.ClearableCache;


### PR DESCRIPTION
This prevents an expensive scenario where a user is outputting lots of small values (e.g. ints) to be precombined and hence takes little to no space to store so updating the cache provides little value.

Note the 5-10x change for all types except for unique keys. Some early profiles show that there is an issue with the G1 garbage collector when storing so many small values that the GC management overhead dominates 75% of the execution which requires further investigation.
![97qWBX8bwxXhHcb](https://user-images.githubusercontent.com/10078956/215604050-1e1e96d2-6ac4-4b52-8210-829779145af7.png)

Before:
```
Benchmark                                                 (distribution)  (globallyWindowed)   Mode  Cnt   Score   Error  Units
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine         uniform                true  thrpt    5   8.306 ± 1.255  ops/s
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine         uniform               false  thrpt    5   7.849 ± 0.476  ops/s
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine          normal                true  thrpt    5  10.575 ± 1.295  ops/s
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine          normal               false  thrpt    5  10.772 ± 0.141  ops/s
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine          hotKey                true  thrpt    5   9.131 ± 2.761  ops/s
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine          hotKey               false  thrpt    5   8.302 ± 1.078  ops/s
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine      uniqueKeys                true  thrpt    5   3.899 ± 1.737  ops/s
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine      uniqueKeys               false  thrpt    5   4.203 ± 2.170  ops/s

```

After:
```
Benchmark                                                 (distribution)  (globallyWindowed)   Mode  Cnt   Score   Error  Units
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine         uniform                true  thrpt    5  88.740 ± 8.925  ops/s
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine         uniform               false  thrpt    5  76.005 ± 5.150  ops/s
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine          normal                true  thrpt    5  43.388 ± 1.966  ops/s
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine          normal               false  thrpt    5  37.804 ± 7.177  ops/s
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine          hotKey                true  thrpt    5  84.881 ± 5.040  ops/s
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine          hotKey               false  thrpt    5  74.183 ± 2.063  ops/s
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine      uniqueKeys                true  thrpt    5   5.567 ± 4.068  ops/s
PrecombineGroupingTableBenchmark.sumIntegerBinaryCombine      uniqueKeys               false  thrpt    5   6.957 ± 1.508  ops/s
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
