### PR TITLE
[AWS2] Bump KCL version and exclude various transitive dependencies to prevent conflicts

### DIFF
--- a/sdks/java/io/amazon-web-services2/build.gradle
+++ b/sdks/java/io/amazon-web-services2/build.gradle
@@ -52,7 +52,16 @@ dependencies {
   implementation library.java.aws_java_sdk2_http_client_spi, excludeNetty
   implementation library.java.aws_java_sdk2_apache_client, excludeNetty
   implementation library.java.aws_java_sdk2_netty_client, excludeNetty
-  implementation "software.amazon.kinesis:amazon-kinesis-client:2.3.4", excludeNetty
+  implementation("software.amazon.kinesis:amazon-kinesis-client:2.4.8") {
+    // Note: The KCL client isn't used. However, unfortunately, some model classes of KCL leak into the
+    // KinesisIO API (KinesisClientRecord, InitialPositionInStream). Additionally, KinesisIO
+    // internally uses KCL utils to generate aggregated messages and de-aggregate them.
+
+    // Exclude unnecessary runtime dependencies of the client as these cause conflicts.
+    exclude group: "software.amazon.glue", module: "*"
+    exclude group: "software.amazon.awssdk", module: "*"
+    exclude group: "io.reactivex.rxjava3", module: "rxjava"
+  }
   implementation library.java.netty_all // force version of netty used by Beam
   implementation library.java.netty_transport
   permitUnusedDeclared library.java.netty_all


### PR DESCRIPTION
The KCL client isn't used by KinesisIO. However, unfortunately, some model classes of KCL leak into the API (KinesisClientRecord, InitialPositionInStream).  Additionally, KinesisIO internally uses KCL utils to generate aggregated messages and de-aggregate them.

The `glue` dependency brings in an additional http client implementation for the SDK, causing the SDK to reject the runtime configuration.

This bumps the KCL version and removes all unused transitive dependencies that cause trouble. These would only be required if running the KCL client itself.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
