### PR TITLE
Make conversion to Iterable tighter

### DIFF
--- a/sdks/python/apache_beam/typehints/native_type_compatibility.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility.py
@@ -201,7 +201,7 @@ def convert_collections_to_typing(typ):
       typ = typing.Iterator[typ.__args__]
     elif hasattr(typ, 'send') and hasattr(typ, 'throw'):
       typ = typing.Generator[typ.__args__]
-    else:
+    elif _match_is_exactly_iterable(typ):
       typ = typing.Iterable[typ.__args__]
   return typ
 

--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -156,6 +156,14 @@ class NativeTypeCompatibilityTest(unittest.TestCase):
               'nested iterable',
               tuple[bytes, collections.abc.Iterable[int]],
               typehints.Tuple[bytes, typehints.Iterable[int]]),
+          (
+              'iterable over tuple',
+              collections.abc.Iterable[tuple[str, int]],
+              typehints.Iterable[typehints.Tuple[str, int]]),
+          (
+              'mapping not caught',
+              collections.abc.Mapping[str, int],
+              collections.abc.Mapping[str, int]),
       ]
 
       for test_case in test_cases:


### PR DESCRIPTION
Avoids other `collections.abc` types that inherit from `Iterable` being mistakenly treated as iterables, causing errors with things like Mappings

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
