### PR TITLE
[Website] change styles to make calendar section fit the page #26347

### DIFF
--- a/website/www/site/assets/scss/_calendar.scss
+++ b/website/www/site/assets/scss/_calendar.scss
@@ -88,7 +88,7 @@
         display: flex;
         flex-direction: column;
         justify-content: space-between;
-        @media (max-width: $tablet) {
+        @media (max-width: $ak-breakpoint-xl) {
           width: 327px;
           height: 216px;
           padding: 24px 19.2px 24.7px 20px;
@@ -151,6 +151,7 @@
         margin-top: 30px;
         margin-bottom: 70px;
         .calendar-desktop {
+          overflow-x: auto;
           @media (max-width: $tablet) {
             display: none;
           }
@@ -241,7 +242,7 @@
   @extend .component-tag;
 }
 
-@media (max-width: $tablet) {
+@media (max-width: $ak-breakpoint-xl) {
   .calendar {
     padding: $pad-md $pad-s;
 
@@ -252,7 +253,6 @@
 
       .calendar-card-big {
         max-width: 327px;
-        height: 356px;
         padding: 32px 20px;
         @media (max-width: $ak-breakpoint-xs) {
           max-width: 260px;


### PR DESCRIPTION
Resolves #26347
- change media query width from `tablet` to `ak-breakpoint-xl`, so calendar section fits the page and doesn't stretch it
- add overflow to `calendar-desktop` so content doesn't overflow container
- delete height from `calendar-card-big` on `ak-breakpoint-xl`, so content not to be restricted by hardcoded value
------------------------
before:
![before_calendar](https://user-images.githubusercontent.com/61748758/233064243-b64cd301-cd8d-4894-919c-b12b108f8c2b.gif)
after:
![after_calendar](https://user-images.githubusercontent.com/61748758/233064267-76fe0a4a-c2cd-4409-a1b6-a85cd51fa093.gif)
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
