### PR TITLE
Fix multi_process_shared.py release with AutoProxy

### DIFF
--- a/sdks/python/apache_beam/utils/multi_process_shared.py
+++ b/sdks/python/apache_beam/utils/multi_process_shared.py
@@ -24,8 +24,6 @@ on it via rpc.
 
 import logging
 import multiprocessing.managers
-from inspect import signature
-from functools import wraps
 import os
 import tempfile
 import threading

--- a/sdks/python/apache_beam/utils/multi_process_shared.py
+++ b/sdks/python/apache_beam/utils/multi_process_shared.py
@@ -46,7 +46,6 @@ autoproxy = multiprocessing.managers.AutoProxy
 
 def patched_autoproxy(token, serializer, manager=None, authkey=None,
           exposed=None, incref=True, manager_owned=True):
-    # Calling original AutoProxy without the unwanted key argument
     return autoproxy(token, serializer, manager, authkey,
                      exposed, incref)
 

--- a/sdks/python/apache_beam/utils/multi_process_shared.py
+++ b/sdks/python/apache_beam/utils/multi_process_shared.py
@@ -44,10 +44,17 @@ import fasteners
 # https://stackoverflow.com/questions/46779860/multiprocessing-managers-and-custom-classes
 autoproxy = multiprocessing.managers.AutoProxy
 
-def patched_autoproxy(token, serializer, manager=None, authkey=None,
-          exposed=None, incref=True, manager_owned=True):
-    return autoproxy(token, serializer, manager, authkey,
-                     exposed, incref)
+
+def patched_autoproxy(
+    token,
+    serializer,
+    manager=None,
+    authkey=None,
+    exposed=None,
+    incref=True,
+    manager_owned=True):
+  return autoproxy(token, serializer, manager, authkey, exposed, incref)
+
 
 multiprocessing.managers.AutoProxy = patched_autoproxy
 

--- a/sdks/python/apache_beam/utils/multi_process_shared.py
+++ b/sdks/python/apache_beam/utils/multi_process_shared.py
@@ -40,7 +40,7 @@ import fasteners
 # the kwarg 'manager_owned'. We implement our own backup here to make sure
 # we avoid this problem. More info here:
 # https://stackoverflow.com/questions/46779860/multiprocessing-managers-and-custom-classes
-autoproxy = multiprocessing.managers.AutoProxy
+autoproxy = multiprocessing.managers.AutoProxy  # type: ignore[attr-defined]
 
 
 def patched_autoproxy(
@@ -54,7 +54,7 @@ def patched_autoproxy(
   return autoproxy(token, serializer, manager, authkey, exposed, incref)
 
 
-multiprocessing.managers.AutoProxy = patched_autoproxy
+multiprocessing.managers.AutoProxy = patched_autoproxy  # type: ignore[attr-defined]
 
 T = TypeVar('T')
 AUTH_KEY = b'mps'


### PR DESCRIPTION
Right now, releasing a multi_process_shared object that exists in a different process fails. There were actually 2 issues I ran into debugging this:

1) The first fix you'll see is more specific to some older python environments. Some environments have a version of AutoProxy that doesn't know how to handle the manager_owned kwarg which is passed in by the multiprocessing library as part of this flow. To work around this, I added a patched version that can handle that arg.

2) The releasing logic was wrong. Specifically, we weren't properly registering the `singletonProxy_release` so that it was discoverable across processes, and we were passing in the wrapped proxy object to call this instead of the actual real proxy object. I updated both of these.

Fixes #27602

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
