### PR TITLE
[SparkReceiverIO] Add startPollTimeoutSec parameter. Fix splitting of restriction

### DIFF
--- a/sdks/java/io/cdap/src/main/java/org/apache/beam/sdk/io/cdap/CdapIO.java
+++ b/sdks/java/io/cdap/src/main/java/org/apache/beam/sdk/io/cdap/CdapIO.java
@@ -152,7 +152,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *
  * <p>Optionally you can pass {@code pullFrequencySec} which is a delay in seconds between polling
  * for new records updates, you can pass {@code startOffset} which is inclusive start offset from
- * which the reading should be started.
+ * which the reading should be started. Also, you can pass {@code startPollTimeoutSec} which is
+ * delay in seconds before start polling.
  *
  * <p>{@link Plugin} is the Wrapper class for the Cdap Plugin. It contains main information about
  * the Plugin. The object of the {@link Plugin} class can be created with the {@link
@@ -186,6 +187,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *             .withKeyClass(String.class)
  *             .withValueClass(String.class)
  *             .withPullFrequencySec(1L)
+ *             .withStartPollTimeoutSec(2L)
  *             .withStartOffset(10L);
  * }</pre>
  */
@@ -226,6 +228,8 @@ public class CdapIO {
 
     abstract @Nullable Long getPullFrequencySec();
 
+    abstract @Nullable Long getStartPollTimeoutSec();
+
     abstract @Nullable Long getStartOffset();
 
     abstract Builder<K, V> toBuilder();
@@ -242,6 +246,8 @@ public class CdapIO {
       abstract Builder<K, V> setValueClass(Class<V> valueClass);
 
       abstract Builder<K, V> setPullFrequencySec(Long pullFrequencySec);
+
+      abstract Builder<K, V> setStartPollTimeoutSec(Long startPollTimeoutSec);
 
       abstract Builder<K, V> setStartOffset(Long startOffset);
 
@@ -288,6 +294,12 @@ public class CdapIO {
       return toBuilder().setPullFrequencySec(pullFrequencySec).build();
     }
 
+    /** Delay in seconds before start polling. Applicable only for streaming Cdap Plugins. */
+    public Read<K, V> withStartPollTimeoutSec(Long startPollTimeoutSec) {
+      checkArgument(startPollTimeoutSec != null, "Start poll timeout can not be null");
+      return toBuilder().setStartPollTimeoutSec(startPollTimeoutSec).build();
+    }
+
     /**
      * Inclusive start offset from which the reading should be started. Applicable only for
      * streaming Cdap Plugins.
@@ -326,6 +338,10 @@ public class CdapIO {
         Long pullFrequencySec = getPullFrequencySec();
         if (pullFrequencySec != null) {
           reader = reader.withPullFrequencySec(pullFrequencySec);
+        }
+        Long startPollTimeoutSec = getStartPollTimeoutSec();
+        if (startPollTimeoutSec != null) {
+          reader = reader.withStartPollTimeoutSec(startPollTimeoutSec);
         }
         Long startOffset = getStartOffset();
         if (startOffset != null) {

--- a/sdks/java/io/sparkreceiver/2/src/main/java/org/apache/beam/sdk/io/sparkreceiver/SparkReceiverIO.java
+++ b/sdks/java/io/sparkreceiver/2/src/main/java/org/apache/beam/sdk/io/sparkreceiver/SparkReceiverIO.java
@@ -50,7 +50,8 @@ import org.slf4j.LoggerFactory;
  * startOffset} which is inclusive start offset from which the reading should be started.
  *
  * <p>Optionally you can pass {@code pullFrequencySec} which is a delay in seconds between polling
- * for new records updates.
+ * for new records updates. Also, you can pass {@code startPollTimeoutSec} which is delay in seconds
+ * before start polling.
  *
  * <p>Example of {@link SparkReceiverIO#read()} usage:
  *
@@ -68,6 +69,7 @@ import org.slf4j.LoggerFactory;
  *      .withGetOffsetFn(Long::valueOf)
  *      .withTimestampFn(Instant::parse)
  *      .withPullFrequencySec(1L)
+ *      .withStartPollTimeoutSec(2L)
  *      .withStartOffset(10L)
  *      .withSparkReceiverBuilder(receiverBuilder);
  * }</pre>
@@ -93,6 +95,8 @@ public class SparkReceiverIO {
 
     abstract @Nullable Long getPullFrequencySec();
 
+    abstract @Nullable Long getStartPollTimeoutSec();
+
     abstract @Nullable Long getStartOffset();
 
     abstract Builder<V> toBuilder();
@@ -108,6 +112,8 @@ public class SparkReceiverIO {
       abstract Builder<V> setTimestampFn(SerializableFunction<V, Instant> timestampFn);
 
       abstract Builder<V> setPullFrequencySec(Long pullFrequencySec);
+
+      abstract Builder<V> setStartPollTimeoutSec(Long startPollTimeoutSec);
 
       abstract Builder<V> setStartOffset(Long startOffset);
 
@@ -137,6 +143,12 @@ public class SparkReceiverIO {
     public Read<V> withPullFrequencySec(Long pullFrequencySec) {
       checkArgument(pullFrequencySec != null, "Pull frequency can not be null");
       return toBuilder().setPullFrequencySec(pullFrequencySec).build();
+    }
+
+    /** Waiting time after the {@link Receiver} starts. Required to prepare for polling. */
+    public Read<V> withStartPollTimeoutSec(Long startPollTimeoutSec) {
+      checkArgument(startPollTimeoutSec != null, "Start poll timeout can not be null");
+      return toBuilder().setStartPollTimeoutSec(startPollTimeoutSec).build();
     }
 
     /** Inclusive start offset from which the reading should be started. */

--- a/sdks/java/io/sparkreceiver/2/src/test/java/org/apache/beam/sdk/io/sparkreceiver/ReadFromSparkReceiverWithOffsetDoFnTest.java
+++ b/sdks/java/io/sparkreceiver/2/src/test/java/org/apache/beam/sdk/io/sparkreceiver/ReadFromSparkReceiverWithOffsetDoFnTest.java
@@ -119,13 +119,14 @@ public class ReadFromSparkReceiverWithOffsetDoFnTest {
             TEST_ELEMENT, dofnInstance.initialRestriction(TEST_ELEMENT));
 
     assertTrue(offsetRangeTracker.tryClaim(0L));
+    // Split is not needed, because check done wasn't called
+    assertNull(offsetRangeTracker.trySplit(0d));
+
+    offsetRangeTracker.checkDone();
+    // Perform split because check done was called
     assertEquals(
         SplitResult.of(new OffsetRange(0, 1), new OffsetRange(1, Long.MAX_VALUE)),
         offsetRangeTracker.trySplit(0d));
-
-    offsetRangeTracker.checkDone();
-    // Split is not needed
-    assertNull(offsetRangeTracker.trySplit(0d));
   }
 
   @Test

--- a/sdks/java/io/sparkreceiver/2/src/test/java/org/apache/beam/sdk/io/sparkreceiver/SparkReceiverIOTest.java
+++ b/sdks/java/io/sparkreceiver/2/src/test/java/org/apache/beam/sdk/io/sparkreceiver/SparkReceiverIOTest.java
@@ -42,6 +42,7 @@ public class SparkReceiverIOTest {
   public static final TestPipelineOptions OPTIONS =
       TestPipeline.testingPipelineOptions().as(TestPipelineOptions.class);
   public static final long PULL_FREQUENCY_SEC = 1L;
+  public static final long START_POLL_TIMEOUT_SEC = 2L;
   public static final long START_OFFSET = 0L;
 
   static {
@@ -62,6 +63,7 @@ public class SparkReceiverIOTest {
             .withGetOffsetFn(offsetFn)
             .withTimestampFn(timestampFn)
             .withPullFrequencySec(PULL_FREQUENCY_SEC)
+            .withStartPollTimeoutSec(START_POLL_TIMEOUT_SEC)
             .withStartOffset(START_OFFSET)
             .withSparkReceiverBuilder(receiverBuilder);
 
@@ -96,6 +98,13 @@ public class SparkReceiverIOTest {
   }
 
   @Test
+  public void testReadObjectCreationFailsIfStartPollTimeoutSecIsNull() {
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> SparkReceiverIO.<String>read().withStartPollTimeoutSec(null));
+  }
+
+  @Test
   public void testReadObjectCreationFailsIfStartOffsetIsNull() {
     assertThrows(
         IllegalArgumentException.class, () -> SparkReceiverIO.<String>read().withStartOffset(null));
@@ -126,6 +135,7 @@ public class SparkReceiverIOTest {
             .withGetOffsetFn(Long::valueOf)
             .withTimestampFn(Instant::parse)
             .withPullFrequencySec(PULL_FREQUENCY_SEC)
+            .withStartPollTimeoutSec(START_POLL_TIMEOUT_SEC)
             .withStartOffset(START_OFFSET)
             .withSparkReceiverBuilder(receiverBuilder);
 
@@ -149,6 +159,7 @@ public class SparkReceiverIOTest {
             .withGetOffsetFn(Long::valueOf)
             .withTimestampFn(Instant::parse)
             .withPullFrequencySec(PULL_FREQUENCY_SEC)
+            .withStartPollTimeoutSec(START_POLL_TIMEOUT_SEC)
             .withStartOffset(START_OFFSET)
             .withSparkReceiverBuilder(receiverBuilder);
 
@@ -171,6 +182,7 @@ public class SparkReceiverIOTest {
             .withGetOffsetFn(Long::valueOf)
             .withTimestampFn(Instant::parse)
             .withPullFrequencySec(PULL_FREQUENCY_SEC)
+            .withStartPollTimeoutSec(START_POLL_TIMEOUT_SEC)
             .withStartOffset(START_OFFSET)
             .withSparkReceiverBuilder(receiverBuilder);
 
@@ -193,6 +205,7 @@ public class SparkReceiverIOTest {
             .withGetOffsetFn(Long::valueOf)
             .withTimestampFn(Instant::parse)
             .withPullFrequencySec(PULL_FREQUENCY_SEC)
+            .withStartPollTimeoutSec(START_POLL_TIMEOUT_SEC)
             .withStartOffset(START_OFFSET)
             .withSparkReceiverBuilder(receiverBuilder);
 
@@ -215,6 +228,7 @@ public class SparkReceiverIOTest {
             .withGetOffsetFn(Long::valueOf)
             .withTimestampFn(Instant::parse)
             .withPullFrequencySec(PULL_FREQUENCY_SEC)
+            .withStartPollTimeoutSec(START_POLL_TIMEOUT_SEC)
             .withStartOffset(START_OFFSET)
             .withSparkReceiverBuilder(receiverBuilder);
 


### PR DESCRIPTION
- Resolves #26621 
- Added `startPollTimeoutSec` parameter to `SparkReceiverIO` and `CdapIO` (previously it was constant)

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
