### PR TITLE
Remove unused `reverse` argument in SmallestPerKey

### DIFF
--- a/sdks/python/apache_beam/transforms/combiners.py
+++ b/sdks/python/apache_beam/transforms/combiners.py
@@ -317,7 +317,7 @@ class Top(object):
 
   @staticmethod
   @ptransform.ptransform_fn
-  def SmallestPerKey(pcoll, n, *, key=None, reverse=None):
+  def SmallestPerKey(pcoll, n, *, key=None):
     """Identifies the N least elements associated with each key."""
     return pcoll | Top.PerKey(n, key, reverse=True)
 


### PR DESCRIPTION
Remove unused `reverse` argument in the SmallestPerKey PTransform as it is a convenience Transform wrapping  `Top.PerKey`.

Similarly, the `Smallest` variant also does not have a `reverse` argument.

https://github.com/apache/beam/blob/cbe2e0f5ad5e45a7f6d380b1b1ac36d5dede8f54/sdks/python/apache_beam/transforms/combiners.py#L305

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
