### PR TITLE
Upgrade com.google.cloud.bigdataoss:gcsio dependency to 2.2.16

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -532,7 +532,7 @@ class BeamModulePlugin implements Plugin<Project> {
     // Try to keep gax_version consistent with gax-grpc version in google_cloud_platform_libraries_bom
     def gax_version = "2.29.0"
     def google_clients_version = "2.0.0"
-    def google_cloud_bigdataoss_version = "2.2.6"
+    def google_cloud_bigdataoss_version = "2.2.16"
     // Try to keep google_cloud_spanner_version consistent with google_cloud_spanner_bom in google_cloud_platform_libraries_bom
     def google_cloud_spanner_version = "6.43.0"
     def google_code_gson_version = "2.9.1"


### PR DESCRIPTION
When trying to use gcsio client through gRPC (on Dataflow, `use_grpc_for_gcs` flag), the current version (2.2.16) fails with:

```
Caused by: java.lang.RuntimeException: Could not stage /var/folders/1b/0t6djpxj5n72_pbmtv4z3ffh010wzc/T/classes15993232808130966042.zip to gs://{bucket}/temp/staging/classes-0Lf2iFDqMLc10z77LXWOZ0kDsXI9nV6I-2TrG4_e2tU.jar
	at org.apache.beam.runners.dataflow.util.PackageUtil.tryStagePackageWithRetry(PackageUtil.java:196)
	at org.apache.beam.runners.dataflow.util.PackageUtil.stagePackageSynchronously(PackageUtil.java:153)
	... 6 more
Caused by: java.io.IOException: Upload failed for 'gs://{bucket}/temp/staging/classes-0Lf2iFDqMLc10z77LXWOZ0kDsXI9nV6I-2TrG4_e2tU.jar'
        ...
	Caused by: java.io.IOException: Caught exception for 'gs://{bucket}/temp/staging/classes-0Lf2iFDqMLc10z77LXWOZ0kDsXI9nV6I-2TrG4_e2tU.jar'
		at com.google.cloud.hadoop.gcsio.GoogleCloudStorageGrpcWriteChannel$UploadOperation$SimpleResponseObserver.onError(GoogleCloudStorageGrpcWriteChannel.java:586)
        ...
	Caused by: io.grpc.StatusRuntimeException: INVALID_ARGUMENT: An x-goog-request-params request metadata property must be provided for this request.
		at io.grpc.Status.asRuntimeException(Status.java:539)
		... 18 more

```  

Upgrading it to latest (2.2.16) fixes the issue.

Transient dependencies also move a couple of CVEs to out-of-range:

- CVE-2023-32732
- CVE-2023-32731
- CVE-2023-1428
- CVE-2022-3510
- CVE-2022-3509
- CVE-2022-3171
- CVE-2021-22573

So it is a clear step in the right direction.