### PR TITLE
Recommend `yield from` for emitting elements from iterables.

### DIFF
--- a/website/www/site/content/en/documentation/programming-guide.md
+++ b/website/www/site/content/en/documentation/programming-guide.md
@@ -955,9 +955,10 @@ the actual processing logic. You don't need to manually extract the elements
 from the input collection; the Beam SDKs handle that for you. Your `process` method
 should accept an argument `element`, which is the input element, and return an
 iterable with its output values. You can accomplish this by emitting individual
-elements with `yield` statements. You can also use a `return` statement
-with an iterable, like a list or a generator. Don't mix `yield` and
-`return` statements in the same `process` method - this leads to [undefined behavior](https://github.com/apache/beam/issues/22969).
+elements with `yield` statements, and use `yield from` to emit all elements from
+an iterable, such as a list or a generator. Using `return` statement
+with an iterable is also acceptable as long as you don't mix `yield` and
+`return` statements in the same `process` method, since that leads to [incorrect behavior](https://github.com/apache/beam/issues/22969).
 {{< /paragraph >}}
 
 {{< paragraph class="language-go">}}


### PR DESCRIPTION
Follow up for https://github.com/apache/beam/pull/25060/files, relates to https://github.com/apache/beam/issues/22969.
