### PR TITLE
Lock ReadChangeStreamPartition so only one DoFn can work on one partition

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dao/MetadataTableDao.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dao/MetadataTableDao.java
@@ -25,6 +25,9 @@ import static org.apache.beam.sdk.io.gcp.bigtable.changestreams.dao.MetadataTabl
 import com.google.api.gax.rpc.ServerStream;
 import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 import com.google.cloud.bigtable.data.v2.models.ChangeStreamContinuationToken;
+import com.google.cloud.bigtable.data.v2.models.ConditionalRowMutation;
+import com.google.cloud.bigtable.data.v2.models.Filters.Filter;
+import com.google.cloud.bigtable.data.v2.models.Mutation;
 import com.google.cloud.bigtable.data.v2.models.Query;
 import com.google.cloud.bigtable.data.v2.models.Range;
 import com.google.cloud.bigtable.data.v2.models.Range.ByteStringRange;
@@ -260,6 +263,53 @@ public class MetadataTableDao {
     ByteString rowKey = convertPartitionToStreamPartitionRowKey(partition);
     RowMutation rowMutation = RowMutation.create(tableId, rowKey).deleteRow();
     dataClient.mutateRow(rowMutation);
+  }
+
+  /**
+   * Lock the partition in the metadata table for the DoFn streaming it. Only one DoFn is allowed to
+   * stream a specific partition at any time. Each DoFn has an uuid and will try to lock the
+   * partition at the very start of the stream. If another DoFn has already locked the partition
+   * (i.e. the uuid in the cell for the partition belongs to the DoFn), any future DoFn trying to
+   * lock the same partition will and terminate.
+   *
+   * @param partition form the row key in the metadata table to lock
+   * @param uuid id of the DoFn
+   * @return true if uuid holds the lock, otherwise false.
+   */
+  public boolean lockPartition(ByteStringRange partition, String uuid) {
+    LOG.debug("Locking partition before processing stream");
+
+    ByteString rowKey = convertPartitionToStreamPartitionRowKey(partition);
+    Filter lockCellFilter =
+        FILTERS
+            .chain()
+            .filter(FILTERS.family().exactMatch(MetadataTableAdminDao.CF_LOCK))
+            .filter(FILTERS.qualifier().exactMatch(MetadataTableAdminDao.QUALIFIER_DEFAULT))
+            .filter(FILTERS.limit().cellsPerRow(1));
+    Row row = dataClient.readRow(tableId, rowKey, lockCellFilter);
+
+    // If the query returns non-null row, that means the lock is being held. Check if the owner is
+    // same as uuid.
+    if (row != null) {
+      return row.getCells().get(0).getValue().toStringUtf8().equals(uuid);
+    }
+
+    // We cannot check whether a cell is empty, We can check if the cell matches any value. If it
+    // does not, we perform the mutation to set the cell.
+    Mutation mutation =
+        Mutation.create()
+            .setCell(MetadataTableAdminDao.CF_LOCK, MetadataTableAdminDao.QUALIFIER_DEFAULT, uuid);
+    Filter matchAnyString =
+        FILTERS
+            .chain()
+            .filter(FILTERS.family().exactMatch(MetadataTableAdminDao.CF_LOCK))
+            .filter(FILTERS.qualifier().exactMatch(MetadataTableAdminDao.QUALIFIER_DEFAULT))
+            .filter(FILTERS.value().regex("\\C*"));
+    ConditionalRowMutation rowMutation =
+        ConditionalRowMutation.create(tableId, rowKey)
+            .condition(matchAnyString)
+            .otherwise(mutation);
+    return !dataClient.checkAndMutateRow(rowMutation);
   }
 
   /**

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/restriction/ReadChangeStreamPartitionProgressTracker.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/restriction/ReadChangeStreamPartitionProgressTracker.java
@@ -81,7 +81,8 @@ public class ReadChangeStreamPartitionProgressTracker
    */
   @Override
   public void checkDone() throws java.lang.IllegalStateException {
-    boolean done = shouldStop || streamProgress.getCloseStream() != null;
+    boolean done =
+        shouldStop || streamProgress.getCloseStream() != null || streamProgress.isFailToLock();
     Preconditions.checkState(done, "There's more work to be done");
   }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/restriction/StreamProgress.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/restriction/StreamProgress.java
@@ -42,18 +42,7 @@ public class StreamProgress implements Serializable {
   private @Nullable ChangeStreamContinuationToken currentToken;
   private @Nullable Instant estimatedLowWatermark;
   private @Nullable CloseStream closeStream;
-
-  public @Nullable ChangeStreamContinuationToken getCurrentToken() {
-    return currentToken;
-  }
-
-  public @Nullable Instant getEstimatedLowWatermark() {
-    return estimatedLowWatermark;
-  }
-
-  public @Nullable CloseStream getCloseStream() {
-    return closeStream;
-  }
+  private boolean failToLock;
 
   public StreamProgress() {}
 
@@ -67,6 +56,26 @@ public class StreamProgress implements Serializable {
     this.closeStream = closeStream;
   }
 
+  public @Nullable ChangeStreamContinuationToken getCurrentToken() {
+    return currentToken;
+  }
+
+  public @Nullable Instant getEstimatedLowWatermark() {
+    return estimatedLowWatermark;
+  }
+
+  public @Nullable CloseStream getCloseStream() {
+    return closeStream;
+  }
+
+  public boolean isFailToLock() {
+    return failToLock;
+  }
+
+  public void setFailToLock(boolean failToLock) {
+    this.failToLock = failToLock;
+  }
+
   @Override
   public boolean equals(@Nullable Object o) {
     if (this == o) {
@@ -78,7 +87,8 @@ public class StreamProgress implements Serializable {
     StreamProgress that = (StreamProgress) o;
     return Objects.equals(getCurrentToken(), that.getCurrentToken())
         && Objects.equals(getEstimatedLowWatermark(), that.getEstimatedLowWatermark())
-        && Objects.equals(getCloseStream(), that.getCloseStream());
+        && Objects.equals(getCloseStream(), that.getCloseStream())
+        && (isFailToLock() == that.isFailToLock());
   }
 
   @Override
@@ -95,6 +105,8 @@ public class StreamProgress implements Serializable {
         + estimatedLowWatermark
         + ", closeStream="
         + closeStream
+        + ", failToLock="
+        + failToLock
         + '}';
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/action/ReadChangeStreamPartitionActionTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/action/ReadChangeStreamPartitionActionTest.java
@@ -81,15 +81,11 @@ public class ReadChangeStreamPartitionActionTest {
     changeStreamDao = mock(ChangeStreamDao.class);
     metrics = mock(ChangeStreamMetrics.class);
     changeStreamAction = mock(ChangeStreamAction.class);
-    Duration heartbeatDurationSeconds = Duration.standardSeconds(1);
+    Duration heartbeatDuration = Duration.standardSeconds(1);
 
     action =
         new ReadChangeStreamPartitionAction(
-            metadataTableDao,
-            changeStreamDao,
-            metrics,
-            changeStreamAction,
-            heartbeatDurationSeconds);
+            metadataTableDao, changeStreamDao, metrics, changeStreamAction, heartbeatDuration);
 
     restriction = mock(StreamProgress.class);
     tracker = mock(ReadChangeStreamPartitionProgressTracker.class);
@@ -102,10 +98,51 @@ public class ReadChangeStreamPartitionActionTest {
     Instant parentLowWatermark = Instant.now();
     partitionRecord = new PartitionRecord(partition, startTime, uuid, parentLowWatermark);
     when(tracker.currentRestriction()).thenReturn(restriction);
+    when(metadataTableDao.lockPartition(partition, uuid)).thenReturn(true);
     when(restriction.getCurrentToken()).thenReturn(null);
     when(restriction.getCloseStream()).thenReturn(null);
     // Setting watermark estimator to now so we don't debug.
     when(watermarkEstimator.getState()).thenReturn(Instant.now());
+  }
+
+  @Test
+  public void testLockingRowSucceed() throws IOException {
+    final ServerStream<ChangeStreamRecord> responses = mock(ServerStream.class);
+    final Iterator<ChangeStreamRecord> responseIterator = mock(Iterator.class);
+    when(responses.iterator()).thenReturn(responseIterator);
+
+    Heartbeat mockHeartBeat = Mockito.mock(Heartbeat.class);
+    when(responseIterator.next()).thenReturn(mockHeartBeat);
+    when(responseIterator.hasNext()).thenReturn(true);
+    when(changeStreamDao.readChangeStreamPartition(any(), any(), any(), anyBoolean()))
+        .thenReturn(responses);
+
+    when(changeStreamAction.run(any(), any(), any(), any(), any(), anyBoolean()))
+        .thenReturn(Optional.of(DoFn.ProcessContinuation.stop()));
+
+    final DoFn.ProcessContinuation result =
+        action.run(partitionRecord, tracker, receiver, watermarkEstimator);
+
+    assertEquals(DoFn.ProcessContinuation.stop(), result);
+    // Verify that on successful lock, we don't tryClaim on the tracker because we have no outputs.
+    verify(tracker, never()).tryClaim(any());
+    verify(changeStreamAction).run(any(), any(), any(), any(), any(), anyBoolean());
+  }
+
+  @Test
+  public void testLockingRowFailsStops() throws IOException {
+    when(metadataTableDao.lockPartition(partition, uuid)).thenReturn(false);
+
+    final DoFn.ProcessContinuation result =
+        action.run(partitionRecord, tracker, receiver, watermarkEstimator);
+
+    assertEquals(DoFn.ProcessContinuation.stop(), result);
+
+    // On failure to lock, we try to claim a fail to lock, so it will terminate gracefully.
+    StreamProgress streamProgress = new StreamProgress();
+    streamProgress.setFailToLock(true);
+    verify(tracker).tryClaim(streamProgress);
+    verify(changeStreamAction, never()).run(any(), any(), any(), any(), any(), anyBoolean());
   }
 
   @Test

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/restriction/ReadChangeStreamPartitionProgressTrackerTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/restriction/ReadChangeStreamPartitionProgressTrackerTest.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.io.gcp.bigtable.changestreams.restriction;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNull;
+import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 
 import com.google.cloud.bigtable.data.v2.models.ChangeStreamContinuationToken;
@@ -80,5 +81,23 @@ public class ReadChangeStreamPartitionProgressTrackerTest {
     assertNull(tracker.trySplit(0));
     assertNull(tracker.trySplit(0));
     tracker.checkDone();
+  }
+
+  @Test
+  public void testDoneOnFailToLockTrue() {
+    StreamProgress streamProgress = new StreamProgress();
+    streamProgress.setFailToLock(true);
+    ReadChangeStreamPartitionProgressTracker tracker =
+        new ReadChangeStreamPartitionProgressTracker(streamProgress);
+    tracker.checkDone();
+  }
+
+  @Test
+  public void testNotDoneOnFailToLockFalse() {
+    StreamProgress streamProgress = new StreamProgress();
+    streamProgress.setFailToLock(false);
+    ReadChangeStreamPartitionProgressTracker tracker =
+        new ReadChangeStreamPartitionProgressTracker(streamProgress);
+    assertThrows(java.lang.IllegalStateException.class, tracker::checkDone);
   }
 }


### PR DESCRIPTION
Lock ReadChangeStreamPartition (RCSP) so only one DoFn can work on one partition. We accept that it's possible for DetectNewPartition (DNP) to output the same partition twice because of various race/failure conditions. We want to reduce duplicate results from the pipeline so RCSP locks the partition before performing any work to ensure that only one DNP output is streamed for each partition.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
