### PR TITLE
Fix Playground on home page with Safari

### DIFF
--- a/website/www/site/assets/js/language-switch-v2.js
+++ b/website/www/site/assets/js/language-switch-v2.js
@@ -208,16 +208,22 @@ $(document).ready(function() {
          *       send messages to them. This is cheap when the page only started loading.
          */
         "onInit": function (lang) {
-            const playgroundIframes = $(".code-snippet-playground iframe").get();
+            const playgroundIframeContainers = document.getElementsByClassName("code-snippet-playground");
             const sdk = this.langToSdk(lang);
 
-            for (const iframe of playgroundIframes) {
-                const url = new URL(iframe.src);
-                const searchParams = new URLSearchParams(url.search);
-                searchParams.set("sdk", sdk);
-                url.search = searchParams.toString();
-                console.log('Setting URL to', url.href);
-//                iframe.src = url.href;
+            for (const div of playgroundIframeContainers) {
+                const src = div.dataset.src;
+                const width = div.dataset.width;
+                const height = div.dataset.height;
+
+                const iframe = document.createElement('iframe');
+                iframe.src = src;
+                iframe.width = width;
+                iframe.height = height;
+                iframe.className = 'playground';
+                iframe.allow = 'clipboard-write';
+
+                div.appendChild(iframe);
             }
         },
 

--- a/website/www/site/assets/js/language-switch-v2.js
+++ b/website/www/site/assets/js/language-switch-v2.js
@@ -216,7 +216,8 @@ $(document).ready(function() {
                 const searchParams = new URLSearchParams(url.search);
                 searchParams.set("sdk", sdk);
                 url.search = searchParams.toString();
-                iframe.src = url.href;
+                console.log('Setting URL to', url.href);
+//                iframe.src = url.href;
             }
         },
 

--- a/website/www/site/assets/js/language-switch-v2.js
+++ b/website/www/site/assets/js/language-switch-v2.js
@@ -216,8 +216,13 @@ $(document).ready(function() {
                 const width = div.dataset.width;
                 const height = div.dataset.height;
 
+                const url = new URL(src);
+                const searchParams = new URLSearchParams(url.search);
+                searchParams.set("sdk", sdk);
+                url.search = searchParams.toString();
+
                 const iframe = document.createElement('iframe');
-                iframe.src = src;
+                iframe.src = url.href;
                 iframe.width = width;
                 iframe.height = height;
                 iframe.className = 'playground';

--- a/website/www/site/assets/scss/_playground.sass
+++ b/website/www/site/assets/scss/_playground.sass
@@ -39,10 +39,13 @@
   width: 100%
 
 @media (max-width: $mobile)
-  .playground
-    display: none
-  .playground__mobile
-    display: flex
+  .playground_or_image
+    .playground-wrapper
+      display: none
+    .playground__mobile
+      display: flex
+      img
+        box-shadow: 0 4px 16px 0 rgba(0, 0, 0, .16), 0 4px 4px 0 rgba(0, 0, 0, .16)
 
 @media (min-width: $mobile)
   .playground__mobile

--- a/website/www/site/layouts/index.html
+++ b/website/www/site/layouts/index.html
@@ -77,7 +77,7 @@ limitations under the License. See accompanying LICENSE file.
 
     <div
       class="code-snippet code-snippet-playground"
-      data-src="https://play.beam.apache.org/embedded?sdk=java&examples={{ jsonify $examples }}"
+      data-src="https://play.beam.apache.org/embedded?examples={{ jsonify $examples }}"
       data-width="100%"
       data-height="700px"
     ></div>

--- a/website/www/site/layouts/index.html
+++ b/website/www/site/layouts/index.html
@@ -57,31 +57,33 @@ limitations under the License. See accompanying LICENSE file.
   </p>
   <br>
   <br>
-  <a class="playground__mobile" href="https://play.beam.apache.org/">
-    <img src="images/playground.png" alt="beam playground">
-  </a>
+  <div class="playground_or_image">
+    <a class="playground__mobile" href="https://play.beam.apache.org/">
+      <img src="images/playground.png" alt="beam playground">
+    </a>
 
-  <div class="playground-wrapper">
-    <div class="playground-snippets">
-      <div class="language-java playground-snippet" data-sdk="java"></div>
-      <div class="language-py playground-snippet" data-sdk="python"></div>
-      <div class="language-go playground-snippet" data-sdk="go"></div>
-      <div class="language-scio playground-snippet" data-sdk="scio"></div>
+    <div class="playground-wrapper">
+      <div class="playground-snippets">
+        <div class="language-java playground-snippet" data-sdk="java"></div>
+        <div class="language-py playground-snippet" data-sdk="python"></div>
+        <div class="language-go playground-snippet" data-sdk="go"></div>
+        <div class="language-scio playground-snippet" data-sdk="scio"></div>
+      </div>
+
+      {{ $javaDict := dict "sdk" "java" "path" "SDK_JAVA_MinimalWordCount" }}
+      {{ $pythonDict := dict "sdk" "python" "path" "SDK_PYTHON_WordCountWithMetrics" }}
+      {{ $goDict := dict "sdk" "go" "path" "SDK_GO_MinimalWordCount" }}
+      {{ $scioDict := dict "sdk" "scio" "path" "SDK_SCIO_MinimalWordCount" }}
+      {{ $examples := slice $javaDict $pythonDict $goDict $scioDict }}
+
+      <div
+        class="code-snippet code-snippet-playground"
+        data-src="https://play.beam.apache.org/embedded?examples={{ jsonify $examples }}"
+        data-width="100%"
+        data-height="700px"
+      ></div>
+      <div class="playground-iframe-overlay"></div>
     </div>
-
-    {{ $javaDict := dict "sdk" "java" "path" "SDK_JAVA_MinimalWordCount" }}
-    {{ $pythonDict := dict "sdk" "python" "path" "SDK_PYTHON_WordCountWithMetrics" }}
-    {{ $goDict := dict "sdk" "go" "path" "SDK_GO_MinimalWordCount" }}
-    {{ $scioDict := dict "sdk" "scio" "path" "SDK_SCIO_MinimalWordCount" }}
-    {{ $examples := slice $javaDict $pythonDict $goDict $scioDict }}
-
-    <div
-      class="code-snippet code-snippet-playground"
-      data-src="https://play.beam.apache.org/embedded?examples={{ jsonify $examples }}"
-      data-width="100%"
-      data-height="700px"
-    ></div>
-    <div class="playground-iframe-overlay"></div>
   </div>
 </div>
 {{ end }}

--- a/website/www/site/layouts/index.html
+++ b/website/www/site/layouts/index.html
@@ -75,14 +75,12 @@ limitations under the License. See accompanying LICENSE file.
     {{ $scioDict := dict "sdk" "scio" "path" "SDK_SCIO_MinimalWordCount" }}
     {{ $examples := slice $javaDict $pythonDict $goDict $scioDict }}
 
-    <div class="code-snippet code-snippet-playground">
-      <iframe
-        src="https://play.beam.apache.org/embedded?sdk=java&examples={{ jsonify $examples }}"
-        width="100%"
-        height="700px"
-        allow="clipboard-write"
-      ></iframe>
-    </div>
+    <div
+      class="code-snippet code-snippet-playground"
+      data-src="https://play.beam.apache.org/embedded?sdk=java&examples={{ jsonify $examples }}"
+      data-width="100%"
+      data-height="700px"
+    ></div>
     <div class="playground-iframe-overlay"></div>
   </div>
 </div>

--- a/website/www/site/layouts/shortcodes/playground.html
+++ b/website/www/site/layouts/shortcodes/playground.html
@@ -77,13 +77,10 @@ See playground_snippet for all supported options.
 
     {{ $snippets := printf "%s%s%s" "[" (delimit $snippetsList ",") "]" }}
     {{ $editable := 1 }}{{ if isset .Params "editable" }}{{ $editable = index .Params "editable" }}{{ end }}
-    <div class="code-snippet code-snippet-playground">
-        <iframe
-            src="https://play.beam.apache.org/embedded?editable={{ $editable }}&examples={{ $snippets }}"
-            width="100%"
-            height="{{ .Get "height" }}"
-            class="playground"
-            allow="clipboard-write"
-        ></iframe>
-    </div>
+    <div
+        class="code-snippet code-snippet-playground"
+        data-src="https://play.beam.apache.org/embedded?editable={{ $editable }}&examples={{ $snippets }}"
+        data-width="100%"
+        data-height="{{ .Get "height" }}"
+    ></div>
 </div>


### PR DESCRIPTION
- Resolves #26844 

See this stage: http://apache-beam-website-pull-requests.storage.googleapis.com/26860/index.html

With the root cause in Safari is still not found, this PR eliminates the change of the iframe's src at runtime. Instead of being in the static HTML, the playground iframes are now created in `language-switch-v2.js` file when the tabs are created. This solves the problem in Safari. This should improve performance a bit because we no longer interrupt iframes that started loading.

Also we had Playground not shown on mobile website, and only a screenshot instead. The click on the screenshot opens the standalone playground.

With Playground being used in examples in docs, it is no longer an option, although the mobile Playground is still unusable for edits and runs. So this PR shows playground instances even on mobile, unless they are in a `<div class="playground_or_image">` (on a home page).

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
