### PR TITLE
#25626 Use the correct constructor when creating StreamWriter

### DIFF
--- a/sdks/java/extensions/timeseries/src/test/java/org/apache/beam/sdk/extensions/timeseries/FillGapsTest.java
+++ b/sdks/java/extensions/timeseries/src/test/java/org/apache/beam/sdk/extensions/timeseries/FillGapsTest.java
@@ -29,12 +29,13 @@ import org.apache.beam.sdk.testing.UsesLoopingTimer;
 import org.apache.beam.sdk.testing.UsesStatefulParDo;
 import org.apache.beam.sdk.testing.UsesStrictTimerOrdering;
 import org.apache.beam.sdk.testing.UsesTimersInParDo;
-import org.apache.beam.sdk.transforms.Create;
-import org.apache.beam.sdk.transforms.Reify;
+import org.apache.beam.sdk.transforms.*;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.TimestampedValue;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
@@ -91,6 +92,20 @@ public class FillGapsTest {
     abstract Builder toBuilder();
   }
 
+  static class PrintingDoFn extends DoFn<KV<Instant, Iterable<TimestampedValue<Message>>>, Void> {
+    @ProcessElement
+    public void process(@Element KV<Instant, Iterable<TimestampedValue<Message>>> el) {
+      StringBuilder builder = new StringBuilder();
+      builder.append("------").append(el.getKey()).append("------").append("\n");
+      Iterable<TimestampedValue<Message>> messages = el.getValue();
+      for (TimestampedValue<Message> message : messages) {
+        builder.append("\t").append(message.getTimestamp()).append(":").append(message.getValue().getKey())
+                .append("|").append(message.getValue().getValue());
+      }
+      System.out.println(builder);
+    }
+  }
+
   @Test
   public void testFillGaps() {
     List<TimestampedValue<Message>> values =
@@ -112,9 +127,15 @@ public class FillGapsTest {
             .apply(
                 FillGaps.<Message>of(Duration.standardSeconds(1), "key")
                     .withStopTime(Instant.ofEpochSecond(5)))
-            .apply(Reify.timestamps());
+            .apply(Reify.timestamps())
+                    .setCoder(TimestampedValue.TimestampedValueCoder.of(input.getCoder()));
 
-    FixedWindows fixedWindows = FixedWindows.of(Duration.standardSeconds(1));
+    PCollection<KV<Instant, Iterable<TimestampedValue<Message>>>> kvTimedMessages = gapFilled
+            .apply(WithKeys.of((TimestampedValue<Message> x)->x.getTimestamp()).withKeyType(TypeDescriptor.of(Instant.class)))
+                    .apply(GroupByKey.create());
+    kvTimedMessages.apply(ParDo.of(new PrintingDoFn()));
+
+            FixedWindows fixedWindows = FixedWindows.of(Duration.standardSeconds(1));
     PAssert.that(gapFilled)
         .containsInAnyOrder(
             Iterables.concat(

--- a/sdks/java/extensions/timeseries/src/test/java/org/apache/beam/sdk/extensions/timeseries/FillGapsTest.java
+++ b/sdks/java/extensions/timeseries/src/test/java/org/apache/beam/sdk/extensions/timeseries/FillGapsTest.java
@@ -99,8 +99,13 @@ public class FillGapsTest {
       builder.append("------").append(el.getKey()).append("------").append("\n");
       Iterable<TimestampedValue<Message>> messages = el.getValue();
       for (TimestampedValue<Message> message : messages) {
-        builder.append("\t").append(message.getTimestamp()).append(":").append(message.getValue().getKey())
-                .append("|").append(message.getValue().getValue());
+        builder
+            .append("\t")
+            .append(message.getTimestamp())
+            .append(":")
+            .append(message.getValue().getKey())
+            .append("|")
+            .append(message.getValue().getValue());
       }
       System.out.println(builder);
     }
@@ -128,14 +133,17 @@ public class FillGapsTest {
                 FillGaps.<Message>of(Duration.standardSeconds(1), "key")
                     .withStopTime(Instant.ofEpochSecond(5)))
             .apply(Reify.timestamps())
-                    .setCoder(TimestampedValue.TimestampedValueCoder.of(input.getCoder()));
+            .setCoder(TimestampedValue.TimestampedValueCoder.of(input.getCoder()));
 
-    PCollection<KV<Instant, Iterable<TimestampedValue<Message>>>> kvTimedMessages = gapFilled
-            .apply(WithKeys.of((TimestampedValue<Message> x)->x.getTimestamp()).withKeyType(TypeDescriptor.of(Instant.class)))
-                    .apply(GroupByKey.create());
+    PCollection<KV<Instant, Iterable<TimestampedValue<Message>>>> kvTimedMessages =
+        gapFilled
+            .apply(
+                WithKeys.of((TimestampedValue<Message> x) -> x.getTimestamp())
+                    .withKeyType(TypeDescriptor.of(Instant.class)))
+            .apply(GroupByKey.create());
     kvTimedMessages.apply(ParDo.of(new PrintingDoFn()));
 
-            FixedWindows fixedWindows = FixedWindows.of(Duration.standardSeconds(1));
+    FixedWindows fixedWindows = FixedWindows.of(Duration.standardSeconds(1));
     PAssert.that(gapFilled)
         .containsInAnyOrder(
             Iterables.concat(

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java
@@ -1338,7 +1338,9 @@ class BigQueryServicesImpl implements BigQueryServices {
               .build();
 
       StreamWriter streamWriter =
-          StreamWriter.newBuilder(streamName, newWriteClient)
+          StreamWriter.newBuilder(
+                  streamName,
+                  org.apache.beam.sdk.util.Preconditions.checkStateNotNull(newWriteClient))
               .setWriterSchema(protoSchema)
               .setChannelProvider(transportChannelProvider)
               .setEnableConnectionPool(useConnectionPool)

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java
@@ -1338,7 +1338,7 @@ class BigQueryServicesImpl implements BigQueryServices {
               .build();
 
       StreamWriter streamWriter =
-          StreamWriter.newBuilder(streamName)
+          StreamWriter.newBuilder(streamName, newWriteClient)
               .setWriterSchema(protoSchema)
               .setChannelProvider(transportChannelProvider)
               .setEnableConnectionPool(useConnectionPool)


### PR DESCRIPTION
This ensures that all StreamWriter instances use the single static threadpool