### PR TITLE
Keep GCThrashingPercentagePerPeriod in DataflowPipelineDebugOptions

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -235,6 +235,23 @@ public interface DataflowPipelineDebugOptions extends ExperimentalOptions, Pipel
   void setJfrRecordingDurationSec(int value);
 
   /**
+   * The GC thrashing threshold percentage. A given period of time is considered "thrashing" if this
+   * percentage of CPU time is spent in garbage collection. Dataflow will force fail tasks after
+   * sustained periods of thrashing.
+   *
+   * <p>If {@literal 100} is given as the value, MemoryMonitor will be disabled.
+   */
+  // TODO: this will be removed after new SDK containers are used
+  @Description(
+      "The GC thrashing threshold percentage. A given period of time is considered \"thrashing\" if this "
+          + "percentage of CPU time is spent in garbage collection. Dataflow will force fail tasks after "
+          + "sustained periods of thrashing.")
+  @Default.Double(50.0)
+  Double getGCThrashingPercentagePerPeriod();
+
+  void setGCThrashingPercentagePerPeriod(Double value);
+
+  /**
    * The size of the worker's in-memory cache, in megabytes.
    *
    * <p>Currently, this cache is used for storing read values of side inputs. as well as the state


### PR DESCRIPTION
https://github.com/apache/beam/pull/27850 will cause problems until new containers are built and used.

```
ERROR 2023-08-07T16:47:48.011Z Uncaught exception in main thread. Exiting with status code 1.
ERROR 2023-08-07T16:47:48.011Z java.lang.NoSuchMethodError: 'java.lang.Double org.apache.beam.runners.dataflow.options.DataflowPipelineDebugOptions.getGCThrashingPercentagePerPeriod()'
ERROR 2023-08-07T16:47:48.012Z at org.apache.beam.runners.dataflow.worker.util.MemoryMonitor.fromOptions(MemoryMonitor.java:243)
ERROR 2023-08-07T16:47:48.012Z at org.apache.beam.runners.dataflow.worker.StreamingDataflowWorker.<init>(StreamingDataflowWorker.java:588)
ERROR 2023-08-07T16:47:48.012Z at org.apache.beam.runners.dataflow.worker.StreamingDataflowWorker.fromDataflowWorkerHarnessOptions(StreamingDataflowWorker.java:556)
ERROR 2023-08-07T16:47:48.012Z at org.apache.beam.runners.dataflow.worker.StreamingDataflowWorker.main(StreamingDataflowWorker.java:273)
```

Keeping it for now to avoid blocking people using Beam @ HEAD.


