### PR TITLE
Improve stage race condition by checking if staged before each try

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/PackageUtil.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/PackageUtil.java
@@ -149,11 +149,6 @@ public class PackageUtil implements Closeable {
     String sourceDescription = attributes.getSourceDescription();
     String target = attributes.getDestination().getLocation();
 
-    if (alreadyStaged(attributes)) {
-      LOG.debug("Skipping file already staged: {} at {}", sourceDescription, target);
-      return StagingResult.cached(attributes);
-    }
-
     try {
       return tryStagePackageWithRetry(attributes, retrySleeper, createOptions);
     } catch (Exception miscException) {
@@ -170,6 +165,11 @@ public class PackageUtil implements Closeable {
     BackOff backoff = BackOffAdapter.toGcpBackOff(BACKOFF_FACTORY.backoff());
 
     while (true) {
+      if (alreadyStaged(attributes)) {
+        LOG.debug("Skipping file already staged: {} at {}", sourceDescription, target);
+        return StagingResult.cached(attributes);
+      }
+
       try {
         return tryStagePackage(attributes, createOptions);
       } catch (IOException ioException) {


### PR DESCRIPTION
A race condition can be easily introduced and exhaust all default `withMaxRetries(4)` with 2 job submissions / threads staging the same JAR at the same time, especially for large JARs:

> 2023-03-13 18:19:40 INFO  TemplateTestBase:35 - 2023-03-13 18:19:40 WARN  RetryHttpRequestInitializer:165 - Request failed with code 412, performed 0 retries due to IOExceptions, performed 0 retries due to unsuccessful status codes, HTTP framework says request can be retried, (caller responsible for retrying): https://storage.googleapis.com/upload/storage/v1/b/{bucket}/o?ifGenerationMatch=1678731567510887&name=2023-03-13-18-11_IT/staging/hbase-shaded-server-1.4.12-{hash}.jar&uploadType=resumable&upload_id={id}. 
>
> 2023-03-13 18:19:40 INFO  TemplateTestBase:35 - 2023-03-13 18:19:40 ERROR PackageUtil:191 - Upload failed, will NOT retry staging of package: /home/{user}/.m2/repository/org/apache/hbase/hbase-shaded-server/1.4.12/hbase-shaded-server-1.4.12.jar
>
> 2023-03-13 18:19:40 INFO  TemplateTestBase:35 - java.io.IOException: Upload failed for 'gs://{bucket}/2023-03-13-18-11_IT/staging/hbase-shaded-server-1.4.12-{hash}.jar'


Even in scenarios in which a concurrent submission goes through, the artifacts are re-uploaded, making the cache useless under racing.


This change will check if the file was already staged before each try, instead of before entering the retry loop. 



------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] ~Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.~
 - [ ] ~Update `CHANGES.md` with noteworthy changes.~
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
