### PR TITLE
[Spark Dataset runner] Implement producer-consumer fusion for ParDos

### DIFF
--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/PipelineTranslator.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/PipelineTranslator.java
@@ -198,12 +198,12 @@ public abstract class PipelineTranslator {
    * <p>An unresolved translation can - in certain cases - be fused together with following
    * transforms. Currently this is only the case for ParDos with linear linage.
    */
-  public interface UnresolvedTranslation<InT, OutT> {
+  public interface UnresolvedTranslation<InT, T> {
     PCollection<InT> getInput();
 
-    <Out2T> UnresolvedTranslation<InT, Out2T> fuse(UnresolvedTranslation<OutT, Out2T> next);
+    <T2> UnresolvedTranslation<InT, T2> fuse(UnresolvedTranslation<T, T2> next);
 
-    Dataset<WindowedValue<OutT>> resolve(
+    Dataset<WindowedValue<T>> resolve(
         Supplier<PipelineOptions> options, Dataset<WindowedValue<InT>> input);
   }
 

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/TransformTranslator.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/TransformTranslator.java
@@ -27,6 +27,7 @@ import java.util.Map;
 import java.util.function.Supplier;
 import org.apache.beam.runners.core.construction.TransformInputs;
 import org.apache.beam.runners.spark.structuredstreaming.translation.PipelineTranslator.TranslationState;
+import org.apache.beam.runners.spark.structuredstreaming.translation.PipelineTranslator.UnresolvedTranslation;
 import org.apache.beam.runners.spark.structuredstreaming.translation.batch.functions.SideInputValues;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.Coder;
@@ -156,6 +157,12 @@ public abstract class TransformTranslator<
     public <T> void putDataset(
         PCollection<T> pCollection, Dataset<WindowedValue<T>> dataset, boolean cache) {
       state.putDataset(pCollection, dataset, cache);
+    }
+
+    @Override
+    public <T1, T2> void putUnresolved(
+        PCollection<T2> out, UnresolvedTranslation<T1, T2> unresolved) {
+      state.putUnresolved(out, unresolved);
     }
 
     @Override

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/TransformTranslator.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/TransformTranslator.java
@@ -160,8 +160,8 @@ public abstract class TransformTranslator<
     }
 
     @Override
-    public <T1, T2> void putUnresolved(
-        PCollection<T2> out, UnresolvedTranslation<T1, T2> unresolved) {
+    public <InputT, T> void putUnresolved(
+        PCollection<T> out, UnresolvedTranslation<InputT, T> unresolved) {
       state.putUnresolved(out, unresolved);
     }
 

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/DoFnRunnerFactory.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/DoFnRunnerFactory.java
@@ -1,0 +1,297 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.spark.structuredstreaming.translation.batch;
+
+import com.google.common.collect.Lists;
+import org.apache.beam.runners.core.DoFnRunner;
+import org.apache.beam.runners.core.DoFnRunners;
+import org.apache.beam.runners.core.DoFnRunners.OutputManager;
+import org.apache.beam.runners.core.SideInputReader;
+import org.apache.beam.runners.core.construction.ParDoTranslation;
+import org.apache.beam.runners.spark.structuredstreaming.metrics.MetricsAccumulator;
+import org.apache.beam.runners.spark.structuredstreaming.translation.batch.functions.CachedSideInputReader;
+import org.apache.beam.runners.spark.structuredstreaming.translation.batch.functions.NoOpStepContext;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.runners.AppliedPTransform;
+import org.apache.beam.sdk.state.TimeDomain;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFnSchemaInformation;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.reflect.DoFnInvokers;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.WindowingStrategy;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Iterables;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
+import org.joda.time.Instant;
+import scala.Serializable;
+
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+
+/**
+ * Factory to create a {@link DoFnRunner}. The factory supports fusing multiple {@link DoFnRunner
+ * runners} into a single one.
+ */
+abstract class DoFnRunnerFactory<InT, OutT> implements Serializable {
+
+  interface DoFnRunnerWithTeardown<InT, OutT> extends DoFnRunner<InT, OutT> {
+    void teardown();
+  }
+
+  /**
+   * Creates a runner that is ready to process elements.
+   *
+   * <p>Both, {@link org.apache.beam.sdk.transforms.reflect.DoFnInvoker#invokeSetup setup} and
+   * {@link DoFnRunner#startBundle()} are already invoked by the factory.
+   */
+  abstract DoFnRunnerWithTeardown<InT, OutT> create(
+      PipelineOptions options, MetricsAccumulator metrics, OutputManager output);
+
+  /**
+   * Fuses the factory for the following {@link DoFnRunner} into a single factory that processes
+   * both DoFns in a single step.
+   */
+  abstract <Out2T> DoFnRunnerFactory<InT, Out2T> fuse(DoFnRunnerFactory<OutT, Out2T> next);
+
+  static <InT, OutT> DoFnRunnerFactory<InT, OutT> simple(
+      AppliedPTransform<PCollection<? extends InT>, ?, ParDo.MultiOutput<InT, OutT>> appliedPT,
+      PCollection<InT> input,
+      SideInputReader sideInputReader,
+      boolean filterMainOutput) {
+    return new SimpleRunnerFactory<>(appliedPT, input, sideInputReader, filterMainOutput);
+  }
+
+  /**
+   * Factory creating a {@link org.apache.beam.runners.core.SimpleDoFnRunner SimpleRunner} with
+   * metrics support.
+   */
+  private static class SimpleRunnerFactory<InT, OutT> extends DoFnRunnerFactory<InT, OutT> {
+    private final String stepName;
+    private final DoFn<InT, OutT> doFn;
+    private final DoFnSchemaInformation doFnSchema;
+    private final Coder<InT> coder;
+    private final WindowingStrategy<?, ?> windowingStrategy;
+    private final TupleTag<OutT> mainOutput;
+    private final List<TupleTag<?>> additionalOutputs;
+    private final Map<TupleTag<?>, Coder<?>> outputCoders;
+    private final Map<String, PCollectionView<?>> sideInputs;
+    private final SideInputReader sideInputReader;
+    private final boolean filterMainOutput;
+
+    SimpleRunnerFactory(
+        AppliedPTransform<PCollection<? extends InT>, ?, ParDo.MultiOutput<InT, OutT>> appliedPT,
+        PCollection<InT> input,
+        SideInputReader sideInputReader,
+        boolean filterMainOutput) {
+      this.stepName = appliedPT.getFullName();
+      this.doFn = appliedPT.getTransform().getFn();
+      this.doFnSchema = ParDoTranslation.getSchemaInformation(appliedPT);
+      this.coder = input.getCoder();
+      this.windowingStrategy = input.getWindowingStrategy();
+      this.mainOutput = appliedPT.getTransform().getMainOutputTag();
+      this.additionalOutputs = additionalOutputs(appliedPT.getTransform());
+      this.outputCoders = coders(appliedPT.getOutputs(), mainOutput);
+      this.sideInputs = appliedPT.getTransform().getSideInputs();
+      this.sideInputReader = sideInputReader;
+      this.filterMainOutput = filterMainOutput;
+    }
+
+    @Override
+    <Out2T> DoFnRunnerFactory<InT, Out2T> fuse(DoFnRunnerFactory<OutT, Out2T> next) {
+      return new FusedRunnerFactory<>(Lists.newArrayList(this, next));
+    }
+
+    @Override
+    DoFnRunnerWithTeardown<InT, OutT> create(
+        PipelineOptions options, MetricsAccumulator metrics, OutputManager output) {
+      DoFnRunner<InT, OutT> simpleRunner =
+          DoFnRunners.simpleRunner(
+              options,
+              doFn,
+              CachedSideInputReader.of(sideInputReader, sideInputs.values()),
+              filterMainOutput ? new FilteredOutput(output, mainOutput) : output,
+              mainOutput,
+              additionalOutputs,
+              new NoOpStepContext(),
+              coder,
+              outputCoders,
+              windowingStrategy,
+              doFnSchema,
+              sideInputs);
+      DoFnRunnerWithTeardown<InT, OutT> runner =
+          new DoFnRunnerWithMetrics<>(stepName, simpleRunner, metrics);
+      // Invoke setup and then startBundle before returning the runner
+      DoFnInvokers.tryInvokeSetupFor(doFn, options);
+      try {
+        runner.startBundle();
+      } catch (RuntimeException re) {
+        DoFnInvokers.invokerFor(doFn).invokeTeardown();
+        throw re;
+      }
+      return runner;
+    }
+
+    /**
+     * Delegate {@link OutputManager} that only forwards outputs matching the provided tag. This is
+     * used in cases where unused, obsolete outputs get dropped to avoid unnecessary caching.
+     */
+    private static class FilteredOutput implements OutputManager {
+      final OutputManager outputManager;
+      final TupleTag<?> tupleTag;
+
+      FilteredOutput(OutputManager outputManager, TupleTag<?> tupleTag) {
+        this.outputManager = outputManager;
+        this.tupleTag = tupleTag;
+      }
+
+      @Override
+      public <T> void output(TupleTag<T> tag, WindowedValue<T> output) {
+        if (tupleTag.equals(tag)) {
+          outputManager.output(tag, output);
+        }
+      }
+    }
+
+    private static Map<TupleTag<?>, Coder<?>> coders(
+        Map<TupleTag<?>, PCollection<?>> pCols, TupleTag<?> main) {
+      if (pCols.size() == 1) {
+        return Collections.singletonMap(main, Iterables.getOnlyElement(pCols.values()).getCoder());
+      }
+      Map<TupleTag<?>, Coder<?>> coders = Maps.newHashMapWithExpectedSize(pCols.size());
+      for (Map.Entry<TupleTag<?>, PCollection<?>> e : pCols.entrySet()) {
+        coders.put(e.getKey(), e.getValue().getCoder());
+      }
+      return coders;
+    }
+
+    private static List<TupleTag<?>> additionalOutputs(ParDo.MultiOutput<?, ?> transform) {
+      List<TupleTag<?>> tags = transform.getAdditionalOutputTags().getAll();
+      return tags.isEmpty() ? Collections.emptyList() : new ArrayList<>(tags);
+    }
+  }
+
+  /**
+   * Factory that produces a fused runner consisting of multiple chained {@link DoFn DoFns}. Outputs
+   * are directly forwarded to the next runner without buffering inbetween.
+   */
+  private static class FusedRunnerFactory<InT, OutT> extends DoFnRunnerFactory<InT, OutT> {
+    private final List<DoFnRunnerFactory<?, ?>> factories;
+
+    FusedRunnerFactory(List<DoFnRunnerFactory<?, ?>> factories) {
+      this.factories = factories;
+    }
+
+    @Override
+    DoFnRunnerWithTeardown<InT, OutT> create(
+        PipelineOptions options, MetricsAccumulator metrics, OutputManager output) {
+      return new FusedRunner<>(options, metrics, output, factories);
+    }
+
+    @Override
+    <Out2T> DoFnRunnerFactory<InT, Out2T> fuse(DoFnRunnerFactory<OutT, Out2T> next) {
+      factories.add(next);
+      return (DoFnRunnerFactory<InT, Out2T>) this;
+    }
+
+    private static class FusedRunner<InT, OutT> implements DoFnRunnerWithTeardown<InT, OutT> {
+      final DoFnRunnerWithTeardown<?, ?>[] runners;
+
+      FusedRunner(
+          PipelineOptions options,
+          MetricsAccumulator metrics,
+          OutputManager output,
+          List<DoFnRunnerFactory<?, ?>> factories) {
+        runners = new DoFnRunnerWithTeardown<?, ?>[factories.size()];
+        runners[runners.length - 1] =
+            factories.get(runners.length - 1).create(options, metrics, output);
+        for (int i = runners.length - 2; i >= 0; i--) {
+          runners[i] = factories.get(i).create(options, metrics, new FusedOutput(runners[i + 1]));
+        }
+      }
+
+      /** {@link OutputManager} that forwards output directly to the next runner. */
+      private static class FusedOutput implements OutputManager {
+        final DoFnRunnerWithTeardown<?, ?> runner;
+
+        FusedOutput(DoFnRunnerWithTeardown<?, ?> runner) {
+          this.runner = runner;
+        }
+
+        @Override
+        public <T> void output(TupleTag<T> tag, WindowedValue<T> output) {
+          runner.processElement((WindowedValue) output);
+        }
+      }
+
+      @Override
+      public void startBundle() {
+        for (int i = 0; i < runners.length; i++) {
+          runners[i].startBundle();
+        }
+      }
+
+      @Override
+      public void processElement(WindowedValue<InT> elem) {
+        runners[0].processElement((WindowedValue) elem);
+      }
+
+      @Override
+      public <KeyT> void onTimer(
+          String timerId,
+          String timerFamilyId,
+          KeyT key,
+          BoundedWindow window,
+          Instant timestamp,
+          Instant outputTimestamp,
+          TimeDomain timeDomain) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public <KeyT> void onWindowExpiration(BoundedWindow window, Instant timestamp, KeyT key) {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void finishBundle() {
+        for (int i = 0; i < runners.length; i++) {
+          runners[i].finishBundle();
+        }
+      }
+
+      @Override
+      public DoFn<InT, OutT> getFn() {
+        throw new UnsupportedOperationException();
+      }
+
+      @Override
+      public void teardown() {
+        for (int i = 0; i < runners.length; i++) {
+          runners[i].teardown();
+        }
+      }
+    }
+  }
+}

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/DoFnRunnerWithMetrics.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/DoFnRunnerWithMetrics.java
@@ -21,31 +21,33 @@ import java.io.Closeable;
 import java.io.IOException;
 import org.apache.beam.runners.core.DoFnRunner;
 import org.apache.beam.runners.spark.structuredstreaming.metrics.MetricsAccumulator;
+import org.apache.beam.runners.spark.structuredstreaming.translation.batch.DoFnRunnerFactory.DoFnRunnerWithTeardown;
 import org.apache.beam.sdk.metrics.MetricsContainer;
 import org.apache.beam.sdk.metrics.MetricsEnvironment;
 import org.apache.beam.sdk.state.TimeDomain;
 import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.reflect.DoFnInvokers;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.joda.time.Instant;
 
 /** DoFnRunner decorator which registers {@link MetricsContainer}. */
-class DoFnRunnerWithMetrics<InputT, OutputT> implements DoFnRunner<InputT, OutputT> {
-  private final DoFnRunner<InputT, OutputT> delegate;
+class DoFnRunnerWithMetrics<InT, OutT> implements DoFnRunnerWithTeardown<InT, OutT> {
+  private final DoFnRunner<InT, OutT> delegate;
   private final MetricsContainer metrics;
 
   DoFnRunnerWithMetrics(
-      String stepName, DoFnRunner<InputT, OutputT> delegate, MetricsAccumulator metricsAccum) {
+      String stepName, DoFnRunner<InT, OutT> delegate, MetricsAccumulator metricsAccum) {
     this(delegate, metricsAccum.value().getContainer(stepName));
   }
 
-  private DoFnRunnerWithMetrics(DoFnRunner<InputT, OutputT> delegate, MetricsContainer metrics) {
+  private DoFnRunnerWithMetrics(DoFnRunner<InT, OutT> delegate, MetricsContainer metrics) {
     this.delegate = delegate;
     this.metrics = metrics;
   }
 
   @Override
-  public DoFn<InputT, OutputT> getFn() {
+  public DoFn<InT, OutT> getFn() {
     return delegate.getFn();
   }
 
@@ -59,7 +61,7 @@ class DoFnRunnerWithMetrics<InputT, OutputT> implements DoFnRunner<InputT, Outpu
   }
 
   @Override
-  public void processElement(final WindowedValue<InputT> elem) {
+  public void processElement(final WindowedValue<InT> elem) {
     try (Closeable ignored = MetricsEnvironment.scopedMetricsContainer(metrics)) {
       delegate.processElement(elem);
     } catch (IOException e) {
@@ -95,5 +97,10 @@ class DoFnRunnerWithMetrics<InputT, OutputT> implements DoFnRunner<InputT, Outpu
   @Override
   public <KeyT> void onWindowExpiration(BoundedWindow window, Instant timestamp, KeyT key) {
     delegate.onWindowExpiration(window, timestamp, key);
+  }
+
+  @Override
+  public void teardown() {
+    DoFnInvokers.invokerFor(delegate.getFn()).invokeTeardown();
   }
 }

--- a/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/ParDoTranslatorBatch.java
+++ b/runners/spark/3/src/main/java/org/apache/beam/runners/spark/structuredstreaming/translation/batch/ParDoTranslatorBatch.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.spark.structuredstreaming.translation.batch;
 
+import static org.apache.beam.runners.spark.structuredstreaming.translation.batch.DoFnRunnerFactory.simple;
 import static org.apache.beam.runners.spark.structuredstreaming.translation.helpers.EncoderHelpers.oneOfEncoder;
 import static org.apache.beam.sdk.util.Preconditions.checkStateNotNull;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkState;
@@ -29,14 +30,17 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.function.Supplier;
 import org.apache.beam.runners.core.DoFnRunners;
 import org.apache.beam.runners.core.SideInputReader;
 import org.apache.beam.runners.spark.SparkCommonPipelineOptions;
 import org.apache.beam.runners.spark.structuredstreaming.metrics.MetricsAccumulator;
+import org.apache.beam.runners.spark.structuredstreaming.translation.PipelineTranslator.UnresolvedTranslation;
 import org.apache.beam.runners.spark.structuredstreaming.translation.TransformTranslator;
 import org.apache.beam.runners.spark.structuredstreaming.translation.batch.functions.SideInputValues;
 import org.apache.beam.runners.spark.structuredstreaming.translation.batch.functions.SparkSideInputReader;
 import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.reflect.DoFnSignature;
@@ -104,8 +108,6 @@ class ParDoTranslatorBatch<InputT, OutputT>
       throws IOException {
 
     PCollection<InputT> input = (PCollection<InputT>) cxt.getInput();
-
-    Dataset<WindowedValue<InputT>> inputDs = cxt.getDataset(input);
     SideInputReader sideInputReader =
         createSideInputReader(transform.getSideInputs().values(), cxt);
     MetricsAccumulator metrics = MetricsAccumulator.getInstance(cxt.getSparkSession());
@@ -124,11 +126,9 @@ class ParDoTranslatorBatch<InputT, OutputT>
 
       DoFnPartitionIteratorFactory<InputT, ?, Tuple2<Integer, WindowedValue<Object>>> doFnMapper =
           DoFnPartitionIteratorFactory.multiOutput(
-              cxt.getCurrentTransform(),
               cxt.getOptionsSupplier(),
-              input,
-              sideInputReader,
               metrics,
+              simple(cxt.getCurrentTransform(), input, sideInputReader, false),
               tagColIdx);
 
       // FIXME What's the strategy to unpersist Datasets / RDDs?
@@ -138,7 +138,7 @@ class ParDoTranslatorBatch<InputT, OutputT>
 
       // Persist as wide rows with one column per TupleTag to support different schemas
       Dataset<Tuple2<Integer, WindowedValue<Object>>> allTagsDS =
-          inputDs.mapPartitions(doFnMapper, oneOfEncoder(encoders));
+          cxt.getDataset(input).mapPartitions(doFnMapper, oneOfEncoder(encoders));
       allTagsDS.persist(storageLevel);
 
       // divide into separate output datasets per tag
@@ -154,14 +154,54 @@ class ParDoTranslatorBatch<InputT, OutputT>
       }
     } else {
       PCollection<OutputT> output = cxt.getOutput(mainOut);
-      DoFnPartitionIteratorFactory<InputT, ?, WindowedValue<OutputT>> doFnMapper =
-          DoFnPartitionIteratorFactory.singleOutput(
-              cxt.getCurrentTransform(), cxt.getOptionsSupplier(), input, sideInputReader, metrics);
+      // Obsolete outputs might have to be filtered out
+      boolean filterMainOutput = cxt.getOutputs().size() > 1;
+      // Provide unresolved translation so that can be fused if possible
+      UnresolvedParDo<InputT, OutputT> unresolvedParDo =
+          new UnresolvedParDo<>(
+              input,
+              simple(cxt.getCurrentTransform(), input, sideInputReader, filterMainOutput),
+              () -> cxt.windowedEncoder(output.getCoder()));
+      cxt.putUnresolved(output, unresolvedParDo);
+    }
+  }
 
-      Dataset<WindowedValue<OutputT>> mainDS =
-          inputDs.mapPartitions(doFnMapper, cxt.windowedEncoder(output.getCoder()));
+  /**
+   * An unresolved {@link ParDo} translation that can be fused with previous / following ParDos for
+   * better performance.
+   */
+  private static class UnresolvedParDo<InT, OutT> implements UnresolvedTranslation<InT, OutT> {
+    private final PCollection<InT> input;
+    private final DoFnRunnerFactory<InT, OutT> doFnFact;
+    private final Supplier<Encoder<WindowedValue<OutT>>> encoder;
 
-      cxt.putDataset(output, mainDS);
+    UnresolvedParDo(
+        PCollection<InT> input,
+        DoFnRunnerFactory<InT, OutT> doFnFact,
+        Supplier<Encoder<WindowedValue<OutT>>> encoder) {
+      this.input = input;
+      this.doFnFact = doFnFact;
+      this.encoder = encoder;
+    }
+
+    @Override
+    public PCollection<InT> getInput() {
+      return input;
+    }
+
+    @Override
+    public <Out2T> UnresolvedTranslation<InT, Out2T> fuse(UnresolvedTranslation<OutT, Out2T> next) {
+      UnresolvedParDo<OutT, Out2T> nextParDo = (UnresolvedParDo<OutT, Out2T>) next;
+      return new UnresolvedParDo<>(input, doFnFact.fuse(nextParDo.doFnFact), nextParDo.encoder);
+    }
+
+    @Override
+    public Dataset<WindowedValue<OutT>> resolve(
+        Supplier<PipelineOptions> options, Dataset<WindowedValue<InT>> input) {
+      MetricsAccumulator metrics = MetricsAccumulator.getInstance(input.sparkSession());
+      DoFnPartitionIteratorFactory<InT, ?, WindowedValue<OutT>> doFnMapper =
+          DoFnPartitionIteratorFactory.singleOutput(options, metrics, doFnFact);
+      return input.mapPartitions(doFnMapper, encoder.get());
     }
   }
 


### PR DESCRIPTION
Beam runners may choose to apply optimizations to a pipeline before it is executed. A key optimization, fusion, relates to ParDo operations. If one ParDo operation produces a PCollection that is then consumed as the main input of another ParDo operation, the two ParDo operations will be fused together into a single ParDo operation and run in a single pass; this is "producer-consumer fusion".

This PR implements producer-consumer fusion for sequential ParDos in the Spark Dataset runner.

Closes #25761
This is also a follow up (optimization) regarding https://github.com/apache/beam/pull/25732.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
