### PR TITLE
fix: Fix BigtableIO to share one BigtableService per worker and increase default attempt timeout

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableConfigTranslator.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableConfigTranslator.java
@@ -183,21 +183,16 @@ class BigtableConfigTranslator {
 
     // The default attempt timeout for version <= 2.46.0 is 6 minutes. Reset the timeout to align
     // with the old behavior.
-    retrySettings
-        .setInitialRpcTimeout(Duration.ofMinutes(6))
-        .setMaxRpcTimeout(Duration.ofMinutes(6));
+    Duration attemptTimeout = Duration.ofMinutes(6);
 
     if (writeOptions.getAttemptTimeout() != null) {
-      // Set the user specified attempt timeout and expand the operation timeout if it's shorter
-      retrySettings
-          .setInitialRpcTimeout(Duration.ofMillis(writeOptions.getAttemptTimeout().getMillis()))
-          .setMaxRpcTimeout(Duration.ofMillis(writeOptions.getAttemptTimeout().getMillis()));
-      retrySettings.setTotalTimeout(
-          Duration.ofMillis(
-              Math.max(
-                  retrySettings.getTotalTimeout().toMillis(),
-                  writeOptions.getAttemptTimeout().getMillis())));
+      attemptTimeout = Duration.ofMillis(writeOptions.getAttemptTimeout().getMillis());
     }
+    retrySettings.setInitialRpcTimeout(attemptTimeout).setMaxRpcTimeout(attemptTimeout);
+    // Expand the operation timeout if it's shorter
+    retrySettings.setTotalTimeout(
+        Duration.ofMillis(
+            Math.max(retrySettings.getTotalTimeout().toMillis(), attemptTimeout.toMillis())));
 
     if (writeOptions.getOperationTimeout() != null) {
       retrySettings.setTotalTimeout(

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableConfigTranslator.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableConfigTranslator.java
@@ -180,10 +180,18 @@ class BigtableConfigTranslator {
         settings.stubSettings().bulkMutateRowsSettings();
     RetrySettings.Builder retrySettings = callSettings.getRetrySettings().toBuilder();
     BatchingSettings.Builder batchingSettings = callSettings.getBatchingSettings().toBuilder();
+
+    // The default attempt timeout for version <= 2.46.0 is 6 minutes. Reset the timeout to align
+    // with the old behavior.
+    retrySettings
+        .setInitialRpcTimeout(Duration.ofMinutes(6))
+        .setMaxRpcTimeout(Duration.ofMinutes(6));
+
     if (writeOptions.getAttemptTimeout() != null) {
       // Set the user specified attempt timeout and expand the operation timeout if it's shorter
-      retrySettings.setInitialRpcTimeout(
-          Duration.ofMillis(writeOptions.getAttemptTimeout().getMillis()));
+      retrySettings
+          .setInitialRpcTimeout(Duration.ofMillis(writeOptions.getAttemptTimeout().getMillis()))
+          .setMaxRpcTimeout(Duration.ofMillis(writeOptions.getAttemptTimeout().getMillis()));
       retrySettings.setTotalTimeout(
           Duration.ofMillis(
               Math.max(

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceFactory.java
@@ -73,6 +73,10 @@ class BigtableServiceFactory implements Serializable {
     public void close() {
       int refCount =
           refCounts.getOrDefault(getConfigId().id(), new AtomicInteger(0)).decrementAndGet();
+      if (refCount < 0) {
+        LOG.error(
+            "close() Ref count is < 0, configId=" + getConfigId().id() + " refCount=" + refCount);
+      }
       LOG.debug("close() for config id " + getConfigId().id() + ", ref count is " + refCount);
       if (refCount == 0) {
         synchronized (lock) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceFactory.java
@@ -24,10 +24,9 @@ import com.google.cloud.bigtable.config.BigtableOptions;
 import com.google.cloud.bigtable.data.v2.BigtableDataClient;
 import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
 import java.io.IOException;
-import java.io.ObjectInputStream;
 import java.io.Serializable;
-import java.util.HashMap;
-import java.util.Map;
+import java.util.UUID;
+import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.slf4j.Logger;
@@ -44,111 +43,120 @@ import org.slf4j.LoggerFactory;
 class BigtableServiceFactory implements Serializable {
 
   private static final Logger LOG = LoggerFactory.getLogger(BigtableServiceFactory.class);
-
-  static final BigtableServiceFactory FACTORY_INSTANCE = new BigtableServiceFactory();
-
-  private transient int nextId = 0;
-
-  private transient Map<ConfigId, BigtableServiceEntry> entries = new HashMap<>();
+  private static final ConcurrentHashMap<UUID, BigtableServiceEntry> entries =
+      new ConcurrentHashMap<>();
+  private static final ConcurrentHashMap<UUID, AtomicInteger> refCounts = new ConcurrentHashMap<>();
+  private static final Object lock = new Object();
 
   @AutoValue
   abstract static class ConfigId implements Serializable {
 
-    abstract int id();
+    abstract UUID id();
 
-    static ConfigId create(int id) {
-      return new AutoValue_BigtableServiceFactory_ConfigId(id);
+    static ConfigId create() {
+      return new AutoValue_BigtableServiceFactory_ConfigId(UUID.randomUUID());
     }
   }
 
   @AutoValue
   abstract static class BigtableServiceEntry implements Serializable, AutoCloseable {
 
-    abstract BigtableServiceFactory getServiceFactory();
-
     abstract ConfigId getConfigId();
 
     abstract BigtableService getService();
 
-    abstract AtomicInteger getRefCount();
-
-    static BigtableServiceEntry create(
-        BigtableServiceFactory factory,
-        ConfigId configId,
-        BigtableService service,
-        AtomicInteger refCount) {
-      return new AutoValue_BigtableServiceFactory_BigtableServiceEntry(
-          factory, configId, service, refCount);
+    static BigtableServiceEntry create(ConfigId configId, BigtableService service) {
+      return new AutoValue_BigtableServiceFactory_BigtableServiceEntry(configId, service);
     }
 
     @Override
     public void close() {
-      getServiceFactory().releaseService(this);
+      int refCount =
+          refCounts.getOrDefault(getConfigId().id(), new AtomicInteger(0)).decrementAndGet();
+      LOG.debug("close() for config id " + getConfigId().id() + ", ref count is " + refCount);
+      if (refCount == 0) {
+        synchronized (lock) {
+          if (refCounts.get(getConfigId().id()).get() <= 0) {
+            entries.remove(getConfigId().id());
+            refCounts.remove(getConfigId().id());
+            getService().close();
+          }
+        }
+      }
     }
   }
 
-  synchronized BigtableServiceEntry getServiceForReading(
+  BigtableServiceEntry getServiceForReading(
       ConfigId configId,
       BigtableConfig config,
       BigtableReadOptions opts,
       PipelineOptions pipelineOptions)
       throws IOException {
-    BigtableServiceEntry entry = entries.get(configId);
-    if (entry != null) {
-      entry.getRefCount().incrementAndGet();
+    synchronized (lock) {
+      LOG.debug("getServiceForReading(), config id: " + configId.id());
+      BigtableServiceEntry entry = entries.get(configId.id());
+      if (entry != null) {
+        // When entry is not null, refCount.get(configId.id()) should always exist.
+        // Do a getOrDefault to avoid unexpected NPEs.
+        refCounts.getOrDefault(configId.id(), new AtomicInteger(0)).getAndIncrement();
+        LOG.debug("getServiceForReading() returning an existing service entry");
+        return entry;
+      }
+
+      BigtableOptions effectiveOptions = getEffectiveOptions(config);
+      if (effectiveOptions != null) {
+        // If BigtableOptions is set, convert it to BigtableConfig and BigtableWriteOptions
+        config = BigtableConfigTranslator.translateToBigtableConfig(config, effectiveOptions);
+        opts = BigtableConfigTranslator.translateToBigtableReadOptions(opts, effectiveOptions);
+      }
+      BigtableDataSettings settings =
+          BigtableConfigTranslator.translateReadToVeneerSettings(config, opts, pipelineOptions);
+      BigtableService service;
+      if (opts.getWaitTimeout() != null) {
+        service = new BigtableServiceImpl(settings, opts.getWaitTimeout());
+      } else {
+        service = new BigtableServiceImpl(settings);
+      }
+      entry = BigtableServiceEntry.create(configId, service);
+      entries.put(configId.id(), entry);
+      refCounts.put(configId.id(), new AtomicInteger(1));
+      LOG.debug("getServiceForReading() created a new service entry");
       return entry;
     }
-
-    BigtableOptions effectiveOptions = getEffectiveOptions(config);
-    if (effectiveOptions != null) {
-      // If BigtableOptions is set, convert it to BigtableConfig and BigtableWriteOptions
-      config = BigtableConfigTranslator.translateToBigtableConfig(config, effectiveOptions);
-      opts = BigtableConfigTranslator.translateToBigtableReadOptions(opts, effectiveOptions);
-    }
-    BigtableDataSettings settings =
-        BigtableConfigTranslator.translateReadToVeneerSettings(config, opts, pipelineOptions);
-    BigtableService service;
-    if (opts.getWaitTimeout() != null) {
-      service = new BigtableServiceImpl(settings, opts.getWaitTimeout());
-    } else {
-      service = new BigtableServiceImpl(settings);
-    }
-    entry = BigtableServiceEntry.create(this, configId, service, new AtomicInteger(1));
-    entries.put(configId, entry);
-    return entry;
   }
 
-  synchronized BigtableServiceEntry getServiceForWriting(
+  BigtableServiceEntry getServiceForWriting(
       ConfigId configId,
       BigtableConfig config,
       BigtableWriteOptions opts,
       PipelineOptions pipelineOptions)
       throws IOException {
-    BigtableServiceEntry entry = entries.get(configId);
-    if (entry != null) {
-      entry.getRefCount().incrementAndGet();
+    synchronized (lock) {
+      BigtableServiceEntry entry = entries.get(configId.id());
+      LOG.debug("getServiceForWriting(), config id: " + configId.id());
+      if (entry != null) {
+        // When entry is not null, refCount.get(configId.id()) should always exist.
+        // Do a getOrDefault to avoid unexpected NPEs.
+        refCounts.getOrDefault(configId.id(), new AtomicInteger(0)).getAndIncrement();
+        LOG.debug("getServiceForWriting() returning an existing service entry");
+        return entry;
+      }
+
+      BigtableOptions effectiveOptions = getEffectiveOptions(config);
+      if (effectiveOptions != null) {
+        // If BigtableOptions is set, convert it to BigtableConfig and BigtableWriteOptions
+        config = BigtableConfigTranslator.translateToBigtableConfig(config, effectiveOptions);
+        opts = BigtableConfigTranslator.translateToBigtableWriteOptions(opts, effectiveOptions);
+      }
+
+      BigtableDataSettings settings =
+          BigtableConfigTranslator.translateWriteToVeneerSettings(config, opts, pipelineOptions);
+      BigtableService service = new BigtableServiceImpl(settings);
+      entry = BigtableServiceEntry.create(configId, service);
+      entries.put(configId.id(), entry);
+      refCounts.put(configId.id(), new AtomicInteger(1));
+      LOG.debug("getServiceForWriting() created a new service entry");
       return entry;
-    }
-
-    BigtableOptions effectiveOptions = getEffectiveOptions(config);
-    if (effectiveOptions != null) {
-      // If BigtableOptions is set, convert it to BigtableConfig and BigtableWriteOptions
-      config = BigtableConfigTranslator.translateToBigtableConfig(config, effectiveOptions);
-      opts = BigtableConfigTranslator.translateToBigtableWriteOptions(opts, effectiveOptions);
-    }
-
-    BigtableDataSettings settings =
-        BigtableConfigTranslator.translateWriteToVeneerSettings(config, opts, pipelineOptions);
-    BigtableService service = new BigtableServiceImpl(settings);
-    entry = BigtableServiceEntry.create(this, configId, service, new AtomicInteger(1));
-    entries.put(configId, entry);
-    return entry;
-  }
-
-  synchronized void releaseService(BigtableServiceEntry entry) {
-    if (entry.getRefCount().decrementAndGet() == 0) {
-      entry.getService().close();
-      entries.remove(entry.getConfigId());
     }
   }
 
@@ -180,7 +188,7 @@ class BigtableServiceFactory implements Serializable {
   }
 
   synchronized ConfigId newId() {
-    return ConfigId.create(nextId++);
+    return ConfigId.create();
   }
 
   private BigtableOptions getEffectiveOptions(BigtableConfig config) {
@@ -190,11 +198,5 @@ class BigtableServiceFactory implements Serializable {
           config.getBigtableOptionsConfigurator().apply(BigtableOptions.builder()).build();
     }
     return effectiveOptions;
-  }
-
-  private void readObject(ObjectInputStream in) throws IOException, ClassNotFoundException {
-    in.defaultReadObject();
-    entries = new HashMap<>();
-    nextId = 0;
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
@@ -77,6 +77,8 @@ import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.util.concurrent.
 import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /**
  * An implementation of {@link BigtableService} that actually communicates with the Cloud Bigtable
@@ -86,6 +88,9 @@ import org.joda.time.Duration;
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
 class BigtableServiceImpl implements BigtableService {
+
+  private static final Logger LOG = LoggerFactory.getLogger(BigtableServiceImpl.class);
+
   // Default byte limit is a percentage of the JVM's available memory
   private static final double DEFAULT_BYTE_LIMIT_PERCENTAGE = .1;
   // Percentage of max number of rows allowed in the buffer
@@ -118,6 +123,7 @@ class BigtableServiceImpl implements BigtableService {
                   .setMaxRpcTimeout(org.threeten.bp.Duration.ofMillis(readWaitTimeout.getMillis()))
                   .build());
     }
+    LOG.info("Started Bigtable service with settings " + builder.build());
     this.client = BigtableDataClient.create(builder.build());
   }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
@@ -510,6 +510,7 @@ class BigtableServiceImpl implements BigtableService {
     public void close() throws IOException {
       if (bulkMutation != null) {
         try {
+          bulkMutation.flush();
           bulkMutation.close();
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
@@ -510,7 +510,6 @@ class BigtableServiceImpl implements BigtableService {
     public void close() throws IOException {
       if (bulkMutation != null) {
         try {
-          bulkMutation.flush();
           bulkMutation.close();
         } catch (InterruptedException e) {
           Thread.currentThread().interrupt();


### PR DESCRIPTION
fix #26166 

In https://github.com/apache/beam/pull/24015, the map that stores BigtableService is transient. During serialized and deserialized, it recreates an empty map which ended up creating a new BigtableService per each thread. The fix makes the map static. 

In the previous version, mutateRows operation has a timeout of 6 minutes. And after the migration, the default timeout became 1 minute, which makes the job fail more easily. Update the timeout back to 6 minutes. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
