### PR TITLE
[Go SDK]: Enable fileio.MatchContinuously to emit duplicate file if modified

### DIFF
--- a/sdks/go/pkg/beam/io/fileio/file.go
+++ b/sdks/go/pkg/beam/io/fileio/file.go
@@ -21,6 +21,7 @@ import (
 	"io"
 	"path/filepath"
 	"reflect"
+	"time"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/io/filesystem"
@@ -32,10 +33,12 @@ func init() {
 	beam.RegisterType(reflect.TypeOf((*ReadableFile)(nil)).Elem())
 }
 
-// FileMetadata contains metadata about a file, namely its path and size in bytes.
+// FileMetadata contains metadata about a file, namely its path, size in bytes and last modified
+// time.
 type FileMetadata struct {
-	Path string
-	Size int64
+	Path         string
+	Size         int64
+	LastModified time.Time
 }
 
 // compressionType is the type of compression used to compress a file.

--- a/sdks/go/pkg/beam/io/fileio/helper_test.go
+++ b/sdks/go/pkg/beam/io/fileio/helper_test.go
@@ -22,6 +22,7 @@ import (
 	"os"
 	"path/filepath"
 	"testing"
+	"time"
 )
 
 // openFile opens a file for reading.
@@ -85,4 +86,15 @@ func writeGzip(t *testing.T, path string, data []byte) {
 	if err := zw.Close(); err != nil {
 		t.Fatal(err)
 	}
+}
+
+func modTime(t *testing.T, path string) time.Time {
+	t.Helper()
+
+	info, err := os.Stat(path)
+	if err != nil {
+		t.Fatal(err)
+	}
+
+	return info.ModTime()
 }

--- a/sdks/go/pkg/beam/io/fileio/match_test.go
+++ b/sdks/go/pkg/beam/io/fileio/match_test.go
@@ -55,6 +55,9 @@ func TestMatchFiles(t *testing.T) {
 		write(t, filepath.Join(testDir, tf.filename), tf.data)
 	}
 
+	fp1 := filepath.Join(testDir, "file1.txt")
+	fp2 := filepath.Join(testDir, "file2.txt")
+
 	tests := []struct {
 		name string
 		glob string
@@ -66,12 +69,14 @@ func TestMatchFiles(t *testing.T) {
 			glob: filepath.Join(dir, "*", "file*.txt"),
 			want: []any{
 				FileMetadata{
-					Path: filepath.Join(testDir, "file1.txt"),
-					Size: 5,
+					Path:         fp1,
+					Size:         5,
+					LastModified: modTime(t, fp1),
 				},
 				FileMetadata{
-					Path: filepath.Join(testDir, "file2.txt"),
-					Size: 0,
+					Path:         fp2,
+					Size:         0,
+					LastModified: modTime(t, fp2),
 				},
 			},
 		},
@@ -104,6 +109,10 @@ func TestMatchAll(t *testing.T) {
 		write(t, filepath.Join(testDir, tf.filename), tf.data)
 	}
 
+	fp1 := filepath.Join(testDir, "file1.txt")
+	fp2 := filepath.Join(testDir, "file2.txt")
+	fp3 := filepath.Join(testDir, "file3.csv")
+
 	tests := []struct {
 		name    string
 		opts    []MatchOptionFn
@@ -119,16 +128,19 @@ func TestMatchAll(t *testing.T) {
 			},
 			want: []any{
 				FileMetadata{
-					Path: filepath.Join(testDir, "file1.txt"),
-					Size: 5,
+					Path:         fp1,
+					Size:         5,
+					LastModified: modTime(t, fp1),
 				},
 				FileMetadata{
-					Path: filepath.Join(testDir, "file2.txt"),
-					Size: 0,
+					Path:         fp2,
+					Size:         0,
+					LastModified: modTime(t, fp2),
 				},
 				FileMetadata{
-					Path: filepath.Join(testDir, "file3.csv"),
-					Size: 5,
+					Path:         fp3,
+					Size:         5,
+					LastModified: modTime(t, fp3),
 				},
 			},
 		},
@@ -238,6 +250,10 @@ func Test_metadataFromFiles(t *testing.T) {
 		files[i] = file
 	}
 
+	fp1 := filepath.Join(dir, "file1.txt")
+	fp2 := filepath.Join(dir, "file2.txt")
+	fp3 := filepath.Join(dir, "file3.csv")
+
 	tests := []struct {
 		name  string
 		files []string
@@ -248,16 +264,19 @@ func Test_metadataFromFiles(t *testing.T) {
 			files: files,
 			want: []FileMetadata{
 				{
-					Path: filepath.Join(dir, "file1.txt"),
-					Size: 5,
+					Path:         fp1,
+					Size:         5,
+					LastModified: modTime(t, fp1),
 				},
 				{
-					Path: filepath.Join(dir, "file2.txt"),
-					Size: 0,
+					Path:         fp2,
+					Size:         0,
+					LastModified: modTime(t, fp2),
 				},
 				{
-					Path: filepath.Join(dir, "file3.csv"),
-					Size: 5,
+					Path:         fp3,
+					Size:         5,
+					LastModified: modTime(t, fp3),
 				},
 			},
 		},


### PR DESCRIPTION
Updates the `fileio.MatchContinuously` transform to support emission of duplicate matches if a file has been modified since it was last observed. The behavior is enabled by passing the `fileio.MatchDuplicateAllowIfModified()` option. Fixes #26523.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
