### PR TITLE
(#26180) Fix go-licenses container COPY, by touching a dummy file.

### DIFF
--- a/sdks/go/container/Dockerfile
+++ b/sdks/go/container/Dockerfile
@@ -17,7 +17,8 @@
 ###############################################################################
 
 FROM debian:bullseye
-MAINTAINER "Apache Beam <dev@beam.apache.org>"
+LABEL Author "Apache Beam <dev@beam.apache.org>"
+
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -34,11 +35,8 @@ ADD target/${TARGETOS}_${TARGETARCH}/boot /opt/apache/beam/
 COPY target/LICENSE /opt/apache/beam/
 COPY target/NOTICE /opt/apache/beam/
 
-# Add golang licenses. Because the go-license directory may be empty if
-# pull_licenses is false, and COPY fails if there are no files,
-# copy an extra LICENSE file then remove it.
-COPY target/LICENSE target/go-licenses/* /opt/apache/beam/third_party_licenses/golang/
-RUN rm /opt/apache/beam/third_party_licenses/golang/LICENSE
+# Add Go licenses.
+COPY target/go-licenses/* /opt/apache/beam/third_party_licenses/golang/
 RUN if [ "$pull_licenses" = "false" ] ; then \
     # Remove above golang license and dir if pull licenses false
     rm -rf /opt/apache/beam/third_party_licenses ; \

--- a/sdks/go/container/build.gradle
+++ b/sdks/go/container/build.gradle
@@ -46,6 +46,7 @@ dockerPrepare.dependsOn tasks.named("goBuild")
 // Ensure that making the docker image builds any required artifacts
 if (project.rootProject.hasProperty(["docker-pull-licenses"])) {
   task copyGolangLicenses(type: Copy) {
+    project.logger.lifecycle('docker-pull-licenses set, running go-licenses')
     from "${project(':release:go-licenses:go').buildDir}/output"
     into "build/target/go-licenses"
     dependsOn ':release:go-licenses:go:createLicenses'
@@ -53,8 +54,10 @@ if (project.rootProject.hasProperty(["docker-pull-licenses"])) {
   dockerPrepare.dependsOn 'copyGolangLicenses'
 } else {
   task skipPullLicenses(type: Exec) {
+    project.logger.lifecycle('docker-pull-licenses not set, skipping go-licenses')
     executable "sh"
-    args "-c", "mkdir -p build/target/go-licenses"
+    // Touch a dummy file to ensure the directory exists.
+    args "-c", "mkdir -p build/target/go-licenses && touch build/target/go-licenses/skip"
   }
   dockerPrepare.dependsOn 'skipPullLicenses'
 }

--- a/sdks/java/container/Dockerfile
+++ b/sdks/java/container/Dockerfile
@@ -17,7 +17,7 @@
 ###############################################################################
 ARG java_version
 FROM eclipse-temurin:${java_version}
-MAINTAINER "Apache Beam <dev@beam.apache.org>"
+LABEL Author "Apache Beam <dev@beam.apache.org>"
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -46,13 +46,9 @@ ADD target/third_party_licenses /opt/apache/beam/third_party_licenses/
 # Copy Java options. Because the options directory may be empty and
 # COPY fails if there are no files, copy an extra LICENSE file then remove it.
 COPY target/LICENSE target/options/* /opt/apache/beam/options/
-RUN rm /opt/apache/beam/options/LICENSE
 
-# Add golang licenses. Because the go-license directory may be empty if
-# pull_licenses is false, and COPY fails if there are no files,
-# copy an extra LICENSE file then remove it.
-COPY target/LICENSE target/go-licenses/* /opt/apache/beam/third_party_licenses/golang/
-RUN rm /opt/apache/beam/third_party_licenses/golang/LICENSE
+# Add golang licenses.
+COPY target/go-licenses/* /opt/apache/beam/third_party_licenses/golang/
 RUN if [ "${pull_licenses}" = "false" ] ; then \
     # Remove above license dir if pull licenses false
     rm -rf /opt/apache/beam/third_party_licenses ; \

--- a/sdks/java/container/common.gradle
+++ b/sdks/java/container/common.gradle
@@ -89,7 +89,7 @@ task copyJdkOptions(type: Copy) {
 
 task skipPullLicenses(type: Exec) {
     executable "sh"
-    args "-c", "mkdir -p build/target/go-licenses build/target/options build/target/third_party_licenses && touch build/target/third_party_licenses/skip"
+    args "-c", "mkdir -p build/target/go-licenses build/target/options build/target/third_party_licenses && touch build/target/go-licenses/skip && touch build/target/third_party_licenses/skip"
 }
 
 task validateJavaHome {
@@ -125,9 +125,11 @@ docker {
 
 if (project.rootProject.hasProperty(["docker-pull-licenses"]) ||
         project.rootProject.hasProperty(["isRelease"])) {
+    project.logger.lifecycle('docker-pull-licenses set, creating go-licenses')
     dockerPrepare.dependsOn copyJavaThirdPartyLicenses
     dockerPrepare.dependsOn copyGolangLicenses
 } else {
+    project.logger.lifecycle('docker-pull-licenses not set, skipping go-licenses')
     dockerPrepare.dependsOn skipPullLicenses
 }
 dockerPrepare.dependsOn copySdkHarnessLauncher

--- a/sdks/python/container/Dockerfile
+++ b/sdks/python/container/Dockerfile
@@ -18,7 +18,7 @@
 
 ARG py_version
 FROM python:"${py_version}"-bullseye as beam
-MAINTAINER "Apache Beam <dev@beam.apache.org>"
+LABEL Author "Apache Beam <dev@beam.apache.org>"
 ARG TARGETOS
 ARG TARGETARCH
 
@@ -93,11 +93,9 @@ ENTRYPOINT ["/opt/apache/beam/boot"]
 FROM beam as third_party_licenses
 ARG pull_licenses
 COPY target/license_scripts /tmp/license_scripts/
-# Add golang licenses. Because the go-license directory may be empty if
-# pull_licenses is false, and COPY fails if there are no files,
-# copy an extra LICENSE file then remove it.
-COPY target/LICENSE target/go-licenses/* /opt/apache/beam/third_party_licenses/golang/
-RUN rm /opt/apache/beam/third_party_licenses/golang/LICENSE
+
+# Add golang licenses.
+COPY  target/go-licenses/* /opt/apache/beam/third_party_licenses/golang/
 
 COPY target/license_scripts /tmp/license_scripts/
 RUN if [ "$pull_licenses" = "true" ] ; then \

--- a/sdks/python/container/common.gradle
+++ b/sdks/python/container/common.gradle
@@ -97,7 +97,8 @@ if (project.rootProject.hasProperty(["docker-pull-licenses"])) {
 } else {
   def skipPullLicenses = tasks.register("skipPullLicenses", Exec) {
     executable "sh"
-    args "-c", "mkdir -p build/target/go-licenses"
+    // Touch a dummy file to ensure the directory exists.
+    args "-c", "mkdir -p build/target/go-licenses && touch build/target/go-licenses/skip"
   }
   dockerPrepare.dependsOn skipPullLicenses
 }

--- a/sdks/typescript/container/Dockerfile
+++ b/sdks/typescript/container/Dockerfile
@@ -17,7 +17,7 @@
 ###############################################################################
 
 FROM node:16
-MAINTAINER "Apache Beam <dev@beam.apache.org>"
+LABEL Author "Apache Beam <dev@beam.apache.org>"
 ARG TARGETOS
 ARG TARGETARCH
 

--- a/sdks/typescript/container/build.gradle
+++ b/sdks/typescript/container/build.gradle
@@ -71,7 +71,8 @@ if (project.rootProject.hasProperty(["docker-pull-licenses"])) {
 } else {
   def skipPullLicenses = tasks.register("skipPullLicenses", Exec) {
     executable "sh"
-    args "-c", "mkdir -p build/target/go-licenses"
+    // Touch a dummy file to ensure the directory exists.
+    args "-c", "mkdir -p build/target/go-licenses && touch build/target/go-licenses/skip"
   }
   dockerPrepare.dependsOn skipPullLicenses
 }


### PR DESCRIPTION
Fix a spontaneous issue with container creation that occurs with the current docker version. COPY requires *all* source directories to produce values for copying, not simply checking the results. 

Touching a file ensures COPY is satisfied, and this reduces the complexity WRT the Docker files. They no longer need to copy a vestigial license file to the destination, and then delete it. Except for the experimental typescript container, the Dockerfiles all delete all third_party licenses directories when the pulls are false anyway.

Fixes #26180

Also replaces the deprecated `MAINTAINER` Dockerfile command with `LABEL Author`, which is all the MAINTAINER command does.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
