### PR TITLE
(AWS S3 FS) Fix performance issue of S3 filesystem when reading large files

### DIFF
--- a/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/s3/S3ReadableSeekableByteChannel.java
+++ b/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/s3/S3ReadableSeekableByteChannel.java
@@ -43,7 +43,7 @@ import software.amazon.awssdk.services.s3.model.HeadObjectRequest;
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
 class S3ReadableSeekableByteChannel implements SeekableByteChannel {
-
+  private static final long ABORT_THRESHOLD = 1024 * 8; // corresponds to default TCP buffer size
   private final S3Client s3Client;
   private final S3ResourceId path;
   private final S3FileSystemConfiguration config;
@@ -144,12 +144,9 @@ class S3ReadableSeekableByteChannel implements SeekableByteChannel {
       return this;
     }
 
-    // The position has changed, so close and destroy the object to induce a re-creation on the next
-    // call to read()
-    if (s3ResponseInputStream != null) {
-      s3ResponseInputStream.close();
-      s3ResponseInputStream = null;
-    }
+    // The position has changed, close stream to force re-creation on the next read()
+    closeStream();
+
     position = newPosition;
     return this;
   }
@@ -162,12 +159,27 @@ class S3ReadableSeekableByteChannel implements SeekableByteChannel {
     return contentLength;
   }
 
+  private void closeStream() throws IOException {
+    if (s3ResponseInputStream == null) {
+      return;
+    }
+    if (contentLength - position > ABORT_THRESHOLD) {
+      // This will close the underlying connection and require establishing an HTTP connection which
+      // may outweigh the cost of reading the additional data.
+      s3ResponseInputStream.abort();
+      s3ResponseInputStream.release();
+    } else {
+      drainInputStream(s3ResponseInputStream);
+    }
+    s3ObjectContentChannel.close(); // will close s3ResponseInputStream
+
+    s3ObjectContentChannel = null;
+    s3ResponseInputStream = null;
+  }
+
   @Override
   public void close() throws IOException {
-    if (s3ResponseInputStream != null) {
-      drainInputStream(s3ResponseInputStream);
-      s3ResponseInputStream.close();
-    }
+    closeStream();
     open = false;
   }
 


### PR DESCRIPTION
Fix performance issue of S3 filesystem when reading large files (fixes #25991)

Draining the S3 input stream is a bad idea as we might not read the entire file. Particularly for large files that get split (and [processed in parallel) this quickly explodes the amount of data that needs to be transferred.

As long as the remaining unread data fits into the TCP buffer this will continue draining the stream.
This is beneficial as the HTTP connection can be reused.

Otherwise the stream / connection is aborted, which involves some significant overhead.

This must be done when closing, but also when moving the channel to a new position.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
