### PR TITLE
Bump commons-io to 2.13.0

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -639,7 +639,7 @@ class BeamModulePlugin implements Plugin<Project> {
         commons_collections                         : "commons-collections:commons-collections:3.2.2",
         commons_compress                            : "org.apache.commons:commons-compress:1.21",
         commons_csv                                 : "org.apache.commons:commons-csv:1.8",
-        commons_io                                  : "commons-io:commons-io:2.7",
+        commons_io                                  : "commons-io:commons-io:2.13.0",
         commons_lang3                               : "org.apache.commons:commons-lang3:3.9",
         commons_logging                             : "commons-logging:commons-logging:1.2",
         commons_math3                               : "org.apache.commons:commons-math3:3.6.1",


### PR DESCRIPTION
We pin an old version of `commons-io`, released in 2020. `commons-io` had a bunch of improvements, including performance / memory footprint [1].

[1] https://commons.apache.org/proper/commons-io/changes-report.html 

