### PR TITLE
Fix google-api-services-bigquery to match new google-cloud-bigquery

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -655,6 +655,7 @@ class BeamModulePlugin implements Plugin<Project> {
         google_api_client_jackson2                  : "com.google.api-client:google-api-client-jackson2:$google_clients_version",
         google_api_client_java6                     : "com.google.api-client:google-api-client-java6:$google_clients_version",
         google_api_common                           : "com.google.api:api-common", // google_cloud_platform_libraries_bom sets version
+        // Keep version consistent with the version in google_cloud_bigquery, managed by google_cloud_platform_libraries_bom
         google_api_services_bigquery                : "com.google.apis:google-api-services-bigquery:v2-rev20230520-$google_clients_version",
         google_api_services_cloudresourcemanager    : "com.google.apis:google-api-services-cloudresourcemanager:v1-rev20220828-$google_clients_version",
         google_api_services_dataflow                : "com.google.apis:google-api-services-dataflow:v1b3-rev20220920-$google_clients_version",

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -655,7 +655,7 @@ class BeamModulePlugin implements Plugin<Project> {
         google_api_client_jackson2                  : "com.google.api-client:google-api-client-jackson2:$google_clients_version",
         google_api_client_java6                     : "com.google.api-client:google-api-client-java6:$google_clients_version",
         google_api_common                           : "com.google.api:api-common", // google_cloud_platform_libraries_bom sets version
-        google_api_services_bigquery                : "com.google.apis:google-api-services-bigquery:v2-rev20220924-$google_clients_version",
+        google_api_services_bigquery                : "com.google.apis:google-api-services-bigquery:v2-rev20230520-$google_clients_version",
         google_api_services_cloudresourcemanager    : "com.google.apis:google-api-services-cloudresourcemanager:v1-rev20220828-$google_clients_version",
         google_api_services_dataflow                : "com.google.apis:google-api-services-dataflow:v1b3-rev20220920-$google_clients_version",
         google_api_services_healthcare              : "com.google.apis:google-api-services-healthcare:v1-rev20230510-$google_clients_version",


### PR DESCRIPTION
Got the following error in a few tests with `2.50.0-SNAPSHOT`

```
java.lang.NoSuchMethodError: 'com.google.api.services.bigquery.model.TableConstraints com.google.api.services.bigquery.model.Table.getTableConstraints()'
	at com.google.cloud.bigquery.StandardTableDefinition.fromPb(StandardTableDefinition.java:409)
	at com.google.cloud.bigquery.TableDefinition.fromPb(TableDefinition.java:161)
	at com.google.cloud.bigquery.TableInfo$BuilderImpl.<init>(TableInfo.java:253)
	at com.google.cloud.bigquery.Table.fromPb(Table.java:690)
	at com.google.cloud.bigquery.BigQueryImpl.create(BigQueryImpl.java:298)
```

We bumped libraries to 26.21.0, which uses BigQuery 2.31.0, which depends on this version (see https://mvnrepository.com/artifact/com.google.cloud/google-cloud-bigquery/2.31.0).

Ideally we would rely on a BOM for this, but it seems that `libraries-bom` doesn't bring it -- so this is more of a short term fix to avoid error above.

