### PR TITLE
Exclude org.apache.beam.sdk.testing.UsesTriggeredSideInputs in StreamingRunnerV2 suite.

### DIFF
--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -503,6 +503,7 @@ task validatesRunnerV2Streaming {
       'org.apache.beam.sdk.testing.LargeKeys$Above10KB',
       'org.apache.beam.sdk.testing.UsesBoundedSplittableParDo',
       'org.apache.beam.sdk.testing.UsesCommittedMetrics',
+      'org.apache.beam.sdk.testing.UsesTriggeredSideInputs',
     ],
     excludedTests: [
       // TestStream only (partially) supported on UW


### PR DESCRIPTION
Follow up for: https://github.com/apache/beam/pull/26707