### PR TITLE
Bump spark3 and hadoop in java buildSrc

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -536,7 +536,7 @@ class BeamModulePlugin implements Plugin<Project> {
     // Try to keep grpc_version consistent with gRPC version in google_cloud_platform_libraries_bom
     def grpc_version = "1.55.1"
     def guava_version = "32.0.1-jre"
-    def hadoop_version = "3.3.6"
+    def hadoop_version = "3.2.4"
     def hamcrest_version = "2.1"
     def influxdb_version = "2.19"
     def httpclient_version = "4.5.13"

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -536,7 +536,7 @@ class BeamModulePlugin implements Plugin<Project> {
     // Try to keep grpc_version consistent with gRPC version in google_cloud_platform_libraries_bom
     def grpc_version = "1.55.1"
     def guava_version = "32.0.1-jre"
-    def hadoop_version = "2.10.2"
+    def hadoop_version = "3.3.6"
     def hamcrest_version = "2.1"
     def influxdb_version = "2.19"
     def httpclient_version = "4.5.13"
@@ -560,7 +560,7 @@ class BeamModulePlugin implements Plugin<Project> {
     def singlestore_jdbc_version = "1.1.4"
     def slf4j_version = "1.7.30"
     def spark2_version = "2.4.8"
-    def spark3_version = "3.2.2"
+    def spark3_version = "3.4.1"
     def spotbugs_version = "4.0.6"
     def testcontainers_version = "1.17.3"
     def arrow_version = "5.0.0"

--- a/sdks/java/io/hcatalog/build.gradle
+++ b/sdks/java/io/hcatalog/build.gradle
@@ -33,6 +33,7 @@ def hadoopVersions = [
     "285": "2.8.5",
     "292": "2.9.2",
     "2102": "2.10.2",
+    "324": "3.2.4"
 ]
 
 hadoopVersions.each {kv -> configurations.create("hadoopVersion$kv.key")}


### PR DESCRIPTION
Hello! I'm a security engineer at Spotify and am assisting the maintainers of our [Scio](https://github.com/spotify/scio) project with resolving several security vulnerabilities. Scio maintains version parity with Beam and would like your blessing in upgrading the following to ensure continued compatibility.

- Hadoop 2.10.2 -> ~3.3.6~ 3.2.4 (changed to 3.2.4 to sync w/ rest of components using Hadoop 3) (Per [BEAM-8569](https://issues.apache.org/jira/browse/BEAM-8569), Hadoop 3 should be compatible).
- Spark 3.2.2 -> 3.4.1 (Spark [migration guide](https://spark.apache.org/docs/latest/core-migration-guide.html) doesn't mention any changes that seem to impact beam).

For compatibility validation, I ran the Java test suites mentioned in the [Contribution Testing Guide](https://cwiki.apache.org/confluence/display/BEAM/Contribution+Testing+Guide). Please let me know if any additional checks need to be ran before this can get merged in.

Thanks!

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI.
