### PR TITLE
[Go SDK][Prism] Improve failed pipeline handling

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/execute_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/execute_test.go
@@ -418,6 +418,20 @@ func TestRunner_Metrics(t *testing.T) {
 	})
 }
 
+func TestFailure(t *testing.T) {
+	initRunner(t)
+
+	p, s := beam.NewPipelineWithRoot()
+	imp := beam.Impulse(s)
+	beam.ParDo(s, doFnFail, imp)
+	_, err := executeWithT(context.Background(), t, p)
+	if err == nil {
+		t.Fatalf("expected pipeline failure, but got a success")
+	}
+	// Job failure state reason isn't communicated with the state change over the API
+	// so we can't check for a reason here.
+}
+
 // TODO: PCollection metrics tests, in particular for element counts, in multi transform pipelines
 // There's a doubling bug since we re-use the same pcollection IDs for the source & sink, and
 // don't do any re-writing.

--- a/sdks/go/pkg/beam/runners/prism/internal/jobservices/management.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/jobservices/management.go
@@ -25,6 +25,7 @@ import (
 	pipepb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/pipeline_v1"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/runners/prism/internal/urns"
 	"golang.org/x/exp/slog"
+	"google.golang.org/protobuf/types/known/timestamppb"
 )
 
 func (s *Server) nextId() string {
@@ -81,8 +82,10 @@ func (s *Server) Prepare(ctx context.Context, req *jobpb.PrepareJobRequest) (*jo
 
 	// Queue initial state of the job.
 	job.state.Store(jobpb.JobState_STOPPED)
+	s.jobs[job.key] = job
 
 	if err := isSupported(job.Pipeline.GetRequirements()); err != nil {
+		job.Failed(err)
 		slog.Error("unable to run job", slog.String("error", err.Error()), slog.String("jobname", req.GetJobName()))
 		return nil, err
 	}
@@ -136,11 +139,12 @@ func (s *Server) Prepare(ctx context.Context, req *jobpb.PrepareJobRequest) (*jo
 		}
 	}
 	if len(errs) > 0 {
-		err := &joinError{errs: errs}
-		slog.Error("unable to run job", slog.String("cause", "unimplemented features"), slog.String("jobname", req.GetJobName()), slog.String("errors", err.Error()))
-		return nil, fmt.Errorf("found %v uses of features unimplemented in prism in job %v: %v", len(errs), req.GetJobName(), err)
+		jErr := &joinError{errs: errs}
+		slog.Error("unable to run job", slog.String("cause", "unimplemented features"), slog.String("jobname", req.GetJobName()), slog.String("errors", jErr.Error()))
+		err := fmt.Errorf("found %v uses of features unimplemented in prism in job %v: %v", len(errs), req.GetJobName(), jErr)
+		job.Failed(err)
+		return nil, err
 	}
-	s.jobs[job.key] = job
 	return &jobpb.PrepareJobResponse{
 		PreparationId:       job.key,
 		StagingSessionToken: job.key,
@@ -177,8 +181,6 @@ func (s *Server) GetMessageStream(req *jobpb.JobMessagesRequest, stream jobpb.Jo
 	defer job.streamCond.L.Unlock()
 	curMsg := job.minMsg
 	curState := job.stateIdx
-
-	stream.Context()
 
 	state := job.state.Load().(jobpb.JobState_Enum)
 	for {
@@ -283,6 +285,7 @@ func (s *Server) GetState(_ context.Context, req *jobpb.GetJobStateRequest) (*jo
 		return nil, fmt.Errorf("job with id %v not found", req.GetJobId())
 	}
 	return &jobpb.JobStateEvent{
-		State: j.state.Load().(jobpb.JobState_Enum),
+		State:     j.state.Load().(jobpb.JobState_Enum),
+		Timestamp: timestamppb.New(j.stateTime),
 	}, nil
 }

--- a/sdks/go/pkg/beam/runners/prism/internal/testdofns.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/testdofns.go
@@ -239,6 +239,11 @@ func dofn1Counter(ctx context.Context, _ []byte, emit func(int64)) {
 	beam.NewCounter(ns, "count").Inc(ctx, 1)
 }
 
+func doFnFail(ctx context.Context, _ []byte, emit func(int64)) error {
+	beam.NewCounter(ns, "count").Inc(ctx, 1)
+	return fmt.Errorf("doFnFail: failing as intended")
+}
+
 func combineIntSum(a, b int64) int64 {
 	return a + b
 }

--- a/sdks/go/pkg/beam/runners/prism/internal/testdofns_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/testdofns_test.go
@@ -47,6 +47,7 @@ func init() {
 	register.Function3x0(dofnGBK3)
 	register.Function3x0(dofn1Counter)
 	register.Function2x0(dofnSink)
+	register.Function3x1(doFnFail)
 
 	register.Function2x1(combineIntSum)
 

--- a/sdks/go/pkg/beam/runners/prism/internal/worker/bundle.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/bundle.go
@@ -56,6 +56,8 @@ type B struct {
 	Resp chan *fnpb.ProcessBundleResponse
 
 	SinkToPCollection map[string]string
+
+	Error string // Set on Respond.
 }
 
 // Init initializes the bundle's internal state for waiting on all
@@ -86,6 +88,11 @@ func (b *B) LogValue() slog.Value {
 }
 
 func (b *B) Respond(resp *fnpb.InstructionResponse) {
+	if resp.GetError() != "" {
+		b.Error = resp.GetError()
+		close(b.Resp)
+		return
+	}
 	b.Resp <- resp.GetProcessBundle()
 }
 

--- a/sdks/go/pkg/beam/runners/prism/internal/worker/worker.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/worker.go
@@ -233,19 +233,19 @@ func (wk *W) GetProcessBundleDescriptor(ctx context.Context, req *fnpb.GetProces
 //
 // Requests come from the runner, and are sent to the client in the SDK.
 func (wk *W) Control(ctrl fnpb.BeamFnControl_ControlServer) error {
-	done := make(chan bool)
+	done := make(chan struct{})
 	go func() {
 		for {
 			resp, err := ctrl.Recv()
 			if err == io.EOF {
 				slog.Debug("ctrl.Recv finished; marking done", "worker", wk)
-				done <- true // means stream is finished
+				done <- struct{}{} // means stream is finished
 				return
 			}
 			if err != nil {
 				switch status.Code(err) {
 				case codes.Canceled:
-					done <- true // means stream is finished
+					done <- struct{}{} // means stream is finished
 					return
 				default:
 					slog.Error("ctrl.Recv failed", err, "worker", wk)
@@ -258,9 +258,8 @@ func (wk *W) Control(ctrl fnpb.BeamFnControl_ControlServer) error {
 			if b, ok := wk.activeInstructions[resp.GetInstructionId()]; ok {
 				// TODO. Better pipeline error handling.
 				if resp.Error != "" {
-					slog.LogAttrs(context.TODO(), slog.LevelError, "ctrl.Recv pipeline error",
+					slog.LogAttrs(ctrl.Context(), slog.LevelError, "ctrl.Recv pipeline error",
 						slog.String("error", resp.GetError()))
-					panic(resp.GetError())
 				}
 				b.Respond(resp)
 			} else {
@@ -270,13 +269,18 @@ func (wk *W) Control(ctrl fnpb.BeamFnControl_ControlServer) error {
 		}
 	}()
 
-	for req := range wk.InstReqs {
-		ctrl.Send(req)
+	for {
+		select {
+		case req := <-wk.InstReqs:
+			ctrl.Send(req)
+		case <-ctrl.Context().Done():
+			slog.Debug("Control context canceled")
+			return ctrl.Context().Err()
+		case <-done:
+			slog.Debug("Control done")
+			return nil
+		}
 	}
-	slog.Debug("ctrl.Send finished waiting on done")
-	<-done
-	slog.Debug("Control done")
-	return nil
 }
 
 // Data relays elements and timer bytes to SDKs and back again, coordinated via


### PR DESCRIPTION
* Include jobs failed by requirements reasons pre-execution in the job list.
* More gracefully handle DoFn/SDK harness bundle failures instead of panicking the runner.
* Adds context cancelation observation to the server side Control implementation.

This adds an initial spot where Retries might be added in the future, and a single point for where Job error messages will flow. Still todo is the right way to surface the actual failure message to the user rather than in the runner logs, since job failure states don't include messages. Likely would pass/extract these along the message stream, which could also surface them on the UI and API.

An SDK side change could be made to try and extract the last message from the job management server if available, and produce that with the returned error, but this would be SDK specific and per SDK without a more involved JobManagement API change proposal.

This isn't a comprehensive overhaul of job abort, which likely needs more work. I suspect that the full failure flow will need additional investigation, such as when there are additional extant elements, and ensuring stray goroutines are cleaned up.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
