### PR TITLE
refs: issue-27728, Improve java sdk docs

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
@@ -648,8 +648,8 @@ public class DatastoreV1 {
      *       chosen dynamically at runtime based on the query data size.
      *   <li>Any value greater than {@link Read#NUM_QUERY_SPLITS_MAX} will be capped at {@code
      *       NUM_QUERY_SPLITS_MAX}.
-     *   <li>If the {@code query} has a user limit set, or contains inequality filters, then {@code numQuerySplits} will be ignored
-     *       and no split will be performed.
+     *   <li>If the {@code query} has a user limit set, or contains inequality filters, 
+     *       then {@code numQuerySplits} will be ignored and no split will be performed.
      *   <li>Under certain cases Cloud Datastore is unable to split query to the requested number of
      *       splits. In such cases we just use whatever the Cloud Datastore returns.
      * </ul>

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
@@ -648,8 +648,8 @@ public class DatastoreV1 {
      *       chosen dynamically at runtime based on the query data size.
      *   <li>Any value greater than {@link Read#NUM_QUERY_SPLITS_MAX} will be capped at {@code
      *       NUM_QUERY_SPLITS_MAX}.
-     *   <li>If the {@code query} has a user limit set, or contains inequality filters, 
-     *       then {@code numQuerySplits} will be ignored and no split will be performed.
+     *   <li>If the {@code query} has a user limit set, or contains inequality filters, then {@code
+     *       numQuerySplits} will be ignored and no split will be performed.
      *   <li>Under certain cases Cloud Datastore is unable to split query to the requested number of
      *       splits. In such cases we just use whatever the Cloud Datastore returns.
      * </ul>

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.java
@@ -648,7 +648,7 @@ public class DatastoreV1 {
      *       chosen dynamically at runtime based on the query data size.
      *   <li>Any value greater than {@link Read#NUM_QUERY_SPLITS_MAX} will be capped at {@code
      *       NUM_QUERY_SPLITS_MAX}.
-     *   <li>If the {@code query} has a user limit set, then {@code numQuerySplits} will be ignored
+     *   <li>If the {@code query} has a user limit set, or contains inequality filters, then {@code numQuerySplits} will be ignored
      *       and no split will be performed.
      *   <li>Under certain cases Cloud Datastore is unable to split query to the requested number of
      *       splits. In such cases we just use whatever the Cloud Datastore returns.


### PR DESCRIPTION
Fixes #27728 

Description:
- Keep documentation consistent across SDKs
- Java SDK docs [doesn't mention](https://beam.apache.org/releases/javadoc/current/org/apache/beam/sdk/io/gcp/datastore/DatastoreV1.Read.html#:~:text=If%20the%20query%20has%20a%20user%20limit%20set%2C%20then%20numQuerySplits%20will%20be%20ignored%20and%20no%20split%20will%20be%20performed) detail about inequality queries for `withNumQuerySplits` function
- Python SDK docs [mention](https://beam.apache.org/releases/pydoc/current/apache_beam.io.gcp.datastore.v1new.datastoreio.html#:~:text=If%20the%20query%20has%20a%20user%20limit%20set%2C%20or%20contains%20inequality%20filters%2C%20then%20num_splits%20will%20be%20ignored%20and%20no%20split%20will%20be%20performed) the same here

javadoc:
<img width="1454" alt="Screenshot 2023-07-27 at 7 55 49 PM" src="https://github.com/apache/beam/assets/10058508/ba2c2820-d3b0-4f00-b07e-21df5bb81ab4">

pydoc:
<img width="714" alt="Screenshot 2023-07-27 at 7 56 40 PM" src="https://github.com/apache/beam/assets/10058508/c25efcf9-03ff-460c-94f7-1f3cd017c55c">

context: faced this exception while running a dataflow job that utilizes this function
<img width="858" alt="Screen Shot 2023-07-27 at 8 00 30 PM" src="https://github.com/apache/beam/assets/10058508/0d1e5904-58af-410c-8d97-2844ef0e252c">

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
