### PR TITLE
Reproducing the compatibility problem between JdbcIO.readRows() and AvroUtils.toAvroSchema() : (#27380)

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/FixedPrecisionNumeric.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/FixedPrecisionNumeric.java
@@ -120,8 +120,9 @@ public class FixedPrecisionNumeric extends PassThroughLogicalType<BigDecimal> {
    * @TODO is byte or fixed?
    * @TODO should is pass namespace/field name, etc?
    * */
-  public org.apache.avro.Schema toAvroType() {
+  public org.apache.avro.Schema toAvroType(String name, String namespace) {
     return LogicalTypes.decimal(precision, scale)
-            .addToSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.FIXED)); // @TODO not bytes??
+            // @TODO should it turn digital precision into bytes size?
+            .addToSchema(org.apache.avro.Schema.createFixed(name,  "dunno", namespace, 4+1));
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/FixedPrecisionNumeric.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/logicaltypes/FixedPrecisionNumeric.java
@@ -22,6 +22,8 @@ import static org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Prec
 
 import java.math.BigDecimal;
 import java.math.MathContext;
+
+import org.apache.avro.LogicalTypes;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.SchemaApi;
 import org.apache.beam.sdk.schemas.Schema;
@@ -112,5 +114,14 @@ public class FixedPrecisionNumeric extends PassThroughLogicalType<BigDecimal> {
           (base == null) ? null : base.scale());
     }
     return base;
+  }
+
+  /**
+   * @TODO is byte or fixed?
+   * @TODO should is pass namespace/field name, etc?
+   * */
+  public org.apache.avro.Schema toAvroType() {
+    return LogicalTypes.decimal(precision, scale)
+            .addToSchema(org.apache.avro.Schema.create(org.apache.avro.Schema.Type.FIXED)); // @TODO not bytes??
   }
 }

--- a/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/schemas/utils/AvroUtils.java
+++ b/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/schemas/utils/AvroUtils.java
@@ -1089,7 +1089,7 @@ public class AvroUtils {
       baseType = fixedBytesField.toAvroType("fixed", namespace + "." + fieldName);
     } else if (FixedPrecisionNumeric.IDENTIFIER.equals(identifier)) {
       FixedPrecisionNumeric decimalType = fieldType.getLogicalType(FixedPrecisionNumeric.class);
-      baseType = decimalType.toAvroType();
+      baseType = decimalType.toAvroType("fix_dec",  namespace + "." + fieldName);
     } else if (VariableBytes.IDENTIFIER.equals(identifier)) {
       // treat VARBINARY as bytes as that is what avro supports
       baseType = org.apache.avro.Schema.create(Type.BYTES);

--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/SchemaUtil.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/SchemaUtil.java
@@ -122,8 +122,6 @@ public class SchemaUtil {
         return beamLogicalField(CHAR.getName(), FixedString::of);
       case DATE:
         return beamFieldOfType(LogicalTypes.JDBC_DATE_TYPE);
-      case DECIMAL:
-        return beamFieldOfType(Schema.FieldType.DECIMAL);
       case DOUBLE:
         return beamFieldOfType(Schema.FieldType.DOUBLE);
       case FLOAT:
@@ -139,6 +137,7 @@ public class SchemaUtil {
       case NCHAR:
         return beamLogicalField(NCHAR.getName(), FixedString::of);
       case NUMERIC:
+      case DECIMAL:
         return beamLogicalNumericField();
       case NVARCHAR:
         return beamLogicalField(NVARCHAR.getName(), VariableString::of);
@@ -217,7 +216,7 @@ public class SchemaUtil {
   private static BeamFieldConverter beamLogicalNumericField() {
     return (index, md) -> {
       int precision = md.getPrecision(index);
-      if (precision == Integer.MAX_VALUE || precision == -1) {
+      if (precision == Integer.MAX_VALUE || precision == -1 || precision == 0 /* by PostgreSQL*/){
         // If a precision is not specified, the column stores values as given (e.g. in Oracle DB)
         return Schema.Field.of(md.getColumnLabel(index), FieldType.DECIMAL)
             .withNullable(md.isNullable(index) == ResultSetMetaData.columnNullable);

--- a/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcIOToAvroIT.java
+++ b/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcIOToAvroIT.java
@@ -1,0 +1,126 @@
+package org.apache.beam.sdk.io.jdbc;
+
+import com.google.common.collect.Lists;
+import org.apache.beam.sdk.PipelineResult;
+import org.apache.beam.sdk.extensions.avro.schemas.utils.AvroUtils;
+import org.apache.beam.sdk.io.common.DatabaseTestHelper;
+import org.apache.beam.sdk.io.common.PostgresIOTestPipelineOptions;
+import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Count;
+
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.Row;
+import org.junit.AfterClass;
+import org.junit.BeforeClass;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.Parameterized;
+import org.postgresql.ds.PGSimpleDataSource;
+import org.apache.beam.sdk.values.KV;
+
+import java.sql.Connection;
+import java.sql.SQLException;
+import java.sql.Statement;
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.List;
+
+import static org.apache.beam.sdk.io.common.IOITHelper.readIOTestPipelineOptions;
+import static org.junit.Assert.assertNotNull;
+
+/**
+ * This class contains integration tests for {@link JdbcIO} with {@link JdbcIO.DataSourceConfiguration}
+ * and {@link JdbcIO.StatementPreparator} using {@link org.apache.beam.sdk.io.jdbc.JdbcIOToAvroIT#COLUMNS}.
+ * <p>
+ * The tests are parameterized by the column under test.
+ *
+ * to run this test, you need to run the following command:
+ * ./gradlew integrationTest -p sdks/java/io/jdbc -DintegrationTestPipelineOptions='["--postgresServerName=localhost","--postgresUsername=guest","--postgresDatabaseName=guest","--postgresPassword=postgres","--postgresSsl=false" ]' --tests org.apache.beam.sdk.io.jdbc.JdbcIOToAvroIT -DintegrationTestRunner=direct
+ *
+ */
+@RunWith(Parameterized.class)
+public class JdbcIOToAvroIT {
+
+    public static final ArrayList<KV<String, String>> COLUMNS = Lists.newArrayList(
+            KV.of("num_nul", "NUMERIC NULL"),
+            KV.of("num_notnul", "NUMERIC NOT NULL"),
+            KV.of("num_ps_nul", "NUMERIC(10,2) NULL"),
+            KV.of("num_ps_notnul", "NUMERIC(10,2) NOT NULL"),
+            KV.of("dec_nul", "DECIMAL NULL"),
+            KV.of("dec_notnul", "DECIMAL NOT NULL"),
+            KV.of("dec_ps_nul", "DECIMAL(10,2) NULL"),
+            KV.of("dec_ps_notnul", "DECIMAL(10,2) NOT NULL"),
+            KV.of("int", "INT NOT NULL")
+    );
+    private static PGSimpleDataSource dataSource;
+    private static String tableName;
+    private final String columnUnderTest;
+    @Rule
+    public TestPipeline pipelineDecimals = TestPipeline.create();
+
+
+    @BeforeClass
+    public static void setup() throws SQLException {
+        PostgresIOTestPipelineOptions options;
+        try {
+            options = readIOTestPipelineOptions(PostgresIOTestPipelineOptions.class);
+        } catch (IllegalArgumentException e) {
+            options = null;
+        }
+        org.junit.Assume.assumeNotNull(options);
+
+        dataSource = DatabaseTestHelper.getPostgresDataSource(options);
+        tableName = DatabaseTestHelper.getTestTableName(JdbcIOToAvroIT.class.getSimpleName());
+
+
+        DatabaseTestHelper.createTable(
+                dataSource,
+                tableName,
+                COLUMNS);
+        try (Connection connection = dataSource.getConnection()) {
+            try (Statement statement = connection.createStatement()) {
+                statement.execute(String.format("insert into %s values (%s,%s,%s,%s,%s,%s,%s,%s    ,%s)," +
+                                "(%s,%s,%s,%s,%s,%s,%s,%s    ,%s) ", tableName,
+                        1,2,"3.45","4.56",      1,2,"3.45","4.56",    "1",
+                        "NULL",2,"NULL","4.56", "NULL",2,"NULL","4.56",   "2"));
+            }
+        }
+
+    }
+
+    @AfterClass
+    public static void tearDown() throws SQLException {
+        DatabaseTestHelper.deleteTable(dataSource, tableName);
+    }
+
+    @Parameterized.Parameters(name = "{index}: {0} {1}")
+    public static Collection<Object[]> data() {
+        List<Object[]> data = new ArrayList<>();
+        for (KV<String, String> column : COLUMNS) {
+            data.add(new Object[]{column.getKey(), column.getValue()});
+        }
+        return data;
+    }
+
+    public JdbcIOToAvroIT(String columnName, String ignore) {
+        this.columnUnderTest = columnName;
+    }
+
+    @Test
+    public void testColumn() {
+        PCollection<Row> jdbcRows = pipelineDecimals
+                .apply(JdbcIO.readRows()
+                        .withQuery("SELECT " + columnUnderTest +                                " FROM " + tableName)
+                        .withDataSourceConfiguration(JdbcIO.DataSourceConfiguration.create(dataSource)));
+        Schema schema = jdbcRows.getSchema();
+        org.apache.avro.Schema avroSchema = AvroUtils.toAvroSchema(schema);
+        assertNotNull( avroSchema.getField(columnUnderTest));
+        PAssert.thatSingleton(jdbcRows.apply("Count All", Count.globally()))
+                .isEqualTo((long) 2);
+        PipelineResult pipelineResult = pipelineDecimals.run();
+        pipelineResult.waitUntilFinish();
+    }
+}

--- a/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcIOToAvroIT.java
+++ b/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcIOToAvroIT.java
@@ -84,8 +84,8 @@ public class JdbcIOToAvroIT {
             try (Statement statement = connection.createStatement()) {
                 statement.execute(String.format("insert into %s values (%s,%s,%s,%s,%s,%s,%s,%s    ,%s)," +
                                 "(%s,%s,%s,%s,%s,%s,%s,%s    ,%s) ", tableName,
-                        1,2,"3.45","4.56",      1,2,"3.45","4.56",    "1",
-                        "NULL",2,"NULL","4.56", "NULL",2,"NULL","4.56",   "2"));
+                        "1.23","1.23","1.23","1.23",      "1.23","1.23","1.23","1.23",   "1",
+                        "NULL","1.23","NULL","1.23", "NULL","1.23","NULL","1.23",   "2"));
             }
         }
 


### PR DESCRIPTION
 - AvroUtils can't create schema from Beam schema made by JdbcIO.readRows() for NUMERIC and DECIMAL types.
 - reproducer for (#27380)

Results seem really sad. AvroUtils.toAvroSchema() fails on NUMERIC and DECIMAL (here it pass for INT but I'm gust verifying the test approach). Failure looks like:

```
java.lang.RuntimeException: Unhandled logical type beam:logical_type:fixed_decimal:v1
	at org.apache.beam.sdk.extensions.avro.schemas.utils.AvroUtils.getFieldSchema(AvroUtils.java:1095)
	at org.apache.beam.sdk.extensions.avro.schemas.utils.AvroUtils.toAvroField(AvroUtils.java:453)
	at org.apache.beam.sdk.extensions.avro.schemas.utils.AvroUtils.toAvroSchema(AvroUtils.java:498)
```
