### PR TITLE
Speed up `IntervalWindow` argument construction

### DIFF
--- a/sdks/python/apache_beam/transforms/window.py
+++ b/sdks/python/apache_beam/transforms/window.py
@@ -511,8 +511,10 @@ class SlidingWindows(NonMergingWindowFn):
     timestamp = context.timestamp
     start = timestamp - ((timestamp - self.offset) % self.period)
     return [
-        IntervalWindow(Timestamp(micros=s), Timestamp(micros=s) + self.size)
-        for s in range(
+        IntervalWindow(
+            (interval_start := Timestamp(micros=s)),
+            interval_start + self.size,
+        ) for s in range(
             start.micros,
             timestamp.micros - self.size.micros,
             -self.period.micros)


### PR DESCRIPTION
In the original snippet, we create two instances of `Timestamp(micros=s)`, the later is rather short
lived as we immediately use the `__add__` dunder
method to create a brand new instance of `Timestamp`.

The change in this commit is to remove the construction of this short lived `Timestamp` and reuse the one already constructed for the `start` argument of `IntervalWindow`.

The speed gain of this change depends on the specification of the `SlidingWindows`. I have a pipeline that is relatively simple and with GCP's profiler in Dataflow, it revealed about ~2.5% of wall time is wasted in constructing this short lived `Timestamp`.

Given that `__add__` doesn't alter the `Timestamp` object inplace (and unlikely to be changed to that behaviour), I think this is a safe change.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

**This is just a oneliner change so I didn't bother, let me know if I should do any of the below.**

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
