### PR TITLE
fix output_handler

### DIFF
--- a/sdks/python/apache_beam/runners/direct/sdf_direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/sdf_direct_runner.py
@@ -121,7 +121,7 @@ class PairWithRestrictionFn(beam.DoFn):
   def start_bundle(self):
     self._invoker = DoFnInvoker.create_invoker(
         self._signature,
-        output_processor=_NoneShallPassOutputHandler(),
+        output_handler=_NoneShallPassOutputHandler(),
         process_invocation=False)
 
   def process(self, element, window=beam.DoFn.WindowParam, *args, **kwargs):
@@ -142,7 +142,7 @@ class SplitRestrictionFn(beam.DoFn):
     signature = DoFnSignature(self._do_fn)
     self._invoker = DoFnInvoker.create_invoker(
         signature,
-        output_processor=_NoneShallPassOutputHandler(),
+        output_handler=_NoneShallPassOutputHandler(),
         process_invocation=False)
 
   def process(self, element_and_restriction, *args, **kwargs):
@@ -273,7 +273,7 @@ class ProcessFn(beam.DoFn):
     self.sdf_invoker = DoFnInvoker.create_invoker(
         DoFnSignature(self.sdf),
         context=DoFnContext('unused_context'),
-        output_processor=self._output_processor,
+        output_handler=self._output_processor,
         input_args=args_for_invoker,
         input_kwargs=kwargs_for_invoker)
 

--- a/sdks/python/apache_beam/transforms/util_test.py
+++ b/sdks/python/apache_beam/transforms/util_test.py
@@ -19,10 +19,12 @@
 
 # pytype: skip-file
 
+import json
 import logging
 import math
 import random
 import re
+import tempfile
 import time
 import unittest
 import warnings
@@ -901,6 +903,19 @@ class GroupIntoBatchesTest(unittest.TestCase):
                       GroupIntoBatchesTest.NUM_ELEMENTS /
                       GroupIntoBatchesTest.BATCH_SIZE))
           ]))
+
+  def test_in_global_window_with_text_file(self):
+    with self.assertRaises(NotImplementedError):
+      with tempfile.NamedTemporaryFile(suffix=".json") as f:
+        with open(f.name, "w") as fh:
+          json.dump(GroupIntoBatchesTest._create_test_data(), fh)
+        with TestPipeline() as pipeline:
+          collection = pipeline \
+                      | beam.io.ReadFromText(file_pattern=f.name) \
+                      | beam.Map(lambda e: json.loads(e)) \
+                      | beam.Map(lambda e: (e["key"], e)) \
+                      | util.GroupIntoBatches(GroupIntoBatchesTest.BATCH_SIZE)
+          assert collection
 
   def test_with_sharded_key_in_global_window(self):
     with TestPipeline() as pipeline:

--- a/sdks/python/apache_beam/transforms/util_test.py
+++ b/sdks/python/apache_beam/transforms/util_test.py
@@ -905,10 +905,10 @@ class GroupIntoBatchesTest(unittest.TestCase):
           ]))
 
   def test_in_global_window_with_text_file(self):
-    with self.assertRaises(NotImplementedError):
-      with tempfile.NamedTemporaryFile(suffix=".json") as f:
-        with open(f.name, "w") as fh:
-          json.dump(GroupIntoBatchesTest._create_test_data(), fh)
+    with tempfile.NamedTemporaryFile(suffix=".json") as f:
+      with open(f.name, "w") as fh:
+        json.dump(GroupIntoBatchesTest._create_test_data(), fh)
+      with self.assertRaises(RuntimeError):
         with TestPipeline() as pipeline:
           collection = pipeline \
                       | beam.io.ReadFromText(file_pattern=f.name) \

--- a/sdks/python/apache_beam/transforms/util_test.py
+++ b/sdks/python/apache_beam/transforms/util_test.py
@@ -906,10 +906,12 @@ class GroupIntoBatchesTest(unittest.TestCase):
           ]))
 
   def test_in_global_window_with_text_file(self):
-    # this test will raise asserts since DirectRunner misses features
-    with tempfile.NamedTemporaryFile(suffix=".json") as f:
-      with open(f.name, "w") as fh:
-        json.dump(GroupIntoBatchesTest._create_test_data(), fh)
+    # this test will raise asserts since DirectRunner misses this feature:
+    # sdf_direct_runner currently does not support GroupIntoBatches
+    # from bundles of SDF source and will throw this AttributeError
+    with tempfile.NamedTemporaryFile(suffix=".json", mode="w+t") as f:
+      f.write(json.dumps(GroupIntoBatchesTest._create_test_data()))
+      f.flush()
       with self.assertRaises((RuntimeError, AttributeError)):
         with TestPipeline() as pipeline:
           collection = pipeline \
@@ -920,7 +922,9 @@ class GroupIntoBatchesTest(unittest.TestCase):
           assert collection
 
   def test_in_global_window_with_synthetic_source(self):
-    # this test will raise asserts since DirectRunner misses features
+    # this test will raise asserts since DirectRunner misses this feature:
+    # sdf_direct_runner currently does not support GroupIntoBatches
+    # from bundles of SDF source and will throw this AttributeError
     with self.assertRaises((RuntimeError, AttributeError)):
       with beam.Pipeline() as pipeline:
         _ = (

--- a/sdks/python/apache_beam/transforms/util_test.py
+++ b/sdks/python/apache_beam/transforms/util_test.py
@@ -908,7 +908,7 @@ class GroupIntoBatchesTest(unittest.TestCase):
     with tempfile.NamedTemporaryFile(suffix=".json") as f:
       with open(f.name, "w") as fh:
         json.dump(GroupIntoBatchesTest._create_test_data(), fh)
-      with self.assertRaises(RuntimeError):
+      with self.assertRaises((RuntimeError, AttributeError)):
         with TestPipeline() as pipeline:
           collection = pipeline \
                       | beam.io.ReadFromText(file_pattern=f.name) \


### PR DESCRIPTION
Fix #26836

#19268 replaced OutputProcessor with OutputHandler but DoFnInvoker.create_invoker still uses `output_processor`.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
