### PR TITLE
Coalesce sources until compressed serialized bundles under API limit

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSources.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSources.java
@@ -247,18 +247,37 @@ public class WorkerCustomSources {
           serializedSize);
     }
 
+    List<BoundedSource<T>> bundlesBeforeCoalesce = bundles;
     int numBundlesBeforeRebundling = bundles.size();
     // To further reduce size of the response and service-side memory usage, coalesce
     // the sources into numBundlesLimit compressed serialized bundles.
-    if (bundles.size() > numBundlesLimit) {
+    while (serializedSize > apiByteLimit || bundles.size() > numBundlesLimit) {
+      // bundle size constrained by API limit, adds 5% allowance
+      int targetBundleSizeApiLimit = (int) (bundles.size() * apiByteLimit / serializedSize * 0.95);
+      // bundle size constrained by numBundlesLimit
+      int targetBundleSizeBundleLimit = Math.min(numBundlesLimit, bundles.size() - 1);
+      int targetBundleSize = Math.min(targetBundleSizeApiLimit, targetBundleSizeBundleLimit);
+
+      if (targetBundleSize <= 1) {
+        String message =
+            String.format(
+                "Unable to coalesce the sources into compressed serialized bundles to satisfy the "
+                    + "allowable limit when splitting %s. With %d bundles, total serialized size "
+                    + "of %d bytes is still larger than the limit %d. For more information, please "
+                    + "check the corresponding FAQ entry at "
+                    + "https://cloud.google.com/dataflow/pipelines/troubleshooting-your-pipeline",
+                source, bundles.size(), serializedSize, apiByteLimit);
+        throw new IllegalArgumentException(message);
+      }
+
+      bundles = limitNumberOfBundles(bundlesBeforeCoalesce, targetBundleSize);
+      serializedSize =
+          DataflowApiUtils.computeSerializedSizeBytes(wrapIntoSourceSplitResponse(bundles));
       LOG.warn(
-          "Splitting source {} into bundles of estimated size {} bytes produced {} bundles. "
-              + "Rebundling into {} bundles.",
+          "Re-bundle source {} into bundles of estimated size {} bytes produced {} bundles.",
           source,
-          desiredBundleSizeBytes,
-          bundles.size(),
-          numBundlesLimit);
-      bundles = limitNumberOfBundles(bundles, numBundlesLimit);
+          serializedSize,
+          bundles.size());
     }
 
     SourceOperationResponse response =

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSources.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSources.java
@@ -265,7 +265,7 @@ public class WorkerCustomSources {
                     + "allowable limit when splitting %s. With %d bundles, total serialized size "
                     + "of %d bytes is still larger than the limit %d. For more information, please "
                     + "check the corresponding FAQ entry at "
-                    + "https://cloud.google.com/dataflow/pipelines/troubleshooting-your-pipeline",
+                    + "https://cloud.google.com/dataflow/docs/guides/common-errors#boundedsource-objects-splitintobundles",
                 source, bundles.size(), serializedSize, apiByteLimit);
         throw new IllegalArgumentException(message);
       }
@@ -296,7 +296,7 @@ public class WorkerCustomSources {
                   + "it generated %d BoundedSource objects with total serialized size of %d bytes "
                   + "which is larger than the limit %d. "
                   + "For more information, please check the corresponding FAQ entry at "
-                  + "https://cloud.google.com/dataflow/pipelines/troubleshooting-your-pipeline",
+                  + "https://cloud.google.com/dataflow/docs/guides/common-errors#boundedsource-objects-splitintobundles",
               source,
               desiredBundleSizeBytes,
               numBundlesBeforeRebundling,

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
@@ -26,6 +26,7 @@ import static org.apache.beam.runners.dataflow.worker.SourceTranslationUtils.dic
 import static org.apache.beam.runners.dataflow.worker.SourceTranslationUtils.readerProgressToCloudProgress;
 import static org.apache.beam.runners.dataflow.worker.WorkerCustomSources.BoundedReaderIterator.getReaderProgress;
 import static org.apache.beam.runners.dataflow.worker.WorkerCustomSources.BoundedReaderIterator.longToParallelism;
+import static org.apache.beam.sdk.testing.ExpectedLogs.verifyLogged;
 import static org.apache.beam.sdk.testing.SourceTestUtils.readFromSource;
 import static org.apache.beam.sdk.util.CoderUtils.encodeToByteArray;
 import static org.apache.beam.sdk.util.SerializableUtils.deserializeFromByteArray;
@@ -67,7 +68,10 @@ import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import java.util.NoSuchElementException;
+import java.util.Random;
 import java.util.concurrent.TimeUnit;
+import java.util.logging.Level;
+import java.util.logging.LogManager;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.runners.core.construction.Environments;
 import org.apache.beam.runners.core.construction.PipelineTranslation;
@@ -112,6 +116,7 @@ import org.apache.beam.sdk.values.ValueWithRecordId;
 import org.apache.beam.vendor.grpc.v1p48p1.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.MoreObjects;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableMap;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.Duration;
@@ -175,6 +180,72 @@ public class WorkerCustomSourcesTest {
           contains(valueInGlobalWindow(0L + 2 * i), valueInGlobalWindow(1L + 2 * i)));
       assertTrue(bundle.getSource().getMetadata().getEstimatedSizeBytes() > 0);
     }
+  }
+
+  private static class SourceProducingSubSourcesInSplit extends MockSource {
+    int numDesiredBundle;
+    int sourceObjectSize;
+
+    private transient @Nullable List<BoundedSource<Integer>> cachedSplitResult = null;
+
+    public SourceProducingSubSourcesInSplit(int numDesiredBundle, int sourceObjectSize) {
+      this.numDesiredBundle = numDesiredBundle;
+      this.sourceObjectSize = sourceObjectSize;
+    }
+
+    @Override
+    public List<? extends BoundedSource<Integer>> split(
+        long desiredBundleSizeBytes, PipelineOptions options) throws Exception {
+      if (cachedSplitResult == null) {
+        ArrayList<SourceWithLargeObject> result = new ArrayList<>(numDesiredBundle);
+        for (int i = 0; i < numDesiredBundle; ++i) {
+          result.add(new SourceWithLargeObject(sourceObjectSize));
+        }
+        cachedSplitResult = ImmutableList.copyOf(result);
+      }
+      return cachedSplitResult;
+    }
+
+    @Override
+    public long getEstimatedSizeBytes(PipelineOptions options) {
+      return numDesiredBundle * 1000L;
+    }
+  }
+
+  private static class SourceWithLargeObject extends MockSource {
+    byte[] array;
+
+    public SourceWithLargeObject(int sourceObjectSize) {
+      byte[] array = new byte[sourceObjectSize];
+      new Random().nextBytes(array);
+    }
+
+    @Override
+    public long getEstimatedSizeBytes(PipelineOptions options) {
+      return 1000L;
+    }
+  }
+
+  @Test
+  public void testSplittingProducedResponseUnderLimit() throws Exception {
+    SourceProducingSubSourcesInSplit source = new SourceProducingSubSourcesInSplit(200, 10_000);
+    com.google.api.services.dataflow.model.Source cloudSource =
+        translateIOToCloudSource(source, options);
+    SourceSplitRequest splitRequest = new SourceSplitRequest();
+    splitRequest.setSource(cloudSource);
+
+    ExpectedLogs.LogSaver logSaver = new ExpectedLogs.LogSaver();
+    LogManager.getLogManager()
+        .getLogger("org.apache.beam.runners.dataflow.worker.WorkerCustomSources")
+        .addHandler(logSaver);
+
+    WorkerCustomSources.performSplitWithApiLimit(splitRequest, options, 100, 10_000);
+    // verify initial split is not valid
+    verifyLogged(
+        ExpectedLogs.matcher(Level.WARNING, "this is too large for the Google Cloud Dataflow API"),
+        logSaver);
+    // verify that re-bundle is effective
+    verifyLogged(ExpectedLogs.matcher(Level.WARNING, "Re-bundle source"), logSaver);
   }
 
   private static class SourceProducingNegativeEstimatedSizes extends MockSource {


### PR DESCRIPTION
Fixes #26264

The original `limitNumberOfBundles` logic has problems that it always limits to 100 bundles if the split bundle is greater than this number and did not check the resulting response size. It could result in IllegalArgumentException immediately below.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
