### PR TITLE
[Feature Request]: Support detached mode for flink runner (#26158)

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkDetachedRunnerResult.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkDetachedRunnerResult.java
@@ -36,7 +36,6 @@ import org.slf4j.LoggerFactory;
 public class FlinkDetachedRunnerResult implements PipelineResult {
 
   private static final Logger LOG = LoggerFactory.getLogger(FlinkDetachedRunnerResult.class);
-  private static final int TEN_YEAR_DAYS = 365 * 10;
 
   private JobClient jobClient;
   private int jobCheckIntervalInSecs;
@@ -85,7 +84,7 @@ public class FlinkDetachedRunnerResult implements PipelineResult {
 
   @Override
   public State waitUntilFinish() {
-    return waitUntilFinish(Duration.standardDays(TEN_YEAR_DAYS));
+    return waitUntilFinish(Duration.standardDays(Long.MAX_VALUE));
   }
 
   @Override

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkDetachedRunnerResult.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkDetachedRunnerResult.java
@@ -84,7 +84,7 @@ public class FlinkDetachedRunnerResult implements PipelineResult {
 
   @Override
   public State waitUntilFinish() {
-    return waitUntilFinish(Duration.standardDays(Long.MAX_VALUE));
+    return waitUntilFinish(Duration.millis(Long.MAX_VALUE));
   }
 
   @Override

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkDetachedRunnerResult.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkDetachedRunnerResult.java
@@ -128,6 +128,7 @@ public class FlinkDetachedRunnerResult implements PipelineResult {
       case FAILED:
         return State.FAILED;
       case SUSPENDED:
+        return State.STOPPED;
       default:
         return State.UNKNOWN;
     }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkDetachedRunnerResult.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkDetachedRunnerResult.java
@@ -18,9 +18,16 @@
 package org.apache.beam.runners.flink;
 
 import java.io.IOException;
+import java.util.concurrent.ExecutionException;
+import org.apache.beam.runners.core.metrics.MetricsContainerStepMap;
+import org.apache.beam.runners.flink.metrics.FlinkMetricContainer;
 import org.apache.beam.sdk.PipelineResult;
 import org.apache.beam.sdk.metrics.MetricResults;
+import org.apache.flink.api.common.JobStatus;
+import org.apache.flink.core.execution.JobClient;
 import org.joda.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * Result of a detached execution of a {@link org.apache.beam.sdk.Pipeline} with Flink. In detached
@@ -28,31 +35,102 @@ import org.joda.time.Duration;
  */
 public class FlinkDetachedRunnerResult implements PipelineResult {
 
-  FlinkDetachedRunnerResult() {}
+  private static final Logger LOG = LoggerFactory.getLogger(FlinkDetachedRunnerResult.class);
+  private static final int TEN_YEAR_DAYS = 365 * 10;
+
+  private JobClient jobClient;
+  private int jobCheckIntervalInSecs;
+
+  FlinkDetachedRunnerResult(JobClient jobClient, int jobCheckIntervalInSecs) {
+    this.jobClient = jobClient;
+    this.jobCheckIntervalInSecs = jobCheckIntervalInSecs;
+  }
 
   @Override
   public State getState() {
-    return State.UNKNOWN;
+    try {
+      return toBeamJobState(jobClient.getJobStatus().get());
+    } catch (InterruptedException | ExecutionException e) {
+      throw new RuntimeException("Fail to get flink job state", e);
+    }
   }
 
   @Override
   public MetricResults metrics() {
-    throw new UnsupportedOperationException("The FlinkRunner does not currently support metrics.");
+    return MetricsContainerStepMap.asAttemptedOnlyMetricResults(getMetricsContainerStepMap());
+  }
+
+  private MetricsContainerStepMap getMetricsContainerStepMap() {
+    try {
+      return (MetricsContainerStepMap)
+          jobClient
+              .getAccumulators()
+              .get()
+              .getOrDefault(FlinkMetricContainer.ACCUMULATOR_NAME, new MetricsContainerStepMap());
+    } catch (InterruptedException | ExecutionException e) {
+      LOG.warn("Fail to get flink job accumulators", e);
+      return new MetricsContainerStepMap();
+    }
   }
 
   @Override
   public State cancel() throws IOException {
-    throw new UnsupportedOperationException("Cancelling is not yet supported.");
+    try {
+      this.jobClient.cancel().get();
+    } catch (InterruptedException | ExecutionException e) {
+      throw new RuntimeException("Fail to cancel flink job", e);
+    }
+    return getState();
   }
 
   @Override
   public State waitUntilFinish() {
-    return State.UNKNOWN;
+    return waitUntilFinish(Duration.standardDays(TEN_YEAR_DAYS));
   }
 
   @Override
   public State waitUntilFinish(Duration duration) {
-    return State.UNKNOWN;
+    long start = System.currentTimeMillis();
+    long durationInMillis = duration.getMillis();
+    State state = State.UNKNOWN;
+    while ((System.currentTimeMillis() - start) < durationInMillis) {
+      state = getState();
+      if (state.isTerminal()) {
+        return state;
+      }
+      try {
+        Thread.sleep(jobCheckIntervalInSecs * 1000);
+      } catch (InterruptedException e) {
+        throw new RuntimeException(e);
+      }
+    }
+
+    if (state != null && !state.isTerminal()) {
+      LOG.warn("Job is not finished in {} seconds", duration.getStandardSeconds());
+    }
+    return state;
+  }
+
+  private State toBeamJobState(JobStatus flinkJobStatus) {
+    switch (flinkJobStatus) {
+      case CANCELLING:
+      case CREATED:
+      case INITIALIZING:
+      case FAILING:
+      case RECONCILING:
+      case RESTARTING:
+      case RUNNING:
+        return State.RUNNING;
+      case FINISHED:
+        return State.DONE;
+      case CANCELED:
+        return State.CANCELLED;
+      case FAILED:
+        return State.FAILED;
+      case SUSPENDED:
+      default:
+        return State.UNKNOWN;
+    }
   }
 
   @Override

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
@@ -31,8 +31,10 @@ import org.apache.flink.api.common.ExecutionMode;
 import org.apache.flink.api.java.CollectionEnvironment;
 import org.apache.flink.api.java.ExecutionEnvironment;
 import org.apache.flink.api.java.LocalEnvironment;
+import org.apache.flink.api.java.RemoteEnvironment;
 import org.apache.flink.configuration.Configuration;
 import org.apache.flink.configuration.CoreOptions;
+import org.apache.flink.configuration.DeploymentOptions;
 import org.apache.flink.configuration.GlobalConfiguration;
 import org.apache.flink.configuration.RestOptions;
 import org.apache.flink.configuration.TaskManagerOptions;
@@ -117,6 +119,17 @@ public class FlinkExecutionEnvironments {
     if (options.getParallelism() != -1 && !(flinkBatchEnv instanceof CollectionEnvironment)) {
       flinkBatchEnv.setParallelism(options.getParallelism());
     }
+
+    // Only RemoteEnvironment support detached mode, other batch environment enforce to use attached
+    // mode
+    if (!options.getAttachedMode()) {
+      if (flinkBatchEnv instanceof RemoteEnvironment) {
+        flinkBatchEnv.getConfiguration().set(DeploymentOptions.ATTACHED, options.getAttachedMode());
+      } else {
+        LOG.warn("Detached mode is only supported in RemoteEnvironment for batch");
+      }
+    }
+
     // Set the correct parallelism, required by UnboundedSourceWrapper to generate consistent
     // splits.
     final int parallelism;
@@ -223,6 +236,18 @@ public class FlinkExecutionEnvironments {
 
     if (!options.getOperatorChaining()) {
       flinkStreamEnv.disableOperatorChaining();
+    }
+
+    // Only RemoteStreamEnvironment support detached mode, other stream environment enforce to use
+    // attached mode.
+    if (!options.getAttachedMode()) {
+      if (flinkStreamEnv instanceof RemoteStreamEnvironment) {
+        ((RemoteStreamEnvironment) flinkStreamEnv)
+            .getClientConfiguration()
+            .set(DeploymentOptions.ATTACHED, options.getAttachedMode());
+      } else {
+        LOG.warn("Detached mode is only supported in RemoteStreamEnvironment for streaming");
+      }
     }
 
     // default to event time

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironment.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineExecutionEnvironment.java
@@ -19,11 +19,16 @@ package org.apache.beam.runners.flink;
 
 import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.Map;
 import org.apache.beam.runners.core.construction.resources.PipelineResources;
+import org.apache.beam.runners.core.metrics.MetricsPusher;
 import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.metrics.MetricsOptions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.flink.api.common.JobExecutionResult;
 import org.apache.flink.api.java.ExecutionEnvironment;
+import org.apache.flink.core.execution.JobClient;
 import org.apache.flink.runtime.jobgraph.JobGraph;
 import org.apache.flink.streaming.api.environment.StreamExecutionEnvironment;
 import org.apache.flink.streaming.api.graph.StreamGraph;
@@ -127,16 +132,54 @@ class FlinkPipelineExecutionEnvironment {
   }
 
   /** Launches the program execution. */
-  public JobExecutionResult executePipeline() throws Exception {
+  public PipelineResult executePipeline() throws Exception {
     final String jobName = options.getJobName();
 
     if (flinkBatchEnv != null) {
-      return flinkBatchEnv.execute(jobName);
+      if (options.getAttachedMode()) {
+        JobExecutionResult jobExecutionResult = flinkBatchEnv.execute(jobName);
+        return createAttachedPipelineResult(jobExecutionResult);
+      } else {
+        JobClient jobClient = flinkBatchEnv.executeAsync(jobName);
+        return createDetachedPipelineResult(jobClient, options);
+      }
     } else if (flinkStreamEnv != null) {
-      return flinkStreamEnv.execute(jobName);
+      if (options.getAttachedMode()) {
+        JobExecutionResult jobExecutionResult = flinkStreamEnv.execute(jobName);
+        return createAttachedPipelineResult(jobExecutionResult);
+      } else {
+        JobClient jobClient = flinkStreamEnv.executeAsync(jobName);
+        return createDetachedPipelineResult(jobClient, options);
+      }
     } else {
       throw new IllegalStateException("The Pipeline has not yet been translated.");
     }
+  }
+
+  private FlinkDetachedRunnerResult createDetachedPipelineResult(
+      JobClient jobClient, FlinkPipelineOptions options) {
+    LOG.info("Pipeline submitted in detached mode");
+    return new FlinkDetachedRunnerResult(jobClient, options.getJobCheckIntervalInSecs());
+  }
+
+  private FlinkRunnerResult createAttachedPipelineResult(JobExecutionResult result) {
+    LOG.info("Execution finished in {} msecs", result.getNetRuntime());
+    Map<String, Object> accumulators = result.getAllAccumulatorResults();
+    if (accumulators != null && !accumulators.isEmpty()) {
+      LOG.info("Final accumulator values:");
+      for (Map.Entry<String, Object> entry : result.getAllAccumulatorResults().entrySet()) {
+        LOG.info("{} : {}", entry.getKey(), entry.getValue());
+      }
+    }
+    FlinkRunnerResult flinkRunnerResult =
+        new FlinkRunnerResult(accumulators, result.getNetRuntime());
+    MetricsPusher metricsPusher =
+        new MetricsPusher(
+            flinkRunnerResult.getMetricsContainerStepMap(),
+            options.as(MetricsOptions.class),
+            flinkRunnerResult);
+    metricsPusher.start();
+    return flinkRunnerResult;
   }
 
   /**

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
@@ -150,7 +150,7 @@ public interface FlinkPipelineOptions
 
   void setJobCheckIntervalInSecs(int seconds);
 
-  @Description("Set the attached mode")
+  @Description("Specifies if the pipeline is submitted in attached or detached mode")
   @Default.Boolean(true)
   boolean getAttachedMode();
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
@@ -143,6 +143,20 @@ public interface FlinkPipelineOptions
   void setNumberOfExecutionRetries(Integer retries);
 
   @Description(
+      "Set job check interval in seconds under detached mode in method waitUntilFinish, "
+          + "by default it is 5 seconds")
+  @Default.Integer(5)
+  int getJobCheckIntervalInSecs();
+
+  void setJobCheckIntervalInSecs(int seconds);
+
+  @Description("Set the attached mode")
+  @Default.Boolean(true)
+  boolean getAttachedMode();
+
+  void setAttachedMode(boolean attachedMode);
+
+  @Description(
       "Sets the delay in milliseconds between executions. A value of {@code -1} "
           + "indicates that the default value should be used.")
   @Default.Long(-1L)

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPortableRunnerResult.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPortableRunnerResult.java
@@ -23,9 +23,6 @@ import org.apache.beam.model.jobmanagement.v1.JobApi;
 import org.apache.beam.model.pipeline.v1.MetricsApi;
 import org.apache.beam.runners.jobsubmission.PortablePipelineResult;
 import org.apache.beam.sdk.metrics.MetricResults;
-import org.checkerframework.checker.initialization.qual.Initialized;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.UnknownKeyFor;
 import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -64,28 +61,27 @@ public class FlinkPortableRunnerResult extends FlinkRunnerResult implements Port
     }
 
     @Override
-    public @UnknownKeyFor @NonNull @Initialized State getState() {
+    public State getState() {
       return State.UNKNOWN;
     }
 
     @Override
-    public @UnknownKeyFor @NonNull @Initialized State cancel() throws IOException {
+    public State cancel() throws IOException {
       throw new UnsupportedOperationException("Cancelling is not yet supported.");
     }
 
     @Override
-    public @UnknownKeyFor @NonNull @Initialized State waitUntilFinish(
-        @UnknownKeyFor @NonNull @Initialized Duration duration) {
+    public State waitUntilFinish(Duration duration) {
       return State.UNKNOWN;
     }
 
     @Override
-    public @UnknownKeyFor @NonNull @Initialized State waitUntilFinish() {
+    public State waitUntilFinish() {
       return State.UNKNOWN;
     }
 
     @Override
-    public @UnknownKeyFor @NonNull @Initialized MetricResults metrics() {
+    public MetricResults metrics() {
       throw new UnsupportedOperationException(
           "The FlinkRunner does not currently support metrics.");
     }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPortableRunnerResult.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPortableRunnerResult.java
@@ -17,10 +17,16 @@
  */
 package org.apache.beam.runners.flink;
 
+import java.io.IOException;
 import java.util.Map;
 import org.apache.beam.model.jobmanagement.v1.JobApi;
 import org.apache.beam.model.pipeline.v1.MetricsApi;
 import org.apache.beam.runners.jobsubmission.PortablePipelineResult;
+import org.apache.beam.sdk.metrics.MetricResults;
+import org.checkerframework.checker.initialization.qual.Initialized;
+import org.checkerframework.checker.nullness.qual.NonNull;
+import org.checkerframework.checker.nullness.qual.UnknownKeyFor;
+import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -44,13 +50,44 @@ public class FlinkPortableRunnerResult extends FlinkRunnerResult implements Port
         .build();
   }
 
-  static class Detached extends FlinkDetachedRunnerResult implements PortablePipelineResult {
+  static class Detached implements PortablePipelineResult {
+
+    Detached() {
+      super();
+    }
 
     @Override
     public JobApi.MetricResults portableMetrics() throws UnsupportedOperationException {
       LOG.warn(
           "Collecting monitoring infos is not implemented yet in Flink portable runner (detached mode).");
       return JobApi.MetricResults.newBuilder().build();
+    }
+
+    @Override
+    public @UnknownKeyFor @NonNull @Initialized State getState() {
+      return State.UNKNOWN;
+    }
+
+    @Override
+    public @UnknownKeyFor @NonNull @Initialized State cancel() throws IOException {
+      throw new UnsupportedOperationException("Cancelling is not yet supported.");
+    }
+
+    @Override
+    public @UnknownKeyFor @NonNull @Initialized State waitUntilFinish(
+        @UnknownKeyFor @NonNull @Initialized Duration duration) {
+      return State.UNKNOWN;
+    }
+
+    @Override
+    public @UnknownKeyFor @NonNull @Initialized State waitUntilFinish() {
+      return State.UNKNOWN;
+    }
+
+    @Override
+    public @UnknownKeyFor @NonNull @Initialized MetricResults metrics() {
+      throw new UnsupportedOperationException(
+          "The FlinkRunner does not currently support metrics.");
     }
   }
 }


### PR DESCRIPTION
**Please** add a meaningful description for your change here

This PR adds the support of detached mode for flink runner, so that `pipeline.run()` become non-blocking mode in detached mode, user can call `PipelineResult#waitUntilFinish` to wait for the pipeline to finish. 2 main changes in this PR

* Add 2 options in `FlinkPipelineOptions`: 
   * AttachedMode (default is true to make it compatible with previous behavior)
   * JobCheckIntervalInSecs (used for checking job status in detached mode, default is  5 seconds)
* Update `FlinkDetachedRunnerResult.java` to make it work in detached mode.

Related flink ticket: https://issues.apache.org/jira/browse/FLINK-31667

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
