### PR TITLE
Make use of prism in periodic tests not cross compile.

### DIFF
--- a/sdks/go/pkg/beam/transforms/periodic/periodic.go
+++ b/sdks/go/pkg/beam/transforms/periodic/periodic.go
@@ -100,7 +100,7 @@ func (fn *sequenceGenDoFn) ProcessElement(ctx context.Context, we *sdf.ManualWat
 	for currentOutputTimestamp.Before(currentTime) {
 		if rt.TryClaim(currentOutputIndex) {
 			emit(mtime.FromTime(currentOutputTimestamp), currentOutputIndex)
-			currentOutputIndex += 1
+			currentOutputIndex++
 			currentOutputTimestamp = mtime.Time(sd.Start).ToTime().Add(sd.Interval * time.Duration(currentOutputIndex))
 			currentTime = time.Now()
 			we.UpdateWatermark(currentOutputTimestamp)

--- a/sdks/go/pkg/beam/transforms/periodic/periodic_test.go
+++ b/sdks/go/pkg/beam/transforms/periodic/periodic_test.go
@@ -21,12 +21,16 @@ import (
 	"time"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/options/jobopts"
 	_ "github.com/apache/beam/sdks/v2/go/pkg/beam/runners/prism"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/testing/passert"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/testing/ptest"
 )
 
 func TestMain(m *testing.M) {
+	// Since we force loopback with prism, avoid cross-compilation.
+	f, _ := os.CreateTemp("", "dummy")
+	*jobopts.WorkerBinary = f.Name()
 	os.Exit(ptest.MainRetWithDefault(m, "prism"))
 }
 


### PR DESCRIPTION
Quick patch to avoid cross compiling the periodic test binary. It's the only test that defaults to prism right now.

It's up for consideration about making this the default mode for invocations of prism locally, which will continue to use loopback by default when it's the default runner. This makes the unit tests less sensitive to environments where the Go tooling may not be available, such as in a Bazel env.

Also: 
* Tiny lint change from += 1 to ++.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
