### PR TITLE
Avro datum factory fixup

### DIFF
--- a/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/schemas/utils/AvroUtils.java
+++ b/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/schemas/utils/AvroUtils.java
@@ -153,7 +153,8 @@ public class AvroUtils {
   private static final ForLoadedType JODA_INSTANT = new ForLoadedType(Instant.class);
 
   public static void addLogicalTypeConversions(final GenericData data) {
-    data.addLogicalTypeConversion(new Conversions.DecimalConversion());
+    // do not add DecimalConversion by default as schema must have extra 'scale' and 'precision'
+    // properties. avro reflect already handles BigDecimal as string with the 'java-class' property
     data.addLogicalTypeConversion(new Conversions.UUIDConversion());
     // joda-time
     data.addLogicalTypeConversion(new AvroJodaTimeConversions.DateConversion());


### PR DESCRIPTION
Addressing post-merge comments for https://github.com/apache/beam/pull/26320

- Remove `DecimalConversion` from default logical-type conversions
- Restore `AvroCoder` cloud object compatibility by checking presence of previous fields.