### PR TITLE
Revert "[BEAM-12164] Enable postgres IT for change streams"

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamPostgresIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/changestreams/it/SpannerChangeStreamPostgresIT.java
@@ -49,6 +49,7 @@ import org.joda.time.Instant;
 import org.junit.Before;
 import org.junit.BeforeClass;
 import org.junit.ClassRule;
+import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -90,6 +91,7 @@ public class SpannerChangeStreamPostgresIT {
     pipeline.getOptions().as(ChangeStreamTestPipelineOptions.class).setBlockOnRun(false);
   }
 
+  @Ignore("BEAM-14277 Until Postgres is supported")
   @Test
   public void testReadSpannerChangeStream() {
     // Defines how many rows are going to be inserted / updated / deleted in the test


### PR DESCRIPTION
Reverts apache/beam#25152

Possibly causing https://ci-beam.apache.org/job/beam_PostCommit_Java_DataflowV1/ timeout