### PR TITLE
[prism] Avoid prism locking on data send on ProcessBundle failure.

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/jobservices/job.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/jobservices/job.go
@@ -83,7 +83,7 @@ type Job struct {
 
 	// Context used to terminate this job.
 	RootCtx  context.Context
-	CancelFn context.CancelFunc
+	CancelFn context.CancelCauseFunc
 
 	metrics metricsStore
 }

--- a/sdks/go/pkg/beam/runners/prism/internal/jobservices/job.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/jobservices/job.go
@@ -162,4 +162,5 @@ func (j *Job) Done() {
 func (j *Job) Failed(err error) {
 	j.failureErr = err
 	j.sendState(jobpb.JobState_FAILED)
+	j.CancelFn(err)
 }

--- a/sdks/go/pkg/beam/runners/prism/internal/jobservices/management.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/jobservices/management.go
@@ -70,7 +70,7 @@ func (s *Server) Prepare(ctx context.Context, req *jobpb.PrepareJobRequest) (*jo
 	defer s.mu.Unlock()
 
 	// Since jobs execute in the background, they should not be tied to a request's context.
-	rootCtx, cancelFn := context.WithCancel(context.Background())
+	rootCtx, cancelFn := context.WithCancelCause(context.Background())
 	job := &Job{
 		key:        s.nextId(),
 		Pipeline:   req.GetPipeline(),

--- a/sdks/go/pkg/beam/runners/prism/internal/stage.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/stage.go
@@ -125,7 +125,6 @@ func (s *stage) Execute(ctx context.Context, j *jobservices.Job, wk *worker.W, c
 			slog.Error("job failed", "bundle", rb, "job", j)
 			err := fmt.Errorf("%v", errMsg)
 			j.Failed(err)
-			j.CancelFn(err)
 		}
 		dataReady = b.ProcessOn(ctx, wk)
 	default:

--- a/sdks/go/pkg/beam/runners/prism/internal/worker/bundle.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/bundle.go
@@ -16,6 +16,7 @@
 package worker
 
 import (
+	"context"
 	"fmt"
 	"sync/atomic"
 
@@ -58,7 +59,7 @@ type B struct {
 
 	SinkToPCollection map[string]string
 
-	Error string // Set on Respond.
+	Fail func(err string) // Called if bundle returns an error.
 }
 
 // Init initializes the bundle's internal state for waiting on all
@@ -90,7 +91,7 @@ func (b *B) LogValue() slog.Value {
 
 func (b *B) Respond(resp *fnpb.InstructionResponse) {
 	if resp.GetError() != "" {
-		b.Error = resp.GetError()
+		b.Fail(resp.GetError())
 		close(b.Resp)
 		return
 	}
@@ -105,7 +106,7 @@ func (b *B) Respond(resp *fnpb.InstructionResponse) {
 //
 // While this method mostly manipulates a W, putting it on a B avoids mixing the workers
 // public GRPC APIs up with local calls.
-func (b *B) ProcessOn(wk *W) <-chan struct{} {
+func (b *B) ProcessOn(ctx context.Context, wk *W) <-chan struct{} {
 	wk.mu.Lock()
 	wk.activeInstructions[b.InstID] = b
 	wk.mu.Unlock()
@@ -124,7 +125,8 @@ func (b *B) ProcessOn(wk *W) <-chan struct{} {
 
 	// TODO: make batching decisions.
 	for i, d := range b.InputData {
-		wk.DataReqs <- &fnpb.Elements{
+		select {
+		case wk.DataReqs <- &fnpb.Elements{
 			Data: []*fnpb.Elements_Data{
 				{
 					InstructionId: b.InstID,
@@ -133,6 +135,10 @@ func (b *B) ProcessOn(wk *W) <-chan struct{} {
 					IsLast:        i+1 == len(b.InputData),
 				},
 			},
+		}:
+		case <-ctx.Done():
+			b.DataDone()
+			return b.DataWait
 		}
 	}
 	return b.DataWait

--- a/sdks/go/pkg/beam/runners/prism/internal/worker/bundle_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/bundle_test.go
@@ -17,6 +17,7 @@ package worker
 
 import (
 	"bytes"
+	"context"
 	"sync"
 	"testing"
 )
@@ -33,7 +34,7 @@ func TestBundle_ProcessOn(t *testing.T) {
 	var completed sync.WaitGroup
 	completed.Add(1)
 	go func() {
-		b.ProcessOn(wk)
+		b.ProcessOn(context.Background(), wk)
 		completed.Done()
 	}()
 	b.DataDone()

--- a/sdks/go/pkg/beam/runners/prism/internal/worker/worker_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/worker_test.go
@@ -146,7 +146,7 @@ func TestWorker_Control_HappyPath(t *testing.T) {
 	b := &B{}
 	b.Init()
 	wk.activeInstructions[instID] = b
-	b.ProcessOn(wk)
+	b.ProcessOn(ctx, wk)
 
 	ctrlStream.Send(&fnpb.InstructionResponse{
 		InstructionId: instID,
@@ -193,7 +193,7 @@ func TestWorker_Data_HappyPath(t *testing.T) {
 	wg.Add(1)
 	go func() {
 		defer wg.Done()
-		b.ProcessOn(wk)
+		b.ProcessOn(ctx, wk)
 	}()
 
 	wk.InstReqs <- &fnpb.InstructionRequest{


### PR DESCRIPTION
Plumb context through prism loops to avoid place where blocks could lead to panic.

* Some cases where a failed bundle was still getting blocked on SDK data ingestion, preventing halting the process.
* Cancel job context with error on failure.
  * This error is presently not directly used.
* Notably happened when test has sufficient data to have multiple data bundles, but didn't have a function registered (which causes deserialization failures on worker side).

Now there's a single place for where a bundle failure leads to the job being canceled, which makes it a ready target for alternative retry logic in the future. However, at present, the goal is to fail as fast and as clearly as possible.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
