### PR TITLE
Fix flaky load_test.go/TestSample test

### DIFF
--- a/learning/tour-of-beam/backend/internal/fs_content/load.go
+++ b/learning/tour-of-beam/backend/internal/fs_content/load.go
@@ -228,7 +228,7 @@ func collectSdk(infopath string) (trees []tob.ContentTree, err error) {
 	if err != nil {
 		return trees, err
 	}
-	for sdk := range sdks {
+	for _, sdk := range sdks {
 		tree := tob.ContentTree{}
 		tree.Sdk = sdk
 		log.Printf("Found Sdk %v metadata at %v\n", sdk, infopath)
@@ -274,22 +274,26 @@ func CollectLearningTree(rootpath string) (trees []tob.ContentTree, err error) {
 }
 
 func isSupportedSdk(sdks []string, ctx *sdkContext, infopath string) (ok bool, err error) {
-	sdk, err := getSupportedSdk(sdks, infopath)
+	supportedSdks, err := getSupportedSdk(sdks, infopath)
 	if err != nil {
 		return false, err
 	}
-	_, ok = sdk[ctx.sdk]
-	return
+	for _, supportedSdk := range supportedSdks {
+		if ctx.sdk == supportedSdk {
+			return true, nil
+		}
+	}
+	return false, nil
 }
 
-func getSupportedSdk(sdk []string, infopath string) (map[tob.Sdk]bool, error) {
-	sdks := make(map[tob.Sdk]bool)
+func getSupportedSdk(sdk []string, infopath string) ([]tob.Sdk, error) {
+	sdks := make([]tob.Sdk, 0)
 	for _, s := range sdk {
 		curSdk := tob.ParseSdk(s)
 		if curSdk == tob.SDK_UNDEFINED {
 			return sdks, fmt.Errorf("unknown SDK at %v", infopath)
 		}
-		sdks[curSdk] = true
+		sdks = append(sdks, curSdk)
 	}
 
 	return sdks, nil

--- a/learning/tour-of-beam/backend/internal/fs_content/load_test.go
+++ b/learning/tour-of-beam/backend/internal/fs_content/load_test.go
@@ -49,7 +49,7 @@ func TestSample(t *testing.T) {
 	trees, err := CollectLearningTree(filepath.Join("..", "..", "samples", "learning-content"))
 	assert.Nil(t, err)
 	assert.Equal(t, 2, len(trees))
-	assert.Equal(t, tob.ContentTree{
+	assert.Contains(t, trees, tob.ContentTree{
 		Sdk: tob.SDK_JAVA,
 		Modules: []tob.Module{
 			{
@@ -67,8 +67,8 @@ func TestSample(t *testing.T) {
 				},
 			},
 		},
-	}, trees[0])
-	assert.Equal(t, tob.ContentTree{
+	})
+	assert.Contains(t, trees, tob.ContentTree{
 		Sdk: tob.SDK_PYTHON,
 		Modules: []tob.Module{
 			{
@@ -88,7 +88,7 @@ func TestSample(t *testing.T) {
 				},
 			},
 		},
-	}, trees[1])
+	})
 }
 
 // TestTemplates test that templating engine is used correctly.


### PR DESCRIPTION
`load_test.go/TestSample` had flaky behavior because order of items returned by `CollectLearningTree()` is not determinate.

This change
- Makes test assertions to be independent of order of returned items
- Makes return values order determinate by using slices instead of a map

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
