### PR TITLE
Pass provisioned options via struct.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/harness/harness.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/harness.go
@@ -45,25 +45,32 @@ import (
 // URNMonitoringInfoShortID is a URN indicating support for short monitoring info IDs.
 const URNMonitoringInfoShortID = "beam:protocol:monitoring_info_short_ids:v1"
 
-// TODO(herohde) 2/8/2017: for now, assume we stage a full binary (not a plugin).
+// Options for harness.Main that affect execution of the harness, such as runner capabilities.
+type Options struct {
+	RunnerCapabilities []string // URNs for what runners are able to understand over the FnAPI.
+	StatusEndpoint     string   // Endpoint for worker status reporting.
+}
 
-// Main is the main entrypoint for the Go harness. It runs at "runtime" -- not
+// MainWithOptions is the main entrypoint for the Go harness. It runs at "runtime" -- not
 // "pipeline-construction time" -- on each worker. It is a FnAPI client and
 // ultimately responsible for correctly executing user code.
+//
+// Deprecated: Prefer MainWithOptions instead.
 func Main(ctx context.Context, loggingEndpoint, controlEndpoint string) error {
+	return MainWithOptions(ctx, loggingEndpoint, controlEndpoint, Options{})
+}
+
+// MainWithOptions is the main entrypoint for the Go harness. It runs at "runtime" -- not
+// "pipeline-construction time" -- on each worker. It is a FnAPI client and
+// ultimately responsible for correctly executing user code.
+//
+// Options are optional configurations for interfacing with the runner or similar.
+func MainWithOptions(ctx context.Context, loggingEndpoint, controlEndpoint string, opts Options) error {
 	hooks.DeserializeHooksFromOptions(ctx)
 
-	// Extract environment variables. These are optional runner supported capabilities.
-	// Expected env variables:
-	// RUNNER_CAPABILITIES : list of runner supported capability urn.
-	// STATUS_ENDPOINT : Endpoint to connect to status server used for worker status reporting.
-	statusEndpoint := os.Getenv("STATUS_ENDPOINT")
-	runnerCapabilities := strings.Split(os.Getenv("RUNNER_CAPABILITIES"), " ")
 	rcMap := make(map[string]bool)
-	if len(runnerCapabilities) > 0 {
-		for _, capability := range runnerCapabilities {
-			rcMap[capability] = true
-		}
+	for _, capability := range opts.RunnerCapabilities {
+		rcMap[capability] = true
 	}
 
 	// Pass in the logging endpoint for use w/the default remote logging hook.
@@ -151,8 +158,8 @@ func Main(ctx context.Context, loggingEndpoint, controlEndpoint string) error {
 	}
 
 	// if the runner supports worker status api then expose SDK harness status
-	if statusEndpoint != "" {
-		statusHandler, err := newWorkerStatusHandler(ctx, statusEndpoint, ctrl.cache, func(statusInfo *strings.Builder) { ctrl.metStoreToString(statusInfo) })
+	if opts.StatusEndpoint != "" {
+		statusHandler, err := newWorkerStatusHandler(ctx, opts.StatusEndpoint, ctrl.cache, func(statusInfo *strings.Builder) { ctrl.metStoreToString(statusInfo) })
 		if err != nil {
 			log.Errorf(ctx, "error establishing connection to worker status API: %v", err)
 		} else {


### PR DESCRIPTION
Migrate provisioned configurations out of harness.Main and pass them in with an options struct. harness.Main is kept around for compatibility, but marked deprecated in favour of harness.MainWithOptions.

This lets Loopback execution or other externally started workers to also use the provisioned features (status worker, and Runner Capabilities), by querying the provisioning service.

The go sdk container bootloader will continue to pass these through via environment variables, but they are now pulled in the harness init package.

This was a minor task while improving [Prism](https://github.com/apache/beam/tree/master/sdks/go/pkg/beam/runners/prism).

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
