### PR TITLE
Revert "expose path to gcloud folder in setup action"

### DIFF
--- a/.github/actions/setup-action/action.yml
+++ b/.github/actions/setup-action/action.yml
@@ -57,8 +57,3 @@ runs:
         github_repository: ${{ github.repository }}     
         github_current_run_id: ${{ github.run_id }}
         pull_request_url: ${{ github.event.issue.pull_request.url }}
-    ### Used for Flink jobs that call docker run and mount gcloud folder
-    - name: expose gcloud path
-      shell: bash
-      run: |
-        echo CLOUDSDK_CONFIG=/var/lib/kubelet/pods/$POD_UID/volumes/kubernetes.io~empty-dir/gcloud >> $GITHUB_ENV


### PR DESCRIPTION
Reverts apache/beam#27923

This broke some actions - https://github.com/apache/beam/actions/runs/5812126326/job/15756842872?pr=27934 and https://github.com/apache/beam/actions/runs/5812123409/job/15756838263?pr=27933 are examples