### PR TITLE
Add explicit PortablePipelineOptions.enableHeapDumps to control heap dumping.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PortablePipelineOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/PortablePipelineOptions.java
@@ -123,4 +123,21 @@ public interface PortablePipelineOptions extends PipelineOptions, FileStagingOpt
 
     return "";
   }
+
+  /**
+   * If {@literal true} and PipelineOption tempLocation is set, save a heap dump before shutting
+   * down the JVM due to GC thrashing or out of memory. The heap will be dumped to local disk and
+   * then uploaded to the tempLocation.
+   *
+   * <p>CAUTION: Heap dumps can take up more disk than the JVM memory. Ensure the local disk is
+   * configured to have sufficient free space before enabling this option.
+   */
+  @Description(
+      "If {@literal true} and PipelineOption tempLocation is set, save a heap dump before shutting"
+          + " down the JVM due to GC thrashing or out of memory. The heap will be dumped to local"
+          + " disk and then uploaded to the tempLocation.")
+  @Default.Boolean(false)
+  boolean getEnableHeapDumps();
+
+  void setEnableHeapDumps(boolean enableHeapDumps);
 }

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/status/MemoryMonitor.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/status/MemoryMonitor.java
@@ -43,6 +43,7 @@ import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.CreateOptions.StandardCreateOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.PortablePipelineOptions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
@@ -202,7 +203,8 @@ public class MemoryMonitor implements Runnable {
 
   public static MemoryMonitor fromOptions(PipelineOptions options) {
     String uploadFilePath = options.getTempLocation();
-    boolean canDumpHeap = uploadFilePath != null;
+    PortablePipelineOptions portableOptions = options.as(PortablePipelineOptions.class);
+    boolean canDumpHeap = uploadFilePath != null && portableOptions.getEnableHeapDumps();
 
     return new MemoryMonitor(
         new SystemGCStatsProvider(),


### PR DESCRIPTION
This changed to be enabled by default for portable MemoryMonitor class compared to Dataflow MemoryMonitor class.
This can lead to heaps being dumped and written when not intended if the common tempFileLocation is set for other reasons such as BigQueryIO.

Heap dumping can cause issues if the disk fills up due to them.

fixes #26979 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
