### PR TITLE
fix docker start build script

### DIFF
--- a/start-build-env.sh
+++ b/start-build-env.sh
@@ -91,7 +91,6 @@ RUN echo "${USER_NAME} ALL=NOPASSWD: ALL" > "/etc/sudoers.d/beam-build-${USER_ID
 ENV HOME "${DOCKER_HOME_DIR}"
 ENV GOPATH ${DOCKER_HOME_DIR}/beam/sdks/go/examples/.gogradle/project_gopath
 # This next command still runs as root causing the ~/.cache/go-build to be owned by root
-RUN go get github.com/linkedin/goavro/v2
 RUN chown -R ${USER_NAME}:${GROUP_ID} ${DOCKER_HOME_DIR}/.cache
 UserSpecificDocker
 


### PR DESCRIPTION
**Please** add a meaningful description for your change here

fix the start up script for docker image. the git url is no longer available. Do I need to fix documentation as well?
```
 => ERROR [7/8] RUN go get github.com/linkedin/goavro/v2                                                                                                                               0.3s
------
 > [7/8] RUN go get github.com/linkedin/goavro/v2:
#0 0.250 qemu-x86_64: Could not open '/lib64/ld-linux-x86-64.so.2': No such file or directory
------
Dockerfile:10
--------------------
   8 |     ENV GOPATH /home/<username>i/beam/sdks/go/examples/.gogradle/project_gopath
   9 |     # This next command still runs as root causing the ~/.cache/go-build to be owned by root
  10 | >>> RUN go get github.com/linkedin/goavro/v2
  11 |     RUN chown -R <username>:100 /home/<username>/.cache
  12 |     
--------------------
ERROR: failed to solve: process "/bin/bash -o pipefail -c go get github.com/linkedin/goavro/v2" did not complete successfully: exit code: 255
```
[github.com/linkedin/goavro/v2](url)


https://beam.apache.org/contribute/get-started-contributing/
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
