### PR TITLE
[Go SDK]: Fix flaky local fs LastModified test

### DIFF
--- a/sdks/go/pkg/beam/io/filesystem/local/local_test.go
+++ b/sdks/go/pkg/beam/io/filesystem/local/local_test.go
@@ -161,12 +161,12 @@ func TestLocal_lastModified(t *testing.T) {
 	dir := t.TempDir()
 	filePath := filepath.Join(dir, "file.txt")
 
-	// Account for a timestamp resolution of one second.
-	t1 := time.Now().Truncate(time.Second)
+	// Account for time skew between system and go runtime.
+	t1 := time.Now().Truncate(time.Second).Add(-time.Second)
 	if err := filesystem.Write(ctx, localFS, filePath, []byte("")); err != nil {
 		t.Fatalf("filesystem.Write(ctx, %q) error = %v, want nil", filePath, err)
 	}
-	t2 := time.Now()
+	t2 := time.Now().Truncate(time.Second).Add(2 * time.Second)
 
 	got, err := localFS.LastModified(ctx, filePath)
 	if err != nil {


### PR DESCRIPTION
Fixes #26703 by increasing the expected time range for the local fs LastModified unit test

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
