### PR TITLE
A sketch for a Pubsub source that maintains message ordering

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubClient.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubClient.java
@@ -482,6 +482,10 @@ public abstract class PubsubClient implements Closeable {
   public abstract void createSubscription(
       TopicPath topic, SubscriptionPath subscription, int ackDeadlineSeconds) throws IOException;
 
+  /** Create a {@code subscription} with ordered delivery guarantees for {@code topic}. */
+  public abstract void createOrderedSubscription(
+      TopicPath topic, SubscriptionPath subscription, int ackDeadlineSeconds) throws IOException;
+
   /**
    * Create a random subscription for {@code topic}. Return the {@link SubscriptionPath}. It is the
    * responsibility of the caller to later delete the subscription.

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubGrpcClient.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubGrpcClient.java
@@ -385,6 +385,19 @@ public class PubsubGrpcClient extends PubsubClient {
   }
 
   @Override
+  public void createOrderedSubscription(
+      TopicPath topic, SubscriptionPath subscription, int ackDeadlineSeconds) throws IOException {
+    Subscription request =
+        Subscription.newBuilder()
+            .setTopic(topic.getPath())
+            .setName(subscription.getPath())
+            .setAckDeadlineSeconds(ackDeadlineSeconds)
+            .setEnableMessageOrdering(true)
+            .build();
+    subscriberStub().createSubscription(request); // ignore Subscription result.
+  }
+
+  @Override
   public void deleteSubscription(SubscriptionPath subscription) throws IOException {
     DeleteSubscriptionRequest request =
         DeleteSubscriptionRequest.newBuilder().setSubscription(subscription.getPath()).build();

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubJsonClient.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubJsonClient.java
@@ -323,6 +323,21 @@ public class PubsubJsonClient extends PubsubClient {
   }
 
   @Override
+  public void createOrderedSubscription(
+      TopicPath topic, SubscriptionPath subscription, int ackDeadlineSeconds) throws IOException {
+    Subscription request =
+        new Subscription()
+            .setTopic(topic.getPath())
+            .setAckDeadlineSeconds(ackDeadlineSeconds)
+            .setEnableMessageOrdering(true);
+    pubsub
+        .projects()
+        .subscriptions()
+        .create(subscription.getPath(), request)
+        .execute(); // ignore Subscription result.
+  }
+
+  @Override
   public void deleteSubscription(SubscriptionPath subscription) throws IOException {
     pubsub
         .projects()

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubTestClient.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubTestClient.java
@@ -612,6 +612,12 @@ public class PubsubTestClient extends PubsubClient implements Serializable {
   }
 
   @Override
+  public void createOrderedSubscription(
+      TopicPath topic, SubscriptionPath subscription, int ackDeadlineSeconds) throws IOException {
+    throw new UnsupportedOperationException();
+  }
+
+  @Override
   public void deleteSubscription(SubscriptionPath subscription) throws IOException {
     throw new UnsupportedOperationException();
   }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/ReadOrderedMessages.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/ReadOrderedMessages.java
@@ -1,0 +1,195 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.pubsub;
+
+import com.google.cloud.pubsub.v1.stub.GrpcSubscriberStub;
+import com.google.cloud.pubsub.v1.stub.SubscriberStub;
+import com.google.cloud.pubsub.v1.stub.SubscriberStubSettings;
+import com.google.pubsub.v1.AcknowledgeRequest;
+import com.google.pubsub.v1.ProjectSubscriptionName;
+import com.google.pubsub.v1.PullRequest;
+import com.google.pubsub.v1.PullResponse;
+import com.google.pubsub.v1.ReceivedMessage;
+import java.io.IOException;
+import java.util.List;
+import java.util.stream.Collectors;
+import java.util.stream.IntStream;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.state.BagState;
+import org.apache.beam.sdk.state.StateSpec;
+import org.apache.beam.sdk.state.StateSpecs;
+import org.apache.beam.sdk.state.TimeDomain;
+import org.apache.beam.sdk.state.Timer;
+import org.apache.beam.sdk.state.TimerSpec;
+import org.apache.beam.sdk.state.TimerSpecs;
+import org.apache.beam.sdk.transforms.Create;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.FlatMapElements;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.Reshuffle;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PBegin;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TypeDescriptors;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
+import org.joda.time.Duration;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class ReadOrderedMessages extends PTransform<PBegin, PCollection<KV<byte[], byte[]>>> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(ReadOrderedMessages.class);
+
+  public static final Integer BATCH_SIZE = 100;
+  public static final Duration POLLING_INTERVAL = Duration.standardSeconds(2);
+  private final String subscription;
+  private final String project;
+
+  @Nullable private transient SubscriberStub pubsubStub = null;
+
+  private final Integer partitions;
+
+  public ReadOrderedMessages(String subscription, String project, Integer partitions) {
+    this.subscription = subscription;
+    this.project = project;
+    this.partitions = partitions;
+  }
+
+  @Override
+  public PCollection<KV<byte[], byte[]>> expand(PBegin input) {
+    return input
+        .getPipeline()
+        .apply(Create.of(0))
+        .apply(
+            FlatMapElements.into(
+                    TypeDescriptors.kvs(TypeDescriptors.integers(), TypeDescriptors.integers()))
+                .via(
+                    in ->
+                        IntStream.range(1, partitions)
+                            .boxed()
+                            .map(i -> KV.of(i, i))
+                            .collect(Collectors.toList())))
+        .apply(ParDo.of(new ConsumeOrderedPubsubPartitions()))
+        .apply(Reshuffle.of());
+  }
+
+  private class ConsumeOrderedPubsubPartitions
+      extends DoFn<KV<Integer, Integer>, KV<byte[], byte[]>> {
+
+    @SuppressWarnings("unused")
+    @TimerId("polling")
+    private final TimerSpec expirySpec = TimerSpecs.timer(TimeDomain.PROCESSING_TIME);
+
+    @SuppressWarnings("unused")
+    @StateId("toack")
+    private final StateSpec<BagState<String>> messagesToAck = StateSpecs.bag();
+
+    private SubscriberStub getPubsubStub() throws IOException {
+      if (pubsubStub == null) {
+        SubscriberStubSettings subscriberStubSettings =
+            SubscriberStubSettings.newBuilder()
+                .setTransportChannelProvider(
+                    SubscriberStubSettings.defaultGrpcTransportProviderBuilder()
+                        .setMaxInboundMessageSize(20 * 1024 * 1024) // 20MB (maximum message size).
+                        .build())
+                .build();
+
+        pubsubStub = GrpcSubscriberStub.create(subscriberStubSettings);
+      }
+      return pubsubStub;
+    }
+
+    private void consumeMessages(
+        OutputReceiver<KV<byte[], byte[]>> receiver, BagState<String> toAckState)
+        throws IOException {
+      String subscriptionName = ProjectSubscriptionName.format(project, subscription);
+      PullRequest pullRequest =
+          PullRequest.newBuilder()
+              .setMaxMessages(BATCH_SIZE)
+              .setSubscription(subscriptionName)
+              .build();
+
+      while (true) {
+        LOG.debug("Pulling messages with config: {}", pullRequest);
+        PullResponse pullResponse = getPubsubStub().pullCallable().call(pullRequest);
+        LOG.debug("Received {} messages", pullResponse.getReceivedMessagesList().size());
+        for (ReceivedMessage message : pullResponse.getReceivedMessagesList()) {
+          receiver.output(
+              KV.of(
+                  message.getMessage().getOrderingKeyBytes().toByteArray(),
+                  message.getMessage().getData().toByteArray()));
+          toAckState.add(message.getAckId());
+        }
+        // If we have pulled less than BATCH_SIZE, it means that we can take a break
+        // and restart pulling in the next cycle.
+        if (pullResponse.getReceivedMessagesList().size() <= BATCH_SIZE) {
+          break;
+        }
+      }
+    }
+
+    private void ackMessages(BagState<String> toAckState) throws IOException {
+      List<String> toack = Lists.newArrayList(toAckState.read());
+      if (toack.size() == 0) {
+        return;
+      }
+      LOG.debug("Acking {} messages.", toack);
+      getPubsubStub()
+          .acknowledgeCallable()
+          .call(
+              AcknowledgeRequest.newBuilder()
+                  .setSubscription(ProjectSubscriptionName.format(project, subscription))
+                  .addAllAckIds(toack)
+                  .build());
+      toAckState.clear();
+    }
+
+    @ProcessElement
+    public void process(
+        OutputReceiver<KV<byte[], byte[]>> receiver,
+        @Element KV<Integer, Integer> elm,
+        @TimerId("polling") Timer pollingTimer,
+        @StateId("toack") BagState<String> toAckState)
+        throws IOException {
+      ackMessages(toAckState);
+      consumeMessages(receiver, toAckState);
+      LOG.debug(
+          "Acklist for partition {} has {} elements",
+          elm.getKey(),
+          Lists.newArrayList(toAckState.read()).size());
+      pollingTimer.offset(POLLING_INTERVAL).setRelative();
+    }
+
+    @OnTimer("polling")
+    public void onPollingTimer(
+        @TimerId("polling") Timer pollingTimer,
+        OutputReceiver<KV<byte[], byte[]>> receiver,
+        @StateId("toack") BagState<String> toAckState,
+        @Key Integer key)
+        throws IOException {
+      ackMessages(toAckState);
+      consumeMessages(receiver, toAckState);
+      LOG.debug(
+          "Acklist for partition {} has {} elements",
+          key,
+          Lists.newArrayList(toAckState.read()).size());
+      pollingTimer.offset(POLLING_INTERVAL).setRelative();
+    }
+  }
+}

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/OrderedPubsubIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/OrderedPubsubIT.java
@@ -1,0 +1,148 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.pubsub;
+
+import com.google.protobuf.ByteString;
+import com.google.pubsub.v1.PubsubMessage;
+import java.io.IOException;
+import java.io.UnsupportedEncodingException;
+import java.nio.charset.StandardCharsets;
+import java.util.Collections;
+import java.util.Objects;
+import org.apache.beam.sdk.io.gcp.pubsub.PubsubClient.TopicPath;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.state.StateSpec;
+import org.apache.beam.sdk.state.StateSpecs;
+import org.apache.beam.sdk.state.ValueState;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.Lists;
+import org.joda.time.Instant;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/** Integration tests for {@link Schema} related {@link PubsubClient} operations. */
+@RunWith(JUnit4.class)
+public class OrderedPubsubIT {
+
+  private static final Logger LOG = LoggerFactory.getLogger(OrderedPubsubIT.class);
+
+  @Rule public transient TestPipeline pipeline = TestPipeline.create();
+  private static PubsubClient pubsubClient;
+
+  public static final String TOPIC_NAME = "ordered-delivery-test-topic";
+  private static TopicPath topic;
+  private static PubsubClient.SubscriptionPath subscription;
+
+  @BeforeClass
+  public static void setup() throws IOException {
+    PubsubOptions options = TestPipeline.testingPipelineOptions().as(PubsubOptions.class);
+    String project = options.getProject();
+    String postFix = "-" + Instant.now().getMillis();
+    pubsubClient = PubsubGrpcClient.FACTORY.newClient(null, null, options);
+    topic = PubsubClient.topicPathFromName(project, TOPIC_NAME + postFix);
+
+    pubsubClient.createTopic(topic);
+    subscription =
+        PubsubClient.subscriptionPathFromName(
+            project, "ordered-delivery-test-subscription" + postFix);
+    pubsubClient.createOrderedSubscription(topic, subscription, 30);
+  }
+
+  @AfterClass
+  public static void tearDown() throws IOException {
+    pubsubClient.deleteTopic(topic);
+    pubsubClient.close();
+  }
+
+  private void publishWithRetry(int i) {
+    while (true) {
+      try {
+        pubsubClient.publish(
+            topic,
+            Lists.newArrayList(
+                PubsubClient.OutgoingMessage.of(
+                    PubsubMessage.newBuilder()
+                        .setData(ByteString.copyFrom(String.format("%d", i).getBytes("utf8")))
+                        .setOrderingKey(String.format("%d", i % 7))
+                        .build(),
+                    12345,
+                    "key" + i,
+                    topic.getFullPath())));
+        return;
+      } catch (Exception e) {
+        LOG.error("problems with pubsub publish", e);
+      }
+    }
+  }
+
+  private void publishMessagesToPubsub() throws IOException, InterruptedException {
+    for (int i = 0; i < 5000; i++) {
+      publishWithRetry(i);
+      if (i % 100 == 0) {
+        System.out.println("Published " + i + " messages");
+        Thread.sleep(1000);
+      }
+    }
+  }
+
+  @Test
+  public void testReadOrderedMessages() throws IOException, InterruptedException {
+    publishMessagesToPubsub();
+
+    pipeline
+        .apply(new ReadOrderedMessages(subscription.getName(), "apache-beam-testing", 10))
+        .apply(ParDo.of(new VerifyOrderFn()));
+    pipeline.runWithAdditionalOptionArgs(Collections.singletonList("--streaming"));
+  }
+
+  private static class VerifyOrderFn extends DoFn<KV<byte[], byte[]>, KV<byte[], byte[]>> {
+
+    @SuppressWarnings("unused")
+    @StateId("lastKey")
+    private final StateSpec<ValueState<Integer>> lastKey = StateSpecs.value();
+
+    @ProcessElement
+    public void process(
+        @Element KV<byte[], byte[]> elm, @StateId("lastKey") ValueState<Integer> lastKey)
+        throws UnsupportedEncodingException {
+      Integer lastVal = lastKey.read();
+      Integer nextVal =
+          Integer.parseInt(
+              new String(Objects.requireNonNull(elm.getValue()), StandardCharsets.UTF_8));
+      if (lastVal != null && nextVal < lastVal) {
+        throw new RuntimeException(
+            "Out of order message for key "
+                + new String(Objects.requireNonNull(elm.getKey()), StandardCharsets.UTF_8)
+                + " lastVal "
+                + lastVal
+                + " nextVal "
+                + nextVal);
+      }
+      lastKey.write(nextVal);
+    }
+  }
+}


### PR DESCRIPTION
I need to document this (even if planning to leave it as a sketch). I will do that this week.


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
