### PR TITLE
[#25582] Use a Pathing Jar instead of long command line class paths in Java Boot loader.

### DIFF
--- a/.github/workflows/go_tests.yml
+++ b/.github/workflows/go_tests.yml
@@ -28,7 +28,7 @@ on:
   pull_request:
     branches: ['master', 'release-*']
     tags: ['v*']
-    paths: ['sdks/go/pkg/**', 'sdks/go.mod', 'sdks/go.sum']
+    paths: ['sdks/go/pkg/**', 'sdks/go.mod', 'sdks/go.sum', 'sdks/go/container/*', 'sdks/java/container/*', 'sdks/python/container/*', 'sdks/typescript/container/*']
 # This allows a subsequently queued workflow run to interrupt previous runs
 concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.pull_request.head.label || github.head_ref || github.ref }}'

--- a/.github/workflows/go_tests.yml
+++ b/.github/workflows/go_tests.yml
@@ -48,7 +48,7 @@ jobs:
       - name: Delete old coverage
         run: "cd sdks/go/pkg && rm -rf .coverage || :"
       - name: Run coverage
-        run: cd sdks/go/pkg && go test -coverprofile=coverage.txt -covermode=atomic ./...
+        run: cd sdks && go test -coverprofile=coverage.txt -covermode=atomic ./go/pkg/... ./go/container/... ./java/container/... ./python/container/... ./typescript/container/...
       - uses: codecov/codecov-action@v3
         with:
           flags: go 

--- a/sdks/java/container/boot.go
+++ b/sdks/java/container/boot.go
@@ -165,7 +165,6 @@ func main() {
 		"-XX:+UseParallelGC",
 		"-XX:+AlwaysActAsServerClassMachine",
 		"-XX:-OmitStackTraceInFastThrow",
-		"-cp", strings.Join(cp, ":"),
 	}
 
 	enableGoogleCloudProfiler := strings.Contains(options, enableGoogleCloudProfilerOption)
@@ -210,13 +209,14 @@ func main() {
 
 	// (2) Add classpath: "-cp foo.jar:bar.jar:.."
 	if len(javaOptions.Classpath) > 0 {
-		pathingjar, err := makePathingJar(javaOptions.Classpath)
-		if err != nil {
-			logger.Fatalf(ctx, "makePathingJar failed: %v", err)
-		}
-		args = append(args, "-cp")
-		args = append(args, pathingjar)
+		cp = append(cp, javaOptions.Classpath...)
 	}
+	pathingjar, err := makePathingJar(cp)
+	if err != nil {
+		logger.Fatalf(ctx, "makePathingJar failed: %v", err)
+	}
+	args = append(args, "-cp")
+	args = append(args, pathingjar)
 
 	// (3) Add (sorted) properties: "-Dbar=baz -Dfoo=bar .."
 	var properties []string

--- a/sdks/java/container/boot.go
+++ b/sdks/java/container/boot.go
@@ -210,8 +210,12 @@ func main() {
 
 	// (2) Add classpath: "-cp foo.jar:bar.jar:.."
 	if len(javaOptions.Classpath) > 0 {
+		pathingjar, err := makePathingJar(javaOptions.Classpath)
+		if err != nil {
+			logger.Fatalf(ctx, "makePathingJar failed: %v", err)
+		}
 		args = append(args, "-cp")
-		args = append(args, strings.Join(javaOptions.Classpath, ":"))
+		args = append(args, pathingjar)
 	}
 
 	// (3) Add (sorted) properties: "-Dbar=baz -Dfoo=bar .."

--- a/sdks/java/container/boot_test.go
+++ b/sdks/java/container/boot_test.go
@@ -18,57 +18,63 @@
 package main
 
 import (
-  "reflect"
-  "testing"
+	"context"
+	"reflect"
+	"testing"
+
+	"github.com/apache/beam/sdks/v2/go/container/tools"
 )
 
 func TestBuildOptionsEmpty(t *testing.T) {
-  dir := "test/empty"
-  metaOptions, err := LoadMetaOptions(dir)
-  if err != nil {
-    t.Fatalf("Got error %v running LoadMetaOptions", err)
-  }
-  if metaOptions != nil {
-    t.Fatalf("LoadMetaOptions(%v) = %v, want nil", dir, metaOptions)
-  }
+	ctx, logger := context.Background(), &tools.Logger{}
+	dir := "test/empty"
+	metaOptions, err := LoadMetaOptions(ctx, logger, dir)
+	if err != nil {
+		t.Fatalf("Got error %v running LoadMetaOptions", err)
+	}
+	if metaOptions != nil {
+		t.Fatalf("LoadMetaOptions(%v) = %v, want nil", dir, metaOptions)
+	}
 
-  javaOptions := BuildOptions(metaOptions)
-  if len(javaOptions.JavaArguments) != 0 || len(javaOptions.Classpath) != 0 || len(javaOptions.Properties) != 0 {
-    t.Errorf("BuildOptions(%v) = %v, want nil", metaOptions, javaOptions)
-  }
+	javaOptions := BuildOptions(ctx, logger, metaOptions)
+	if len(javaOptions.JavaArguments) != 0 || len(javaOptions.Classpath) != 0 || len(javaOptions.Properties) != 0 {
+		t.Errorf("BuildOptions(%v) = %v, want nil", metaOptions, javaOptions)
+	}
 }
 
 func TestBuildOptionsDisabled(t *testing.T) {
-  metaOptions, err := LoadMetaOptions("test/disabled")
-  if err != nil {
-    t.Fatalf("Got error %v running LoadMetaOptions", err)
-  }
+	ctx, logger := context.Background(), &tools.Logger{}
+	metaOptions, err := LoadMetaOptions(ctx, logger, "test/disabled")
+	if err != nil {
+		t.Fatalf("Got error %v running LoadMetaOptions", err)
+	}
 
-  javaOptions := BuildOptions(metaOptions)
-  if len(javaOptions.JavaArguments) != 0 || len(javaOptions.Classpath) != 0 || len(javaOptions.Properties) != 0 {
-    t.Errorf("BuildOptions(%v) = %v, want nil", metaOptions, javaOptions)
-  }
+	javaOptions := BuildOptions(ctx, logger, metaOptions)
+	if len(javaOptions.JavaArguments) != 0 || len(javaOptions.Classpath) != 0 || len(javaOptions.Properties) != 0 {
+		t.Errorf("BuildOptions(%v) = %v, want nil", metaOptions, javaOptions)
+	}
 }
 
 func TestBuildOptions(t *testing.T) {
-  metaOptions, err := LoadMetaOptions("test/priority")
-  if err != nil {
-    t.Fatalf("Got error %v running LoadMetaOptions", err)
-  }
+	ctx, logger := context.Background(), &tools.Logger{}
+	metaOptions, err := LoadMetaOptions(ctx, logger, "test/priority")
+	if err != nil {
+		t.Fatalf("Got error %v running LoadMetaOptions", err)
+	}
 
-  javaOptions := BuildOptions(metaOptions)
-  wantJavaArguments := []string{"java_args=low", "java_args=high"}
-  wantClasspath := []string{"classpath_high", "classpath_low"}
-  wantProperties := map[string]string{
-                        "priority":"high",
-                    }
-  if !reflect.DeepEqual(javaOptions.JavaArguments, wantJavaArguments) {
-    t.Errorf("BuildOptions(%v).JavaArguments = %v, want %v", metaOptions, javaOptions.JavaArguments, wantJavaArguments)
-  }
-  if !reflect.DeepEqual(javaOptions.Classpath, wantClasspath) {
-    t.Errorf("BuildOptions(%v).Classpath = %v, want %v", metaOptions, javaOptions.Classpath, wantClasspath)
-  }
-  if !reflect.DeepEqual(javaOptions.Properties, wantProperties) {
-    t.Errorf("BuildOptions(%v).JavaProperties = %v, want %v", metaOptions, javaOptions.Properties, wantProperties)
-  }
+	javaOptions := BuildOptions(ctx, logger, metaOptions)
+	wantJavaArguments := []string{"java_args=low", "java_args=high"}
+	wantClasspath := []string{"classpath_high", "classpath_low"}
+	wantProperties := map[string]string{
+		"priority": "high",
+	}
+	if !reflect.DeepEqual(javaOptions.JavaArguments, wantJavaArguments) {
+		t.Errorf("BuildOptions(%v).JavaArguments = %v, want %v", metaOptions, javaOptions.JavaArguments, wantJavaArguments)
+	}
+	if !reflect.DeepEqual(javaOptions.Classpath, wantClasspath) {
+		t.Errorf("BuildOptions(%v).Classpath = %v, want %v", metaOptions, javaOptions.Classpath, wantClasspath)
+	}
+	if !reflect.DeepEqual(javaOptions.Properties, wantProperties) {
+		t.Errorf("BuildOptions(%v).JavaProperties = %v, want %v", metaOptions, javaOptions.Properties, wantProperties)
+	}
 }

--- a/sdks/java/container/pathingjar.go
+++ b/sdks/java/container/pathingjar.go
@@ -62,7 +62,7 @@ func writePathingJar(classpaths []string, w io.Writer) error {
 
 	zf.Write([]byte("Manifest-Version: 1.0\n"))
 	zf.Write([]byte("Created-By: sdks/java/container/pathingjar.go"))
-	zf.Write([]byte("Class-Path: " + strings.Join(classpaths, " ")))
+	zf.Write([]byte("Class-Path: file:" + strings.Join(classpaths, " file:")))
 	zf.Write([]byte("\n"))
 	return nil
 }

--- a/sdks/java/container/pathingjar.go
+++ b/sdks/java/container/pathingjar.go
@@ -62,6 +62,8 @@ func writePathingJar(classpaths []string, w io.Writer) error {
 
 	zf.Write([]byte("Manifest-Version: 1.0\n"))
 	zf.Write([]byte("Created-By: sdks/java/container/pathingjar.go"))
+	// Class-Path: must have a sequence of relative URIs for the paths
+	// which we assume outright in this case.
 	zf.Write([]byte("Class-Path: file:" + strings.Join(classpaths, " file:")))
 	zf.Write([]byte("\n"))
 	return nil

--- a/sdks/java/container/pathingjar.go
+++ b/sdks/java/container/pathingjar.go
@@ -23,6 +23,18 @@ import (
 	"strings"
 )
 
+// makePathingJar produces a context or 'pathing' jar which only contains the relative
+// classpaths in its META-INF/MANIFEST.MF.
+//
+// Since we build with Java 8 as a minimum, this is the only supported way of reducing
+// command line length, since argsfile support wasn't added until Java 9.
+//
+// https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html is the spec.
+//
+// In particular, we only need to populate the Jar with a Manifest-Version and Class-Path
+// attributes.
+// Per https://docs.oracle.com/javase/8/docs/technotes/guides/jar/jar.html#classpath
+// the classpath URLs must be relative for security reasons.
 func makePathingJar(classpaths []string) (string, error) {
 	f, err := os.Create("pathing.jar")
 	if err != nil {
@@ -49,6 +61,7 @@ func writePathingJar(classpaths []string, w io.Writer) error {
 	}
 
 	zf.Write([]byte("Manifest-Version: 1.0\n"))
+	zf.Write([]byte("Created-By: sdks/java/container/pathingjar.go"))
 	zf.Write([]byte("Class-Path: " + strings.Join(classpaths, " ")))
 	zf.Write([]byte("\n"))
 	return nil

--- a/sdks/java/container/pathingjar.go
+++ b/sdks/java/container/pathingjar.go
@@ -1,0 +1,55 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"archive/zip"
+	"fmt"
+	"io"
+	"os"
+	"strings"
+)
+
+func makePathingJar(classpaths []string) (string, error) {
+	f, err := os.Create("pathing.jar")
+	if err != nil {
+		return "", fmt.Errorf("unable to create pathing.jar: %w", err)
+	}
+	defer f.Close()
+	if err := writePathingJar(classpaths, f); err != nil {
+		return "", fmt.Errorf("unable to write pathing.jar: %w", err)
+	}
+	return f.Name(), nil
+}
+
+func writePathingJar(classpaths []string, w io.Writer) error {
+	jar := zip.NewWriter(w)
+	defer jar.Close()
+
+	if _, err := jar.Create("META-INF/"); err != nil {
+		return fmt.Errorf("unable to create META-INF/ directory: %w", err)
+	}
+
+	zf, err := jar.Create("META-INF/MANIFEST.MF")
+	if err != nil {
+		return fmt.Errorf("unable to create META-INF/MANIFEST.MF: %w", err)
+	}
+
+	zf.Write([]byte("Manifest-Version: 1.0\n"))
+	zf.Write([]byte("Class-Path: " + strings.Join(classpaths, " ")))
+	zf.Write([]byte("\n"))
+	return nil
+}

--- a/sdks/java/container/pathingjar_test.go
+++ b/sdks/java/container/pathingjar_test.go
@@ -25,10 +25,10 @@ import (
 
 func TestWritePathingJar(t *testing.T) {
 	var buf bytes.Buffer
-	want := []string{"a.jar", "b.jar", "c.jar"}
-	err := writePathingJar(want, &buf)
+	input := []string{"a.jar", "b.jar", "c.jar"}
+	err := writePathingJar(input, &buf)
 	if err != nil {
-		t.Errorf("writePathingJar(%v) = %v, want nil", want, err)
+		t.Errorf("writePathingJar(%v) = %v, want nil", input, err)
 	}
 
 	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
@@ -50,7 +50,8 @@ func TestWritePathingJar(t *testing.T) {
 		if err != nil {
 			t.Errorf("(%v).Open() = %v, want nil", f.Name, err)
 		}
-		if !strings.Contains(string(all), "Class-Path: "+strings.Join(want, " ")) {
+		want := "Class-Path: file:a.jar file:b.jar file:c.jar"
+		if !strings.Contains(string(all), want) {
 			t.Errorf("%v = %v, want nil", f.Name, err)
 		}
 	}

--- a/sdks/java/container/pathingjar_test.go
+++ b/sdks/java/container/pathingjar_test.go
@@ -1,0 +1,60 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package main
+
+import (
+	"archive/zip"
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+)
+
+func TestWritePathingJar(t *testing.T) {
+	var buf bytes.Buffer
+	want := []string{"a.jar", "b.jar", "c.jar"}
+	err := writePathingJar(want, &buf)
+	if err != nil {
+		t.Errorf("writePathingJar(%v) = %v, want nil", want, err)
+	}
+
+	zr, err := zip.NewReader(bytes.NewReader(buf.Bytes()), int64(buf.Len()))
+	if err != nil {
+		t.Errorf("zip.NewReader() = %v, want nil", err)
+	}
+
+	var found bool
+	for _, f := range zr.File {
+		if f.Name != "META-INF/MANIFEST.MF" {
+			continue
+		}
+		found = true
+		fr, err := f.Open()
+		if err != nil {
+			t.Errorf("(%v).Open() = %v, want nil", f.Name, err)
+		}
+		all, err := io.ReadAll(fr)
+		if err != nil {
+			t.Errorf("(%v).Open() = %v, want nil", f.Name, err)
+		}
+		if !strings.Contains(string(all), "Class-Path: "+strings.Join(want, " ")) {
+			t.Errorf("%v = %v, want nil", f.Name, err)
+		}
+	}
+	if !found {
+		t.Error("Jar didn't contain manifest")
+	}
+}


### PR DESCRIPTION
Jars are recursive! If the manifest of one contains a manifest with a class path attribute, the JVM will load those jars. This gets around long jar sequences that can make an argument list too long.

This PR fixes an unchanged test in the Java boot_test.go, as well as adds a unit test for the pathing jar. Further, adds the container tests to the Go Tests github action, so this error doesn't recur.

Fixes #25582.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
