### PR TITLE
Show legend for postcommit job duration.

### DIFF
--- a/.test-infra/metrics/grafana/dashboards/post-commit_tests.json
+++ b/.test-infra/metrics/grafana/dashboards/post-commit_tests.json
@@ -647,7 +647,7 @@
           "calcs": [
             "lastNotNull"
           ],
-          "displayMode": "hidden",
+          "displayMode": "table",
           "placement": "right"
         },
         "tooltip": {


### PR DESCRIPTION
Couldn't find a way to filter particular postcommit job duration on https://s.apache.org/beam-metrics, suspecting b/c legend is disabled.