### PR TITLE
BigTableReadSchemaTransform

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigTableReadSchemaTransformProvider.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigTableReadSchemaTransformProvider.java
@@ -1,0 +1,226 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.bigtable;
+
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+
+import com.google.auto.service.AutoService;
+import com.google.auto.value.AutoValue;
+import com.google.bigtable.v2.Cell;
+import com.google.bigtable.v2.Column;
+import com.google.bigtable.v2.Family;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.sdk.annotations.Experimental;
+import org.apache.beam.sdk.annotations.Experimental.Kind;
+import org.apache.beam.sdk.io.gcp.bigtable.BigTableReadSchemaTransformProvider.BigTableReadSchemaTransformConfiguration;
+import org.apache.beam.sdk.schemas.AutoValueSchema;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
+import org.apache.beam.sdk.schemas.transforms.SchemaTransform;
+import org.apache.beam.sdk.schemas.transforms.SchemaTransformProvider;
+import org.apache.beam.sdk.schemas.transforms.TypedSchemaTransformProvider;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.SimpleFunction;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionRowTuple;
+import org.apache.beam.sdk.values.Row;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Strings;
+
+/**
+ * An implementation of {@link TypedSchemaTransformProvider} for BigTable Read jobs configured via
+ * {@link BigTableReadSchemaTransformConfiguration}.
+ *
+ * <p><b>Internal only:</b> This class is actively being worked on, and it will likely change. We
+ * provide no backwards compatibility guarantees, and it should not be implemented outside the Beam
+ * repository.
+ */
+@Experimental(Kind.SCHEMAS)
+@AutoService(SchemaTransformProvider.class)
+public class BigTableReadSchemaTransformProvider
+    extends TypedSchemaTransformProvider<BigTableReadSchemaTransformConfiguration> {
+
+  private static final String OUTPUT_TAG = "output";
+
+  public static final Schema CELL_SCHEMA =
+      Schema.builder()
+          .addStringField("value")
+          .addInt64Field("timestamp")
+          .addArrayField("labels", Schema.FieldType.array(Schema.FieldType.STRING))
+          .build();
+
+  public static final Schema ROW_SCHEMA =
+      Schema.builder()
+          .addStringField("key")
+          .addMapField(
+              "families",
+              Schema.FieldType.STRING,
+              Schema.FieldType.map(
+                  Schema.FieldType.STRING,
+                  Schema.FieldType.array(Schema.FieldType.row(CELL_SCHEMA))))
+          .build();
+
+  @Override
+  protected Class<BigTableReadSchemaTransformConfiguration> configurationClass() {
+    return BigTableReadSchemaTransformConfiguration.class;
+  }
+
+  @Override
+  protected SchemaTransform from(BigTableReadSchemaTransformConfiguration configuration) {
+    return new BigTableReadSchemaTransform(configuration);
+  }
+
+  @Override
+  public String identifier() {
+    return "beam:schematransform:org.apache.beam:bigtable_read:v1";
+  }
+
+  @Override
+  public List<String> inputCollectionNames() {
+    return Collections.emptyList();
+  }
+
+  @Override
+  public List<String> outputCollectionNames() {
+    return Collections.singletonList(OUTPUT_TAG);
+  }
+
+  /** Configuration for reading from BigTable. */
+  @DefaultSchema(AutoValueSchema.class)
+  @AutoValue
+  public abstract static class BigTableReadSchemaTransformConfiguration {
+
+    public void validate() {
+      String invalidConfigMessage = "Invalid BigTable Read configuration: ";
+      checkArgument(
+          !Strings.isNullOrEmpty(this.getTable()), invalidConfigMessage + "Missing table");
+      checkArgument(
+          !Strings.isNullOrEmpty(this.getInstance()), invalidConfigMessage + "Missing instance");
+      checkArgument(
+          !Strings.isNullOrEmpty(this.getProject()), invalidConfigMessage + "Missing project");
+    }
+
+    /** Instantiates a {@link BigTableReadSchemaTransformConfiguration.Builder} instance. */
+    public static Builder builder() {
+      return new AutoValue_BigTableReadSchemaTransformProvider_BigTableReadSchemaTransformConfiguration
+          .Builder();
+    }
+
+    public abstract String getTable();
+
+    public abstract String getInstance();
+
+    public abstract String getProject();
+
+    /** Builder for the {@link BigTableReadSchemaTransformConfiguration}. */
+    @AutoValue.Builder
+    public abstract static class Builder {
+      public abstract Builder setTable(String table);
+
+      public abstract Builder setInstance(String instance);
+
+      public abstract Builder setProject(String project);
+
+      /** Builds a {@link BigTableReadSchemaTransformConfiguration} instance. */
+      public abstract BigTableReadSchemaTransformConfiguration build();
+    }
+  }
+
+  /**
+   * A {@link SchemaTransform} for Bigtable reads, configured with {@link
+   * BigTableReadSchemaTransformConfiguration} and instantiated by {@link
+   * BigTableReadSchemaTransformProvider}.
+   */
+  private static class BigTableReadSchemaTransform
+      extends PTransform<PCollectionRowTuple, PCollectionRowTuple> implements SchemaTransform {
+    private final BigTableReadSchemaTransformConfiguration configuration;
+
+    BigTableReadSchemaTransform(BigTableReadSchemaTransformConfiguration configuration) {
+      // Validate configuration parameters before PTransform expansion
+      configuration.validate();
+      this.configuration = configuration;
+    }
+
+    @Override
+    public PCollectionRowTuple expand(PCollectionRowTuple input) {
+      checkArgument(
+          input.getAll().isEmpty(),
+          String.format(
+              "Input to %s is expected to be empty, but is not.", getClass().getSimpleName()));
+
+      PCollection<com.google.bigtable.v2.Row> bigtableRows =
+          input
+              .getPipeline()
+              .apply(
+                  BigtableIO.read()
+                      .withTableId(configuration.getTable())
+                      .withInstanceId(configuration.getInstance())
+                      .withProjectId(configuration.getProject()));
+
+      PCollection<Row> beamRows =
+          bigtableRows.apply(MapElements.via(new BigTableRowToBeamRow())).setRowSchema(ROW_SCHEMA);
+
+      return PCollectionRowTuple.of(OUTPUT_TAG, beamRows);
+    }
+
+    @Override
+    public PTransform<PCollectionRowTuple, PCollectionRowTuple> buildTransform() {
+      return this;
+    }
+  }
+
+  public static class BigTableRowToBeamRow extends SimpleFunction<com.google.bigtable.v2.Row, Row> {
+    @Override
+    public Row apply(com.google.bigtable.v2.Row bigtableRow) {
+      // The collection of families is represented as a Map of column families.
+      // Each column family is represented as a Map of columns.
+      // Each column is represented as a List of cells
+      // Each cell is represented as a Beam Row consisting of value, timestamp, and labels
+      Map<String, Map<String, List<Row>>> families = new HashMap<>();
+
+      for (Family fam : bigtableRow.getFamiliesList()) {
+        // Map of column qualifier to list of cells
+        Map<String, List<Row>> columns = new HashMap<>();
+        for (Column col : fam.getColumnsList()) {
+          List<Row> cells = new ArrayList<>();
+          for (Cell cell : col.getCellsList()) {
+            Row cellRow =
+                Row.withSchema(CELL_SCHEMA)
+                    .withFieldValue("value", cell.getValue().toStringUtf8())
+                    .withFieldValue("timestamp", cell.getTimestampMicros())
+                    .withFieldValue("labels", cell.getLabelsList())
+                    .build();
+            cells.add(cellRow);
+          }
+          columns.put(col.getQualifier().toStringUtf8(), cells);
+        }
+        families.put(fam.getName(), columns);
+      }
+      Row beamRow =
+          Row.withSchema(ROW_SCHEMA)
+              .withFieldValue("key", bigtableRow.getKey().toStringUtf8())
+              .withFieldValue("families", families)
+              .build();
+      return beamRow;
+    }
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigTableReadSchemaTransformProviderTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigTableReadSchemaTransformProviderTest.java
@@ -1,5 +1,225 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.beam.sdk.io.gcp.bigtable;
 
-public class BigTableReadSchemaTransformProviderTest {
+import static org.apache.beam.sdk.io.gcp.bigtable.BigTableReadSchemaTransformProvider.CELL_SCHEMA;
+import static org.apache.beam.sdk.io.gcp.bigtable.BigTableReadSchemaTransformProvider.ROW_SCHEMA;
+import static org.junit.Assert.assertThrows;
 
+import com.google.api.gax.rpc.NotFoundException;
+import com.google.cloud.bigtable.admin.v2.BigtableTableAdminClient;
+import com.google.cloud.bigtable.admin.v2.BigtableTableAdminSettings;
+import com.google.cloud.bigtable.admin.v2.models.CreateTableRequest;
+import com.google.cloud.bigtable.data.v2.BigtableDataClient;
+import com.google.cloud.bigtable.data.v2.BigtableDataSettings;
+import com.google.cloud.bigtable.data.v2.models.RowMutation;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
+import org.apache.beam.sdk.io.gcp.bigtable.BigTableReadSchemaTransformProvider.BigTableReadSchemaTransformConfiguration;
+import org.apache.beam.sdk.schemas.transforms.SchemaTransform;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionRowTuple;
+import org.apache.beam.sdk.values.Row;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class BigTableReadSchemaTransformProviderTest {
+  @Rule public final transient TestPipeline p = TestPipeline.create();
+
+  private static final String COLUMN_FAMILY_NAME_1 = "test_cf_1";
+  private static final String COLUMN_FAMILY_NAME_2 = "test_cf_2";
+  private BigtableTableAdminClient adminClient;
+  private BigtableDataClient dataClient;
+  private String tableId;
+  private String projectId;
+  private String instanceId;
+
+  @Test
+  public void testInvalidConfigs() {
+    // All properties are required (project, instance, and table)
+    List<BigTableReadSchemaTransformConfiguration> invalidConfigs =
+        Arrays.asList(
+            BigTableReadSchemaTransformConfiguration.builder()
+                .setProject("project")
+                .setInstance("instance")
+                .build(),
+            BigTableReadSchemaTransformConfiguration.builder()
+                .setInstance("instance")
+                .setTable("table")
+                .build(),
+            BigTableReadSchemaTransformConfiguration.builder()
+                .setProject("project")
+                .setTable("table")
+                .build());
+
+    for (BigTableReadSchemaTransformConfiguration config : invalidConfigs) {
+      assertThrows(
+          IllegalArgumentException.class,
+          () -> {
+            config.validate();
+          });
+    }
+  }
+
+  @Before
+  public void setup() throws Exception {
+    BigtableTestOptions options =
+        TestPipeline.testingPipelineOptions().as(BigtableTestOptions.class);
+    projectId = options.as(GcpOptions.class).getProject();
+    instanceId = options.getInstanceId();
+
+    BigtableDataSettings settings =
+        BigtableDataSettings.newBuilder().setProjectId(projectId).setInstanceId(instanceId).build();
+    // Creates a bigtable data client.
+    dataClient = BigtableDataClient.create(settings);
+
+    BigtableTableAdminSettings adminSettings =
+        BigtableTableAdminSettings.newBuilder()
+            .setProjectId(projectId)
+            .setInstanceId(instanceId)
+            .build();
+    adminClient = BigtableTableAdminClient.create(adminSettings);
+  }
+
+  @After
+  public void tearDown() {
+    try {
+      adminClient.deleteTable(tableId);
+      System.out.printf("Table %s deleted successfully%n", tableId);
+    } catch (NotFoundException e) {
+      System.err.println("Failed to delete a non-existent table: " + e.getMessage());
+    }
+    dataClient.close();
+    adminClient.close();
+  }
+
+  public List<Row> writeToTable(int numRows) throws Exception {
+    // Checks if table exists, creates table if does not exist.
+    if (!adminClient.exists(tableId)) {
+      CreateTableRequest createTableRequest =
+          CreateTableRequest.of(tableId)
+              .addFamily(COLUMN_FAMILY_NAME_1)
+              .addFamily(COLUMN_FAMILY_NAME_2);
+      adminClient.createTable(createTableRequest);
+    }
+
+    List<Row> expectedRows = new ArrayList<>();
+
+    try {
+      for (int i = 1; i <= numRows; i++) {
+        String key = "key" + i;
+        String valueA = "value a" + i;
+        String valueB = "value b" + i;
+        String valueC = "value c" + i;
+        String valueD = "value d" + i;
+        long timestamp = 1000L * i;
+
+        RowMutation rowMutation =
+            RowMutation.create(tableId, key)
+                .setCell(COLUMN_FAMILY_NAME_1, "a", timestamp, valueA)
+                .setCell(COLUMN_FAMILY_NAME_1, "b", timestamp, valueB)
+                .setCell(COLUMN_FAMILY_NAME_2, "c", timestamp, valueC)
+                .setCell(COLUMN_FAMILY_NAME_2, "d", timestamp, valueD);
+        dataClient.mutateRow(rowMutation);
+
+        // Set up expected Beam Row
+        Map<String, List<Row>> columns1 = new HashMap<>();
+        columns1.put(
+            "a",
+            Arrays.asList(
+                Row.withSchema(CELL_SCHEMA)
+                    .withFieldValue("value", valueA)
+                    .withFieldValue("timestamp", timestamp)
+                    .withFieldValue("labels", Collections.emptyList())
+                    .build()));
+        columns1.put(
+            "b",
+            Arrays.asList(
+                Row.withSchema(CELL_SCHEMA)
+                    .withFieldValue("value", valueB)
+                    .withFieldValue("timestamp", timestamp)
+                    .withFieldValue("labels", Collections.emptyList())
+                    .build()));
+
+        Map<String, List<Row>> columns2 = new HashMap<>();
+        columns2.put(
+            "c",
+            Arrays.asList(
+                Row.withSchema(CELL_SCHEMA)
+                    .withFieldValue("value", valueC)
+                    .withFieldValue("timestamp", timestamp)
+                    .withFieldValue("labels", Collections.emptyList())
+                    .build()));
+        columns2.put(
+            "d",
+            Arrays.asList(
+                Row.withSchema(CELL_SCHEMA)
+                    .withFieldValue("value", valueD)
+                    .withFieldValue("timestamp", timestamp)
+                    .withFieldValue("labels", Collections.emptyList())
+                    .build()));
+
+        Map<String, Map<String, List<Row>>> families = new HashMap<>();
+        families.put(COLUMN_FAMILY_NAME_1, columns1);
+        families.put(COLUMN_FAMILY_NAME_2, columns2);
+
+        Row expectedRow =
+            Row.withSchema(ROW_SCHEMA)
+                .withFieldValue("key", key)
+                .withFieldValue("families", families)
+                .build();
+
+        expectedRows.add(expectedRow);
+      }
+    } catch (NotFoundException e) {
+      throw new RuntimeException("Failed to write to table", e);
+    }
+    return expectedRows;
+  }
+
+  @Test
+  public void testRead() throws Exception {
+    tableId = "BigtableReadSchemaTransformIT";
+    List<Row> expectedRows = writeToTable(10);
+
+    BigTableReadSchemaTransformConfiguration config =
+        BigTableReadSchemaTransformConfiguration.builder()
+            .setTable(tableId)
+            .setInstance(instanceId)
+            .setProject(projectId)
+            .build();
+    SchemaTransform transform = new BigTableReadSchemaTransformProvider().from(config);
+
+    PCollection<Row> rows =
+        PCollectionRowTuple.empty(p).apply(transform.buildTransform()).get("output");
+    PAssert.that(rows).containsInAnyOrder(expectedRows);
+    p.run().waitUntilFinish();
+  }
 }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigTableReadSchemaTransformProviderTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigTableReadSchemaTransformProviderTest.java
@@ -1,0 +1,5 @@
+package org.apache.beam.sdk.io.gcp.bigtable;
+
+public class BigTableReadSchemaTransformProviderTest {
+
+}


### PR DESCRIPTION
SchemaTransform for BigTable reads. Returns Beam Rows with the following schema:

Row
- Field `key`
- Field `families`: HashMap
  - HashMap `<column family name>`: Column family name (key) to HashMap (value)
    - HashMap `<column qualifier>`: Column qualifier name (key) to List<Row> (value)
      - List<Row>: list of row cells
        - Row: represents a single cell. Has fields `value` (String), `timestamp` (long), `labels` (array)

This SchemaTransform's Python wrapper will need to keep this schema in mind. Will follow up this PR with the wrapper.