### PR TITLE
Set an auth key in multi_process_shared.py

### DIFF
--- a/sdks/python/apache_beam/utils/multi_process_shared.py
+++ b/sdks/python/apache_beam/utils/multi_process_shared.py
@@ -119,11 +119,6 @@ class _SingletonRegistrar(multiprocessing.managers.BaseManager):
   pass
 
 
-# TODO (https://github.com/apache/beam/issues/26169)
-# Expose __call__ function here.
-# We need to do this without removing access to other public methods.
-# This will allow us to have multi_process_shared objects which are callable
-# (e.g. ML models which are invoked via `model(args)`).
 _SingletonRegistrar.register(
     'acquire_singleton',
     callable=_process_level_singleton_manager.acquire_singleton)

--- a/sdks/python/apache_beam/utils/multi_process_shared.py
+++ b/sdks/python/apache_beam/utils/multi_process_shared.py
@@ -38,7 +38,7 @@ from typing import TypeVar
 import fasteners
 
 T = TypeVar('T')
-AUTH_KEY=b'mps'
+AUTH_KEY = b'mps'
 
 
 class _SingletonProxy:
@@ -117,6 +117,7 @@ _process_local_lock = threading.Lock()
 
 class _SingletonRegistrar(multiprocessing.managers.BaseManager):
   pass
+
 
 # TODO (https://github.com/apache/beam/issues/26169)
 # Expose __call__ function here.
@@ -209,7 +210,8 @@ class MultiProcessShared(Generic[T]):
               logging.info('Connecting to remote proxy at %s', address)
               host, port = address.split(':')
               # We need to be able to authenticate with both the manager and the process.
-              manager = _SingletonRegistrar(address=(host, int(port)), authkey=AUTH_KEY)
+              manager = _SingletonRegistrar(
+                  address=(host, int(port)), authkey=AUTH_KEY)
               multiprocessing.current_process().authkey = AUTH_KEY
               try:
                 manager.connect()
@@ -233,7 +235,8 @@ class MultiProcessShared(Generic[T]):
 
   def _create_server(self, address_file):
     # We need to be able to authenticate with both the manager and the process.
-    self._serving_manager = _SingletonRegistrar(address=('localhost', 0), authkey=AUTH_KEY)
+    self._serving_manager = _SingletonRegistrar(
+        address=('localhost', 0), authkey=AUTH_KEY)
     multiprocessing.current_process().authkey = AUTH_KEY
     # Initialize eagerly to avoid acting as the server if there are issues.
     # Note, however, that _create_server itself is called lazily.

--- a/sdks/python/apache_beam/utils/multi_process_shared.py
+++ b/sdks/python/apache_beam/utils/multi_process_shared.py
@@ -124,7 +124,6 @@ class _SingletonRegistrar(multiprocessing.managers.BaseManager):
 # We need to do this without removing access to other public methods.
 # This will allow us to have multi_process_shared objects which are callable
 # (e.g. ML models which are invoked via `model(args)`).
-# See https://docs.python.org/3/library/multiprocessing.html#multiprocessing.managers.BaseManager.register
 _SingletonRegistrar.register(
     'acquire_singleton',
     callable=_process_level_singleton_manager.acquire_singleton)

--- a/sdks/python/apache_beam/utils/multi_process_shared.py
+++ b/sdks/python/apache_beam/utils/multi_process_shared.py
@@ -203,7 +203,8 @@ class MultiProcessShared(Generic[T]):
                 address = fin.read()
               logging.info('Connecting to remote proxy at %s', address)
               host, port = address.split(':')
-              # We need to be able to authenticate with both the manager and the process.
+              # We need to be able to authenticate with both the manager and
+              # the process.
               manager = _SingletonRegistrar(
                   address=(host, int(port)), authkey=AUTH_KEY)
               multiprocessing.current_process().authkey = AUTH_KEY


### PR DESCRIPTION
Right now, multi_process_shared doesn't set an auth key. When that happens, the manager still creates an auth key for that process based on the current process's authKey - https://github.com/python/cpython/blob/4dc339b4d69195448207e1faecc3e258700daf33/Lib/multiprocessing/managers.py#L503

This causes cross-process authentication to fail and means that multi_process_shared.py doesn't correctly work.

This PR fixes this by using a constant auth key for all managers/requesters/processes.

I was able to get an example running on Dataflow using this approach. https://github.com/apache/beam/pull/26178 also causes unit tests to fail which will be fixed by this change, so I'm deferring tests to that PR

Fixes #26167

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
