### PR TITLE
Bump the version for Kafka deserializer dependencies

### DIFF
--- a/examples/java/build.gradle
+++ b/examples/java/build.gradle
@@ -85,7 +85,7 @@ dependencies {
   implementation library.java.vendored_grpc_1_54_0
   implementation library.java.vendored_guava_26_0_jre
   implementation "com.google.api.grpc:proto-google-cloud-language-v1:1.81.4"
-  implementation ("io.confluent:kafka-avro-serializer:5.3.2") {
+  implementation ("io.confluent:kafka-avro-serializer:5.5.15") {
     // It depends on "spotbugs-annotations:3.1.9" which clashes with current
     // "spotbugs-annotations:3.1.12" used in Beam. Not required.
     exclude group: "org.apache.zookeeper", module: "zookeeper"

--- a/sdks/java/io/kafka/build.gradle
+++ b/sdks/java/io/kafka/build.gradle
@@ -63,14 +63,14 @@ dependencies {
   implementation library.java.jackson_annotations
   implementation library.java.jackson_databind
   implementation "org.springframework:spring-expression:5.3.27"
-  implementation ("io.confluent:kafka-avro-serializer:5.3.2") {
+  implementation ("io.confluent:kafka-avro-serializer:5.5.15") {
     // zookeeper depends on "spotbugs-annotations:3.1.9" which clashes with current
     // "spotbugs-annotations:3.1.12" used in Beam. Not required.
     exclude group: "org.apache.zookeeper", module: "zookeeper"
     // "kafka-clients" has to be provided since user can use its own version.
     exclude group: "org.apache.kafka", module: "kafka-clients"
   }
-  implementation ("io.confluent:kafka-schema-registry-client:5.3.2") {
+  implementation ("io.confluent:kafka-schema-registry-client:5.5.15") {
     // It depends on "spotbugs-annotations:3.1.9" which clashes with current
     // "spotbugs-annotations:3.1.12" used in Beam. Not required.
     exclude group: "org.apache.zookeeper", module: "zookeeper"


### PR DESCRIPTION
We recently had difficulties using KafkaIO with SchemaRegistry, in the case where we need to use custom / specific certificates to connect to it.

It turns out that `io.confluent:kafka-schema-registry-client:5.3.2` is not aware of `schema.registry.ssl.*` parameters, and just by pinning a newer version, it works as expected.
