### PR TITLE
New examples are missing in the Playground catalog

### DIFF
--- a/playground/backend/internal/cache/redis/redis_cache.go
+++ b/playground/backend/internal/cache/redis/redis_cache.go
@@ -30,6 +30,10 @@ import (
 	"beam.apache.org/playground/backend/internal/logger"
 )
 
+const (
+	catalogExpire = 5 * time.Minute
+)
+
 type Cache struct {
 	*redis.Client
 }
@@ -105,7 +109,7 @@ func (rc *Cache) SetCatalog(ctx context.Context, catalog []*pb.Categories) error
 		logger.Errorf("Redis Cache: set catalog: error during marshal catalog: %s, err: %s\n", catalog, err.Error())
 		return err
 	}
-	err = rc.Set(ctx, cache.ExamplesCatalog, catalogMarsh, 0).Err()
+	err = rc.Set(ctx, cache.ExamplesCatalog, catalogMarsh, catalogExpire).Err()
 	if err != nil {
 		logger.Errorf("Redis Cache: set catalog: error during Set operation, err: %s\n", err.Error())
 		return err

--- a/playground/backend/internal/cache/redis/redis_cache_test.go
+++ b/playground/backend/internal/cache/redis/redis_cache_test.go
@@ -436,7 +436,7 @@ func TestCache_SetCatalog(t *testing.T) {
 		{
 			name: "Set catalog",
 			mocks: func() {
-				mock.ExpectSet(cache.ExamplesCatalog, catalogMarsh, 0).SetVal("")
+				mock.ExpectSet(cache.ExamplesCatalog, catalogMarsh, catalogExpire).SetVal("")
 			},
 			fields: fields{client},
 			args: args{
@@ -448,7 +448,7 @@ func TestCache_SetCatalog(t *testing.T) {
 		{
 			name: "Error during Set operation",
 			mocks: func() {
-				mock.ExpectSet(cache.ExamplesCatalog, catalogMarsh, 0).SetErr(fmt.Errorf("MOCK_ERROR"))
+				mock.ExpectSet(cache.ExamplesCatalog, catalogMarsh, catalogExpire).SetErr(fmt.Errorf("MOCK_ERROR"))
 			},
 			fields: fields{client},
 			args: args{


### PR DESCRIPTION
Expiration time added to redis catalog cache (5 minutes)
Tests updated
resolves #23927
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
