### PR TITLE
Allow for same name and type, if it is not ambiguous in yaml inputs

### DIFF
--- a/sdks/python/apache_beam/yaml/yaml_transform.py
+++ b/sdks/python/apache_beam/yaml/yaml_transform.py
@@ -110,12 +110,12 @@ class LightweightScope(object):
   def __init__(self, transforms):
     self._transforms = transforms
     self._transforms_by_uuid = {t['__uuid__']: t for t in self._transforms}
-    self._uuid_by_name = collections.defaultdict(list)
+    self._uuid_by_name = collections.defaultdict(set)
     for spec in self._transforms:
       if 'name' in spec:
-        self._uuid_by_name[spec['name']].append(spec['__uuid__'])
+        self._uuid_by_name[spec['name']].add(spec['__uuid__'])
       if 'type' in spec:
-        self._uuid_by_name[spec['type']].append(spec['__uuid__'])
+        self._uuid_by_name[spec['type']].add(spec['__uuid__'])
 
   def get_transform_id_and_output_name(self, name):
     if '.' in name:

--- a/sdks/python/apache_beam/yaml/yaml_transform_test.py
+++ b/sdks/python/apache_beam/yaml/yaml_transform_test.py
@@ -283,7 +283,6 @@ class YamlWindowingTest(unittest.TestCase):
   def test_name_is_not_ambiguous(self):
     with beam.Pipeline(options=beam.options.pipeline_options.PipelineOptions(
         pickle_library='cloudpickle')) as p:
-
       result = p | YamlTransform(
           '''
           type: composite
@@ -303,9 +302,8 @@ class YamlWindowingTest(unittest.TestCase):
   def test_name_is_ambiguous(self):
     with beam.Pipeline(options=beam.options.pipeline_options.PipelineOptions(
         pickle_library='cloudpickle')) as p:
-
       with self.assertRaises(ValueError):
-        result = p | YamlTransform(
+        p | YamlTransform(
             '''
             type: composite
             transforms:

--- a/sdks/python/apache_beam/yaml/yaml_transform_test.py
+++ b/sdks/python/apache_beam/yaml/yaml_transform_test.py
@@ -324,7 +324,6 @@ class YamlWindowingTest(unittest.TestCase):
             ''')
 
 
-
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)
   unittest.main()

--- a/sdks/python/apache_beam/yaml/yaml_transform_test.py
+++ b/sdks/python/apache_beam/yaml/yaml_transform_test.py
@@ -280,6 +280,50 @@ class YamlWindowingTest(unittest.TestCase):
           providers=TEST_PROVIDERS)
       assert_that(result, equal_to([6, 9]))
 
+  def test_name_is_not_ambiguous(self):
+    with beam.Pipeline(options=beam.options.pipeline_options.PipelineOptions(
+        pickle_library='cloudpickle')) as p:
+
+      result = p | YamlTransform(
+          '''
+          type: composite
+          transforms:
+            - type: Create
+              name: Create
+              elements: [0, 1, 3, 4]
+            - type: PyFilter
+              name: Filter
+              keep: "lambda elem: elem > 2"
+              input: Create
+          output: Filter
+          ''')
+      # No exception raised
+      assert_that(result, equal_to([3, 4]))
+
+  def test_name_is_ambiguous(self):
+    with beam.Pipeline(options=beam.options.pipeline_options.PipelineOptions(
+        pickle_library='cloudpickle')) as p:
+
+      with self.assertRaises(ValueError):
+        result = p | YamlTransform(
+            '''
+            type: composite
+            transforms:
+              - type: Create
+                name: CreateData
+                elements: [0, 1, 3, 4]
+              - type: PyFilter
+                name: PyFilter
+                keep: "lambda elem: elem > 2"
+                input: CreateData
+              - type: PyFilter
+                name: AnotherFilter
+                keep: "lambda elem: elem > 3"
+                input: PyFilter
+            output: AnotherFilter
+            ''')
+
+
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)

--- a/sdks/python/apache_beam/yaml/yaml_transform_test.py
+++ b/sdks/python/apache_beam/yaml/yaml_transform_test.py
@@ -165,6 +165,48 @@ class YamlTransformTest(unittest.TestCase):
           lines=True).sort_values('rank').reindex()
       pd.testing.assert_frame_equal(data, result)
 
+  def test_name_is_not_ambiguous(self):
+    with beam.Pipeline(options=beam.options.pipeline_options.PipelineOptions(
+        pickle_library='cloudpickle')) as p:
+      result = p | YamlTransform(
+          '''
+            type: composite
+            transforms:
+              - type: Create
+                name: Create
+                elements: [0, 1, 3, 4]
+              - type: PyFilter
+                name: Filter
+                keep: "lambda elem: elem > 2"
+                input: Create
+            output: Filter
+            ''')
+      # No exception raised
+      assert_that(result, equal_to([3, 4]))
+
+  def test_name_is_ambiguous(self):
+    with beam.Pipeline(options=beam.options.pipeline_options.PipelineOptions(
+        pickle_library='cloudpickle')) as p:
+      # pylint: disable=expression-not-assigned
+      with self.assertRaises(ValueError):
+        p | YamlTransform(
+            '''
+            type: composite
+            transforms:
+              - type: Create
+                name: CreateData
+                elements: [0, 1, 3, 4]
+              - type: PyFilter
+                name: PyFilter
+                keep: "lambda elem: elem > 2"
+                input: CreateData
+              - type: PyFilter
+                name: AnotherFilter
+                keep: "lambda elem: elem > 3"
+                input: PyFilter
+            output: AnotherFilter
+            ''')
+
 
 class CreateTimestamped(beam.PTransform):
   def __init__(self, elements):
@@ -279,47 +321,6 @@ class YamlWindowingTest(unittest.TestCase):
           ''',
           providers=TEST_PROVIDERS)
       assert_that(result, equal_to([6, 9]))
-
-  def test_name_is_not_ambiguous(self):
-    with beam.Pipeline(options=beam.options.pipeline_options.PipelineOptions(
-        pickle_library='cloudpickle')) as p:
-      result = p | YamlTransform(
-          '''
-          type: composite
-          transforms:
-            - type: Create
-              name: Create
-              elements: [0, 1, 3, 4]
-            - type: PyFilter
-              name: Filter
-              keep: "lambda elem: elem > 2"
-              input: Create
-          output: Filter
-          ''')
-      # No exception raised
-      assert_that(result, equal_to([3, 4]))
-
-  def test_name_is_ambiguous(self):
-    with beam.Pipeline(options=beam.options.pipeline_options.PipelineOptions(
-        pickle_library='cloudpickle')) as p:
-      with self.assertRaises(ValueError):
-        p | YamlTransform(
-            '''
-            type: composite
-            transforms:
-              - type: Create
-                name: CreateData
-                elements: [0, 1, 3, 4]
-              - type: PyFilter
-                name: PyFilter
-                keep: "lambda elem: elem > 2"
-                input: CreateData
-              - type: PyFilter
-                name: AnotherFilter
-                keep: "lambda elem: elem > 3"
-                input: PyFilter
-            output: AnotherFilter
-            ''')
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
**How it is:**
If the transform name is the same as the type, a "Value Error - Ambiguous name" is raised.
**How it should be:**
If the transform name is the same as the type, and there is no other transform of this type nor name, this is not ambiguous.
Example:
```
pipeline:
  - type: ReadFromCsv
    name: ReadFromCsv
    path: "gs://apache-beam-samples/nasa_jpl_asteroid/sample_1000.csv"
  - type: PyFilter
    name: Filter
    fn: "lambda astroid: (astroid.diameter or 0) > 250"
    input: Read
  - type: PyMap
    fn: print
    input: Filter
```
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
