### PR TITLE
[Security] Upgrade snappy-java to 1.1.10.0

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -793,7 +793,7 @@ class BeamModulePlugin implements Plugin<Project> {
         slf4j_jul_to_slf4j                          : "org.slf4j:jul-to-slf4j:$slf4j_version",
         slf4j_log4j12                               : "org.slf4j:slf4j-log4j12:$slf4j_version",
         slf4j_jcl                                   : "org.slf4j:slf4j-jcl:$slf4j_version",
-        snappy_java                                 : "org.xerial.snappy:snappy-java:1.1.8.4",
+        snappy_java                                 : "org.xerial.snappy:snappy-java:1.1.10.0",
         spark_core                                  : "org.apache.spark:spark-core_2.11:$spark2_version",
         spark_streaming                             : "org.apache.spark:spark-streaming_2.11:$spark2_version",
         spark3_core                                 : "org.apache.spark:spark-core_2.12:$spark3_version",


### PR DESCRIPTION
`snappy-java` is currently 1.1.8.4, and is within a range for a couple of fixed CVEs:

CVE-2022-25168
CVE-2021-37404
CVE-2020-9492
CVE-2020-15250
CVE-2017-7669
CVE-2016-6811

(See https://mvnrepository.com/artifact/org.xerial.snappy/snappy-java/1.1.8.4)
