### PR TITLE
Structured logging support - Java SDK

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/SdkHarnessOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/SdkHarnessOptions.java
@@ -102,11 +102,10 @@ public interface SdkHarnessOptions extends PipelineOptions {
 
   void setSdkHarnessLogLevelOverrides(SdkHarnessLogLevelOverrides value);
 
-  /**
-   * Whether to include SLF4J MDC in log entries.
-   */
+  /** Whether to include SLF4J MDC in log entries. */
   @Experimental()
-  @Description("This option controls whether SLF4J MDC keys and values will be appended to log entries. This used by Beam to add structured data to log entries, such as quota events and return statuses.")
+  @Description(
+      "This option controls whether SLF4J MDC keys and values will be appended to log entries. This used by Beam to add structured data to log entries, such as quota events and return statuses.")
   @Default.Boolean(true)
   boolean getLogMdc();
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/SdkHarnessOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/SdkHarnessOptions.java
@@ -103,9 +103,11 @@ public interface SdkHarnessOptions extends PipelineOptions {
   void setSdkHarnessLogLevelOverrides(SdkHarnessLogLevelOverrides value);
 
   /** Whether to include SLF4J MDC in log entries. */
-  @Experimental()
+  @Experimental
   @Description(
-      "This option controls whether SLF4J MDC keys and values will be appended to log entries. This used by Beam to add structured data to log entries, such as quota events and return statuses.")
+      "This option controls whether SLF4J MDC keys and values will be appended to log entries. "
+          + "This used by Beam to add structured data to log entries, such as quota events and "
+          + "return statuses.")
   @Default.Boolean(true)
   boolean getLogMdc();
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/SdkHarnessOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/SdkHarnessOptions.java
@@ -103,7 +103,6 @@ public interface SdkHarnessOptions extends PipelineOptions {
   void setSdkHarnessLogLevelOverrides(SdkHarnessLogLevelOverrides value);
 
   /** Whether to include SLF4J MDC in log entries. */
-  @Experimental
   @Description(
       "This option controls whether SLF4J MDC keys and values will be appended to log entries. "
           + "This used by Beam to add structured data to log entries, such as quota events and "

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/SdkHarnessOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/SdkHarnessOptions.java
@@ -103,6 +103,16 @@ public interface SdkHarnessOptions extends PipelineOptions {
   void setSdkHarnessLogLevelOverrides(SdkHarnessLogLevelOverrides value);
 
   /**
+   * Whether to include SLF4J MDC in log entries.
+   */
+  @Experimental()
+  @Description("This option controls whether SLF4J MDC keys and values will be appended to log entries. This used by Beam to add structured data to log entries, such as quota events and return statuses.")
+  @Default.Boolean(true)
+  boolean getLogMdc();
+
+  void setLogMdc(boolean value);
+
+  /**
    * Size (in MB) of each grouping table used to pre-combine elements. Larger values may reduce the
    * amount of data shuffled. If unset, defaults to 100 MB.
    *

--- a/sdks/java/harness/jmh/src/main/java/org/apache/beam/fn/harness/jmh/logging/BeamFnLoggingClientBenchmark.java
+++ b/sdks/java/harness/jmh/src/main/java/org/apache/beam/fn/harness/jmh/logging/BeamFnLoggingClientBenchmark.java
@@ -43,6 +43,7 @@ import org.openjdk.jmh.annotations.TearDown;
 import org.openjdk.jmh.annotations.Threads;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.slf4j.MDC;
 
 /** Benchmarks for {@link BeamFnLoggingClient}. */
 public class BeamFnLoggingClientBenchmark {
@@ -190,6 +191,19 @@ public class BeamFnLoggingClientBenchmark {
       LOG.warn("log me");
     }
     BeamFnLoggingMDC.setInstructionId(null);
+  }
+
+  @Benchmark
+  @Threads(16) // Use several threads since we expect contention during logging
+  public void testLoggingWithCustomData(
+      ManyExpectedCallsLoggingClientAndService client, ManageExecutionState executionState)
+      throws Exception {
+    try (Closeable state =
+        executionState.executionStateTracker.enterState(executionState.simpleExecutionState)) {
+      try (Closeable mdc = MDC.putCloseable("key", "value")) {
+        LOG.warn("log me");
+      }
+    }
   }
 
   @Benchmark

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/logging/BeamFnLoggingClientTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/logging/BeamFnLoggingClientTest.java
@@ -41,7 +41,9 @@ import org.apache.beam.model.fnexecution.v1.BeamFnLoggingGrpc;
 import org.apache.beam.model.pipeline.v1.Endpoints;
 import org.apache.beam.sdk.fn.test.TestStreams;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.vendor.grpc.v1p54p0.com.google.protobuf.Struct;
 import org.apache.beam.vendor.grpc.v1p54p0.com.google.protobuf.Timestamp;
+import org.apache.beam.vendor.grpc.v1p54p0.com.google.protobuf.Value;
 import org.apache.beam.vendor.grpc.v1p54p0.io.grpc.ManagedChannel;
 import org.apache.beam.vendor.grpc.v1p54p0.io.grpc.Server;
 import org.apache.beam.vendor.grpc.v1p54p0.io.grpc.Status;
@@ -94,6 +96,7 @@ public class BeamFnLoggingClientTest {
           .setInstructionId("instruction-1")
           .setSeverity(BeamFnApi.LogEntry.Severity.Enum.DEBUG)
           .setMessage("testMdcValue:Message")
+          .setCustomData(Struct.newBuilder().putFields("testMdcKey", Value.newBuilder().setStringValue("testMdcValue").build()))
           .setThread("12345")
           .setTimestamp(Timestamp.newBuilder().setSeconds(1234567).setNanos(890000000).build())
           .setLogLocation("LoggerName")

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/logging/BeamFnLoggingClientTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/logging/BeamFnLoggingClientTest.java
@@ -96,7 +96,10 @@ public class BeamFnLoggingClientTest {
           .setInstructionId("instruction-1")
           .setSeverity(BeamFnApi.LogEntry.Severity.Enum.DEBUG)
           .setMessage("testMdcValue:Message")
-          .setCustomData(Struct.newBuilder().putFields("testMdcKey", Value.newBuilder().setStringValue("testMdcValue").build()))
+          .setCustomData(
+              Struct.newBuilder()
+                  .putFields(
+                      "testMdcKey", Value.newBuilder().setStringValue("testMdcValue").build()))
           .setThread("12345")
           .setTimestamp(Timestamp.newBuilder().setSeconds(1234567).setNanos(890000000).build())
           .setLogLocation("LoggerName")


### PR DESCRIPTION
edit: part of #26460

This enables logging data in the SLF4J MDC to the Fn Logging API by default.
This is safe:
1. No measurable change in performance (see below).
2. FnAPI changes are only in a new field (`custom_data`), which should be ignored by older implementations.

Benchmark | --logMdc | Mode | Cnt | Score (avg) | Error (CI 99.9%) | Units
-- | -- | -- | -- | -- | -- | --
BeamFnLoggingClientBenchmark.testLogging | FALSE | thrpt | 15 | 250797.094 | ± 6472.762 | ops/s
BeamFnLoggingClientBenchmark.testLoggingWithAllOptionalParameters | FALSE | thrpt | 15 | 248842.826 | ± 7465.302 | ops/s
BeamFnLoggingClientBenchmark.testLoggingWithCustomData | FALSE | thrpt | 15 | 240627.748 | ± 11956.723 | ops/s
BeamFnLoggingClientBenchmark.testLogging | TRUE | thrpt | 15 | 259780.715 | ± 2568.376 | ops/s
BeamFnLoggingClientBenchmark.testLoggingWithAllOptionalParameters | TRUE | thrpt | 15 | 258343.644 | ± 3613.817 | ops/s
BeamFnLoggingClientBenchmark.testLoggingWithCustomData | TRUE | thrpt | 15 | 253175.462 | ± 19008.712 | ops/s


Benchmark command: `./gradlew :sdks:java:harness:jmh:jmh -Pbenchmark=BeamFnLoggingClientBenchmark`
`--logMdc` set by changing the default value in SdkHarnessOption


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
