### PR TITLE
Enable combiner lifting for the Group transform

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingSideInputDoFnRunner.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingSideInputDoFnRunner.java
@@ -38,7 +38,7 @@ public class StreamingSideInputDoFnRunner<InputT, OutputT, W extends BoundedWind
   private final DoFnRunner<InputT, OutputT> simpleDoFnRunner;
   private final StreamingSideInputFetcher<InputT, W> sideInputFetcher;
 
-  public StreamingSideInputDoFnRunner(
+  public StreamingSideInputDoFnRunner (
       DoFnRunner<InputT, OutputT> simpleDoFnRunner,
       StreamingSideInputFetcher<InputT, W> sideInputFetcher) {
     this.simpleDoFnRunner = simpleDoFnRunner;

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingSideInputDoFnRunner.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingSideInputDoFnRunner.java
@@ -38,7 +38,7 @@ public class StreamingSideInputDoFnRunner<InputT, OutputT, W extends BoundedWind
   private final DoFnRunner<InputT, OutputT> simpleDoFnRunner;
   private final StreamingSideInputFetcher<InputT, W> sideInputFetcher;
 
-  public StreamingSideInputDoFnRunner (
+  public StreamingSideInputDoFnRunner(
       DoFnRunner<InputT, OutputT> simpleDoFnRunner,
       StreamingSideInputFetcher<InputT, W> sideInputFetcher) {
     this.simpleDoFnRunner = simpleDoFnRunner;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Group.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/Group.java
@@ -21,6 +21,8 @@ import com.google.auto.value.AutoOneOf;
 import com.google.auto.value.AutoValue;
 import java.io.Serializable;
 import java.util.List;
+
+import com.sun.org.apache.xpath.internal.operations.Bool;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.schemas.FieldAccessDescriptor;
 import org.apache.beam.sdk.schemas.Schema;
@@ -998,6 +1000,8 @@ public class Group {
 
     abstract @Nullable Fanout getFanout();
 
+    abstract Boolean getFewKeys();
+
     abstract ByFields<InputT> getByFields();
 
     abstract SchemaAggregateFn.Inner getSchemaAggregateFn();
@@ -1011,6 +1015,8 @@ public class Group {
     @AutoValue.Builder
     abstract static class Builder<InputT> {
       public abstract Builder<InputT> setFanout(@Nullable Fanout value);
+
+      public abstract Builder<InputT> setFewKeys(Boolean fewKeys);
 
       abstract Builder<InputT> setByFields(ByFields<InputT> byFields);
 
@@ -1033,6 +1039,7 @@ public class Group {
           .setSchemaAggregateFn(schemaAggregateFn)
           .setKeyField(keyField)
           .setValueField(valueField)
+              .setFewKeys(false)
           .build();
     }
 
@@ -1267,7 +1274,7 @@ public class Group {
             throw new RuntimeException("Unexpected kind: " + fanout.getKind());
         }
       }
-      return Combine.perKey(fn);
+      return getFewKeys() ? Combine.fewKeys(fn) : Combine.perKey(fn);
     }
 
     @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Combine.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Combine.java
@@ -29,6 +29,8 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
+
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
@@ -200,6 +202,13 @@ public class Combine {
       GlobalCombineFn<? super InputT, ?, OutputT> fn,
       DisplayData.ItemSpec<? extends Class<?>> fnDisplayData) {
     return new PerKey<>(fn, fnDisplayData, false /*fewKeys*/);
+  }
+
+  /** Returns a {@link PerKey Combine.PerKey}, and set fewKeys in {@link GroupByKey}. */
+  @Internal
+  public static <K, InputT, OutputT> PerKey<K, InputT, OutputT> fewKeys(
+          GlobalCombineFn<? super InputT, ?, OutputT> fn) {
+    return new PerKey<>(fn, displayDataForFn(fn), true /*fewKeys*/);
   }
 
   /** Returns a {@link PerKey Combine.PerKey}, and set fewKeys in {@link GroupByKey}. */

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Combine.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/Combine.java
@@ -29,7 +29,6 @@ import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ThreadLocalRandom;
-
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
@@ -207,7 +206,7 @@ public class Combine {
   /** Returns a {@link PerKey Combine.PerKey}, and set fewKeys in {@link GroupByKey}. */
   @Internal
   public static <K, InputT, OutputT> PerKey<K, InputT, OutputT> fewKeys(
-          GlobalCombineFn<? super InputT, ?, OutputT> fn) {
+      GlobalCombineFn<? super InputT, ?, OutputT> fn) {
     return new PerKey<>(fn, displayDataForFn(fn), true /*fewKeys*/);
   }
 


### PR DESCRIPTION
R: @slavachernyak 

Note: for Dataflow users, this change will block update. In order to update a use of Group.byFieldNames from before this change, the user must explicitly disable this new behavior by calling withPrecombining(false).