### PR TITLE
Add logs when staging file/artifact can not be found

### DIFF
--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/EnvironmentsTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/EnvironmentsTest.java
@@ -326,7 +326,7 @@ public class EnvironmentsTest implements Serializable {
   }
 
   @Test
-  public void testGetArtifactsBadFileThrowsInfo() throws Exception {
+  public void testGetArtifactsBadFileLogsInfo() throws Exception {
     File file1 = File.createTempFile("file1-", ".txt");
     file1.deleteOnExit();
 
@@ -338,7 +338,7 @@ public class EnvironmentsTest implements Serializable {
   }
 
   @Test
-  public void testGetArtifactsBadNamedFileThrowsWarn() throws Exception {
+  public void testGetArtifactsBadNamedFileLogsWarn() throws Exception {
     File file1 = File.createTempFile("file1-", ".txt");
     file1.deleteOnExit();
 

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/EnvironmentsTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/EnvironmentsTest.java
@@ -21,14 +21,18 @@ import static org.apache.beam.runners.core.construction.Environments.JAVA_SDK_HA
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.equalTo;
 import static org.hamcrest.Matchers.hasItem;
+import static org.hamcrest.Matchers.hasSize;
 import static org.hamcrest.Matchers.is;
 import static org.junit.Assert.assertEquals;
 
+import java.io.File;
 import java.io.IOException;
 import java.io.Serializable;
+import java.util.List;
 import java.util.Optional;
 import org.apache.beam.model.pipeline.v1.Endpoints;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
+import org.apache.beam.model.pipeline.v1.RunnerApi.ArtifactInformation;
 import org.apache.beam.model.pipeline.v1.RunnerApi.DockerPayload;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Environment;
 import org.apache.beam.model.pipeline.v1.RunnerApi.FunctionSpec;
@@ -41,6 +45,7 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.PortablePipelineOptions;
+import org.apache.beam.sdk.testing.ExpectedLogs;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.DoFnSchemaInformation;
 import org.apache.beam.sdk.transforms.ParDo;
@@ -60,6 +65,7 @@ import org.junit.runners.JUnit4;
 @RunWith(JUnit4.class)
 public class EnvironmentsTest implements Serializable {
   @Rule public transient ExpectedException thrown = ExpectedException.none();
+  @Rule public transient ExpectedLogs expectedLogs = ExpectedLogs.none(Environments.class);
 
   @Test
   public void createEnvironmentDockerFromEnvironmentConfig() throws IOException {
@@ -303,5 +309,44 @@ public class EnvironmentsTest implements Serializable {
   @Test(expected = UnsupportedOperationException.class)
   public void testJavaVersionStrictInvalid() {
     assertEquals(JavaVersion.java8, JavaVersion.forSpecificationStrict("invalid"));
+  }
+
+  @Test
+  public void testGetArtifactsExistingNoLogs() throws Exception {
+    File file1 = File.createTempFile("file1-", ".txt");
+    file1.deleteOnExit();
+    File file2 = File.createTempFile("file2-", ".txt");
+    file2.deleteOnExit();
+
+    List<ArtifactInformation> artifacts =
+        Environments.getArtifacts(ImmutableList.of(file1.getAbsolutePath(), "file2=" + file2));
+
+    assertThat(artifacts, hasSize(2));
+    expectedLogs.verifyNotLogged("was not found");
+  }
+
+  @Test
+  public void testGetArtifactsBadFileThrowsInfo() throws Exception {
+    File file1 = File.createTempFile("file1-", ".txt");
+    file1.deleteOnExit();
+
+    List<ArtifactInformation> artifacts =
+        Environments.getArtifacts(ImmutableList.of(file1.getAbsolutePath(), "spurious_file"));
+
+    assertThat(artifacts, hasSize(1));
+    expectedLogs.verifyInfo("'spurious_file' was not found");
+  }
+
+  @Test
+  public void testGetArtifactsBadNamedFileThrowsWarn() throws Exception {
+    File file1 = File.createTempFile("file1-", ".txt");
+    file1.deleteOnExit();
+
+    List<ArtifactInformation> artifacts =
+        Environments.getArtifacts(
+            ImmutableList.of(file1.getAbsolutePath(), "file_name=spurious_file"));
+
+    assertThat(artifacts, hasSize(1));
+    expectedLogs.verifyWarn("name 'file_name' was not found");
   }
 }


### PR DESCRIPTION
(Suggest reviewing ignoring whitespace differences -- add `?w=1` to the URL - e.g., https://github.com/apache/beam/pull/27882/files?w=1)

Runners are currently ignoring spurious `filesToStage` / classpath elements. 

The behavior was not changed, but I've added logs, since failing silently can cause a lot of confusion.

Logging level is INFO for the common elements, and for the named elements (in which Dataflow, for example, expects a specific name such as `dataflow-worker.jar` or `windmill_main`), if they are not found, a WARN is issued. 