### PR TITLE
Revert "Increase streaming wordcount IT timeout "

### DIFF
--- a/sdks/python/apache_beam/examples/streaming_wordcount_it_test.py
+++ b/sdks/python/apache_beam/examples/streaming_wordcount_it_test.py
@@ -53,7 +53,7 @@ INPUT_SUB = 'wc_subscription_input'
 OUTPUT_SUB = 'wc_subscription_output'
 
 DEFAULT_INPUT_NUMBERS = 500
-WAIT_UNTIL_FINISH_DURATION = 15 * 60 * 1000  # in milliseconds
+WAIT_UNTIL_FINISH_DURATION = 10 * 60 * 1000  # in milliseconds
 
 
 class StreamingWordCountIT(unittest.TestCase):


### PR DESCRIPTION
Reverts apache/beam#26554

Per https://github.com/apache/beam/pull/26554#issuecomment-1535232589 the test on master installs wheels and should save 3.5 minutes each test.