### PR TITLE
Properly translate TimestampedValueCoder on runnerv1

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/CloudObjectTranslators.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/CloudObjectTranslators.java
@@ -45,6 +45,7 @@ import org.apache.beam.sdk.util.InstanceBuilder;
 import org.apache.beam.sdk.util.SerializableUtils;
 import org.apache.beam.sdk.util.StringUtils;
 import org.apache.beam.sdk.util.WindowedValue.FullWindowedValueCoder;
+import org.apache.beam.sdk.values.TimestampedValue;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
 
@@ -497,6 +498,39 @@ class CloudObjectTranslators {
       @Override
       public String cloudObjectClassName() {
         return CloudObject.forClass(MapCoder.class).getClassName();
+      }
+    };
+  }
+
+  public static CloudObjectTranslator<TimestampedValue.TimestampedValueCoder> timestampedValue() {
+    return new CloudObjectTranslator<TimestampedValue.TimestampedValueCoder>() {
+      @Override
+      public CloudObject toCloudObject(
+          TimestampedValue.TimestampedValueCoder target, SdkComponents sdkComponents) {
+        CloudObject base = CloudObject.forClass(TimestampedValue.TimestampedValueCoder.class);
+        return addComponents(
+            base, ImmutableList.<Coder<?>>of(target.getValueCoder()), sdkComponents);
+      }
+
+      @Override
+      public TimestampedValue.TimestampedValueCoder<?> fromCloudObject(CloudObject cloudObject) {
+        List<Coder<?>> components = getComponents(cloudObject);
+        checkArgument(
+            components.size() == 1,
+            "Expected 1 components for %s, got %s",
+            TimestampedValue.TimestampedValueCoder.class.getSimpleName(),
+            components.size());
+        return TimestampedValue.TimestampedValueCoder.of(components.get(0));
+      }
+
+      @Override
+      public Class<? extends TimestampedValue.TimestampedValueCoder> getSupportedClass() {
+        return TimestampedValue.TimestampedValueCoder.class;
+      }
+
+      @Override
+      public String cloudObjectClassName() {
+        return CloudObject.forClass(TimestampedValue.TimestampedValueCoder.class).getClassName();
       }
     };
   }

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/DefaultCoderCloudObjectTranslatorRegistrar.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/DefaultCoderCloudObjectTranslatorRegistrar.java
@@ -80,6 +80,7 @@ public class DefaultCoderCloudObjectTranslatorRegistrar
           CloudObjectTranslators.iterableLike(ListCoder.class),
           CloudObjectTranslators.iterableLike(SetCoder.class),
           CloudObjectTranslators.map(),
+          CloudObjectTranslators.timestampedValue(),
           CloudObjectTranslators.nullable(),
           CloudObjectTranslators.union(),
           CloudObjectTranslators.coGroupByKeyResult(),

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/util/CloudObjectsTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/util/CloudObjectsTest.java
@@ -67,6 +67,7 @@ import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
 import org.apache.beam.sdk.util.InstanceBuilder;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.Row;
+import org.apache.beam.sdk.values.TimestampedValue;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TypeDescriptors;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableList;
@@ -167,6 +168,7 @@ public class CloudObjectsTest {
               .add(SetCoder.of(VarLongCoder.of()))
               .add(MapCoder.of(VarLongCoder.of(), ByteArrayCoder.of()))
               .add(NullableCoder.of(IntervalWindow.getCoder()))
+              .add(TimestampedValue.TimestampedValueCoder.of(VarLongCoder.of()))
               .add(
                   UnionCoder.of(
                       ImmutableList.of(


### PR DESCRIPTION
TimestampedValue is a key built-in type, however there was not a properly coder translator. This meant that this was simply Java Serialized, and any pipeline that used this coder was not updatable on Dataflow.

R: @arunpandianp 
R: @johnjcasey 