### PR TITLE
[Go] Add machine_type alias to dataflow pipeline options

### DIFF
--- a/sdks/go/pkg/beam/runners/dataflow/dataflow.go
+++ b/sdks/go/pkg/beam/runners/dataflow/dataflow.go
@@ -70,7 +70,8 @@ var (
 	subnetwork             = flag.String("subnetwork", "", "GCP subnetwork (optional)")
 	noUsePublicIPs         = flag.Bool("no_use_public_ips", false, "Workers must not use public IP addresses (optional)")
 	tempLocation           = flag.String("temp_location", "", "Temp location (optional)")
-	machineType            = flag.String("worker_machine_type", "", "GCE machine type (optional)")
+	workerMachineType      = flag.String("worker_machine_type", "", "GCE machine type (optional)")
+	machineType            = flag.String("machine_type", "", "alias of worker_machine_type (optional)")
 	minCPUPlatform         = flag.String("min_cpu_platform", "", "GCE minimum cpu platform (optional)")
 	workerRegion           = flag.String("worker_region", "", "Dataflow worker region (optional)")
 	workerZone             = flag.String("worker_zone", "", "Dataflow worker zone (optional)")
@@ -120,6 +121,7 @@ var flagFilter = map[string]bool{
 	"no_use_public_ips":              true,
 	"template_location":              true,
 	"worker_machine_type":            true,
+	"machine_type":                   true,
 	"min_cpu_platform":               true,
 	"dataflow_worker_jar":            true,
 	"worker_region":                  true,
@@ -169,6 +171,16 @@ func init() {
 }
 
 var unique int32
+
+// Helper function finding first non empty string. Used for handling alias options.
+func firstNonEmpty(values ...*string) *string {
+	for _, value := range values {
+		if *value != "" {
+			return value
+		}
+	}
+	return values[0]
+}
 
 // Execute runs the given pipeline on Google Cloud Dataflow. It uses the
 // default application credentials to submit the job.
@@ -361,7 +373,7 @@ func getJobOptions(ctx context.Context, streaming bool) (*dataflowlib.JobOptions
 		DiskType:               *diskType,
 		Algorithm:              *autoscalingAlgorithm,
 		FlexRSGoal:             *flexRSGoal,
-		MachineType:            *machineType,
+		MachineType:            *firstNonEmpty(workerMachineType, machineType),
 		Labels:                 jobLabels,
 		ServiceAccountEmail:    *serviceAccountEmail,
 		TempLocation:           *tempLocation,


### PR DESCRIPTION
Go SDK's dataflow pipeline option recognizes "--worker_machine_type" but [dataflow API](https://cloud.google.com/dataflow/docs/reference/rest/v1b3/projects.locations.flexTemplates/launch#FlexTemplateRuntimeEnvironment) has `machineType` option. This discrepancy causes pipeline launch failure when running a dataflow flex-template.

Actually in Python SDK where '--worker_machine_type', '--machine_type' are the same: https://github.com/aaltay/beam/blob/0290315623d2734563b6b163257a160045c1ad6c/sdks/python/apache_beam/options/pipeline_options.py#L948

This PR makes '--machine_type' the alias of "--worker_machine_type". However the flag package standard go library does not support alias: https://github.com/golang/go/issues/35761 (closed as won't do). A littble bit less straightforward approach is needed.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
