### PR TITLE
[Playground] Fix Test_getRunOrTestCmd on Go 1.20

### DIFF
--- a/playground/backend/go.mod
+++ b/playground/backend/go.mod
@@ -30,6 +30,7 @@ require (
 	github.com/rs/cors v1.8.2
 	github.com/spf13/viper v1.14.0
 	github.com/stretchr/testify v1.8.1
+	github.com/google/go-cmp v0.5.9
 	go.uber.org/goleak v1.2.0
 	google.golang.org/grpc v1.51.0
 	google.golang.org/protobuf v1.28.1
@@ -49,7 +50,6 @@ require (
 	github.com/golang/groupcache v0.0.0-20210331224755-41bb18bfe9da // indirect
 	github.com/golang/protobuf v1.5.2 // indirect
 	github.com/golang/snappy v0.0.4 // indirect
-	github.com/google/go-cmp v0.5.9 // indirect
 	github.com/googleapis/enterprise-certificate-proxy v0.2.0 // indirect
 	github.com/googleapis/gax-go/v2 v2.6.0 // indirect
 	github.com/hashicorp/hcl v1.0.0 // indirect

--- a/playground/backend/internal/code_processing/code_processing_test.go
+++ b/playground/backend/internal/code_processing/code_processing_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"encoding/json"
 	"fmt"
+	"github.com/google/go-cmp/cmp"
 	"io/fs"
 	"os"
 	"os/exec"
@@ -626,10 +627,18 @@ func Test_getRunOrTestCmd(t *testing.T) {
 			want: wantTestExec,
 		},
 	}
+
+	execComparer := cmp.Comparer(func(a exec.Cmd, b exec.Cmd) bool {
+		return a.Path == b.Path &&
+			cmp.Equal(a.Args, b.Args) &&
+			cmp.Equal(a.Env, b.Env) &&
+			a.Dir == b.Dir
+	})
+
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getExecuteCmd(tt.args.isUnitTest, tt.args.executor, tt.args.ctxWithTimeout); got.String() != tt.want.String() {
-				t.Errorf("getExecuteCmd() = '%v', want '%v'", got.String(), tt.want.String())
+			if got := getExecuteCmd(tt.args.isUnitTest, tt.args.executor, tt.args.ctxWithTimeout); !cmp.Equal(got, tt.want, execComparer) {
+				t.Errorf("getExecuteCmd() = '%v', want '%v', diff = %v", got, tt.want, cmp.Diff(got, tt.want, execComparer))
 			}
 		})
 	}

--- a/playground/backend/internal/code_processing/code_processing_test.go
+++ b/playground/backend/internal/code_processing/code_processing_test.go
@@ -628,8 +628,8 @@ func Test_getRunOrTestCmd(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			if got := getExecuteCmd(tt.args.isUnitTest, tt.args.executor, tt.args.ctxWithTimeout); !reflect.DeepEqual(got, tt.want) {
-				t.Errorf("getExecuteCmd() = %v, want %v", got, tt.want)
+			if got := getExecuteCmd(tt.args.isUnitTest, tt.args.executor, tt.args.ctxWithTimeout); got.String() != tt.want.String() {
+				t.Errorf("getExecuteCmd() = '%v', want '%v'", got.String(), tt.want.String())
 			}
 		})
 	}


### PR DESCRIPTION
`os.exec.Cmd` struct was changed in Go 1.20, a new field `Cancel func() error` [had been added](https://cs.opensource.google/go/go/+/refs/tags/go1.20:src/os/exec/exec.go;drc=ea4631cc0cf301c824bd665a7980c13289ab5c9d;l=259) to it.

The `Test_getRunOrTestCmd` test relies on comparing two instances of `exec.Cmd` using `reflect.DeepEqual()`. Deep equality of structs is performed by doing deep equality checks on all of their members. Deep equality of `Func` values is [defined](https://cs.opensource.google/go/go/+/refs/tags/go1.20:src/reflect/deepequal.go;drc=ee0e40aaef3dc5c6fb8612dd80622e02fc4b574f;l=153) as `false` for all non-`nil` values. Because of this the test is failing on Go 1.20, as even two equivalent instances of `exec.Cmd` struct are no longer deeply equal due to the new `Cancel` field of type `func()`, because, as defined above, two non-`nil` functions are always not deeply equal.

This PR replaces the deep comparison with string comparison of the generated command line, as it's the intention of the test.

resolves #25380

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
