### PR TITLE
Fix stateful processing using direct runner with type checks enabled

### DIFF
--- a/sdks/python/apache_beam/transforms/util_test.py
+++ b/sdks/python/apache_beam/transforms/util_test.py
@@ -1046,9 +1046,10 @@ class GroupIntoBatchesTest(unittest.TestCase):
     options = PipelineOptions()
     options.view_as(TypeOptions).runtime_type_check = True
     with TestPipeline(options=options) as pipeline:
-      collection = pipeline \
-        | beam.Create(GroupIntoBatchesTest._create_test_data()) \
-        | util.GroupIntoBatches(GroupIntoBatchesTest.BATCH_SIZE)
+      collection = (
+          pipeline
+          | beam.Create(GroupIntoBatchesTest._create_test_data())
+          | util.GroupIntoBatches(GroupIntoBatchesTest.BATCH_SIZE))
       num_batches = collection | beam.combiners.Count.Globally()
       assert_that(
           num_batches,

--- a/sdks/python/apache_beam/transforms/util_test.py
+++ b/sdks/python/apache_beam/transforms/util_test.py
@@ -1046,9 +1046,18 @@ class GroupIntoBatchesTest(unittest.TestCase):
     options = PipelineOptions()
     options.view_as(TypeOptions).runtime_type_check = True
     with TestPipeline(options=options) as pipeline:
-      pipeline \
+      collection = pipeline \
         | beam.Create(GroupIntoBatchesTest._create_test_data()) \
         | util.GroupIntoBatches(GroupIntoBatchesTest.BATCH_SIZE)
+      num_batches = collection | beam.combiners.Count.Globally()
+      assert_that(
+          num_batches,
+          equal_to([
+              int(
+                  math.ceil(
+                      GroupIntoBatchesTest.NUM_ELEMENTS /
+                      GroupIntoBatchesTest.BATCH_SIZE))
+          ]))
 
   def _test_runner_api_round_trip(self, transform, urn):
     context = pipeline_context.PipelineContext()

--- a/sdks/python/apache_beam/transforms/util_test.py
+++ b/sdks/python/apache_beam/transforms/util_test.py
@@ -1042,7 +1042,7 @@ class GroupIntoBatchesTest(unittest.TestCase):
               ShardedKeyType[typehints.Tuple[int, int]],  # type: ignore[misc]
               typehints.Iterable[str]])
 
-  def test_with_type_hints(self):
+  def test_runtime_type_check(self):
     options = PipelineOptions()
     options.view_as(TypeOptions).runtime_type_check = True
     with TestPipeline(options=options) as pipeline:

--- a/sdks/python/apache_beam/transforms/util_test.py
+++ b/sdks/python/apache_beam/transforms/util_test.py
@@ -39,6 +39,7 @@ from apache_beam.coders import coders
 from apache_beam.metrics import MetricsFilter
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import StandardOptions
+from apache_beam.options.pipeline_options import TypeOptions
 from apache_beam.portability import common_urns
 from apache_beam.portability.api import beam_runner_api_pb2
 from apache_beam.pvalue import AsList
@@ -1040,6 +1041,14 @@ class GroupIntoBatchesTest(unittest.TestCase):
           typehints.Tuple[
               ShardedKeyType[typehints.Tuple[int, int]],  # type: ignore[misc]
               typehints.Iterable[str]])
+
+  def test_with_type_hints(self):
+    options = PipelineOptions()
+    options.view_as(TypeOptions).runtime_type_check = True
+    with TestPipeline(options=options) as pipeline:
+      pipeline \
+        | beam.Create(GroupIntoBatchesTest._create_test_data()) \
+        | util.GroupIntoBatches(GroupIntoBatchesTest.BATCH_SIZE)
 
   def _test_runner_api_round_trip(self, transform, urn):
     context = pipeline_context.PipelineContext()

--- a/sdks/python/apache_beam/typehints/typecheck.py
+++ b/sdks/python/apache_beam/typehints/typecheck.py
@@ -48,6 +48,10 @@ class AbstractDoFnWrapper(DoFn):
   def __init__(self, dofn):
     super().__init__()
     self.dofn = dofn
+    if hasattr(dofn, 'on_window_timer'):
+      self.on_window_timer = dofn.on_window_timer
+    if hasattr(dofn, 'on_buffering_timer'):
+      self.on_buffering_timer = dofn.on_buffering_timer
 
   def _inspect_start_bundle(self):
     return self.dofn.get_function_arguments('start_bundle')

--- a/sdks/python/apache_beam/typehints/typecheck.py
+++ b/sdks/python/apache_beam/typehints/typecheck.py
@@ -68,6 +68,9 @@ class AbstractDoFnWrapper(DoFn):
   def wrapper(self, method, args, kwargs):
     return method(*args, **kwargs)
 
+  def setup(self):
+    return self.dofn.setup()
+
   def start_bundle(self, *args, **kwargs):
     return self.wrapper(self.dofn.start_bundle, args, kwargs)
 
@@ -76,6 +79,9 @@ class AbstractDoFnWrapper(DoFn):
 
   def finish_bundle(self, *args, **kwargs):
     return self.wrapper(self.dofn.finish_bundle, args, kwargs)
+
+  def teardown(self):
+    return self.dofn.teardown()
 
 
 class OutputCheckWrapperDoFn(AbstractDoFnWrapper):

--- a/sdks/python/apache_beam/typehints/typecheck.py
+++ b/sdks/python/apache_beam/typehints/typecheck.py
@@ -68,9 +68,6 @@ class AbstractDoFnWrapper(DoFn):
   def wrapper(self, method, args, kwargs):
     return method(*args, **kwargs)
 
-  def setup(self):
-    return self.dofn.setup()
-
   def start_bundle(self, *args, **kwargs):
     return self.wrapper(self.dofn.start_bundle, args, kwargs)
 
@@ -79,9 +76,6 @@ class AbstractDoFnWrapper(DoFn):
 
   def finish_bundle(self, *args, **kwargs):
     return self.wrapper(self.dofn.finish_bundle, args, kwargs)
-
-  def teardown(self):
-    return self.dofn.teardown()
 
 
 class OutputCheckWrapperDoFn(AbstractDoFnWrapper):

--- a/sdks/python/apache_beam/typehints/typecheck.py
+++ b/sdks/python/apache_beam/typehints/typecheck.py
@@ -50,7 +50,7 @@ class AbstractDoFnWrapper(DoFn):
     self.dofn = dofn
 
   def __getattribute__(self, name):
-    if (name.startswith('__') or name in self.__dict__ or
+    if (name.startswith('_') or name in self.__dict__ or
         hasattr(type(self), name)):
       return object.__getattribute__(self, name)
     else:

--- a/sdks/python/apache_beam/typehints/typecheck.py
+++ b/sdks/python/apache_beam/typehints/typecheck.py
@@ -48,10 +48,13 @@ class AbstractDoFnWrapper(DoFn):
   def __init__(self, dofn):
     super().__init__()
     self.dofn = dofn
-    if hasattr(dofn, 'on_window_timer'):
-      self.on_window_timer = dofn.on_window_timer
-    if hasattr(dofn, 'on_buffering_timer'):
-      self.on_buffering_timer = dofn.on_buffering_timer
+
+  def __getattribute__(self, name):
+    if (name.startswith('__') or name in self.__dict__ or
+        hasattr(type(self), name)):
+      return object.__getattribute__(self, name)
+    else:
+      return getattr(self.dofn, name)
 
   def _inspect_start_bundle(self):
     return self.dofn.get_function_arguments('start_bundle')


### PR DESCRIPTION
With this change all of the public methods of DoFns are now properly proxied from `AbstractDoFnWrapper`, which fixes an issue with using stateful DoFns on direct runner with runtime type checks enabled.

Closes #27167

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
