### PR TITLE
Only use updated schema if auto update is enabled

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
@@ -691,7 +691,7 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
           @Nullable
           TableSchema updatedTableSchema =
               (streamAppendClient != null) ? streamAppendClient.getUpdatedSchema() : null;
-          if (updatedTableSchema != null) {
+          if (updatedTableSchema != null && autoUpdateSchema) {
             invalidateWriteStream();
             appendClientInfo =
                 Preconditions.checkStateNotNull(getAppendClientInfo(false, updatedTableSchema));


### PR DESCRIPTION
Updating the schema on-the-fly may cause problems and we need to improve.

This change avoids that problem in case autoSchemaUpdate is disabled, as it shouldn't be considering new schemas anyways.