### PR TITLE
[#26373] Fix some dataraces in the Go SDK

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/datasource_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasource_test.go
@@ -306,7 +306,7 @@ func TestDataSource_Split(t *testing.T) {
 					t.Fatalf("error in root[%d].Up: %v", i, err)
 				}
 			}
-			p.status = Active
+			p.setStatus(Active)
 
 			runOnRoots(ctx, t, p, "StartBundle", func(root Root, ctx context.Context) error { return root.StartBundle(ctx, "1", dc) })
 
@@ -444,7 +444,7 @@ func TestDataSource_Split(t *testing.T) {
 				t.Fatalf("error in root[%d].Up: %v", i, err)
 			}
 		}
-		p.status = Active
+		p.setStatus(Active)
 
 		runOnRoots(ctx, t, p, "StartBundle", func(root Root, ctx context.Context) error { return root.StartBundle(ctx, "1", dc) })
 
@@ -588,7 +588,7 @@ func TestDataSource_Split(t *testing.T) {
 				t.Fatalf("error in root[%d].Up: %v", i, err)
 			}
 		}
-		p.status = Active
+		p.setStatus(Active)
 		if sr, err := p.Split(ctx, SplitPoints{Splits: []int64{0, 3}, Frac: -1}); err != nil || !sr.Unsuccessful {
 			t.Fatalf("p.Split(active, not started) = %v,%v want unsuccessful split & nil err", sr, err)
 		}

--- a/sdks/go/pkg/beam/core/runtime/exec/plan.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/plan.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"fmt"
 	"strings"
+	"sync/atomic"
 	"time"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/internal/errors"
@@ -38,7 +39,7 @@ type Plan struct {
 	bf          *bundleFinalizer
 	checkpoints []*Checkpoint
 
-	status Status
+	status Status // Uses atomic getter and setter to avoid dataraces on Splits.
 
 	// TODO: there can be more than 1 DataSource in a bundle.
 	source *DataSource
@@ -86,6 +87,14 @@ func NewPlan(id string, units []Unit) (*Plan, error) {
 	}, nil
 }
 
+func (p *Plan) getStatus() Status {
+	return Status(atomic.LoadInt32((*int32)(&p.status)))
+}
+
+func (p *Plan) setStatus(s Status) {
+	atomic.StoreInt32((*int32)(&p.status), int32(s))
+}
+
 // ID returns the plan identifier.
 func (p *Plan) ID() string {
 	return p.id
@@ -100,29 +109,29 @@ func (p *Plan) SourcePTransformID() string {
 // are brought up on the first execution. If a bundle fails, the plan cannot
 // be reused for further bundles. Does not panic. Blocking.
 func (p *Plan) Execute(ctx context.Context, id string, manager DataContext) error {
-	if p.status == Initializing {
+	if p.getStatus() == Initializing {
 		for _, u := range p.units {
 			if err := callNoPanic(ctx, u.Up); err != nil {
-				p.status = Broken
+				p.setStatus(Broken)
 				return errors.Wrapf(err, "while executing Up for %v", p)
 			}
 		}
-		p.status = Up
+		p.setStatus(Up)
 	}
 	if p.source != nil {
 		p.source.InitSplittable()
 	}
 
-	if p.status != Up {
-		return errors.Errorf("invalid status for plan %v: %v", p.id, p.status)
+	if s := p.getStatus(); s != Up {
+		return errors.Errorf("invalid status for plan %v: %v", p.id, s)
 	}
 
 	// Process bundle. If there are any kinds of failures, we bail and mark the plan broken.
 
-	p.status = Active
+	p.setStatus(Active)
 	for _, root := range p.roots {
 		if err := callNoPanic(ctx, func(ctx context.Context) error { return root.StartBundle(ctx, id, manager) }); err != nil {
-			p.status = Broken
+			p.setStatus(Broken)
 			return errors.Wrapf(err, "while executing StartBundle for %v", p)
 		}
 	}
@@ -132,25 +141,24 @@ func (p *Plan) Execute(ctx context.Context, id string, manager DataContext) erro
 			p.checkpoints = cps
 			return err
 		}); err != nil {
-			p.status = Broken
+			p.setStatus(Broken)
 			return errors.Wrapf(err, "while executing Process for %v", p)
 		}
 	}
 	for _, root := range p.roots {
 		if err := callNoPanic(ctx, root.FinishBundle); err != nil {
-			p.status = Broken
+			p.setStatus(Broken)
 			return errors.Wrapf(err, "while executing FinishBundle for %v", p)
 		}
 	}
-
-	p.status = Up
+	p.setStatus(Up)
 	return nil
 }
 
 // Finalize runs any callbacks registered by the bundleFinalizer. Should be run on bundle finalization.
 func (p *Plan) Finalize() error {
-	if p.status != Up {
-		return errors.Errorf("invalid status for plan %v: %v", p.id, p.status)
+	if s := p.getStatus(); s != Up {
+		return errors.Errorf("invalid status for plan %v: %v", p.id, s)
 	}
 	failedIndices := []int{}
 	for idx, bfc := range p.bf.callbacks {
@@ -189,10 +197,11 @@ func (p *Plan) GetExpirationTime() time.Time {
 
 // Down takes the plan and associated units down. Does not panic.
 func (p *Plan) Down(ctx context.Context) error {
-	if p.status == Down {
+	// Technically racy, but only one thread calls this method on the plan.
+	if p.getStatus() == Down {
 		return nil // ok: already down
 	}
-	p.status = Down
+	p.setStatus(Down)
 
 	var errs []error
 	for _, u := range p.units {
@@ -277,7 +286,8 @@ type SplitResult struct {
 // Returns an error when unable to split.
 func (p *Plan) Split(ctx context.Context, s SplitPoints) (SplitResult, error) {
 	// Can't split inactive plans.
-	if p.status != Active {
+	// Split occurs asynchronously, so the state check here must be atomic.
+	if p.getStatus() != Active {
 		return SplitResult{Unsuccessful: true}, nil
 	}
 	// TODO: When bundles with multiple sources, are supported, perform splits

--- a/sdks/go/pkg/beam/core/runtime/exec/plan_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/plan_test.go
@@ -38,7 +38,7 @@ func TestPlan_Checkpoint(t *testing.T) {
 func TestPlan_BundleFinalizers(t *testing.T) {
 	newPlan := func() Plan {
 		var p Plan
-		p.status = Up
+		p.setStatus(Up)
 		return p
 	}
 	t.Run("NoCallbacks", func(t *testing.T) {

--- a/sdks/go/pkg/beam/core/runtime/exec/status.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/status.go
@@ -18,7 +18,7 @@ package exec
 import "fmt"
 
 // Status is the status of a unit or plan.
-type Status int
+type Status int32
 
 const (
 	Initializing Status = iota

--- a/sdks/go/pkg/beam/core/runtime/graphx/schema/logicaltypes.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/schema/logicaltypes.go
@@ -18,6 +18,7 @@ package schema
 import (
 	"fmt"
 	"reflect"
+	"sync"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/util/reflectx"
 	pipepb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/pipeline_v1"
@@ -51,6 +52,8 @@ type LogicalTypeProvider = func(reflect.Type) (reflect.Type, error)
 
 // Registry retains mappings from go types to Schemas and LogicalTypes.
 type Registry struct {
+	rwmu            sync.RWMutex
+	
 	typeToSchema    map[reflect.Type]*pipepb.Schema
 	idToType        map[string]reflect.Type
 	syntheticToUser map[reflect.Type]reflect.Type

--- a/sdks/go/pkg/beam/core/runtime/graphx/schema/logicaltypes.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/schema/logicaltypes.go
@@ -52,8 +52,8 @@ type LogicalTypeProvider = func(reflect.Type) (reflect.Type, error)
 
 // Registry retains mappings from go types to Schemas and LogicalTypes.
 type Registry struct {
-	rwmu            sync.RWMutex
-	
+	rwmu sync.RWMutex
+
 	typeToSchema    map[reflect.Type]*pipepb.Schema
 	idToType        map[string]reflect.Type
 	syntheticToUser map[reflect.Type]reflect.Type

--- a/sdks/go/pkg/beam/core/runtime/harness/statemgr_test.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/statemgr_test.go
@@ -322,6 +322,7 @@ func TestStateKeyReader(t *testing.T) {
 		},
 	}
 	for _, test := range tests {
+		test := test // avoid issues on parallel execution.
 		t.Run(test.name, func(t *testing.T) {
 			ctx, cancelFn := context.WithCancel(context.Background())
 			ch := &StateChannel{

--- a/sdks/go/pkg/beam/core/util/hooks/hooks_test.go
+++ b/sdks/go/pkg/beam/core/util/hooks/hooks_test.go
@@ -91,9 +91,6 @@ func TestConcurrentWrites(t *testing.T) {
 	}
 	r.RegisterHook("google_logging", hf)
 
-	var actual, expected error
-	expected = nil
-
 	ch := make(chan struct{})
 	wg := sync.WaitGroup{}
 
@@ -107,9 +104,8 @@ func TestConcurrentWrites(t *testing.T) {
 					// When the channel is closed, exit.
 					return
 				default:
-					actual = r.EnableHook("google_logging")
-					if actual != expected {
-						t.Errorf("Got %s, wanted %s", actual, expected)
+					if got, want := r.EnableHook("google_logging"), error(nil); got != want {
+						t.Errorf("Got %s, wanted %s", got, want)
 					}
 				}
 			}


### PR DESCRIPTION
Internal Google scans found some races when running tests in parallel, and some minor races during execution.

* Fixes race in hooks test.
* Fixes race in statemgr test.
* Fixes race against status on exec/plan during splits.
* Fixes race in schema coder reconciliation when constructing bundles. (RW lock)

Some of these could have been caught by running the tests in race detector mode, but the latter two require a multiprocessing runner that splits, and that won't be meaningfully available until the Prism runner is default.

Fixes #26373.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
