### PR TITLE
Try a second time to delete old images

### DIFF
--- a/.test-infra/tools/stale_dataflow_prebuilt_image_cleaner.sh
+++ b/.test-infra/tools/stale_dataflow_prebuilt_image_cleaner.sh
@@ -51,6 +51,7 @@ done
 
 for image_name in ${IMAGE_NAMES[@]}; do
   echo IMAGES FOR image ${image_name}
+  FAILED_TO_DELETE=""
   # get the newest image without latest label
   LATEST_IN_TIME=$(gcloud container images list-tags \
      ${image_name} --sort-by="~TIMESTAMP"  --filter="NOT tags:latest " --format="get(digest)" --limit=1)
@@ -70,10 +71,17 @@ for image_name in ${IMAGE_NAMES[@]}; do
       # this make sure we leave at least one container under each image name, either labelled "latest" or not
       if [ "$LATEST_IN_TIME" != "$current" ]; then
         echo "Deleting image. Command: gcloud container images delete ${image_name}@"${current}" --force-delete-tags -q"
-        gcloud container images delete ${image_name}@"${current}" --force-delete-tags -q
+        gcloud container images delete ${image_name}@"${current}" --force-delete-tags -q || FAILED_TO_DELETE+="${current} "
       fi
     done
   fi
+
+  # Some images may not be successfully deleted the first time due to flakiness or having a dependency that hasn't been deleted yet.
+  RETRY_DELETE=("${FAILED_TO_DELETE[@]}")
+  for current in $RETRY_DELETE; do
+    echo "Trying again to delete image ${image_name}@"${current}". Command: gcloud container images delete ${image_name}@"${current}" --force-delete-tags -q"
+    gcloud container images delete ${image_name}@"${current}" --force-delete-tags -q || FAILED_TO_DELETE+="${current} "
+  done
 done
 
 if [[ ${STALE_IMAGES} ]]; then

--- a/.test-infra/tools/stale_dataflow_prebuilt_image_cleaner.sh
+++ b/.test-infra/tools/stale_dataflow_prebuilt_image_cleaner.sh
@@ -78,9 +78,10 @@ for image_name in ${IMAGE_NAMES[@]}; do
 
   # Some images may not be successfully deleted the first time due to flakiness or having a dependency that hasn't been deleted yet.
   RETRY_DELETE=("${FAILED_TO_DELETE[@]}")
+  echo "Failed to delete the following images: ${FAILED_TO_DELETE}. Retrying each of them."
   for current in $RETRY_DELETE; do
     echo "Trying again to delete image ${image_name}@"${current}". Command: gcloud container images delete ${image_name}@"${current}" --force-delete-tags -q"
-    gcloud container images delete ${image_name}@"${current}" --force-delete-tags -q || FAILED_TO_DELETE+="${current} "
+    gcloud container images delete ${image_name}@"${current}" --force-delete-tags -q
   done
 done
 


### PR DESCRIPTION
After updating to delete arm containers, this job is consistently failing because its trying to delete an image that other images reference. This updates to (a) allow other images scheduled for deletion to still get deleted and (b) retry images that we fail to delete on the first pass.

Example failing run: https://ci-beam.apache.org/job/beam_CleanUpPrebuiltSDKImages/1548/console

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
