### PR TITLE
Fix PostCommit_XVR_JavaUsingPython_Dataflow fail cleanUpDockerJavaImages

### DIFF
--- a/runners/google-cloud-dataflow-java/scripts/cleanup_untagged_gcr_images.sh
+++ b/runners/google-cloud-dataflow-java/scripts/cleanup_untagged_gcr_images.sh
@@ -27,6 +27,7 @@ echo "${DIGESTS}" | while read -r digest; do
   if [[ ! -z "${digest}" ]]; then
     img="${IMAGE_NAME}@${digest}"
     echo "Removing untagged image ${img}"
-    gcloud container images delete --quiet "${img}"
+    # Tolerate 404 as tags may target to same image and already removed.
+    DELETE_RESULT="$(gcloud container images delete --quiet "${img}" 2>&1)" || [[ "$DELETE_RESULT" == *"'status': 404"* ]]
   fi
 done


### PR DESCRIPTION
https://ci-beam.apache.org/view/PostCommit/job/beam_PostCommit_XVR_JavaUsingPython_Dataflow/ failing last two runs. Log:

```
12:23:36 Deleted: sha256:94589e5cb50dd98f12f8d8c118546052172c76ab8eeebef93aecfc295c48e0e6
12:23:36 WARNING: Successfully resolved tag to sha256, but it is recommended to use sha256 directly.
12:23:37 Tag: [us.gcr.io/apache-beam-testing/java-postcommit-it/java:20230628154409]
12:23:37 - referencing digest: [us.gcr.io/apache-beam-testing/java-postcommit-it/java@sha256:26b9e84445a60cab3ee3f2bac8579d3ce884ff457143314f72679044f3124b83]
12:23:37 
12:23:37 Deleted [[us.gcr.io/apache-beam-testing/java-postcommit-it/java:20230628154409] (referencing [us.gcr.io/apache-beam-testing/java-postcommit-it/java@sha256:26b9e84445a60cab3ee3f2bac8579d3ce884ff457143314f72679044f3124b83])].
12:23:37 Removing untagged image us.gcr.io/apache-beam-testing/java-postcommit-it/java@sha256:26b9e84445a60cab3ee3f2bac8579d3ce884ff457143314f72679044f3124b83
12:23:41 Digests:
12:23:43 - us.gcr.io/apache-beam-testing/java-postcommit-it/java@sha256:26b9e84445a60cab3ee3f2bac8579d3ce884ff457143314f72679044f3124b83
12:23:43 ERROR: (gcloud.container.images.delete) Not found: response: {'docker-distribution-api-version': 'registry/2.0', 'content-type': 'application/json', 'content-encoding': 'gzip', 'date': 'Wed, 28 Jun 2023 16:23:44 GMT', 'server': 'Docker Registry', 'cache-control': 'private', 'x-xss-protection': '0', 'x-frame-options': 'SAMEORIGIN', 'transfer-encoding': 'chunked', 'status': 404}
12:23:44 Failed to compute blob liveness for manifest: 'sha256:26b9e84445a60cab3ee3f2bac8579d3ce884ff457143314f72679044f3124b83': None
```

Previously, the log was

```
00:31:05 WARNING: Successfully resolved tag to sha256, but it is recommended to use sha256 directly.
00:31:05 Tag: [us.gcr.io/apache-beam-testing/java-postcommit-it/java:20230628035445]
00:31:05 - referencing digest: [us.gcr.io/apache-beam-testing/java-postcommit-it/java@sha256:3a34ec683d49c49a59a8ddca38d671cc82c9cf4f7dbf1058aad0e688c8ecf362]
00:31:05 
00:31:05 Deleted [[us.gcr.io/apache-beam-testing/java-postcommit-it/java:20230628035445] (referencing [us.gcr.io/apache-beam-testing/java-postcommit-it/java@sha256:3a34ec683d49c49a59a8ddca38d671cc82c9cf4f7dbf1058aad0e688c8ecf362])].
00:31:05 Removing untagged image us.gcr.io/apache-beam-testing/java-postcommit-it/java@sha256:3a34ec683d49c49a59a8ddca38d671cc82c9cf4f7dbf1058aad0e688c8ecf362
00:31:06 Digests:
00:31:07 - us.gcr.io/apache-beam-testing/java-postcommit-it/java@sha256:3a34ec683d49c49a59a8ddca38d671cc82c9cf4f7dbf1058aad0e688c8ecf362
00:31:07 Deleted [us.gcr.io/apache-beam-testing/java-postcommit-it/java@sha256:3a34ec683d49c49a59a8ddca38d671cc82c9cf4f7dbf1058aad0e688c8ecf362].
```

Likely due to some internal optimization of container registry, now two tags now target to the same image, and deleting second one causes 404 and gcloud returns 1.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
