### PR TITLE
Upgrade version of Apache Commons (dbcp2, pool2) due to advisory/CVE

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -525,7 +525,7 @@ class BeamModulePlugin implements Plugin<Project> {
     def cdap_version = "6.5.1"
     def checkerframework_version = "3.27.0"
     def classgraph_version = "4.8.104"
-    def dbcp2_version = "2.8.0"
+    def dbcp2_version = "2.9.0"
     def errorprone_version = "2.10.0"
     // Try to keep gax_version consistent with gax-grpc version in google_cloud_platform_libraries_bom
     def gax_version = "2.23.3"

--- a/sdks/java/io/jdbc/build.gradle
+++ b/sdks/java/io/jdbc/build.gradle
@@ -29,9 +29,9 @@ ext.summary = "IO to read and write on JDBC datasource."
 dependencies {
   implementation library.java.vendored_guava_26_0_jre
   implementation project(path: ":sdks:java:core", configuration: "shadow")
-  implementation "org.apache.commons:commons-dbcp2:2.8.0"
+  implementation library.java.dbcp2
   implementation library.java.joda_time
-  implementation "org.apache.commons:commons-pool2:2.8.1"
+  implementation "org.apache.commons:commons-pool2:2.11.1"
   implementation library.java.slf4j_api
   testImplementation "org.apache.derby:derby:10.14.2.0"
   testImplementation "org.apache.derby:derbyclient:10.14.2.0"


### PR DESCRIPTION
Upgrading commons-dbcp2 to latest (2.9.0) due to Snyk Advisory:


>  ✗ Information Exposure [Low Severity][https://security.snyk.io/vuln/SNYK-JAVA-ORGAPACHECOMMONS-559327] in org.apache.commons:commons-dbcp2@2.8.0
>    introduced by {groupId}:{artifactId}@{version} > org.apache.commons:commons-dbcp2@2.8.0
>
>  This issue was fixed in versions: 2.9.0


Also upgrading commons-pool2 to latest due to dependencies being at the [CVE-2020-15250](https://nvd.nist.gov/vuln/detail/cve-2020-15250) range.



GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
