### PR TITLE
[Python] Make BigQuery load job names deterministic for retry resilience

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads.py
@@ -697,7 +697,7 @@ class TriggerLoadJobs(beam.DoFn):
             table_reference.projectId,
             table_reference.datasetId,
             table_reference.tableId))
-    job_name = '%s_%s_%s_%s' % (
+    job_name = '%s_%s_pane%s_partition%s' % (
         load_job_name_prefix, destination_hash, pane_info.index, partition_key)
     _LOGGER.info('Load job has %s files. Job name is %s.', len(files), job_name)
 

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
@@ -1041,7 +1041,7 @@ class BigQueryFileLoadsIT(unittest.TestCase):
 
     # Override these parameters to induce copy jobs
     bqfl._DEFAULT_MAX_FILE_SIZE = 100
-    bqfl._MAXIMUM_LOAD_SIZE = 400
+    bqfl._MAXIMUM_LOAD_SIZE = 200
 
     with beam.Pipeline(argv=args) as p:
       stream_source = (

--- a/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_file_loads_test.py
@@ -349,9 +349,9 @@ class TestPartitionFiles(unittest.TestCase):
 
   def test_partition_files_dofn_file_split(self):
     """Force partitions to split based on max_files"""
-    multiple_partitions_result = [('destination0', ['file0', 'file1']),
-                                  ('destination0', ['file2', 'file3'])]
-    single_partition_result = [('destination1', ['file0', 'file1'])]
+    multiple_partitions_result = [('destination0', (0, ['file0', 'file1'])),
+                                  ('destination0', (1, ['file2', 'file3']))]
+    single_partition_result = [('destination1', (0, ['file0', 'file1']))]
     with TestPipeline() as p:
       destination_file_pairs = p | beam.Create(self._ELEMENTS, reshuffle=False)
       partitioned_files = (
@@ -364,20 +364,22 @@ class TestPartitionFiles(unittest.TestCase):
       single_partition = partitioned_files[bqfl.PartitionFiles\
                                            .SINGLE_PARTITION_TAG]
 
-    assert_that(
-        multiple_partitions,
-        equal_to(multiple_partitions_result),
-        label='CheckMultiplePartitions')
-    assert_that(
-        single_partition,
-        equal_to(single_partition_result),
-        label='CheckSinglePartition')
+      assert_that(
+          multiple_partitions,
+          equal_to(multiple_partitions_result),
+          label='CheckMultiplePartitions')
+      assert_that(
+          single_partition,
+          equal_to(single_partition_result),
+          label='CheckSinglePartition')
 
   def test_partition_files_dofn_size_split(self):
     """Force partitions to split based on max_partition_size"""
-    multiple_partitions_result = [('destination0', ['file0', 'file1', 'file2']),
-                                  ('destination0', ['file3'])]
-    single_partition_result = [('destination1', ['file0', 'file1'])]
+    multiple_partitions_result = [
+        ('destination0', (0, ['file0', 'file1',
+                              'file2'])), ('destination0', (1, ['file3']))
+    ]
+    single_partition_result = [('destination1', (0, ['file0', 'file1']))]
     with TestPipeline() as p:
       destination_file_pairs = p | beam.Create(self._ELEMENTS, reshuffle=False)
       partitioned_files = (
@@ -390,14 +392,14 @@ class TestPartitionFiles(unittest.TestCase):
       single_partition = partitioned_files[bqfl.PartitionFiles\
                                            .SINGLE_PARTITION_TAG]
 
-    assert_that(
-        multiple_partitions,
-        equal_to(multiple_partitions_result),
-        label='CheckMultiplePartitions')
-    assert_that(
-        single_partition,
-        equal_to(single_partition_result),
-        label='CheckSinglePartition')
+      assert_that(
+          multiple_partitions,
+          equal_to(multiple_partitions_result),
+          label='CheckMultiplePartitions')
+      assert_that(
+          single_partition,
+          equal_to(single_partition_result),
+          label='CheckSinglePartition')
 
 
 class TestBigQueryFileLoads(_TestCaseWithTempDirCleanUp):
@@ -584,8 +586,8 @@ class TestBigQueryFileLoads(_TestCaseWithTempDirCleanUp):
     bq_client.jobs.Get.side_effect = [
         job_1_waiting, job_2_done, job_1_done, job_2_done
     ]
-    partition_1 = ('project:dataset.table0', ['file0'])
-    partition_2 = ('project:dataset.table1', ['file1'])
+    partition_1 = ('project:dataset.table0', (0, ['file0']))
+    partition_2 = ('project:dataset.table1', (1, ['file1']))
     bq_client.jobs.Insert.side_effect = [job_1, job_2]
     test_job_prefix = "test_job"
 
@@ -627,8 +629,8 @@ class TestBigQueryFileLoads(_TestCaseWithTempDirCleanUp):
     bq_client.jobs.Get.side_effect = [
         job_1_waiting, job_2_done, job_1_error, job_2_done
     ]
-    partition_1 = ('project:dataset.table0', ['file0'])
-    partition_2 = ('project:dataset.table1', ['file1'])
+    partition_1 = ('project:dataset.table0', (0, ['file0']))
+    partition_2 = ('project:dataset.table1', (1, ['file1']))
     bq_client.jobs.Insert.side_effect = [job_1, job_2]
     test_job_prefix = "test_job"
 

--- a/sdks/python/apache_beam/io/gcp/bigquery_tools.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_tools.py
@@ -645,7 +645,7 @@ class BigQueryWrapper(object):
       retry += 1
       job = self.get_job(
           job_reference.projectId, job_reference.jobId, job_reference.location)
-      logging.info('Job status: %s', job.status.state)
+      logging.info('Job %s status: %s', job.id, job.status.state)
       if job.status.state == 'DONE' and job.status.errorResult:
         raise RuntimeError(
             'BigQuery job {} failed. Error Result: {}'.format(


### PR DESCRIPTION
Users were running into an issue where a worker would fail (for whatever reason) after a load job was submitted to BigQuery but before it could finish and return as successful. In Beam's perspective, this is a bundle failure and so the bundle is retried. The same files are collected into a load configuration and a job is again submitted to BigQuery **with a different job ID**. Now BigQuery receives two essentially identical load jobs under different names and accepts both, which leads to duplication of data in the table.

This PR serves to make load job names deterministic so that under such a scenario when Beam retries by loading the same files, it will use the same job ID. When BigQuery receives the same job ID, it returns a 409 "already exists" error, which we already handle.
- use partition key for copy job cases
- use pane index for streaming

Other steps in this write method (copy jobs, schema update, table deletion) are already deterministic.