### PR TITLE
Fix pull_licenses_java returning 404 from opensource.org

### DIFF
--- a/sdks/java/container/license_scripts/pull_licenses_java.py
+++ b/sdks/java/container/license_scripts/pull_licenses_java.py
@@ -54,6 +54,10 @@ def pull_from_url(file_name, url, dep, no_list):
         url = url.format(manual_license_path)
         logging.info('Replaced local file URL with {url} for {dep}'.format(url=url, dep=dep))
 
+    # Take into account opensource.org changes that cause 404 on licenses
+    if 'opensource.org' in url and url.endswith('-license.php'):
+        url = url.replace('-license.php', '')
+
     try:
         url_read = urlopen(Request(url, headers={
             'User-Agent': 'Apache Beam',


### PR DESCRIPTION
Apparently opensource.org changed the paths to reach license from https://opensource.org/licenses/mit-license.php -> https://opensource.org/licenses/mit/

This change fixes recent snapshot breakages.


For example: https://ci-beam.apache.org/job/beam_Publish_Beam_SDK_Snapshots/4836/console

```
11:17:12 ERROR:root:Invalid url for pcollections-2.1.2: http://www.opensource.org/licenses/mit-license.php. Retrying...
11:17:12 Traceback (most recent call last):
11:17:12   File "/home/jenkins/jenkins-slave/workspace/beam_Publish_Beam_SDK_Snapshots/src/sdks/java/container/license_scripts/pull_licenses_java.py", line 58, in pull_from_url
11:17:12     url_read = urlopen(Request(url, headers={
```