### PR TITLE
Upgrade parquet-hadoop to 1.13.1

### DIFF
--- a/sdks/java/io/parquet/build.gradle
+++ b/sdks/java/io/parquet/build.gradle
@@ -35,7 +35,7 @@ def hadoopVersions = [
 
 hadoopVersions.each {kv -> configurations.create("hadoopVersion$kv.key")}
 
-def parquet_version = "1.12.0"
+def parquet_version = "1.13.1"
 
 dependencies {
   implementation library.java.vendored_guava_26_0_jre


### PR DESCRIPTION
(Draft) Testing an upgrade to parquet-hadoop 1.13.1.
