### PR TITLE
fix dataloss bug in batch Storage API sink.

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
@@ -516,6 +516,7 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
 
         long offset = -1;
         if (!this.useDefaultStream) {
+          getOrCreateStreamName(); // Force creation of the stream.
           offset = this.currentOffset;
           this.currentOffset += inserts.getSerializedRowsCount();
           LOG.error("SCHEDULING APPEND TO STREAM " + this.streamName + " AT OFFSET " + offset + " SETTING NEW OFFSET TO " + this.currentOffset);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
@@ -31,11 +31,13 @@ import com.google.cloud.bigquery.storage.v1.WriteStream.Type;
 import com.google.protobuf.ByteString;
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.InvalidProtocolBufferException;
+import io.grpc.Status;
 import java.io.IOException;
 import java.time.Instant;
 import java.util.Arrays;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Random;
 import java.util.Set;
 import java.util.concurrent.ExecutorService;
@@ -224,11 +226,14 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
       ProtoRows protoRows;
       List<org.joda.time.Instant> timestamps;
 
+      int failureCount;
+
       public AppendRowsContext(
           long offset, ProtoRows protoRows, List<org.joda.time.Instant> timestamps) {
         this.offset = offset;
         this.protoRows = protoRows;
         this.timestamps = timestamps;
+        this.failureCount = 0;
       }
     }
 
@@ -301,17 +306,20 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
       }
 
       String getOrCreateStreamName() {
-        try {
-          if (!useDefaultStream) {
-            this.streamName =
-                Preconditions.checkStateNotNull(maybeDatasetService)
-                    .createWriteStream(tableUrn, Type.PENDING)
-                    .getName();
-          } else {
-            this.streamName = getDefaultStreamName();
+        if (Strings.isNullOrEmpty(this.streamName)) {
+          try {
+            if (!useDefaultStream) {
+              this.streamName =
+                  Preconditions.checkStateNotNull(maybeDatasetService)
+                      .createWriteStream(tableUrn, Type.PENDING)
+                      .getName();
+              this.currentOffset = 0;
+            } else {
+              this.streamName = getDefaultStreamName();
+            }
+          } catch (Exception e) {
+            throw new RuntimeException(e);
           }
-        } catch (Exception e) {
-          throw new RuntimeException(e);
         }
         return this.streamName;
       }
@@ -598,7 +606,42 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
                   streamName,
                   clientNumber,
                   retrieveErrorDetails(contexts));
+              failedContext.failureCount += 1;
+
+              // Maximum number of times we retry before we fail the work item.
+              if (failedContext.failureCount > 5) {
+                throw new RuntimeException("More than 5 attempts to call AppendRows failed.");
+              }
+
+              // The following errors are known to be persistent, so always fail the work item in
+              // this case.
+              Throwable error = Preconditions.checkStateNotNull(failedContext.getError());
+              Status.Code statusCode = Status.fromThrowable(error).getCode();
+              if (statusCode.equals(Status.Code.OUT_OF_RANGE)
+                  || statusCode.equals(Status.Code.ALREADY_EXISTS)) {
+                throw new RuntimeException(
+                    "Append to stream "
+                        + this.streamName
+                        + " failed with invalid "
+                        + "offset of "
+                        + failedContext.offset);
+              }
+
+              boolean streamDoesNotExist =
+                  failedContext.getError() instanceof Exceptions.StreamFinalizedException
+                      || statusCode.equals(Status.Code.INVALID_ARGUMENT)
+                      || statusCode.equals(Status.Code.NOT_FOUND)
+                      || statusCode.equals(Status.Code.FAILED_PRECONDITION);
+              if (streamDoesNotExist) {
+                throw new RuntimeException(
+                    "Append to stream "
+                        + this.streamName
+                        + " failed with stream "
+                        + "doesn't exist");
+              }
+
               invalidateWriteStream();
+
               appendFailures.inc();
               return RetryType.RETRY_ALL_OPERATIONS;
             },
@@ -629,7 +672,7 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
       String retrieveErrorDetails(Iterable<AppendRowsContext> failedContext) {
         return StreamSupport.stream(failedContext.spliterator(), false)
             .<@Nullable Throwable>map(AppendRowsContext::getError)
-            .filter(err -> err != null)
+            .filter(Objects::nonNull)
             .map(
                 thrw ->
                     Preconditions.checkStateNotNull(thrw).toString()

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
@@ -314,6 +314,7 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
                       .createWriteStream(tableUrn, Type.PENDING)
                       .getName();
               this.currentOffset = 0;
+              LOG.error("CREATED NEW STREAM " + this.streamName + " SETTING OFFSET TO 0");
             } else {
               this.streamName = getDefaultStreamName();
             }
@@ -517,6 +518,7 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
         if (!this.useDefaultStream) {
           offset = this.currentOffset;
           this.currentOffset += inserts.getSerializedRowsCount();
+          LOG.error("SCHEDULING APPEND TO STREAM " + this.streamName + " AT OFFSET " + offset + " SETTING NEW OFFSET TO " + this.currentOffset);
         }
         AppendRowsContext appendRowsContext =
             new AppendRowsContext(offset, inserts, insertTimestamps);
@@ -532,6 +534,7 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
                 StreamAppendClient writeStream =
                     Preconditions.checkStateNotNull(
                         getAppendClientInfo(true, null).getStreamAppendClient());
+                LOG.error("APPENDING TO STREAM " + this.streamName + " AT OFFSET " + c.offset + " NUM ROWS " + c.protoRows.getSerializedRowsCount());
                 ApiFuture<AppendRowsResponse> response =
                     writeStream.appendRows(c.offset, c.protoRows);
                 inflightWaitSecondsDistribution.update(writeStream.getInflightWaitSeconds());

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
@@ -405,6 +405,7 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
 
       void invalidateWriteStream() {
         if (appendClientInfo != null) {
+          LOG.error("INVALIDATING WRITE STREAM FOR " + this.streamName);
           synchronized (APPEND_CLIENTS) {
             // Unpin in a different thread, as it may execute a blocking close.
             StreamAppendClient client = appendClientInfo.getStreamAppendClient();
@@ -642,6 +643,7 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
                         + "doesn't exist");
               }
 
+              LOG.error("INVALIDATING WRITE STREAM FOR " + streamName + " DUE TO ERROR");
               invalidateWriteStream();
 
               appendFailures.inc();
@@ -694,6 +696,7 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
           TableSchema updatedTableSchema =
               (streamAppendClient != null) ? streamAppendClient.getUpdatedSchema() : null;
           if (updatedTableSchema != null) {
+            LOG.error("INVALIDATING WRITE STREAM FOR " + streamName + " DUE TO NEW SCHEMA");
             invalidateWriteStream();
             appendClientInfo =
                 Preconditions.checkStateNotNull(getAppendClientInfo(false, updatedTableSchema));

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
@@ -385,7 +385,6 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
               // This pin is "owned" by the current DoFn.
               Preconditions.checkStateNotNull(newAppendClientInfo.getStreamAppendClient()).pin();
             }
-            this.currentOffset = 0;
             nextCacheTickle = Instant.now().plus(java.time.Duration.ofMinutes(1));
             this.appendClientInfo = newAppendClientInfo;
           }


### PR DESCRIPTION
Two issues fixed:
   1. Retry behavior was incorrect. We created a new stream abandoning the old, but then only retried the current append.
   2.  Offset was inadvertently reset to 0 the first time we called append, which meant that the second append would always fail with invalid offset. This triggered the data-loss bug in 1.

We fixed the offset bug and no longer create a new stream on failure. In cases where the stream is known to be unusable (e.g. it's been deleted), we raise an exception which forces retry of the entire work item.