### PR TITLE
[#26902] Add switch for supporting cross compile arm64 for dataflow

### DIFF
--- a/sdks/go/container/build.gradle
+++ b/sdks/go/container/build.gradle
@@ -40,6 +40,7 @@ docker {
                      project.rootProject.hasProperty(["isRelease"])])
   buildx project.containerPlatforms() != [project.nativeArchitecture()]
   platform(*project.containerPlatforms())
+  push true
 }
 dockerPrepare.dependsOn tasks.named("goBuild")
 

--- a/sdks/go/pkg/beam/runners/dataflow/dataflowlib/execute.go
+++ b/sdks/go/pkg/beam/runners/dataflow/dataflowlib/execute.go
@@ -21,6 +21,7 @@ import (
 	"context"
 	"encoding/json"
 	"os"
+	"strings"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/metrics"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime/graphx"
@@ -47,7 +48,12 @@ func Execute(ctx context.Context, raw *pipepb.Pipeline, opts *JobOptions, worker
 		} else {
 			// Cross-compile as last resort.
 
-			worker, err := runnerlib.BuildTempWorkerBinary(ctx)
+			var copts runnerlib.CompileOpts
+			if strings.HasPrefix(opts.MachineType, "t2a") {
+				copts.Arch = "arm64"
+			}
+
+			worker, err := runnerlib.BuildTempWorkerBinary(ctx, copts)
 			if err != nil {
 				return presult, err
 			}

--- a/sdks/go/pkg/beam/runners/universal/runnerlib/execute.go
+++ b/sdks/go/pkg/beam/runners/universal/runnerlib/execute.go
@@ -48,7 +48,7 @@ func Execute(ctx context.Context, p *pipepb.Pipeline, endpoint string, opt *JobO
 		} else {
 			// Cross-compile as last resort.
 
-			worker, err := BuildTempWorkerBinary(ctx)
+			worker, err := BuildTempWorkerBinary(ctx, CompileOpts{})
 			if err != nil {
 				return presult, err
 			}

--- a/sdks/go/test/build.gradle
+++ b/sdks/go/test/build.gradle
@@ -45,6 +45,31 @@ task dataflowValidatesRunner() {
   }
 }
 
+// ValidatesRunner tests for Dataflow. Runs tests in the integration directory
+// with Dataflow to validate that the runner behaves as expected, on arm64 machines.
+task dataflowValidatesRunnerARM64() {
+  group = "Verification"
+
+  dependsOn ":sdks:go:test:goBuild"
+  dependsOn ":sdks:java:testing:expansion-service:buildTestExpansionServiceJar"
+
+  doLast {
+    def pipelineOptions = [  // Pipeline options piped directly to Go SDK flags.
+        "--expansion_jar=test:${project(":sdks:java:testing:expansion-service").buildTestExpansionServiceJar.archivePath}",
+        "--machine_type=t2a-standard-1",
+    ]
+    def options = [
+        "--runner dataflow",
+        "--pipeline_opts \"${pipelineOptions.join(' ')}\"",
+    ]
+    exec {
+      executable "sh"
+      args "-c", "./run_validatesrunner_tests.sh ${options.join(' ')}"
+    }
+  }
+}
+
+
 // ValidatesRunner tests for Flink. Runs tests in the integration directory
 // with Flink to validate that the runner behaves as expected.
 task flinkValidatesRunner {


### PR DESCRIPTION
Adds a switch to prepare for Arm64 support against Google Cloud Dataflow, via machine type specification.

This change adds an additional option for supporting arbitrary architectures for the automatic cross compile which is necessary for adding testing against the service. See https://github.com/apache/beam/issues/26902 and 27311.

A subsequent change should have a more general flag for users who want the cross compile to target other machines. This should be added to JobOpts. End users can continue to work around this by building their own worker binary and setting the --worker_binary flag when submitting a job, per https://beam.apache.org/documentation/sdks/go-cross-compilation/. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
