### PR TITLE
Cherry-pick: Always invalidate write stream (#26872)

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
@@ -609,6 +609,8 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
                   retrieveErrorDetails(contexts));
               failedContext.failureCount += 1;
 
+              invalidateWriteStream();
+
               // Maximum number of times we retry before we fail the work item.
               if (failedContext.failureCount > 5) {
                 throw new RuntimeException("More than 5 attempts to call AppendRows failed.");
@@ -640,8 +642,6 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
                         + " failed with stream "
                         + "doesn't exist");
               }
-
-              invalidateWriteStream();
 
               appendFailures.inc();
               return RetryType.RETRY_ALL_OPERATIONS;


### PR DESCRIPTION
Cherry-picking https://github.com/apache/beam/pull/26872 to Beam 2.48.0