### PR TITLE
Handle types.GenericAlias types properly during validation

### DIFF
--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -49,7 +49,7 @@ class _TestGeneric(typing.Generic[T]):
   pass
 
 
-class _TestPair(typing.NamedTuple('DataPair', [('base', T), ('diff', T)]),
+class _TestPair(typing.NamedTuple('TestTuple', [('first', T), ('second', T)]),
                 typing.Generic[T]):
   pass
 

--- a/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/native_type_compatibility_test.py
@@ -49,6 +49,11 @@ class _TestGeneric(typing.Generic[T]):
   pass
 
 
+class _TestPair(typing.NamedTuple('DataPair', [('base', T), ('diff', T)]),
+                typing.Generic[T]):
+  pass
+
+
 class NativeTypeCompatibilityTest(unittest.TestCase):
   def test_convert_to_beam_type(self):
     test_cases = [
@@ -99,6 +104,8 @@ class NativeTypeCompatibilityTest(unittest.TestCase):
          typehints.List[_TestGeneric]),
         ('nested generic subscripted', typing.List[_TestGeneric[int]],
          typehints.List[_TestGeneric[int]]),
+        ('nested generic with any', typing.List[_TestPair[typing.Any]],
+         typehints.List[_TestPair[typing.Any]]),
     ]
 
     for test_case in test_cases:

--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -355,14 +355,12 @@ def is_typing_generic(type_param):
 
   Such objects are considered valid type parameters.
 
-  Always returns false for Python versions below 3.7. For versions 3.9 and
-  above, also permits types.GenericAlias.
+  For Python versions 3.9 and above, also permits types.GenericAlias.
   """
-  if hasattr(typing, '_GenericAlias') and hasattr(types, "GenericAlias"):
-    return isinstance(type_param, (typing._GenericAlias, types.GenericAlias))
-  elif hasattr(typing, '_GenericAlias'):
-    return isinstance(type_param, typing._GenericAlias)
-  return False
+  if hasattr(types, "GenericAlias") and isinstance(type_param,
+                                                   types.GenericAlias):
+    return True
+  return isinstance(type_param, typing._GenericAlias)
 
 
 def validate_composite_type_param(type_param, error_msg_prefix):

--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -358,7 +358,7 @@ def is_typing_generic(type_param):
   Always returns false for Python versions below 3.7.
   """
   if hasattr(typing, '_GenericAlias'):
-    return isinstance(type_param, typing._GenericAlias)
+    return isinstance(type_param, (typing._GenericAlias, types.GenericAlias))
   return False
 
 

--- a/sdks/python/apache_beam/typehints/typehints.py
+++ b/sdks/python/apache_beam/typehints/typehints.py
@@ -355,10 +355,13 @@ def is_typing_generic(type_param):
 
   Such objects are considered valid type parameters.
 
-  Always returns false for Python versions below 3.7.
+  Always returns false for Python versions below 3.7. For versions 3.9 and
+  above, also permits types.GenericAlias.
   """
-  if hasattr(typing, '_GenericAlias'):
+  if hasattr(typing, '_GenericAlias') and hasattr(types, "GenericAlias"):
     return isinstance(type_param, (typing._GenericAlias, types.GenericAlias))
+  elif hasattr(typing, '_GenericAlias'):
+    return isinstance(type_param, typing._GenericAlias)
   return False
 
 

--- a/sdks/python/apache_beam/typehints/typehints_test.py
+++ b/sdks/python/apache_beam/typehints/typehints_test.py
@@ -619,6 +619,13 @@ class ListHintTestCase(TypeHintTestCase):
       self.assertCompatible(list, typing.List)
       self.assertCompatible(list[int], typing.List[int])
 
+  def test_is_typing_generic(self):
+    self.assertTrue(typehints.is_typing_generic(typing.List[str]))
+
+  def test_builtin_is_typing_generic(self):
+    if sys.version_info >= (3, 9):
+      self.assertTrue(typehints.is_typing_generic(list[str]))
+
 
 class KVHintTestCase(TypeHintTestCase):
   def test_getitem_param_must_be_tuple(self):
@@ -790,6 +797,10 @@ class BaseSetHintTest:
           self.beam_type[list]
         except TypeError:
           self.fail("built-in composite raised TypeError unexpectedly")
+
+    def test_non_typing_generic(self):
+      testCase = DummyTestClass1()
+      self.assertFalse(typehints.is_typing_generic(testCase))
 
     def test_compatibility(self):
       hint1 = self.beam_type[typehints.List[str]]


### PR DESCRIPTION
A bug was found by a user jumping from Python 3.10 to Python 3.11 failing a parameterized generic type check improperly. The root cause seems to be a lack of support for the PEP-585 types.GenericAlias class, which was not being treated as a typing generic by the type hinting code. This corrects that issue and adds a unit test case that reproduced the original issue.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
