### PR TITLE
[Playground][Tour of Beam] Use example id as CloudPath

### DIFF
--- a/playground/backend/cmd/server/controller.go
+++ b/playground/backend/cmd/server/controller.go
@@ -5,7 +5,7 @@
 // (the "License"); you may not use this file except in compliance with
 // the License.  You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -48,7 +48,6 @@ const (
 	errorTitleGetDefaultExample = "Error during getting default example"
 	errorTitleRunCode           = "Error during run code"
 
-	userBadCloudPathErrMsg     = "Invalid cloud path parameter"
 	userCloudConnectionErrMsg  = "Cloud connection error"
 	resourceNotFoundErrMsg     = "Resource is not found"
 	resourceInconsistentErrMsg = "Resource is not consistent"
@@ -69,11 +68,11 @@ type playgroundController struct {
 }
 
 // RunCode is running code from requests using a particular SDK
-// - In case of incorrect sdk returns codes.InvalidArgument
-// - In case of error during preparing files/folders returns codes.Internal
-// - In case of no errors saves playground.Status_STATUS_EXECUTING as cache.Status into cache and sets expiration time
-//   for all cache values which will be saved into cache during processing received code.
-//   Returns id of code processing (pipelineId)
+//   - In case of incorrect sdk returns codes.InvalidArgument
+//   - In case of error during preparing files/folders returns codes.Internal
+//   - In case of no errors saves playground.Status_STATUS_EXECUTING as cache.Status into cache and sets expiration time
+//     for all cache values which will be saved into cache during processing received code.
+//     Returns id of code processing (pipelineId)
 func (controller *playgroundController) RunCode(ctx context.Context, info *pb.RunCodeRequest) (*pb.RunCodeResponse, error) {
 	// check for correct sdk
 	if info.Sdk != controller.env.BeamSdkEnvs.ApacheBeamSdk {
@@ -245,7 +244,7 @@ func (controller *playgroundController) GetRunError(ctx context.Context, info *p
 	return &pb.GetRunErrorResponse{Output: runError}, nil
 }
 
-//GetValidationOutput is returning output of validation for specific pipeline by PipelineUuid
+// GetValidationOutput is returning output of validation for specific pipeline by PipelineUuid
 func (controller *playgroundController) GetValidationOutput(ctx context.Context, info *pb.GetValidationOutputRequest) (*pb.GetValidationOutputResponse, error) {
 	pipelineId, err := uuid.Parse(info.PipelineUuid)
 	errorMessage := "Error during getting compilation output"
@@ -260,7 +259,7 @@ func (controller *playgroundController) GetValidationOutput(ctx context.Context,
 	return &pb.GetValidationOutputResponse{Output: validationOutput}, nil
 }
 
-//GetPreparationOutput is returning output of prepare step for specific pipeline by PipelineUuid
+// GetPreparationOutput is returning output of prepare step for specific pipeline by PipelineUuid
 func (controller *playgroundController) GetPreparationOutput(ctx context.Context, info *pb.GetPreparationOutputRequest) (*pb.GetPreparationOutputResponse, error) {
 	pipelineId, err := uuid.Parse(info.PipelineUuid)
 	errorMessage := "Error during getting compilation output"
@@ -275,7 +274,7 @@ func (controller *playgroundController) GetPreparationOutput(ctx context.Context
 	return &pb.GetPreparationOutputResponse{Output: preparationOutput}, nil
 }
 
-//GetCompileOutput is returning output of compilation for specific pipeline by PipelineUuid
+// GetCompileOutput is returning output of compilation for specific pipeline by PipelineUuid
 func (controller *playgroundController) GetCompileOutput(ctx context.Context, info *pb.GetCompileOutputRequest) (*pb.GetCompileOutputResponse, error) {
 	pipelineId, err := uuid.Parse(info.PipelineUuid)
 	errorMessage := "Error during getting compilation output"
@@ -290,7 +289,7 @@ func (controller *playgroundController) GetCompileOutput(ctx context.Context, in
 	return &pb.GetCompileOutputResponse{Output: compileOutput}, nil
 }
 
-//GetGraph is returning graph of execution for specific pipeline by PipelineUuid
+// GetGraph is returning graph of execution for specific pipeline by PipelineUuid
 func (controller *playgroundController) GetGraph(ctx context.Context, info *pb.GetGraphRequest) (*pb.GetGraphResponse, error) {
 	pipelineId, err := uuid.Parse(info.PipelineUuid)
 	errorMessage := "Error during getting graph output"
@@ -335,10 +334,7 @@ func (controller *playgroundController) GetPrecompiledObjects(ctx context.Contex
 
 // GetPrecompiledObject returns precompiled object from the Datastore or the cache
 func (controller *playgroundController) GetPrecompiledObject(ctx context.Context, info *pb.GetPrecompiledObjectRequest) (*pb.GetPrecompiledObjectResponse, error) {
-	exampleId, err := utils.GetExampleID(info.GetCloudPath())
-	if err != nil {
-		return nil, cerrors.InvalidArgumentError(errorTitleGetExample, userBadCloudPathErrMsg)
-	}
+	exampleId := info.GetCloudPath()
 	sdks, err := controller.cacheComponent.GetSdkCatalogFromCacheOrDatastore(ctx, controller.env.ApplicationEnvs.CacheRequestTimeout())
 	if err != nil {
 		return nil, cerrors.InternalError(errorTitleGetExample, userCloudConnectionErrMsg)
@@ -357,10 +353,7 @@ func (controller *playgroundController) GetPrecompiledObject(ctx context.Context
 
 // GetPrecompiledObjectCode returns the code of the specific example
 func (controller *playgroundController) GetPrecompiledObjectCode(ctx context.Context, info *pb.GetPrecompiledObjectCodeRequest) (*pb.GetPrecompiledObjectCodeResponse, error) {
-	exampleId, err := utils.GetExampleID(info.GetCloudPath())
-	if err != nil {
-		return nil, cerrors.InvalidArgumentError(errorTitleGetExampleCode, userBadCloudPathErrMsg)
-	}
+	exampleId := info.GetCloudPath()
 	files, err := controller.db.GetExampleCode(ctx, exampleId)
 	if err != nil {
 		switch err {
@@ -392,10 +385,7 @@ func (controller *playgroundController) GetPrecompiledObjectCode(ctx context.Con
 
 // GetPrecompiledObjectOutput returns the output of the compiled and run example
 func (controller *playgroundController) GetPrecompiledObjectOutput(ctx context.Context, info *pb.GetPrecompiledObjectOutputRequest) (*pb.GetPrecompiledObjectOutputResponse, error) {
-	exampleId, err := utils.GetExampleID(info.GetCloudPath())
-	if err != nil {
-		return nil, cerrors.InvalidArgumentError(errorTitleGetExampleOutput, userBadCloudPathErrMsg)
-	}
+	exampleId := info.GetCloudPath()
 	output, err := controller.db.GetExampleOutput(ctx, exampleId)
 	if err != nil {
 		switch err {
@@ -411,10 +401,7 @@ func (controller *playgroundController) GetPrecompiledObjectOutput(ctx context.C
 
 // GetPrecompiledObjectLogs returns the logs of the compiled and run example
 func (controller *playgroundController) GetPrecompiledObjectLogs(ctx context.Context, info *pb.GetPrecompiledObjectLogsRequest) (*pb.GetPrecompiledObjectLogsResponse, error) {
-	exampleId, err := utils.GetExampleID(info.GetCloudPath())
-	if err != nil {
-		return nil, cerrors.InvalidArgumentError(errorTitleGetExampleLogs, userBadCloudPathErrMsg)
-	}
+	exampleId := info.GetCloudPath()
 	logs, err := controller.db.GetExampleLogs(ctx, exampleId)
 	if err != nil {
 		switch err {
@@ -430,10 +417,7 @@ func (controller *playgroundController) GetPrecompiledObjectLogs(ctx context.Con
 
 // GetPrecompiledObjectGraph returns the graph of the compiled and run example
 func (controller *playgroundController) GetPrecompiledObjectGraph(ctx context.Context, info *pb.GetPrecompiledObjectGraphRequest) (*pb.GetPrecompiledObjectGraphResponse, error) {
-	exampleId, err := utils.GetExampleID(info.GetCloudPath())
-	if err != nil {
-		return nil, cerrors.InvalidArgumentError(errorTitleGetExampleGraph, userBadCloudPathErrMsg)
-	}
+	exampleId := info.GetCloudPath()
 	graph, err := controller.db.GetExampleGraph(ctx, exampleId)
 	if err != nil {
 		switch err {

--- a/playground/backend/cmd/server/controller_test.go
+++ b/playground/backend/cmd/server/controller_test.go
@@ -5,7 +5,7 @@
 // (the "License"); you may not use this file except in compliance with
 // the License.  You may obtain a copy of the License at
 //
-//    http://www.apache.org/licenses/LICENSE-2.0
+//	http://www.apache.org/licenses/LICENSE-2.0
 //
 // Unless required by applicable law or agreed to in writing, software
 // distributed under the License is distributed on an "AS IS" BASIS,
@@ -1121,14 +1121,14 @@ func TestPlaygroundController_GetPrecompiledObject(t *testing.T) {
 			name: "Getting an example in the usual case",
 			args: args{
 				ctx:  ctx,
-				info: &pb.GetPrecompiledObjectRequest{CloudPath: "SDK_JAVA/PRECOMPILED_OBJECT_TYPE_EXAMPLE/MOCK_DEFAULT_EXAMPLE"},
+				info: &pb.GetPrecompiledObjectRequest{CloudPath: "SDK_JAVA_MOCK_DEFAULT_EXAMPLE"},
 			},
 			wantErr: false,
 			check: func(response *pb.GetPrecompiledObjectResponse) {
 				expected := &pb.PrecompiledObject{
 					Sdk:             pb.Sdk_SDK_JAVA,
 					Multifile:       false,
-					CloudPath:       "SDK_JAVA/PRECOMPILED_OBJECT_TYPE_EXAMPLE/MOCK_DEFAULT_EXAMPLE",
+					CloudPath:       "SDK_JAVA_MOCK_DEFAULT_EXAMPLE",
 					Name:            "MOCK_DEFAULT_EXAMPLE",
 					Type:            pb.PrecompiledObjectType_PRECOMPILED_OBJECT_TYPE_EXAMPLE,
 					ContextLine:     10,
@@ -1148,14 +1148,14 @@ func TestPlaygroundController_GetPrecompiledObject(t *testing.T) {
 			name: "Getting an example with a dataset",
 			args: args{
 				ctx:  ctx,
-				info: &pb.GetPrecompiledObjectRequest{CloudPath: "SDK_JAVA/PRECOMPILED_OBJECT_TYPE_EXAMPLE/MOCK_NAME_DATASET"},
+				info: &pb.GetPrecompiledObjectRequest{CloudPath: "SDK_JAVA_MOCK_NAME_DATASET"},
 			},
 			wantErr: false,
 			check: func(response *pb.GetPrecompiledObjectResponse) {
 				expected := &pb.PrecompiledObject{
 					Sdk:             pb.Sdk_SDK_JAVA,
 					Multifile:       false,
-					CloudPath:       "SDK_JAVA/PRECOMPILED_OBJECT_TYPE_EXAMPLE/MOCK_NAME_DATASET",
+					CloudPath:       "SDK_JAVA_MOCK_NAME_DATASET",
 					Name:            "MOCK_NAME_DATASET",
 					Type:            pb.PrecompiledObjectType_PRECOMPILED_OBJECT_TYPE_EXAMPLE,
 					ContextLine:     10,
@@ -1210,7 +1210,7 @@ func TestPlaygroundController_GetPrecompiledObjectCode(t *testing.T) {
 			name: "Getting the code of single-file example",
 			args: args{
 				ctx:  ctx,
-				info: &pb.GetPrecompiledObjectCodeRequest{CloudPath: "SDK_JAVA/PRECOMPILED_OBJECT_TYPE_EXAMPLE/MOCK_DEFAULT_EXAMPLE"},
+				info: &pb.GetPrecompiledObjectCodeRequest{CloudPath: "SDK_JAVA_MOCK_DEFAULT_EXAMPLE"},
 			},
 			wantErr: false,
 			wantResponse: &pb.GetPrecompiledObjectCodeResponse{
@@ -1224,7 +1224,7 @@ func TestPlaygroundController_GetPrecompiledObjectCode(t *testing.T) {
 			name: "Getting the code of multifile example",
 			args: args{
 				ctx:  ctx,
-				info: &pb.GetPrecompiledObjectCodeRequest{CloudPath: "SDK_JAVA/PRECOMPILED_OBJECT_TYPE_EXAMPLE/MOCK_MULTIFILE"},
+				info: &pb.GetPrecompiledObjectCodeRequest{CloudPath: "SDK_JAVA_MOCK_MULTIFILE"},
 			},
 			wantErr: false,
 			wantResponse: &pb.GetPrecompiledObjectCodeResponse{
@@ -1269,7 +1269,7 @@ func TestPlaygroundController_GetPrecompiledObjectOutput(t *testing.T) {
 			name: "Getting the output of the compiled and run example in the usual case",
 			args: args{
 				ctx:  ctx,
-				info: &pb.GetPrecompiledObjectOutputRequest{CloudPath: "SDK_JAVA/PRECOMPILED_OBJECT_TYPE_EXAMPLE/MOCK_DEFAULT_EXAMPLE"},
+				info: &pb.GetPrecompiledObjectOutputRequest{CloudPath: "SDK_JAVA_MOCK_DEFAULT_EXAMPLE"},
 			},
 			wantErr:      false,
 			wantResponse: "MOCK_CONTENT_" + constants.PCOutputType,
@@ -1309,7 +1309,7 @@ func TestPlaygroundController_GetPrecompiledObjectLogs(t *testing.T) {
 			name: "Getting the logs of the compiled and run example in the usual case",
 			args: args{
 				ctx:  ctx,
-				info: &pb.GetPrecompiledObjectLogsRequest{CloudPath: "SDK_JAVA/PRECOMPILED_OBJECT_TYPE_EXAMPLE/MOCK_DEFAULT_EXAMPLE"},
+				info: &pb.GetPrecompiledObjectLogsRequest{CloudPath: "SDK_JAVA_MOCK_DEFAULT_EXAMPLE"},
 			},
 			wantErr:      false,
 			wantResponse: "MOCK_CONTENT_" + constants.PCLogType,
@@ -1349,7 +1349,7 @@ func TestPlaygroundController_GetPrecompiledObjectGraph(t *testing.T) {
 			name: "Getting the logs of the compiled and run example in the usual case",
 			args: args{
 				ctx:  ctx,
-				info: &pb.GetPrecompiledObjectGraphRequest{CloudPath: "SDK_JAVA/PRECOMPILED_OBJECT_TYPE_EXAMPLE/MOCK_DEFAULT_EXAMPLE"},
+				info: &pb.GetPrecompiledObjectGraphRequest{CloudPath: "SDK_JAVA_MOCK_DEFAULT_EXAMPLE"},
 			},
 			wantErr:      false,
 			wantResponse: "MOCK_CONTENT_" + constants.PCGraphType,
@@ -1402,7 +1402,7 @@ func TestPlaygroundController_GetDefaultPrecompiledObject(t *testing.T) {
 				return
 			}
 			if got.PrecompiledObject.Multifile != false ||
-				got.PrecompiledObject.CloudPath != "SDK_JAVA/PRECOMPILED_OBJECT_TYPE_EXAMPLE/MOCK_DEFAULT_EXAMPLE" ||
+				got.PrecompiledObject.CloudPath != "SDK_JAVA_MOCK_DEFAULT_EXAMPLE" ||
 				got.PrecompiledObject.Name != "MOCK_DEFAULT_EXAMPLE" ||
 				got.PrecompiledObject.Type != pb.PrecompiledObjectType_PRECOMPILED_OBJECT_TYPE_EXAMPLE ||
 				got.PrecompiledObject.ContextLine != 10 ||

--- a/playground/backend/internal/components/cache_component_test.go
+++ b/playground/backend/internal/components/cache_component_test.go
@@ -171,7 +171,7 @@ func TestCacheComponent_GetCatalogFromCacheOrDatastore(t *testing.T) {
 					actualPCObj.Multifile != false ||
 					actualPCObj.Name != "MOCK_EXAMPLE" ||
 					actualPCObj.Type.String() != "PRECOMPILED_OBJECT_TYPE_EXAMPLE" ||
-					actualPCObj.CloudPath != "SDK_JAVA/PRECOMPILED_OBJECT_TYPE_EXAMPLE/MOCK_EXAMPLE" ||
+					actualPCObj.CloudPath != "SDK_JAVA_MOCK_EXAMPLE" ||
 					actualPCObj.PipelineOptions != "MOCK_OPTIONS" ||
 					actualPCObj.Description != "MOCK_DESCR" ||
 					actualPCObj.Link != "MOCK_PATH" ||

--- a/playground/backend/internal/db/datastore/datastore_db_test.go
+++ b/playground/backend/internal/db/datastore/datastore_db_test.go
@@ -463,7 +463,7 @@ func TestDatastore_GetCatalog(t *testing.T) {
 					actualPCObj.Multifile != false ||
 					actualPCObj.Name != "MOCK_EXAMPLE" ||
 					actualPCObj.Type.String() != "PRECOMPILED_OBJECT_TYPE_EXAMPLE" ||
-					actualPCObj.CloudPath != "SDK_JAVA/PRECOMPILED_OBJECT_TYPE_EXAMPLE/MOCK_EXAMPLE" ||
+					actualPCObj.CloudPath != "SDK_JAVA_MOCK_EXAMPLE" ||
 					actualPCObj.PipelineOptions != "MOCK_OPTIONS" ||
 					actualPCObj.Description != "MOCK_DESCR" ||
 					actualPCObj.Link != "MOCK_PATH" ||
@@ -599,7 +599,7 @@ func TestDatastore_GetExample(t *testing.T) {
 					example.Type.String() != "PRECOMPILED_OBJECT_TYPE_EXAMPLE" ||
 					example.Link != "MOCK_PATH" ||
 					example.PipelineOptions != "MOCK_OPTIONS" ||
-					example.CloudPath != "SDK_JAVA/PRECOMPILED_OBJECT_TYPE_EXAMPLE/MOCK_EXAMPLE" ||
+					example.CloudPath != "SDK_JAVA_MOCK_EXAMPLE" ||
 					example.Complexity != pb.Complexity_COMPLEXITY_MEDIUM {
 					t.Errorf("GetExample() unexpected result: wrong precompiled obj")
 				}

--- a/playground/backend/internal/db/mapper/precompiled_object_mapper.go
+++ b/playground/backend/internal/db/mapper/precompiled_object_mapper.go
@@ -226,5 +226,5 @@ func putPrecompiledObjectsToCategory(categoryName string, precompiledObjects *dt
 
 // getCloudPath returns the cloud path by example entity
 func getCloudPath(example *entity.ExampleEntity) string {
-	return fmt.Sprintf("%s/%s/%s", example.Sdk.Name, example.Type, example.Name)
+	return fmt.Sprintf("%s_%s", example.Sdk.Name, example.Name)
 }

--- a/playground/backend/internal/db/mapper/precompiled_object_mapper_test.go
+++ b/playground/backend/internal/db/mapper/precompiled_object_mapper_test.go
@@ -33,7 +33,7 @@ var pcObjMapperCtx = context.Background()
 func TestPrecompiledObjectMapper_ToObjectInfo(t *testing.T) {
 	expected := &dto.ObjectInfo{
 		Name:            "MOCK_NAME",
-		CloudPath:       "SDK_JAVA/PRECOMPILED_OBJECT_TYPE_EXAMPLE/MOCK_NAME",
+		CloudPath:       "SDK_JAVA_MOCK_NAME",
 		Description:     "MOCK_DESCR",
 		Type:            pb.PrecompiledObjectType_PRECOMPILED_OBJECT_TYPE_EXAMPLE,
 		Complexity:      pb.Complexity_COMPLEXITY_MEDIUM,
@@ -61,7 +61,7 @@ func TestPrecompiledObjectMapper_ToObjectInfo(t *testing.T) {
 func TestPrecompiledObjectMapper_ToPrecompiledObj(t *testing.T) {
 	expected := &pb.PrecompiledObject{
 		Name:            "MOCK_NAME",
-		CloudPath:       "SDK_JAVA/PRECOMPILED_OBJECT_TYPE_EXAMPLE/MOCK_NAME",
+		CloudPath:       "SDK_JAVA_MOCK_NAME",
 		Description:     "MOCK_DESCR",
 		Type:            pb.PrecompiledObjectType_PRECOMPILED_OBJECT_TYPE_EXAMPLE,
 		Complexity:      pb.Complexity_COMPLEXITY_MEDIUM,
@@ -98,7 +98,7 @@ func TestPrecompiledObjectMapper_ToDefaultPrecompiledObjects(t *testing.T) {
 			Link:            "MOCK_PATH",
 			Description:     "MOCK_DESCR",
 			PipelineOptions: "MOCK_OPTIONS",
-			CloudPath:       "SDK_JAVA/PRECOMPILED_OBJECT_TYPE_EXAMPLE/1_MOCK_DEFAULT_EXAMPLE",
+			CloudPath:       "SDK_JAVA_1_MOCK_DEFAULT_EXAMPLE",
 			Sdk:             pb.Sdk_SDK_JAVA,
 		},
 		pb.Sdk_SDK_GO: {
@@ -111,7 +111,7 @@ func TestPrecompiledObjectMapper_ToDefaultPrecompiledObjects(t *testing.T) {
 			Link:            "MOCK_PATH",
 			Description:     "MOCK_DESCR",
 			PipelineOptions: "MOCK_OPTIONS",
-			CloudPath:       "SDK_GO/PRECOMPILED_OBJECT_TYPE_EXAMPLE/2_MOCK_DEFAULT_EXAMPLE",
+			CloudPath:       "SDK_GO_2_MOCK_DEFAULT_EXAMPLE",
 			Sdk:             pb.Sdk_SDK_GO,
 		},
 		pb.Sdk_SDK_PYTHON: {
@@ -124,7 +124,7 @@ func TestPrecompiledObjectMapper_ToDefaultPrecompiledObjects(t *testing.T) {
 			Link:            "MOCK_PATH",
 			Description:     "MOCK_DESCR",
 			PipelineOptions: "MOCK_OPTIONS",
-			CloudPath:       "SDK_PYTHON/PRECOMPILED_OBJECT_TYPE_EXAMPLE/3_MOCK_DEFAULT_EXAMPLE",
+			CloudPath:       "SDK_PYTHON_3_MOCK_DEFAULT_EXAMPLE",
 			Sdk:             pb.Sdk_SDK_PYTHON,
 		},
 		pb.Sdk_SDK_SCIO: {
@@ -137,7 +137,7 @@ func TestPrecompiledObjectMapper_ToDefaultPrecompiledObjects(t *testing.T) {
 			Link:            "MOCK_PATH",
 			Description:     "MOCK_DESCR",
 			PipelineOptions: "MOCK_OPTIONS",
-			CloudPath:       "SDK_SCIO/PRECOMPILED_OBJECT_TYPE_EXAMPLE/4_MOCK_DEFAULT_EXAMPLE",
+			CloudPath:       "SDK_SCIO_4_MOCK_DEFAULT_EXAMPLE",
 			Sdk:             pb.Sdk_SDK_SCIO,
 		},
 	}
@@ -151,7 +151,7 @@ func TestPrecompiledObjectMapper_ToArrayCategories(t *testing.T) {
 		len(javaCatalog.Categories[0].PrecompiledObjects) != 1 ||
 		javaCatalog.Categories[0].PrecompiledObjects[0].Name != "SDK_JAVA_MOCK_NAME" ||
 		javaCatalog.Categories[0].PrecompiledObjects[0].Description != "MOCK_DESCR" ||
-		javaCatalog.Categories[0].PrecompiledObjects[0].CloudPath != "SDK_JAVA/PRECOMPILED_OBJECT_TYPE_EXAMPLE/SDK_JAVA_MOCK_NAME" ||
+		javaCatalog.Categories[0].PrecompiledObjects[0].CloudPath != "SDK_JAVA_SDK_JAVA_MOCK_NAME" ||
 		javaCatalog.Categories[0].PrecompiledObjects[0].Multifile != false ||
 		javaCatalog.Categories[0].PrecompiledObjects[0].DefaultExample != false ||
 		javaCatalog.Categories[0].PrecompiledObjects[0].Link != "MOCK_PATH" ||
@@ -166,7 +166,7 @@ func TestPrecompiledObjectMapper_ToArrayCategories(t *testing.T) {
 		len(goCatalog.Categories[0].PrecompiledObjects) != 1 ||
 		goCatalog.Categories[0].PrecompiledObjects[0].Name != "SDK_GO_MOCK_NAME" ||
 		goCatalog.Categories[0].PrecompiledObjects[0].Description != "MOCK_DESCR" ||
-		goCatalog.Categories[0].PrecompiledObjects[0].CloudPath != "SDK_GO/PRECOMPILED_OBJECT_TYPE_EXAMPLE/SDK_GO_MOCK_NAME" ||
+		goCatalog.Categories[0].PrecompiledObjects[0].CloudPath != "SDK_GO_SDK_GO_MOCK_NAME" ||
 		goCatalog.Categories[0].PrecompiledObjects[0].Multifile != false ||
 		goCatalog.Categories[0].PrecompiledObjects[0].DefaultExample != false ||
 		goCatalog.Categories[0].PrecompiledObjects[0].Link != "MOCK_PATH" ||
@@ -181,7 +181,7 @@ func TestPrecompiledObjectMapper_ToArrayCategories(t *testing.T) {
 		len(pythonCatalog.Categories[0].PrecompiledObjects) != 1 ||
 		pythonCatalog.Categories[0].PrecompiledObjects[0].Name != "SDK_PYTHON_MOCK_NAME" ||
 		pythonCatalog.Categories[0].PrecompiledObjects[0].Description != "MOCK_DESCR" ||
-		pythonCatalog.Categories[0].PrecompiledObjects[0].CloudPath != "SDK_PYTHON/PRECOMPILED_OBJECT_TYPE_EXAMPLE/SDK_PYTHON_MOCK_NAME" ||
+		pythonCatalog.Categories[0].PrecompiledObjects[0].CloudPath != "SDK_PYTHON_SDK_PYTHON_MOCK_NAME" ||
 		pythonCatalog.Categories[0].PrecompiledObjects[0].Multifile != false ||
 		pythonCatalog.Categories[0].PrecompiledObjects[0].DefaultExample != false ||
 		pythonCatalog.Categories[0].PrecompiledObjects[0].Link != "MOCK_PATH" ||
@@ -196,7 +196,7 @@ func TestPrecompiledObjectMapper_ToArrayCategories(t *testing.T) {
 		len(scioCatalog.Categories[0].PrecompiledObjects) != 1 ||
 		scioCatalog.Categories[0].PrecompiledObjects[0].Name != "SDK_SCIO_MOCK_NAME" ||
 		scioCatalog.Categories[0].PrecompiledObjects[0].Description != "MOCK_DESCR" ||
-		scioCatalog.Categories[0].PrecompiledObjects[0].CloudPath != "SDK_SCIO/PRECOMPILED_OBJECT_TYPE_EXAMPLE/SDK_SCIO_MOCK_NAME" ||
+		scioCatalog.Categories[0].PrecompiledObjects[0].CloudPath != "SDK_SCIO_SDK_SCIO_MOCK_NAME" ||
 		scioCatalog.Categories[0].PrecompiledObjects[0].Multifile != false ||
 		scioCatalog.Categories[0].PrecompiledObjects[0].DefaultExample != false ||
 		scioCatalog.Categories[0].PrecompiledObjects[0].Link != "MOCK_PATH" ||

--- a/playground/backend/internal/utils/datastore_utils.go
+++ b/playground/backend/internal/utils/datastore_utils.go
@@ -17,7 +17,6 @@ package utils
 
 import (
 	"context"
-	"fmt"
 	"os"
 	"strconv"
 	"strings"
@@ -25,7 +24,6 @@ import (
 	"cloud.google.com/go/datastore"
 
 	"beam.apache.org/playground/backend/internal/constants"
-	"beam.apache.org/playground/backend/internal/logger"
 )
 
 func GetExampleKey(ctx context.Context, values ...interface{}) *datastore.Key {
@@ -61,15 +59,6 @@ func GetSnippetKey(ctx context.Context, values ...interface{}) *datastore.Key {
 func GetPCObjectKey(ctx context.Context, values ...interface{}) *datastore.Key {
 	id := GetIDWithDelimiter(values...)
 	return getNameKey(ctx, constants.PCObjectKind, id, nil)
-}
-
-func GetExampleID(cloudPath string) (string, error) {
-	cloudPathParams := strings.Split(cloudPath, constants.CloudPathDelimiter)
-	if len(cloudPathParams) < 3 {
-		logger.Error("the wrong cloud path from a client")
-		return "", fmt.Errorf("cloud path doesn't have all options. The minimum size must be 3")
-	}
-	return GetIDWithDelimiter(cloudPathParams[0], cloudPathParams[2]), nil
 }
 
 func GetIDWithDelimiter(values ...interface{}) string {

--- a/playground/backend/internal/utils/datastore_utils_test.go
+++ b/playground/backend/internal/utils/datastore_utils_test.go
@@ -84,48 +84,6 @@ func TestGetPCObjectKey(t *testing.T) {
 	}
 }
 
-func TestGetExampleID(t *testing.T) {
-	tests := []struct {
-		name              string
-		cloudPath         string
-		expectedExampleId string
-		wantErr           bool
-	}{
-		{
-			name:              "Getting example identifier in the usual case",
-			cloudPath:         "SDK_JAVA/PRECOMPILED_OBJECT_TYPE_EXAMPLE/MOCK_EXAMPLE",
-			expectedExampleId: "SDK_JAVA_MOCK_EXAMPLE",
-			wantErr:           false,
-		},
-		{
-			name:              "Getting example identifier when invalid the cloud path",
-			cloudPath:         "SDK_JAVA/PRECOMPILED_OBJECT_TYPE_EXAMPLE",
-			expectedExampleId: "SDK_JAVA_MOCK_EXAMPLE",
-			wantErr:           true,
-		},
-		{
-			name:              "Getting example identifier when the cloud path is empty",
-			cloudPath:         "",
-			expectedExampleId: "SDK_JAVA_MOCK_EXAMPLE",
-			wantErr:           true,
-		},
-	}
-
-	for _, tt := range tests {
-		t.Run(tt.name, func(t *testing.T) {
-			exampleId, err := GetExampleID(tt.cloudPath)
-			if (err != nil) != tt.wantErr {
-				t.Errorf("GetExampleID() error = %v, wantErr %v", err, tt.wantErr)
-			}
-			if err == nil {
-				if exampleId != tt.expectedExampleId {
-					t.Error("GetExampleID() unexpected result")
-				}
-			}
-		})
-	}
-}
-
 func TestGetIDWithDelimiter(t *testing.T) {
 	tests := []struct {
 		name           string


### PR DESCRIPTION
Make `CloudPath` values to be examples' IDs . The intention is to allow Tour of Beam to load precompiled examples easily, without having to rewrite IDs into CloudPath strings.

This change has no effect on Playground frontend as it doesn't do any transformations to the CloudPath string and uses it as is.

addresses #25484

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
