### PR TITLE
Fix paginated windmill sorted list state

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WindmillStateReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WindmillStateReader.java
@@ -985,12 +985,17 @@ class WindmillStateReader {
               throw new RuntimeException("Unable to read value from state", e);
             }
             currentPage = valuesAndContPosition.values.iterator();
-            nextPagePos =
+            StateTag.Builder<ContinuationT> nextPageBuilder =
                 StateTag.of(
-                    nextPagePos.getKind(),
-                    nextPagePos.getTag(),
-                    nextPagePos.getStateFamily(),
-                    valuesAndContPosition.continuationPosition);
+                        nextPagePos.getKind(),
+                        nextPagePos.getTag(),
+                        nextPagePos.getStateFamily(),
+                        valuesAndContPosition.continuationPosition)
+                    .toBuilder();
+            if (secondPagePos.getSortedListRange() != null) {
+              nextPageBuilder.setSortedListRange(secondPagePos.getSortedListRange());
+            }
+            nextPagePos = nextPageBuilder.build();
             pendingNextPage =
                 // NOTE: The results of continuation page reads are never cached.
                 reader.continuationFuture(nextPagePos, coder);


### PR DESCRIPTION
Currently, when the 3rd or later page request for a sorted list state is created, the state tag `nextPagePos` will not have the `sortedListRange` field set and thus NPE when creating `KeyedGetDataRequest` using `nextPagePos`. The modified unit test in this PR will fail [here](https://github.com/zhengbuqian/beam/blob/1087abeb734663ec76bb738099fb8fa1c2d34bb1/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WindmillStateReader.java#L580).

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
