### PR TITLE
Light cache weigher for StateFetchingIterators

### DIFF
--- a/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/WeightedList.java
+++ b/sdks/java/fn-execution/src/main/java/org/apache/beam/sdk/fn/data/WeightedList.java
@@ -1,0 +1,78 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.fn.data;
+
+import java.util.List;
+import java.util.concurrent.atomic.AtomicLong;
+
+/** Facade for a {@link List<T>} that keeps track of weight, for cache limit reasons. */
+public class WeightedList<T> {
+
+  /** Original list that is being wrapped. */
+  private final List<T> backing;
+
+  /** Weight of all the elements being tracked. */
+  private final AtomicLong weight;
+
+  public WeightedList(List<T> backing, long weight) {
+    this.backing = backing;
+    this.weight = new AtomicLong(weight);
+  }
+
+  public List<T> getBacking() {
+    return this.backing;
+  }
+
+  public int size() {
+    return this.backing.size();
+  }
+
+  public boolean isEmpty() {
+    return this.backing.isEmpty();
+  }
+
+  public long getWeight() {
+    return weight.longValue();
+  }
+
+  public void add(T element, long weight) {
+    this.backing.add(element);
+    accumulateWeight(weight);
+  }
+
+  public void addAll(WeightedList<T> values) {
+    this.addAll(values.getBacking(), values.getWeight());
+  }
+
+  public void addAll(List<T> values, long weight) {
+    this.backing.addAll(values);
+    accumulateWeight(weight);
+  }
+
+  public void accumulateWeight(long weight) {
+    this.weight.accumulateAndGet(
+        weight,
+        (first, second) -> {
+          try {
+            return Math.addExact(first, second);
+          } catch (ArithmeticException e) {
+            return Long.MAX_VALUE;
+          }
+        });
+  }
+}

--- a/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/stream/DataStreamsTest.java
+++ b/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/stream/DataStreamsTest.java
@@ -141,11 +141,11 @@ public class DataStreamsTest {
 
       WeightedList<String> weightedListA = decoder.decodeFromChunkBoundaryToChunkBoundary();
       assertThat(weightedListA.getBacking(), contains("A"));
-      assertThat(weightedListA.getWeight(), equalTo(2L));
+      assertThat(weightedListA.getWeight(), equalTo(10L)); // 2 + 8
 
       WeightedList<String> weightedListBC = decoder.decodeFromChunkBoundaryToChunkBoundary();
       assertThat(weightedListBC.getBacking(), contains("B", "BigElementC"));
-      assertThat(weightedListBC.getWeight(), equalTo(14L));
+      assertThat(weightedListBC.getWeight(), equalTo(32L)); // 1 + 8 + 4 + 11 + 8
 
       assertThat(decoder.decodeFromChunkBoundaryToChunkBoundary().getBacking(), contains("D"));
       assertThat(decoder.decodeFromChunkBoundaryToChunkBoundary().getBacking(), is(empty()));

--- a/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/stream/DataStreamsTest.java
+++ b/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/stream/DataStreamsTest.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.fn.stream;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.is;
 import static org.hamcrest.collection.IsCollectionWithSize.hasSize;
 import static org.junit.Assert.assertArrayEquals;
@@ -35,6 +36,7 @@ import java.util.List;
 import java.util.NoSuchElementException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.fn.data.WeightedList;
 import org.apache.beam.sdk.fn.stream.DataStreams.DataStreamDecoder;
 import org.apache.beam.sdk.fn.stream.DataStreams.ElementDelimitedOutputStream;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
@@ -57,6 +59,7 @@ public class DataStreamsTest {
   /** Tests for {@link DataStreams.DataStreamDecoder}. */
   @RunWith(JUnit4.class)
   public static class DataStreamDecoderTest {
+
     @Rule public ExpectedException thrown = ExpectedException.none();
 
     @Test
@@ -136,12 +139,19 @@ public class DataStreamsTest {
                       singleElementToSplit.substring(0, singleElementToSplit.size() - 1),
                       singleElementToSplit.substring(singleElementToSplit.size() - 1))));
 
-      assertThat(decoder.decodeFromChunkBoundaryToChunkBoundary(), contains("A"));
-      assertThat(decoder.decodeFromChunkBoundaryToChunkBoundary(), contains("B", "BigElementC"));
-      assertThat(decoder.decodeFromChunkBoundaryToChunkBoundary(), contains("D"));
-      assertThat(decoder.decodeFromChunkBoundaryToChunkBoundary(), is(empty()));
-      assertThat(decoder.decodeFromChunkBoundaryToChunkBoundary(), contains("E", "F"));
-      assertThat(decoder.decodeFromChunkBoundaryToChunkBoundary(), contains("BigElementG"));
+      WeightedList<String> weightedListA = decoder.decodeFromChunkBoundaryToChunkBoundary();
+      assertThat(weightedListA.getBacking(), contains("A"));
+      assertThat(weightedListA.getWeight(), equalTo(2L));
+
+      WeightedList<String> weightedListBC = decoder.decodeFromChunkBoundaryToChunkBoundary();
+      assertThat(weightedListBC.getBacking(), contains("B", "BigElementC"));
+      assertThat(weightedListBC.getWeight(), equalTo(14L));
+
+      assertThat(decoder.decodeFromChunkBoundaryToChunkBoundary().getBacking(), contains("D"));
+      assertThat(decoder.decodeFromChunkBoundaryToChunkBoundary().getBacking(), is(empty()));
+      assertThat(decoder.decodeFromChunkBoundaryToChunkBoundary().getBacking(), contains("E", "F"));
+      assertThat(
+          decoder.decodeFromChunkBoundaryToChunkBoundary().getBacking(), contains("BigElementG"));
       assertFalse(decoder.hasNext());
     }
 
@@ -188,6 +198,7 @@ public class DataStreamsTest {
   /** Tests for {@link ElementDelimitedOutputStream delimited streams}. */
   @RunWith(JUnit4.class)
   public static class ElementDelimitedOutputStreamTest {
+
     @Test
     public void testNothingWritten() throws Exception {
       List<ByteString> output = new ArrayList<>();

--- a/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/stream/DataStreamsTest.java
+++ b/sdks/java/fn-execution/src/test/java/org/apache/beam/sdk/fn/stream/DataStreamsTest.java
@@ -145,7 +145,7 @@ public class DataStreamsTest {
 
       WeightedList<String> weightedListBC = decoder.decodeFromChunkBoundaryToChunkBoundary();
       assertThat(weightedListBC.getBacking(), contains("B", "BigElementC"));
-      assertThat(weightedListBC.getWeight(), equalTo(32L)); // 1 + 8 + 4 + 11 + 8
+      assertThat(weightedListBC.getWeight(), equalTo(29L)); // 2 + 8 + 11 + 8
 
       assertThat(decoder.decodeFromChunkBoundaryToChunkBoundary().getBacking(), contains("D"));
       assertThat(decoder.decodeFromChunkBoundaryToChunkBoundary().getBacking(), is(empty()));

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/StateFetchingIterators.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/StateFetchingIterators.java
@@ -38,6 +38,7 @@ import org.apache.beam.model.fnexecution.v1.BeamFnApi.StateGetRequest;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.StateRequest;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.StateResponse;
 import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.fn.data.WeightedList;
 import org.apache.beam.sdk.fn.stream.DataStreams.DataStreamDecoder;
 import org.apache.beam.sdk.fn.stream.PrefetchableIterables;
 import org.apache.beam.sdk.fn.stream.PrefetchableIterator;
@@ -92,6 +93,7 @@ public class StateFetchingIterators {
 
   @VisibleForTesting
   static class IterableCacheKey implements Weighted {
+
     private IterableCacheKey() {}
 
     static final IterableCacheKey INSTANCE = new IterableCacheKey();
@@ -110,10 +112,12 @@ public class StateFetchingIterators {
 
     /** Represents a set of elements. */
     abstract static class Blocks<T> implements Weighted {
+
       public abstract List<Block<T>> getBlocks();
     }
 
     static class MutatedBlocks<T> extends Blocks<T> {
+
       private final Block<T> wholeBlock;
 
       MutatedBlocks(Block<T> wholeBlock) {
@@ -143,19 +147,12 @@ public class StateFetchingIterators {
       }
     }
 
-    private static long addBoundByMax(long first, long second) {
-      try {
-        return Math.addExact(first, second);
-      } catch (ArithmeticException e) {
-        return Long.MAX_VALUE;
-      }
-    }
-
     /**
      * Represents a logical prefix of elements for the logical stream over the state API. This
      * prefix cannot represent a mutated in memory representation.
      */
     static class BlocksPrefix<T> extends Blocks<T> implements Shrinkable<BlocksPrefix<T>> {
+
       private final List<Block<T>> blocks;
 
       @Override
@@ -185,14 +182,24 @@ public class StateFetchingIterators {
 
     @AutoValue
     abstract static class Block<T> implements Weighted {
+
       public static <T> Block<T> mutatedBlock(List<T> values, long weight) {
+        return mutatedBlock(new WeightedList<>(values, weight));
+      }
+
+      public static <T> Block<T> mutatedBlock(WeightedList<T> weightedList) {
         return new AutoValue_StateFetchingIterators_CachingStateIterable_Block<>(
-            values, null, weight);
+            weightedList.getBacking(), null, weightedList.getWeight());
       }
 
       public static <T> Block<T> fromValues(List<T> values, @Nullable ByteString nextToken) {
+        return fromValues(new WeightedList<>(values, Caches.weigh(values)), nextToken);
+      }
+
+      public static <T> Block<T> fromValues(
+          WeightedList<T> values, @Nullable ByteString nextToken) {
         return new AutoValue_StateFetchingIterators_CachingStateIterable_Block<>(
-            values, nextToken, Caches.weigh(values) + Caches.weigh(nextToken));
+            values.getBacking(), nextToken, values.getWeight() + Caches.weigh(nextToken));
       }
 
       abstract List<T> getValues();
@@ -243,37 +250,36 @@ public class StateFetchingIterators {
       }
 
       // Combine all the individual blocks into one block containing all the values since
-      // they were mutated and we must evict all or none of the blocks. When consuming the blocks,
+      // they were mutated, and we must evict all or none of the blocks. When consuming the blocks,
       // we must have a reference to all or none of the blocks (which forces a load).
       List<Block<T>> blocks = existing.getBlocks();
-      long totalWeight = 0;
       int totalSize = 0;
-      for (int i = 0; i < blocks.size(); ++i) {
-        totalSize += blocks.get(i).getValues().size();
+      for (Block<T> tBlock : blocks) {
+        totalSize += tBlock.getValues().size();
       }
-      List<T> allValues = new ArrayList<>(totalSize);
-      for (int i = 0; i < blocks.size(); ++i) {
-        int startIndex = allValues.size();
-        for (T value : blocks.get(i).getValues()) {
+
+      WeightedList<T> allValues = new WeightedList<>(new ArrayList<>(totalSize), 0L);
+      for (Block<T> block : blocks) {
+        boolean valueRemovedFromBlock = false;
+        List<T> blockValuesToKeep = new ArrayList<>();
+        for (T value : block.getValues()) {
           if (!toRemoveStructuralValues.contains(valueCoder.structuralValue(value))) {
-            allValues.add(value);
+            blockValuesToKeep.add(value);
+          } else {
+            valueRemovedFromBlock = true;
           }
         }
-        // If we didn't remove a value then use the weight of the entire block that has
-        // already been calculated as a shortcut.
-        if (startIndex + blocks.get(i).getValues().size() == allValues.size()) {
-          totalWeight = addBoundByMax(totalWeight, blocks.get(i).getWeight());
-          continue;
-        }
-        // Fallback to getting the weight of each element.
-        for (int j = startIndex; j < allValues.size(); ++j) {
-          totalWeight = addBoundByMax(totalWeight, Caches.weigh(allValues.get(j)));
+
+        // If any value was removed from this block, need to estimate the weight again.
+        // Otherwise, just reuse the block's weight.
+        if (valueRemovedFromBlock) {
+          allValues.addAll(blockValuesToKeep, Caches.weigh(block.getValues()));
+        } else {
+          allValues.addAll(block.getValues(), block.getWeight());
         }
       }
 
-      cache.put(
-          IterableCacheKey.INSTANCE,
-          new MutatedBlocks<>(Block.mutatedBlock(allValues, totalWeight)));
+      cache.put(IterableCacheKey.INSTANCE, new MutatedBlocks<>(Block.mutatedBlock(allValues)));
     }
 
     /**
@@ -285,9 +291,20 @@ public class StateFetchingIterators {
      * requesting data from the state cache.
      */
     public void clearAndAppend(List<T> values) {
-      cache.put(
-          IterableCacheKey.INSTANCE,
-          new MutatedBlocks<>(Block.mutatedBlock(values, Caches.weigh(values))));
+      clearAndAppend(new WeightedList<>(values, Caches.weigh(values)));
+    }
+
+    /**
+     * Clears the cached iterable and appends the set of values wrapped as a {@link
+     * WeightedList<T>}, taking ownership of the list.
+     *
+     * <p>Mutations over the Beam Fn State API must have been performed before any future lookups.
+     *
+     * <p>Ensures that a cache entry exists for the entire iterable enabling future lookups to miss
+     * requesting data from the state cache.
+     */
+    public void clearAndAppend(WeightedList<T> values) {
+      cache.put(IterableCacheKey.INSTANCE, new MutatedBlocks<>(Block.mutatedBlock(values)));
     }
 
     @Override
@@ -304,6 +321,18 @@ public class StateFetchingIterators {
      * cache.
      */
     public void append(List<T> values) {
+      append(new WeightedList<>(values, Caches.weigh(values)));
+    }
+
+    /**
+     * Appends the values, wrapped as a {@link WeightedList<T>}, to the cached iterable.
+     *
+     * <p>Mutations over the Beam Fn State API must have been performed before any future lookups.
+     *
+     * <p>A cache entry will only continue to exist if the entire iterable has been loaded into the
+     * cache.
+     */
+    public void append(WeightedList<T> values) {
       if (values.isEmpty()) {
         return;
       }
@@ -318,23 +347,20 @@ public class StateFetchingIterators {
       }
 
       // Combine all the individual blocks into one block containing all the values since
-      // they were mutated and we must evict all or none of the blocks. When consuming the blocks,
+      // they were mutated, and we must evict all or none of the blocks. When consuming the blocks,
       // we must have a reference to all or none of the blocks (which forces a load).
       List<Block<T>> blocks = existing.getBlocks();
-      long totalWeight = addBoundByMax(Caches.weigh(values), sumWeight(blocks));
       int totalSize = values.size();
-      for (int i = 0; i < blocks.size(); ++i) {
-        totalSize += blocks.get(i).getValues().size();
+      for (Block<T> block : blocks) {
+        totalSize += block.getValues().size();
       }
-      List<T> allValues = new ArrayList<>(totalSize);
-      for (int i = 0; i < blocks.size(); ++i) {
-        allValues.addAll(blocks.get(i).getValues());
+      WeightedList<T> allValues = new WeightedList<>(new ArrayList<>(totalSize), 0L);
+      for (Block<T> block : blocks) {
+        allValues.addAll(block.getValues(), block.getWeight());
       }
       allValues.addAll(values);
 
-      cache.put(
-          IterableCacheKey.INSTANCE,
-          new MutatedBlocks<>(Block.mutatedBlock(allValues, totalWeight)));
+      cache.put(IterableCacheKey.INSTANCE, new MutatedBlocks<>(Block.mutatedBlock(allValues)));
     }
 
     class CachingStateIterator implements PrefetchableIterator<T> {
@@ -351,7 +377,8 @@ public class StateFetchingIterators {
             new DataStreamDecoder<>(valueCoder, underlyingStateFetchingIterator);
         this.currentBlock =
             Block.fromValues(
-                Collections.emptyList(), stateRequestForFirstChunk.getGet().getContinuationToken());
+                new WeightedList<>(Collections.emptyList(), 0L),
+                stateRequestForFirstChunk.getGet().getContinuationToken());
         this.currentCachedBlockValueIndex = 0;
       }
 
@@ -464,7 +491,7 @@ public class StateFetchingIterators {
       @VisibleForTesting
       Block<T> loadNextBlock(ByteString continuationToken) {
         underlyingStateFetchingIterator.seekToContinuationToken(continuationToken);
-        List<T> values = dataStreamDecoder.decodeFromChunkBoundaryToChunkBoundary();
+        WeightedList<T> values = dataStreamDecoder.decodeFromChunkBoundaryToChunkBoundary();
         ByteString nextToken = underlyingStateFetchingIterator.getContinuationToken();
         if (ByteString.EMPTY.equals(nextToken)) {
           nextToken = null;


### PR DESCRIPTION
Instead of using JAMM's `Caches.weigh(values)` when a chunk is fetched + decoded from the ByteString, we can use the amount of bytes that were read for that decoder to happen.

Since all we want are estimates of the weight for caching sizing purposes, this is a more lightweight alternative, as we've noticed considerable overhead / OutOfMemoryErrors induced by JAMM itself.


