### PR TITLE
Add JavaDoc to BundleManager

### DIFF
--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/BundleManager.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/BundleManager.java
@@ -20,14 +20,36 @@ package org.apache.beam.runners.samza.runtime;
 import org.joda.time.Instant;
 
 public interface BundleManager<OutT> {
-  void tryStartBundle();
+  /**
+   * Accounts a new element to the bundle. Also lazy starts the bundle, if it is not started yet.
+   */
+  void countNewElement();
 
+  /**
+   * Signals a watermark event arrived. The BundleManager will decide if the watermark needs to be processed, and notify the listener if needed.
+   * @param watermark
+   * @param emitter
+   */
   void processWatermark(Instant watermark, OpEmitter<OutT> emitter);
 
+  /**
+   * Signals the BundleManager that a timer is up.
+   * @param keyedTimerData
+   * @param emitter
+   */
   void processTimer(KeyedTimerData<Void> keyedTimerData, OpEmitter<OutT> emitter);
 
+  /**
+   * Fails the current bundle, throws away the pending output, and resets the bundle to an empty state.
+   *
+   * @param t the throwable that caused the failure.
+   */
   void signalFailure(Throwable t);
 
+  /**
+   * Tries to close the bundle, and reset the bundle to an empty state.
+   * @param emitter
+   */
   void tryFinishBundle(OpEmitter<OutT> emitter);
 
   /**

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/BundleManager.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/BundleManager.java
@@ -19,6 +19,21 @@ package org.apache.beam.runners.samza.runtime;
 
 import org.joda.time.Instant;
 
+/**
+ * Bundle management for the {@link DoFnOp} that handles lifecycle of a bundle. It also serves as a
+ * proxy for the {@link DoFnOp} to process watermark and decides to 1. Hold watermark if there is at
+ * least one bundle in progress. 2. Propagates the watermark to downstream DAG, if all the previous
+ * bundles have completed.
+ *
+ * <p>A bundle is considered complete only when the outputs corresponding to each element in the
+ * bundle have been resolved and the watermark associated with the bundle(if any) is propagated
+ * downstream. The output of an element is considered resolved based on the nature of the ParDoFn 1.
+ * In case of synchronous ParDo, outputs of the element is resolved immediately after the
+ * processElement returns. 2. In case of asynchronous ParDo, outputs of the element is resolved when
+ * all the future emitted by the processElement is resolved.
+ *
+ * @param <OutT> output type of the {@link DoFnOp}
+ */
 public interface BundleManager<OutT> {
   /** Starts a new bundle if not already started, then adds an element to the existing bundle. */
   void tryStartBundle();

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/BundleManager.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/BundleManager.java
@@ -20,10 +20,8 @@ package org.apache.beam.runners.samza.runtime;
 import org.joda.time.Instant;
 
 public interface BundleManager<OutT> {
-  /**
-   * Accounts a new element to the bundle. Also lazy starts the bundle, if it is not started yet.
-   */
-  void countNewElement();
+  /** Starts a new bundle if not already started, then adds an element to the existing bundle. */
+  void tryStartBundle();
 
   /**
    * Signals a watermark event arrived. The BundleManager will decide if the watermark needs to be

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/BundleManager.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/BundleManager.java
@@ -26,7 +26,9 @@ public interface BundleManager<OutT> {
   void countNewElement();
 
   /**
-   * Signals a watermark event arrived. The BundleManager will decide if the watermark needs to be processed, and notify the listener if needed.
+   * Signals a watermark event arrived. The BundleManager will decide if the watermark needs to be
+   * processed, and notify the listener if needed.
+   *
    * @param watermark
    * @param emitter
    */
@@ -34,13 +36,15 @@ public interface BundleManager<OutT> {
 
   /**
    * Signals the BundleManager that a timer is up.
+   *
    * @param keyedTimerData
    * @param emitter
    */
   void processTimer(KeyedTimerData<Void> keyedTimerData, OpEmitter<OutT> emitter);
 
   /**
-   * Fails the current bundle, throws away the pending output, and resets the bundle to an empty state.
+   * Fails the current bundle, throws away the pending output, and resets the bundle to an empty
+   * state.
    *
    * @param t the throwable that caused the failure.
    */
@@ -48,6 +52,7 @@ public interface BundleManager<OutT> {
 
   /**
    * Tries to close the bundle, and reset the bundle to an empty state.
+   *
    * @param emitter
    */
   void tryFinishBundle(OpEmitter<OutT> emitter);

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/ClassicBundleManager.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/ClassicBundleManager.java
@@ -39,22 +39,10 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Bundle management for the {@link DoFnOp} that handles lifecycle of a bundle. It also serves as a
- * proxy for the {@link DoFnOp} to process watermark and decides to 1. Hold watermark if there is at
- * least one bundle in progress. 2. Propagates the watermark to downstream DAG, if all the previous
- * bundles have completed.
- *
- * <p>A bundle is considered complete only when the outputs corresponding to each element in the
- * bundle have been resolved and the watermark associated with the bundle(if any) is propagated
- * downstream. The output of an element is considered resolved based on the nature of the ParDoFn 1.
- * In case of synchronous ParDo, outputs of the element is resolved immediately after the
- * processElement returns. 2. In case of asynchronous ParDo, outputs of the element is resolved when
- * all the future emitted by the processElement is resolved.
- *
- * <p>This class is not thread safe and the current implementation relies on the assumption that
- * messages are dispatched to BundleManager in a single threaded mode.
- *
- * @param <OutT> output type of the {@link DoFnOp}
+ * @inheritDoc Implementation of BundleManager for non-portable mode. Keeps track of the async
+ *     function completions.
+ *     <p>This class is not thread safe and the current implementation relies on the assumption that
+ *     messages are dispatched to BundleManager in a single threaded mode.
  */
 @SuppressWarnings({
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/ClassicBundleManager.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/ClassicBundleManager.java
@@ -135,7 +135,7 @@ public class ClassicBundleManager<OutT> implements BundleManager<OutT> {
   }
 
   @Override
-  public void tryStartBundle() {
+  public void countNewElement() {
     futureCollector.prepare();
 
     if (isBundleStarted.compareAndSet(false, true)) {

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/ClassicBundleManager.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/ClassicBundleManager.java
@@ -135,7 +135,7 @@ public class ClassicBundleManager<OutT> implements BundleManager<OutT> {
   }
 
   @Override
-  public void countNewElement() {
+  public void tryStartBundle() {
     futureCollector.prepare();
 
     if (isBundleStarted.compareAndSet(false, true)) {

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/DoFnOp.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/DoFnOp.java
@@ -295,7 +295,7 @@ public class DoFnOp<InT, FnOutT, OutT> implements Op<InT, OutT, Void> {
   @Override
   public void processElement(WindowedValue<InT> inputElement, OpEmitter<OutT> emitter) {
     try {
-      bundleManager.tryStartBundle();
+      bundleManager.countNewElement();
       final Iterable<WindowedValue<InT>> rejectedValues =
           pushbackFnRunner.processElementInReadyWindows(inputElement);
       for (WindowedValue<InT> rejectedValue : rejectedValues) {

--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/DoFnOp.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/runtime/DoFnOp.java
@@ -295,7 +295,7 @@ public class DoFnOp<InT, FnOutT, OutT> implements Op<InT, OutT, Void> {
   @Override
   public void processElement(WindowedValue<InT> inputElement, OpEmitter<OutT> emitter) {
     try {
-      bundleManager.countNewElement();
+      bundleManager.tryStartBundle();
       final Iterable<WindowedValue<InT>> rejectedValues =
           pushbackFnRunner.processElementInReadyWindows(inputElement);
       for (WindowedValue<InT> rejectedValue : rejectedValues) {

--- a/runners/samza/src/test/java/org/apache/beam/runners/samza/runtime/ClassicBundleManagerTest.java
+++ b/runners/samza/src/test/java/org/apache/beam/runners/samza/runtime/ClassicBundleManagerTest.java
@@ -69,7 +69,7 @@ public final class ClassicBundleManagerTest {
   }
 
   @Test
-  public void testTryStartBundleStartsBundle() {
+  public void testAddingFirstElementStartsBundle() {
     bundleManager.countNewElement();
 
     verify(bundleProgressListener, times(1)).onBundleStarted();
@@ -82,29 +82,14 @@ public final class ClassicBundleManagerTest {
     assertTrue("tryStartBundle() did not start the bundle", bundleManager.isBundleStarted());
   }
 
-  @Test
-  public void testTryStartBundleThrowsExceptionAndSignalError() {
+  @Test(expected = IllegalArgumentException.class)
+  public void testWhenCurrentBundleDoneFutureIsNotNullThenStartBundleFails() {
     bundleManager.setCurrentBundleDoneFuture(CompletableFuture.completedFuture(null));
-    try {
-      bundleManager.countNewElement();
-    } catch (IllegalArgumentException e) {
-      bundleManager.signalFailure(e);
-    }
-
-    // verify if the signal failure only resets appropriate attributes of bundle
-    verify(mockFutureCollector, times(1)).prepare();
-    verify(mockFutureCollector, times(1)).discard();
-    assertEquals(
-        "Expected the number of element in the current bundle to 0",
-        0L,
-        bundleManager.getCurrentBundleElementCount());
-    assertEquals(
-        "Expected pending bundle count to be 0", 0L, bundleManager.getPendingBundleCount());
-    assertFalse("Error didn't reset the bundle as expected.", bundleManager.isBundleStarted());
+    bundleManager.countNewElement();
   }
 
   @Test
-  public void testWhenSignalFailureAfterBundleStartedThenResetBundle() {
+  public void testWhenSignalFailureThenResetCurrentBundle() {
     doThrow(new RuntimeException("User start bundle threw an exception"))
         .when(bundleProgressListener)
         .onBundleStarted();

--- a/runners/samza/src/test/java/org/apache/beam/runners/samza/runtime/ClassicBundleManagerTest.java
+++ b/runners/samza/src/test/java/org/apache/beam/runners/samza/runtime/ClassicBundleManagerTest.java
@@ -69,8 +69,8 @@ public final class ClassicBundleManagerTest {
   }
 
   @Test
-  public void testAddingFirstElementStartsBundle() {
-    bundleManager.countNewElement();
+  public void testWhenFirstTryStartBundleThenStartsBundle() {
+    bundleManager.tryStartBundle();
 
     verify(bundleProgressListener, times(1)).onBundleStarted();
     assertEquals(
@@ -85,7 +85,7 @@ public final class ClassicBundleManagerTest {
   @Test(expected = IllegalArgumentException.class)
   public void testWhenCurrentBundleDoneFutureIsNotNullThenStartBundleFails() {
     bundleManager.setCurrentBundleDoneFuture(CompletableFuture.completedFuture(null));
-    bundleManager.countNewElement();
+    bundleManager.tryStartBundle();
   }
 
   @Test
@@ -95,7 +95,7 @@ public final class ClassicBundleManagerTest {
         .onBundleStarted();
 
     try {
-      bundleManager.countNewElement();
+      bundleManager.tryStartBundle();
     } catch (RuntimeException e) {
       bundleManager.signalFailure(e);
     }
@@ -113,9 +113,9 @@ public final class ClassicBundleManagerTest {
   }
 
   @Test
-  public void testWhenAddMultipleElementsThenOnlyStartBundleOnce() {
-    bundleManager.countNewElement();
-    bundleManager.countNewElement();
+  public void testWhenMultipleTryStartThenOnlyStartBundleOnce() {
+    bundleManager.tryStartBundle();
+    bundleManager.tryStartBundle();
 
     // second invocation should not start the bundle
     verify(bundleProgressListener, times(1)).onBundleStarted();
@@ -144,9 +144,9 @@ public final class ClassicBundleManagerTest {
         .thenReturn(
             CompletableFuture.completedFuture(Collections.singleton(mock(WindowedValue.class))));
 
-    bundleManager.countNewElement();
-    bundleManager.countNewElement();
-    bundleManager.countNewElement();
+    bundleManager.tryStartBundle();
+    bundleManager.tryStartBundle();
+    bundleManager.tryStartBundle();
     bundleManager.tryFinishBundle(mockEmitter);
 
     verify(mockEmitter, times(1)).emitFuture(anyObject());
@@ -168,8 +168,8 @@ public final class ClassicBundleManagerTest {
             CompletableFuture.completedFuture(Collections.singleton(mock(WindowedValue.class))));
     bundleManager.setBundleWatermarkHold(BoundedWindow.TIMESTAMP_MAX_VALUE);
 
-    bundleManager.countNewElement();
-    bundleManager.countNewElement();
+    bundleManager.tryStartBundle();
+    bundleManager.tryStartBundle();
     bundleManager.tryFinishBundle(mockEmitter);
 
     verify(mockEmitter, times(1)).emitFuture(anyObject());
@@ -193,7 +193,7 @@ public final class ClassicBundleManagerTest {
         .thenReturn(
             CompletableFuture.completedFuture(Collections.singleton(mock(WindowedValue.class))));
 
-    bundleManager.countNewElement();
+    bundleManager.tryStartBundle();
     bundleManager.tryFinishBundle(mockEmitter);
 
     verify(mockFutureCollector, times(1)).finish();
@@ -282,8 +282,8 @@ public final class ClassicBundleManagerTest {
         .thenReturn(
             CompletableFuture.completedFuture(Collections.singleton(mock(WindowedValue.class))));
 
-    bundleManager.countNewElement();
-    bundleManager.countNewElement();
+    bundleManager.tryStartBundle();
+    bundleManager.tryStartBundle();
 
     // should force close bundle
     bundleManager.processWatermark(watermark, mockEmitter);
@@ -310,7 +310,7 @@ public final class ClassicBundleManagerTest {
     when(mockTimerData.getTimerId()).thenReturn(BUNDLE_CHECK_TIMER_ID);
     when(mockTimer.getTimerData()).thenReturn(mockTimerData);
 
-    bundleManager.countNewElement();
+    bundleManager.tryStartBundle();
     bundleManager.processTimer(mockTimer, mockEmitter);
 
     verify(mockEmitter, times(1)).emitFuture(anyObject());
@@ -336,7 +336,7 @@ public final class ClassicBundleManagerTest {
     when(mockFutureCollector.finish())
         .thenReturn(CompletableFuture.completedFuture(Collections.emptyList()));
 
-    bundleManager.countNewElement();
+    bundleManager.tryStartBundle();
     bundleManager.processTimer(mockTimer, mockEmitter);
 
     verify(mockFutureCollector, times(1)).finish();
@@ -360,7 +360,7 @@ public final class ClassicBundleManagerTest {
     when(mockTimerData.getTimerId()).thenReturn("NotBundleTimer");
     when(mockTimer.getTimerData()).thenReturn(mockTimerData);
 
-    bundleManager.countNewElement();
+    bundleManager.tryStartBundle();
     bundleManager.processTimer(mockTimer, mockEmitter);
 
     verify(mockFutureCollector, times(0)).finish();
@@ -377,7 +377,7 @@ public final class ClassicBundleManagerTest {
 
   @Test
   public void testSignalFailureResetsTheBundleAndCollector() {
-    bundleManager.countNewElement();
+    bundleManager.tryStartBundle();
 
     bundleManager.signalFailure(mock(Throwable.class));
     verify(mockFutureCollector, times(1)).prepare();
@@ -441,9 +441,9 @@ public final class ClassicBundleManagerTest {
       Instant watermark) {
     // Starts the bundle and reach the max bundle size so that tryFinishBundle() seals the current
     // bundle
-    bundleManager.countNewElement();
-    bundleManager.countNewElement();
-    bundleManager.countNewElement();
+    bundleManager.tryStartBundle();
+    bundleManager.tryStartBundle();
+    bundleManager.tryStartBundle();
 
     bundleManager.processWatermark(watermark, mockEmitter);
     verify(bundleProgressListener, times(0)).onWatermark(watermark, mockEmitter);


### PR DESCRIPTION
Add JavaDoc to BundleManager.
1. Add JavaDoc
2. Rename some tests

------------------------
This was a repurposed PR.

Original description: name tryStartBundle to countNewElement.
The current implementation tries to start the bundle, then adds an element to the new bundle. countNewElement is a better naming, because

1. A new element is always added, but a bundle is not always started.
3. The only usage of this method is in DoFnOp.processElement, it reads better to context.

We can also add a startBundle interface in the future, but there are currently no use cases.

The new name changes the subject to adding an element as a theme, and starting the bundle as a lazy side effect. It aligns more with what the method is actually doing.

One symmetry we are breaking is in DoFnOp.processElement, we had a `tryStartBundle` paired with a `tryFinishBundle`. Instead now we have `countNewElement` paired with `tryFinishBundle`. I think the old reading favors 1 element per bundle, while the new reading favors multiple elements in a bundle, and we check if the bundle is full/should be finished after each add.

Other changes:
1. Update unit test names.
2. Remove duplicate tests.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
