### PR TITLE
[Go SDK]: Implement fileio.MatchContinuously transform

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -62,6 +62,7 @@
 * Added support for enhanced fan-out in KinesisIO.Read (Java) ([#19967](https://github.com/apache/beam/issues/19967)).
   * This change is not compatible with Flink savepoints created by Beam 2.46.0 applications which had KinesisIO sources.
 * Added textio.ReadWithFilename transform (Go) ([#25812](https://github.com/apache/beam/issues/25812)).
+* Added fileio.MatchContinuously transform (Go) ([#26186](https://github.com/apache/beam/issues/26186)).
 
 ## New Features / Improvements
 

--- a/sdks/go/pkg/beam/io/fileio/example_test.go
+++ b/sdks/go/pkg/beam/io/fileio/example_test.go
@@ -18,6 +18,7 @@ package fileio_test
 import (
 	"context"
 	"log"
+	"time"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/io/fileio"
@@ -43,6 +44,18 @@ func ExampleMatchAll() {
 
 	globs := beam.Create(s, "gs://path/to/sub1/*.gz", "gs://path/to/sub2/*.gz")
 	matches := fileio.MatchAll(s, globs)
+	debug.Print(s, matches)
+
+	if err := beamx.Run(context.Background(), p); err != nil {
+		log.Fatalf("Failed to execute job: %v", err)
+	}
+}
+
+func ExampleMatchContinuously() {
+	beam.Init()
+	p, s := beam.NewPipelineWithRoot()
+
+	matches := fileio.MatchContinuously(s, "gs://path/to/*.json", 10*time.Second)
 	debug.Print(s, matches)
 
 	if err := beamx.Run(context.Background(), p); err != nil {

--- a/sdks/go/pkg/beam/io/fileio/read.go
+++ b/sdks/go/pkg/beam/io/fileio/read.go
@@ -82,12 +82,12 @@ func ReadDirectoryDisallow() ReadOptionFn {
 	}
 }
 
-// ReadMatches accepts the result of MatchFiles or MatchAll as a PCollection<FileMetadata> and
-// converts it to a PCollection<ReadableFile>. The ReadableFile can be used to retrieve file
-// metadata, open the file for reading or read the entire file into memory. ReadMatches accepts a
-// variadic number of ReadOptionFn that can be used to configure the compression type of the files
-// and treatment of directories. By default, the compression type is determined by the file
-// extension and directories are skipped.
+// ReadMatches accepts the result of MatchFiles, MatchAll or MatchContinuously as a
+// PCollection<FileMetadata> and converts it to a PCollection<ReadableFile>. The ReadableFile can be
+// used to retrieve file metadata, open the file for reading or read the entire file into memory.
+// ReadMatches accepts a variadic number of ReadOptionFn that can be used to configure the
+// compression type of the files and treatment of directories. By default, the compression type is
+// determined by the file extension and directories are skipped.
 func ReadMatches(s beam.Scope, col beam.PCollection, opts ...ReadOptionFn) beam.PCollection {
 	s = s.Scope("fileio.ReadMatches")
 


### PR DESCRIPTION
Fixes #26186 and adds a `fileio.MatchContinuously` transform to the Go SDK.

I have tested the transform manually on Dataflow and Flink, which seem to be the only runners that currently support all of watermark estimation, self-checkpointing and state provisioning, that this transform relies on. I have not added any unit tests for the same reason, and there were limitations with running integration tests with some of these features for Dataflow and Flink so I have skipped that as well.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
