### PR TITLE
[Security] Bump netty version due to security advisory

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -548,7 +548,7 @@ class BeamModulePlugin implements Plugin<Project> {
     def kafka_version = "2.4.1"
     def log4j2_version = "2.20.0"
     def nemo_version = "0.1"
-    def netty_version = "4.1.77.Final"
+    def netty_version = "4.1.94.Final"
     def postgres_version = "42.2.16"
     def powermock_version = "2.0.9"
     // Try to keep protobuf_version consistent with the protobuf version in google_cloud_platform_libraries_bom


### PR DESCRIPTION
Bumping netty from `4.1.77.Final` to `4.1.94.Final`.

The current version is in the range of 2 CVEs:
- CVE-2023-34462
- CVE-2022-41881

