### PR TITLE
Replace synthetic field this$0 by explicit instance

### DIFF
--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkNativePipelineVisitor.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkNativePipelineVisitor.java
@@ -183,7 +183,7 @@ public class SparkNativePipelineVisitor extends SparkRunner.Evaluator {
       String doFnName;
       Class<?> enclosingClass = fnClass.getEnclosingClass();
       if (enclosingClass != null && enclosingClass.equals(MapElements.class)) {
-        Field parent = fnClass.getDeclaredField("this$0");
+        Field parent = fnClass.getDeclaredField("outer");
         parent.setAccessible(true);
         Field fnField = enclosingClass.getDeclaredField(fnFieldName);
         fnField.setAccessible(true);

--- a/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkNativePipelineVisitor.java
+++ b/runners/spark/src/main/java/org/apache/beam/runners/spark/SparkNativePipelineVisitor.java
@@ -183,7 +183,7 @@ public class SparkNativePipelineVisitor extends SparkRunner.Evaluator {
       String doFnName;
       Class<?> enclosingClass = fnClass.getEnclosingClass();
       if (enclosingClass != null && enclosingClass.equals(MapElements.class)) {
-        Field parent = fnClass.getDeclaredField("outer");
+        Field parent = fnClass.getSuperclass().getDeclaredField("outer");
         parent.setAccessible(true);
         Field fnField = enclosingClass.getDeclaredField(fnFieldName);
         fnField.setAccessible(true);

--- a/runners/spark/src/test/java/org/apache/beam/runners/spark/SparkRunnerDebuggerTest.java
+++ b/runners/spark/src/test/java/org/apache/beam/runners/spark/SparkRunnerDebuggerTest.java
@@ -17,13 +17,17 @@
  */
 package org.apache.beam.runners.spark;
 
+import static org.apache.beam.sdk.transforms.Contextful.fn;
+import static org.apache.beam.sdk.transforms.Requirements.requiresSideInputs;
 import static org.hamcrest.MatcherAssert.assertThat;
 
+import java.util.Arrays;
 import java.util.Collections;
 import org.apache.beam.runners.spark.examples.WordCount;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.coders.VarIntCoder;
 import org.apache.beam.sdk.io.TextIO;
 import org.apache.beam.sdk.io.kafka.KafkaIO;
 import org.apache.beam.sdk.options.PipelineOptions;
@@ -39,12 +43,15 @@ import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.SimpleFunction;
 import org.apache.beam.sdk.transforms.Sum;
+import org.apache.beam.sdk.transforms.View;
 import org.apache.beam.sdk.transforms.WithKeys;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionList;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.kafka.common.serialization.StringDeserializer;
 import org.apache.kafka.common.serialization.StringSerializer;
 import org.hamcrest.Matchers;
@@ -153,6 +160,40 @@ public class SparkRunnerDebuggerTest {
 
     SparkRunnerDebugger.DebugSparkPipelineResult result =
         (SparkRunnerDebugger.DebugSparkPipelineResult) pipeline.run();
+
+    assertThat(
+        "Debug pipeline did not equal expected",
+        result.getDebugString(),
+        Matchers.equalTo(expectedPipeline));
+  }
+
+  @Test
+  public void debugBatchPipelineWithContextfulTransform() {
+    PipelineOptions options = contextRule.configure(PipelineOptionsFactory.create());
+    options.setRunner(SparkRunnerDebugger.class);
+    Pipeline pipeline = Pipeline.create(options);
+
+    final PCollectionView<Integer> view =
+        pipeline.apply("Dummy", Create.of(0)).apply(View.asSingleton());
+
+    pipeline
+        .apply(Create.of(Arrays.asList(0)))
+        .setCoder(VarIntCoder.of())
+        .apply(
+            MapElements.into(new TypeDescriptor<Integer>() {})
+                .via(fn((element, c) -> element, requiresSideInputs(view))));
+
+    SparkRunnerDebugger.DebugSparkPipelineResult result =
+        (SparkRunnerDebugger.DebugSparkPipelineResult) pipeline.run();
+
+    final String expectedPipeline =
+        "sparkContext.<impulse>()\n"
+            + "_.mapPartitions(new org.apache.beam.sdk.transforms.Create$Values$2())\n"
+            + "_.aggregate(..., new org.apache.beam.sdk.transforms.View$SingletonCombineFn(), ...)\n"
+            + "_.<createPCollectionView>\n"
+            + "sparkContext.<impulse>()\n"
+            + "_.mapPartitions(new org.apache.beam.sdk.transforms.Create$Values$2())\n"
+            + "_.mapPartitions(new org.apache.beam.sdk.transforms.Contextful())";
 
     assertThat(
         "Debug pipeline did not equal expected",

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/MapElements.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/MapElements.java
@@ -161,8 +161,8 @@ public class MapElements<InputT, OutputT>
   private abstract class MapDoFn extends DoFn<InputT, OutputT> {
 
     /**
-     * Holds {@link MapDoFn#outer} instance of enclosing class, used by {@link java.lang.reflect.Field} in
-     * {@code SparkNativePipelineVisitor$NativeTransform}
+     * Holds {@link MapDoFn#outer} instance of enclosing class, used by {@link
+     * java.lang.reflect.Field} in {@code SparkNativePipelineVisitor$NativeTransform}.
      */
     final MapElements<InputT, OutputT> outer = MapElements.this;
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/MapElements.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/MapElements.java
@@ -159,6 +159,13 @@ public class MapElements<InputT, OutputT>
 
   /** A DoFn implementation that handles a trivial map call. */
   private abstract class MapDoFn extends DoFn<InputT, OutputT> {
+
+    /**
+     * Holds {@link MapDoFn#outer} instance of enclosing class, used by {@link java.lang.reflect.Field} in
+     * {@code SparkNativePipelineVisitor$NativeTransform}
+     */
+    final MapElements<InputT, OutputT> outer = MapElements.this;
+
     @Override
     public void populateDisplayData(DisplayData.Builder builder) {
       builder.delegate(MapElements.this);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/MapElements.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/MapElements.java
@@ -160,10 +160,7 @@ public class MapElements<InputT, OutputT>
   /** A DoFn implementation that handles a trivial map call. */
   private abstract class MapDoFn extends DoFn<InputT, OutputT> {
 
-    /**
-     * Holds {@link MapDoFn#outer} instance of enclosing class, used by {@link
-     * java.lang.reflect.Field} in {@code SparkNativePipelineVisitor$NativeTransform}.
-     */
+    /** Holds {@link MapDoFn#outer instance} of enclosing class, used by runner implementations. */
     final MapElements<InputT, OutputT> outer = MapElements.this;
 
     @Override


### PR DESCRIPTION
fixes #21207.

Synthetic field generated for inner classes is replaced by explicit reference to `outer` class instance of  [MapElements](https://github.com/apache/beam/blob/7754ab9eab8951eb047643857623ea435ccbe894/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/MapElements.java#L161C28-L161C28). It will remove usage of synthetic field `this$0`, which is planned to be [omitted](https://bugs.openjdk.java.net/browse/JDK-8271717) in Inner classes not referencing instance variables of enclosing class.