### PR TITLE
Fixes avro nyc trips example integration test case on Spark and Flink

### DIFF
--- a/sdks/python/apache_beam/examples/avro_nyc_trips_it_test.py
+++ b/sdks/python/apache_beam/examples/avro_nyc_trips_it_test.py
@@ -196,11 +196,16 @@ class AvroNycTripsIT(unittest.TestCase):
     avro_nyc_trips.run(test_pipeline.get_full_options_as_args(**extra_opts))
 
     # load result avro file and compare
-    metadata = FileSystems.match([f'{test_output}*'])[0].metadata_list[0]
-    with FileSystems.open(metadata.path) as f:
-      avro_reader = fastavro.reader(f)
+    metadata_list = FileSystems.match([f'{test_output}*'])[0].metadata_list
+    result = []
 
-      result = sorted(avro_reader, key=lambda x: x['service'])
+    for metadata in metadata_list:
+      with FileSystems.open(metadata.path) as f:
+        avro_reader = fastavro.reader(f)
+
+        result.extend(avro_reader)
+
+    result.sort(key=lambda x: x['service'])
 
     self.assertEqual(self.EXPECTED, result)
 


### PR DESCRIPTION
**Please** add a meaningful description for your change here

- fixes https://github.com/apache/beam/issues/27046
- reads all files from the metadata list rather than assuming both records will be in the first index. The spark/flink runners partition the data differently than the direct/dataflow runners and thus ended up with records in multiple files in the test case.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
