### PR TITLE
[Go SDK]: Retrieve file size in CreateInitialRestriction in textio.Read

### DIFF
--- a/sdks/go/pkg/beam/io/textio/textio.go
+++ b/sdks/go/pkg/beam/io/textio/textio.go
@@ -34,7 +34,6 @@ import (
 
 func init() {
 	beam.RegisterType(reflect.TypeOf((*readFn)(nil)).Elem())
-	beam.RegisterFunction(sizeFn)
 	beam.RegisterType(reflect.TypeOf((*writeFileFn)(nil)).Elem())
 	beam.RegisterFunction(expandFn)
 }
@@ -82,8 +81,7 @@ func ReadAllSdf(s beam.Scope, col beam.PCollection) beam.PCollection {
 // into separate bundles.
 func read(s beam.Scope, col beam.PCollection) beam.PCollection {
 	files := beam.ParDo(s, expandFn, col)
-	sized := beam.ParDo(s, sizeFn, files)
-	return beam.ParDo(s, &readFn{}, sized)
+	return beam.ParDo(s, &readFn{}, files)
 }
 
 // expandFn expands a glob pattern into all matching file names.
@@ -108,23 +106,6 @@ func expandFn(ctx context.Context, glob string, emit func(string)) error {
 	return nil
 }
 
-// sizeFn pairs a filename with the size of that file in bytes.
-// TODO(https://github.com/apache/beam/issues/20607): Once CreateInitialRestriction supports Context params and
-// error return values, this can be done in readSdfFn.CreateInitialRestriction.
-func sizeFn(ctx context.Context, filename string) (string, int64, error) {
-	fs, err := filesystem.New(ctx, filename)
-	if err != nil {
-		return "", -1, err
-	}
-	defer fs.Close()
-
-	size, err := fs.Size(ctx, filename)
-	if err != nil {
-		return "", -1, err
-	}
-	return filename, size, nil
-}
-
 // readFn reads individual lines from a text file, given a filename and a
 // size in bytes for that file. Implemented as an SDF to allow splitting
 // within a file.
@@ -132,12 +113,23 @@ type readFn struct {
 }
 
 // CreateInitialRestriction creates an offset range restriction representing
-// the file, using the paired size rather than fetching the file's size.
-func (fn *readFn) CreateInitialRestriction(_ string, size int64) offsetrange.Restriction {
+// the file's size in bytes.
+func (fn *readFn) CreateInitialRestriction(ctx context.Context, filename string) (offsetrange.Restriction, error) {
+	fs, err := filesystem.New(ctx, filename)
+	if err != nil {
+		return offsetrange.Restriction{}, err
+	}
+	defer fs.Close()
+
+	size, err := fs.Size(ctx, filename)
+	if err != nil {
+		return offsetrange.Restriction{}, err
+	}
+
 	return offsetrange.Restriction{
 		Start: 0,
 		End:   size,
-	}
+	}, nil
 }
 
 const (
@@ -150,7 +142,7 @@ const (
 
 // SplitRestriction splits each file restriction into blocks of a predeterined
 // size, with some checks to avoid having small remainders.
-func (fn *readFn) SplitRestriction(_ string, _ int64, rest offsetrange.Restriction) []offsetrange.Restriction {
+func (fn *readFn) SplitRestriction(_ string, rest offsetrange.Restriction) []offsetrange.Restriction {
 	splits := rest.SizedSplits(blockSize)
 	numSplits := len(splits)
 	if numSplits > 1 {
@@ -165,7 +157,7 @@ func (fn *readFn) SplitRestriction(_ string, _ int64, rest offsetrange.Restricti
 }
 
 // Size returns the size of each restriction as its range.
-func (fn *readFn) RestrictionSize(_ string, _ int64, rest offsetrange.Restriction) float64 {
+func (fn *readFn) RestrictionSize(_ string, rest offsetrange.Restriction) float64 {
 	return rest.Size()
 }
 
@@ -183,7 +175,7 @@ func (fn *readFn) CreateTracker(rest offsetrange.Restriction) *sdf.LockRTracker 
 // begin within the restriction and past the restriction (those are entirely
 // output, including the portion outside the restriction). In some cases a
 // valid restriction might not output any lines.
-func (fn *readFn) ProcessElement(ctx context.Context, rt *sdf.LockRTracker, filename string, _ int64, emit func(string)) error {
+func (fn *readFn) ProcessElement(ctx context.Context, rt *sdf.LockRTracker, filename string, emit func(string)) error {
 	log.Infof(ctx, "Reading from %v", filename)
 
 	fs, err := filesystem.New(ctx, filename)

--- a/sdks/go/pkg/beam/io/textio/textio.go
+++ b/sdks/go/pkg/beam/io/textio/textio.go
@@ -106,9 +106,8 @@ func expandFn(ctx context.Context, glob string, emit func(string)) error {
 	return nil
 }
 
-// readFn reads individual lines from a text file, given a filename and a
-// size in bytes for that file. Implemented as an SDF to allow splitting
-// within a file.
+// readFn reads individual lines from a text file. Implemented as an SDF
+// to allow splitting within a file.
 type readFn struct {
 }
 


### PR DESCRIPTION
Fixes #25532 and refactors `textio.Read` to retrieve the file's size in `readFn.CreateInitialRestriction` instead of in a separate DoFn.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
