### PR TITLE
Revert Playground links to prod environment

### DIFF
--- a/website/www/site/content/en/blog/ApachePlayground.md
+++ b/website/www/site/content/en/blog/ApachePlayground.md
@@ -21,7 +21,7 @@ limitations under the License.
 -->
 
 ### **What is Apache Beam Playground?**
-[Apache Beam Playground](https://play-dev.beam.apache.org/) is an interactive environment to try Apache Beam transforms and examples without requiring to install or set up a Beam environment.
+[Apache Beam Playground](https://play.beam.apache.org/) is an interactive environment to try Apache Beam transforms and examples without requiring to install or set up a Beam environment.
 
 
 ### **Apache Beam Playground Features**
@@ -39,7 +39,7 @@ limitations under the License.
 
 
 ### **What’s Next**
-* Try examples in [Apache Beam Playground](https://play-dev.beam.apache.org/)
+* Try examples in [Apache Beam Playground](https://play.beam.apache.org/)
 * Submit your feedback using “Enjoying Playground?” in Apache Beam Playground or via [this form](https://docs.google.com/forms/d/e/1FAIpQLSd5_5XeOwwW2yjEVHUXmiBad8Lxk-4OtNcgG45pbyAZzd4EbA/viewform?usp=pp_url)
 * Join the Beam [users@](/community/contact-us) mailing list
 * Contribute to the Apache Beam Playground codebase by following a few steps in this  [Contribution Guide](/contribute)

--- a/website/www/site/content/en/get-started/resources/learning-resources.md
+++ b/website/www/site/content/en/get-started/resources/learning-resources.md
@@ -146,8 +146,8 @@ complexity. Beam Katas are available for both Java and Python SDKs.
 
 ### Beam Playground
 
-* [Beam Playground](https://play-dev.beam.apache.org) is an interactive environment to try out Beam transforms and examples without having to install Apache Beam in your environment.
-    You can try the available Apache Beam examples at [Beam Playground](https://play-dev.beam.apache.org).
+* [Beam Playground](https://play.beam.apache.org) is an interactive environment to try out Beam transforms and examples without having to install Apache Beam in your environment.
+    You can try the available Apache Beam examples at [Beam Playground](https://play.beam.apache.org).
 * Learn more about how to add an Apache Beam example/test/kata into Beam Playground catalog [here](/get-started/try-beam-playground/#how-to-add-new-examples).
 
 ## API Reference {#api-reference}

--- a/website/www/site/content/en/get-started/try-beam-playground.md
+++ b/website/www/site/content/en/get-started/try-beam-playground.md
@@ -21,7 +21,7 @@ Beam Playground is an interactive environment to try out Beam transforms and exa
 without having to install Apache Beam in your environment.
 
 You can try the available Apache Beam examples at
-[Beam Playground](https://play-dev.beam.apache.org/).
+[Beam Playground](https://play.beam.apache.org/).
 
 ## Beam Playground WordCount Example
 
@@ -107,9 +107,9 @@ More details on examples in Apache Beam Playground can be found
 
 ## Next Steps
 
-* Try examples in [Apache Beam Playground](https://play-dev.beam.apache.org/).
+* Try examples in [Apache Beam Playground](https://play.beam.apache.org/).
 * Submit feedback using "Enjoying Playground?" in
-[Apache Beam Playground](https://play-dev.beam.apache.org/) or via
+[Apache Beam Playground](https://play.beam.apache.org/) or via
 [this form](https://docs.google.com/forms/d/e/1FAIpQLSd5_5XeOwwW2yjEVHUXmiBad8Lxk-4OtNcgG45pbyAZzd4EbA/viewform?usp=pp_url).
 * Join the Beam [users@](/community/contact-us) mailing list.
 * If you're interested in contributing to the Apache Beam Playground codebase, see the [Contribution Guide](/contribute).

--- a/website/www/site/layouts/index.html
+++ b/website/www/site/layouts/index.html
@@ -53,11 +53,11 @@ limitations under the License. See accompanying LICENSE file.
 <div class="body__contained body__section-nav playground-section" tabindex="-1">
   <h1>Try Beam Playground</h1>
   <p>Beam Playground is an interactive environment to try out Beam transforms and examples without having to install Apache Beam in your environment.
-    You can try the Apache Beam examples at <a href="https://play-dev.beam.apache.org/">Beam Playground (Beta)</a>.
+    You can try the Apache Beam examples at <a href="https://play.beam.apache.org/">Beam Playground (Beta)</a>.
   </p>
   <br>
   <br>
-  <a class="playground__mobile" href="https://play-dev.beam.apache.org/">
+  <a class="playground__mobile" href="https://play.beam.apache.org/">
     <img src="images/playground.png" alt="beam playground">
   </a>
 
@@ -77,7 +77,7 @@ limitations under the License. See accompanying LICENSE file.
 
     <div class="code-snippet code-snippet-playground">
       <iframe
-        src="https://play-dev.beam.apache.org/embedded?sdk=java&examples={{ jsonify $examples }}"
+        src="https://play.beam.apache.org/embedded?sdk=java&examples={{ jsonify $examples }}"
         width="100%"
         height="700px"
         allow="clipboard-write"
@@ -233,7 +233,7 @@ limitations under the License. See accompanying LICENSE file.
     <a class="ctas_button" href={{ "/get-started/quickstart-go/" | relLangURL }}>{{ T "home-go-quickstart" }}</a>
   </div>
   <div class='ctas_row'>
-    <a class="ctas_button" href={{ "https://play-dev.beam.apache.org/" | relLangURL }}>{{ T "home-playground" }}</a>
+    <a class="ctas_button" href={{ "https://play.beam.apache.org/" | relLangURL }}>{{ T "home-playground" }}</a>
   </div>
 </div>
 {{ end }}

--- a/website/www/site/layouts/shortcodes/playground.html
+++ b/website/www/site/layouts/shortcodes/playground.html
@@ -79,7 +79,7 @@ See playground_snippet for all supported options.
     {{ $editable := 1 }}{{ if isset .Params "editable" }}{{ $editable = index .Params "editable" }}{{ end }}
     <div class="code-snippet code-snippet-playground">
         <iframe
-            src="https://play-dev.beam.apache.org/embedded?editable={{ $editable }}&examples={{ $snippets }}"
+            src="https://play.beam.apache.org/embedded?editable={{ $editable }}&examples={{ $snippets }}"
             width="100%"
             height="{{ .Get "height" }}"
             class="playground"

--- a/website/www/site/layouts/shortcodes/playground_iframe.html
+++ b/website/www/site/layouts/shortcodes/playground_iframe.html
@@ -12,7 +12,7 @@ limitations under the License. See accompanying LICENSE file.
 
 <div class="playground-iframe-wrapper-no-scroll">
     <iframe
-        src="https://play-dev.beam.apache.org/embedded?editable={{ .Get `editable` }}&example={{ .Get `example` }}&code={{ .Get `code` }}"
+        src="https://play.beam.apache.org/embedded?editable={{ .Get `editable` }}&example={{ .Get `example` }}&code={{ .Get `code` }}"
         width="100%"
         height="{{ .Get `height` }}"
         class="code-snippet playground"


### PR DESCRIPTION
Playground links were changed to stg environment in #25275.
Reverting to production PG instance

Resolves #26818