### PR TITLE
[#23043] Re-enable single iteration for the Go SDK.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/datasource.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasource.go
@@ -131,7 +131,9 @@ func (n *DataSource) process(ctx context.Context, data func(bcr *byteCountReader
 	bcr := byteCountReader{reader: &r, count: &byteCount}
 
 	splitPrimaryComplete := map[string]bool{}
+	count := -1
 	for {
+		count++
 		var err error
 		select {
 		case e, ok := <-elms:
@@ -285,7 +287,6 @@ func (n *DataSource) makeReStream(ctx context.Context, cv ElementDecoder, bcr *b
 	}
 
 	if onlyStream {
-		log.Warnf(ctx, "ONLY STREAM bytes read: %v, iter size: %v", bcr.count, size)
 		// If we know the stream won't be re-iterated,
 		// decode elements on demand instead to reduce memory usage.
 		switch {

--- a/sdks/go/pkg/beam/core/runtime/exec/datasource.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasource.go
@@ -223,7 +223,7 @@ func (n *DataSource) Process(ctx context.Context) ([]*Checkpoint, error) {
 			// Decode key or parallel element.
 			pe, err := cp.Decode(bcr)
 			if err != nil {
-				return errors.Wrap(err, "source decode failed")
+				return errors.Wrapf(err, "source decode failed: ws %v, t %v, pn %v, pe %+v", ws, t, pn, pe)
 			}
 			pe.Timestamp = t
 			pe.Windows = ws

--- a/sdks/go/pkg/beam/core/runtime/exec/datasource.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasource.go
@@ -285,6 +285,7 @@ func (n *DataSource) makeReStream(ctx context.Context, cv ElementDecoder, bcr *b
 	}
 
 	if onlyStream {
+		log.Warnf(ctx, "ONLY STREAM bytes read: %v, iter size: %v", bcr.count, size)
 		// If we know the stream won't be re-iterated,
 		// decode elements on demand instead to reduce memory usage.
 		switch {

--- a/sdks/go/pkg/beam/core/runtime/exec/datasource.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasource.go
@@ -84,7 +84,7 @@ func (n *DataSource) ID() UnitID {
 // Up initializes this datasource.
 func (n *DataSource) Up(ctx context.Context) error {
 	// TODO(https://github.com/apache/beam/issues/23043) - Reenable single iteration or more fully rip this out.
-	safeToSingleIterate := false
+	safeToSingleIterate := true
 	switch n.Out.(type) {
 	case *Expand, *Multiplex:
 		// CoGBK Expands aren't safe, as they may re-iterate the GBK stream.

--- a/sdks/go/pkg/beam/core/runtime/exec/datasource.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasource.go
@@ -83,7 +83,6 @@ func (n *DataSource) ID() UnitID {
 
 // Up initializes this datasource.
 func (n *DataSource) Up(ctx context.Context) error {
-	// TODO(https://github.com/apache/beam/issues/23043) - Reenable single iteration or more fully rip this out.
 	safeToSingleIterate := true
 	switch n.Out.(type) {
 	case *Expand, *Multiplex:
@@ -131,9 +130,7 @@ func (n *DataSource) process(ctx context.Context, data func(bcr *byteCountReader
 	bcr := byteCountReader{reader: &r, count: &byteCount}
 
 	splitPrimaryComplete := map[string]bool{}
-	count := -1
 	for {
-		count++
 		var err error
 		select {
 		case e, ok := <-elms:
@@ -225,7 +222,7 @@ func (n *DataSource) Process(ctx context.Context) ([]*Checkpoint, error) {
 			// Decode key or parallel element.
 			pe, err := cp.Decode(bcr)
 			if err != nil {
-				return errors.Wrapf(err, "source decode failed: ws %v, t %v, pn %v, pe %+v", ws, t, pn, pe)
+				return errors.Wrap(err, "source decode failed")
 			}
 			pe.Timestamp = t
 			pe.Windows = ws

--- a/sdks/go/pkg/beam/core/runtime/exec/fullvalue.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/fullvalue.go
@@ -269,6 +269,7 @@ type singleUseMultiChunkReStream struct {
 
 // Open returns the Stream from the start of the in-memory ReStream. Returns error if called twice.
 func (n *singleUseMultiChunkReStream) Open() (Stream, error) {
+	fmt.Println("CCCC singleUseMultiChunkReStream.Open")
 	if n.r == nil {
 		return nil, errors.New("decodeReStream opened twice")
 	}
@@ -296,12 +297,19 @@ func (s *decodeMultiChunkStream) Close() error {
 	// TODO(https://github.com/apache/beam/issues/22901):
 	// Optimize the case where we have length prefixed values
 	// so we can avoid allocating the values in the first place.
-	for s.next < s.chunk {
-		err := s.d.DecodeTo(s.r, &s.ret)
-		if err != nil {
-			return errors.Wrap(err, "decodeStream value decode failed on close")
+
+	for {
+		// If we have a stream, we're with the available bytes, we move to close it after this loop.
+		if s.stream != nil {
+			break
 		}
-		s.next++
+		// Drain the whole available iterable to ensure the reader is in the right position.
+		_, err := s.Read()
+		if err == io.EOF {
+			break
+		} else if err != nil {
+			return err
+		}
 	}
 	if s.stream != nil {
 		s.stream.Close()

--- a/sdks/go/pkg/beam/core/runtime/exec/fullvalue.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/fullvalue.go
@@ -269,7 +269,6 @@ type singleUseMultiChunkReStream struct {
 
 // Open returns the Stream from the start of the in-memory ReStream. Returns error if called twice.
 func (n *singleUseMultiChunkReStream) Open() (Stream, error) {
-	fmt.Println("CCCC singleUseMultiChunkReStream.Open")
 	if n.r == nil {
 		return nil, errors.New("decodeReStream opened twice")
 	}
@@ -299,7 +298,8 @@ func (s *decodeMultiChunkStream) Close() error {
 	// so we can avoid allocating the values in the first place.
 
 	for {
-		// If we have a stream, we're with the available bytes, we move to close it after this loop.
+		// If we have a stream, we're finished with the available bytes from the reader,
+		// so we move to close it after this loop.
 		if s.stream != nil {
 			break
 		}

--- a/sdks/go/pkg/beam/core/runtime/exec/fullvalue_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/fullvalue_test.go
@@ -397,10 +397,13 @@ func TestDecodeMultiChunkStream(t *testing.T) {
 		if fv, err := ds.Read(); err != io.EOF {
 			t.Errorf("unexpected error on decodeStream.Read after close: %v, %v", fv, err)
 		}
-		// Check that next was iterated to equal size
+		// Check that next was iterated to an empty stream.
 		dds := ds.(*decodeMultiChunkStream)
-		if got, want := dds.next, int64(size); got != want {
+		if got, want := dds.next, int64(0); got != want {
 			t.Errorf("unexpected configuration after decodeStream.Close: got %v, want %v", got, want)
+		}
+		if dds.stream != nil {
+			t.Errorf("got non-nil stream after close: %#v", dds.stream)	
 		}
 
 		// Check that a 2nd stream will fail:

--- a/sdks/go/pkg/beam/core/runtime/exec/fullvalue_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/fullvalue_test.go
@@ -403,7 +403,7 @@ func TestDecodeMultiChunkStream(t *testing.T) {
 			t.Errorf("unexpected configuration after decodeStream.Close: got %v, want %v", got, want)
 		}
 		if dds.stream != nil {
-			t.Errorf("got non-nil stream after close: %#v", dds.stream)	
+			t.Errorf("got non-nil stream after close: %#v", dds.stream)
 		}
 
 		// Check that a 2nd stream will fail:

--- a/sdks/go/pkg/beam/core/runtime/exec/plan.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/plan.go
@@ -233,7 +233,7 @@ func (p *Plan) Down(ctx context.Context) error {
 
 func (p *Plan) String() string {
 	var units []string
-	for i := len(units) - 1; i >= 0; i-- {
+	for i := len(p.units) - 1; i >= 0; i-- {
 		u := p.units[i]
 		units = append(units, fmt.Sprintf("%v: %v", u.ID(), u))
 	}

--- a/sdks/go/pkg/beam/core/runtime/exec/plan.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/plan.go
@@ -233,7 +233,8 @@ func (p *Plan) Down(ctx context.Context) error {
 
 func (p *Plan) String() string {
 	var units []string
-	for _, u := range p.units {
+	for i := len(units) - 1; i >= 0; i-- {
+		u := p.units[i]
 		units = append(units, fmt.Sprintf("%v: %v", u.ID(), u))
 	}
 	return fmt.Sprintf("Plan[%v]:\n%v", p.ID(), strings.Join(units, "\n"))


### PR DESCRIPTION
Re-enable single iteration "decode on-demand" stream for the Go SDK.

Originally disabled due to #22933, in #23042, the principle remains sound, and it's long past time to look at why it failed in the first place.

The issue was that we didn't drain the iterable properly if there were no reads at all, so we go with the slightly more ham fisted approach of iterating until io.EOF, or stream != nil. If the stream isn't nil, it means the reader got handed off, and it's up to that stream to close.

This avoids unnecessarily draining something off of the main reader which could be very large and costly.

Fixes #23043

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
