### PR TITLE
Adding support for GCS-stored files for consumer config overrides

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaReadSchemaTransformProvider.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaReadSchemaTransformProvider.java
@@ -18,13 +18,23 @@
 package org.apache.beam.sdk.io.kafka;
 
 import com.google.auto.service.AutoService;
+import java.io.FileOutputStream;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
+import java.nio.channels.WritableByteChannel;
+import java.nio.file.Files;
+import java.nio.file.Path;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.stream.Collectors;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.extensions.avro.coders.AvroCoder;
 import org.apache.beam.sdk.extensions.avro.schemas.utils.AvroUtils;
+import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.transforms.Convert;
 import org.apache.beam.sdk.schemas.transforms.SchemaTransform;
@@ -43,6 +53,8 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.Visi
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Strings;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Maps;
+import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.joda.time.Duration;
@@ -137,6 +149,7 @@ public class KafkaReadSchemaTransformProvider
             KafkaIO.Read<byte[], byte[]> kafkaRead =
                 KafkaIO.readBytes()
                     .withConsumerConfigUpdates(consumerConfigs)
+                    .withConsumerFactoryFn(new ConsumerFactoryWithGcsTrustStores())
                     .withTopic(configuration.getTopic())
                     .withBootstrapServers(configuration.getBootstrapServers());
             if (isTest) {
@@ -171,6 +184,7 @@ public class KafkaReadSchemaTransformProvider
             KafkaIO.Read<byte[], GenericRecord> kafkaRead =
                 KafkaIO.<byte[], GenericRecord>read()
                     .withTopic(configuration.getTopic())
+                    .withConsumerFactoryFn(new ConsumerFactoryWithGcsTrustStores())
                     .withBootstrapServers(configuration.getBootstrapServers())
                     .withConsumerConfigUpdates(consumerConfigs)
                     .withKeyDeserializer(ByteArrayDeserializer.class)
@@ -193,4 +207,59 @@ public class KafkaReadSchemaTransformProvider
       }
     }
   };
+
+  private static class ConsumerFactoryWithGcsTrustStores
+      implements SerializableFunction<Map<String, Object>, Consumer<byte[], byte[]>> {
+
+    @Override
+    public Consumer<byte[], byte[]> apply(Map<String, Object> input) {
+      return KafkaIOUtils.KAFKA_CONSUMER_FACTORY_FN.apply(
+          input.entrySet().stream()
+              .map(
+                  entry ->
+                      Maps.immutableEntry(
+                          entry.getKey(), identityOrGcsToLocalFile(entry.getValue())))
+              .collect(Collectors.toMap(Map.Entry::getKey, Map.Entry::getValue)));
+    }
+
+    private static Object identityOrGcsToLocalFile(Object configValue) {
+      if (configValue instanceof String) {
+        String configStr = (String) configValue;
+        if (configStr.startsWith("gs://")) {
+          try {
+            ReadableByteChannel channel =
+                FileSystems.open(FileSystems.match(configStr).metadata().get(0).resourceId());
+            Path localFile = Files.createTempFile(null, null);
+            FileOutputStream outputStream = new FileOutputStream(localFile.toFile());
+
+            // Create a WritableByteChannel to write data to the FileOutputStream
+            WritableByteChannel outputChannel = Channels.newChannel(outputStream);
+
+            // Read data from the ReadableByteChannel and write it to the WritableByteChannel
+            ByteBuffer buffer = ByteBuffer.allocate(1024);
+            while (channel.read(buffer) != -1) {
+              buffer.flip();
+              outputChannel.write(buffer);
+              buffer.compact();
+            }
+
+            // Close the channels and the output stream
+            channel.close();
+            outputChannel.close();
+            outputStream.close();
+            return localFile.toAbsolutePath().toString();
+          } catch (IOException e) {
+            throw new IllegalArgumentException(
+                String.format(
+                    "Unable to fetch file %s to be used locally to create a Kafka Consumer.",
+                    configStr));
+          }
+        } else {
+          return configValue;
+        }
+      } else {
+        return configValue;
+      }
+    }
+  }
 }

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaReadSchemaTransformProvider.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaReadSchemaTransformProvider.java
@@ -58,10 +58,14 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.common.serialization.ByteArrayDeserializer;
 import org.joda.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 @AutoService(SchemaTransformProvider.class)
 public class KafkaReadSchemaTransformProvider
     extends TypedSchemaTransformProvider<KafkaReadSchemaTransformConfiguration> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaReadSchemaTransformProvider.class);
 
   final Boolean isTest;
   final Integer testTimeoutSecs;
@@ -227,9 +231,12 @@ public class KafkaReadSchemaTransformProvider
         String configStr = (String) configValue;
         if (configStr.startsWith("gs://")) {
           try {
+            Path localFile = Files.createTempFile("", "");
+            LOG.info(
+                "Downloading {} into local filesystem ({})", configStr, localFile.toAbsolutePath());
+            // TODO(pabloem): Only copy if file does not exist.
             ReadableByteChannel channel =
                 FileSystems.open(FileSystems.match(configStr).metadata().get(0).resourceId());
-            Path localFile = Files.createTempFile(null, null);
             FileOutputStream outputStream = new FileOutputStream(localFile.toFile());
 
             // Create a WritableByteChannel to write data to the FileOutputStream


### PR DESCRIPTION
r: @johnjcasey 

This is for users to pass truststore / keystore files for Kafka consumers that are stored in GCS, and we can then store them in the local worker for Kafka to create a consumer properly. It's an 'ease-of-use' feature for x-lang (and syndeo) users.

It can be extended to other filesystems (e.g. s3)

fyi @chamikaramj @bvolpato I'd also like your thoughts on this...

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
