### PR TITLE
Make lulls message in Python SDK to be consistent with the implementation in Java SDK 

### DIFF
--- a/sdks/python/apache_beam/runners/worker/worker_status_test.py
+++ b/sdks/python/apache_beam/runners/worker/worker_status_test.py
@@ -88,7 +88,7 @@ class FnApiWorkerStatusHandlerTest(unittest.TestCase):
 
   def test_log_lull_in_bundle_processor(self):
     def get_state_sampler_info_for_lull(lull_duration_s):
-      return statesampler.StateSamplerInfo(
+      return "bundle-id", statesampler.StateSamplerInfo(
           CounterName('progress-msecs', 'stage_name', 'step_name'),
           1,
           lull_duration_s * 1e9,
@@ -98,31 +98,33 @@ class FnApiWorkerStatusHandlerTest(unittest.TestCase):
     with mock.patch('logging.Logger.warning') as warn_mock:
       with mock.patch('time.time') as time_mock:
         time_mock.return_value = now
-        sampler_info = get_state_sampler_info_for_lull(21 * 60)
-        self.fn_status_handler._log_lull_sampler_info(sampler_info)
+        bundle_id, sampler_info = get_state_sampler_info_for_lull(21 * 60)
+        self.fn_status_handler._log_lull_sampler_info(sampler_info, bundle_id)
 
-        processing_template = warn_mock.call_args[0][1]
+        bundle_id_template = warn_mock.call_args[0][1]
         step_name_template = warn_mock.call_args[0][2]
-        traceback = warn_mock.call_args = warn_mock.call_args[0][3]
+        processing_template = warn_mock.call_args[0][3]
+        traceback = warn_mock.call_args = warn_mock.call_args[0][4]
 
-        self.assertIn('progress-msecs', processing_template)
+        self.assertIn('bundle-id', bundle_id_template)
         self.assertIn('step_name', step_name_template)
+        self.assertEquals(21 * 60, processing_template)
         self.assertIn('test_log_lull_in_bundle_processor', traceback)
 
       with mock.patch('time.time') as time_mock:
         time_mock.return_value = now + 6 * 60  # 6 minutes
-        sampler_info = get_state_sampler_info_for_lull(21 * 60)
-        self.fn_status_handler._log_lull_sampler_info(sampler_info)
+        bundle_id, sampler_info = get_state_sampler_info_for_lull(21 * 60)
+        self.fn_status_handler._log_lull_sampler_info(sampler_info, bundle_id)
 
       with mock.patch('time.time') as time_mock:
         time_mock.return_value = now + 21 * 60  # 21 minutes
-        sampler_info = get_state_sampler_info_for_lull(10 * 60)
-        self.fn_status_handler._log_lull_sampler_info(sampler_info)
+        bundle_id, sampler_info = get_state_sampler_info_for_lull(10 * 60)
+        self.fn_status_handler._log_lull_sampler_info(sampler_info, bundle_id)
 
       with mock.patch('time.time') as time_mock:
         time_mock.return_value = now + 42 * 60  # 21 minutes after previous one
-        sampler_info = get_state_sampler_info_for_lull(21 * 60)
-        self.fn_status_handler._log_lull_sampler_info(sampler_info)
+        bundle_id, sampler_info = get_state_sampler_info_for_lull(21 * 60)
+        self.fn_status_handler._log_lull_sampler_info(sampler_info, bundle_id)
 
 
 class HeapDumpTest(unittest.TestCase):

--- a/sdks/python/apache_beam/runners/worker/worker_status_test.py
+++ b/sdks/python/apache_beam/runners/worker/worker_status_test.py
@@ -108,7 +108,7 @@ class FnApiWorkerStatusHandlerTest(unittest.TestCase):
 
         self.assertIn('bundle-id', bundle_id_template)
         self.assertIn('step_name', step_name_template)
-        self.assertEquals(21 * 60, processing_template)
+        self.assertEqual(21 * 60, processing_template)
         self.assertIn('test_log_lull_in_bundle_processor', traceback)
 
       with mock.patch('time.time') as time_mock:


### PR DESCRIPTION
Resolves #26278 

Implementation in Java: [link](https://github.com/bzablocki/beam/blob/ff270573316b29c5a1d303ed53335ef6f7916635/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ExecutionStateSampler.java
https://github.com/apache/beam/blob/ff270573316b29c5a1d303ed53335ef6f7916635/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ExecutionStateSampler.java)

The message in Java is in the following format:
```
String.format(
    "Operation ongoing in bundle %s for PTransform{id=%s, name=%s, state=%s} for at least %s without outputting or completing:%n  at %s",
    processBundleId.get(),
    currentExecutionState.ptransformId,
    currentExecutionState.ptransformUniqueName,
    currentExecutionState.stateName,
    DURATION_FORMATTER.print(Duration.millis(lullTimeMs).toPeriod()),
    Joiner.on("\n  at ").join(thread.getStackTrace())));
```

The implementation in this PR will bring Python's lulls message closer to Java's format.
```
step_name_log = (
    ' for PTransform{name=%s, state=%s}' % (step_name, state_name))
     
stack_trace = self._get_stack_trace(sampler_info)

_LOGGER.warning(
    (
        'Operation ongoing in bundle %s%s for at least %.2f seconds'
        ' without outputting or completing.\n'
        'Current Traceback:\n%s'),
    instruction,
    step_name_log,
    lull_seconds,
    stack_trace,
)
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
