### PR TITLE
changed rerun logic to accomodate when job is not in check list

### DIFF
--- a/.github/actions/rerun-job-action/action.yml
+++ b/.github/actions/rerun-job-action/action.yml
@@ -57,17 +57,24 @@ runs:
     shell: bash
     run: | 
       URL="${{github.api_url}}/repos/${{inputs.github_repository}}/commits/${{env.prsha}}/check-runs"
-      read -r STATUS CONCLUSION CHECK_SUITE_ID<<< $(curl  \
+      CHECK_RUN=$(curl  \
       -H 'Authorization: Bearer ${{inputs.github_token}}' \
       -H "Accept: application/vnd.github+json" \
       -H "X-GitHub-Api-Version: 2022-11-28" \
-      -s $URL | jq -r '.check_runs | .[] | select(.name=="${{inputs.github_job}}") | "\(.status) \(.conclusion) \(.check_suite.id)"')
+      -s $URL | jq -r '.check_runs | .[] | select(.name=="${{inputs.github_job}}")')
+      if [ -z "$CHECK_RUN" ]; then
+        echo "No check runs found for this job"
+        echo skip=true >> $GITHUB_ENV
+        exit 0
+      fi
+      read -r STATUS CONCLUSION CHECK_SUITE_ID<<< $(echo $CHECK_RUN | jq -r '"\(.status) \(.conclusion) \(.check_suite.id)"')
       echo status=$STATUS >> $GITHUB_ENV
       echo conclusion=$CONCLUSION >> $GITHUB_ENV
       echo check_suite_id=$CHECK_SUITE_ID >> $GITHUB_ENV
  
-  - name: Enable Rerun
-    if: ${{env.status == 'completed' && (env.conclusion == 'success' || env.conclusion == 'skipped')}}
+
+  - name: Disable Rerun for Success or Skipped
+    if: ${{(env.status == 'completed' && (env.conclusion == 'success' || env.conclusion == 'skipped')) || env.skip == 'true'}}
     shell: bash
     run: echo rerun=false >> $GITHUB_ENV
 


### PR DESCRIPTION
Changes the rerun detection step to accommodate cases when selected job is not in check list. This is used to run the job when its not originally triggered by path or other condition

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
