### PR TITLE
Fix OutputSampler's coder

### DIFF
--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/debug/DataSamplerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/debug/DataSamplerTest.java
@@ -36,6 +36,7 @@ import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.vendor.grpc.v1p48p1.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.junit.Test;
@@ -63,6 +64,10 @@ public class DataSamplerTest {
     ByteArrayOutputStream stream = new ByteArrayOutputStream();
     coder.encode(b, stream, Coder.Context.NESTED);
     return stream.toByteArray();
+  }
+
+  <T> WindowedValue<T> globalWindowedValue(T el) {
+    return WindowedValue.valueInGlobalWindow(el);
   }
 
   BeamFnApi.InstructionResponse getAllSamples(DataSampler dataSampler) {
@@ -122,7 +127,7 @@ public class DataSamplerTest {
     DataSampler sampler = new DataSampler();
 
     VarIntCoder coder = VarIntCoder.of();
-    sampler.sampleOutput("pcollection-id", coder).sample(1);
+    sampler.sampleOutput("pcollection-id", coder).sample(globalWindowedValue(1));
 
     BeamFnApi.InstructionResponse samples = getAllSamples(sampler);
     assertHasSamples(samples, "pcollection-id", Collections.singleton(encodeInt(1)));
@@ -140,7 +145,7 @@ public class DataSamplerTest {
     String rawString = "hello";
     byte[] byteArray = rawString.getBytes(StandardCharsets.US_ASCII);
     ByteArrayCoder coder = ByteArrayCoder.of();
-    sampler.sampleOutput("pcollection-id", coder).sample(byteArray);
+    sampler.sampleOutput("pcollection-id", coder).sample(globalWindowedValue(byteArray));
 
     BeamFnApi.InstructionResponse samples = getAllSamples(sampler);
     assertHasSamples(samples, "pcollection-id", Collections.singleton(encodeByteArray(byteArray)));
@@ -156,8 +161,8 @@ public class DataSamplerTest {
     DataSampler sampler = new DataSampler();
 
     VarIntCoder coder = VarIntCoder.of();
-    sampler.sampleOutput("pcollection-id-1", coder).sample(1);
-    sampler.sampleOutput("pcollection-id-2", coder).sample(2);
+    sampler.sampleOutput("pcollection-id-1", coder).sample(globalWindowedValue(1));
+    sampler.sampleOutput("pcollection-id-2", coder).sample(globalWindowedValue(2));
 
     BeamFnApi.InstructionResponse samples = getAllSamples(sampler);
     assertHasSamples(samples, "pcollection-id-1", Collections.singleton(encodeInt(1)));
@@ -174,8 +179,8 @@ public class DataSamplerTest {
     DataSampler sampler = new DataSampler();
 
     VarIntCoder coder = VarIntCoder.of();
-    sampler.sampleOutput("pcollection-id", coder).sample(1);
-    sampler.sampleOutput("pcollection-id", coder).sample(2);
+    sampler.sampleOutput("pcollection-id", coder).sample(globalWindowedValue(1));
+    sampler.sampleOutput("pcollection-id", coder).sample(globalWindowedValue(2));
 
     BeamFnApi.InstructionResponse samples = getAllSamples(sampler);
     assertHasSamples(samples, "pcollection-id", ImmutableList.of(encodeInt(1), encodeInt(2)));
@@ -183,12 +188,12 @@ public class DataSamplerTest {
 
   void generateStringSamples(DataSampler sampler) {
     StringUtf8Coder coder = StringUtf8Coder.of();
-    sampler.sampleOutput("a", coder).sample("a1");
-    sampler.sampleOutput("a", coder).sample("a2");
-    sampler.sampleOutput("b", coder).sample("b1");
-    sampler.sampleOutput("b", coder).sample("b2");
-    sampler.sampleOutput("c", coder).sample("c1");
-    sampler.sampleOutput("c", coder).sample("c2");
+    sampler.sampleOutput("a", coder).sample(globalWindowedValue("a1"));
+    sampler.sampleOutput("a", coder).sample(globalWindowedValue("a2"));
+    sampler.sampleOutput("b", coder).sample(globalWindowedValue("b1"));
+    sampler.sampleOutput("b", coder).sample(globalWindowedValue("b2"));
+    sampler.sampleOutput("c", coder).sample(globalWindowedValue("c1"));
+    sampler.sampleOutput("c", coder).sample(globalWindowedValue("c2"));
   }
 
   /**
@@ -250,7 +255,7 @@ public class DataSamplerTest {
                 }
 
                 for (int j = 0; j < 100; j++) {
-                  sampler.sampleOutput("pcollection-" + j, coder).sample(0);
+                  sampler.sampleOutput("pcollection-" + j, coder).sample(globalWindowedValue(0));
                 }
 
                 doneSignal.countDown();


### PR DESCRIPTION
Previously, the OutputSampler coder would always be the Value coder (from a windowed value). This would cause a mismatch between the encoding for the PCollection defined in the ProcessBundleDescriptor vs. what is being given to the OutputSampler. The fix is to always sample WindowedValues and give the OutputSampler the literal rehydrated coder.

Task #25064

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
