### PR TITLE
Fix tensorflowhub caching issue

### DIFF
--- a/sdks/python/apache_beam/ml/inference/tensorflow_inference_it_test.py
+++ b/sdks/python/apache_beam/ml/inference/tensorflow_inference_it_test.py
@@ -20,12 +20,12 @@
 import logging
 import unittest
 import uuid
+from pathlib import Path
 
 import pytest
 
 from apache_beam.io.filesystems import FileSystems
 from apache_beam.testing.test_pipeline import TestPipeline
-from pathlib import Path
 
 # pylint: disable=ungrouped-imports
 try:
@@ -44,6 +44,7 @@ def process_outputs(filepath):
   lines = [l.decode('utf-8').strip('\n') for l in lines]
   return lines
 
+
 def rmdir(directory):
   directory = Path(directory)
   for item in directory.iterdir():
@@ -52,6 +53,7 @@ def rmdir(directory):
     else:
       item.unlink()
   directory.rmdir()
+
 
 def clear_tf_hub_temp_dir(model_path):
   # When loading from tensorflow hub using tfhub.resolve, the model is saved in
@@ -62,7 +64,6 @@ def clear_tf_hub_temp_dir(model_path):
   # directory entirely between runs.
   local_path = hub.resolve(model_path)
   rmdir(local_path)
-
 
 
 @unittest.skipIf(

--- a/sdks/python/apache_beam/ml/inference/tensorflow_inference_it_test.py
+++ b/sdks/python/apache_beam/ml/inference/tensorflow_inference_it_test.py
@@ -25,10 +25,12 @@ import pytest
 
 from apache_beam.io.filesystems import FileSystems
 from apache_beam.testing.test_pipeline import TestPipeline
+from pathlib import Path
 
 # pylint: disable=ungrouped-imports
 try:
   import tensorflow as tf
+  import tensorflow_hub as hub
   from apache_beam.examples.inference import tensorflow_imagenet_segmentation
   from apache_beam.examples.inference import tensorflow_mnist_classification
   from apache_beam.examples.inference import tensorflow_mnist_with_weights
@@ -41,6 +43,26 @@ def process_outputs(filepath):
     lines = f.readlines()
   lines = [l.decode('utf-8').strip('\n') for l in lines]
   return lines
+
+def rmdir(directory):
+  directory = Path(directory)
+  for item in directory.iterdir():
+    if item.is_dir():
+      rmdir(item)
+    else:
+      item.unlink()
+  directory.rmdir()
+
+def clear_tf_hub_temp_dir(model_path):
+  # When loading a tensorflow hub using tfhub.resolve, the model is saved in a
+  # temporary directory. That file can be persisted between test runs, in which
+  # case tfhub.resolve will no-op. If the model is deleted and the file isn't,
+  # tfhub.resolve will still no-op and tf.keras.models.load_model will throw.
+  # To avoid this (and test more robustly) we delete the temporary directory
+  # entirely between runs.
+  local_path = hub.resolve(model_path)
+  rmdir(local_path)
+
 
 
 @unittest.skipIf(
@@ -90,6 +112,7 @@ class TensorflowInference(unittest.TestCase):
     output_file = '/'.join([output_file_dir, str(uuid.uuid4()), 'result.txt'])
     model_path = (
         'https://tfhub.dev/google/tf2-preview/mobilenet_v2/classification/4')
+    clear_tf_hub_temp_dir(model_path)
     extra_opts = {
         'input': input_file,
         'output': output_file,

--- a/sdks/python/apache_beam/ml/inference/tensorflow_inference_it_test.py
+++ b/sdks/python/apache_beam/ml/inference/tensorflow_inference_it_test.py
@@ -54,12 +54,12 @@ def rmdir(directory):
   directory.rmdir()
 
 def clear_tf_hub_temp_dir(model_path):
-  # When loading a tensorflow hub using tfhub.resolve, the model is saved in a
-  # temporary directory. That file can be persisted between test runs, in which
-  # case tfhub.resolve will no-op. If the model is deleted and the file isn't,
-  # tfhub.resolve will still no-op and tf.keras.models.load_model will throw.
-  # To avoid this (and test more robustly) we delete the temporary directory
-  # entirely between runs.
+  # When loading from tensorflow hub using tfhub.resolve, the model is saved in
+  # a temporary directory. That file can be persisted between test runs, in
+  # which case tfhub.resolve will no-op. If the model is deleted and the file
+  # isn't, tfhub.resolve will still no-op and tf.keras.models.load_model will
+  # throw. To avoid this (and test more robustly) we delete the temporary
+  # directory entirely between runs.
   local_path = hub.resolve(model_path)
   rmdir(local_path)
 


### PR DESCRIPTION
Right now, the tfhub test can fail because of a caching issue. When loading from tensorflow hub using tfhub.resolve, the model is saved in a temporary directory. That file can be persisted between test runs, in which case tfhub.resolve will no-op. If the model is deleted and the file isn't, tfhub.resolve will still no-op and tf.keras.models.load_model will throw.To avoid this (and test more robustly) we can delete the temporary directory entirely between runs.

This fixes the currently failing python 3.7 postcommit (along with https://github.com/apache/beam/pull/25654)

See some more discussion here - https://stackoverflow.com/questions/63078695/savedmodel-file-does-not-exist-when-using-tensorflow-hub

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
