### PR TITLE
[prism] Move to a conditionVariable for messages+state stream + test.

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/jobservices/job.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/jobservices/job.go
@@ -29,6 +29,7 @@ import (
 	"fmt"
 	"sort"
 	"strings"
+	"sync"
 	"sync/atomic"
 
 	fnpb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/fnexecution_v1"
@@ -70,9 +71,12 @@ type Job struct {
 	options  *structpb.Struct
 
 	// Management side concerns.
-	msgChan   chan string
-	state     atomic.Value // jobpb.JobState_Enum
-	stateChan chan jobpb.JobState_Enum
+	streamCond *sync.Cond
+	// TODO, consider unifying messages and state to a single ordered buffer.
+	minMsg, maxMsg int // logical indices into the message slice
+	msgs           []string
+	stateIdx       int
+	state          atomic.Value // jobpb.JobState_Enum
 
 	// Context used to terminate this job.
 	RootCtx  context.Context
@@ -107,25 +111,50 @@ func (j *Job) LogValue() slog.Value {
 }
 
 func (j *Job) SendMsg(msg string) {
-	j.msgChan <- msg
+	j.streamCond.L.Lock()
+	defer j.streamCond.L.Unlock()
+	j.maxMsg++
+	// Trim so we never have more than 120 messages, keeping the last 100 for sure
+	// but amortize it so that messages are only trimmed every 20 messages beyond
+	// that.
+	// TODO, make this configurable
+	const buffered, trigger = 100, 20
+	if len(j.msgs) > buffered+trigger {
+		copy(j.msgs[0:], j.msgs[trigger:])
+		for k, n := len(j.msgs)-trigger, len(j.msgs); k < n; k++ {
+			j.msgs[k] = ""
+		}
+		j.msgs = j.msgs[:len(j.msgs)-trigger]
+		j.minMsg += trigger // increase the "min" message higher as a result.
+	}
+	j.msgs = append(j.msgs, msg)
+	j.streamCond.Broadcast()
+}
+
+func (j *Job) sendState(state jobpb.JobState_Enum) {
+	j.streamCond.L.Lock()
+	defer j.streamCond.L.Unlock()
+	j.stateIdx++
+	j.state.Store(state)
+	j.streamCond.Broadcast()
 }
 
 // Start indicates that the job is preparing to execute.
 func (j *Job) Start() {
-	j.stateChan <- jobpb.JobState_STARTING
+	j.sendState(jobpb.JobState_STARTING)
 }
 
 // Running indicates that the job is executing.
 func (j *Job) Running() {
-	j.stateChan <- jobpb.JobState_RUNNING
+	j.sendState(jobpb.JobState_RUNNING)
 }
 
 // Done indicates that the job completed successfully.
 func (j *Job) Done() {
-	j.stateChan <- jobpb.JobState_DONE
+	j.sendState(jobpb.JobState_DONE)
 }
 
 // Failed indicates that the job completed unsuccessfully.
 func (j *Job) Failed() {
-	j.stateChan <- jobpb.JobState_FAILED
+	j.sendState(jobpb.JobState_FAILED)
 }

--- a/sdks/go/pkg/beam/runners/prism/internal/jobservices/management_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/jobservices/management_test.go
@@ -17,6 +17,10 @@ package jobservices
 
 import (
 	"context"
+	"errors"
+	"fmt"
+	"io"
+	"net"
 	"sync"
 	"testing"
 
@@ -27,6 +31,9 @@ import (
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/runners/prism/internal/urns"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
+	"google.golang.org/grpc"
+	"google.golang.org/grpc/credentials/insecure"
+	"google.golang.org/grpc/test/bufconn"
 	"google.golang.org/protobuf/testing/protocmp"
 )
 
@@ -114,7 +121,7 @@ func TestServer(t *testing.T) {
 				if err != nil {
 					t.Errorf("GetPipeline(\"job-001\") = %v, want nil", err)
 				}
-				if diff := cmp.Diff(jobpb.GetJobMetricsResponse{
+				if diff := cmp.Diff(&jobpb.GetJobMetricsResponse{
 					Metrics: &jobpb.MetricResults{
 						Committed: []*pipepb.MonitoringInfo{
 							{
@@ -218,4 +225,225 @@ func TestServer(t *testing.T) {
 	}
 }
 
-// TODO impelment message stream test, once message/State implementation is sync.Cond based.
+func TestGetMessageStream(t *testing.T) {
+	wantName := "testJob"
+	wantPipeline := &pipepb.Pipeline{
+		Requirements: []string{urns.RequirementSplittableDoFn},
+	}
+	var called sync.WaitGroup
+	called.Add(1)
+	ctx, _, clientConn := serveTestServer(t, func(j *Job) {
+		j.Start()
+		j.SendMsg("job starting")
+		j.Running()
+		j.SendMsg("job running")
+		j.SendMsg("job finished")
+		j.Done()
+		j.SendMsg("job done")
+		called.Done()
+	})
+	jobCli := jobpb.NewJobServiceClient(clientConn)
+
+	// PreJob submission
+	msgStream, err := jobCli.GetMessageStream(ctx, &jobpb.JobMessagesRequest{
+		JobId: "job-001",
+	})
+	if err != nil {
+		t.Errorf("GetMessageStream: wanted successful connection, got %v", err)
+	}
+	_, err = msgStream.Recv()
+	if err == nil {
+		t.Error("wanted error on non-existent job, but didn't happen.")
+	}
+
+	prepResp, err := jobCli.Prepare(ctx, &jobpb.PrepareJobRequest{
+		Pipeline: wantPipeline,
+		JobName:  wantName,
+	})
+	if err != nil {
+		t.Fatalf("Prepare(%v) = %v, want nil", wantName, err)
+	}
+
+	// Post Job submission
+	msgStream, err = jobCli.GetMessageStream(ctx, &jobpb.JobMessagesRequest{
+		JobId: "job-001",
+	})
+	if err != nil {
+		t.Errorf("GetMessageStream: wanted successful connection, got %v", err)
+	}
+	stateResponse, err := msgStream.Recv()
+	if err != nil {
+		t.Errorf("GetMessageStream().Recv() = %v, want nil", err)
+	}
+	if got, want := stateResponse.GetStateResponse().GetState(), jobpb.JobState_STOPPED; got != want {
+		t.Errorf("GetMessageStream().Recv() = %v, want %v", got, want)
+	}
+
+	_, err = jobCli.Run(ctx, &jobpb.RunJobRequest{
+		PreparationId: prepResp.GetPreparationId(),
+	})
+	if err != nil {
+		t.Fatalf("Run(%v) = %v, want nil", wantName, err)
+	}
+
+	called.Wait() // Wait for the job to terminate.
+
+	receivedDone := false
+	var msgCount int
+	for {
+		// Continue with the same message stream.
+		resp, err := msgStream.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break // successful message stream completion
+			}
+			t.Errorf("GetMessageStream().Recv() = %v, want nil", err)
+		}
+		switch {
+
+		case resp.GetMessageResponse() != nil:
+			msgCount++
+		case resp.GetStateResponse() != nil:
+			if resp.GetStateResponse().GetState() == jobpb.JobState_DONE {
+				receivedDone = true
+			}
+		}
+	}
+	if got, want := msgCount, 4; got != want {
+		t.Errorf("GetMessageStream() didn't correct number of messages, got %v, want %v", got, want)
+	}
+	if !receivedDone {
+		t.Error("GetMessageStream() didn't return job done state")
+	}
+	msgStream.CloseSend()
+
+	// Create a new message stream, we should still get a tail of messages (in this case, all of them)
+	// And the final state.
+	msgStream, err = jobCli.GetMessageStream(ctx, &jobpb.JobMessagesRequest{
+		JobId: "job-001",
+	})
+	if err != nil {
+		t.Errorf("GetMessageStream: wanted successful connection, got %v", err)
+	}
+
+	receivedDone = false
+	msgCount = 0
+	for {
+		// Continue with the same message stream.
+		resp, err := msgStream.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break // successful message stream completion
+			}
+			t.Errorf("GetMessageStream().Recv() = %v, want nil", err)
+		}
+		switch {
+
+		case resp.GetMessageResponse() != nil:
+			msgCount++
+		case resp.GetStateResponse() != nil:
+			if resp.GetStateResponse().GetState() == jobpb.JobState_DONE {
+				receivedDone = true
+			}
+		}
+	}
+	if got, want := msgCount, 4; got != want {
+		t.Errorf("GetMessageStream() didn't correct number of messages, got %v, want %v", got, want)
+	}
+	if !receivedDone {
+		t.Error("GetMessageStream() didn't return job done state")
+	}
+}
+
+func TestGetMessageStream_BufferCycling(t *testing.T) {
+	wantName := "testJob"
+	wantPipeline := &pipepb.Pipeline{
+		Requirements: []string{urns.RequirementSplittableDoFn},
+	}
+	var called sync.WaitGroup
+	called.Add(1)
+	ctx, _, clientConn := serveTestServer(t, func(j *Job) {
+		j.Start()
+		// Using an offset from the trigger amount to ensure expected
+		// behavior (we can sometimes get more than the last 100 messages).
+		for i := 0; i < 512; i++ {
+			j.SendMsg(fmt.Sprintf("message number %v", i))
+		}
+		j.Done()
+		called.Done()
+	})
+	jobCli := jobpb.NewJobServiceClient(clientConn)
+
+	prepResp, err := jobCli.Prepare(ctx, &jobpb.PrepareJobRequest{
+		Pipeline: wantPipeline,
+		JobName:  wantName,
+	})
+	if err != nil {
+		t.Fatalf("Prepare(%v) = %v, want nil", wantName, err)
+	}
+	_, err = jobCli.Run(ctx, &jobpb.RunJobRequest{
+		PreparationId: prepResp.GetPreparationId(),
+	})
+	if err != nil {
+		t.Fatalf("Run(%v) = %v, want nil", wantName, err)
+	}
+
+	called.Wait() // Wait for the job to terminate.
+
+	// Create a new message stream, we should still get a tail of messages (in this case, all of them)
+	// And the final state.
+	msgStream, err := jobCli.GetMessageStream(ctx, &jobpb.JobMessagesRequest{
+		JobId: "job-001",
+	})
+	if err != nil {
+		t.Errorf("GetMessageStream: wanted successful connection, got %v", err)
+	}
+
+	receivedDone := false
+	var msgCount int
+	for {
+		// Continue with the same message stream.
+		resp, err := msgStream.Recv()
+		if err != nil {
+			if errors.Is(err, io.EOF) {
+				break // successful message stream completion
+			}
+			t.Errorf("GetMessageStream().Recv() = %v, want nil", err)
+		}
+		switch {
+		case resp.GetMessageResponse() != nil:
+			msgCount++
+		case resp.GetStateResponse() != nil:
+			if resp.GetStateResponse().GetState() == jobpb.JobState_DONE {
+				receivedDone = true
+			}
+		}
+	}
+	if got, want := msgCount, 112; got != want {
+		t.Errorf("GetMessageStream() didn't correct number of messages, got %v, want %v", got, want)
+	}
+	if !receivedDone {
+		t.Error("GetMessageStream() didn't return job done state")
+	}
+
+}
+
+func serveTestServer(t *testing.T, execute func(j *Job)) (context.Context, *Server, *grpc.ClientConn) {
+	t.Helper()
+	ctx, cancelFn := context.WithCancel(context.Background())
+	t.Cleanup(cancelFn)
+
+	s := NewServer(0, execute)
+	lis := bufconn.Listen(1024 * 64)
+	s.lis = lis
+	t.Cleanup(func() { s.Stop() })
+	go s.Serve()
+
+	clientConn, err := grpc.DialContext(ctx, "", grpc.WithContextDialer(func(ctx context.Context, _ string) (net.Conn, error) {
+		return lis.DialContext(ctx)
+	}), grpc.WithTransportCredentials(insecure.NewCredentials()), grpc.WithBlock())
+	if err != nil {
+		t.Fatal("couldn't create bufconn grpc connection:", err)
+	}
+	return ctx, s, clientConn
+}


### PR DESCRIPTION
This change was required to allow for testing, and allow multiple consumers to get the MessageStream at the same time.

In particular:
* The current state is always available to be returned on new streams.
* Messages are buffered to a fixed amount, so new subscribers can get the tail of previous messages. This will be useful for observing jobs from the UI.
* Buffer reduces the likelyhood of lock contention, but it's unlikely that prism will have a "too many subscribers" problem for the messages stream.

TODO in another PR: Timestamp state and message events. Consider just using a single unified buffer instead of having two versions.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
