### PR TITLE
[Security] Upgrade snappy-java to 1.1.10.3

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -800,7 +800,7 @@ class BeamModulePlugin implements Plugin<Project> {
         slf4j_jul_to_slf4j                          : "org.slf4j:jul-to-slf4j:$slf4j_version",
         slf4j_log4j12                               : "org.slf4j:slf4j-log4j12:$slf4j_version",
         slf4j_jcl                                   : "org.slf4j:slf4j-jcl:$slf4j_version",
-        snappy_java                                 : "org.xerial.snappy:snappy-java:1.1.10.0",
+        snappy_java                                 : "org.xerial.snappy:snappy-java:1.1.10.3",
         spark_core                                  : "org.apache.spark:spark-core_2.11:$spark2_version",
         spark_streaming                             : "org.apache.spark:spark-streaming_2.11:$spark2_version",
         spark3_core                                 : "org.apache.spark:spark-core_2.12:$spark3_version",


### PR DESCRIPTION
`snappy-java` is currently 1.1.10.0, and is within the range for a couple of recent CVEs:

CVE-2023-34455 [High]
CVE-2023-34454 [Moderate]
CVE-2023-34453 [Moderate]

(See https://mvnrepository.com/artifact/org.xerial.snappy/snappy-java/1.1.10.0)
