### PR TITLE
Return a useful error when we fail to create a MonitoringInfo object

### DIFF
--- a/sdks/python/apache_beam/metrics/monitoring_infos.py
+++ b/sdks/python/apache_beam/metrics/monitoring_infos.py
@@ -299,8 +299,13 @@ def create_monitoring_info(urn, type_urn, payload, labels=None):
     payload: The payload field to use in the monitoring info.
     labels: The label dictionary to use in the MonitoringInfo.
   """
-  return metrics_pb2.MonitoringInfo(
-      urn=urn, type=type_urn, labels=labels or {}, payload=payload)
+  try:
+    return metrics_pb2.MonitoringInfo(
+        urn=urn, type=type_urn, labels=labels or {}, payload=payload)
+  except TypeError as e:
+    raise Exception(
+        f'Failed to create MonitoringInfo for urn {urn} type {type} labels ' +
+        '{labels} and payload {payload}') from e
 
 
 def is_counter(monitoring_info_proto):

--- a/sdks/python/apache_beam/metrics/monitoring_infos.py
+++ b/sdks/python/apache_beam/metrics/monitoring_infos.py
@@ -303,7 +303,7 @@ def create_monitoring_info(urn, type_urn, payload, labels=None):
     return metrics_pb2.MonitoringInfo(
         urn=urn, type=type_urn, labels=labels or {}, payload=payload)
   except TypeError as e:
-    raise Exception(
+    raise RuntimeError(
         f'Failed to create MonitoringInfo for urn {urn} type {type} labels ' +
         '{labels} and payload {payload}') from e
 


### PR DESCRIPTION
Right now, it is possible for users to increment counters incorrectly, leading to errors when we try to construct the counters. These errors are usually opaque and unhelpful (e.g. `TypeError: 123 has type numpy.int64, but expected one of: bytes`). These don't provide enough info to debug. This PR enriches these errors so that users can self serve issues by looking at the metric in question.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
