### PR TITLE
Update python options in runners/spark.md.

### DIFF
--- a/website/www/site/content/en/documentation/runners/spark.md
+++ b/website/www/site/content/en/documentation/runners/spark.md
@@ -215,7 +215,7 @@ options = PipelineOptions([
     "--job_endpoint=localhost:8099",
     "--environment_type=LOOPBACK"
 ])
-with beam.Pipeline(options) as p:
+with beam.Pipeline(options=options) as p:
     ...
 {{< /highlight >}}
 


### PR DESCRIPTION
similar to https://github.com/apache/beam/pull/10465/, but for Spark

currently suggested code ends with this exception

```bash
Traceback (most recent call last):      
  File "/home/retro/code/work/FUGA/git/beam/test-csv.py", line 41, in <module>
    with beam.Pipeline(options) as p:
  File "/home/retro/.local/lib/python3.10/site-packages/apache_beam/pipeline.py", line 196, in __init__
    raise TypeError(
TypeError: Runner PipelineOptions() is not a PipelineRunner object or the name of a registered runner.
```