### PR TITLE
Unpin azurite version.

### DIFF
--- a/sdks/python/apache_beam/io/azure/integration_test/docker-compose.yml
+++ b/sdks/python/apache_beam/io/azure/integration_test/docker-compose.yml
@@ -19,7 +19,7 @@ version: '3'
 
 services:
   azurite:
-    image: mcr.microsoft.com/azure-storage/azurite:3.22.0
+    image: mcr.microsoft.com/azure-storage/azurite
     command:
       - "azurite-blob"
       - "--blobHost"


### PR DESCRIPTION
Unpin the version of fake azure used in our Azure IO ITs. Current pin is not compatible with latest clients that we install at runtime.

Verified the fix by running: `gradlew :sdks:python:test-suites:direct:py37:azureIntegrationTest` locally .

Fixes https://github.com/apache/beam/issues/26272