### PR TITLE
Use `PipelineOptions` for constructing `BigQueryWrapper` when estimating BigQuery table size (#26622)

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -709,7 +709,7 @@ class _CustomBigQuerySource(BoundedSource):
     }
 
   def estimate_size(self):
-    bq = bigquery_tools.BigQueryWrapper()
+    bq = bigquery_tools.BigQueryWrapper.from_pipeline_options(self.options)
     if self.table_reference is not None:
       table_ref = self.table_reference
       if (isinstance(self.table_reference, vp.ValueProvider) and

--- a/sdks/python/apache_beam/io/gcp/bigquery_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_tools.py
@@ -1346,17 +1346,18 @@ class BigQueryWrapper(object):
 
   @staticmethod
   def from_pipeline_options(pipeline_options: PipelineOptions):
-    return BigQueryWrapper(client=BigQueryWrapper._bigquery_client(pipeline_options))
+    return BigQueryWrapper(
+        client=BigQueryWrapper._bigquery_client(pipeline_options))
 
   @staticmethod
   def _bigquery_client(pipeline_options: PipelineOptions):
     return bigquery.BigqueryV2(
-          http=get_new_http(),
-          credentials=auth.get_service_credentials(pipeline_options),
-          response_encoding='utf8',
-          additional_http_headers={
-              "user-agent": "apache-beam-%s" % apache_beam.__version__
-          })
+        http=get_new_http(),
+        credentials=auth.get_service_credentials(pipeline_options),
+        response_encoding='utf8',
+        additional_http_headers={
+            "user-agent": "apache-beam-%s" % apache_beam.__version__
+        })
 
 
 class RowAsDictJsonCoder(coders.Coder):

--- a/sdks/python/apache_beam/io/gcp/bigquery_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_tools.py
@@ -349,13 +349,7 @@ class BigQueryWrapper(object):
   HISTOGRAM_METRIC_LOGGER = MetricLogger()
 
   def __init__(self, client=None, temp_dataset_id=None, temp_table_ref=None):
-    self.client = client or bigquery.BigqueryV2(
-        http=get_new_http(),
-        credentials=auth.get_service_credentials(PipelineOptions()),
-        response_encoding='utf8',
-        additional_http_headers={
-            "user-agent": "apache-beam-%s" % apache_beam.__version__
-        })
+    self.client = client or BigQueryWrapper._bigquery_client(PipelineOptions())
     self.gcp_bq_client = client or gcp_bigquery.Client(
         client_info=ClientInfo(
             user_agent="apache-beam-%s" % apache_beam.__version__))
@@ -1349,6 +1343,20 @@ class BigQueryWrapper(object):
       else:
         result[field.name] = self._convert_cell_value_to_dict(value, field)
     return result
+
+  @staticmethod
+  def from_pipeline_options(pipeline_options: PipelineOptions):
+    return BigQueryWrapper(client=BigQueryWrapper._bigquery_client(pipeline_options))
+
+  @staticmethod
+  def _bigquery_client(pipeline_options: PipelineOptions):
+    return bigquery.BigqueryV2(
+          http=get_new_http(),
+          credentials=auth.get_service_credentials(pipeline_options),
+          response_encoding='utf8',
+          additional_http_headers={
+              "user-agent": "apache-beam-%s" % apache_beam.__version__
+          })
 
 
 class RowAsDictJsonCoder(coders.Coder):


### PR DESCRIPTION
This _Pull Request_ addresses issue #26622.

Changes made:
1. Added factory method to `BigQueryWrapper` that allows for specifying `PipelineOptions` for which the _Google Cloud Platform_ credentials are retrieved for the underlying _BigQuery_ client,
2. Passed appropriate `PipelineOptions` to `BigQueryWrapper` when estimating _BigQuery_ table size.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [X] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [X] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
