### PR TITLE
[Java] Cleanup BigQuery write tests

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/DynamicDestinationsHelpers.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/DynamicDestinationsHelpers.java
@@ -421,12 +421,17 @@ class DynamicDestinationsHelpers {
       }
     }
 
-    /** Returns the table schema for the destination. */
+    /**
+     * Returns the table schema for the destination. If possible, will return the existing table
+     * schema.
+     */
     @Override
     public @Nullable TableSchema getSchema(DestinationT destination) {
       TableDestination wrappedDestination = super.getTable(destination);
       @Nullable Table existingTable = getBigQueryTable(wrappedDestination.getTableReference());
-      if (existingTable == null || existingTable.getSchema() == null) {
+      if (existingTable == null
+          || existingTable.getSchema() == null
+          || existingTable.getSchema().isEmpty()) {
         return super.getSchema(destination);
       } else {
         return existingTable.getSchema();

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/UpdateSchemaDestination.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/UpdateSchemaDestination.java
@@ -271,7 +271,7 @@ public class UpdateSchemaDestination<DestinationT>
     try {
       destinationTable = datasetService.getTable(tableReference);
       if (destinationTable == null) {
-        return null; // no need to update schema ahead if table does not exists
+        return null; // no need to update schema ahead if table does not exist
       }
     } catch (IOException | InterruptedException e) {
       LOG.warn("Failed to get table {} with {}", tableReference, e.toString());
@@ -281,6 +281,7 @@ public class UpdateSchemaDestination<DestinationT>
     // or when destination schema is null (the write will set the schema)
     // or when provided schema is null (e.g. when using CREATE_NEVER disposition)
     if (destinationTable.getSchema() == null
+        || destinationTable.getSchema().isEmpty()
         || destinationTable.getSchema().equals(schema)
         || schema == null) {
       return null;
@@ -322,7 +323,7 @@ public class UpdateSchemaDestination<DestinationT>
                 jobService.startLoadJob(
                     jobRef, loadConfig, new ByteArrayContent("text/plain", new byte[0]));
               } catch (IOException | InterruptedException e) {
-                LOG.warn("Load job {} failed with {}", jobRef, e.toString());
+                LOG.warn("Schema update load job {} failed with {}", jobRef, e.toString());
                 throw new RuntimeException(e);
               }
               return null;

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageWriteIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageWriteIT.java
@@ -128,15 +128,15 @@ public class BigQueryIOStorageWriteIT {
   }
 
   @Test
-  public void testBigQueryStorageWrite30MProto() {
+  public void testBigQueryStorageWrite3MProto() {
     setUpTestEnvironment(WriteMode.EXACT_ONCE);
-    runBigQueryIOStorageWritePipeline(3000000, WriteMode.EXACT_ONCE, false);
+    runBigQueryIOStorageWritePipeline(3_000_000, WriteMode.EXACT_ONCE, false);
   }
 
   @Test
-  public void testBigQueryStorageWrite30MProtoALO() {
+  public void testBigQueryStorageWrite3MProtoALO() {
     setUpTestEnvironment(WriteMode.AT_LEAST_ONCE);
-    runBigQueryIOStorageWritePipeline(3000000, WriteMode.AT_LEAST_ONCE, false);
+    runBigQueryIOStorageWritePipeline(3_000_000, WriteMode.AT_LEAST_ONCE, false);
   }
 
   @Test


### PR DESCRIPTION
Most of our BigQuery write connector tests live in [BigQueryIOWriteTest](https://github.com/ahmedabu98/beam/blob/master/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOWriteTest.java). I took a closer look recently and saw that it's in need of a cleanup. There are some tests that are duplicates, some that could be written more concisely, some have test names that are too vague (some names are even incorrect), some that run with an incorrect write method.

This PR seeks to take care of some of these issues. 

This also fixes a long-standing flake `testTriggeredFileLoadsWithTempTablesToExistingNullSchemaTable[1]` ([example run](https://ci-beam.apache.org/job/beam_PreCommit_Java_GCP_IO_Direct_Cron/1482/testReport/org.apache.beam.sdk.io.gcp.bigquery/BigQueryIOWriteTest/testTriggeredFileLoadsWithTempTablesToExistingNullSchemaTable_1_/))

Update: we also have a gap in our tests for batch file loads that use copy jobs. This PR addresses that too.