### PR TITLE
Update to libraries-bom 26.20.0

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -530,16 +530,16 @@ class BeamModulePlugin implements Plugin<Project> {
     def dbcp2_version = "2.9.0"
     def errorprone_version = "2.10.0"
     // Try to keep gax_version consistent with gax-grpc version in google_cloud_platform_libraries_bom
-    def gax_version = "2.29.0"
+    def gax_version = "2.31.1"
     def google_clients_version = "2.0.0"
     def google_cloud_bigdataoss_version = "2.2.6"
     // Try to keep google_cloud_spanner_version consistent with google_cloud_spanner_bom in google_cloud_platform_libraries_bom
-    def google_cloud_spanner_version = "6.43.0"
-    def google_code_gson_version = "2.9.1"
+    def google_cloud_spanner_version = "6.44.0"
+    def google_code_gson_version = "2.10.1"
     def google_oauth_clients_version = "1.34.1"
     // Try to keep grpc_version consistent with gRPC version in google_cloud_platform_libraries_bom
-    def grpc_version = "1.55.1"
-    def guava_version = "32.0.1-jre"
+    def grpc_version = "1.56.1"
+    def guava_version = "32.1.1-jre"
     def hadoop_version = "2.10.2"
     def hamcrest_version = "2.1"
     def influxdb_version = "2.19"
@@ -677,9 +677,9 @@ class BeamModulePlugin implements Plugin<Project> {
         google_cloud_pubsub                         : "com.google.cloud:google-cloud-pubsub", // google_cloud_platform_libraries_bom sets version
         google_cloud_pubsublite                     : "com.google.cloud:google-cloud-pubsublite",  // google_cloud_platform_libraries_bom sets version
         // The release notes shows the versions set by the BOM:
-        // https://github.com/googleapis/java-cloud-bom/releases/tag/v26.17.0
+        // https://github.com/googleapis/java-cloud-bom/releases/tag/v26.20.0
         // Update libraries-bom version on sdks/java/container/license_scripts/dep_urls_java.yaml
-        google_cloud_platform_libraries_bom         : "com.google.cloud:libraries-bom:26.17.0",
+        google_cloud_platform_libraries_bom         : "com.google.cloud:libraries-bom:26.20.0",
         google_cloud_spanner                        : "com.google.cloud:google-cloud-spanner", // google_cloud_platform_libraries_bom sets version
         google_cloud_spanner_test                   : "com.google.cloud:google-cloud-spanner:$google_cloud_spanner_version:tests",
         google_code_gson                            : "com.google.code.gson:gson:$google_code_gson_version",
@@ -824,7 +824,7 @@ class BeamModulePlugin implements Plugin<Project> {
         testcontainers_oracle                       : "org.testcontainers:oracle-xe:$testcontainers_version",
         testcontainers_postgresql                   : "org.testcontainers:postgresql:$testcontainers_version",
         testcontainers_rabbitmq                     : "org.testcontainers:rabbitmq:$testcontainers_version",
-        truth                                       : "com.google.truth:truth:1.0.1",
+        truth                                       : "com.google.truth:truth:1.1.5",
         threetenbp                                  : "org.threeten:threetenbp:1.6.8",
         vendored_grpc_1_54_0                        : "org.apache.beam:beam-vendor-grpc-1_54_0:0.1",
         vendored_guava_26_0_jre                     : "org.apache.beam:beam-vendor-guava-26_0-jre:0.1",
@@ -1137,6 +1137,10 @@ class BeamModulePlugin implements Plugin<Project> {
         // test libraries classes causing version conflicts. Users should rely
         // on using the yyy-core package instead of the yyy-all package.
         exclude group: "org.hamcrest", module: "hamcrest-all"
+
+        // https://github.com/google/guava/releases/tag/v32.1.0#user-content-overlap
+        // Guava starting on v32.1.0 report classes as duplicate
+        exclude group: "com.google.guava", module: "listenablefuture"
       }
 
       // Force usage of the libraries defined within our common set found in the root

--- a/it/cassandra/build.gradle
+++ b/it/cassandra/build.gradle
@@ -30,7 +30,10 @@ dependencies {
     implementation library.java.testcontainers_cassandra
     implementation 'com.datastax.oss:java-driver-core:4.15.0'
 
-    testImplementation library.java.truth
+    // TODO: excluding Guava until Truth updates it to >32.1.x
+    testImplementation(library.java.truth) {
+        exclude group: 'com.google.guava', module: 'guava'
+    }
     testImplementation library.java.mockito_core
     testRuntimeOnly library.java.slf4j_simple
 }

--- a/it/common/build.gradle
+++ b/it/common/build.gradle
@@ -41,7 +41,10 @@ dependencies {
     implementation library.java.google_http_client
     implementation library.java.guava
 
-    testImplementation library.java.truth
+    // TODO: excluding Guava until Truth updates it to >32.1.x
+    testImplementation(library.java.truth) {
+        exclude group: 'com.google.guava', module: 'guava'
+    }
     testImplementation library.java.junit
     testImplementation library.java.mockito_inline
     testRuntimeOnly library.java.slf4j_simple

--- a/it/elasticsearch/build.gradle
+++ b/it/elasticsearch/build.gradle
@@ -32,8 +32,10 @@ dependencies {
     implementation "org.elasticsearch.client:elasticsearch-rest-high-level-client:$elastic_search_version"
     implementation "org.elasticsearch.client:elasticsearch-rest-client:$elastic_search_version"
     implementation "org.elasticsearch:elasticsearch:$elastic_search_version"
-
-    testImplementation library.java.truth
+    // TODO: excluding Guava until Truth updates it to >32.1.x
+    testImplementation(library.java.truth) {
+        exclude group: 'com.google.guava', module: 'guava'
+    }
     testImplementation library.java.mockito_inline
     testImplementation library.java.commons_lang3
     testRuntimeOnly library.java.slf4j_simple

--- a/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/artifacts/matchers/ArtifactsSubject.java
+++ b/it/google-cloud-platform/src/main/java/org/apache/beam/it/gcp/artifacts/matchers/ArtifactsSubject.java
@@ -41,6 +41,9 @@ import org.apache.beam.it.truthmatchers.RecordsSubject;
  * Subject that has assertion operations for artifact lists (GCS files), usually coming from the
  * result of a template.
  */
+@SuppressWarnings({
+  "nullness" // TODO(https://github.com/apache/beam/issues/20497)
+})
 public final class ArtifactsSubject extends Subject {
 
   private final List<Artifact> actual;

--- a/it/jdbc/build.gradle
+++ b/it/jdbc/build.gradle
@@ -34,7 +34,10 @@ dependencies {
     implementation library.java.testcontainers_mssqlserver
 
     testImplementation project(":it:truthmatchers")
-    testImplementation library.java.truth
+    // TODO: excluding Guava until Truth updates it to >32.1.x
+    testImplementation(library.java.truth) {
+        exclude group: 'com.google.guava', module: 'guava'
+    }
     testImplementation library.java.mockito_core
     testImplementation library.java.mockito_inline
     testRuntimeOnly library.java.slf4j_simple

--- a/it/kafka/build.gradle
+++ b/it/kafka/build.gradle
@@ -29,7 +29,10 @@ dependencies {
     implementation library.java.testcontainers_kafka
     implementation library.java.kafka_clients
 
-    testImplementation library.java.truth
+    // TODO: excluding Guava until Truth updates it to >32.1.x
+    testImplementation(library.java.truth) {
+        exclude group: 'com.google.guava', module: 'guava'
+    }
     testImplementation library.java.mockito_core
     testRuntimeOnly library.java.slf4j_simple
 }

--- a/it/mongodb/build.gradle
+++ b/it/mongodb/build.gradle
@@ -32,7 +32,10 @@ dependencies {
     implementation library.java.mongo_java_driver
 
     testImplementation library.java.mockito_core
-    testImplementation library.java.truth
+    // TODO: excluding Guava until Truth updates it to >32.1.x
+    testImplementation(library.java.truth) {
+        exclude group: 'com.google.guava', module: 'guava'
+    }
     testImplementation library.java.commons_lang3
     testRuntimeOnly library.java.slf4j_simple
 }

--- a/it/testcontainers/build.gradle
+++ b/it/testcontainers/build.gradle
@@ -30,8 +30,10 @@ ext.summary = "Integration test utilities for Testcontainers."
 dependencies {
     implementation project(path: ":it:common", configuration: "shadow")
     implementation library.java.testcontainers_base
-
-    testImplementation library.java.truth
+    // TODO: excluding Guava until Truth updates it to >32.1.x
+    testImplementation(library.java.truth) {
+        exclude group: 'com.google.guava', module: 'guava'
+    }
     testImplementation library.java.mockito_core
     testRuntimeOnly library.java.slf4j_simple
 }

--- a/it/truthmatchers/build.gradle
+++ b/it/truthmatchers/build.gradle
@@ -29,7 +29,10 @@ ext.summary = "Truth matchers for integration tests."
 
 dependencies {
     implementation project(path: ":it:common", configuration: "shadow")
-    implementation library.java.truth
+    // TODO: excluding Guava until Truth updates it to >32.1.x
+    implementation(library.java.truth) {
+        exclude group: 'com.google.guava', module: 'guava'
+    }
     implementation library.java.vendored_guava_26_0_jre
     permitUnusedDeclared library.java.vendored_guava_26_0_jre
 }

--- a/it/truthmatchers/src/main/java/org/apache/beam/it/truthmatchers/LaunchInfoSubject.java
+++ b/it/truthmatchers/src/main/java/org/apache/beam/it/truthmatchers/LaunchInfoSubject.java
@@ -26,6 +26,9 @@ import org.apache.beam.it.common.PipelineLauncher.LaunchInfo;
  * Subject that has assertion operations for {@link LaunchInfo}, which has the information for a
  * recently launched pipeline.
  */
+@SuppressWarnings({
+  "nullness" // TODO(https://github.com/apache/beam/issues/20497)
+})
 public final class LaunchInfoSubject extends Subject {
 
   private final LaunchInfo actual;

--- a/it/truthmatchers/src/main/java/org/apache/beam/it/truthmatchers/ResultSubject.java
+++ b/it/truthmatchers/src/main/java/org/apache/beam/it/truthmatchers/ResultSubject.java
@@ -28,6 +28,9 @@ import org.apache.beam.it.common.PipelineOperator.Result;
  * Subject that has assertion operations for {@link Result}, which is the end result of a pipeline
  * run.
  */
+@SuppressWarnings({
+  "nullness" // TODO(https://github.com/apache/beam/issues/20497)
+})
 public final class ResultSubject extends Subject {
 
   private final Result actual;

--- a/sdks/java/container/license_scripts/dep_urls_java.yaml
+++ b/sdks/java/container/license_scripts/dep_urls_java.yaml
@@ -38,11 +38,15 @@ jcip-annotations:
   '1.0':
     license: "https://raw.githubusercontent.com/stephenc/jcip-annotations/master/LICENSE.txt"
     type: "Apache License 2.0"
+guava-parent:
+  '32.1.1-jre':
+    license: "https://raw.githubusercontent.com/google/guava/master/LICENSE"
+    type: "Apache License 2.0"
 jaxen:
   '1.1.6':
     type: "3-Clause BSD"
 libraries-bom:
-  '26.17.0':
+  '26.20.0':
     license: "https://raw.githubusercontent.com/GoogleCloudPlatform/cloud-opensource-java/master/LICENSE"
     type: "Apache License 2.0"
 paranamer:


### PR DESCRIPTION
Update `google_cloud_platform_libraries_bom` to `26.20.0`. 

Associated updates to `gax_version`, `google_cloud_spanner_version`, `google_code_gson_version`, and `grpc_version` following versions from https://mvnrepository.com/artifact/com.google.cloud/libraries-bom/26.20.0 (being indexed).


Attaching the effective pom generated with:
```
wget https://repo1.maven.org/maven2/com/google/cloud/libraries-bom/26.20.0/libraries-bom-26.20.0.pom

mvn help:effective-pom -f libraries-bom-26.20.0.pom
```

[libraries-bom-26.20.0-effective-pom.txt](https://github.com/apache/beam/files/12197833/libraries-bom-26.20.0-effective-pom.txt)
