### PR TITLE
[Spark Dataset runner] Fix collection encoder bug leading to corrupt data

### DIFF
--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/helpers/EncoderHelpers.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/helpers/EncoderHelpers.java
@@ -29,6 +29,7 @@ import static org.apache.spark.sql.types.DataTypes.IntegerType;
 import static org.apache.spark.sql.types.DataTypes.LongType;
 
 import java.math.BigDecimal;
+import java.util.Arrays;
 import java.util.Collection;
 import java.util.HashMap;
 import java.util.List;
@@ -95,6 +96,7 @@ public class EncoderHelpers {
   private static final DataType WINDOWED_VALUE = new ObjectType(WindowedValue.class);
   private static final DataType KV_TYPE = new ObjectType(KV.class);
   private static final DataType MUTABLE_PAIR_TYPE = new ObjectType(MutablePair.class);
+  private static final DataType LIST_TYPE = new ObjectType(List.class);
 
   // Collections / maps of these types can be (de)serialized without (de)serializing each member
   private static final Set<Class<?>> PRIMITIV_TYPES =
@@ -464,13 +466,16 @@ public class EncoderHelpers {
   }
 
   private static <T> Expression deserializeSeq(
-      Expression in, Encoder<T> enc, boolean nullable, boolean asJava) {
+      Expression in, Encoder<T> enc, boolean nullable, boolean exposeAsJava) {
     DataType type = serializedType(enc); // input type is the serializer result type
     if (isPrimitiveEnc(enc)) {
-      ObjectType listType = new ObjectType(List.class);
-      return asJava ? invoke(Utils.class, "toList", listType, in, lit(type, DataType.class)) : in;
+      // Spark may reuse unsafe array data, if directly exposed it must be copied before
+      return exposeAsJava
+          ? invoke(Utils.class, "copyToList", LIST_TYPE, in, lit(type, DataType.class))
+          : in;
     }
-    Option<Class<?>> optCls = asJava ? Option.apply(List.class) : Option.empty();
+    Option<Class<?>> optCls = exposeAsJava ? Option.apply(List.class) : Option.empty();
+    // MapObjects will always copy
     return MapObjects$.MODULE$.apply(exp -> deserialize(exp, enc), in, type, nullable, optCls);
   }
 
@@ -547,8 +552,10 @@ public class EncoderHelpers {
       return Iterables.getOnlyElement(windows).maxTimestamp();
     }
 
-    public static List<Object> toList(ArrayData arrayData, DataType type) {
-      return JavaConverters.seqAsJavaList(arrayData.toSeq(type));
+    public static List<Object> copyToList(ArrayData arrayData, DataType type) {
+      // Note, this could be optimized for primitive arrays (if elements are not nullable) using
+      // Ints.asList(arrayData.toIntArray()) and similar
+      return Arrays.asList(arrayData.toObjectArray(type));
     }
 
     public static Seq<Object> toSeq(ArrayData arrayData) {


### PR DESCRIPTION
A bug in the collection encoder of the Spark dataset runner (aka Spark structured streaming runner) may result in corrupted data after a groupByKey if the dataset is converted to an RDD and persisted.

The collection encoder just wraps the underlying serialized UnsafeArrayData for primitive types to present a Collection as a result of deserialization. However, Spark may reuse the underlying unsafe object and with that corrupt values. 

This PR ensures the data is always copied when exposed. Usage in other cases such as Map deserialization is fine as values are eventually copied when constructing the map.

I wasn't able to reproduce this in a Unit test. VR tests in https://github.com/apache/beam/pull/25187 will verify the behavior.

Fixes #25296 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
