### PR TITLE
Run the quickstart command has incorrect flag name

### DIFF
--- a/website/www/site/content/en/get-started/quickstart/go.md
+++ b/website/www/site/content/en/get-started/quickstart/go.md
@@ -56,7 +56,7 @@ cd beam-starter-go
 Run the following command:
 
 {{< highlight >}}
-go run main.go --inputText="Greetings"
+go run main.go --input-text="Greetings"
 {{< /highlight >}}
 
 The output is similar to the following:


### PR DESCRIPTION
Line 59 is using the flag `--inputText` which is different from the actual code repository which uses `--input-text`. Running the code with `--inputText` returns an error message `flag provided but not defined: -inputText` while running the code with  `--input-text` returns the expected output

```markdown
go run main.go --inputText="Greetings"
```


This is inconsistent with the code which named the flag as `input-text` instead of `inputText` as shown in the snippet found in [Line 24 of main.go](https://github.com/apache/beam-starter-go/blob/main/main.go#L24)

```go
var (
	input_text = flag.String("input-text", "default input text", "Input text to print.")
)
```

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
