### PR TITLE
Update Python textio documentation to support reading with different encodings

### DIFF
--- a/sdks/python/apache_beam/io/textio.py
+++ b/sdks/python/apache_beam/io/textio.py
@@ -61,8 +61,9 @@ class _TextSource(filebasedsource.FileBasedSource):
   Parses a text file as newline-delimited elements. Supports newline delimiters
   '\n' and '\r\n.
 
-  This implementation only supports reading text encoded using UTF-8 or
-  ASCII.
+  This implementation reads encoded text and uses the input coder's encoding to
+  decode from bytes to str. This does not support ``UTF-16`` or ``UTF-32``
+  encodings.
   """
 
   DEFAULT_READ_BUFFER_SIZE = 8192
@@ -571,8 +572,12 @@ class ReadAllFromText(PTransform):
   similar to ``ReadFromTextWithFilename`` but this ``PTransform`` can be placed
   anywhere in the pipeline.
 
-  This implementation only supports reading text encoded using UTF-8 or ASCII.
-  This does not support other encodings such as UTF-16 or UTF-32.
+  If reading from a text file that that requires a different encoding, you may
+  provide a custom :class:`~apache_beam.coders.coders.Coder` that encodes and
+  decodes with the appropriate codec. For example, see the implementation of
+  :class:`~apache_beam.coders.coders.StrUtf8Coder`.
+
+  This does not support ``UTF-16`` or ``UTF-32`` encodings.
 
   This implementation is only tested with batch pipeline. In streaming,
   reading may happen with delay due to the limitation in ReShuffle involved.
@@ -719,11 +724,14 @@ class ReadFromText(PTransform):
 
   Parses a text file as newline-delimited elements, by default assuming
   ``UTF-8`` encoding. Supports newline delimiters ``\n`` and ``\r\n``
-  or specified delimiter .
+  or specified delimiter.
 
-  This implementation only supports reading text encoded using ``UTF-8`` or
-  ``ASCII``.
-  This does not support other encodings such as ``UTF-16`` or ``UTF-32``.
+  If reading from a text file that that requires a different encoding, you may
+  provide a custom :class:`~apache_beam.coders.coders.Coder` that encodes and
+  decodes with the appropriate codec. For example, see the implementation of
+  :class:`~apache_beam.coders.coders.StrUtf8Coder`.
+
+  This does not support ``UTF-16`` or ``UTF-32`` encodings.
   """
 
   _source_class = _TextSource


### PR DESCRIPTION
Textio documentation states that only `UTF-8` and `ASCII` encodings are supported. This is not true because a coder with custom encoding can be passed in and used to decode the text.

Example:

```
class VariableCodecCoder(Coder):
  def __init__(self, codec):
    self._codec = codec

  def encode(self, value):
    return value.encode(self._codec)

  def decode(self, value):
    return value.decode(self._codec)

  def is_deterministic(self):
    return True

  def to_type_hint(self):
    return str

with beam.Pipeline() as p:
  (
    p
    | beam.io.ReadFromText("a", coder = VariableCodecCoder('cp864'))
    | beam.Map(print)
  )
```