### PR TITLE
Use default value true for autoSharding if not configured for BigQuery with STORAGE_WRITE_API

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySchemaIOProvider.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySchemaIOProvider.java
@@ -205,7 +205,8 @@ public class BigQuerySchemaIOProvider implements SchemaIOProvider {
                   .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_APPEND);
 
           final Boolean autoSharding = config.getBoolean("autoSharding");
-          if (autoSharding != null && autoSharding) {
+          // use default value true for autoSharding if not configured for STORAGE_WRITE_API
+          if (autoSharding == null || autoSharding) {
             write = write.withAutoSharding();
           }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProvider.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProvider.java
@@ -312,7 +312,7 @@ public class BigQueryStorageWriteApiSchemaTransformProvider
                 (triggeringFrequency == null || triggeringFrequency <= 0)
                     ? DEFAULT_TRIGGERING_FREQUENCY
                     : Duration.standardSeconds(triggeringFrequency));
-        // use default value true for autoSharding if not configured
+        // use default value true for autoSharding if not configured for STORAGE_WRITE_API
         if (autoSharding == null || autoSharding) {
           write = write.withAutoSharding();
         }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProvider.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProvider.java
@@ -312,8 +312,8 @@ public class BigQueryStorageWriteApiSchemaTransformProvider
                 (triggeringFrequency == null || triggeringFrequency <= 0)
                     ? DEFAULT_TRIGGERING_FREQUENCY
                     : Duration.standardSeconds(triggeringFrequency));
-
-        if (autoSharding != null && autoSharding) {
+        // use default value true for autoSharding if not configured
+        if (autoSharding == null || autoSharding) {
           write = write.withAutoSharding();
         }
       }


### PR DESCRIPTION
When STORAGE_WRITE_API is used as the method for BigQueryIO.Write, autoSharding needs to be enabled. To avoid issues, by default autoSharding will be enabled when  STORAGE_WRITE_API is used.
