### PR TITLE
[#26030] Add PTransformID to logged messages & add message batching & immeadiate flushing.

### DIFF
--- a/sdks/go/pkg/beam/core/metrics/metrics.go
+++ b/sdks/go/pkg/beam/core/metrics/metrics.go
@@ -68,8 +68,10 @@ import (
 type ctxKey string
 
 const (
-	counterSetKey ctxKey = "beam:counterset"
-	storeKey      ctxKey = "beam:bundlestore"
+	counterSetKey   ctxKey = "beam:counterset"
+	storeKey        ctxKey = "beam:bundlestore"
+	bundleIDKey     ctxKey = "beam:instructionID"
+	ptransformIDKey ctxKey = "beam:transformID"
 )
 
 // beamCtx is a caching context for IDs necessary to place metric updates.
@@ -113,6 +115,10 @@ func (ctx *beamCtx) Value(key any) any {
 			}
 		}
 		return ctx.store
+	case bundleIDKey:
+		return ctx.bundleID
+	case ptransformIDKey:
+		return ctx.ptransformID
 	}
 	return ctx.Context.Value(key)
 }
@@ -146,6 +152,28 @@ func SetPTransformID(ctx context.Context, id string) context.Context {
 	}
 	// Avoid breaking if the bundle is unset in testing.
 	return &beamCtx{Context: ctx, bundleID: bundleIDUnset, store: newStore(), ptransformID: id}
+}
+
+// GetTransformID sources the TransformID from a context, if available.
+//
+// For Beam internal use only. Subject to change.
+func GetTransformID(ctx context.Context) string {
+	ret := ctx.Value(ptransformIDKey)
+	if id, ok := ret.(string); ok {
+		return id
+	}
+	return ""
+}
+
+// GetBundleID sources the Bundle's instruction ID from a context, if available.
+//
+// For Beam internal use only. Subject to change.
+func GetBundleID(ctx context.Context) string {
+	ret := ctx.Value(bundleIDKey)
+	if id, ok := ret.(string); ok {
+		return id
+	}
+	return ""
 }
 
 // GetStore extracts the metrics Store for the given context for a bundle.

--- a/sdks/go/pkg/beam/core/runtime/harness/harness.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/harness.go
@@ -347,7 +347,7 @@ func (c *control) getOrCreatePlan(bdID bundleDescriptorID) (*exec.Plan, error) {
 
 func (c *control) handleInstruction(ctx context.Context, req *fnpb.InstructionRequest) *fnpb.InstructionResponse {
 	instID := instructionID(req.GetInstructionId())
-	ctx = setInstID(ctx, instID)
+	ctx = metrics.SetBundleID(ctx, string(instID))
 
 	switch {
 	case req.GetRegister() != nil:
@@ -381,7 +381,6 @@ func (c *control) handleInstruction(ctx context.Context, req *fnpb.InstructionRe
 		c.inactive.Remove(instID)
 		c.active[instID] = plan
 		// Get the user metrics store for this bundle.
-		ctx = metrics.SetBundleID(ctx, string(instID))
 		store := metrics.GetStore(ctx)
 		c.metStore[instID] = store
 		c.mu.Unlock()

--- a/sdks/go/pkg/beam/core/runtime/harness/logging.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/logging.go
@@ -23,33 +23,13 @@ import (
 	"runtime"
 	"time"
 
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/metrics"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/util/hooks"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/internal/errors"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/log"
 	fnpb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/fnexecution_v1"
 	"google.golang.org/protobuf/types/known/timestamppb"
 )
-
-// TODO(herohde) 10/12/2017: make this file a separate package. Then
-// populate InstructionId and TransformId properly.
-
-// TODO(herohde) 10/13/2017: add top-level harness.Main panic handler that flushes logs.
-// Also make logger flush on Fatal severity messages.
-type contextKey string
-
-const instKey contextKey = "beam:inst"
-
-func setInstID(ctx context.Context, id instructionID) context.Context {
-	return context.WithValue(ctx, instKey, id)
-}
-
-func tryGetInstID(ctx context.Context) (string, bool) {
-	id := ctx.Value(instKey)
-	if id == nil {
-		return "", false
-	}
-	return string(id.(instructionID)), true
-}
 
 type logger struct {
 	out chan<- *fnpb.LogEntry
@@ -66,9 +46,8 @@ func (l *logger) Log(ctx context.Context, sev log.Severity, calldepth int, msg s
 	if _, file, line, ok := runtime.Caller(calldepth + 1); ok {
 		entry.LogLocation = fmt.Sprintf("%v:%v", file, line)
 	}
-	if id, ok := tryGetInstID(ctx); ok {
-		entry.InstructionId = id
-	}
+	entry.InstructionId = metrics.GetBundleID(ctx)
+	entry.TransformId = metrics.GetTransformID(ctx)
 
 	select {
 	case l.out <- entry:
@@ -135,7 +114,7 @@ type remoteWriter struct {
 
 func (w *remoteWriter) Run(ctx context.Context) error {
 	for {
-		err := w.connect(ctx)
+		err := w.connect(ctx, w.dialLogClient)
 		if err == io.EOF {
 			return nil
 		}
@@ -151,47 +130,80 @@ func (w *remoteWriter) Run(ctx context.Context) error {
 	}
 }
 
-func (w *remoteWriter) connect(ctx context.Context) error {
+func (w *remoteWriter) dialLogClient(ctx context.Context) (logSender, func(), error) {
 	conn, err := dial(ctx, w.endpoint, "logging", 30*time.Second)
 	if err != nil {
-		return err
+		return nil, func() {}, err
 	}
-	defer conn.Close()
 
 	client, err := fnpb.NewBeamFnLoggingClient(conn).Logging(ctx)
 	if err != nil {
+		conn.Close()
+		return nil, func() {}, err
+	}
+
+	toDefer := func() {
+		client.CloseSend()
+		conn.Close()
+	}
+	return client, toDefer, nil
+}
+
+type logSender interface {
+	Send(*fnpb.LogEntry_List) error
+}
+
+var bufClosedErr = errors.New("internal: log message buffer closed")
+
+func (w *remoteWriter) connect(ctx context.Context, makeClient func(ctx context.Context) (logSender, func(), error)) error {
+	client, toDefer, err := makeClient(ctx)
+	if err != nil {
 		return err
 	}
-	defer client.CloseSend()
+	defer toDefer()
 
 	for {
-		var msg *fnpb.LogEntry
+		const batchSize = 64
+		msgs := make([]*fnpb.LogEntry, 0, batchSize)
+		var flush bool
 		select {
 		case <-ctx.Done():
 			return nil
 		case newMsg, ok := <-w.buffer:
 			if !ok {
-				return errors.New("internal: buffer closed?")
+				return bufClosedErr
 			}
-			msg = newMsg
+			msgs = append(msgs, newMsg)
+			flush = newMsg.Severity >= fnpb.LogEntry_Severity_CRITICAL
 		}
-		// fmt.Fprintf(os.Stderr, "REMOTE: %v\n", proto.MarshalTextString(msg))
 
-		// TODO: batch up log messages
+		// If there are still messages in the buffer, drain them out to batch them to a cap.
+		// If there's a critical message, flush immeadiately.
+		for len(w.buffer) > 0 && len(msgs) < batchSize && !flush {
+			newMsg, ok := <-w.buffer
+			if !ok {
+				return bufClosedErr
+			}
+			msgs = append(msgs, newMsg)
+			flush = newMsg.Severity >= fnpb.LogEntry_Severity_CRITICAL
+		}
 
 		list := &fnpb.LogEntry_List{
-			LogEntries: []*fnpb.LogEntry{msg},
+			LogEntries: msgs,
 		}
 
 		if err := client.Send(list); err != nil {
 			if err == io.EOF {
-				(&log.Standard{}).Log(ctx, log.SevInfo, 0, msg.GetMessage())
+				for _, msg := range msgs {
+					(&log.Standard{}).Log(ctx, log.SevInfo, 0, msg.GetMessage())
+				}
 				return io.EOF
 			}
-			fmt.Fprintf(os.Stderr, "Failed to send message: %v\n %v", err, msg.GetMessage())
+			fmt.Fprintf(os.Stderr, "Failed to send %v messages. Messages follow error.\n %v", len(msgs), err)
+			for _, msg := range msgs {
+				fmt.Fprintf(os.Stderr, "Failed to send message: %v\n %v", err, msg.GetMessage())
+			}
 			return err
 		}
-
-		// fmt.Fprintf(os.Stderr, "SENT: %v\n", msg)
 	}
 }

--- a/sdks/go/pkg/beam/core/runtime/harness/logging_test.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/logging_test.go
@@ -17,9 +17,11 @@ package harness
 
 import (
 	"context"
+	"errors"
 	"strings"
 	"testing"
 
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/metrics"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/log"
 	fnpb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/fnexecution_v1"
 )
@@ -29,7 +31,9 @@ func TestLogger(t *testing.T) {
 	l := logger{out: ch}
 
 	instID := "INST"
-	ctx := setInstID(context.Background(), instructionID(instID))
+	transformID := "TRANSFORM"
+	ctx := metrics.SetBundleID(context.Background(), instID)
+	ctx = metrics.SetPTransformID(ctx, transformID)
 	msg := "expectedMessage"
 	l.Log(ctx, log.SevInfo, 0, msg)
 
@@ -38,14 +42,71 @@ func TestLogger(t *testing.T) {
 	if got, want := e.GetInstructionId(), instID; got != want {
 		t.Errorf("incorrect InstructionID: got %v, want %v", got, want)
 	}
+	if got, want := e.GetTransformId(), transformID; got != want {
+		t.Errorf("incorrect TransformID: got %v, want %v", got, want)
+	}
 	if got, want := e.GetMessage(), msg; got != want {
 		t.Errorf("incorrect Message: got %v, want %v", got, want)
 	}
 	// This check will fail if the imports change.
-	if got, want := e.GetLogLocation(), "logging_test.go:34"; !strings.HasSuffix(got, want) {
+	if got, want := e.GetLogLocation(), "logging_test.go:38"; !strings.HasSuffix(got, want) {
 		t.Errorf("incorrect LogLocation: got %v, want suffix %v", got, want)
 	}
 	if got, want := e.GetSeverity(), fnpb.LogEntry_Severity_INFO; got != want {
 		t.Errorf("incorrect Severity: got %v, want %v", got, want)
+	}
+}
+
+type logCacher struct {
+	logs []*fnpb.LogEntry_List
+}
+
+func (l *logCacher) Send(v *fnpb.LogEntry_List) error {
+	l.logs = append(l.logs, v)
+	return nil
+}
+
+func TestLogger_connect(t *testing.T) {
+	buf := make(chan *fnpb.LogEntry, 20)
+	l := logger{out: buf}
+	w := &remoteWriter{buffer: buf, endpoint: "dummyEndpoint"}
+
+	ctx, cancelFn := context.WithCancel(context.Background())
+	t.Cleanup(cancelFn)
+
+	cacher := &logCacher{}
+
+	// Batch up several messages.
+	l.Log(ctx, log.SevDebug, 0, "debug")
+	l.Log(ctx, log.SevInfo, 0, "info")
+	l.Log(ctx, log.SevWarn, 0, "warn")
+	l.Log(ctx, log.SevError, 0, "error")
+	l.Log(ctx, log.SevFatal, 0, "fatal") // batch flushed from fatal
+	l.Log(ctx, log.SevFatal, 0, "fatal") // immeadiately flushed from fatal
+	l.Log(ctx, log.SevFatal, 0, "fatal") // immeadiately flushed from fatal
+	l.Log(ctx, log.SevInfo, 0, "info")
+	l.Log(ctx, log.SevInfo, 0, "info")
+	l.Log(ctx, log.SevInfo, 0, "info") // batched since nothing else in the buffer
+	close(buf)
+
+	err := w.connect(ctx, func(ctx context.Context) (logSender, func(), error) {
+		return cacher, func() {}, nil
+	})
+
+	if got, want := err, bufClosedErr; !errors.Is(got, want) {
+		t.Errorf("connect error: got %v, want %v", got, want)
+	}
+
+	if got, want := len(cacher.logs), 4; got != want {
+		t.Errorf("batching error: got %v batches, want %v", got, want)
+	}
+
+	var count int
+	for _, batch := range cacher.logs {
+		count += len(batch.LogEntries)
+	}
+
+	if got, want := count, 10; got != want {
+		t.Errorf("missing messages: got %v, want %v", got, want)
 	}
 }


### PR DESCRIPTION
Re-uses the metrics package's context work to extract the PTransformID of the logged message. This allows for attribution of logged messages to specific transforms for filtering and searching purposes.

Also adds message batching to reduce round trips to the logging service, but only up to a current cap of 64 messages at a time.

To avoid delays, fatal/critical logs are immediately flushed. However, if the logger is "caught up", then a batch is sent anyway.

Refactored the log handler slightly to be easier to test, and added a unit test for batching and flushing cases.

Fixes https://github.com/apache/beam/issues/26030

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
