### PR TITLE
Upgrade Node dependency to 14.x

### DIFF
--- a/website/Dockerfile
+++ b/website/Dockerfile
@@ -43,7 +43,7 @@ RUN apt-get update \
     && rm -rf /var/lib/apt/lists/*
 
 # Install node environment
-RUN curl -sL https://deb.nodesource.com/setup_10.x | bash - \
+RUN curl -sL https://deb.nodesource.com/setup_14.x | bash - \
     && apt-get update \
     && apt-get install -y --no-install-recommends \
         nodejs \


### PR DESCRIPTION
Upgrading Node version for the website the the most recent LTS.

When building the images, we get the following:

```
                              DEPRECATION WARNING

  Node.js 10.x is no longer actively supported!

  You will not receive security or critical stability updates for this version.

  You should migrate to a supported version of Node.js as soon as possible.
  Use the installation script that corresponds to the version of Node.js you
  wish to install. e.g.

   * https://deb.nodesource.com/setup_12.x — Node.js 12 LTS "Erbium"
   * https://deb.nodesource.com/setup_14.x — Node.js 14 LTS "Fermium" (recommended)
   * https://deb.nodesource.com/setup_16.x — Node.js 16 "Gallium"

  Please see https://github.com/nodejs/Release for details about which
  version may be appropriate for you.

  The NodeSource Node.js distributions repository contains
  information both about supported versions of Node.js and supported Linux
  distributions. To learn more about usage, see the repository:
    https://github.com/nodesource/distributions

```

I have tested `./gradlew :website:serveWebsite` and everything still works fine.