### PR TITLE
validated  the input schema matches with the bigquery output schema

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpers.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpers.java
@@ -574,6 +574,17 @@ public class BigQueryHelpers {
     }
   }
 
+  public static @Nullable Table getTable(BigQueryOptions options, TableReference tableRef)
+      throws InterruptedException, IOException {
+    try (DatasetService datasetService = new BigQueryServicesImpl().getDatasetService(options)) {
+      return datasetService.getTable(tableRef);
+    } catch (IOException | InterruptedException e) {
+      throw e;
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
   static String getDatasetLocation(
       DatasetService datasetService, String projectId, String datasetId) {
     Dataset dataset;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProvider.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProvider.java
@@ -20,6 +20,8 @@ package org.apache.beam.sdk.io.gcp.bigquery.providers;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
 
+import com.google.api.services.bigquery.model.Table;
+import com.google.api.services.bigquery.model.TableReference;
 import com.google.auto.service.AutoService;
 import com.google.auto.value.AutoValue;
 import java.util.Collections;
@@ -33,12 +35,14 @@ import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.CreateDisposition;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.Method;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.WriteDisposition;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryOptions;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryUtils;
 import org.apache.beam.sdk.io.gcp.bigquery.WriteResult;
 import org.apache.beam.sdk.io.gcp.bigquery.providers.BigQueryStorageWriteApiSchemaTransformProvider.BigQueryStorageWriteApiSchemaTransformConfiguration;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.schemas.AutoValueSchema;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.Field;
@@ -61,6 +65,8 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.Visi
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Strings;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 import org.joda.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An implementation of {@link TypedSchemaTransformProvider} for BigQuery Storage Write API jobs
@@ -77,6 +83,8 @@ import org.joda.time.Duration;
 @AutoService(SchemaTransformProvider.class)
 public class BigQueryStorageWriteApiSchemaTransformProvider
     extends TypedSchemaTransformProvider<BigQueryStorageWriteApiSchemaTransformConfiguration> {
+  private static final Logger LOG =
+      LoggerFactory.getLogger(BigQueryStorageWriteApiSchemaTransformProvider.class);
   private static final Integer DEFAULT_TRIGGER_FREQUENCY_SECS = 5;
   private static final Duration DEFAULT_TRIGGERING_FREQUENCY =
       Duration.standardSeconds(DEFAULT_TRIGGER_FREQUENCY_SECS);
@@ -113,6 +121,7 @@ public class BigQueryStorageWriteApiSchemaTransformProvider
   @DefaultSchema(AutoValueSchema.class)
   @AutoValue
   public abstract static class BigQueryStorageWriteApiSchemaTransformConfiguration {
+
     static final Map<String, CreateDisposition> CREATE_DISPOSITIONS =
         ImmutableMap.<String, CreateDisposition>builder()
             .put(CreateDisposition.CREATE_IF_NEEDED.name(), CreateDisposition.CREATE_IF_NEEDED)
@@ -200,6 +209,7 @@ public class BigQueryStorageWriteApiSchemaTransformProvider
     /** Builder for {@link BigQueryStorageWriteApiSchemaTransformConfiguration}. */
     @AutoValue.Builder
     public abstract static class Builder {
+
       public abstract Builder setTable(String table);
 
       public abstract Builder setCreateDisposition(String createDisposition);
@@ -225,6 +235,7 @@ public class BigQueryStorageWriteApiSchemaTransformProvider
    * BigQueryStorageWriteApiSchemaTransformProvider}.
    */
   private static class BigQueryStorageWriteApiSchemaTransform implements SchemaTransform {
+
     private final BigQueryStorageWriteApiSchemaTransformConfiguration configuration;
 
     BigQueryStorageWriteApiSchemaTransform(
@@ -241,6 +252,7 @@ public class BigQueryStorageWriteApiSchemaTransformProvider
 
   static class BigQueryStorageWriteApiPCollectionRowTupleTransform
       extends PTransform<PCollectionRowTuple, PCollectionRowTuple> {
+
     private final BigQueryStorageWriteApiSchemaTransformConfiguration configuration;
     private BigQueryServices testBigQueryServices = null;
 
@@ -257,6 +269,7 @@ public class BigQueryStorageWriteApiSchemaTransformProvider
     // A generic counter for PCollection of Row. Will be initialized with the given
     // name argument. Performs element-wise counter of the input PCollection.
     private static class ElementCounterFn extends DoFn<Row, Row> {
+
       private Counter bqGenericElementCounter;
       private Long elementsInBundle = 0L;
 
@@ -301,6 +314,13 @@ public class BigQueryStorageWriteApiSchemaTransformProvider
       }
 
       Schema inputSchema = inputRows.getSchema();
+
+      // check if input schema is assignable to the output schema with nullability
+      // check disabled for field
+      if (write.getTable() != null) {
+        TableReference tableRef = write.getTable().get();
+        validateSchema(input.getPipeline().getOptions(), inputSchema, tableRef);
+      }
       WriteResult result =
           inputRows
               .apply(
@@ -369,6 +389,29 @@ public class BigQueryStorageWriteApiSchemaTransformProvider
       }
 
       return write;
+    }
+
+    private void validateSchema(
+        PipelineOptions pipelineOptions, Schema inputSchema, TableReference tableRef) {
+      LOG.info("Validating schema ...");
+      BigQueryOptions options = pipelineOptions.as(BigQueryOptions.class);
+      try {
+        Table table = BigQueryHelpers.getTable(options, tableRef);
+        if (table == null) {
+          LOG.info("Table not found and skipped schema validation: " + tableRef.getTableId());
+          return;
+        }
+        Schema outputSchema = BigQueryUtils.fromTableSchema(table.getSchema());
+        if (!inputSchema.assignableToIgnoreNullable(outputSchema)) {
+          throw new IllegalArgumentException(
+              "Input schema is not assignable to output schema. Input schema="
+                  + inputSchema
+                  + ", Output schema="
+                  + outputSchema);
+        }
+      } catch (Exception e) {
+        throw new RuntimeException(e);
+      }
     }
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProvider.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProvider.java
@@ -37,6 +37,7 @@ import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.Method;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.Write.WriteDisposition;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryOptions;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices.DatasetService;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryUtils;
 import org.apache.beam.sdk.io.gcp.bigquery.WriteResult;
 import org.apache.beam.sdk.io.gcp.bigquery.providers.BigQueryStorageWriteApiSchemaTransformProvider.BigQueryStorageWriteApiSchemaTransformConfiguration;
@@ -396,7 +397,15 @@ public class BigQueryStorageWriteApiSchemaTransformProvider
       LOG.info("Validating schema ...");
       BigQueryOptions options = pipelineOptions.as(BigQueryOptions.class);
       try {
-        Table table = BigQueryHelpers.getTable(options, tableRef);
+        Table table = null;
+        if (this.testBigQueryServices != null) {
+          DatasetService datasetService = testBigQueryServices.getDatasetService(options);
+          if (datasetService != null) {
+            table = datasetService.getTable(tableRef);
+          }
+        } else {
+          table = BigQueryHelpers.getTable(options, tableRef);
+        }
         if (table == null) {
           LOG.info("Table not found and skipped schema validation: " + tableRef.getTableId());
           return;

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProviderTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProviderTest.java
@@ -21,12 +21,15 @@ import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertThrows;
 
+import com.google.api.services.bigquery.model.Table;
+import com.google.api.services.bigquery.model.TableReference;
 import com.google.api.services.bigquery.model.TableRow;
 import java.io.Serializable;
 import java.time.LocalDateTime;
 import java.util.Arrays;
 import java.util.List;
 import java.util.function.Function;
+import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryUtils;
@@ -40,6 +43,8 @@ import org.apache.beam.sdk.metrics.MetricQueryResults;
 import org.apache.beam.sdk.metrics.MetricResult;
 import org.apache.beam.sdk.metrics.MetricResults;
 import org.apache.beam.sdk.metrics.MetricsFilter;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
@@ -59,6 +64,7 @@ import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
 public class BigQueryStorageWriteApiSchemaTransformProviderTest {
+
   private FakeDatasetService fakeDatasetService = new FakeDatasetService();
   private FakeJobService fakeJobService = new FakeJobService();
   private FakeBigQueryServices fakeBigQueryServices =
@@ -72,6 +78,11 @@ public class BigQueryStorageWriteApiSchemaTransformProviderTest {
           Field.of("number", FieldType.INT64),
           Field.of("dt", FieldType.logicalType(SqlTypes.DATETIME)));
 
+  private static final Schema SCHEMA_WRONG =
+      Schema.of(
+          Field.of("name_wrong", FieldType.STRING),
+          Field.of("number", FieldType.INT64),
+          Field.of("dt", FieldType.logicalType(SqlTypes.DATETIME)));
   @Rule public final transient TestPipeline p = TestPipeline.create();
 
   @Before
@@ -149,6 +160,63 @@ public class BigQueryStorageWriteApiSchemaTransformProviderTest {
 
     assertNotNull(fakeDatasetService.getTable(BigQueryHelpers.parseTableSpec(tableSpec)));
     assertEquals(3, fakeDatasetService.getAllRows("project", "dataset", "simple_write").size());
+  }
+
+  @Test
+  public void testSchemaValidationSuccess() throws Exception {
+    String tableSpec = "project:dataset.schema_validation_success";
+    Table table = new Table();
+    TableReference tableReference = BigQueryHelpers.parseTableSpec(tableSpec);
+    table.setTableReference(tableReference);
+    table.setSchema(BigQueryUtils.toTableSchema(SCHEMA));
+    fakeDatasetService.createTable(table);
+    BigQueryStorageWriteApiSchemaTransformConfiguration config =
+        BigQueryStorageWriteApiSchemaTransformConfiguration.builder()
+            .setTable(tableSpec)
+            .setCreateDisposition("CREATE_IF_NEEDED")
+            .build();
+
+    runWithConfig(config);
+    p.run().waitUntilFinish();
+
+    assertNotNull(fakeDatasetService.getTable(BigQueryHelpers.parseTableSpec(tableSpec)));
+    assertEquals(
+        3, fakeDatasetService.getAllRows("project", "dataset", "schema_validation_success").size());
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testSchemaValidationFail() throws Exception {
+    String tableSpec = "project:dataset.schema_validation_fail";
+    Table table = new Table();
+    TableReference tableReference = BigQueryHelpers.parseTableSpec(tableSpec);
+    table.setTableReference(tableReference);
+    table.setSchema(BigQueryUtils.toTableSchema(SCHEMA_WRONG));
+    fakeDatasetService.createTable(table);
+    BigQueryStorageWriteApiSchemaTransformConfiguration config =
+        BigQueryStorageWriteApiSchemaTransformConfiguration.builder()
+            .setTable(tableSpec)
+            .setCreateDisposition("CREATE_IF_NEEDED")
+            .build();
+    BigQueryStorageWriteApiSchemaTransformProvider provider =
+        new BigQueryStorageWriteApiSchemaTransformProvider();
+
+    BigQueryStorageWriteApiPCollectionRowTupleTransform writeRowTupleTransform =
+        (BigQueryStorageWriteApiPCollectionRowTupleTransform)
+            provider.from(config).buildTransform();
+    writeRowTupleTransform.setBigQueryServices(fakeBigQueryServices);
+    List<Row> testRows =
+        Arrays.asList(
+            Row.withSchema(SCHEMA)
+                .withFieldValue("name", "a")
+                .withFieldValue("number", 1L)
+                .withFieldValue("dt", LocalDateTime.parse("2000-01-01T00:00:00"))
+                .build());
+    String tag = provider.inputCollectionNames().get(0);
+    PipelineOptions options = PipelineOptionsFactory.create();
+    Pipeline pipeline = Pipeline.create(options);
+    PCollection<Row> rows = pipeline.apply(Create.of(testRows).withRowSchema(SCHEMA));
+    PCollectionRowTuple input = PCollectionRowTuple.of(tag, rows);
+    writeRowTupleTransform.expand(input);
   }
 
   @Test


### PR DESCRIPTION
Validated the input schema is assignable to the output schema for BigQuery SchemaIO write transform.  
------------------------

Currently when input schema does not match with the BigQuery output table schema, the pipeline runs normal without reporting any error. The schema validation implemented in this PR will cause pipeline with mis-matched schema fail to start with appropriate error reported in log.  
