### PR TITLE
[Java] Track pipeline options revision for idempotent initialization of file systems

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptions.java
@@ -358,6 +358,12 @@ public interface PipelineOptions extends HasDisplayData {
   Map<String, Map<String, Object>> outputRuntimeOptions();
 
   /**
+   * A monotonically increasing revision number of this {@link PipelineOptions} object that can be
+   * used to detect changes.
+   */
+  int revision();
+
+  /**
    * Provides a process wide unique ID for this {@link PipelineOptions} object, assigned at graph
    * construction time.
    */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PipelineOptionsFactory.java
@@ -1269,6 +1269,7 @@ public class PipelineOptionsFactory {
     try {
       knownMethods.add(iface.getMethod("as", Class.class));
       knownMethods.add(iface.getMethod("outputRuntimeOptions"));
+      knownMethods.add(iface.getMethod("revision"));
       knownMethods.add(iface.getMethod("populateDisplayData", DisplayData.Builder.class));
     } catch (NoSuchMethodException | SecurityException e) {
       throw new RuntimeException(e);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/ProxyInvocationHandler.java
@@ -49,11 +49,13 @@ import java.util.HashSet;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
+import java.util.Objects;
 import java.util.Set;
 import java.util.SortedMap;
 import java.util.TreeMap;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.ThreadLocalRandom;
+import java.util.concurrent.atomic.AtomicInteger;
 import javax.annotation.concurrent.ThreadSafe;
 import org.apache.beam.sdk.options.PipelineOptionsFactory.AnnotationPredicates;
 import org.apache.beam.sdk.options.PipelineOptionsFactory.Registration;
@@ -97,6 +99,8 @@ class ProxyInvocationHandler implements InvocationHandler, Serializable {
    * No two instances of this class are considered equivalent hence we generate a random hash code.
    */
   private final int hashCode = ThreadLocalRandom.current().nextInt();
+
+  private final AtomicInteger revision;
 
   private static final class ComputedProperties {
     final ImmutableClassToInstanceMap<PipelineOptions> interfaceToProxyCache;
@@ -158,7 +162,7 @@ class ProxyInvocationHandler implements InvocationHandler, Serializable {
   private final ImmutableMap<String, JsonNode> jsonOptions;
 
   ProxyInvocationHandler(Map<String, Object> options) {
-    this(bindOptions(options), Maps.newHashMap());
+    this(bindOptions(options), Maps.newHashMap(), 0);
   }
 
   private static Map<String, BoundValue> bindOptions(Map<String, Object> inputOptions) {
@@ -171,9 +175,10 @@ class ProxyInvocationHandler implements InvocationHandler, Serializable {
   }
 
   private ProxyInvocationHandler(
-      Map<String, BoundValue> options, Map<String, JsonNode> jsonOptions) {
+      Map<String, BoundValue> options, Map<String, JsonNode> jsonOptions, int revision) {
     this.options = new ConcurrentHashMap<>(options);
     this.jsonOptions = ImmutableMap.copyOf(jsonOptions);
+    this.revision = new AtomicInteger(revision);
     this.computedProperties =
         new ComputedProperties(
             ImmutableClassToInstanceMap.of(),
@@ -193,6 +198,8 @@ class ProxyInvocationHandler implements InvocationHandler, Serializable {
       return hashCode();
     } else if (args == null && "outputRuntimeOptions".equals(method.getName())) {
       return outputRuntimeOptions((PipelineOptions) proxy);
+    } else if (args == null && "revision".equals(method.getName())) {
+      return revision.get();
     } else if (args != null && "as".equals(method.getName()) && args[0] instanceof Class) {
       @SuppressWarnings("unchecked")
       Class<? extends PipelineOptions> clazz = (Class<? extends PipelineOptions>) args[0];
@@ -222,9 +229,13 @@ class ProxyInvocationHandler implements InvocationHandler, Serializable {
       }
       return options.get(propertyName).getValue();
     } else if (properties.settersToPropertyNames.containsKey(methodName)) {
-      options.put(
-          properties.settersToPropertyNames.get(methodName),
-          BoundValue.fromExplicitOption(args[0]));
+      BoundValue prev =
+          options.put(
+              properties.settersToPropertyNames.get(methodName),
+              BoundValue.fromExplicitOption(args[0]));
+      if (prev == null ? args[0] != null : !Objects.equals(args[0], prev.getValue())) {
+        revision.incrementAndGet();
+      }
       return Void.TYPE;
     }
     throw new RuntimeException(
@@ -781,6 +792,8 @@ class ProxyInvocationHandler implements InvocationHandler, Serializable {
 
       jgen.writeFieldName("display_data");
       jgen.writeObject(serializedDisplayData);
+
+      jgen.writeNumberField("revision", handler.revision.get());
       jgen.writeEndObject();
     }
 
@@ -879,9 +892,9 @@ class ProxyInvocationHandler implements InvocationHandler, Serializable {
           fields.put(field.getKey(), field.getValue());
         }
       }
-
+      int revision = objectNode.hasNonNull("revision") ? objectNode.get("revision").asInt() : 0;
       PipelineOptions options =
-          new ProxyInvocationHandler(Maps.newHashMap(), fields).as(PipelineOptions.class);
+          new ProxyInvocationHandler(Maps.newHashMap(), fields, revision).as(PipelineOptions.class);
       ValueProvider.RuntimeValueProvider.setRuntimeOptions(options);
       return options;
     }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsFactoryTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/options/PipelineOptionsFactoryTest.java
@@ -104,6 +104,18 @@ public class PipelineOptionsFactoryTest {
   @Rule public ExpectedLogs expectedLogs = ExpectedLogs.none(PipelineOptionsFactory.class);
 
   @Test
+  public void testRevision() {
+    PipelineOptions options = PipelineOptionsFactory.create();
+    assertEquals(1, options.revision());
+    for (int i = 0; i < 10; i++) {
+      options.setJobName("other" + i);
+      // updates are idempotent, the 2nd call won't increment the revision
+      options.setJobName("other" + i);
+    }
+    assertEquals(11, options.revision());
+  }
+
+  @Test
   public void testAutomaticRegistrationOfPipelineOptions() {
     assertTrue(PipelineOptionsFactory.getRegisteredOptions().contains(RegisteredTestOptions.class));
   }


### PR DESCRIPTION
Current initialization of FileSystems through `FileSystems.setDefaultPipelineOptions` is problematic and prone to race conditions, especially when triggered on deserialization of `SerializablePipelineOptions` (see #18430, [BEAM-14465](https://issues.apache.org/jira/browse/BEAM-14465), [BEAM-14355](https://issues.apache.org/jira/browse/BEAM-14355)).

Particularly with `S3FileSystem` this is bad as it can easily leak resources (threads!) if used this way (see #26321).

### Observations
- Removing `FileSystems.setDefaultPipelineOptions` from deserialization in SerializablePipelineOptions (#18430) is unlikely to happen any time soon as it requires a coordinated push across various runners and it’s not obvious where and when initialization is supposed to happen for each runner. As a consequence we must expect `FileSystems.setDefaultPipelineOptions` to be called any number of times.
- Looking into previous related issues ([BEAM-14465](https://issues.apache.org/jira/browse/BEAM-14465), [BEAM-14355](https://issues.apache.org/jira/browse/BEAM-14355)), logs give a clear hint how often the file systems got re-initialized. The logs mentioned in the tickets happen(ed) once per initialization of the S3 FS:  In the case of the Go Flink integration tests that was almost 80k times, running Python wordcount on Beam it was happening > 600 times.
- I spend quite some time investigating if Pipeline options could be locked during execution. That requires a lot of effort changing runners, but that part is possible. However, test cases strongly suggest being able to mutate pipeline options while running is an intended feature. 

### Changes in this PR

- Extend pipeline options to track a monotonically increasing revision with each update.
- Change the initialization of file systems to be idempotent by means of that revision. Additionally this is scoped to a particular pipeline using the options id.

Closes #27535, fixes #26321

(cc @robertwb Thanks for your reply on the email thread)


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
