### PR TITLE
Don't fail if creating a venv didn't succeed. Also provide a way to disable creating separate venvs.

### DIFF
--- a/sdks/python/container/boot.go
+++ b/sdks/python/container/boot.go
@@ -156,12 +156,12 @@ func launchSDKProcess() error {
 	signalChannel := make(chan os.Signal, 1)
 	signal.Notify(signalChannel, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
 
-	// Create a separate virtual envirionment (with access to globally installed packages), unless disabled by the user.
-	// This improves usability on runners that persit the execution environment for the boot entrypoint between multiple pipeline executions.
+	// Create a separate virtual environment (with access to globally installed packages), unless disabled by the user.
+	// This improves usability on runners that persist the execution environment for the boot entrypoint between multiple pipeline executions.
 	if os.Getenv("RUN_PYTHON_SDK_IN_DEFAULT_ENVIRONMENT") == "" {
 		venvDir, err := setupVenv(ctx, logger, "/opt/apache/beam-venv", *id)
 		if err != nil {
-			logger.Printf(ctx, "Using default environment, since creating a virtual environment for the SDK harness didn't succeed: "+err.Error())
+			logger.Printf(ctx, "Using default environment, since creating a virtual environment for the SDK harness didn't succeed: %v", err)
 		} else {
 			cleanupFunc := func() {
 				os.RemoveAll(venvDir)
@@ -313,7 +313,7 @@ func StartCommandEnv(env map[string]string, prog string, args ...string) *exec.C
 // setupVenv initializes a local Python venv and sets the corresponding env variables
 func setupVenv(ctx context.Context, logger *tools.Logger, baseDir, workerId string) (string, error) {
 	dir := filepath.Join(baseDir, "beam-venv-worker-"+workerId)
-	logger.Printf(ctx, "Initializing temporary Python venv in "+dir)
+	logger.Printf(ctx, "Initializing temporary Python venv in %v", dir)
 	if _, err := os.Stat(dir); !os.IsNotExist(err) {
 		// Probably leftovers from a previous run
 		logger.Printf(ctx, "Cleaning up previous venv ...")

--- a/sdks/python/container/boot.go
+++ b/sdks/python/container/boot.go
@@ -20,7 +20,6 @@ package main
 import (
 	"context"
 	"encoding/json"
-	"errors"
 	"flag"
 	"fmt"
 	"log"
@@ -157,15 +156,20 @@ func launchSDKProcess() error {
 	signalChannel := make(chan os.Signal, 1)
 	signal.Notify(signalChannel, syscall.SIGHUP, syscall.SIGINT, syscall.SIGTERM)
 
-	venvDir, err := setupVenv(ctx, logger, "/opt/apache/beam-venv", *id)
-	if err != nil {
-		return errors.New("failed to initialize Python venv")
+	// Create a separate virtual envirionment (with access to globally installed packages), unless disabled by the user.
+	// This improves usability on runners that persit the execution environment for the boot entrypoint between multiple pipeline executions.
+	if os.Getenv("RUN_PYTHON_SDK_IN_DEFAULT_ENVIRONMENT") == "" {
+		venvDir, err := setupVenv(ctx, logger, "/opt/apache/beam-venv", *id)
+		if err != nil {
+			logger.Printf(ctx, "Using default environment, since creating a virtual environment for the SDK harness didn't succeed: "+err.Error())
+		} else {
+			cleanupFunc := func() {
+				os.RemoveAll(venvDir)
+				logger.Printf(ctx, "Cleaned up temporary venv for worker %v.", *id)
+			}
+			defer cleanupFunc()
+		}
 	}
-	cleanupFunc := func() {
-		os.RemoveAll(venvDir)
-		logger.Printf(ctx, "Cleaned up temporary venv for worker %v.", *id)
-	}
-	defer cleanupFunc()
 
 	dir := filepath.Join(*semiPersistDir, "staged")
 	files, err := artifact.Materialize(ctx, *artifactEndpoint, info.GetDependencies(), info.GetRetrievalToken(), dir)
@@ -308,9 +312,8 @@ func StartCommandEnv(env map[string]string, prog string, args ...string) *exec.C
 
 // setupVenv initializes a local Python venv and sets the corresponding env variables
 func setupVenv(ctx context.Context, logger *tools.Logger, baseDir, workerId string) (string, error) {
-	logger.Printf(ctx, "Initializing temporary Python venv ...")
-
 	dir := filepath.Join(baseDir, "beam-venv-worker-"+workerId)
+	logger.Printf(ctx, "Initializing temporary Python venv in "+dir)
 	if _, err := os.Stat(dir); !os.IsNotExist(err) {
 		// Probably leftovers from a previous run
 		logger.Printf(ctx, "Cleaning up previous venv ...")


### PR DESCRIPTION
https://github.com/apache/beam/pull/16658 made a change to Python SDK harness container boot sequence to launch SDK processes in separately created virtual environments.

It appears that the venv dependency is sometimes not available on non-beam Python container images. Users who supply  custom containers  may run into errors when `python3-venv` is not installed, and need to install it separately, which is inconvenient.

Creating a venv is not strictly required, therefore we can fallback on prior behavior to use global environment. 

Drive-by changes:
 - Log why creating a venv didn't succeed.
 - Provide an way to disable venv creation, which may benefit users who wish to re-use a precreated virtual environment on their image.  To disable creating isolated venvs, users can add the following line to their Dockerfiles: 
  `ENV RUN_PYTHON_SDK_IN_DEFAULT_ENVIRONMENT=1`
 
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
