### PR TITLE
Fix most Go SDK compile and bugs on Windows.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/download_test.go
+++ b/sdks/go/pkg/beam/core/runtime/xlangx/expansionx/download_test.go
@@ -172,7 +172,7 @@ func TestJarExists_bad(t *testing.T) {
 }
 
 func getGeneratedNumberInFile(fileName, jarPrefix string) string {
-	tmpFileNameSplit := strings.Split(fileName, "/")
+	tmpFileNameSplit := strings.Split(fileName, string(filepath.Separator))
 	tmpFileName := tmpFileNameSplit[len(tmpFileNameSplit)-1]
 	numSuffix := strings.TrimPrefix(tmpFileName, jarPrefix)
 	return strings.TrimSuffix(numSuffix, ".jar")

--- a/sdks/go/pkg/beam/core/util/symtab/symtab_test.go
+++ b/sdks/go/pkg/beam/core/util/symtab/symtab_test.go
@@ -85,6 +85,9 @@ func TestSym2Addr(t *testing.T) {
 	}
 
 	bin := strings.TrimSuffix(fname, ".go")
+	if runtime.GOOS == "windows" {
+		bin += ".exe"
+	}
 	defer os.Remove(bin)
 
 	gotool := filepath.Join(runtime.GOROOT(), "bin", "go")

--- a/sdks/go/pkg/beam/io/filesystem/local/local_test.go
+++ b/sdks/go/pkg/beam/io/filesystem/local/local_test.go
@@ -135,11 +135,12 @@ func TestLocal_util(t *testing.T) {
 
 func TestLocal_rename(t *testing.T) {
 	ctx := context.Background()
-	dirPath := filepath.Join(os.TempDir(), "beamgolocalfilesystemtest")
+	tempDir := t.TempDir()
+	dirPath := filepath.Join(tempDir, "beamgolocalfilesystemtest")
 	filePath1 := filepath.Join(dirPath, "file1.txt")
 	filePath2 := filepath.Join(dirPath, "file2.txt")
 	t.Cleanup(func() {
-		os.RemoveAll(dirPath)
+		os.RemoveAll(tempDir)
 	})
 
 	c, err := filesystem.New(ctx, dirPath)

--- a/sdks/go/pkg/beam/io/filesystem/memfs/memory.go
+++ b/sdks/go/pkg/beam/io/filesystem/memfs/memory.go
@@ -22,7 +22,7 @@ import (
 	"fmt"
 	"io"
 	"os"
-	"path/filepath"
+	"runtime"
 	"sort"
 	"strings"
 	"sync"
@@ -59,7 +59,7 @@ func (f *fs) List(_ context.Context, glob string) ([]string, error) {
 
 	var ret []string
 	for k := range f.m {
-		matched, err := filepath.Match(globNoScheme, strings.TrimPrefix(k, "memfs://"))
+		matched, err := filesystem.Match(globNoScheme, strings.TrimPrefix(k, "memfs://"))
 		if err != nil {
 			return nil, fmt.Errorf("invalid glob pattern: %w", err)
 		}
@@ -145,6 +145,9 @@ func Write(key string, value []byte) {
 }
 
 func normalize(key string) string {
+	if runtime.GOOS == "windows" {
+		key = strings.ReplaceAll(key, "\\", "/")
+	}
 	if strings.HasPrefix(key, "memfs://") {
 		return key
 	}

--- a/sdks/go/pkg/beam/io/filesystem/memfs/memory_test.go
+++ b/sdks/go/pkg/beam/io/filesystem/memfs/memory_test.go
@@ -18,7 +18,6 @@ package memfs
 import (
 	"context"
 	"os"
-	"path/filepath"
 	"testing"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/io/filesystem"
@@ -155,17 +154,17 @@ func TestListTable(t *testing.T) {
 			name: "dirs",
 			files: []string{
 				"fizzbuzz",
-				filepath.Join("xyz", "12"),
-				filepath.Join("xyz", "1234"),
-				filepath.Join("xyz", "1235"),
+				"xyz/12",
+				"xyz/1234",
+				"xyz/1235",
 				"foobar",
 				"baz",
 				"bazfoo",
 			},
 			pattern: "memfs://xyz/123*",
 			want: []string{
-				"memfs://" + filepath.Join("xyz", "1234"),
-				"memfs://" + filepath.Join("xyz", "1235"),
+				"memfs://xyz/1234",
+				"memfs://xyz/1235",
 			},
 		},
 	} {

--- a/sdks/go/pkg/beam/io/filesystem/util.go
+++ b/sdks/go/pkg/beam/io/filesystem/util.go
@@ -19,6 +19,9 @@ import (
 	"context"
 	"fmt"
 	"io"
+	"path/filepath"
+	"runtime"
+	"strings"
 )
 
 // Read fully reads the given file from the file system.
@@ -99,6 +102,15 @@ func Rename(ctx context.Context, fs Interface, oldpath, newpath string) error {
 	}
 
 	return nil
+}
+
+// Match is a platform agnostic version of filepath.Match where \ is treated as / on Windows.
+func Match(pattern, name string) (bool, error) {
+	// Windows accepts / and \ as directory separators. For the sake of consistency with other schemes such as memfs:// we'll convert \ to /.
+	if runtime.GOOS == "windows" {
+		return filepath.Match(strings.ReplaceAll(pattern, "/", "//"), strings.ReplaceAll(name, "/", "//"))
+	}
+	return filepath.Match(pattern, name)
 }
 
 type unimplementedError struct {

--- a/sdks/go/test/integration/internal/jars/run_nonunix.go
+++ b/sdks/go/test/integration/internal/jars/run_nonunix.go
@@ -21,6 +21,7 @@ package jars
 
 import (
 	"fmt"
+	"os/exec"
 	"runtime"
 	"time"
 )
@@ -29,7 +30,7 @@ import (
 // non-unix version does not handle timeout durations.
 func getTimeoutRunner() runCallback {
 	// Wrap run with error handling for OS that does not support timeout duration.
-	return func(dur time.Duration, jar string, args ...string) (*Process, error) {
+	return func(dur time.Duration, jar string, args ...string) (Process, error) {
 		// Currently, we hard-fail here if a duration is provided but timeout is unsupported. If
 		// we ever decide to soft-fail instead, this is the code to change.
 		if dur != 0 {


### PR DESCRIPTION
Fix most Go SDK compile and test bugs for Windows.

Most of the bugs are due to undesirable/inconsistent usage of `filepath` package since on Windows the `os.Separator` is `\` instead of `/`. 

* `memfs://` URIs on Windows now require `/`'s rather than `\`'s.

`TestNewJarGetter` will continue to fail after this change but the other fixes should address their respective failures.


The following failures occur on the current codebase:
```bash
# github.com/apache/beam/sdks/v2/go/test/integration/internal/jars
test\integration\internal\jars\run_nonunix.go:32:9: cannot use func(dur time.Duration, jar string, args ...string) (*Process, error) {…} (value of type func(dur time.Duration, jar string, args ...string) (*Process, error)) as runCallback value in return statement
test\integration\internal\jars\run_nonunix.go:38:10: cannot use run(jar, args...) (value of type Process) as *Process value in return statement: Process does not implement *Process (type *Process is pointer to interface, not interface)
test\integration\internal\jars\run_nonunix.go:48:9: undefined: exec
FAIL	github.com/apache/beam/sdks/v2/go/examples/large_wordcount [build failed]
--- FAIL: TestNewJarGetter (0.00s)
    download_test.go:138: failed to get correct cache directory: wanted ~/, got C:\Users\Jeremy Edwards\.apache_beam\cache\jars
--- FAIL: TestGetJar_present (0.18s)
    download_test.go:203: getJar returned error when it should have succeeded, got failed to connect to https://repo.maven.apache.org/maven2/org/apache/beam/beam-sdks-java-fake/C:\Users\JEREMY~1\AppData\Local\Temp\expansionx-3264457556\beam-sdks-java-fake-3756825146/beam-sdks-java-fake-C:\Users\JEREMY~1\AppData\Local\Temp\expansionx-3264457556\beam-sdks-java-fake-3756825146.jar: received non 200 response code, got 404
    download_test.go:206: Jar path mismatch: wanted C:\Users\JEREMY~1\AppData\Local\Temp\expansionx-3264457556\beam-sdks-java-fake-C:\Users\JEREMY~1\AppData\Local\Temp\expansionx-3264457556\beam-sdks-java-fake-3756825146.jar, got 
FAIL
FAIL	github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime/xlangx/expansionx	2.208s
--- FAIL: TestSym2Addr (2.80s)
    symtab_test.go:112: 
    symtab_test.go:113: test program built with [C:\Program Files\Go\bin\go build -o C:\Users\JEREMY~1\AppData\Local\Temp\TestSym2Addr3689885862 -buildmode=exe C:\Users\JEREMY~1\AppData\Local\Temp\TestSym2Addr3689885862.go] failed: exec: "C:\\Users\\JEREMY~1\\AppData\\Local\\Temp\\TestSym2Addr3689885862": file does not exist
    symtab_test.go:112: 
    symtab_test.go:113: test program built with [C:\Program Files\Go\bin\go build -o C:\Users\JEREMY~1\AppData\Local\Temp\TestSym2Addr3689885862 -buildmode=exe -ldflags=-w C:\Users\JEREMY~1\AppData\Local\Temp\TestSym2Addr3689885862.go] failed: exec: "C:\\Users\\JEREMY~1\\AppData\\Local\\Temp\\TestSym2Addr3689885862": file does not exist
    symtab_test.go:112: 
    symtab_test.go:113: test program built with [C:\Program Files\Go\bin\go build -o C:\Users\JEREMY~1\AppData\Local\Temp\TestSym2Addr3689885862 -buildmode=pie C:\Users\JEREMY~1\AppData\Local\Temp\TestSym2Addr3689885862.go] failed: exec: "C:\\Users\\JEREMY~1\\AppData\\Local\\Temp\\TestSym2Addr3689885862": file does not exist
    symtab_test.go:112: 
    symtab_test.go:113: test program built with [C:\Program Files\Go\bin\go build -o C:\Users\JEREMY~1\AppData\Local\Temp\TestSym2Addr3689885862 -buildmode=pie -ldflags=-w C:\Users\JEREMY~1\AppData\Local\Temp\TestSym2Addr3689885862.go] failed: exec: "C:\\Users\\JEREMY~1\\AppData\\Local\\Temp\\TestSym2Addr3689885862": file does not exist
FAIL
FAIL	github.com/apache/beam/sdks/v2/go/pkg/beam/core/util/symtab	2.967s
--- FAIL: TestLocal_rename (0.00s)
    local_test.go:177: List(C:\Users\JEREMY~1\AppData\Local\Temp\beamgolocalfilesystemtest\*.txt) = [C:\Users\JEREMY~1\AppData\Local\Temp\beamgolocalfilesystemtest\file.txt C:\Users\JEREMY~1\AppData\Local\Temp\beamgolocalfilesystemtest\file2.txt], want []string{C:\Users\JEREMY~1\AppData\Local\Temp\beamgolocalfilesystemtest\file2.txt}
FAIL
FAIL	github.com/apache/beam/sdks/v2/go/pkg/beam/io/filesystem/local	0.231s
--- FAIL: TestListTable (0.00s)
    --- FAIL: TestListTable/dirs (0.00s)
        memory_test.go:190: List("memfs://xyz/123*") resulted in unexpected diff (-want, +got):
                []string(
            - 	{`memfs://xyz\1234`, `memfs://xyz\1235`},
            + 	nil,
              )
FAIL
FAIL	github.com/apache/beam/sdks/v2/go/pkg/beam/io/filesystem/memfs	0.264s
FAIL	github.com/apache/beam/sdks/v2/go/test/integration [build failed]
FAIL	github.com/apache/beam/sdks/v2/go/test/integration/io/fhirio [build failed]
FAIL	github.com/apache/beam/sdks/v2/go/test/integration/io/mongodbio [build failed]
FAIL	github.com/apache/beam/sdks/v2/go/test/integration/io/xlang/bigquery [build failed]
FAIL	github.com/apache/beam/sdks/v2/go/test/integration/io/xlang/debezium [build failed]
FAIL	github.com/apache/beam/sdks/v2/go/test/integration/io/xlang/jdbc [build failed]
FAIL	github.com/apache/beam/sdks/v2/go/test/integration/io/xlang/kafka [build failed]
FAIL	github.com/apache/beam/sdks/v2/go/test/integration/primitives [build failed]
FAIL	github.com/apache/beam/sdks/v2/go/test/integration/synthetic [build failed]
FAIL	github.com/apache/beam/sdks/v2/go/test/integration/transforms/xlang/dataframe [build failed]
FAIL	github.com/apache/beam/sdks/v2/go/test/integration/transforms/xlang/inference [build failed]
FAIL	github.com/apache/beam/sdks/v2/go/test/integration/wordcount [build failed]
FAIL	github.com/apache/beam/sdks/v2/go/test/integration/xlang [build failed]
FAIL	github.com/apache/beam/sdks/v2/go/test/regression [build failed]
FAIL
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
