### PR TITLE
Bump beam-master legacy container to 20230807

### DIFF
--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -53,7 +53,7 @@ processResources {
   filter org.apache.tools.ant.filters.ReplaceTokens, tokens: [
     'dataflow.legacy_environment_major_version' : '8',
     'dataflow.fnapi_environment_major_version' : '8',
-    'dataflow.legacy_container_version' : 'beam-master-20230426',
+    'dataflow.legacy_container_version' : 'beam-master-20230807',
     'dataflow.fnapi_container_version' : 'beam-master-20230426',
     'dataflow.container_base_repository' : 'gcr.io/cloud-dataflow/v1beta3',
   ]


### PR DESCRIPTION
Generated legacy containers

Verified

https://gcr.io/cloud-dataflow/v1beta3/beam-java-batch:beam-master-20230807
https://gcr.io/cloud-dataflow/v1beta3/beam-java-streaming:beam-master-20230807

https://gcr.io/cloud-dataflow/v1beta3/beam-java11-batch:beam-master-20230807
https://gcr.io/cloud-dataflow/v1beta3/beam-java11-streaming:beam-master-20230807

https://gcr.io/cloud-dataflow/v1beta3/beam-java17-batch:beam-master-20230807
https://gcr.io/cloud-dataflow/v1beta3/beam-java17-streaming:beam-master-20230807
