### PR TITLE
Evaluate removal of RDD caching for MEMORY_ONLY in the Spark Dataset runner

### DIFF
--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/ParDoTranslatorBatch.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/ParDoTranslatorBatch.java
@@ -23,7 +23,6 @@ import static org.apache.beam.runners.spark.structuredstreaming.translation.util
 import static org.apache.beam.sdk.util.Preconditions.checkStateNotNull;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkState;
 import static org.apache.spark.sql.functions.col;
-import static org.apache.spark.storage.StorageLevel.MEMORY_ONLY;
 
 import java.io.IOException;
 import java.util.ArrayList;
@@ -51,14 +50,12 @@ import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
 import org.apache.spark.broadcast.Broadcast;
-import org.apache.spark.rdd.RDD;
 import org.apache.spark.sql.Dataset;
 import org.apache.spark.sql.Encoder;
 import org.apache.spark.sql.TypedColumn;
 import org.apache.spark.storage.StorageLevel;
 import scala.Tuple2;
 import scala.collection.TraversableOnce;
-import scala.reflect.ClassTag;
 
 /**
  * Translator for {@link ParDo.MultiOutput} based on {@link DoFnRunners#simpleRunner}.
@@ -72,12 +69,6 @@ import scala.reflect.ClassTag;
 class ParDoTranslatorBatch<InputT, OutputT>
     extends TransformTranslator<
         PCollection<? extends InputT>, PCollectionTuple, ParDo.MultiOutput<InputT, OutputT>> {
-
-  private static final ClassTag<WindowedValue<Object>> WINDOWED_VALUE_CTAG =
-      ClassTag.apply(WindowedValue.class);
-
-  private static final ClassTag<Tuple2<Integer, WindowedValue<Object>>> TUPLE2_CTAG =
-      ClassTag.apply(Tuple2.class);
 
   ParDoTranslatorBatch() {
     super(0.2f);
@@ -148,46 +139,22 @@ class ParDoTranslatorBatch<InputT, OutputT>
 
       SparkCommonPipelineOptions opts = cxt.getOptions().as(SparkCommonPipelineOptions.class);
       StorageLevel storageLevel = StorageLevel.fromString(opts.getStorageLevel());
-      // If using storage level MEMORY_ONLY, it's best to persist the dataset as RDD to avoid any
-      // serialization / use of encoders. Persisting a Dataset, even if using a "deserialized"
-      // storage level, involves converting the data to the internal representation (InternalRow)
-      // by use of an encoder.
-      // For any other storage level, persist as Dataset, so we can select columns by TupleTag
-      // individually without restoring the entire row.
-      // In both cases caching of the outputs in the translation context is disabled to avoid
-      // caching the same data twice.
-      if (MEMORY_ONLY().equals(storageLevel)) {
 
-        RDD<Tuple2<Integer, WindowedValue<Object>>> allTagsRDD =
-            inputDs.rdd().mapPartitions(doFnMapper, false, TUPLE2_CTAG);
-        allTagsRDD.persist();
+      // Persist as wide rows with one column per TupleTag to support different schemas
+      Dataset<Tuple2<Integer, WindowedValue<Object>>> allTagsDS =
+          inputDs.mapPartitions(doFnMapper, oneOfEncoder(encoders));
+      allTagsDS.persist(storageLevel);
 
-        // divide into separate output datasets per tag
-        for (TupleTag<?> tag : outputs.keySet()) {
-          int colIdx = checkStateNotNull(tagColIdx.get(tag.getId()), "Unknown tag");
-          RDD<WindowedValue<Object>> rddByTag =
-              allTagsRDD.flatMap(selectByColumnIdx(colIdx), WINDOWED_VALUE_CTAG);
-          cxt.putDataset(
-              cxt.getOutput((TupleTag) tag),
-              cxt.getSparkSession().createDataset(rddByTag, encoders.get(colIdx)),
-              false);
-        }
-      } else {
-        // Persist as wide rows with one column per TupleTag to support different schemas
-        Dataset<Tuple2<Integer, WindowedValue<Object>>> allTagsDS =
-            inputDs.mapPartitions(doFnMapper, oneOfEncoder(encoders));
-        allTagsDS.persist(storageLevel);
+      // divide into separate output datasets per tag
+      for (TupleTag<?> tag : outputs.keySet()) {
+        int colIdx = checkStateNotNull(tagColIdx.get(tag.getId()), "Unknown tag");
+        // Resolve specific column matching the tuple tag (by id)
+        TypedColumn<Tuple2<Integer, WindowedValue<Object>>, WindowedValue<Object>> col =
+            (TypedColumn) col(Integer.toString(colIdx)).as(encoders.get(colIdx));
 
-        // divide into separate output datasets per tag
-        for (TupleTag<?> tag : outputs.keySet()) {
-          int colIdx = checkStateNotNull(tagColIdx.get(tag.getId()), "Unknown tag");
-          // Resolve specific column matching the tuple tag (by id)
-          TypedColumn<Tuple2<Integer, WindowedValue<Object>>, WindowedValue<Object>> col =
-              (TypedColumn) col(Integer.toString(colIdx)).as(encoders.get(colIdx));
-
-          cxt.putDataset(
-              cxt.getOutput((TupleTag) tag), allTagsDS.filter(col.isNotNull()).select(col), false);
-        }
+        // Caching of the returned outputs is disabled to avoid caching the same data twice.
+        cxt.putDataset(
+            cxt.getOutput((TupleTag) tag), allTagsDS.filter(col.isNotNull()).select(col), false);
       }
     } else {
       PCollection<OutputT> output = cxt.getOutput(mainOut);


### PR DESCRIPTION
A small simplification ... removing RDD caching for the Spark Dataset runner.

With the recent RDD linage fix (#25187) there's no visible improvement that justifies the added complexity. Moreover, the recommended storage level with Spark Datasets is MEMORY_AND_DISK (rather than MEMORY_ONLY). This makes RDD caching fairly irrelevant for production use cases with the Dataset runner.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
