### PR TITLE
Increase logging buffer size to 256kb

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/logging/DataflowWorkerLoggingHandler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/logging/DataflowWorkerLoggingHandler.java
@@ -76,6 +76,13 @@ public class DataflowWorkerLoggingHandler extends Handler {
   }
 
   /**
+   * Buffer size to use when writing logs. This matches <a
+   * href="https://cloud.google.com/logging/quotas#log-limits">Logging usage limits</a> to avoid
+   * spreading the same log entry across multiple disk flushes.
+   */
+  private static final int LOGGING_WRITER_BUFFER_SIZE = 262144; // 256kb
+
+  /**
    * Formats the throwable as per {@link Throwable#printStackTrace()}.
    *
    * @param thrown The throwable to format.
@@ -278,7 +285,8 @@ public class DataflowWorkerLoggingHandler extends Handler {
       try {
         String filename = filepath + "." + formatter.format(new Date()) + ".log";
         return new BufferedOutputStream(
-            new FileOutputStream(new File(filename), true /* append */));
+            new FileOutputStream(new File(filename), true /* append */),
+            LOGGING_WRITER_BUFFER_SIZE);
       } catch (IOException e) {
         throw new RuntimeException(e);
       }


### PR DESCRIPTION
DataflowWorkerLoggingHandler writes logs using a BufferedOutputStream, which [by default holds 8192 bytes](https://github.com/openjdk/jdk/blob/master/src/java.base/share/classes/java/io/BufferedOutputStream.java#L43).

Which means that large logs can be split up in multiple flushes -- and that can cause Cloud Logging to have partial writes when reading files, causing parse problems due to invalid/incomplete JSON.

This change increases the buffer size from 8kb to match [Cloud Logging's limit](https://cloud.google.com/logging/quotas#log-limits): 256 kb, so we make sure that the buffer can hold any entry. 

In general, the latency won't be affected, as after every call to `publish`, [`flush` is guaranteed](https://github.com/apache/beam/blob/master/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/logging/DataflowWorkerLoggingHandler.java#L166-L171).




------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] ~Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.~
 - [ ] ~Update `CHANGES.md` with noteworthy changes.~
 - [x] ~If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).~

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
