### PR TITLE
Revert "Update sqlalchemy requirement from <2.0,>=1.3 to >=1.3,<3.0 in /sdks/python"

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -283,7 +283,7 @@ if __name__ == '__main__':
             'pytest-xdist>=2.5.0,<3',
             'pytest-timeout>=2.1.0,<3',
             'scikit-learn>=0.20.0',
-            'sqlalchemy>=1.3,<3.0',
+            'sqlalchemy>=1.3,<2.0',
             'psycopg2-binary>=2.8.5,<3.0.0',
             'testcontainers[mysql]>=3.0.3,<4.0.0',
             'cryptography>=36.0.0',


### PR DESCRIPTION
Reverts apache/beam#25855

breaks Python PostCommit tests
```
apache_beam.io.external.xlang_jdbcio_it_test.CrossLanguageJdbcIOTest.test_xlang_jdbc_write_read_1_mysql
```