### PR TITLE
Fix direct SDF runner handle_process_outputs

### DIFF
--- a/sdks/python/apache_beam/runners/common.pxd
+++ b/sdks/python/apache_beam/runners/common.pxd
@@ -46,7 +46,7 @@ cdef class MethodWrapper(object):
   cdef object key_arg_name
   cdef object restriction_provider
   cdef object restriction_provider_arg_name
-  cdef object watermark_estimator_provider
+  cdef public object watermark_estimator_provider
   cdef object watermark_estimator_provider_arg_name
   cdef object dynamic_timer_tag_arg_name
   cdef bint unbounded_per_element

--- a/sdks/python/apache_beam/runners/direct/sdf_direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/sdf_direct_runner.py
@@ -116,7 +116,10 @@ class ElementAndRestriction(object):
 class PairWithRestrictionFn(beam.DoFn):
   """A transform that pairs each element with a restriction."""
   def __init__(self, do_fn):
+    print("in PairWithRestrictionFn init", do_fn)
     self._signature = DoFnSignature(do_fn)
+    print("after PairWithRestrictionFn init", self._signature, self._signature.process_method)
+    print(self._signature.process_method.watermark_estimator_provider)
 
   def start_bundle(self):
     self._invoker = DoFnInvoker.create_invoker(
@@ -125,6 +128,7 @@ class PairWithRestrictionFn(beam.DoFn):
         process_invocation=False)
 
   def process(self, element, window=beam.DoFn.WindowParam, *args, **kwargs):
+    print("in process", self._signature, self._signature.process_method)
     initial_restriction = self._invoker.invoke_initial_restriction(element)
     watermark_estimator_state = (
         self._signature.process_method.watermark_estimator_provider.
@@ -289,6 +293,7 @@ class ProcessFn(beam.DoFn):
     self._step_context = step_context
 
   def set_process_element_invoker(self, process_element_invoker):
+    print('set_process_element_invoker', process_element_invoker)
     assert isinstance(process_element_invoker, SDFProcessElementInvoker)
     self._process_element_invoker = process_element_invoker
 
@@ -540,7 +545,7 @@ class _OutputHandler(OutputHandler):
   def __init__(self):
     self.output_iter = None
 
-  def process_outputs(
+  def handle_process_outputs(
       self, windowed_input_element, output_iter, watermark_estimator=None):
     # type: (WindowedValue, Iterable[Any], Optional[WatermarkEstimator]) -> None
     self.output_iter = output_iter
@@ -550,7 +555,7 @@ class _OutputHandler(OutputHandler):
 
 
 class _NoneShallPassOutputHandler(OutputHandler):
-  def process_outputs(
+  def handle_process_outputs(
       self, windowed_input_element, output_iter, watermark_estimator=None):
     # type: (WindowedValue, Iterable[Any], Optional[WatermarkEstimator]) -> None
     raise RuntimeError()

--- a/sdks/python/apache_beam/runners/direct/sdf_direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/sdf_direct_runner.py
@@ -116,10 +116,7 @@ class ElementAndRestriction(object):
 class PairWithRestrictionFn(beam.DoFn):
   """A transform that pairs each element with a restriction."""
   def __init__(self, do_fn):
-    print("in PairWithRestrictionFn init", do_fn)
     self._signature = DoFnSignature(do_fn)
-    print("after PairWithRestrictionFn init", self._signature, self._signature.process_method)
-    print(self._signature.process_method.watermark_estimator_provider)
 
   def start_bundle(self):
     self._invoker = DoFnInvoker.create_invoker(
@@ -128,7 +125,6 @@ class PairWithRestrictionFn(beam.DoFn):
         process_invocation=False)
 
   def process(self, element, window=beam.DoFn.WindowParam, *args, **kwargs):
-    print("in process", self._signature, self._signature.process_method)
     initial_restriction = self._invoker.invoke_initial_restriction(element)
     watermark_estimator_state = (
         self._signature.process_method.watermark_estimator_provider.
@@ -293,7 +289,6 @@ class ProcessFn(beam.DoFn):
     self._step_context = step_context
 
   def set_process_element_invoker(self, process_element_invoker):
-    print('set_process_element_invoker', process_element_invoker)
     assert isinstance(process_element_invoker, SDFProcessElementInvoker)
     self._process_element_invoker = process_element_invoker
 

--- a/sdks/python/apache_beam/transforms/util_test.py
+++ b/sdks/python/apache_beam/transforms/util_test.py
@@ -19,12 +19,10 @@
 
 # pytype: skip-file
 
-import json
 import logging
 import math
 import random
 import re
-import tempfile
 import time
 import unittest
 import warnings

--- a/sdks/python/apache_beam/transforms/util_test.py
+++ b/sdks/python/apache_beam/transforms/util_test.py
@@ -905,24 +905,6 @@ class GroupIntoBatchesTest(unittest.TestCase):
                       GroupIntoBatchesTest.BATCH_SIZE))
           ]))
 
-  # The test fails on certain Windows system with Permission Error read file
-  # Even succeeded, it fails with
-  # TypeError: list indices must be integers or slices, not str [while running
-  # 'Map(<lambda at util_test.py:916>)']
-  @unittest.skip("TypeError")
-  def test_in_global_window_with_text_file(self):
-    with tempfile.NamedTemporaryFile(suffix=".json", mode="w+t") as f:
-      f.write(json.dumps(GroupIntoBatchesTest._create_test_data()))
-      f.flush()
-      with self.assertRaises((RuntimeError, AttributeError)):
-        with TestPipeline() as pipeline:
-          collection = pipeline \
-                      | beam.io.ReadFromText(file_pattern=f.name) \
-                      | beam.Map(lambda e: json.loads(e)) \
-                      | beam.Map(lambda e: (e["key"], e)) \
-                      | util.GroupIntoBatches(GroupIntoBatchesTest.BATCH_SIZE)
-          assert collection
-
   def test_in_global_window_with_synthetic_source(self):
     with beam.Pipeline() as pipeline:
       collection = (


### PR DESCRIPTION
There are still two bugs after #26923, both are trivial

- watermark_estimator_provider not made public in cython. This results in the AttributeError seen in #26923
- The override method should named process_outputs -> handle_process_outputs

removed a test of duplicate purpose since it cannot be fixed, see reason in the first commit's comment

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
