### PR TITLE
Corrected GscUtil.RewriteOp.OnFailure() error message

### DIFF
--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/GcsUtil.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/GcsUtil.java
@@ -932,7 +932,8 @@ public class GcsUtil {
         } else {
           throw new FileNotFoundException(
               String.format(
-                  "Source %s not found. Failed with error: %s", from.toString(), e.getMessage()));
+                  "Rewrite from %s to %s has failed. Either source or sink not found. "
+                      + "Failed with error: %s", from.toString(), to.toString(), e.getMessage()));
         }
       } else if (e.getCode() == 403
           && e.getErrors().size() == 1

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/GcsUtil.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/GcsUtil.java
@@ -933,7 +933,8 @@ public class GcsUtil {
           throw new FileNotFoundException(
               String.format(
                   "Rewrite from %s to %s has failed. Either source or sink not found. "
-                      + "Failed with error: %s", from.toString(), to.toString(), e.getMessage()));
+                      + "Failed with error: %s",
+                  from.toString(), to.toString(), e.getMessage()));
         }
       } else if (e.getCode() == 403
           && e.getErrors().size() == 1


### PR DESCRIPTION
Addresses [b/272593880](https://buganizer.corp.google.com/issues/272593880) by changing the offending error message to entail the possibility that either end of the rewrite could be missing. Previous implementation assumed that the source had to be missing, when the sink not being present could also cause the rewrite to fail.