### PR TITLE
Cherry-pick #26752 - Only use updated schema if auto update is enabled

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
@@ -691,7 +691,7 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
           @Nullable
           TableSchema updatedTableSchema =
               (streamAppendClient != null) ? streamAppendClient.getUpdatedSchema() : null;
-          if (updatedTableSchema != null) {
+          if (updatedTableSchema != null && autoUpdateSchema) {
             invalidateWriteStream();
             appendClientInfo =
                 Preconditions.checkStateNotNull(getAppendClientInfo(false, updatedTableSchema));


### PR DESCRIPTION
Cherry-picking the fix https://github.com/apache/beam/pull/26752 to Beam 2.48.0 release.
