### PR TITLE
Add logging at error to Bootloader logger

### DIFF
--- a/sdks/go/container/tools/logging.go
+++ b/sdks/go/container/tools/logging.go
@@ -111,6 +111,11 @@ func (l *Logger) Warnf(ctx context.Context, format string, args ...any) {
 	l.Log(ctx, fnpb.LogEntry_Severity_WARN, fmt.Sprintf(format, args...))
 }
 
+// Errorf logs the message with Error severity.
+func (l *Logger) Errorf(ctx context.Context, format string, args ...any) {
+	l.Log(ctx, fnpb.LogEntry_Severity_ERROR, fmt.Sprintf(format, args...))
+}
+
 // Fatalf logs the message with Critical severity, and then calls os.Exit(1).
 func (l *Logger) Fatalf(ctx context.Context, format string, args ...any) {
 	l.Log(ctx, fnpb.LogEntry_Severity_CRITICAL, fmt.Sprintf(format, args...))

--- a/sdks/go/container/tools/logging_test.go
+++ b/sdks/go/container/tools/logging_test.go
@@ -58,6 +58,22 @@ func TestLogger(t *testing.T) {
 			t.Errorf("l.Printf(\"foo %%v\", \"bar\"): got severity %v, want %v", got, want)
 		}
 	})
+	t.Run("SuccessfulLoggingAtError", func(t *testing.T) {
+		catcher := &logCatcher{}
+		l := &Logger{client: catcher}
+
+		l.Errorf(ctx, "failed to install dependency %v", "bar")
+
+		received := catcher.msgs[0].GetLogEntries()[0]
+
+		if got, want := received.Message, "failed to install dependency bar"; got != want {
+			t.Errorf("l.Printf(\"foo %%v\", \"bar\"): got message %q, want %q", got, want)
+		}
+
+		if got, want := received.Severity, fnpb.LogEntry_Severity_ERROR; got != want {
+			t.Errorf("l.Errorf(\"failed to install dependency %%v\", \"bar\"): got severity %v, want %v", got, want)
+		}
+	})
 	t.Run("backup path", func(t *testing.T) {
 		catcher := &logCatcher{}
 		l := &Logger{client: catcher}

--- a/sdks/python/container/boot.go
+++ b/sdks/python/container/boot.go
@@ -23,6 +23,7 @@ import (
 	"errors"
 	"flag"
 	"fmt"
+	"log"
 	"os"
 	"os/exec"
 	"os/signal"
@@ -35,7 +36,6 @@ import (
 
 	"github.com/apache/beam/sdks/v2/go/container/tools"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/artifact"
-	"github.com/apache/beam/sdks/v2/go/pkg/beam/log"
 	pipepb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/pipeline_v1"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/util/execx"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/util/grpcx"
@@ -75,9 +75,9 @@ const (
 
 func main() {
 	flag.Parse()
-	ctx := context.Background()
+
 	if *setupOnly {
-		processArtifactsInSetupOnlyMode(ctx)
+		processArtifactsInSetupOnlyMode()
 		os.Exit(0)
 	}
 
@@ -90,23 +90,23 @@ func main() {
 			"--service_port=50000",
 			"--container_executable=/opt/apache/beam/boot",
 		}
-		log.Infof(ctx, "Starting worker pool %v: python %v", workerPoolId, strings.Join(args, " "))
+		log.Printf("Starting worker pool %v: python %v", workerPoolId, strings.Join(args, " "))
 		if err := execx.Execute("python", args...); err != nil {
-			log.Fatalf(ctx, "Python SDK worker pool exited with error: %v", err)
+			log.Fatalf("Python SDK worker pool exited with error: %v", err)
 		}
-		log.Info(ctx, "Python SDK worker pool exited.")
+		log.Print("Python SDK worker pool exited.")
 		os.Exit(0)
 	}
 
 	if *id == "" {
-		log.Fatalf(ctx, "No id provided.")
+		log.Fatalf("No id provided.")
 	}
 	if *provisionEndpoint == "" {
-		log.Fatalf(ctx, "No provision endpoint provided.")
+		log.Fatalf("No provision endpoint provided.")
 	}
 
 	if err := launchSDKProcess(); err != nil {
-		log.Fatal(ctx, err)
+		log.Fatal(err)
 	}
 }
 
@@ -115,9 +115,9 @@ func launchSDKProcess() error {
 
 	info, err := tools.ProvisionInfo(ctx, *provisionEndpoint)
 	if err != nil {
-		log.Fatalf(ctx, "Failed to obtain provisioning information: %v", err)
+		log.Fatalf("Failed to obtain provisioning information: %v", err)
 	}
-	log.Infof(ctx, "Provision info:\n%v", info)
+	log.Printf("Provision info:\n%v", info)
 
 	// TODO(BEAM-8201): Simplify once flags are no longer used.
 	if info.GetLoggingEndpoint().GetUrl() != "" {
@@ -131,13 +131,13 @@ func launchSDKProcess() error {
 	}
 
 	if *loggingEndpoint == "" {
-		log.Fatalf(ctx, "No logging endpoint provided.")
+		log.Fatalf("No logging endpoint provided.")
 	}
 	if *artifactEndpoint == "" {
-		log.Fatalf(ctx, "No artifact endpoint provided.")
+		log.Fatalf("No artifact endpoint provided.")
 	}
 	if *controlEndpoint == "" {
-		log.Fatalf(ctx, "No control endpoint provided.")
+		log.Fatalf("No control endpoint provided.")
 	}
 	logger := &tools.Logger{Endpoint: *loggingEndpoint}
 	logger.Printf(ctx, "Initializing python harness: %v", strings.Join(os.Args, " "))
@@ -200,7 +200,7 @@ func launchSDKProcess() error {
 		}
 	}
 
-	if setupErr := installSetupPackages(ctx, fileNames, dir, requirementsFiles); setupErr != nil {
+	if setupErr := installSetupPackages(fileNames, dir, requirementsFiles); setupErr != nil {
 		fmtErr := fmt.Errorf("failed to install required packages: %v", setupErr)
 		// Send error message to logging service before returning up the call stack
 		logger.Errorf(ctx, fmtErr.Error())
@@ -370,17 +370,17 @@ func setupAcceptableWheelSpecs() error {
 }
 
 // installSetupPackages installs Beam SDK and user dependencies.
-func installSetupPackages(ctx context.Context, files []string, workDir string, requirementsFiles []string) error {
-	log.Infof(ctx, "Installing setup packages ...")
+func installSetupPackages(files []string, workDir string, requirementsFiles []string) error {
+	log.Printf("Installing setup packages ...")
 
 	if err := setupAcceptableWheelSpecs(); err != nil {
-		log.Infof(ctx, "Failed to setup acceptable wheel specs, leave it as empty: %v", err)
+		log.Printf("Failed to setup acceptable wheel specs, leave it as empty: %v", err)
 	}
 
 	// Install the Dataflow Python SDK and worker packages.
 	// We install the extra requirements in case of using the beam sdk. These are ignored by pip
 	// if the user is using an SDK that does not provide these.
-	if err := installSdk(ctx, files, workDir, sdkSrcFile, acceptableWhlSpecs, false); err != nil {
+	if err := installSdk(files, workDir, sdkSrcFile, acceptableWhlSpecs, false); err != nil {
 		return fmt.Errorf("failed to install SDK: %v", err)
 	}
 	// The staged files will not disappear due to restarts because workDir is a
@@ -390,7 +390,7 @@ func installSetupPackages(ctx context.Context, files []string, workDir string, r
 			return fmt.Errorf("failed to install requirements: %v", err)
 		}
 	}
-	if err := installExtraPackages(ctx, files, extraPackagesFile, workDir); err != nil {
+	if err := installExtraPackages(files, extraPackagesFile, workDir); err != nil {
 		return fmt.Errorf("failed to install extra packages: %v", err)
 	}
 	if err := pipInstallPackage(files, workDir, workflowFile, false, true, nil); err != nil {
@@ -405,38 +405,38 @@ func installSetupPackages(ctx context.Context, files []string, workDir string, r
 // process the provided artifacts and skip the actual worker program start up.
 // The mode is useful for building new images with dependencies pre-installed so
 // that the installation can be skipped at the pipeline runtime.
-func processArtifactsInSetupOnlyMode(ctx context.Context) {
+func processArtifactsInSetupOnlyMode() {
 	if *artifacts == "" {
-		log.Fatal(ctx, "No --artifacts provided along with --setup_only flag.")
+		log.Fatal("No --artifacts provided along with --setup_only flag.")
 	}
 	workDir := filepath.Dir(*artifacts)
 	metadata, err := os.ReadFile(*artifacts)
 	if err != nil {
-		log.Fatalf(ctx, "Unable to open artifacts metadata file %v with error %v", *artifacts, err)
+		log.Fatalf("Unable to open artifacts metadata file %v with error %v", *artifacts, err)
 	}
 	var infoJsons []string
 	if err := json.Unmarshal(metadata, &infoJsons); err != nil {
-		log.Fatalf(ctx, "Unable to parse metadata, error: %v", err)
+		log.Fatalf("Unable to parse metadata, error: %v", err)
 	}
 
 	files := make([]string, len(infoJsons))
 	for i, info := range infoJsons {
 		var artifactInformation pipepb.ArtifactInformation
 		if err := jsonpb.UnmarshalString(info, &artifactInformation); err != nil {
-			log.Fatalf(ctx, "Unable to unmarshal artifact information from json string %v", info)
+			log.Fatalf("Unable to unmarshal artifact information from json string %v", info)
 		}
 
 		// For now we only expect artifacts in file type. The condition should be revisited if the assumption is not valid any more.
 		if artifactInformation.GetTypeUrn() != standardArtifactFileTypeUrn {
-			log.Fatalf(ctx, "Expect file artifact type in setup only mode, found %v.", artifactInformation.GetTypeUrn())
+			log.Fatalf("Expect file artifact type in setup only mode, found %v.", artifactInformation.GetTypeUrn())
 		}
 		filePayload := &pipepb.ArtifactFilePayload{}
 		if err := proto.Unmarshal(artifactInformation.GetTypePayload(), filePayload); err != nil {
-			log.Fatal(ctx, "Unable to unmarshal artifact information type payload.")
+			log.Fatal("Unable to unmarshal artifact information type payload.")
 		}
 		files[i] = filePayload.GetPath()
 	}
-	if setupErr := installSetupPackages(ctx, files, workDir, []string{requirementsFile}); setupErr != nil {
-		log.Fatalf(ctx, "Failed to install required packages: %v", setupErr)
+	if setupErr := installSetupPackages(files, workDir, []string{requirementsFile}); setupErr != nil {
+		log.Fatalf("Failed to install required packages: %v", setupErr)
 	}
 }

--- a/sdks/python/container/piputil.go
+++ b/sdks/python/container/piputil.go
@@ -20,7 +20,6 @@ import (
 	"bytes"
 	"errors"
 	"fmt"
-	"io/ioutil"
 	"log"
 	"os"
 	"path/filepath"
@@ -107,7 +106,7 @@ func installExtraPackages(files []string, extraPackagesFile, dir string) error {
 		}
 
 		// Found the manifest. Install extra packages.
-		manifest, err := ioutil.ReadFile(filepath.Join(dir, extraPackagesFile))
+		manifest, err := os.ReadFile(filepath.Join(dir, extraPackagesFile))
 		if err != nil {
 			return fmt.Errorf("failed to read extra packages manifest file: %v", err)
 		}

--- a/sdks/python/container/piputil.go
+++ b/sdks/python/container/piputil.go
@@ -18,14 +18,13 @@ package main
 import (
 	"bufio"
 	"bytes"
-	"context"
 	"errors"
 	"fmt"
+	"log"
 	"os"
 	"path/filepath"
 	"strings"
 
-	"github.com/apache/beam/sdks/v2/go/pkg/beam/log"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/util/execx"
 )
 
@@ -99,7 +98,7 @@ func pipInstallPackage(files []string, dir, name string, force, optional bool, e
 
 // installExtraPackages installs all the packages declared in the extra
 // packages manifest file.
-func installExtraPackages(ctx context.Context, files []string, extraPackagesFile, dir string) error {
+func installExtraPackages(files []string, extraPackagesFile, dir string) error {
 	// First check that extra packages manifest file is present.
 	for _, file := range files {
 		if file != extraPackagesFile {
@@ -117,7 +116,7 @@ func installExtraPackages(ctx context.Context, files []string, extraPackagesFile
 
 		for s.Scan() {
 			extraPackage := s.Text()
-			log.Infof(ctx, "Installing extra package: %s", extraPackage)
+			log.Printf("Installing extra package: %s", extraPackage)
 			if err = pipInstallPackage(files, dir, extraPackage, true, false, nil); err != nil {
 				return fmt.Errorf("failed to install extra package %s: %v", extraPackage, err)
 			}
@@ -127,12 +126,12 @@ func installExtraPackages(ctx context.Context, files []string, extraPackagesFile
 	return nil
 }
 
-func findBeamSdkWhl(ctx context.Context, files []string, acceptableWhlSpecs []string) string {
+func findBeamSdkWhl(files []string, acceptableWhlSpecs []string) string {
 	for _, file := range files {
 		if strings.HasPrefix(file, "apache_beam") {
 			for _, s := range acceptableWhlSpecs {
 				if strings.HasSuffix(file, s) {
-					log.Infof(ctx, "Found Apache Beam SDK wheel: %v", file)
+					log.Printf("Found Apache Beam SDK wheel: %v", file)
 					return file
 				}
 			}
@@ -146,8 +145,8 @@ func findBeamSdkWhl(ctx context.Context, files []string, acceptableWhlSpecs []st
 // assume that the pipleine was started with the Beam SDK found in the wheel
 // file, and we try to install it. If not successful, we fall back to installing
 // SDK from source tarball provided in sdkSrcFile.
-func installSdk(ctx context.Context, files []string, workDir string, sdkSrcFile string, acceptableWhlSpecs []string, required bool) error {
-	sdkWhlFile := findBeamSdkWhl(ctx, files, acceptableWhlSpecs)
+func installSdk(files []string, workDir string, sdkSrcFile string, acceptableWhlSpecs []string, required bool) error {
+	sdkWhlFile := findBeamSdkWhl(files, acceptableWhlSpecs)
 
 	if sdkWhlFile != "" {
 		// by default, pip rejects to install wheel if same version already installed
@@ -156,7 +155,7 @@ func installSdk(ctx context.Context, files []string, workDir string, sdkSrcFile 
 		if err == nil {
 			return nil
 		}
-		log.Infof(ctx, "Could not install Apache Beam SDK from a wheel: %v, proceeding to install SDK from source tarball.", err)
+		log.Printf("Could not install Apache Beam SDK from a wheel: %v, proceeding to install SDK from source tarball.", err)
 	}
 	if !required {
 		_, err := os.Stat(filepath.Join(workDir, sdkSrcFile))


### PR DESCRIPTION
Adds `Errorf()` logging to the tools.Logger type, enabling sending error-leveled logs across the FnAPI to a logging service. The first usage of this is to propagate some dependency errors to logs as errors to the logging service before they are logged to stderr at a `FATAL` level. Also does a little extra cleanup, replacing a deprecated `ioutil.ReadFile()` invocation with `os.ReadFile()`. 
 
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://beam.apache.org/contribute/get-started-contributing/#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
