### PR TITLE
Use external config schema to construct Python SchemaTransform payload

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -447,7 +447,6 @@ __all__ = [
     'BigQueryQueryPriority',
     'WriteToBigQuery',
     'WriteResult',
-    'StorageWriteToBigQuery',
     'ReadFromBigQuery',
     'ReadFromBigQueryRequest',
     'ReadAllFromBigQuery',
@@ -2467,6 +2466,7 @@ class StorageWriteToBigQuery(PTransform):
     external_storage_write = SchemaAwareExternalTransform(
         identifier=self.schematransform_config.identifier,
         expansion_service=self._expansion_service,
+        rearrange_based_on_discovery=True,
         autoSharding=self._with_auto_sharding,
         createDisposition=self._create_disposition,
         table=self._table,

--- a/sdks/python/apache_beam/transforms/external.py
+++ b/sdks/python/apache_beam/transforms/external.py
@@ -361,7 +361,7 @@ class SchemaAwareExternalTransform(ptransform.PTransform):
         self._expansion_service, identifier)
 
     external_config_fields = schematransform_config.configuration_schema._fields
-    ordered_kwargs = {}
+    ordered_kwargs = OrderedDict()
     missing_fields = []
 
     for field in external_config_fields:

--- a/sdks/python/apache_beam/transforms/external.py
+++ b/sdks/python/apache_beam/transforms/external.py
@@ -365,6 +365,10 @@ class SchemaAwareExternalTransform(ptransform.PTransform):
   :param expansion_service: an expansion service to use. This should already be
       available and the Schema-aware transforms to be used must already be
       deployed.
+  :param strict_schema: a flag that determines if the order of parameters in
+      `kwargs` should exactly match the external configuration schema order.
+      When :data:`True`, will fail if there is a mismatch. Defaults to
+      :data:`False`.
   :param classpath: (Optional) A list paths to additional jars to place on the
       expansion service classpath.
   :kwargs: field name to value mapping for configuring the schema transform.

--- a/sdks/python/apache_beam/transforms/external_test.py
+++ b/sdks/python/apache_beam/transforms/external_test.py
@@ -503,6 +503,9 @@ class SchemaTransformPayloadBuilderTest(unittest.TestCase):
         int_field=123,
         str_field='aaa')
 
+    # schema: str_field, int_field
+    # payload: int_field, str_field
+    # mismatch should throw an error because strict_schema is True
     with self.assertRaises(ValueError):
       payload_builder.payload()
 


### PR DESCRIPTION
Development on external SchemaTransforms may lead to changes in how their configurations look (ie. adding and removing fields, changing the order of fields). In addition to that, currently most Java SchemaTransformProviders inherit from [TypedSchemaTransformProvider](https://github.com/apache/beam/blob/master/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/TypedSchemaTransformProvider.java), which infers its configuration schema by using a configuration class and [AutoValueSchema](https://github.com/apache/beam/blob/master/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/AutoValueSchema.java). While this approach is very convenient, the ordering of fields in the inferred schema is unfortunately not consistent. All of this is to say that the configuration schema of external transforms is prone to changes.

When we use an external SchemaTransform in Python, we build a payload that includes the configuration fields. These are the same fields used to set up the external SchemaTransform. Currently, we only use the input kwargs to construct the payload, so we are blind to what the external configuration schema actually is. The changes in this PR make it so that we first fetch the external configuration schema then construct the payload in accordance to that schema.