### PR TITLE
Show the proper error message if a GCS exception is thrown without a .message.

### DIFF
--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -824,11 +824,7 @@ class GcsUploader(Uploader):
     self._upload_thread.join()
     # Check for exception since the last put() call.
     if self._upload_thread.last_error is not None:
-      try:
-        message = self._upload_thread.last_error.message
-      except AttributeError:
-        message = str(self._upload_thread.last_error)
+      e = self._upload_thread.last_error
       raise type(self._upload_thread.last_error)(
-          "Error while uploading file %s: %s",
-          self._path,
-          message)  # pylint: disable=raising-bad-type
+          "Error while uploading file %s" % self._path
+      ) from e # pylint: disable=raising-bad-type

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -824,7 +824,11 @@ class GcsUploader(Uploader):
     self._upload_thread.join()
     # Check for exception since the last put() call.
     if self._upload_thread.last_error is not None:
+      try:
+        message = self._upload_thread.last_error.message
+      except AttributeError:
+        message = str(self._upload_thread.last_error)
       raise type(self._upload_thread.last_error)(
           "Error while uploading file %s: %s",
           self._path,
-          self._upload_thread.last_error.message)  # pylint: disable=raising-bad-type
+          message)  # pylint: disable=raising-bad-type

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -826,5 +826,4 @@ class GcsUploader(Uploader):
     if self._upload_thread.last_error is not None:
       e = self._upload_thread.last_error
       raise type(self._upload_thread.last_error)(
-          "Error while uploading file %s" % self._path
-      ) from e # pylint: disable=raising-bad-type
+          "Error while uploading file %s" % self._path) from e  # pylint: disable=raising-bad-type


### PR DESCRIPTION
In a number of production Beam/Dataflow pipelines, we've seen errors like:

```
Traceback (most recent call last):
  File "apache_beam/runners/common.py", line 1459, in apache_beam.runners.common.DoFnRunner._invoke_bundle_method
  File "apache_beam/runners/common.py", line 562, in apache_beam.runners.common.DoFnInvoker.invoke_finish_bundle
  File "apache_beam/runners/common.py", line 567, in apache_beam.runners.common.DoFnInvoker.invoke_finish_bundle
  File "apache_beam/runners/common.py", line 1731, in apache_beam.runners.common._OutputHandler.finish_bundle_outputs
  File "/usr/local/lib/python3.7/site-packages/apache_beam/io/iobase.py", line 1202, in finish_bundle
    self.writer.close(),
  File "/usr/local/lib/python3.7/site-packages/apache_beam/io/filebasedsink.py", line 434, in close
    self.sink.close(self.temp_handle)
  File "/usr/local/lib/python3.7/site-packages/apache_beam/io/textio.py", line 525, in close
    super().close(file_handle)
  File "/usr/local/lib/python3.7/site-packages/apache_beam/io/filebasedsink.py", line 167, in close
    file_handle.close()
  File "/usr/local/lib/python3.7/site-packages/apache_beam/io/filesystemio.py", line 215, in close
    self._uploader.finish()
  File "/usr/local/lib/python3.7/site-packages/apache_beam/io/gcp/gcsio.py", line 829, in finish
    self._upload_thread.last_error.message)  # pylint: disable=raising-bad-type
AttributeError: 'HttpError' object has no attribute 'message'
```

While this error would likely have still caused the pipeline to fail, we don't know what went wrong as the exception handler swallows the exception due to the `AttributeError`.

This PR attempts to show more accurate debug information by using `raise from` to add context to the exception, without requiring the original exception to have a `.message` attribute.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
