### PR TITLE
Backlog metrics do not showing up in FlinkRunner

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/ReaderInvocationUtil.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/ReaderInvocationUtil.java
@@ -71,8 +71,8 @@ public class ReaderInvocationUtil<OutputT, ReaderT extends Source.Reader<OutputT
     }
   }
 
-  public UnboundedSource.CheckpointMark invokeCheckpointMark(UnboundedSource.UnboundedReader<OutputT> reader)
-          throws IOException {
+  public UnboundedSource.CheckpointMark invokeCheckpointMark(
+      UnboundedSource.UnboundedReader<OutputT> reader) throws IOException {
     if (enableMetrics) {
       try (Closeable ignored =
           MetricsEnvironment.scopedMetricsContainer(container.getMetricsContainer(stepName))) {

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/ReaderInvocationUtil.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/ReaderInvocationUtil.java
@@ -22,6 +22,7 @@ import java.io.IOException;
 import org.apache.beam.runners.core.metrics.MetricsContainerImpl;
 import org.apache.beam.runners.flink.FlinkPipelineOptions;
 import org.apache.beam.sdk.io.Source;
+import org.apache.beam.sdk.io.UnboundedSource;
 import org.apache.beam.sdk.metrics.MetricsEnvironment;
 import org.apache.beam.sdk.options.PipelineOptions;
 
@@ -67,6 +68,20 @@ public class ReaderInvocationUtil<OutputT, ReaderT extends Source.Reader<OutputT
       }
     } else {
       return reader.advance();
+    }
+  }
+
+  public UnboundedSource.CheckpointMark invokeCheckpointMark(UnboundedSource.UnboundedReader<OutputT> reader)
+          throws IOException {
+    if (enableMetrics) {
+      try (Closeable ignored =
+          MetricsEnvironment.scopedMetricsContainer(container.getMetricsContainer(stepName))) {
+        UnboundedSource.CheckpointMark result = reader.getCheckpointMark();
+        container.updateMetrics(stepName);
+        return result;
+      }
+    } else {
+      return reader.getCheckpointMark();
     }
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
@@ -392,7 +392,7 @@ public class UnboundedSourceWrapper<OutputT, CheckpointMarkT extends UnboundedSo
       }
 
       ReaderInvocationUtil<OutputT, UnboundedSource.UnboundedReader<OutputT>> readerInvoker =
-              new ReaderInvocationUtil<>(stepName, serializedOptions.get(), metricContainer);
+          new ReaderInvocationUtil<>(stepName, serializedOptions.get(), metricContainer);
 
       stateForCheckpoint.clear();
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/UnboundedSourceWrapper.java
@@ -391,6 +391,9 @@ public class UnboundedSourceWrapper<OutputT, CheckpointMarkT extends UnboundedSo
         return;
       }
 
+      ReaderInvocationUtil<OutputT, UnboundedSource.UnboundedReader<OutputT>> readerInvoker =
+              new ReaderInvocationUtil<>(stepName, serializedOptions.get(), metricContainer);
+
       stateForCheckpoint.clear();
 
       long checkpointId = functionSnapshotContext.getCheckpointId();
@@ -405,7 +408,7 @@ public class UnboundedSourceWrapper<OutputT, CheckpointMarkT extends UnboundedSo
         UnboundedSource.UnboundedReader<OutputT> reader = localReaders.get(i);
 
         @SuppressWarnings("unchecked")
-        CheckpointMarkT mark = (CheckpointMarkT) reader.getCheckpointMark();
+        CheckpointMarkT mark = (CheckpointMarkT) readerInvoker.invokeCheckpointMark(reader);
         checkpointMarks.add(mark);
         KV<UnboundedSource<OutputT, CheckpointMarkT>, CheckpointMarkT> kv = KV.of(source, mark);
         stateForCheckpoint.add(kv);


### PR DESCRIPTION
We have a Flink Job which does not emit backlog metrics. Actually metrics are emitting in KafkaIO. However I could not see them on Flink Metric system. Looks like Beam -> Flink wiring is broken. I set metricContext in Checkpointing phase which is the place metrics emit on UnBoundedReader.

@mxm @tweise @angoenka Could you please review my MR ? I tested in our env. It is working as expected.


