### PR TITLE
Explicitly link the license to Keras dependency

### DIFF
--- a/sdks/python/container/license_scripts/dep_urls_py.yaml
+++ b/sdks/python/container/license_scripts/dep_urls_py.yaml
@@ -94,6 +94,8 @@ pip_dependencies:
     license: "https://raw.githubusercontent.com/mtth/hdfs/master/LICENSE"
   httplib2:
     license: "https://raw.githubusercontent.com/httplib2/httplib2/master/LICENSE"
+  keras:
+    licence: "https://raw.githubusercontent.com/keras-team/keras/master/LICENSE"
   keras-nightly:
     license: "https://raw.githubusercontent.com/keras-team/keras/master/LICENSE"
   mmh3:

--- a/sdks/python/container/license_scripts/dep_urls_py.yaml
+++ b/sdks/python/container/license_scripts/dep_urls_py.yaml
@@ -95,7 +95,7 @@ pip_dependencies:
   httplib2:
     license: "https://raw.githubusercontent.com/httplib2/httplib2/master/LICENSE"
   keras:
-    licence: "https://raw.githubusercontent.com/keras-team/keras/master/LICENSE"
+    license: "https://raw.githubusercontent.com/keras-team/keras/master/LICENSE"
   keras-nightly:
     license: "https://raw.githubusercontent.com/keras-team/keras/master/LICENSE"
   mmh3:


### PR DESCRIPTION
Keras recently changed release tooling and now their wheel doesn't have the license file in the previous location, so pip-licenses doesn't fetch it.

This fixes: https://ci-beam.apache.org/job/beam_PostCommit_Py_ValCont_with_RC/ suite.