### PR TITLE
Fix example code on from-spark.md

### DIFF
--- a/website/www/site/content/en/get-started/from-spark.md
+++ b/website/www/site/content/en/get-started/from-spark.md
@@ -312,11 +312,12 @@ with beam.Pipeline() as pipeline:
     min_value = values | beam.CombineGlobally(min)
     max_value = values | beam.CombineGlobally(max)
 
-    # To access `total`, we need to pass it as a side input.
+    # To access `min_value` and `max_value`, we need to pass them as a side input.
     scaled_values = values | beam.Map(
-        lambda x, min_value, max_value: x / lambda x: (x - min_value) / (max_value - min_value),
-        min_value =beam.pvalue.AsSingleton(min_value),
-        max_value =beam.pvalue.AsSingleton(max_value))
+        lambda x, minimum, maximum: (x - minimum) / (maximum - minimum),
+        minimum=beam.pvalue.AsSingleton(min_value),
+        maximum=beam.pvalue.AsSingleton(max_value),
+    )
 
     scaled_values | beam.Map(print)
 {{< /highlight >}}


### PR DESCRIPTION
The following example with Python code for Beam is invalid in the [documentation](https://beam.apache.org/get-started/from-spark/#using-calculated-values):
```python
import apache_beam as beam

with beam.Pipeline() as pipeline:
    values = pipeline | beam.Create([1, 2, 3, 4])
    min_value = values | beam.CombineGlobally(min)
    max_value = values | beam.CombineGlobally(max)

    # To access `total`, we need to pass it as a side input.
    scaled_values = values | beam.Map(
        lambda x, min_value, max_value: x / lambda x: (x - min_value) / (max_value - min_value),
        min_value =beam.pvalue.AsSingleton(min_value),
        max_value =beam.pvalue.AsSingleton(max_value))

    scaled_values | beam.Map(print)
```

Python interpreter returns **SyntaxError** during the execution of this code:
```bash
  File "playground/spark_side_inputs.py", line 10
    lambda x, min_value, max_value: x / lambda x: (x - min_value) / (max_value - min_value),
                                        ^
SyntaxError: invalid syntax

```

In this PR, I fix this code block to make it valid for Python interpreter.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
