### PR TITLE
JdbcIO.readRows() to handle DECIMAL(10,2) with scale as the proper LogicalType.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -80,6 +80,7 @@
 
 * Fixed X (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
 * Fixed KinesisIO `NullPointerException` when a progress check is made before the reader is started (IO) ([#23868](https://github.com/apache/beam/issues/23868))
+* Fixed Schema representation for DECIMAL(10,2) with precision and scale (JdbcIO) ([#27380](https://github.com/apache/beam/issues/27380))
 
 ## Known Issues
 

--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/SchemaUtil.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/SchemaUtil.java
@@ -217,7 +217,7 @@ public class SchemaUtil {
     return (index, md) -> {
       int precision = md.getPrecision(index);
       int scale = md.getScale(index);
-      if ((precision == Integer.MAX_VALUE || precision == -1) && scale==0) {
+      if ((precision == Integer.MAX_VALUE || precision == -1) && scale == 0) {
         // If a precision is not specified, the column stores values as given (e.g. in Oracle DB)
         return Schema.Field.of(md.getColumnLabel(index), FieldType.DECIMAL)
             .withNullable(md.isNullable(index) == ResultSetMetaData.columnNullable);

--- a/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/SchemaUtilTest.java
+++ b/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/SchemaUtilTest.java
@@ -64,7 +64,8 @@ public class SchemaUtilTest {
             JdbcFieldInfo.of("boolean_col", Types.BOOLEAN),
             JdbcFieldInfo.of("char_col", Types.CHAR, 255),
             JdbcFieldInfo.of("date_col", Types.DATE),
-            JdbcFieldInfo.of("decimal_col", Types.DECIMAL),
+            JdbcFieldInfo.of("decimal_col", Types.DECIMAL, Integer.MAX_VALUE),
+            JdbcFieldInfo.of("decimal_scale_col", Types.DECIMAL, 12, 4),
             JdbcFieldInfo.of("double_col", Types.DOUBLE),
             JdbcFieldInfo.of("float_col", Types.FLOAT),
             JdbcFieldInfo.of("integer_col", Types.INTEGER),
@@ -72,7 +73,8 @@ public class SchemaUtilTest {
             JdbcFieldInfo.of("longvarchar_col", Types.LONGVARCHAR, 1024),
             JdbcFieldInfo.of("longvarbinary_col", Types.LONGVARBINARY, 1024),
             JdbcFieldInfo.of("nchar_col", Types.NCHAR, 255),
-            JdbcFieldInfo.of("numeric_col", Types.NUMERIC, 12, 4),
+            JdbcFieldInfo.of("numeric_col", Types.NUMERIC, -1),
+            JdbcFieldInfo.of("numeric_scale_col", Types.NUMERIC, 12, 4),
             JdbcFieldInfo.of("nvarchar_col", Types.NVARCHAR, 255),
             JdbcFieldInfo.of("real_col", Types.REAL),
             JdbcFieldInfo.of("smallint_col", Types.SMALLINT),
@@ -106,6 +108,7 @@ public class SchemaUtilTest {
             .addField("char_col", LogicalTypes.fixedLengthString(JDBCType.CHAR, 255))
             .addField("date_col", LogicalTypes.JDBC_DATE_TYPE)
             .addField("decimal_col", Schema.FieldType.DECIMAL)
+            .addField("decimal_scale_col", LogicalTypes.numeric(12, 4))
             .addField("double_col", Schema.FieldType.DOUBLE)
             .addField("float_col", LogicalTypes.JDBC_FLOAT_TYPE)
             .addField("integer_col", Schema.FieldType.INT32)
@@ -116,7 +119,8 @@ public class SchemaUtilTest {
             .addField(
                 "longvarbinary_col", LogicalTypes.variableLengthBytes(JDBCType.LONGVARBINARY, 1024))
             .addField("nchar_col", LogicalTypes.fixedLengthString(JDBCType.NCHAR, 255))
-            .addField("numeric_col", LogicalTypes.numeric(12, 4))
+            .addField("numeric_col", Schema.FieldType.DECIMAL)
+            .addField("numeric_scale_col", LogicalTypes.numeric(12, 4))
             .addField("nvarchar_col", LogicalTypes.variableLengthString(JDBCType.NVARCHAR, 255))
             .addField("real_col", Schema.FieldType.FLOAT)
             .addField("smallint_col", Schema.FieldType.INT16)

--- a/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/SchemaUtilTest.java
+++ b/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/SchemaUtilTest.java
@@ -64,7 +64,8 @@ public class SchemaUtilTest {
             JdbcFieldInfo.of("boolean_col", Types.BOOLEAN),
             JdbcFieldInfo.of("char_col", Types.CHAR, 255),
             JdbcFieldInfo.of("date_col", Types.DATE),
-            JdbcFieldInfo.of("decimal_col", Types.DECIMAL, Integer.MAX_VALUE),
+            JdbcFieldInfo.of("decimal_col", Types.DECIMAL),
+            JdbcFieldInfo.of("decimal_max_col", Types.DECIMAL, Integer.MAX_VALUE),
             JdbcFieldInfo.of("decimal_scale_col", Types.DECIMAL, 12, 4),
             JdbcFieldInfo.of("double_col", Types.DOUBLE),
             JdbcFieldInfo.of("float_col", Types.FLOAT),
@@ -73,7 +74,8 @@ public class SchemaUtilTest {
             JdbcFieldInfo.of("longvarchar_col", Types.LONGVARCHAR, 1024),
             JdbcFieldInfo.of("longvarbinary_col", Types.LONGVARBINARY, 1024),
             JdbcFieldInfo.of("nchar_col", Types.NCHAR, 255),
-            JdbcFieldInfo.of("numeric_col", Types.NUMERIC, -1),
+            JdbcFieldInfo.of("numeric_col", Types.NUMERIC),
+            JdbcFieldInfo.of("numeric_minone_col", Types.NUMERIC, -1),
             JdbcFieldInfo.of("numeric_scale_col", Types.NUMERIC, 12, 4),
             JdbcFieldInfo.of("nvarchar_col", Types.NVARCHAR, 255),
             JdbcFieldInfo.of("real_col", Types.REAL),
@@ -107,7 +109,8 @@ public class SchemaUtilTest {
             .addField("boolean_col", Schema.FieldType.BOOLEAN)
             .addField("char_col", LogicalTypes.fixedLengthString(JDBCType.CHAR, 255))
             .addField("date_col", LogicalTypes.JDBC_DATE_TYPE)
-            .addField("decimal_col", Schema.FieldType.DECIMAL)
+            .addField("decimal_col", LogicalTypes.numeric(0, 0)) // doubtful
+            .addField("decimal_max_col", Schema.FieldType.DECIMAL)
             .addField("decimal_scale_col", LogicalTypes.numeric(12, 4))
             .addField("double_col", Schema.FieldType.DOUBLE)
             .addField("float_col", LogicalTypes.JDBC_FLOAT_TYPE)
@@ -119,7 +122,8 @@ public class SchemaUtilTest {
             .addField(
                 "longvarbinary_col", LogicalTypes.variableLengthBytes(JDBCType.LONGVARBINARY, 1024))
             .addField("nchar_col", LogicalTypes.fixedLengthString(JDBCType.NCHAR, 255))
-            .addField("numeric_col", Schema.FieldType.DECIMAL)
+            .addField("numeric_col", LogicalTypes.numeric(0, 0))
+            .addField("numeric_minone_col", Schema.FieldType.DECIMAL)
             .addField("numeric_scale_col", LogicalTypes.numeric(12, 4))
             .addField("nvarchar_col", LogicalTypes.variableLengthString(JDBCType.NVARCHAR, 255))
             .addField("real_col", Schema.FieldType.FLOAT)


### PR DESCRIPTION
When JdbcIO.readRows() schema ignores scale in DECIMAL(20,2) 
This is the first of the problem described at https://lists.apache.org/thread/qxwron01myf5fzrb3d8tsh71grt5cpzk