### PR TITLE
[Spark Dataset runner] Change default storage level to Sparks respective default MEMORY_AND_DISK

### DIFF
--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkCommonPipelineOptions.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkCommonPipelineOptions.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.spark;
 
 import org.apache.beam.runners.core.construction.resources.PipelineResources;
+import org.apache.beam.runners.spark.structuredstreaming.SparkStructuredStreamingRunner;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.options.ApplicationNameOptions;
 import org.apache.beam.sdk.options.Default;
@@ -51,7 +52,7 @@ public interface SparkCommonPipelineOptions
   void setCheckpointDir(String checkpointDir);
 
   @Description("Batch default storage level")
-  @Default.String("MEMORY_ONLY")
+  @Default.InstanceFactory(StorageLevelFactory.class)
   String getStorageLevel();
 
   void setStorageLevel(String storageLevel);
@@ -82,6 +83,19 @@ public interface SparkCommonPipelineOptions
   static void prepareFilesToStage(SparkCommonPipelineOptions options) {
     if (!options.getSparkMaster().matches("local\\[?\\d*]?")) {
       PipelineResources.prepareFilesForStaging(options);
+    }
+  }
+
+  /**
+   * Returns Spark's default storage level for the Dataset or RDD API based on the respective
+   * runner.
+   */
+  class StorageLevelFactory implements DefaultValueFactory<String> {
+    @Override
+    public String create(PipelineOptions options) {
+      return SparkStructuredStreamingRunner.class.equals(options.getRunner())
+          ? "MEMORY_AND_DISK"
+          : "MEMORY_ONLY";
     }
   }
 }


### PR DESCRIPTION
Change the default storage level to the respective default of Spark's Dataset API (`MEMORY_AND_DISK` ) rather than using the default of the RDD API / the SparkRunner (`MEMORY_ONLY`).

Closes #25737

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
