### PR TITLE
Override encoding positions for nested schemas

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/RowCoderCloudObjectTranslator.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/RowCoderCloudObjectTranslator.java
@@ -18,8 +18,6 @@
 package org.apache.beam.runners.dataflow.util;
 
 import java.io.IOException;
-import java.util.UUID;
-import javax.annotation.Nullable;
 import org.apache.beam.model.pipeline.v1.SchemaApi;
 import org.apache.beam.runners.core.construction.SdkComponents;
 import org.apache.beam.sdk.coders.RowCoder;
@@ -58,10 +56,7 @@ public class RowCoderCloudObjectTranslator implements CloudObjectTranslator<RowC
       SchemaApi.Schema.Builder schemaBuilder = SchemaApi.Schema.newBuilder();
       JsonFormat.parser().merge(Structs.getString(cloudObject, SCHEMA), schemaBuilder);
       Schema schema = SchemaTranslation.schemaFromProto(schemaBuilder.build());
-      @Nullable UUID uuid = schema.getUUID();
-      if (schema.isEncodingPositionsOverridden() && uuid != null) {
-        RowCoder.overrideEncodingPositions(uuid, schema.getEncodingPositions());
-      }
+      SchemaCoderCloudObjectTranslator.overrideEncodingPositions(schema);
       return RowCoder.of(schema);
     } catch (IOException e) {
       throw new RuntimeException(e);


### PR DESCRIPTION
The runner wasn't properly overriding encoding positions for nested subschemas. This PR properly recurses through the schema to override positions.