### PR TITLE
[#27312] fix(JmsIO): create a session pool for JmsIO #27312

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -58,7 +58,8 @@
 
 ## I/Os
 
-* Support for X source added (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
+* Add Jms pool session to control number of connections (Java) ([#27312](https://github.com/apache/beam/issues/27312)).
+* Fixed JmsIO unit tests trying to bind on a hard coded port number (Java) ([#26203](https://github.com/apache/beam/issues/26203)).
 * Support for Bigtable Change Streams added in Java `BigtableIO.ReadChangeStream` ([#27183](https://github.com/apache/beam/issues/27183))
 
 ## New Features / Improvements

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -637,6 +637,7 @@ class BeamModulePlugin implements Plugin<Project> {
         commons_lang3                               : "org.apache.commons:commons-lang3:3.9",
         commons_logging                             : "commons-logging:commons-logging:1.2",
         commons_math3                               : "org.apache.commons:commons-math3:3.6.1",
+        commons_pool2                               : "org.apache.commons:commons-pool2:2.11.1",
         dbcp2                                       : "org.apache.commons:commons-dbcp2:$dbcp2_version",
         error_prone_annotations                     : "com.google.errorprone:error_prone_annotations:$errorprone_version",
         flogger_system_backend                      : "com.google.flogger:flogger-system-backend:0.7.3",

--- a/sdks/java/io/jdbc/build.gradle
+++ b/sdks/java/io/jdbc/build.gradle
@@ -31,7 +31,7 @@ dependencies {
   implementation project(path: ":sdks:java:core", configuration: "shadow")
   implementation library.java.dbcp2
   implementation library.java.joda_time
-  implementation "org.apache.commons:commons-pool2:2.11.1"
+  implementation library.java.commons_pool2
   implementation library.java.slf4j_api
   testImplementation "org.apache.derby:derby:10.14.2.0"
   testImplementation "org.apache.derby:derbyclient:10.14.2.0"

--- a/sdks/java/io/jms/build.gradle
+++ b/sdks/java/io/jms/build.gradle
@@ -32,6 +32,7 @@ dependencies {
   implementation project(path: ":sdks:java:core", configuration: "shadow")
   implementation library.java.slf4j_api
   implementation library.java.joda_time
+  implementation library.java.commons_pool2
   implementation "org.apache.geronimo.specs:geronimo-jms_1.1_spec:1.1.1"
   testImplementation library.java.activemq_amqp
   testImplementation library.java.activemq_broker

--- a/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/pool/JmsPoolConfiguration.java
+++ b/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/pool/JmsPoolConfiguration.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.jms.pool;
+
+import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions.checkArgument;
+
+import com.google.auto.value.AutoValue;
+import java.io.Serializable;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.joda.time.Duration;
+
+@AutoValue
+public abstract class JmsPoolConfiguration implements Serializable {
+  private static final Integer DEFAULT_MAX_ACTIVE_CONNECTIONS = 100;
+  private static final Integer DEFAULT_INITIAL_ACTIVE_CONNECTIONS = 20;
+  private static final Duration DEFAULT_MAX_TIMEOUT_DURATION = Duration.standardMinutes(5);
+
+  abstract int getMaxActiveConnections();
+
+  public abstract int getInitialActiveConnections();
+
+  public abstract Duration getMaxTimeout();
+
+  public static JmsPoolConfiguration create() {
+    return create(DEFAULT_MAX_ACTIVE_CONNECTIONS, DEFAULT_INITIAL_ACTIVE_CONNECTIONS, null);
+  }
+
+  public static JmsPoolConfiguration create(
+      int maxActiveConnections, int initialActiveConnections, @Nullable Duration maxTimeout) {
+    checkArgument(maxActiveConnections > 0, "maxActiveConnections should be greater than 0");
+    checkArgument(
+        initialActiveConnections > 0, "initialActiveConnections should be greater than 0");
+
+    if (maxTimeout == null || maxTimeout.equals(Duration.ZERO)) {
+      maxTimeout = DEFAULT_MAX_TIMEOUT_DURATION;
+    }
+
+    return new AutoValue_JmsPoolConfiguration.Builder()
+        .setMaxActiveConnections(maxActiveConnections)
+        .setInitialActiveConnections(initialActiveConnections)
+        .setMaxTimeout(maxTimeout)
+        .build();
+  }
+
+  @AutoValue.Builder
+  abstract static class Builder {
+    abstract JmsPoolConfiguration.Builder setMaxActiveConnections(int maxActiveConnections);
+
+    abstract JmsPoolConfiguration.Builder setInitialActiveConnections(int initialActiveConnections);
+
+    abstract JmsPoolConfiguration.Builder setMaxTimeout(Duration maxTimeout);
+
+    abstract JmsPoolConfiguration build();
+  }
+}

--- a/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/pool/JmsSessionFactory.java
+++ b/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/pool/JmsSessionFactory.java
@@ -1,0 +1,122 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.jms.pool;
+
+import static org.apache.beam.sdk.io.jms.JmsIO.Writer.JMS_IO_PRODUCER_METRIC_NAME;
+
+import java.lang.reflect.InvocationTargetException;
+import java.lang.reflect.Method;
+import javax.jms.Connection;
+import javax.jms.ConnectionFactory;
+import javax.jms.JMSException;
+import javax.jms.Session;
+import org.apache.beam.sdk.io.jms.JmsIO;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
+import org.apache.commons.pool2.BasePooledObjectFactory;
+import org.apache.commons.pool2.PooledObject;
+import org.apache.commons.pool2.impl.DefaultPooledObject;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@SuppressWarnings({
+  "nullness" // TODO(https://github.com/apache/beam/issues/20497)
+})
+public class JmsSessionFactory<T> extends BasePooledObjectFactory<Session> {
+
+  private static final Logger LOG = LoggerFactory.getLogger(JmsSessionFactory.class);
+  public static final String CONNECTION_ERRORS_METRIC_NAME = "connectionErrors";
+
+  private final Counter connectionErrors =
+      Metrics.counter(JMS_IO_PRODUCER_METRIC_NAME, CONNECTION_ERRORS_METRIC_NAME);
+
+  private final JmsIO.Write<T> spec;
+  private boolean isConnectionClosed;
+
+  public JmsSessionFactory(JmsIO.Write<T> spec) {
+    this.spec = spec;
+  }
+
+  @Override
+  public Session create() throws JMSException {
+    Connection connection;
+    // reset the connection flag
+    this.isConnectionClosed = false;
+    ConnectionFactory connectionFactory = spec.getConnectionFactory();
+    if (spec.getUsername() != null) {
+      connection = connectionFactory.createConnection(spec.getUsername(), spec.getPassword());
+    } else {
+      connection = connectionFactory.createConnection();
+    }
+    connection.setExceptionListener(
+        exception -> {
+          this.isConnectionClosed = true;
+          this.connectionErrors.inc();
+        });
+    LOG.debug("creating new connection: {}", connection);
+    connection.start();
+    // false means we don't use JMS transaction.
+    return connection.createSession(false, Session.AUTO_ACKNOWLEDGE);
+  }
+
+  @Override
+  public boolean validateObject(PooledObject<Session> pooledObject) {
+    return !isConnectionClosed && !callSessionMethod(pooledObject.getObject(), "isClosed", true);
+  }
+
+  @Override
+  public void destroyObject(PooledObject<Session> pooledObject) throws JMSException {
+    Session session = pooledObject.getObject();
+    session.close();
+    Connection connection = callSessionMethod(session, "getConnection", null);
+    if (connection != null) {
+      connection.close();
+    }
+  }
+
+  @Override
+  public PooledObject<Session> wrap(Session session) {
+    return new DefaultPooledObject<>(session);
+  }
+
+  private <U> U callSessionMethod(Session session, String methodName, U defaultValue) {
+    Method isClosed = getSessionMethod(session, methodName);
+    if (isClosed != null) {
+      try {
+        return (U) isClosed.invoke(session);
+      } catch (IllegalAccessException | InvocationTargetException exception) {
+        LOG.debug(
+            "The class {} couldn't allow access to the function 'isClosed' with the following error {}",
+            session.getClass(),
+            exception.getMessage());
+      }
+    }
+    return defaultValue;
+  }
+
+  private Method getSessionMethod(Object session, String methodName) {
+    try {
+      return session.getClass().getDeclaredMethod(methodName);
+    } catch (NoSuchMethodException e) {
+      LOG.debug(
+          "The class {} implemented JMS Session doesn't contain a function to check if session is closed",
+          session.getClass());
+    }
+    return null;
+  }
+}

--- a/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/pool/JmsSessionPool.java
+++ b/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/pool/JmsSessionPool.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.jms.pool;
+
+import java.time.Duration;
+import java.util.Objects;
+import java.util.UUID;
+import javax.jms.Session;
+import org.apache.beam.sdk.io.jms.JmsIO;
+import org.apache.commons.pool2.ObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPool;
+import org.apache.commons.pool2.impl.GenericObjectPoolConfig;
+
+@SuppressWarnings({
+  "nullness" // TODO(https://github.com/apache/beam/issues/20497)
+})
+public class JmsSessionPool<T> extends SerializableSessionPool<Session> {
+
+  private final String id = UUID.randomUUID().toString();
+
+  private final JmsIO.Write<T> spec;
+
+  public JmsSessionPool(JmsIO.Write<T> spec) {
+    super(spec.getJmsPoolConfiguration().getMaxActiveConnections());
+    this.spec = spec;
+  }
+
+  @Override
+  public ObjectPool<Session> createDelegate() {
+    JmsPoolConfiguration configuration = spec.getJmsPoolConfiguration();
+    JmsSessionFactory<T> factory = new JmsSessionFactory<>(spec);
+    GenericObjectPoolConfig<Session> config = new GenericObjectPoolConfig<>();
+    config.setLifo(false);
+    config.setFairness(true);
+    config.setJmxEnabled(false);
+    config.setTestOnCreate(true);
+    config.setTestOnBorrow(true);
+    config.setTestWhileIdle(true);
+    config.setTestOnReturn(true);
+    config.setNumTestsPerEvictionRun(-1);
+    config.setMinEvictableIdleTime(Duration.ofSeconds(60));
+    config.setTimeBetweenEvictionRuns(Duration.ofSeconds(15));
+    config.setSoftMinEvictableIdleTime(Duration.ofSeconds(60));
+    config.setMaxWait(
+        Duration.ofSeconds(
+            Objects.requireNonNull(configuration.getMaxTimeout()).getStandardSeconds()));
+    config.setMaxTotal(configuration.getMaxActiveConnections());
+    return new GenericObjectPool<>(factory, config);
+  }
+
+  @Override
+  public String toString() {
+    return String.format("Session Pool id: %s", id);
+  }
+}

--- a/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/pool/SerializableSessionPool.java
+++ b/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/pool/SerializableSessionPool.java
@@ -1,0 +1,94 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.jms.pool;
+
+import java.io.Closeable;
+import java.io.Serializable;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.commons.pool2.ObjectPool;
+
+public abstract class SerializableSessionPool<T> implements ObjectPool<T>, Serializable, Closeable {
+
+  private final int maxConnections;
+  private final AtomicReference<ObjectPool<T>> delegate = new AtomicReference<>();
+
+  protected SerializableSessionPool(int maxConnections) {
+    this.maxConnections = maxConnections;
+  }
+
+  protected abstract ObjectPool<T> createDelegate();
+
+  public ObjectPool<T> getDelegate() {
+    ObjectPool<T> value = this.delegate.get();
+    if (value == null) {
+      synchronized (this.delegate) {
+        value = this.delegate.get();
+        if (value == null) {
+          final ObjectPool<T> actualValue = createDelegate();
+          value = actualValue;
+          this.delegate.set(actualValue);
+        }
+      }
+    }
+    return value;
+  }
+
+  @Override
+  public T borrowObject() throws Exception {
+    ObjectPool<T> pool = getDelegate();
+    if (pool.getNumIdle() == 0 && pool.getNumActive() < maxConnections) {
+      pool.addObject();
+    }
+    return pool.borrowObject();
+  }
+
+  @Override
+  public void returnObject(T obj) throws Exception {
+    getDelegate().returnObject(obj);
+  }
+
+  @Override
+  public void invalidateObject(T obj) throws Exception {
+    getDelegate().invalidateObject(obj);
+  }
+
+  @Override
+  public void addObject() throws Exception {
+    getDelegate().addObject();
+  }
+
+  @Override
+  public int getNumIdle() {
+    return getDelegate().getNumIdle();
+  }
+
+  @Override
+  public int getNumActive() {
+    return getDelegate().getNumActive();
+  }
+
+  @Override
+  public void clear() throws Exception {
+    getDelegate().clear();
+  }
+
+  @Override
+  public void close() {
+    getDelegate().close();
+  }
+}

--- a/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/pool/package-info.java
+++ b/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/pool/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** Transforms for reading and writing from Jms. */
+package org.apache.beam.sdk.io.jms.pool;

--- a/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOIT.java
+++ b/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOIT.java
@@ -41,6 +41,7 @@ import org.apache.beam.sdk.coders.SerializableCoder;
 import org.apache.beam.sdk.io.GenerateSequence;
 import org.apache.beam.sdk.io.common.IOITHelper;
 import org.apache.beam.sdk.io.common.IOTestPipelineOptions;
+import org.apache.beam.sdk.io.jms.pool.JmsPoolConfiguration;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.options.Default;
@@ -241,7 +242,9 @@ public class JmsIOIT implements Serializable {
                 .withUsername(USERNAME)
                 .withPassword(PASSWORD)
                 .withValueMapper(new TextMessageMapper())
-                .withConnectionFactory(connectionFactory));
+                .withConnectionFactory(connectionFactory)
+                .withJmsPoolConfiguration(
+                    JmsPoolConfiguration.create(50, 10, Duration.standardSeconds(15))));
     return pipelineWrite.run();
   }
 

--- a/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/utils/JmsIOTestUtils.java
+++ b/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/utils/JmsIOTestUtils.java
@@ -1,0 +1,159 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.jms.utils;
+
+import java.io.IOException;
+import java.io.Serializable;
+import java.net.ServerSocket;
+import java.util.Random;
+import javax.jms.*;
+import org.apache.beam.sdk.io.jms.JmsIOException;
+import org.apache.beam.sdk.transforms.SerializableBiFunction;
+
+public class JmsIOTestUtils {
+
+  private JmsIOTestUtils() {}
+
+  public static class TestEvent implements Serializable {
+    private final String topicName;
+    private final String value;
+
+    public TestEvent(String topicName, String value) {
+      this.topicName = topicName;
+      this.value = value;
+    }
+
+    public String getTopicName() {
+      return this.topicName;
+    }
+
+    public String getValue() {
+      return this.value;
+    }
+  }
+
+  public static class TextMessageMapperWithError
+      implements SerializableBiFunction<String, Session, Message> {
+    @Override
+    public Message apply(String value, Session session) {
+      try {
+        if (value.equals("Message 1") || value.equals("Message 2")) {
+          throw new JMSException("Error!!");
+        }
+        TextMessage msg = session.createTextMessage();
+        msg.setText(value);
+        return msg;
+      } catch (JMSException e) {
+        throw new JmsIOException("Error creating TextMessage", e);
+      }
+    }
+  }
+
+  public static class TextMessageMapperWithErrorCounter
+      implements SerializableBiFunction<String, Session, Message> {
+
+    private static int errorCounter = 0;
+
+    @Override
+    public Message apply(String value, Session session) {
+      try {
+        if (errorCounter == 0) {
+          errorCounter++;
+          throw new JMSException("Error!!");
+        }
+        TextMessage msg = session.createTextMessage();
+        msg.setText(value);
+        return msg;
+      } catch (JMSException e) {
+        throw new JmsIOException("Error creating TextMessage", e);
+      }
+    }
+  }
+
+  public static class TextMessageMapperWithErrorAndCounter
+      implements SerializableBiFunction<String, Session, Message> {
+    private static int errorCounter = 0;
+
+    @Override
+    public Message apply(String value, Session session) {
+      try {
+        if (value.equals("Message 1") || value.equals("Message 2")) {
+          if (errorCounter != 0 && value.equals("Message 1")) {
+            TextMessage msg = session.createTextMessage();
+            msg.setText(value);
+            return msg;
+          }
+          errorCounter++;
+          throw new JMSException("Error!!");
+        }
+        TextMessage msg = session.createTextMessage();
+        msg.setText(value);
+        return msg;
+      } catch (JMSException e) {
+        throw new JmsIOException("Error creating TextMessage", e);
+      }
+    }
+  }
+
+  public static class TextMessageMapperWithSessionClosed
+      implements SerializableBiFunction<String, Session, Message> {
+    private static int errorCounter = 0;
+
+    @Override
+    public Message apply(String value, Session session) {
+      try {
+        if (value.equals("Message 1") || value.equals("Message 2")) {
+          if (errorCounter == 0) {
+            errorCounter++;
+            session.close();
+          }
+        }
+        TextMessage msg = session.createTextMessage();
+        msg.setText(value);
+        return msg;
+      } catch (JMSException e) {
+        throw new JmsIOException("Error creating TextMessage", e);
+      }
+    }
+  }
+
+  private static int getRandomNumber() {
+    int max = 65535, min = 1024;
+    return new Random().nextInt(max - min + 1) + min;
+  }
+
+  private static boolean isPortUnused(int portNumber) {
+    try (ServerSocket serverSocket = new ServerSocket(portNumber)) {
+      serverSocket.close();
+      return true;
+    } catch (IOException exception) {
+      return false;
+    }
+  }
+
+  public static int getUnusedPort() {
+    int portNumber = getRandomNumber();
+    while (true) {
+      if (isPortUnused(portNumber)) {
+        return portNumber;
+      } else {
+        portNumber = getRandomNumber();
+      }
+    }
+  }
+}


### PR DESCRIPTION
[#26203] fix(JmsIO): use a unused port for tests in JmsIO #26203

Fixes #27312, #26203

In this PR, I added a session pool so that it can be used for either reading or writing (for now it's only for writing). This will allow the user to configure the number of connection maximum to not be exceeded.

>Note: We used [Apache Commons Pool](https://github.com/apache/commons-pool), but they are some module that are more performant.
>- https://github.com/DanielYWoo/fast-object-pool
>- https://code.google.com/archive/p/furious-objectpool/
>- https://github.com/chrisvest/stormpot/
> Here is an [article](https://medium.com/@chrishantha/benchmarking-object-pools-6df007a31ada) that display the benchmark of each object pool

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
