### PR TITLE
[#26061][Go SDK] Return server error on stream close for artifact upload.

### DIFF
--- a/sdks/go/pkg/beam/runners/universal/runnerlib/stage.go
+++ b/sdks/go/pkg/beam/runners/universal/runnerlib/stage.go
@@ -103,7 +103,7 @@ func StageViaPortableApi(ctx context.Context, cc *grpc.ClientConn, binary, st st
 			case graphx.URNArtifactGoWorker:
 				if err := StageFile(binary, stream); err != nil {
 					if err == io.EOF {
-						log.Infof(ctx, "failed to Go worker binary %v:", binary, err)
+						log.Infof(ctx, "failed to Go worker binary %v due to server side close.", binary)
 						continue // so we can get the real error from stream.Recv.
 					}
 					return errors.Wrap(err, "failed to stage Go worker binary")
@@ -115,7 +115,7 @@ func StageViaPortableApi(ctx context.Context, cc *grpc.ClientConn, binary, st st
 				}
 				if err := StageFile(typePl.GetPath(), stream); err != nil {
 					if err == io.EOF {
-						log.Infof(ctx, "failed to stage file %v:", typePl.GetPath(), err)
+						log.Infof(ctx, "failed to stage file %v due to server side close.", typePl.GetPath())
 						continue // so we can get the real error from stream.Recv.
 					}
 					return errors.Wrapf(err, "failed to stage file %v", typePl.GetPath())

--- a/sdks/go/pkg/beam/runners/universal/runnerlib/stage.go
+++ b/sdks/go/pkg/beam/runners/universal/runnerlib/stage.go
@@ -24,6 +24,7 @@ import (
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/artifact"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime/graphx"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/internal/errors"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/log"
 	jobpb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/jobmanagement_v1"
 	pipepb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/pipeline_v1"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/util/grpcx"
@@ -41,8 +42,11 @@ func Stage(ctx context.Context, id, endpoint, binary, st string) (retrievalToken
 	}
 	defer cc.Close()
 
-	if err := StageViaPortableApi(ctx, cc, binary, st); err == nil {
+	err = StageViaPortableApi(ctx, cc, binary, st)
+	if err == nil {
 		return "", nil
+	} else {
+		log.Warnf(ctx, "unable to stage with PortableAPI: %v; falling back to legacy", err)
 	}
 
 	return StageViaLegacyApi(ctx, cc, binary, st)

--- a/sdks/go/pkg/beam/runners/universal/runnerlib/stage.go
+++ b/sdks/go/pkg/beam/runners/universal/runnerlib/stage.go
@@ -140,11 +140,12 @@ func StageFile(filename string, stream jobpb.ArtifactStagingService_ReverseArtif
 					},
 				}})
 			if sendErr == io.EOF {
+				log.Infof(context.TODO(), "StageFile error on Send of len %v for %v: %v", n, filename, sendErr)
 				return sendErr
 			}
 
 			if sendErr != nil {
-				return errors.Wrap(sendErr, "chunk send failed")
+				return errors.Wrap(sendErr, "StageFile chunk send failed")
 			}
 		}
 
@@ -156,7 +157,7 @@ func StageFile(filename string, stream jobpb.ArtifactStagingService_ReverseArtif
 				}})
 
 			if sendErr != nil {
-				log.Infof(context.TODO(), "error on Final Send for %v: %v", filename, sendErr)
+				log.Infof(context.TODO(), "StageFile error on Final Send for %v: %v", filename, sendErr)
 			}
 			return sendErr
 		}

--- a/sdks/go/pkg/beam/runners/universal/runnerlib/stage_test.go
+++ b/sdks/go/pkg/beam/runners/universal/runnerlib/stage_test.go
@@ -1,0 +1,173 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package runnerlib
+
+import (
+	"context"
+	"io"
+	"net"
+	"testing"
+	"time"
+
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime/graphx"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/util/protox"
+	jobpb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/jobmanagement_v1"
+	pipepb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/pipeline_v1"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
+	"google.golang.org/protobuf/encoding/prototext"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func initDummyServer(ctx context.Context, t *testing.T) (*grpc.ClientConn, *dummyArtifactServer) {
+	t.Helper()
+	const buffsize = 1024 * 1024
+	l := bufconn.Listen(buffsize)
+
+	server := grpc.NewServer()
+	das := &dummyArtifactServer{
+		t: t,
+	}
+	jobpb.RegisterArtifactStagingServiceServer(server, das)
+	jobpb.RegisterLegacyArtifactStagingServiceServer(server, das)
+
+	go func() {
+		server.Serve(l)
+	}()
+
+	t.Cleanup(func() {
+		server.Stop()
+		l.Close()
+	})
+
+	clientConn, err := grpc.DialContext(ctx, "", grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+		return l.DialContext(ctx)
+	}), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+	if err != nil {
+		t.Fatal("couldn't create bufconn grpc connection:", err)
+	}
+	return clientConn, das
+}
+
+func TestPortableArtifactStaging(t *testing.T) {
+	ctx, cancelFn := context.WithTimeout(context.Background(), 5*time.Second)
+	t.Cleanup(cancelFn)
+
+	cc, das := initDummyServer(ctx, t)
+
+	das.wantToken = "token"
+	das.reqFile = "stage.go"
+
+	err := StageViaPortableApi(ctx, cc, "reqFile", das.wantToken)
+	if err != nil {
+		t.Fatal(err)
+	}
+}
+
+type dummyArtifactServer struct {
+	jobpb.UnimplementedArtifactStagingServiceServer
+	jobpb.UnimplementedLegacyArtifactStagingServiceServer
+
+	t *testing.T
+
+	wantToken, reqFile string
+}
+
+func (das *dummyArtifactServer) ReverseArtifactRetrievalService(stream jobpb.ArtifactStagingService_ReverseArtifactRetrievalServiceServer) error {
+	msg, err := stream.Recv()
+	if err == io.EOF {
+		das.t.Error("ReverseArtifactRetrievalService.Recv: unexpected EOF")
+		return nil
+	}
+	if err != nil {
+		das.t.Errorf("ReverseArtifactRetrievalService.Recv: unexpected error %v", err)
+		return err
+	}
+	if got, want := msg.GetStagingToken(), das.wantToken; got != want {
+		das.t.Errorf("ReverseArtifactRetrievalService.Recv: unexpected token %v, want %v", got, want)
+	}
+
+	// Check artifact Resolve Requests.
+	wantArts := []*pipepb.ArtifactInformation{
+		{
+			TypeUrn:     "dummy",
+			TypePayload: []byte("dummy"),
+			RoleUrn:     "dummy",
+			RolePayload: []byte("dummy"),
+		},
+	}
+
+	if err := stream.Send(&jobpb.ArtifactRequestWrapper{
+		Request: &jobpb.ArtifactRequestWrapper_ResolveArtifact{
+			ResolveArtifact: &jobpb.ResolveArtifactsRequest{
+				Artifacts: wantArts,
+			},
+		},
+	}); err != nil {
+		das.t.Fatalf("unexpected err on artifact resolve request Send: %v", err)
+	}
+
+	msg, err = stream.Recv()
+	if err != nil {
+		das.t.Fatalf("unexpected err on artifact resolve response Recv: %v", err)
+	}
+	resolve := msg.GetResolveArtifactResponse()
+	if resolve == nil {
+		das.t.Fatalf("unexpected err on artifact resolve response Resp, got %T", msg.GetResponse())
+	}
+	gotArts := resolve.GetReplacements()
+	if d := cmp.Diff(wantArts, gotArts, protocmp.Transform()); d != "" {
+		das.t.Errorf("diff on artifact resolve response (-want, +got):\n%v", d)
+	}
+
+	typePl := protox.MustEncode(&pipepb.ArtifactFilePayload{
+		Path: das.reqFile,
+	})
+
+	// Check file upload requests
+	if err := stream.Send(&jobpb.ArtifactRequestWrapper{
+		Request: &jobpb.ArtifactRequestWrapper_GetArtifact{
+			GetArtifact: &jobpb.GetArtifactRequest{
+				Artifact: &pipepb.ArtifactInformation{
+					TypeUrn:     graphx.URNArtifactFileType,
+					TypePayload: typePl,
+				},
+			},
+		},
+	}); err != nil {
+		das.t.Fatalf("unexpected err on get artifact request Send: %v", err)
+	}
+
+	msg, err = stream.Recv()
+	if err != nil {
+		das.t.Fatalf("unexpected err on get artifact response Recv: %v", err)
+	}
+
+	if msg.GetIsLast() {
+		das.t.Fatalf("unexpected IsLast on get artifact response Recv: %v", prototext.Format(msg))
+	}
+	msg, err = stream.Recv()
+	if err != nil {
+		das.t.Fatalf("unexpected err on artifact resolve response Recv: %v", err)
+	}
+	if !msg.GetIsLast() {
+		das.t.Fatalf("want IsLast on get artifact response Recv: %v", prototext.Format(msg))
+	}
+
+	return nil
+}


### PR DESCRIPTION
Adds retries for the portable artifact path, and corrects the error handling.

Python artifact server is closing the stream `StageViaPortableApi Recv error: rpc error: code = Internal desc = stream terminated by RST_STREAM with error code: PROTOCOL_ERROR` which implies an implementation error on either the Python side, or the Go side of the divide, but most likely in the HTTP2 protocol handling, which is lower level than beam tends to go.

The Go half was following the sequence correctly, but wasn't logging server side close errors correctly. This PR surfaces allows those errors to be properly surfaced. It further adds retrying by restarting the reverse retrieval protocol. This should be sufficient to deflake the Go tests against the Portable Python runner, as the flake only happens rarely. But this isn't a for sure thing.

Also adds a test for the happy path on uploads. So retries aren't done, nor is the legacy backup path checked.

Closes #26061 for now, but we can always re-open if the same flakes recur, along with the improved logging.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
