### PR TITLE
renamed dictionary variable addresses #27166

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery_schema_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_schema_tools.py
@@ -77,7 +77,8 @@ def generate_user_type_from_bq_schema(the_table_schema):
           f"Encountered "
           f"an unsupported type: {the_schema['fields'][i]['type']!r}")
     field_names_and_types.append((the_schema['fields'][i]['name'], typ))
-  sample_schema = beam.typehints.schemas.named_fields_to_schema(field_names_and_types)
+  sample_schema = beam.typehints.schemas.named_fields_to_schema(
+      field_names_and_types)
   usertype = beam.typehints.schemas.named_tuple_from_schema(sample_schema)
   return usertype
 

--- a/sdks/python/apache_beam/io/gcp/bigquery_schema_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_schema_tools.py
@@ -76,7 +76,6 @@ def generate_user_type_from_bq_schema(the_table_schema):
       raise ValueError(
           f"Encountered "
           f"an unsupported type: {the_schema['fields'][i]['type']!r}")
-    # TODO @svetaksundhar: Map remaining BQ types
     field_names_and_types.append((the_schema['fields'][i]['name'], typ))
   sample_schema = beam.typehints.schemas.named_fields_to_schema(field_names_and_types)
   usertype = beam.typehints.schemas.named_tuple_from_schema(sample_schema)

--- a/sdks/python/apache_beam/io/gcp/bigquery_schema_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_schema_tools.py
@@ -67,7 +67,7 @@ def generate_user_type_from_bq_schema(the_table_schema):
       the_table_schema)
   if the_schema == {}:
     raise ValueError("Encountered an empty schema")
-  dict_of_tuples = []
+  field_names_and_types = []
   for i in range(len(the_schema['fields'])):
     if the_schema['fields'][i]['type'] in BIG_QUERY_TO_PYTHON_TYPES:
       typ = bq_field_to_type(
@@ -76,9 +76,9 @@ def generate_user_type_from_bq_schema(the_table_schema):
       raise ValueError(
           f"Encountered "
           f"an unsupported type: {the_schema['fields'][i]['type']!r}")
-    # TODO svetaksundhar@: Map remaining BQ types
-    dict_of_tuples.append((the_schema['fields'][i]['name'], typ))
-  sample_schema = beam.typehints.schemas.named_fields_to_schema(dict_of_tuples)
+    # TODO @svetaksundhar: Map remaining BQ types
+    field_names_and_types.append((the_schema['fields'][i]['name'], typ))
+  sample_schema = beam.typehints.schemas.named_fields_to_schema(field_names_and_types)
   usertype = beam.typehints.schemas.named_tuple_from_schema(sample_schema)
   return usertype
 


### PR DESCRIPTION
As dicussed in [issue 27166](https://github.com/apache/beam/issues/27166), broke down the changes of [PR 27166](https://github.com/apache/beam/pull/27199) and started with renaming of `dict_of_tuples` to `field_names_and_types`.

The entries in `field_names_and_types` could have the following content:
```python
print(field_names_and_types)
>>> [('string_feature_nullable', typing.Union[str, NoneType]),
>>>  ('timestamp_feature_nullable', typing.Union[apache_beam.utils.timestamp.Timestamp, NoneType]),
>>>  ('float_feature_repeated', typing.Sequence[numpy.float64]),
>>>  ('bytes_features_required', <class 'bytes'>]
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
