### PR TITLE
Add MetricsContainer support to the Flink sources.

### DIFF
--- a/runners/flink/1.14/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/SourceTestCompat.java
+++ b/runners/flink/1.14/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/SourceTestCompat.java
@@ -34,6 +34,7 @@ public class SourceTestCompat {
   public static class TestMetricGroup extends UnregisteredMetricsGroup
       implements SourceReaderMetricGroup {
     public final Map<String, Gauge<?>> registeredGauge = new HashMap<>();
+    public final Map<String, Counter> registeredCounter = new HashMap<>();
     public final Counter numRecordsInCounter = new SimpleCounter();
 
     @Override
@@ -50,6 +51,18 @@ public class SourceTestCompat {
     public <T, GaugeT extends Gauge<T>> GaugeT gauge(String name, GaugeT gauge) {
       registeredGauge.put(name, gauge);
       return gauge;
+    }
+
+    @Override
+    public Counter counter(String name) {
+      // The OperatorIOMetricsGroup will register some IO metrics in the constructor.
+      // At that time, the construction of this class has not finihsed yet, so we
+      // need to delegate the call to the parent class.
+      if (registeredCounter != null) {
+        return registeredCounter.computeIfAbsent(name, ignored -> super.counter(name));
+      } else {
+        return super.counter(name);
+      }
     }
 
     @Override

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkRunnerResult.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkRunnerResult.java
@@ -18,11 +18,11 @@
 package org.apache.beam.runners.flink;
 
 import static org.apache.beam.runners.core.metrics.MetricsContainerStepMap.asAttemptedOnlyMetricResults;
+import static org.apache.beam.runners.flink.metrics.FlinkMetricContainer.ACCUMULATOR_NAME;
 
 import java.util.Collections;
 import java.util.Map;
 import org.apache.beam.runners.core.metrics.MetricsContainerStepMap;
-import org.apache.beam.runners.flink.metrics.FlinkMetricContainer;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.metrics.MetricResults;
 import org.joda.time.Duration;
@@ -80,6 +80,6 @@ public class FlinkRunnerResult implements PipelineResult {
   }
 
   MetricsContainerStepMap getMetricsContainerStepMap() {
-    return (MetricsContainerStepMap) accumulators.get(FlinkMetricContainer.ACCUMULATOR_NAME);
+    return (MetricsContainerStepMap) accumulators.get(ACCUMULATOR_NAME);
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainer.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainer.java
@@ -17,29 +17,11 @@
  */
 package org.apache.beam.runners.flink.metrics;
 
-import static org.apache.beam.runners.core.metrics.MetricsContainerStepMap.asAttemptedOnlyMetricResults;
-
-import java.util.HashMap;
-import java.util.List;
-import java.util.Map;
-import org.apache.beam.model.pipeline.v1.MetricsApi.MonitoringInfo;
 import org.apache.beam.runners.core.metrics.MetricsContainerImpl;
 import org.apache.beam.runners.core.metrics.MetricsContainerStepMap;
-import org.apache.beam.sdk.metrics.DistributionResult;
-import org.apache.beam.sdk.metrics.GaugeResult;
-import org.apache.beam.sdk.metrics.MetricKey;
-import org.apache.beam.sdk.metrics.MetricName;
-import org.apache.beam.sdk.metrics.MetricQueryResults;
-import org.apache.beam.sdk.metrics.MetricResult;
-import org.apache.beam.sdk.metrics.MetricResults;
-import org.apache.beam.sdk.metrics.MetricsFilter;
-import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.flink.api.common.accumulators.Accumulator;
 import org.apache.flink.api.common.functions.RuntimeContext;
-import org.apache.flink.configuration.GlobalConfiguration;
-import org.apache.flink.configuration.MetricOptions;
-import org.apache.flink.metrics.Counter;
-import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,31 +34,14 @@ import org.slf4j.LoggerFactory;
  * which have a defined end. They are not essential during execution because metrics will also be
  * reported using the configured metrics reporter.
  */
-public class FlinkMetricContainer {
-
+public class FlinkMetricContainer extends FlinkMetricContainerBase {
   public static final String ACCUMULATOR_NAME = "__metricscontainers";
-
   private static final Logger LOG = LoggerFactory.getLogger(FlinkMetricContainer.class);
 
-  private static final String METRIC_KEY_SEPARATOR =
-      GlobalConfiguration.loadConfiguration().getString(MetricOptions.SCOPE_DELIMITER);
-
-  private final MetricsContainerStepMap metricsContainers;
   private final RuntimeContext runtimeContext;
-  private final Map<String, Counter> flinkCounterCache;
-  private final Map<String, FlinkDistributionGauge> flinkDistributionGaugeCache;
-  private final Map<String, FlinkGauge> flinkGaugeCache;
 
   public FlinkMetricContainer(RuntimeContext runtimeContext) {
     this.runtimeContext = runtimeContext;
-    this.flinkCounterCache = new HashMap<>();
-    this.flinkDistributionGaugeCache = new HashMap<>();
-    this.flinkGaugeCache = new HashMap<>();
-    this.metricsContainers = new MetricsContainerStepMap();
-  }
-
-  public MetricsContainerImpl getMetricsContainer(String stepName) {
-    return metricsContainers.getContainer(stepName);
   }
 
   /**
@@ -100,124 +65,8 @@ public class FlinkMetricContainer {
     metricsAccumulator.add(metricsContainers);
   }
 
-  /**
-   * Update this container with metrics from the passed {@link MonitoringInfo}s, and send updates
-   * along to Flink's internal metrics framework.
-   */
-  public void updateMetrics(String stepName, List<MonitoringInfo> monitoringInfos) {
-    getMetricsContainer(stepName).update(monitoringInfos);
-    updateMetrics(stepName);
-  }
-
-  /**
-   * Update Flink's internal metrics ({@link this#flinkCounterCache}) with the latest metrics for a
-   * given step.
-   */
-  void updateMetrics(String stepName) {
-    MetricResults metricResults = asAttemptedOnlyMetricResults(metricsContainers);
-    MetricQueryResults metricQueryResults =
-        metricResults.queryMetrics(MetricsFilter.builder().addStep(stepName).build());
-    updateCounters(metricQueryResults.getCounters());
-    updateDistributions(metricQueryResults.getDistributions());
-    updateGauge(metricQueryResults.getGauges());
-  }
-
-  private void updateCounters(Iterable<MetricResult<Long>> counters) {
-    for (MetricResult<Long> metricResult : counters) {
-      String flinkMetricName = getFlinkMetricNameString(metricResult.getKey());
-
-      Long update = metricResult.getAttempted();
-
-      // update flink metric
-      Counter counter =
-          flinkCounterCache.computeIfAbsent(
-              flinkMetricName, n -> runtimeContext.getMetricGroup().counter(n));
-      // Beam counters are already pre-aggregated, just update with the current value here
-      counter.inc(update - counter.getCount());
-    }
-  }
-
-  private void updateDistributions(Iterable<MetricResult<DistributionResult>> distributions) {
-    for (MetricResult<DistributionResult> metricResult : distributions) {
-      String flinkMetricName = getFlinkMetricNameString(metricResult.getKey());
-
-      DistributionResult update = metricResult.getAttempted();
-
-      // update flink metric
-      FlinkDistributionGauge gauge = flinkDistributionGaugeCache.get(flinkMetricName);
-      if (gauge == null) {
-        gauge =
-            runtimeContext
-                .getMetricGroup()
-                .gauge(flinkMetricName, new FlinkDistributionGauge(update));
-        flinkDistributionGaugeCache.put(flinkMetricName, gauge);
-      } else {
-        gauge.update(update);
-      }
-    }
-  }
-
-  private void updateGauge(Iterable<MetricResult<GaugeResult>> gauges) {
-    for (MetricResult<GaugeResult> metricResult : gauges) {
-      String flinkMetricName = getFlinkMetricNameString(metricResult.getKey());
-
-      GaugeResult update = metricResult.getAttempted();
-
-      // update flink metric
-      FlinkGauge gauge = flinkGaugeCache.get(flinkMetricName);
-      if (gauge == null) {
-        gauge = runtimeContext.getMetricGroup().gauge(flinkMetricName, new FlinkGauge(update));
-        flinkGaugeCache.put(flinkMetricName, gauge);
-      } else {
-        gauge.update(update);
-      }
-    }
-  }
-
-  @VisibleForTesting
-  static String getFlinkMetricNameString(MetricKey metricKey) {
-    MetricName metricName = metricKey.metricName();
-    // We use only the MetricName here, the step name is already contained
-    // in the operator name which is passed to Flink's MetricGroup to which
-    // the metric with the following name will be added.
-    return metricName.getNamespace() + METRIC_KEY_SEPARATOR + metricName.getName();
-  }
-
-  /** Flink {@link Gauge} for {@link DistributionResult}. */
-  public static class FlinkDistributionGauge implements Gauge<DistributionResult> {
-
-    DistributionResult data;
-
-    FlinkDistributionGauge(DistributionResult data) {
-      this.data = data;
-    }
-
-    void update(DistributionResult data) {
-      this.data = data;
-    }
-
-    @Override
-    public DistributionResult getValue() {
-      return data;
-    }
-  }
-
-  /** Flink {@link Gauge} for {@link GaugeResult}. */
-  public static class FlinkGauge implements Gauge<Long> {
-
-    GaugeResult data;
-
-    FlinkGauge(GaugeResult data) {
-      this.data = data;
-    }
-
-    void update(GaugeResult update) {
-      this.data = update;
-    }
-
-    @Override
-    public Long getValue() {
-      return data.getValue();
-    }
+  @Override
+  protected MetricGroup getMetricGroup() {
+    return runtimeContext.getMetricGroup();
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerBase.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerBase.java
@@ -1,0 +1,189 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.metrics;
+
+import static org.apache.beam.runners.core.metrics.MetricsContainerStepMap.asAttemptedOnlyMetricResults;
+
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.model.pipeline.v1.MetricsApi;
+import org.apache.beam.runners.core.metrics.MetricsContainerImpl;
+import org.apache.beam.runners.core.metrics.MetricsContainerStepMap;
+import org.apache.beam.sdk.metrics.DistributionResult;
+import org.apache.beam.sdk.metrics.GaugeResult;
+import org.apache.beam.sdk.metrics.MetricKey;
+import org.apache.beam.sdk.metrics.MetricName;
+import org.apache.beam.sdk.metrics.MetricQueryResults;
+import org.apache.beam.sdk.metrics.MetricResult;
+import org.apache.beam.sdk.metrics.MetricResults;
+import org.apache.beam.sdk.metrics.MetricsFilter;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
+import org.apache.flink.configuration.GlobalConfiguration;
+import org.apache.flink.configuration.MetricOptions;
+import org.apache.flink.metrics.Counter;
+import org.apache.flink.metrics.Gauge;
+import org.apache.flink.metrics.MetricGroup;
+
+/**
+ * The base helper class for holding a {@link MetricsContainerImpl} and forwarding Beam metrics to
+ * Flink accumulators and metrics. The two subclasses of this base class are {@link
+ * FlinkMetricContainer} and {@link FlinkMetricContainerWithoutAccumulator}. The former is used when
+ * {@link org.apache.flink.api.common.functions.RuntimeContext Flink RuntimeContext} is available.
+ * The latter is used otherwise.
+ */
+abstract class FlinkMetricContainerBase {
+
+  private static final String METRIC_KEY_SEPARATOR =
+      GlobalConfiguration.loadConfiguration().getString(MetricOptions.SCOPE_DELIMITER);
+
+  protected final MetricsContainerStepMap metricsContainers;
+  private final Map<String, Counter> flinkCounterCache;
+  private final Map<String, FlinkDistributionGauge> flinkDistributionGaugeCache;
+  private final Map<String, FlinkGauge> flinkGaugeCache;
+
+  public FlinkMetricContainerBase() {
+    this.flinkCounterCache = new HashMap<>();
+    this.flinkDistributionGaugeCache = new HashMap<>();
+    this.flinkGaugeCache = new HashMap<>();
+    this.metricsContainers = new MetricsContainerStepMap();
+  }
+
+  protected abstract MetricGroup getMetricGroup();
+
+  public MetricsContainerImpl getMetricsContainer(String stepName) {
+    return metricsContainers.getContainer(stepName);
+  }
+
+  /**
+   * Update this container with metrics from the passed {@link MetricsApi.MonitoringInfo}s, and send
+   * updates along to Flink's internal metrics framework.
+   */
+  public void updateMetrics(String stepName, List<MetricsApi.MonitoringInfo> monitoringInfos) {
+    getMetricsContainer(stepName).update(monitoringInfos);
+    updateMetrics(stepName);
+  }
+
+  /**
+   * Update Flink's internal metrics ({@link this#flinkCounterCache}) with the latest metrics for a
+   * given step.
+   */
+  void updateMetrics(String stepName) {
+    MetricResults metricResults = asAttemptedOnlyMetricResults(metricsContainers);
+    MetricQueryResults metricQueryResults =
+        metricResults.queryMetrics(MetricsFilter.builder().addStep(stepName).build());
+    updateCounters(metricQueryResults.getCounters());
+    updateDistributions(metricQueryResults.getDistributions());
+    updateGauge(metricQueryResults.getGauges());
+  }
+
+  private void updateCounters(Iterable<MetricResult<Long>> counters) {
+    for (MetricResult<Long> metricResult : counters) {
+      String flinkMetricName = getFlinkMetricNameString(metricResult.getKey());
+
+      Long update = metricResult.getAttempted();
+
+      // update flink metric
+      Counter counter =
+          flinkCounterCache.computeIfAbsent(flinkMetricName, n -> getMetricGroup().counter(n));
+      // Beam counters are already pre-aggregated, just update with the current value here
+      counter.inc(update - counter.getCount());
+    }
+  }
+
+  private void updateDistributions(Iterable<MetricResult<DistributionResult>> distributions) {
+    for (MetricResult<DistributionResult> metricResult : distributions) {
+      String flinkMetricName = getFlinkMetricNameString(metricResult.getKey());
+
+      DistributionResult update = metricResult.getAttempted();
+
+      // update flink metric
+      FlinkDistributionGauge gauge = flinkDistributionGaugeCache.get(flinkMetricName);
+      if (gauge == null) {
+        gauge = getMetricGroup().gauge(flinkMetricName, new FlinkDistributionGauge(update));
+        flinkDistributionGaugeCache.put(flinkMetricName, gauge);
+      } else {
+        gauge.update(update);
+      }
+    }
+  }
+
+  private void updateGauge(Iterable<MetricResult<GaugeResult>> gauges) {
+    for (MetricResult<GaugeResult> metricResult : gauges) {
+      String flinkMetricName = getFlinkMetricNameString(metricResult.getKey());
+
+      GaugeResult update = metricResult.getAttempted();
+
+      // update flink metric
+      FlinkGauge gauge = flinkGaugeCache.get(flinkMetricName);
+      if (gauge == null) {
+        gauge = getMetricGroup().gauge(flinkMetricName, new FlinkGauge(update));
+        flinkGaugeCache.put(flinkMetricName, gauge);
+      } else {
+        gauge.update(update);
+      }
+    }
+  }
+
+  @VisibleForTesting
+  static String getFlinkMetricNameString(MetricKey metricKey) {
+    MetricName metricName = metricKey.metricName();
+    // We use only the MetricName here, the step name is already contained
+    // in the operator name which is passed to Flink's MetricGroup to which
+    // the metric with the following name will be added.
+    return metricName.getNamespace() + METRIC_KEY_SEPARATOR + metricName.getName();
+  }
+
+  /** Flink {@link Gauge} for {@link DistributionResult}. */
+  public static class FlinkDistributionGauge implements Gauge<DistributionResult> {
+
+    DistributionResult data;
+
+    FlinkDistributionGauge(DistributionResult data) {
+      this.data = data;
+    }
+
+    void update(DistributionResult data) {
+      this.data = data;
+    }
+
+    @Override
+    public DistributionResult getValue() {
+      return data;
+    }
+  }
+
+  /** Flink {@link Gauge} for {@link GaugeResult}. */
+  public static class FlinkGauge implements Gauge<Long> {
+
+    GaugeResult data;
+
+    FlinkGauge(GaugeResult data) {
+      this.data = data;
+    }
+
+    void update(GaugeResult update) {
+      this.data = update;
+    }
+
+    @Override
+    public Long getValue() {
+      return data.getValue();
+    }
+  }
+}

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerWithoutAccumulator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerWithoutAccumulator.java
@@ -1,0 +1,41 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.metrics;
+
+import org.apache.flink.metrics.MetricGroup;
+
+/**
+ * The base helper class for holding a {@link
+ * org.apache.beam.runners.core.metrics.MetricsContainerImpl MetricsContainerImpl} and forwarding
+ * Beam metrics to Flink accumulators and metrics. This class is used when {@link
+ * org.apache.flink.api.common.functions.RuntimeContext Flink RuntimeContext} is not available.
+ *
+ * @see FlinkMetricContainer
+ */
+public class FlinkMetricContainerWithoutAccumulator extends FlinkMetricContainerBase {
+  private final MetricGroup metricGroup;
+
+  public FlinkMetricContainerWithoutAccumulator(MetricGroup metricGroup) {
+    this.metricGroup = metricGroup;
+  }
+
+  @Override
+  protected MetricGroup getMetricGroup() {
+    return metricGroup;
+  }
+}

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/ReaderInvocationUtil.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/metrics/ReaderInvocationUtil.java
@@ -33,11 +33,11 @@ import org.apache.beam.sdk.options.PipelineOptions;
 public class ReaderInvocationUtil<OutputT, ReaderT extends Source.Reader<OutputT>> {
 
   private final String stepName;
-  private final FlinkMetricContainer container;
+  private final FlinkMetricContainerBase container;
   private final Boolean enableMetrics;
 
   public ReaderInvocationUtil(
-      String stepName, PipelineOptions options, FlinkMetricContainer container) {
+      String stepName, PipelineOptions options, FlinkMetricContainerBase container) {
     FlinkPipelineOptions flinkPipelineOptions = options.as(FlinkPipelineOptions.class);
     this.stepName = stepName;
     this.enableMetrics = !flinkPipelineOptions.getDisableMetrics();

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/bounded/FlinkBoundedSource.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/bounded/FlinkBoundedSource.java
@@ -41,20 +41,22 @@ public class FlinkBoundedSource<T> extends FlinkSource<T, WindowedValue<T>> {
   protected final @Nullable TimestampExtractor<WindowedValue<T>> timestampExtractor;
 
   public FlinkBoundedSource(
+      String stepName,
       BoundedSource<T> beamSource,
       SerializablePipelineOptions serializablePipelineOptions,
       Boundedness boundedness,
       int numSplits) {
-    this(beamSource, serializablePipelineOptions, boundedness, numSplits, null);
+    this(stepName, beamSource, serializablePipelineOptions, boundedness, numSplits, null);
   }
 
   public FlinkBoundedSource(
+      String stepName,
       BoundedSource<T> beamSource,
       SerializablePipelineOptions serializablePipelineOptions,
       Boundedness boundedness,
       int numSplits,
       @Nullable TimestampExtractor<WindowedValue<T>> timestampExtractor) {
-    super(beamSource, serializablePipelineOptions, boundedness, numSplits);
+    super(stepName, beamSource, serializablePipelineOptions, boundedness, numSplits);
     this.timestampExtractor = timestampExtractor;
   }
 
@@ -62,6 +64,6 @@ public class FlinkBoundedSource<T> extends FlinkSource<T, WindowedValue<T>> {
   public SourceReader<WindowedValue<T>, FlinkSourceSplit<T>> createReader(
       SourceReaderContext readerContext) throws Exception {
     return new FlinkBoundedSourceReader<>(
-        readerContext, serializablePipelineOptions.get(), timestampExtractor);
+        stepName, readerContext, serializablePipelineOptions.get(), timestampExtractor);
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/unbounded/FlinkUnboundedSource.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/unbounded/FlinkUnboundedSource.java
@@ -40,18 +40,25 @@ public class FlinkUnboundedSource<T> extends FlinkSource<T, WindowedValue<ValueW
       timestampExtractor;
 
   public FlinkUnboundedSource(
+      String stepName,
       UnboundedSource<T, ?> beamSource,
       SerializablePipelineOptions serializablePipelineOptions,
       int numSplits) {
-    this(beamSource, serializablePipelineOptions, numSplits, null);
+    this(stepName, beamSource, serializablePipelineOptions, numSplits, null);
   }
 
   public FlinkUnboundedSource(
+      String stepName,
       UnboundedSource<T, ?> beamSource,
       SerializablePipelineOptions serializablePipelineOptions,
       int numSplits,
       @Nullable TimestampExtractor<WindowedValue<ValueWithRecordId<T>>> timestampExtractor) {
-    super(beamSource, serializablePipelineOptions, Boundedness.CONTINUOUS_UNBOUNDED, numSplits);
+    super(
+        stepName,
+        beamSource,
+        serializablePipelineOptions,
+        Boundedness.CONTINUOUS_UNBOUNDED,
+        numSplits);
     this.timestampExtractor = timestampExtractor;
   }
 
@@ -59,6 +66,6 @@ public class FlinkUnboundedSource<T> extends FlinkSource<T, WindowedValue<ValueW
   public SourceReader<WindowedValue<ValueWithRecordId<T>>, FlinkSourceSplit<T>> createReader(
       SourceReaderContext readerContext) throws Exception {
     return new FlinkUnboundedSourceReader<>(
-        readerContext, serializablePipelineOptions.get(), timestampExtractor);
+        stepName, readerContext, serializablePipelineOptions.get(), timestampExtractor);
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/unbounded/FlinkUnboundedSourceReader.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/unbounded/FlinkUnboundedSourceReader.java
@@ -69,10 +69,11 @@ public class FlinkUnboundedSourceReader<T>
   private volatile boolean shouldEmitWatermark;
 
   public FlinkUnboundedSourceReader(
+      String stepName,
       SourceReaderContext context,
       PipelineOptions pipelineOptions,
       @Nullable Function<WindowedValue<ValueWithRecordId<T>>, Long> timestampExtractor) {
-    super(context, pipelineOptions, timestampExtractor);
+    super(stepName, context, pipelineOptions, timestampExtractor);
     this.readers = new ArrayList<>();
     this.dataAvailableFutureRef = new AtomicReference<>(DUMMY_FUTURE);
     this.currentReaderIndex = 0;
@@ -80,11 +81,12 @@ public class FlinkUnboundedSourceReader<T>
 
   @VisibleForTesting
   protected FlinkUnboundedSourceReader(
+      String stepName,
       SourceReaderContext context,
       PipelineOptions pipelineOptions,
       ScheduledExecutorService executor,
       @Nullable Function<WindowedValue<ValueWithRecordId<T>>, Long> timestampExtractor) {
-    super(executor, context, pipelineOptions, timestampExtractor);
+    super(stepName, executor, context, pipelineOptions, timestampExtractor);
     this.readers = new ArrayList<>();
     this.dataAvailableFutureRef = new AtomicReference<>(DUMMY_FUTURE);
     this.currentReaderIndex = 0;

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/metrics/FlinkMetricContainerTest.java
@@ -37,7 +37,7 @@ import org.apache.beam.runners.core.metrics.MetricsContainerStepMap;
 import org.apache.beam.runners.core.metrics.MonitoringInfoConstants;
 import org.apache.beam.runners.core.metrics.MonitoringInfoMetricName;
 import org.apache.beam.runners.core.metrics.SimpleMonitoringInfoBuilder;
-import org.apache.beam.runners.flink.metrics.FlinkMetricContainer.FlinkDistributionGauge;
+import org.apache.beam.runners.flink.metrics.FlinkMetricContainerBase.FlinkDistributionGauge;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Distribution;
 import org.apache.beam.sdk.metrics.DistributionResult;

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/TestCountingSource.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/TestCountingSource.java
@@ -29,6 +29,8 @@ import org.apache.beam.sdk.coders.DelegateCoder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.io.UnboundedSource;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.KV;
@@ -198,6 +200,10 @@ public class TestCountingSource
    */
   public class CountingSourceReader extends UnboundedReader<KV<Integer, Integer>>
       implements TestReader {
+    public static final String ADVANCE_COUNTER_NAMESPACE = "testNameSpace";
+    public static final String ADVANCE_COUNTER_NAME = "advanceCounter";
+    private final Counter advanceCounter =
+        Metrics.counter(ADVANCE_COUNTER_NAMESPACE, ADVANCE_COUNTER_NAME);
     private int current;
     private boolean closed;
 
@@ -213,6 +219,7 @@ public class TestCountingSource
 
     @Override
     public boolean advance() {
+      advanceCounter.inc();
       if (current >= numMessagesPerShard - 1 || haltEmission) {
         return false;
       }

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/bounded/FlinkBoundedSourceReaderTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/bounded/FlinkBoundedSourceReaderTest.java
@@ -138,9 +138,10 @@ public class FlinkBoundedSourceReaderTest
     SourceReaderContext mockContext = createSourceReaderContext(testMetricGroup);
     if (executor != null) {
       return new FlinkBoundedSourceReader<>(
-          mockContext, pipelineOptions, executor, timestampExtractor);
+          "FlinkBoundedSource", mockContext, pipelineOptions, executor, timestampExtractor);
     } else {
-      return new FlinkBoundedSourceReader<>(mockContext, pipelineOptions, timestampExtractor);
+      return new FlinkBoundedSourceReader<>(
+          "FlinkBoundedSource", mockContext, pipelineOptions, timestampExtractor);
     }
   }
 }

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/unbounded/FlinkUnboundedSourceReaderTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/unbounded/FlinkUnboundedSourceReaderTest.java
@@ -303,9 +303,10 @@ public class FlinkUnboundedSourceReaderTest
     SourceReaderContext mockContext = createSourceReaderContext(metricGroup);
     if (executor != null) {
       return new FlinkUnboundedSourceReader<>(
-          mockContext, pipelineOptions, executor, timestampExtractor);
+          "FlinkUnboundedReader", mockContext, pipelineOptions, executor, timestampExtractor);
     } else {
-      return new FlinkUnboundedSourceReader<>(mockContext, pipelineOptions, timestampExtractor);
+      return new FlinkUnboundedSourceReader<>(
+          "FlinkUnboundedReader", mockContext, pipelineOptions, timestampExtractor);
     }
   }
 


### PR DESCRIPTION
This patch is a follow-up patch for the Flink runner migration from DataSet API to DataStream API. It adds support for MetricsContainer which exposes the metrics defined in Beam metrics via the Flink metric framework.

fixes #25741 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
