### PR TITLE
Match catch clause in the codepath that reports the error to the worker to a clause that marks the bundle as failed.

### DIFF
--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -293,7 +293,7 @@ class SdkHarness(object):
     with statesampler.instruction_id(request.instruction_id):
       try:
         response = task()
-      except Exception:  # pylint: disable=broad-except
+      except:  # pylint: disable=bare-except
         traceback_string = traceback.format_exc()
         print(traceback_string, file=sys.stderr)
         _LOGGER.error(
@@ -680,7 +680,7 @@ class SdkWorker(object):
       if not requests_finalization:
         self.bundle_processor_cache.release(instruction_id)
       return response
-    except:  # pylint: disable=broad-except
+    except:  # pylint: disable=bare-except
       # Don't re-use bundle processors on failure.
       self.bundle_processor_cache.discard(instruction_id)
       raise


### PR DESCRIPTION
If user code raises a BaseException during processing, bundle will be marked as failed by the SDK but will not be reported as failed to the worker harness. To fix this, match the error handling catch clause in the outer method to the error handling close where bundle is marked failed: https://github.com/apache/beam/blob/dbefe4f8b0915d4d1bd83f315705efaf0b526d3d/sdks/python/apache_beam/runners/worker/sdk_worker.py#L683