### PR TITLE
ci: set minimal permissions for Github Workflows

### DIFF
--- a/.github/workflows/assign_milestone.yml
+++ b/.github/workflows/assign_milestone.yml
@@ -23,6 +23,8 @@ on:
   issues:
     types: [closed]
 
+permissions: read-all
+
 jobs:
   assign-milestone:
     if: github.event.issue.state_reason == 'completed'

--- a/.github/workflows/build_playground_backend.yml
+++ b/.github/workflows/build_playground_backend.yml
@@ -27,7 +27,7 @@ on:
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
-  
+permissions: read-all  
 jobs:
   build_playground_backend_docker_image:
     name: Build Playground Backend App

--- a/.github/workflows/build_playground_frontend.yml
+++ b/.github/workflows/build_playground_frontend.yml
@@ -29,6 +29,8 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   build_playground_frontend_docker_image:
     name: Build Playground Frontend App

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -39,6 +39,7 @@ concurrency:
 env:
   GCP_PATH: "gs://${{ secrets.GCP_PYTHON_WHEELS_BUCKET }}/${GITHUB_REF##*/}/${GITHUB_SHA}-${GITHUB_RUN_ID}/"
 
+permissions: read-all
 
 jobs:
 

--- a/.github/workflows/cancel.yml
+++ b/.github/workflows/cancel.yml
@@ -25,6 +25,8 @@ on:
       - "Python tests"
     types: ['requested']
 
+permissions: read-all
+
 jobs:
   cancel-duplicate-workflow-runs:
     permissions:

--- a/.github/workflows/choose_rc_commit.yml
+++ b/.github/workflows/choose_rc_commit.yml
@@ -46,8 +46,12 @@ on:
         required: false
         default: no
 
+permissions: read-all
+
 jobs:
   choose_rc_commit:
+    permissions:
+      contents: write # for Git to git push
     runs-on: [self-hosted, ubuntu-20.04]
     env:
       RC_TAG: v${{ github.event.inputs.RELEASE }}-RC${{ github.event.inputs.RC }}

--- a/.github/workflows/cut_release_branch.yml
+++ b/.github/workflows/cut_release_branch.yml
@@ -31,8 +31,12 @@ on:
         description: Next release version
         required: true
 
+permissions: read-all
+
 jobs:
   update_master:
+    permissions:
+      contents: write  # for Git to git push
     runs-on: [self-hosted, ubuntu-20.04]
     env:
       MASTER_BRANCH: master
@@ -66,6 +70,8 @@ jobs:
           git push origin ${MASTER_BRANCH}
 
   update_release_branch:
+    permissions:
+      contents: write  # for Git to git push
     needs: update_master
     runs-on: [self-hosted, ubuntu-20.04]
     env:

--- a/.github/workflows/dask_runner_tests.yml
+++ b/.github/workflows/dask_runner_tests.yml
@@ -32,6 +32,8 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
 
   build_python_sdk_source:

--- a/.github/workflows/git_tag_released_version.yml
+++ b/.github/workflows/git_tag_released_version.yml
@@ -30,8 +30,12 @@ on:
         description: Beam RC Tag
         required: true
 
+permissions: read-all
+
 jobs:
   generate_tags:
+    permissions:
+      contents: write  # for Git to git push
     runs-on: ubuntu-latest
     env:
       VERSION_PATH: ${{ github.event.inputs.VERSION_TAG }}

--- a/.github/workflows/go_tests.yml
+++ b/.github/workflows/go_tests.yml
@@ -33,6 +33,7 @@ on:
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
+permissions: read-all
 jobs:
   build:
     runs-on: ubuntu-latest

--- a/.github/workflows/issue-tagger.yml
+++ b/.github/workflows/issue-tagger.yml
@@ -18,6 +18,8 @@ on:
   issues:
     types: [opened]
 
+permissions: read-all
+
 jobs:
   label:
     runs-on: ubuntu-latest

--- a/.github/workflows/java_tests.yml
+++ b/.github/workflows/java_tests.yml
@@ -39,6 +39,7 @@ on:
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
+permissions: read-all
 jobs:
   check_gcp_variables:
     timeout-minutes: 5

--- a/.github/workflows/local_env_tests.yml
+++ b/.github/workflows/local_env_tests.yml
@@ -34,6 +34,8 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   run_local_env_install_ubuntu:
     timeout-minutes: 25

--- a/.github/workflows/playground_deploy_backend.yml
+++ b/.github/workflows/playground_deploy_backend.yml
@@ -29,6 +29,8 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   build_playground_backend_docker_image:
     name: Build Playground Backend App

--- a/.github/workflows/playground_deploy_examples.yml
+++ b/.github/workflows/playground_deploy_examples.yml
@@ -26,6 +26,7 @@ env:
   HELM_APP_NAME: playground-backend
   SUBDIRS: "./learning/katas ./examples ./sdks"
   ORIGIN: PG_EXAMPLES
+permissions: read-all
 jobs:
   check_examples:
     name: Check examples

--- a/.github/workflows/playground_deploy_infrastructure.yml
+++ b/.github/workflows/playground_deploy_infrastructure.yml
@@ -16,6 +16,7 @@
 name: New environment creation
 on:
   workflow_dispatch:
+permissions: read-all
 jobs:
   Infrastructure_deployment:
     runs-on: ubuntu-latest

--- a/.github/workflows/playground_examples_cd.yml
+++ b/.github/workflows/playground_examples_cd.yml
@@ -19,6 +19,7 @@ on:
   workflow_dispatch:
 # Concurrency group for all deployment ops
 concurrency: playground_production
+permissions: read-all
 jobs:
   deploy_examples:
     strategy:

--- a/.github/workflows/playground_examples_cd_reusable.yml
+++ b/.github/workflows/playground_examples_cd_reusable.yml
@@ -33,6 +33,8 @@ on:
       sa_key_content:
         required: true
 
+permissions: read-all
+
 jobs:
   cd:
     name: CD ${{ inputs.sdk }} ${{ inputs.origin }}

--- a/.github/workflows/playground_examples_ci.yml
+++ b/.github/workflows/playground_examples_ci.yml
@@ -30,6 +30,7 @@ on:
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
+permissions: read-all
 jobs:
   check:
     strategy:

--- a/.github/workflows/playground_examples_ci_reusable.yml
+++ b/.github/workflows/playground_examples_ci_reusable.yml
@@ -35,6 +35,7 @@ on:
         required: true
 env:
   BEAM_VERSION: 2.44.0
+permissions: read-all
 jobs:
   check_has_examples:
     name: pre-check

--- a/.github/workflows/playground_frontend_test.yml
+++ b/.github/workflows/playground_frontend_test.yml
@@ -29,6 +29,8 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   playground_frontend_test:
     name: Playground Frontend Test

--- a/.github/workflows/pr-bot-new-prs.yml
+++ b/.github/workflows/pr-bot-new-prs.yml
@@ -21,6 +21,8 @@ on:
   - cron: '0,30 * * * *'
   workflow_dispatch:
 
+permissions: read-all
+
 jobs:
   process-prs:
     permissions:

--- a/.github/workflows/pr-bot-prs-needing-attention.yml
+++ b/.github/workflows/pr-bot-prs-needing-attention.yml
@@ -21,6 +21,8 @@ on:
   - cron: '7 12 * * *'
   workflow_dispatch:
 
+permissions: read-all
+
 jobs:
   process-prs:
     permissions:

--- a/.github/workflows/pr-bot-update-reviewers.yml
+++ b/.github/workflows/pr-bot-update-reviewers.yml
@@ -21,6 +21,8 @@ on:
   - cron: '5 16 * * 0'
   workflow_dispatch:
 
+permissions: read-all
+
 jobs:
   update-reviewers:
     permissions:

--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -40,6 +40,8 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
 
   check_gcp_variables:

--- a/.github/workflows/reportGenerator.yml
+++ b/.github/workflows/reportGenerator.yml
@@ -21,6 +21,8 @@ on:
   - cron: "0 10 * * 1-5"
   workflow_dispatch:
 
+permissions: read-all
+
 jobs:
   assign:
     name: Generate issue report

--- a/.github/workflows/run_perf_alert_tool.yml
+++ b/.github/workflows/run_perf_alert_tool.yml
@@ -23,6 +23,8 @@ on:
   schedule:
     - cron: '5 22 * * *'
 
+permissions: read-all
+
 jobs:
   python_run_change_point_analysis:
     name: Run Change Point Analysis.

--- a/.github/workflows/run_rc_validation.yml
+++ b/.github/workflows/run_rc_validation.yml
@@ -66,6 +66,7 @@ env:
   USER_GCP_ZONE: us-central1-a
   APACHE_CONTENTS_REPO: ${{github.event.inputs.APACHE_CONTENTS_REPO}}
   FIXED_WINDOW_DURATION: 20
+permissions: read-all
 jobs:
   python_release_candidate:
     runs-on: [self-hosted, ubuntu-20.04]

--- a/.github/workflows/self-assign.yml
+++ b/.github/workflows/self-assign.yml
@@ -17,6 +17,8 @@ name: Assign or close an issue
 on: 
   issue_comment:
 
+permissions: read-all
+
 jobs:
   assign:
     permissions:

--- a/.github/workflows/start_snapshot_build.yml
+++ b/.github/workflows/start_snapshot_build.yml
@@ -32,8 +32,12 @@ on:
         required: true
         default: https://github.com/apache/beam.git
 
+permissions: read-all
+
 jobs:
   start_snapshot_build:
+    permissions:
+      contents: write  # for Git to git push
     runs-on: [self-hosted, ubuntu-20.04]
     env:
       REMOTE_NAME: remote_repo

--- a/.github/workflows/tour_of_beam_backend.yml
+++ b/.github/workflows/tour_of_beam_backend.yml
@@ -34,6 +34,8 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
 
+permissions: read-all
+
 jobs:
   checks:
     runs-on: ubuntu-latest

--- a/.github/workflows/tour_of_beam_backend_integration.yml
+++ b/.github/workflows/tour_of_beam_backend_integration.yml
@@ -61,6 +61,7 @@ env:
   PORT_POST_USER_CODE: 8806
   PORT_POST_DELETE_PROGRESS: 8807
 
+permissions: read-all
 
 jobs:
   integration:

--- a/.github/workflows/tour_of_beam_examples_ci.yml
+++ b/.github/workflows/tour_of_beam_examples_ci.yml
@@ -27,6 +27,7 @@ on:
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
+permissions: read-all
 jobs:
   check_examples:
     strategy:

--- a/.github/workflows/triaged-on-assign.yml
+++ b/.github/workflows/triaged-on-assign.yml
@@ -17,6 +17,7 @@ name: Mark issue as triaged when assigned
 on:
   issues:
     types: [assigned]
+permissions: read-all
 jobs:
   assign:
     permissions:

--- a/.github/workflows/typescript_tests.yml
+++ b/.github/workflows/typescript_tests.yml
@@ -35,6 +35,9 @@ on:
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'
   cancel-in-progress: true
+
+permissions: read-all
+
 jobs:
   typescript_unit_tests:
     name: 'TypeScript Unit Tests'

--- a/.github/workflows/verify_release_build.yml
+++ b/.github/workflows/verify_release_build.yml
@@ -29,6 +29,7 @@ on:
         required: true
 env:
   WORKING_BRANCH: postcommit_validation_pr
+permissions: read-all
 jobs:
   verify_release:
     runs-on: [self-hosted, ubuntu-20.04]


### PR DESCRIPTION
The changes were done to always leave top-level read-only permissions, and then have permissive job-level permissions if any job requires them.

WARN: I was not able to determine the specific permissions required for the following jobs:
- java_tests.yml
- run_rc_validation.yml 
So I left them read-only and it should be tested. If you wish, I can enable the workflows on my fork and test them there.

Closes #25641
