### PR TITLE
Cherry-pick: Capture all writes to the failed records in a metric (#26878)

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
@@ -458,6 +458,7 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
               // outputting to the
               // failed-rows consumer.
               org.joda.time.Instant timestamp = payload.getTimestamp();
+              rowsSentToFailedRowsCollection.inc();
               failedRowsReceiver.outputWithTimestamp(
                   new BigQueryStorageApiInsertError(tableRow, e.toString()),
                   timestamp != null ? timestamp : elementTs);
@@ -510,6 +511,7 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
                     failedRow, "Row payload too large. Maximum size " + maxRequestSize),
                 timestamp);
           }
+          rowsSentToFailedRowsCollection.inc(inserts.getSerializedRowsCount());
           return 0;
         }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWritesShardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWritesShardedRecords.java
@@ -495,11 +495,13 @@ public class StorageApiWritesShardedRecords<DestinationT extends @NonNull Object
               splitSize,
               (fields, ignore) -> appendClientInfo.get().encodeUnknownFields(fields, ignore),
               bytes -> appendClientInfo.get().toTableRow(bytes),
-              (failedRow, errorMessage) ->
-                  o.get(failedRowsTag)
-                      .outputWithTimestamp(
-                          new BigQueryStorageApiInsertError(failedRow.getValue(), errorMessage),
-                          failedRow.getTimestamp()),
+              (failedRow, errorMessage) -> {
+                o.get(failedRowsTag)
+                    .outputWithTimestamp(
+                        new BigQueryStorageApiInsertError(failedRow.getValue(), errorMessage),
+                        failedRow.getTimestamp());
+                rowsSentToFailedRowsCollection.inc();
+              },
               autoUpdateSchema,
               ignoreUnknownValues,
               elementTs);
@@ -722,6 +724,7 @@ public class StorageApiWritesShardedRecords<DestinationT extends @NonNull Object
                         failedRow, "Row payload too large. Maximum size " + maxRequestSize),
                     timestamp);
           }
+          rowsSentToFailedRowsCollection.inc(splitValue.getProtoRows().getSerializedRowsCount());
         } else {
           ++numAppends;
           // RetryManager


### PR DESCRIPTION
Cherry-picking https://github.com/apache/beam/pull/26878 to Beam 2.48.0