### PR TITLE
Align Neo4jIO with GCP Dataflow Neo4j Flex Template 

### DIFF
--- a/sdks/java/io/neo4j/src/main/java/org/apache/beam/sdk/io/neo4j/Neo4jIO.java
+++ b/sdks/java/io/neo4j/src/main/java/org/apache/beam/sdk/io/neo4j/Neo4jIO.java
@@ -889,7 +889,7 @@ public class Neo4jIO {
   /** This is the class which handles the work behind the {@link #writeUnwind()} method. */
   @AutoValue
   public abstract static class WriteUnwind<ParameterT>
-      extends PTransform<PCollection<ParameterT>, PDone> {
+      extends PTransform<PCollection<ParameterT>, PCollection<ParameterT>> {
 
     abstract @Nullable SerializableFunction<Void, Driver> getDriverProviderFn();
 
@@ -998,7 +998,7 @@ public class Neo4jIO {
     }
 
     @Override
-    public PDone expand(PCollection<ParameterT> input) {
+    public PCollection<ParameterT> expand(PCollection<ParameterT> input) {
 
       final SerializableFunction<Void, Driver> driverProviderFn = getDriverProviderFn();
       final SerializableFunction<ParameterT, Map<String, Object>> parametersFunction =
@@ -1043,9 +1043,8 @@ public class Neo4jIO {
               logCypher,
               unwindMapName);
 
-      input.apply(ParDo.of(writeFn));
-
-      return PDone.in(input.getPipeline());
+      return input.apply(ParDo.of(writeFn))
+              .setRowSchema(input.getSchema());
     }
 
     @Override
@@ -1087,7 +1086,7 @@ public class Neo4jIO {
   }
 
   /** A {@link DoFn} to execute a Cypher query to read from Neo4j. */
-  private static class WriteUnwindFn<ParameterT> extends ReadWriteFn<ParameterT, Void> {
+  private static class WriteUnwindFn<ParameterT> extends ReadWriteFn<ParameterT, ParameterT> {
 
     private final @NonNull String cypher;
     private final @Nullable SerializableFunction<ParameterT, Map<String, Object>>

--- a/sdks/java/io/neo4j/src/main/java/org/apache/beam/sdk/io/neo4j/Neo4jIO.java
+++ b/sdks/java/io/neo4j/src/main/java/org/apache/beam/sdk/io/neo4j/Neo4jIO.java
@@ -47,8 +47,6 @@ import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.transforms.display.HasDisplayData;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
-import org.apache.beam.sdk.values.PDone;
-import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
 import org.checkerframework.checker.initialization.qual.Initialized;
@@ -1001,7 +999,8 @@ public class Neo4jIO {
 
     public WriteUnwind<ParameterT> withParallelism(int parallelism) {
       checkArgument(
-          parallelism > 0, "Neo4jIO.writeUnwind().withBatchSize(parallelism) called with parallelism<=0");
+          parallelism > 0,
+          "Neo4jIO.writeUnwind().withBatchSize(parallelism) called with parallelism<=0");
       return withParallelism(ValueProvider.StaticValueProvider.of(parallelism));
     }
 
@@ -1069,10 +1068,10 @@ public class Neo4jIO {
       }
 
       return input
-              .apply(ParDo.of(new Reshuffle.AssignShardFn<>(parallelism)))
-              .setCoder(KvCoder.of(BigEndianIntegerCoder.of(), input.getCoder()))
-              .apply(ParDo.of(writeFn))
-              .setRowSchema(input.getSchema());
+          .apply(ParDo.of(new Reshuffle.AssignShardFn<>(parallelism)))
+          .setCoder(KvCoder.of(BigEndianIntegerCoder.of(), input.getCoder()))
+          .apply(ParDo.of(writeFn))
+          .setRowSchema(input.getSchema());
     }
 
     @Override
@@ -1116,7 +1115,8 @@ public class Neo4jIO {
   }
 
   /** A {@link DoFn} to execute a Cypher query to read from Neo4j. */
-  private static class WriteUnwindFn<ParameterT> extends ReadWriteFn<KV<Integer, ParameterT>, ParameterT> {
+  private static class WriteUnwindFn<ParameterT>
+      extends ReadWriteFn<KV<Integer, ParameterT>, ParameterT> {
 
     private final @NonNull String cypher;
     private final @Nullable SerializableFunction<ParameterT, Map<String, Object>>


### PR DESCRIPTION
The [Neo4j Flex Template for GCP Dataflow](https://github.com/GoogleCloudPlatform/DataflowTemplates/tree/main/v2/googlecloud-to-neo4j) currently duplicates what Apache Beam's Neo4jIO provides.

Most of the logic is indeed duplicated and moving to the battle-tested Neo4jIO is a prerequisite for the Neo4j Flex template to graduate to an official template.

There are mainly two differences between the two projects.

The template's write unwind transform returns a `PCollection<Row>`, so that it can be waited on, whereas Neo4jIO's write unwind transform is terminal (and return a `PDone`).

Moreover, the template allows users to specify how much in parallel a node or edge import runs, leveraged by a custom [KV transform](https://github.com/GoogleCloudPlatform/DataflowTemplates/blob/main/v2/googlecloud-to-neo4j/src/main/java/com/google/cloud/teleport/v2/neo4j/transforms/CreateKvTransform.java).
After discussing with @bvolpato, it turns out Apache Beam already provides an equivalent functionality with `Reshuffle.AssignShardFn`.

This PR aligns the two implementations and would unblock the integration of Neo4jIO into Neo4j's Flex Template.
