### PR TITLE
Option to return timezone aware datetime for to_utc_datetime

### DIFF
--- a/sdks/python/apache_beam/utils/timestamp.py
+++ b/sdks/python/apache_beam/utils/timestamp.py
@@ -157,7 +157,7 @@ class Timestamp(object):
     return 'Timestamp(%s%d)' % (sign, int_part)
 
   def to_utc_datetime(self, has_tz=False):
-    # type: () -> datetime.datetime
+    # type: (bool) -> datetime.datetime
 
     """Returns a ``datetime.datetime`` object of UTC for this Timestamp.
 

--- a/sdks/python/apache_beam/utils/timestamp.py
+++ b/sdks/python/apache_beam/utils/timestamp.py
@@ -162,9 +162,9 @@ class Timestamp(object):
     """Returns a ``datetime.datetime`` object of UTC for this Timestamp.
 
     Note that this method returns a ``datetime.datetime`` object without a
-    timezone info by default, as builtin :func:`~datetime.datetime.utcnow`
-    method. If this is used as part of the processed data, one should set
-    has_tz=True to avoid offset due to default timezone mismatch.
+    timezone info by default, as builtin `datetime.datetime.utcnow` method. If
+    this is used as part of the processed data, one should set has_tz=True to
+    avoid offset due to default timezone mismatch.
 
     Args:
       has_tz: whether the timezone info is attached, default to False.

--- a/sdks/python/apache_beam/utils/timestamp.py
+++ b/sdks/python/apache_beam/utils/timestamp.py
@@ -161,6 +161,11 @@ class Timestamp(object):
 
     """Returns a ``datetime.datetime`` object of UTC for this Timestamp.
 
+    Note that this method returns a ``datetime.datetime`` object without a
+    timezone info by default, as builtin :func:`~datetime.datetime.utcnow`
+    method. If this is used as part of the processed data, one should set
+    has_tz=True to avoid offset due to default timezone mismatch.
+
     Args:
       has_tz: whether the timezone info is attached, default to False.
 

--- a/sdks/python/apache_beam/utils/timestamp.py
+++ b/sdks/python/apache_beam/utils/timestamp.py
@@ -156,12 +156,24 @@ class Timestamp(object):
       return 'Timestamp(%s%d.%06d)' % (sign, int_part, frac_part)
     return 'Timestamp(%s%d)' % (sign, int_part)
 
-  def to_utc_datetime(self):
+  def to_utc_datetime(self, has_tz=False):
     # type: () -> datetime.datetime
+
+    """Returns a ``datetime.datetime`` object of UTC for this Timestamp.
+
+    Args:
+      has_tz: whether the timezone info is attached, default to False.
+
+    Returns:
+      a ``datetime.datetime`` object of UTC for this Timestamp.
+    """
+
     # We can't easily construct a datetime object from microseconds, so we
     # create one at the epoch and add an appropriate timedelta interval.
-    return self._epoch_datetime_utc().replace(tzinfo=None) + datetime.timedelta(
-        microseconds=self.micros)
+    epoch = self._epoch_datetime_utc()
+    if not has_tz:
+      epoch = epoch.replace(tzinfo=None)
+    return epoch + datetime.timedelta(microseconds=self.micros)
 
   def to_rfc3339(self):
     # type: () -> str

--- a/sdks/python/apache_beam/utils/timestamp_test.py
+++ b/sdks/python/apache_beam/utils/timestamp_test.py
@@ -92,6 +92,11 @@ class TimestampTest(unittest.TestCase):
     with self.assertRaisesRegex(ValueError, r'dt has no timezone info'):
       Timestamp.from_utc_datetime(datetime.datetime(1970, 1, 1, tzinfo=None))
 
+  def test_from_to_utc_datetime(self):
+    timestamp = Timestamp(seconds=1458343379.123456)
+    dt = timestamp.to_utc_datetime(has_tz=True)
+    self.assertEqual(timestamp, Timestamp.from_utc_datetime(dt))
+
   def test_arithmetic(self):
     # Supported operations.
     self.assertEqual(Timestamp(123) + 456, 579)


### PR DESCRIPTION
Fixes #26942

The underlying issue is that the json and avro writer treat datetime.datetime object without time zone differently. The former assumes it is in local time zone while the latter assumes its UTC.

There is not a easy way to fix this discrepancy as change either will introduce a breaking change. For avro, it is not easy to warn user either, because the input PCollection element (dict) is sent to fastavro directly. Beam does not check the dict.

One thing we can do here is to add an option to Timestamp.to_utc_datetime to return a time zone aware datetime.datime object. This will work consistently for both json and avro temp file in the use case reported in #26942

Also added pydoc for Timestamp.to_utc_datetime.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
