### PR TITLE
[Go SDK] Work around for #26066 in mongodbio.

### DIFF
--- a/sdks/go/pkg/beam/io/mongodbio/coder.go
+++ b/sdks/go/pkg/beam/io/mongodbio/coder.go
@@ -27,19 +27,36 @@ import (
 func init() {
 	beam.RegisterCoder(
 		reflect.TypeOf((*idRangeRestriction)(nil)).Elem(),
-		encodeBSON[idRangeRestriction],
-		decodeBSON[idRangeRestriction],
+		encodeRestriction,
+		decodeRestriction,
 	)
 	beam.RegisterCoder(
 		reflect.TypeOf((*idRange)(nil)).Elem(),
-		encodeBSON[idRange],
-		decodeBSON[idRange],
+		encodeRange,
+		decodeRange,
 	)
 	beam.RegisterCoder(
 		reflect.TypeOf((*primitive.ObjectID)(nil)).Elem(),
 		encodeObjectID,
 		decodeObjectID,
 	)
+}
+
+// Working around https://github.com/apache/beam/issues/26066
+// with explicit wrappers for the generic functions.
+
+func encodeRestriction(in idRangeRestriction) ([]byte, error) {
+	return encodeBSON(in)
+}
+func decodeRestriction(in []byte) (idRangeRestriction, error) {
+	return decodeBSON[idRangeRestriction](in)
+}
+
+func encodeRange(in idRange) ([]byte, error) {
+	return encodeBSON(in)
+}
+func decodeRange(in []byte) (idRange, error) {
+	return decodeBSON[idRange](in)
 }
 
 func encodeBSON[T any](in T) ([]byte, error) {


### PR DESCRIPTION
Works around #26066 which manifests in Go 1.20 in #26054. Wrapping the generic function instances explicitly avoids the name change in the reflect package for generic types. This unblocks migration beam infra to Go 1.20.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
