### PR TITLE
Fix Neo4jIO result consumption

### DIFF
--- a/sdks/java/io/neo4j/src/main/java/org/apache/beam/sdk/io/neo4j/Neo4jIO.java
+++ b/sdks/java/io/neo4j/src/main/java/org/apache/beam/sdk/io/neo4j/Neo4jIO.java
@@ -1168,13 +1168,7 @@ public class Neo4jIO {
       //
       TransactionWork<Void> transactionWork =
           transaction -> {
-            Result result = transaction.run(cypher, parametersMap);
-            while (result.hasNext()) {
-              // This just consumes any output but the function basically has no output
-              // To be revisited based on requirements.
-              //
-              result.next();
-            }
+            transaction.run(cypher, parametersMap).consume();
             return null;
           };
 


### PR DESCRIPTION
Rely on `consume` to consume the results batch by batch, instead of fetching results row per row.
