### PR TITLE
Make sure spark/flink get tagged correctly

### DIFF
--- a/runners/flink/job-server-container/flink_job_server_container.gradle
+++ b/runners/flink/job-server-container/flink_job_server_container.gradle
@@ -57,7 +57,11 @@ docker {
           name: project.docker_image_default_repo_prefix + "flink${project.parent.name}_job_server",
           root: project.rootProject.hasProperty(["docker-repository-root"]) ?
                   project.rootProject["docker-repository-root"] :
-                  project.docker_image_default_repo_root)
+                  project.docker_image_default_repo_root,
+          tag: project.rootProject.hasProperty(["docker-tag"]) ?
+                  project.rootProject["docker-tag"] : project.sdk_version)
+  // tags used by dockerTag task
+  tags containerImageTags()
   files "./build/"
 }
 

--- a/runners/spark/job-server/container/spark_job_server_container.gradle
+++ b/runners/spark/job-server/container/spark_job_server_container.gradle
@@ -55,7 +55,11 @@ docker {
   name containerImageName(name: project.docker_image_default_repo_prefix + spark_job_server_image,
                           root: project.rootProject.hasProperty(["docker-repository-root"]) ?
                                   project.rootProject["docker-repository-root"] :
-                                  project.docker_image_default_repo_root)
+                                  project.docker_image_default_repo_root,
+                          tag: project.rootProject.hasProperty(["docker-tag"]) ?
+                                  project.rootProject["docker-tag"] : project.sdk_version)
+  // tags used by dockerTag task
+  tags containerImageTags()
   files "./build/"
 }
 


### PR DESCRIPTION
Right now, when we run the [pushAllDockerImages](https://github.com/apache/beam/blob/205cbcea9b030ebd5c2dc6bd6479c5c381248aab/build.gradle.kts#L601) task to release, for most container images it pushes 2 tags for the image: `2.XX.0` and `2.XX.0.RCX`. For example, see https://hub.docker.com/r/apache/beam_python3.8_sdk/tags

For some images, though, we only publish the `2.XX.0` image. For example, https://hub.docker.com/r/apache/beam_spark3_job_server/tags needed a manual push to get the `2.48.RC2` tag. We should be consistent here.

This comes from different configurations of the gradle plugin.

Plugin - https://github.com/palantir/gradle-docker
Example doing it correctly - https://github.com/apache/beam/blob/205cbcea9b030ebd5c2dc6bd6479c5c381248aab/sdks/java/container/common.gradle#L107

This PR fixes the problem. I tested it against some local docker repos (e.g. https://hub.docker.com/repository/docker/damccorm/beam_flink1.12_job_server/tags?page=1&ordering=last_updated and https://hub.docker.com/repository/docker/damccorm/beam_spark3_job_server/tags?page=1&ordering=last_updated both show the `test` tag)

Fixes #26956

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
