### PR TITLE
[Go SDK] Fix poor implementation of type identity checks.

### DIFF
--- a/sdks/go/pkg/beam/core/graph/coder/registry_test.go
+++ b/sdks/go/pkg/beam/core/graph/coder/registry_test.go
@@ -21,7 +21,7 @@ import (
 )
 
 func clearRegistry() {
-	coderRegistry = make(map[uintptr]func(reflect.Type) *CustomCoder)
+	coderRegistry = make(map[reflect.Type]func(reflect.Type) *CustomCoder)
 	interfaceOrdering = []reflect.Type{}
 }
 

--- a/sdks/go/pkg/beam/core/typex/class.go
+++ b/sdks/go/pkg/beam/core/typex/class.go
@@ -92,7 +92,7 @@ func ClassOf(t reflect.Type) Class {
 // data must be fully serializable. Functions and channels are examples of invalid
 // types. Aggregate types with no universals are considered concrete here.
 func IsConcrete(t reflect.Type) bool {
-	err := isConcrete(t, make(map[uintptr]bool))
+	err := isConcrete(t, make(map[reflect.Type]bool))
 	return err == nil
 }
 
@@ -101,19 +101,18 @@ func IsConcrete(t reflect.Type) bool {
 // data must be fully serializable. Functions and channels are examples of invalid
 // types. Aggregate types with no universals are considered concrete here.
 func CheckConcrete(t reflect.Type) (bool, error) {
-	err := isConcrete(t, make(map[uintptr]bool))
+	err := isConcrete(t, make(map[reflect.Type]bool))
 	return err == nil, err
 }
 
-func isConcrete(t reflect.Type, visited map[uintptr]bool) error {
+func isConcrete(t reflect.Type, visited map[reflect.Type]bool) error {
 	// Check that we haven't hit a recursive loop.
-	key := reflect.ValueOf(t).Pointer()
 	// If there's an invalid field in a recursive type
 	// then the layer above will find it.
-	if visited[key] {
+	if visited[t] {
 		return nil
 	}
-	visited[key] = true
+	visited[t] = true
 
 	// Handle special types.
 	if t == nil ||


### PR DESCRIPTION
Discovered by an upcoming (but ultimately reverted) change to Go for 1.21, where these checks were doing something that worked, but were misusing the reflect APIs to achieve it. Fixing this avoids relying on a brittle implementation detail.

`reflect.Type` is safe to use as a map key, so looking up the pointer identifier for the specific type instance isn't necessary. This worked before because the reflect package caches Type instances, and reuses the same one for the same type, leading to the same behavior.

The pattern was only used in coder/registry.go and for checking concrete types in typex/class.go.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
