### PR TITLE
Use autoSharding from config when BigQueryIO.Write is created.

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySchemaIOProvider.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySchemaIOProvider.java
@@ -95,6 +95,7 @@ public class BigQuerySchemaIOProvider implements SchemaIOProvider {
         .addNullableField("queryLocation", FieldType.STRING)
         .addNullableField("createDisposition", FieldType.STRING)
         .addNullableField("useTestingBigQueryServices", FieldType.BOOLEAN)
+        .addNullableField("autoSharding", FieldType.BOOLEAN)
         .build();
   }
 
@@ -202,7 +203,7 @@ public class BigQuerySchemaIOProvider implements SchemaIOProvider {
                   .withMethod(BigQueryIO.Write.Method.STORAGE_WRITE_API)
                   .withTriggeringFrequency(Duration.standardSeconds(5))
                   .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_APPEND)
-                  .withAutoSharding();
+                  .withAutoSharding(config.getBoolean("autoSharding"));
 
           final Boolean useTestingBigQueryServices =
               config.getBoolean("useTestingBigQueryServices");

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySchemaIOProvider.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySchemaIOProvider.java
@@ -203,12 +203,12 @@ public class BigQuerySchemaIOProvider implements SchemaIOProvider {
                   .withMethod(BigQueryIO.Write.Method.STORAGE_WRITE_API)
                   .withTriggeringFrequency(Duration.standardSeconds(5))
                   .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_APPEND);
-          
+
           final Boolean autoSharding = config.getBoolean("autoSharding");
-          if(autoSharding != null && autoSharding){
+          if (autoSharding != null && autoSharding) {
             write = write.withAutoSharding();
           }
-          
+
           final Boolean useTestingBigQueryServices =
               config.getBoolean("useTestingBigQueryServices");
           if (useTestingBigQueryServices != null && useTestingBigQueryServices) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySchemaIOProvider.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySchemaIOProvider.java
@@ -202,9 +202,13 @@ public class BigQuerySchemaIOProvider implements SchemaIOProvider {
                   .useBeamSchema()
                   .withMethod(BigQueryIO.Write.Method.STORAGE_WRITE_API)
                   .withTriggeringFrequency(Duration.standardSeconds(5))
-                  .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_APPEND)
-                  .withAutoSharding(config.getBoolean("autoSharding"));
-
+                  .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_APPEND);
+          
+          final Boolean autoSharding = config.getBoolean("autoSharding");
+          if(autoSharding != null && autoSharding){
+            write = write.withAutoSharding(config.getBoolean("autoSharding"));
+          }
+          
           final Boolean useTestingBigQueryServices =
               config.getBoolean("useTestingBigQueryServices");
           if (useTestingBigQueryServices != null && useTestingBigQueryServices) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySchemaIOProvider.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySchemaIOProvider.java
@@ -206,7 +206,7 @@ public class BigQuerySchemaIOProvider implements SchemaIOProvider {
           
           final Boolean autoSharding = config.getBoolean("autoSharding");
           if(autoSharding != null && autoSharding){
-            write = write.withAutoSharding(config.getBoolean("autoSharding"));
+            write = write.withAutoSharding();
           }
           
           final Boolean useTestingBigQueryServices =

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProvider.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProvider.java
@@ -190,9 +190,9 @@ public class BigQueryStorageWriteApiSchemaTransformProvider
             + "duplicate data elements.")
     @Nullable
     public abstract Boolean getUseAtLeastOnceSemantics();
-    
+
     @SchemaFieldDescription(
-      "This option enables using a dynamically determined number of shards to write to "
+        "This option enables using a dynamically determined number of shards to write to "
             + "BigQuery. Only applicable to unbounded data.")
     @Nullable
     public abstract Boolean getAutoSharding();
@@ -209,7 +209,7 @@ public class BigQueryStorageWriteApiSchemaTransformProvider
       public abstract Builder setTriggeringFrequencySeconds(Long seconds);
 
       public abstract Builder setUseAtLeastOnceSemantics(Boolean use);
-      
+
       public abstract Builder setAutoSharding(Boolean autoSharding);
 
       /** Builds a {@link BigQueryStorageWriteApiSchemaTransformConfiguration} instance. */
@@ -291,11 +291,11 @@ public class BigQueryStorageWriteApiSchemaTransformProvider
         Boolean autoSharding = configuration.getAutoSharding();
         write =
             write.withTriggeringFrequency(
-                    (triggeringFrequency == null || triggeringFrequency <= 0)
-                        ? DEFAULT_TRIGGERING_FREQUENCY
-                        : Duration.standardSeconds(triggeringFrequency));
-        
-        if(autoSharding != null && autoSharding) {
+                (triggeringFrequency == null || triggeringFrequency <= 0)
+                    ? DEFAULT_TRIGGERING_FREQUENCY
+                    : Duration.standardSeconds(triggeringFrequency));
+
+        if (autoSharding != null && autoSharding) {
           write = write.withAutoSharding();
         }
       }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProvider.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProvider.java
@@ -190,6 +190,12 @@ public class BigQueryStorageWriteApiSchemaTransformProvider
             + "duplicate data elements.")
     @Nullable
     public abstract Boolean getUseAtLeastOnceSemantics();
+    
+    @SchemaFieldDescription(
+      "This option enables using a dynamically determined number of shards to write to "
+            + "BigQuery. Only applicable to unbounded data.")
+    @Nullable
+    public abstract Boolean getAutoSharding();
 
     /** Builder for {@link BigQueryStorageWriteApiSchemaTransformConfiguration}. */
     @AutoValue.Builder
@@ -203,6 +209,8 @@ public class BigQueryStorageWriteApiSchemaTransformProvider
       public abstract Builder setTriggeringFrequencySeconds(Long seconds);
 
       public abstract Builder setUseAtLeastOnceSemantics(Boolean use);
+      
+      public abstract Builder setAutoSharding(Boolean autoSharding);
 
       /** Builds a {@link BigQueryStorageWriteApiSchemaTransformConfiguration} instance. */
       public abstract BigQueryStorageWriteApiSchemaTransformProvider
@@ -280,13 +288,16 @@ public class BigQueryStorageWriteApiSchemaTransformProvider
 
       if (inputRows.isBounded() == IsBounded.UNBOUNDED) {
         Long triggeringFrequency = configuration.getTriggeringFrequencySeconds();
+        Boolean autoSharding = configuration.getAutoSharding();
         write =
-            write
-                .withAutoSharding()
-                .withTriggeringFrequency(
+            write.withTriggeringFrequency(
                     (triggeringFrequency == null || triggeringFrequency <= 0)
                         ? DEFAULT_TRIGGERING_FREQUENCY
                         : Duration.standardSeconds(triggeringFrequency));
+        
+        if(autoSharding != null && autoSharding) {
+          write = write.withAutoSharding();
+        }
       }
 
       Schema inputSchema = inputRows.getSchema();


### PR DESCRIPTION
Use autoSharding from config when BigQueryIO.Write is created

------------------------

Currently autoSharding configuration is not used for BigQueryIO.Write and it is always set to true. This caused potential issue when autoSharding is not supported in some runners. 
