### PR TITLE
Reduce number of connections used by KafkaIO restriction trackers

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedSource.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedSource.java
@@ -93,8 +93,7 @@ class KafkaUnboundedSource<K, V> extends UnboundedSource<KafkaRecord<K, V>, Kafk
     }
 
     partitions.sort(
-        Comparator.comparing(TopicPartition::topic)
-            .thenComparing(Comparator.comparingInt(TopicPartition::partition)));
+        Comparator.comparing(TopicPartition::topic).thenComparingInt(TopicPartition::partition));
 
     checkArgument(desiredNumSplits > 0);
     checkState(
@@ -176,7 +175,7 @@ class KafkaUnboundedSource<K, V> extends UnboundedSource<KafkaRecord<K, V>, Kafk
 
   private static final Logger LOG = LoggerFactory.getLogger(KafkaUnboundedSource.class);
 
-  private final Read<K, V> spec; // Contains all the relevant configuratiton of the source.
+  private final Read<K, V> spec; // Contains all the relevant configuration of the source.
   private final int id; // split id, mainly for debugging
 
   public KafkaUnboundedSource(Read<K, V> spec, int id) {


### PR DESCRIPTION
It was recently identified that `ReadFromKafkaDoFn`'s `restrictionTracker` leaked connections that are not being polled anymore.

This can cause considerable performance degradation for Kafka clusters, as they rely on the `connections.max.idle.ms` to clean it up.


It was also hard to track where new connections were coming from, so I've added a few logs to indicate when a new connection is needed in the critical path.


`KafkaLatestOffsetEstimator` doesn't hold any state, so by reusing it across backlog statistics for the same DoFn instance, we can save a huge amount of connections.


![image](https://github.com/apache/beam/assets/3207647/2d394410-f4dd-4daa-87c8-2b0aacab2cb0)


