### PR TITLE
[Security] Upgrade guava to 32.0.1-jre

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -535,7 +535,7 @@ class BeamModulePlugin implements Plugin<Project> {
     def google_oauth_clients_version = "1.34.1"
     // Try to keep grpc_version consistent with gRPC version in google_cloud_platform_libraries_bom
     def grpc_version = "1.55.1"
-    def guava_version = "31.1-jre"
+    def guava_version = "32.0.1-jre"
     def hadoop_version = "2.10.2"
     def hamcrest_version = "2.1"
     def influxdb_version = "2.19"


### PR DESCRIPTION
Update Guava due to CVE-2023-2976.

See advisory https://github.com/advisories/GHSA-7g45-4rm6-3mm3 for more information.