### PR TITLE
Replace deprecated codecov package with codecov uploader

### DIFF
--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -98,14 +98,17 @@ commands =
   bash {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"
 [testenv:py38-cloudcoverage]
 deps =
-  codecov
   pytest-cov==3.0.0
 passenv = GIT_* BUILD_* ghprb* CHANGE_ID BRANCH_NAME JENKINS_* CODECOV_*
 extras = test,gcp,interactive,dataframe,aws
 commands =
   -rm .coverage
   bash {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}" "--cov-report=xml --cov=. --cov-append"
-  codecov -F python
+  
+  curl -Os https://uploader.codecov.io/v0.1.0_4653/linux/codecov
+  chmod +x codecov
+  ./codecov -F python
+  rm ./codecov
 
 [testenv:py37-lint]
 # Don't set TMPDIR to avoid "AF_UNIX path too long" errors in pylint.


### PR DESCRIPTION
The original package we depended on has been removed - https://pypi.org/project/codecov/ - and https://docs.codecov.com/docs/deprecated-uploader-migration-guide#python-uploader for reference.

This has been causing the python coverage job to be permared - https://ci-beam.apache.org/job/beam_PreCommit_Python_Coverage_Commit/

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
