### PR TITLE
Allow usage of GCThrashing settings on Fn Harness

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -235,22 +235,6 @@ public interface DataflowPipelineDebugOptions extends ExperimentalOptions, Pipel
   void setJfrRecordingDurationSec(int value);
 
   /**
-   * The GC thrashing threshold percentage. A given period of time is considered "thrashing" if this
-   * percentage of CPU time is spent in garbage collection. Dataflow will force fail tasks after
-   * sustained periods of thrashing.
-   *
-   * <p>If {@literal 100} is given as the value, MemoryMonitor will be disabled.
-   */
-  @Description(
-      "The GC thrashing threshold percentage. A given period of time is considered \"thrashing\" if this "
-          + "percentage of CPU time is spent in garbage collection. Dataflow will force fail tasks after "
-          + "sustained periods of thrashing.")
-  @Default.Double(50.0)
-  Double getGCThrashingPercentagePerPeriod();
-
-  void setGCThrashingPercentagePerPeriod(Double value);
-
-  /**
    * The size of the worker's in-memory cache, in megabytes.
    *
    * <p>Currently, this cache is used for storing read values of side inputs. as well as the state

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/MemoryMonitor.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/MemoryMonitor.java
@@ -56,6 +56,7 @@ import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.fs.CreateOptions.StandardCreateOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.options.SdkHarnessOptions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
@@ -237,10 +238,11 @@ public class MemoryMonitor implements Runnable, StatusDataProvider {
     DataflowPipelineDebugOptions debugOptions = options.as(DataflowPipelineDebugOptions.class);
     DataflowWorkerHarnessOptions workerHarnessOptions =
         options.as(DataflowWorkerHarnessOptions.class);
+    SdkHarnessOptions sdkHarnessOptions = options.as(SdkHarnessOptions.class);
     String uploadToGCSPath = debugOptions.getSaveHeapDumpsToGcsPath();
     String workerId = workerHarnessOptions.getWorkerId();
     boolean canDumpHeap = uploadToGCSPath != null || debugOptions.getDumpHeapOnOOM();
-    double gcThrashingPercentagePerPeriod = debugOptions.getGCThrashingPercentagePerPeriod();
+    double gcThrashingPercentagePerPeriod = sdkHarnessOptions.getGCThrashingPercentagePerPeriod();
 
     Duration jfrProfileDuration;
     if (uploadToGCSPath != null && debugOptions.getRecordJfrOnGcThrashing()) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/SdkHarnessOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/SdkHarnessOptions.java
@@ -194,6 +194,22 @@ public interface SdkHarnessOptions extends PipelineOptions {
   void setMaxCacheMemoryUsageMbClass(Class<? extends MaxCacheMemoryUsageMb> kls);
 
   /**
+   * The GC thrashing threshold percentage. A given period of time is considered "thrashing" if this
+   * percentage of CPU time is spent in garbage collection. Harness will force fail tasks after
+   * sustained periods of thrashing.
+   *
+   * <p>If {@literal 100} is given as the value, MemoryMonitor will be disabled.
+   */
+  @Description(
+      "The GC thrashing threshold percentage. A given period of time is considered \"thrashing\" if this "
+          + "percentage of CPU time is spent in garbage collection. Dataflow will force fail tasks after "
+          + "sustained periods of thrashing.")
+  @Default.Double(50.0)
+  Double getGCThrashingPercentagePerPeriod();
+
+  void setGCThrashingPercentagePerPeriod(Double value);
+
+  /**
    * A {@link DefaultValueFactory} which constructs an instance of the class specified by {@link
    * #getMaxCacheMemoryUsageMbClass maxCacheMemoryUsageMbClass} to compute the maximum amount of
    * memory to allocate to the process wide cache within an SDK harness instance.

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnHarness.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnHarness.java
@@ -154,7 +154,7 @@ public class FnHarness {
    *
    * @param id Harness ID
    * @param options The options for this pipeline
-   * @param runnerCapabilites
+   * @param runnerCapabilities
    * @param loggingApiServiceDescriptor
    * @param controlApiServiceDescriptor
    * @param statusApiServiceDescriptor
@@ -163,7 +163,7 @@ public class FnHarness {
   public static void main(
       String id,
       PipelineOptions options,
-      Set<String> runnerCapabilites,
+      Set<String> runnerCapabilities,
       Endpoints.ApiServiceDescriptor loggingApiServiceDescriptor,
       Endpoints.ApiServiceDescriptor controlApiServiceDescriptor,
       @Nullable Endpoints.ApiServiceDescriptor statusApiServiceDescriptor)
@@ -180,7 +180,7 @@ public class FnHarness {
     main(
         id,
         options,
-        runnerCapabilites,
+        runnerCapabilities,
         loggingApiServiceDescriptor,
         controlApiServiceDescriptor,
         statusApiServiceDescriptor,

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/status/MemoryMonitor.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/status/MemoryMonitor.java
@@ -44,6 +44,7 @@ import org.apache.beam.sdk.io.fs.CreateOptions.StandardCreateOptions;
 import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PortablePipelineOptions;
+import org.apache.beam.sdk.options.SdkHarnessOptions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v26_0_jre.com.google.common.collect.ImmutableSet;
@@ -202,16 +203,18 @@ public class MemoryMonitor implements Runnable {
   private final File localDumpFolder;
 
   public static MemoryMonitor fromOptions(PipelineOptions options) {
+    SdkHarnessOptions sdkHarnessOptions = options.as(SdkHarnessOptions.class);
     String uploadFilePath = options.getTempLocation();
     PortablePipelineOptions portableOptions = options.as(PortablePipelineOptions.class);
     boolean canDumpHeap = uploadFilePath != null && portableOptions.getEnableHeapDumps();
+    double gcThrashingPercentagePerPeriod = sdkHarnessOptions.getGCThrashingPercentagePerPeriod();
 
     return new MemoryMonitor(
         new SystemGCStatsProvider(),
         DEFAULT_SLEEP_TIME_MILLIS,
         DEFAULT_SHUT_DOWN_AFTER_NUM_GCTHRASHING,
         canDumpHeap,
-        GC_THRASHING_PERCENTAGE_PER_PERIOD,
+        gcThrashingPercentagePerPeriod,
         uploadFilePath,
         getLoggingDir());
   }

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/status/MemoryMonitor.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/status/MemoryMonitor.java
@@ -98,14 +98,6 @@ public class MemoryMonitor implements Runnable {
   private static final double GC_THRASHING_PERCENTAGE_PER_SERVER = 60.0;
 
   /**
-   * The GC thrashing threshold percentage. A given period of time is considered "thrashing" if this
-   * percentage of CPU time is spent in garbage collection.
-   *
-   * <p>If {@literal 100} is given as the value, MemoryMonitor will be disabled.
-   */
-  private static final double GC_THRASHING_PERCENTAGE_PER_PERIOD = 50.0;
-
-  /**
    * The amount of memory (in bytes) we should pre-allocate, in order to be able to dump the heap.
    *
    * <p>Since the server is in GC thrashing when we try to dump the heap, we might not be able to


### PR DESCRIPTION
DataflowRunner sets up MemoryMonitor aware of the GC thrashing setting:

https://github.com/apache/beam/blob/master/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/util/MemoryMonitor.java#L237-L269

But when MemoryMonitor is setup by the Fn Harness, it was always assuming the default of 50.0, as it doesn't have a way to reach `DataflowPipelineDebugOptions`.

Granted that this option is generalizable, I've moved `gcThrashingPercentagePerPeriod` to `SdkHarnessOptions`, and will use from there for both runner & harness.
