### PR TITLE
[prism] middle sized fixes, avro, datastore, spanner

### DIFF
--- a/sdks/go/pkg/beam/io/avroio/avroio.go
+++ b/sdks/go/pkg/beam/io/avroio/avroio.go
@@ -25,13 +25,16 @@ import (
 	"github.com/apache/beam/sdks/v2/go/pkg/beam"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/io/filesystem"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/log"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/register"
 	"github.com/linkedin/goavro/v2"
 )
 
 func init() {
-	beam.RegisterFunction(expandFn)
-	beam.RegisterType(reflect.TypeOf((*avroReadFn)(nil)).Elem())
-	beam.RegisterType(reflect.TypeOf((*writeAvroFn)(nil)).Elem())
+	register.Function3x1(expandFn)
+	register.DoFn3x1[context.Context, string, func(beam.X), error]((*avroReadFn)(nil))
+	register.DoFn3x1[context.Context, int, func(*string) bool, error]((*writeAvroFn)(nil))
+	register.Emitter1[beam.X]()
+	register.Iter1[string]()
 }
 
 // Read reads a set of files and returns lines as a PCollection<elem>

--- a/sdks/go/pkg/beam/io/avroio/avroio_test.go
+++ b/sdks/go/pkg/beam/io/avroio/avroio_test.go
@@ -25,11 +25,29 @@ import (
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam"
 	_ "github.com/apache/beam/sdks/v2/go/pkg/beam/io/filesystem/local"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/register"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/testing/passert"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/testing/ptest"
 
 	"github.com/linkedin/goavro/v2"
 )
+
+func TestMain(m *testing.M) {
+	ptest.Main(m)
+}
+
+func init() {
+	beam.RegisterType(reflect.TypeOf((*Tweet)(nil)).Elem())
+	beam.RegisterType(reflect.TypeOf((*NullableFloat64)(nil)).Elem())
+	beam.RegisterType(reflect.TypeOf((*NullableString)(nil)).Elem())
+	beam.RegisterType(reflect.TypeOf((*NullableTweet)(nil)).Elem())
+	register.Function2x0(toJSONString)
+}
+
+func toJSONString(user TwitterUser, emit func(string)) {
+	b, _ := json.Marshal(user)
+	emit(string(b))
+}
 
 type Tweet struct {
 	Stamp int64  `json:"timestamp"`
@@ -126,16 +144,11 @@ func TestWrite(t *testing.T) {
 	avroFile := "./user.avro"
 	testUsername := "user1"
 	testInfo := "userInfo"
-	p, s, sequence := ptest.CreateList([]string{testUsername})
-	format := beam.ParDo(s, func(username string, emit func(string)) {
-		newUser := TwitterUser{
-			User: username,
-			Info: testInfo,
-		}
-
-		b, _ := json.Marshal(newUser)
-		emit(string(b))
-	}, sequence)
+	p, s, sequence := ptest.CreateList([]TwitterUser{{
+		User: testUsername,
+		Info: testInfo,
+	}})
+	format := beam.ParDo(s, toJSONString, sequence)
 	Write(s, avroFile, userSchema, format)
 	t.Cleanup(func() {
 		os.Remove(avroFile)

--- a/sdks/go/pkg/beam/io/spannerio/common.go
+++ b/sdks/go/pkg/beam/io/spannerio/common.go
@@ -18,9 +18,10 @@
 package spannerio
 
 import (
-	"cloud.google.com/go/spanner"
 	"context"
 	"fmt"
+
+	"cloud.google.com/go/spanner"
 	"google.golang.org/api/option"
 	"google.golang.org/api/option/internaloption"
 	"google.golang.org/grpc"
@@ -28,9 +29,9 @@ import (
 )
 
 type spannerFn struct {
-	Database string          `json:"database"` // Database is the spanner connection string
-	endpoint string          // Override spanner endpoint in tests
-	client   *spanner.Client // Spanner Client
+	Database     string          `json:"database"` // Database is the spanner connection string
+	TestEndpoint string          // Optional endpoint override for local testing. Not required for production pipelines.
+	client       *spanner.Client // Spanner Client
 }
 
 func newSpannerFn(db string) spannerFn {
@@ -48,9 +49,9 @@ func (f *spannerFn) Setup(ctx context.Context) error {
 		var opts []option.ClientOption
 
 		// Append emulator options assuming endpoint is local (for testing).
-		if f.endpoint != "" {
+		if f.TestEndpoint != "" {
 			opts = []option.ClientOption{
-				option.WithEndpoint(f.endpoint),
+				option.WithEndpoint(f.TestEndpoint),
 				option.WithGRPCDialOption(grpc.WithTransportCredentials(insecure.NewCredentials())),
 				option.WithoutAuthentication(),
 				internaloption.SkipDialSettingsValidation(),

--- a/sdks/go/pkg/beam/io/spannerio/read_test.go
+++ b/sdks/go/pkg/beam/io/spannerio/read_test.go
@@ -27,6 +27,10 @@ import (
 	spannertest "github.com/apache/beam/sdks/v2/go/test/integration/io/spannerio"
 )
 
+func TestMain(m *testing.M) {
+	ptest.Main(m)
+}
+
 func TestRead(t *testing.T) {
 	ctx := context.Background()
 
@@ -102,7 +106,7 @@ func TestRead(t *testing.T) {
 
 			p, s := beam.NewPipelineWithRoot()
 			fn := newQueryFn(testCase.database, "SELECT * from "+testCase.table, reflect.TypeOf(TestDto{}), queryOptions{})
-			fn.endpoint = srv.Addr
+			fn.TestEndpoint = srv.Addr
 
 			imp := beam.Impulse(s)
 			rows := beam.ParDo(s, fn, imp, beam.TypeDefinition{Var: beam.XType, T: reflect.TypeOf(TestDto{})})

--- a/sdks/go/pkg/beam/io/spannerio/write_test.go
+++ b/sdks/go/pkg/beam/io/spannerio/write_test.go
@@ -17,12 +17,12 @@ package spannerio
 
 import (
 	"context"
-	spannertest "github.com/apache/beam/sdks/v2/go/test/integration/io/spannerio"
 	"testing"
 
 	"cloud.google.com/go/spanner"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/testing/ptest"
+	spannertest "github.com/apache/beam/sdks/v2/go/test/integration/io/spannerio"
 	"google.golang.org/api/iterator"
 )
 
@@ -77,7 +77,7 @@ func TestWrite(t *testing.T) {
 			p, s, col := ptest.CreateList(testCase.rows)
 
 			fn := newWriteFn(testCase.database, testCase.table, col.Type().Type())
-			fn.endpoint = srv.Addr
+			fn.TestEndpoint = srv.Addr
 
 			beam.ParDo0(s, fn, col)
 


### PR DESCRIPTION
Slightly larger fixes to enable prism to run all the unit tests.

* Avro needed more registered for execution.
* Datastore was doing interesting things with the type registration keys, running afoul of "registrations after init"
* Spanner needed to externalize its test server mechanism a little.

See https://github.com/apache/beam/pull/27550 and https://github.com/apache/beam/issues/24789.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
