### PR TITLE
populate jobs with gradle scans access

### DIFF
--- a/.test-infra/jenkins/CommonJobProperties.groovy
+++ b/.test-infra/jenkins/CommonJobProperties.groovy
@@ -108,6 +108,7 @@ class CommonJobProperties {
       credentialsBinding {
         string("CODECOV_TOKEN", "beam-codecov-token")
         string("COVERALLS_REPO_TOKEN", "beam-coveralls-token")
+        string("GRADLE_ENTERPRISE_ACCESS_KEY", "GE_ACCESS_TOKEN")
       }
       timestamps()
       colorizeOutput()


### PR DESCRIPTION
Populate Beam Jenkins with Gradle access key to push scans to ge.apache.org


