### PR TITLE
[#27476] Fix BigQuery batch insertion loop

### DIFF
--- a/sdks/go/pkg/beam/io/bigqueryio/bigquery.go
+++ b/sdks/go/pkg/beam/io/bigqueryio/bigquery.go
@@ -337,10 +337,9 @@ func (f *writeFn) ProcessElement(ctx context.Context, _ int, iter func(*beam.X) 
 			}
 			data = nil
 			size = writeOverheadBytes
-		} else {
-			data = append(data, reflect.ValueOf(val.(any)))
-			size += current
 		}
+		data = append(data, reflect.ValueOf(val.(any)))
+		size += current
 	}
 	if len(data) == 0 {
 		return nil


### PR DESCRIPTION
The `writeFn` implementation in the `bigqueryio` package (part of the Go SDK) may lose rows when attempting to insert a large amount of data.

https://github.com/apache/beam/blob/843e7fdb239e0a61b47e39ce635c37221cd09f4e/sdks/go/pkg/beam/io/bigqueryio/bigquery.go#L328-L344

The loop iterates over the elements of the given PCollection. For each `val` it encounters it either puts the current batch into BigQuery or appends `val` to the current batch. If `val` is about to make the current batch go over BigQuery's limitations, the batch is put into BigQuery. But, the `val` is then not included in the next batch.

Here is a simplified example: https://play.golang.com/p/_3Enne857Rh vs https://play.golang.com/p/-OaX3HpPZkd. Notice that with the first code "f" is missed. But in the second code "f" is included in the second batch.

This PR moves the contents of the `else` block outside of the conditional flow. When a batch is put into BigQuery, the accumulators are reset (marking the start of a new batch) and then immediately `val` is included in the new batch.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
