### PR TITLE
Fix triggered side inputs

### DIFF
--- a/runners/flink/flink_runner.gradle
+++ b/runners/flink/flink_runner.gradle
@@ -279,6 +279,7 @@ def createValidatesRunnerTask(Map m) {
         excludeCategories 'org.apache.beam.sdk.testing.UsesTimerMap'
         excludeCategories 'org.apache.beam.sdk.testing.UsesTestStreamWithMultipleStages'  // BEAM-8598
         excludeCategories 'org.apache.beam.sdk.testing.UsesTestStreamWithProcessingTime'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesTriggeredSideInputs'
       } else {
         excludeCategories 'org.apache.beam.sdk.testing.UsesBundleFinalizer'
         excludeCategories 'org.apache.beam.sdk.testing.UsesUnboundedPCollections'

--- a/runners/flink/job-server/flink_job_server.gradle
+++ b/runners/flink/job-server/flink_job_server.gradle
@@ -185,6 +185,7 @@ def portableValidatesRunnerTask(String name, boolean streaming, boolean checkpoi
           excludeCategories 'org.apache.beam.sdk.testing.UsesTestStreamWithProcessingTime'
           excludeCategories 'org.apache.beam.sdk.testing.UsesTestStreamWithMultipleStages'
           excludeCategories 'org.apache.beam.sdk.testing.UsesTestStreamWithOutputTimestamp'
+          excludeCategories 'org.apache.beam.sdk.testing.UsesTriggeredSideInputs'
           return
         }
 

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/StreamingViewOverrides.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/StreamingViewOverrides.java
@@ -28,11 +28,14 @@ import org.apache.beam.sdk.coders.ListCoder;
 import org.apache.beam.sdk.runners.AppliedPTransform;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.Combine.CombineFn;
+import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.View.CreatePCollectionView;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.PCollectionViews;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
 
 /**
  * Dataflow streaming overrides for {@link CreatePCollectionView}, specialized for different view
@@ -63,8 +66,23 @@ class StreamingViewOverrides {
 
       @Override
       public PCollection<ElemT> expand(PCollection<ElemT> input) {
-        return input
-            .apply(Combine.globally(new Concatenate<ElemT>()).withoutDefaults())
+        PCollection<List<ElemT>> elements;
+        if (view.getViewFn() instanceof PCollectionViews.IsSingletonView) {
+          elements =
+              input.apply(
+                  ParDo.of(
+                      new DoFn<ElemT, List<ElemT>>() {
+                        @DoFn.ProcessElement
+                        public void process(@Element ElemT elemT, OutputReceiver<List<ElemT>> o) {
+                          List<ElemT> elements = Lists.newArrayListWithExpectedSize(1);
+                          elements.add(elemT);
+                          o.output(elements);
+                        }
+                      }));
+        } else {
+          elements = input.apply(Combine.globally(new Concatenate<ElemT>()).withoutDefaults());
+        }
+        return elements
             .apply(ParDo.of(StreamingPCollectionViewWriterFn.create(view, input.getCoder())))
             .apply(CreateDataflowView.forStreaming(view));
       }

--- a/runners/jet/build.gradle
+++ b/runners/jet/build.gradle
@@ -84,6 +84,8 @@ task validatesRunnerBatch(type: Test) {
         excludeCategories 'org.apache.beam.sdk.testing.UsesMultimapState'
         excludeCategories 'org.apache.beam.sdk.testing.UsesBundleFinalizer'
         excludeCategories 'org.apache.beam.sdk.testing.UsesUnboundedSplittableParDo'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesTriggeredSideInputs'
+
 
         //Jet Runner doesn't current support @RequiresTimeSortedInput annotation.
         excludeCategories 'org.apache.beam.sdk.testing.UsesRequiresTimeSortedInput'
@@ -129,6 +131,7 @@ task needsRunnerTests(type: Test) {
         includeCategories "org.apache.beam.sdk.testing.NeedsRunner"
         excludeCategories "org.apache.beam.sdk.testing.LargeKeys\$Above100MB"
         excludeCategories 'org.apache.beam.sdk.testing.UsesBundleFinalizer'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesTriggeredSideInputs'
     }
 }
 

--- a/runners/samza/build.gradle
+++ b/runners/samza/build.gradle
@@ -143,6 +143,7 @@ tasks.register("validatesRunner", Test) {
     excludeCategories 'org.apache.beam.sdk.testing.UsesMultimapState'
     excludeCategories 'org.apache.beam.sdk.testing.UsesBundleFinalizer'
     excludeCategories 'org.apache.beam.sdk.testing.UsesLoopingTimer'
+    excludeCategories 'org.apache.beam.sdk.testing.UsesTriggeredSideInputs'
   }
   filter {
     for (String test : sickbayTests) {

--- a/runners/samza/job-server/build.gradle
+++ b/runners/samza/job-server/build.gradle
@@ -106,7 +106,8 @@ def portableValidatesRunnerTask(String name, boolean docker) {
             excludeCategories 'org.apache.beam.sdk.testing.UsesTestStreamWithMultipleStages'
             excludeCategories 'org.apache.beam.sdk.testing.UsesUnboundedSplittableParDo'
             excludeCategories 'org.apache.beam.sdk.testing.UsesLoopingTimer'
-        },
+            excludeCategories 'org.apache.beam.sdk.testing.UsesTriggeredSideInputs'
+      },
         testFilter: {
             // TODO(https://github.com/apache/beam/issues/21042)
             excludeTestsMatching "org.apache.beam.sdk.transforms.FlattenTest.testFlattenWithDifferentInputAndOutputCoders2"

--- a/runners/spark/job-server/spark_job_server.gradle
+++ b/runners/spark/job-server/spark_job_server.gradle
@@ -135,6 +135,7 @@ def portableValidatesRunnerTask(String name, boolean streaming, boolean docker, 
         excludeCategories 'org.apache.beam.sdk.testing.UsesStatefulParDo'
         // TODO (https://github.com/apache/beam/issues/20397)
         excludeCategories 'org.apache.beam.sdk.testing.UsesTimersInParDo'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesTriggeredSideInputs'
       }
 
       testFilter = {

--- a/runners/spark/spark_runner.gradle
+++ b/runners/spark/spark_runner.gradle
@@ -279,6 +279,7 @@ def applyBatchValidatesRunnerSetup = { Test it ->
     // Ordering
     excludeCategories 'org.apache.beam.sdk.testing.UsesPerKeyOrderedDelivery'
     excludeCategories 'org.apache.beam.sdk.testing.UsesPerKeyOrderInBundle'
+    excludeCategories 'org.apache.beam.sdk.testing.UsesTriggeredSideInputs'
   }
 }
 
@@ -351,6 +352,7 @@ def validatesRunnerStreaming = tasks.register("validatesRunnerStreaming", Test) 
     // Ordering
     excludeCategories 'org.apache.beam.sdk.testing.UsesPerKeyOrderedDelivery'
     excludeCategories 'org.apache.beam.sdk.testing.UsesPerKeyOrderInBundle'
+    excludeCategories 'org.apache.beam.sdk.testing.UsesTriggeredSideInputs'
   }
 }
 
@@ -403,6 +405,7 @@ tasks.register("validatesStructuredStreamingRunnerBatch", Test) {
     excludeCategories 'org.apache.beam.sdk.testing.UsesJavaExpansionService'
     excludeCategories 'org.apache.beam.sdk.testing.UsesPythonExpansionService'
     excludeCategories 'org.apache.beam.sdk.testing.UsesBundleFinalizer'
+    excludeCategories 'org.apache.beam.sdk.testing.UsesTriggeredSideInputs'
   }
   filter {
     // Combine with context not implemented

--- a/runners/twister2/build.gradle
+++ b/runners/twister2/build.gradle
@@ -96,6 +96,7 @@ def validatesRunnerBatch = tasks.register("validatesRunnerBatch", Test) {
         // Feature unsupported by this runner
         excludeCategories 'org.apache.beam.sdk.testing.UsesPerKeyOrderedDelivery'
         excludeCategories 'org.apache.beam.sdk.testing.UsesPerKeyOrderInBundle'
+        excludeCategories 'org.apache.beam.sdk.testing.UsesTriggeredSideInputs'
     }
 
     maxHeapSize = '6g'

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/GenerateSequence.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/GenerateSequence.java
@@ -23,6 +23,8 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import com.google.auto.service.AutoService;
 import com.google.auto.value.AutoValue;
 import java.util.Map;
+
+import javax.annotation.Nullable;
 import org.apache.beam.sdk.expansion.ExternalTransformRegistrar;
 import org.apache.beam.sdk.transforms.ExternalTransformBuilder;
 import org.apache.beam.sdk.transforms.PTransform;
@@ -32,7 +34,6 @@ import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
-import org.checkerframework.checker.nullness.qual.Nullable;
 import org.checkerframework.dataflow.qual.Pure;
 import org.joda.time.Duration;
 import org.joda.time.Instant;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/GenerateSequence.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/GenerateSequence.java
@@ -23,7 +23,6 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 import com.google.auto.service.AutoService;
 import com.google.auto.value.AutoValue;
 import java.util.Map;
-
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.expansion.ExternalTransformRegistrar;
 import org.apache.beam.sdk.transforms.ExternalTransformBuilder;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/UsesTriggeredSideInputs.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/UsesTriggeredSideInputs.java
@@ -1,0 +1,27 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.testing;
+
+import org.apache.beam.sdk.annotations.Internal;
+
+/**
+ * Category tag for validation tests which use triggered sideinputs. Tests tagged with {@link
+ * UsesTriggeredSideInputs} should be run for runners which support triggered sideinputs.
+ */
+@Internal
+public interface UsesTriggeredSideInputs {}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/View.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/View.java
@@ -391,7 +391,6 @@ public class View {
       } catch (IllegalStateException e) {
         throw new IllegalStateException("Unable to create a side-input view from input", e);
       }
-
       Combine.Globally<T, T> singletonCombine =
           Combine.globally(new SingletonCombineFn<>(hasDefault, input.getCoder(), defaultValue));
       if (!hasDefault) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionViews.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/PCollectionViews.java
@@ -338,7 +338,7 @@ public class PCollectionViews {
    */
   @Internal
   public static class SingletonViewFn2<T> extends ViewFn<IterableView<T>, T>
-      implements HasDefaultValue<T> {
+      implements HasDefaultValue<T>, IsSingletonView<T> {
     private byte @Nullable [] encodedDefaultValue;
     private transient @Nullable T defaultValue;
     private @Nullable Coder<T> valueCoder;
@@ -425,6 +425,9 @@ public class PCollectionViews {
     T getDefaultValue();
   }
 
+  @Internal
+  public interface IsSingletonView<T> {}
+
   /**
    * Implementation which is able to adapt a multimap materialization to a {@code T}.
    *
@@ -434,7 +437,7 @@ public class PCollectionViews {
    */
   @Deprecated
   public static class SingletonViewFn<T> extends ViewFn<MultimapView<Void, T>, T>
-      implements HasDefaultValue<T> {
+      implements HasDefaultValue<T>, IsSingletonView<T> {
     private byte @Nullable [] encodedDefaultValue;
     private transient @Nullable T defaultValue;
     private @Nullable Coder<T> valueCoder;
@@ -460,7 +463,6 @@ public class PCollectionViews {
     }
 
     /** Returns if a default value was specified. */
-    @Internal
     public boolean hasDefault() {
       return hasDefault;
     }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -122,6 +122,7 @@ import org.apache.beam.sdk.testing.UsesTestStreamWithOutputTimestamp;
 import org.apache.beam.sdk.testing.UsesTestStreamWithProcessingTime;
 import org.apache.beam.sdk.testing.UsesTimerMap;
 import org.apache.beam.sdk.testing.UsesTimersInParDo;
+import org.apache.beam.sdk.testing.UsesTriggeredSideInputs;
 import org.apache.beam.sdk.testing.UsesUnboundedPCollections;
 import org.apache.beam.sdk.testing.ValidatesRunner;
 import org.apache.beam.sdk.transforms.Create.TimestampedValues;
@@ -3583,7 +3584,12 @@ public class ParDoTest implements Serializable {
     }
 
     @Test
-    @Category({ValidatesRunner.class, UsesStatefulParDo.class, UsesSideInputs.class})
+    @Category({
+      ValidatesRunner.class,
+      UsesStatefulParDo.class,
+      UsesSideInputs.class,
+      UsesTriggeredSideInputs.class
+    })
     public void testStateSideInput() {
 
       // SideInput tag id

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ViewTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ViewTest.java
@@ -18,7 +18,7 @@
 package org.apache.beam.sdk.transforms;
 
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
-import static org.hamcrest.Matchers.isA;
+import static org.hamcrest.MatcherAssert.assertThat;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertTrue;
@@ -34,9 +34,7 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
-import java.util.NoSuchElementException;
 import org.apache.beam.sdk.Pipeline;
-import org.apache.beam.sdk.Pipeline.PipelineExecutionException;
 import org.apache.beam.sdk.coders.AtomicCoder;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
@@ -46,16 +44,18 @@ import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.coders.VarLongCoder;
 import org.apache.beam.sdk.coders.VoidCoder;
-import org.apache.beam.sdk.testing.NeedsRunner;
+import org.apache.beam.sdk.io.GenerateSequence;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.testing.TestStream;
 import org.apache.beam.sdk.testing.UsesSideInputs;
 import org.apache.beam.sdk.testing.UsesTestStream;
 import org.apache.beam.sdk.testing.ValidatesRunner;
+import org.apache.beam.sdk.transforms.windowing.AfterProcessingTime;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindows;
 import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.transforms.windowing.Repeatedly;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PBegin;
@@ -199,7 +199,7 @@ public class ViewTest implements Serializable {
   }
 
   @Test
-  @Category(NeedsRunner.class)
+  @Category(ValidatesRunner.class)
   public void testEmptySingletonSideInput() throws Exception {
 
     final PCollectionView<Integer> view =
@@ -220,17 +220,14 @@ public class ViewTest implements Serializable {
                     })
                 .withSideInputs(view));
 
-    thrown.expect(PipelineExecutionException.class);
-    thrown.expectCause(isA(NoSuchElementException.class));
-    thrown.expectMessage("Empty");
-    thrown.expectMessage("PCollection");
-    thrown.expectMessage("singleton");
+    // As long as we get an error, be flexible with how a runner surfaces it
+    thrown.expect(Exception.class);
 
     pipeline.run();
   }
 
   @Test
-  @Category(NeedsRunner.class)
+  @Category(ValidatesRunner.class)
   public void testNonSingletonSideInput() throws Exception {
 
     PCollection<Integer> oneTwoThree = pipeline.apply(Create.of(1, 2, 3));
@@ -247,11 +244,87 @@ public class ViewTest implements Serializable {
                 })
             .withSideInputs(view));
 
-    thrown.expect(PipelineExecutionException.class);
-    thrown.expectCause(isA(IllegalArgumentException.class));
-    thrown.expectMessage("PCollection");
-    thrown.expectMessage("more than one");
-    thrown.expectMessage("singleton");
+    // As long as we get an error, be flexible with how a runner surfaces it
+    thrown.expect(Exception.class);
+
+    pipeline.run();
+  }
+
+  @Test
+  @Category(ValidatesRunner.class)
+  public void testDiscardingNonSingletonSideInput() throws Exception {
+
+    PCollection<Integer> oneTwoThree = pipeline.apply(Create.of(1, 2, 3));
+    final PCollectionView<Integer> view =
+        oneTwoThree
+            .apply(Window.<Integer>configure().discardingFiredPanes())
+            .apply(View.asSingleton());
+
+    oneTwoThree.apply(
+        "OutputSideInputs",
+        ParDo.of(
+                new DoFn<Integer, Integer>() {
+                  @ProcessElement
+                  public void processElement(ProcessContext c) {
+                    c.output(c.sideInput(view));
+                  }
+                })
+            .withSideInputs(view));
+
+    // As long as we get an error, be flexible with how a runner surfaces it
+    thrown.expect(Exception.class);
+
+    pipeline.run();
+  }
+
+  @Test
+  @Category(ValidatesRunner.class)
+  public void testTriggeredLatestSingleton() {
+    IntervalWindow zeroWindow = new IntervalWindow(new Instant(0), new Instant(1000));
+
+    PCollectionView<Long> view =
+        pipeline
+            .apply(
+                GenerateSequence.from(0)
+                    .withRate(1, Duration.millis(100))
+                    .withTimestampFn(Instant::new)
+                    .withMaxReadTime(Duration.standardSeconds(10)))
+            .apply(
+                "Window side input",
+                Window.<Long>into(FixedWindows.of(Duration.standardSeconds(1)))
+                    .triggering(Repeatedly.forever(AfterProcessingTime.pastFirstElementInPane()))
+                    .withAllowedLateness(Duration.ZERO)
+                    .discardingFiredPanes())
+            .apply(Reify.timestamps())
+            .apply(Combine.globally(Latest.<Long>combineFn()).withoutDefaults().asSingletonView());
+
+    final String tag = "singleton";
+    PCollection<Long> pc =
+        pipeline
+            .apply(Impulse.create())
+            .apply(WithTimestamps.of(impulse -> new Instant(0)))
+            .apply("Window main input", Window.into(FixedWindows.of(Duration.standardSeconds(1))))
+            .apply(
+                ParDo.of(
+                        new DoFn<byte[], Long>() {
+                          @ProcessElement
+                          public void process(
+                              @SideInput(tag) Long sideInput, OutputReceiver<Long> out)
+                              throws InterruptedException {
+                            // waiting to ensure multiple outputs to side input before reading it
+                            Thread.sleep(1000L);
+                            out.output(sideInput);
+                          }
+                        })
+                    .withSideInput(tag, view));
+
+    PAssert.that(pc)
+        .inWindow(zeroWindow)
+        .satisfies(
+            (Iterable<Long> values) -> {
+              assertThat(values, Matchers.iterableWithSize(1));
+              return null;
+            });
 
     pipeline.run();
   }
@@ -1258,7 +1331,7 @@ public class ViewTest implements Serializable {
   }
 
   @Test
-  @Category(NeedsRunner.class)
+  @Category(ValidatesRunner.class)
   public void testMapSideInputWithNullValuesCatchesDuplicates() {
 
     final PCollectionView<Map<String, Integer>> view =
@@ -1291,10 +1364,9 @@ public class ViewTest implements Serializable {
     PAssert.that(output)
         .containsInAnyOrder(KV.of("apple", 1), KV.of("banana", 3), KV.of("blackberry", 3));
 
-    // PipelineExecutionException is thrown with cause having a message stating that a
-    // duplicate is not allowed.
-    thrown.expectCause(
-        ThrowableMessageMatcher.hasMessage(Matchers.containsString("Duplicate values for a")));
+    // As long as we get an error, be flexible with how a runner surfaces it
+    thrown.expect(Exception.class);
+
     pipeline.run();
   }
 


### PR DESCRIPTION
The intended semantics for triggered side inputs is that the value written should always be the value of the "latest" pane. This ensure that readers will eventually (there is no immediate consistency on read) read the latest side input value.

For singleton side inputs, users are expected to put a global combine before the side-input creation to ensure a single output value per pane. However the implementation adds a Concatenate combiner, which depending on timing could pull in multiple firings from the user's global combine. This will result in a multi-element PCollection, which will cause a crash when reading the side input. This Concatenate is not needed for singleton side inputs, so this PR removes it for that case.

Note: this does not fix all issues with triggered side inputs. In particular, Map-valued side inputs are still problematic for a number of reasons. 