### PR TITLE
Increase consistency for BQ typed read with avro source

### DIFF
--- a/examples/kotlin/src/main/java/org/apache/beam/examples/kotlin/snippets/Snippets.kt
+++ b/examples/kotlin/src/main/java/org/apache/beam/examples/kotlin/snippets/Snippets.kt
@@ -121,30 +121,27 @@ object Snippets {
             val tableSpec = "apache-beam-testing.samples.weather_stations"
             // [START BigQueryReadFunction]
             val maxTemperatures = pipeline.apply(
-                    BigQueryIO.read { it.record["max_temperature"] as Double? }
-                            .from(tableSpec)
-                            .withCoder(DoubleCoder.of()))
+                    BigQueryIO.read({ it["max_temperature"] as Double? }, DoubleCoder.of())
+                            .from(tableSpec))
             // [END BigQueryReadFunction]
         }
 
         run {
             // [START BigQueryReadQuery]
             val maxTemperatures = pipeline.apply(
-                    BigQueryIO.read { it.record["max_temperature"] as Double? }
+                    BigQueryIO.read({ it["max_temperature"] as Double? }, DoubleCoder.of())
                             .fromQuery(
-                                    "SELECT max_temperature FROM [apache-beam-testing.samples.weather_stations]")
-                            .withCoder(DoubleCoder.of()))
+                                    "SELECT max_temperature FROM [apache-beam-testing.samples.weather_stations]"))
             // [END BigQueryReadQuery]
         }
 
         run {
             // [START BigQueryReadQueryStdSQL]
             val maxTemperatures = pipeline.apply(
-                    BigQueryIO.read { it.record["max_temperature"] as Double? }
+                    BigQueryIO.read({ it["max_temperature"] as Double? }, DoubleCoder.of())
                             .fromQuery(
                                     "SELECT max_temperature FROM `clouddataflow-readonly.samples.weather_stations`")
-                            .usingStandardSql()
-                            .withCoder(DoubleCoder.of()))
+                            .usingStandardSql())
             // [END BigQueryReadQueryStdSQL]
         }
 
@@ -249,20 +246,19 @@ object Snippets {
             )
             */
             val weatherData = pipeline.apply(
-                    BigQueryIO.read {
-                        val record = it.record
+                    BigQueryIO.read({
                         WeatherData(
-                                record.get("year") as Long,
-                                record.get("month") as Long,
-                                record.get("day") as Long,
-                                record.get("max_temperature") as Double)
-                    }
+                                it["year"] as Long,
+                                it["month"] as Long,
+                                it["day"] as Long,
+                                it["max_temperature"] as Double
+                        )
+                    }, AvroCoder.of(WeatherData::class.java))
                             .fromQuery("""
                                 SELECT year, month, day, max_temperature
                                 FROM [apache-beam-testing.samples.weather_stations]
                                 WHERE year BETWEEN 2007 AND 2009
-                            """.trimIndent())
-                            .withCoder(AvroCoder.of(WeatherData::class.java)))
+                            """.trimIndent()))
 
             // We will send the weather data into different tables for every year.
             weatherData.apply<WriteResult>(

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/AvroByteReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/AvroByteReader.java
@@ -75,10 +75,7 @@ public class AvroByteReader<T> extends NativeReader<T> {
     this.endPosition = endPosition;
     this.coder = coder;
     this.options = options;
-    this.avroSource =
-        // given schema is not a record. force casting to avro primitive type
-        (AvroSource<ByteBuffer, ByteBuffer>)
-            ((AvroSource) AvroSource.from(filename).withSchema(schema));
+    this.avroSource = AvroSource.from(filename).withSchema(ByteBuffer.class, schema);
   }
 
   @Override

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/AvroByteReader.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/AvroByteReader.java
@@ -55,7 +55,7 @@ public class AvroByteReader<T> extends NativeReader<T> {
   final long startPosition;
   final long endPosition;
   final String filename;
-  final AvroSource<ByteBuffer> avroSource;
+  final AvroSource<ByteBuffer, ByteBuffer> avroSource;
   final PipelineOptions options;
 
   final Coder<T> coder;
@@ -76,7 +76,9 @@ public class AvroByteReader<T> extends NativeReader<T> {
     this.coder = coder;
     this.options = options;
     this.avroSource =
-        (AvroSource<ByteBuffer>) ((AvroSource) AvroSource.from(filename).withSchema(schema));
+        // given schema is not a record. force casting to avro primitive type
+        (AvroSource<ByteBuffer, ByteBuffer>)
+            ((AvroSource) AvroSource.from(filename).withSchema(schema));
   }
 
   @Override
@@ -93,14 +95,14 @@ public class AvroByteReader<T> extends NativeReader<T> {
                   FileSystems.matchSingleFileSpec(filename), startPosition, endPosition)
               .createReader(options);
     }
-    return new AvroByteFileIterator((AvroReader<ByteBuffer>) reader);
+    return new AvroByteFileIterator((AvroReader<ByteBuffer, ByteBuffer>) reader);
   }
 
   class AvroByteFileIterator extends NativeReaderIterator<T> {
-    private final AvroReader<ByteBuffer> reader;
+    private final AvroReader<ByteBuffer, ByteBuffer> reader;
     private Optional<T> current;
 
-    public AvroByteFileIterator(AvroReader<ByteBuffer> reader) {
+    public AvroByteFileIterator(AvroReader<ByteBuffer, ByteBuffer> reader) {
       this.reader = reader;
     }
 

--- a/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/io/AvroIO.java
+++ b/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/io/AvroIO.java
@@ -804,19 +804,19 @@ public class AvroIO {
     }
 
     @SuppressWarnings("unchecked")
-    private static <T> AvroSource<T> createSource(
+    private static <T> AvroSource<T, T> createSource(
         ValueProvider<String> filepattern,
         EmptyMatchTreatment emptyMatchTreatment,
         Class<T> recordClass,
         Schema schema,
         @Nullable Coder<T> coder,
         AvroSource.@Nullable DatumReaderFactory<T> readerFactory) {
-      AvroSource<?> base =
+      AvroSource<GenericRecord, GenericRecord> base =
           AvroSource.from(filepattern).withEmptyMatchTreatment(emptyMatchTreatment);
 
-      AvroSource<T> source =
+      AvroSource<T, T> source =
           recordClass == GenericRecord.class
-              ? (AvroSource<T>) base.withSchema(schema)
+              ? (AvroSource<T, T>) base.withSchema(schema)
               : base.withSchema(recordClass);
 
       if (readerFactory != null) {

--- a/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/io/AvroSource.java
+++ b/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/io/AvroSource.java
@@ -142,11 +142,14 @@ public class AvroSource<AvroT, T> extends BlockBasedSource<T> {
   }
 
   // Use cases of AvroSource are:
-  // 1) AvroSource<GenericRecord, GenericRecord> Reading GenericRecord records with a specified schema.
+  // 1) AvroSource<GenericRecord, GenericRecord> Reading GenericRecord records with a specified
+  // schema.
   // 2) AvroSource<Foo, Foo> Reading records of a generated Avro class Foo.
-  // 3) AvroSource<GenericRecord, T> Reading GenericRecord records with or without a specified schema
+  // 3) AvroSource<GenericRecord, T> Reading GenericRecord records with or without a specified
+  // schema
   //    and converting them to type T.
-  // 4) AvroSource<Foo, T> Reading records of a generated Avro class Foo and converting them to type T.
+  // 4) AvroSource<Foo, T> Reading records of a generated Avro class Foo and converting them to type
+  // T.
   //                     |    Case 1     |    Case 2   |     Case 3    |     Case 4    |
   // AvroT               | GenericRecord |     Foo     | GenericRecord |      Foo      |
   // T                   | GenericRecord |     Foo     | GenericRecord |       T       |
@@ -210,8 +213,8 @@ public class AvroSource<AvroT, T> extends BlockBasedSource<T> {
     private void validate() {
       if (parseFn == null) {
         checkArgument(
-                readerSchemaString != null,
-                "schema must be specified using withSchema() when not using a parse fn");
+            readerSchemaString != null,
+            "schema must be specified using withSchema() when not using a parse fn");
       }
     }
 

--- a/sdks/java/extensions/avro/src/test/avro/org/apache/beam/sdk/extensions/avro/io/user.avsc
+++ b/sdks/java/extensions/avro/src/test/avro/org/apache/beam/sdk/extensions/avro/io/user.avsc
@@ -3,8 +3,8 @@
   "type": "record",
   "name": "AvroGeneratedUser",
   "fields": [
-    { "name": "name", "type": "string"},
-    { "name": "favorite_number", "type": ["int", "null"]},
-    { "name": "favorite_color", "type": ["string", "null"]}
+    { "name": "name", "type": "string" },
+    { "name": "favorite_number", "type": ["long", "null"] },
+    { "name": "favorite_color", "type": ["string", "null"] }
   ]
 }

--- a/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/io/AvroGeneratedUserFactory.java
+++ b/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/io/AvroGeneratedUserFactory.java
@@ -28,7 +28,7 @@ public class AvroGeneratedUserFactory {
   private static final String VERSION_AVRO = Schema.class.getPackage().getImplementationVersion();
 
   public static AvroGeneratedUser newInstance(
-      String name, Integer favoriteNumber, String favoriteColor) {
+      String name, Long favoriteNumber, String favoriteColor) {
 
     if (VERSION_AVRO.equals("1.8.2")) {
       return new AvroGeneratedUser(name, favoriteNumber, favoriteColor);

--- a/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/io/AvroIOTest.java
+++ b/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/io/AvroIOTest.java
@@ -367,8 +367,8 @@ public class AvroIOTest implements Serializable {
 
       List<T> values =
           ImmutableList.of(
-              (T) AvroGeneratedUserFactory.newInstance("Bob", 256, null),
-              (T) AvroGeneratedUserFactory.newInstance("Alice", 128, null),
+              (T) AvroGeneratedUserFactory.newInstance("Bob", 256L, null),
+              (T) AvroGeneratedUserFactory.newInstance("Alice", 128L, null),
               (T) AvroGeneratedUserFactory.newInstance("Ted", null, "white"));
 
       writePipeline

--- a/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/io/AvroPojoUser.java
+++ b/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/io/AvroPojoUser.java
@@ -17,10 +17,10 @@
  */
 package org.apache.beam.sdk.extensions.avro.io;
 
-import com.google.common.base.MoreObjects;
 import java.util.Objects;
 import org.apache.avro.reflect.AvroName;
 import org.apache.avro.reflect.Nullable;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.MoreObjects;
 
 public class AvroPojoUser {
   private String name;
@@ -76,13 +76,17 @@ public class AvroPojoUser {
 
   @Override
   public boolean equals(Object o) {
-    if (this == o) return true;
-    if (o == null || getClass() != o.getClass()) return false;
+    if (this == o) {
+      return true;
+    }
+    if (o instanceof AvroPojoUser) {
+      AvroPojoUser that = (AvroPojoUser) o;
+      return this.name.equals(that.name)
+          && Objects.equals(this.favoriteNumber, that.favoriteNumber)
+          && Objects.equals(this.favoriteColor, that.favoriteColor);
+    }
 
-    AvroPojoUser pojoUser = (AvroPojoUser) o;
-    if (!name.equals(pojoUser.name)) return false;
-    if (!Objects.equals(favoriteNumber, pojoUser.favoriteNumber)) return false;
-    return Objects.equals(favoriteColor, pojoUser.favoriteColor);
+    return false;
   }
 
   @Override

--- a/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/io/AvroPojoUser.java
+++ b/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/io/AvroPojoUser.java
@@ -1,0 +1,95 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.extensions.avro.io;
+
+import com.google.common.base.MoreObjects;
+import java.util.Objects;
+import org.apache.avro.reflect.AvroName;
+import org.apache.avro.reflect.Nullable;
+
+public class AvroPojoUser {
+  private String name;
+
+  @Nullable
+  @AvroName("favorite_number")
+  private Long favoriteNumber;
+
+  @Nullable
+  @AvroName("favorite_color")
+  private String favoriteColor;
+
+  public AvroPojoUser() {}
+
+  public AvroPojoUser(String name, Long favoriteNumber, String favoriteColor) {
+    this.name = name;
+    this.favoriteColor = favoriteColor;
+    this.favoriteNumber = favoriteNumber;
+  }
+
+  public String getName() {
+    return name;
+  }
+
+  public void setName(String name) {
+    this.name = name;
+  }
+
+  public Long getFavoriteNumber() {
+    return favoriteNumber;
+  }
+
+  public void setFavoriteNumber(Long favoriteNumber) {
+    this.favoriteNumber = favoriteNumber;
+  }
+
+  public String getFavoriteColor() {
+    return favoriteColor;
+  }
+
+  public void setFavoriteColor(String favoriteColor) {
+    this.favoriteColor = favoriteColor;
+  }
+
+  @Override
+  public String toString() {
+    return MoreObjects.toStringHelper(this)
+        .add("name", name)
+        .add("favoriteNumber", favoriteNumber)
+        .add("favoriteColor", favoriteColor)
+        .toString();
+  }
+
+  @Override
+  public boolean equals(Object o) {
+    if (this == o) return true;
+    if (o == null || getClass() != o.getClass()) return false;
+
+    AvroPojoUser pojoUser = (AvroPojoUser) o;
+    if (!name.equals(pojoUser.name)) return false;
+    if (!Objects.equals(favoriteNumber, pojoUser.favoriteNumber)) return false;
+    return Objects.equals(favoriteColor, pojoUser.favoriteColor);
+  }
+
+  @Override
+  public int hashCode() {
+    int result = name.hashCode();
+    result = 31 * result + (favoriteNumber != null ? favoriteNumber.hashCode() : 0);
+    result = 31 * result + (favoriteColor != null ? favoriteColor.hashCode() : 0);
+    return result;
+  }
+}

--- a/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/io/AvroSourceTest.java
+++ b/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/io/AvroSourceTest.java
@@ -167,7 +167,7 @@ public class AvroSourceTest {
       String filename =
           generateTestFile(
               codec, expected, SyncBehavior.SYNC_DEFAULT, 0, AvroCoder.of(Bird.class), codec);
-      AvroSource<Bird> source = AvroSource.from(filename).withSchema(Bird.class);
+      AvroSource<Bird, Bird> source = AvroSource.from(filename).withSchema(Bird.class);
       List<Bird> actual = SourceTestUtils.readFromSource(source, null);
       assertThat(expected, containsInAnyOrder(actual.toArray()));
     }
@@ -188,7 +188,8 @@ public class AvroSourceTest {
             DataFileConstants.NULL_CODEC);
     File file = new File(filename);
 
-    AvroSource<FixedRecord> source = AvroSource.from(filename).withSchema(FixedRecord.class);
+    AvroSource<FixedRecord, FixedRecord> source =
+        AvroSource.from(filename).withSchema(FixedRecord.class);
     List<? extends BoundedSource<FixedRecord>> splits = source.split(file.length() / 3, null);
     for (BoundedSource<FixedRecord> subSource : splits) {
       int items = SourceTestUtils.readFromSource(subSource, null).size();
@@ -222,7 +223,8 @@ public class AvroSourceTest {
             DataFileConstants.NULL_CODEC);
     File file = new File(filename);
 
-    AvroSource<FixedRecord> source = AvroSource.from(filename).withSchema(FixedRecord.class);
+    AvroSource<FixedRecord, FixedRecord> source =
+        AvroSource.from(filename).withSchema(FixedRecord.class);
     try (BoundedReader<FixedRecord> reader = source.createReader(null)) {
       assertEquals(Double.valueOf(0.0), reader.getFractionConsumed());
     }
@@ -248,7 +250,8 @@ public class AvroSourceTest {
             AvroCoder.of(FixedRecord.class),
             DataFileConstants.NULL_CODEC);
 
-    AvroSource<FixedRecord> source = AvroSource.from(filename).withSchema(FixedRecord.class);
+    AvroSource<FixedRecord, FixedRecord> source =
+        AvroSource.from(filename).withSchema(FixedRecord.class);
     try (BoundedReader<FixedRecord> readerOrig = source.createReader(null)) {
       assertThat(readerOrig, Matchers.instanceOf(BlockBasedReader.class));
       BlockBasedReader<FixedRecord> reader = (BlockBasedReader<FixedRecord>) readerOrig;
@@ -307,7 +310,8 @@ public class AvroSourceTest {
             AvroCoder.of(FixedRecord.class),
             DataFileConstants.NULL_CODEC);
 
-    AvroSource<FixedRecord> source = AvroSource.from(filename).withSchema(FixedRecord.class);
+    AvroSource<FixedRecord, FixedRecord> source =
+        AvroSource.from(filename).withSchema(FixedRecord.class);
     try (BoundedReader<FixedRecord> readerOrig = source.createReader(null)) {
       assertThat(readerOrig, Matchers.instanceOf(BlockBasedReader.class));
       BlockBasedReader<FixedRecord> reader = (BlockBasedReader<FixedRecord>) readerOrig;
@@ -339,7 +343,8 @@ public class AvroSourceTest {
             AvroCoder.of(FixedRecord.class),
             DataFileConstants.NULL_CODEC);
 
-    AvroSource<FixedRecord> source = AvroSource.from(filename).withSchema(FixedRecord.class);
+    AvroSource<FixedRecord, FixedRecord> source =
+        AvroSource.from(filename).withSchema(FixedRecord.class);
     try (BlockBasedSource.BlockBasedReader<FixedRecord> reader =
         (BlockBasedSource.BlockBasedReader<FixedRecord>) source.createReader(null)) {
       assertEquals(null, reader.getCurrentBlock());
@@ -363,7 +368,8 @@ public class AvroSourceTest {
             AvroCoder.of(FixedRecord.class),
             DataFileConstants.NULL_CODEC);
 
-    AvroSource<FixedRecord> source = AvroSource.from(filename).withSchema(FixedRecord.class);
+    AvroSource<FixedRecord, FixedRecord> source =
+        AvroSource.from(filename).withSchema(FixedRecord.class);
     SourceTestUtils.assertSplitAtFractionExhaustive(source, null);
   }
 
@@ -384,7 +390,7 @@ public class AvroSourceTest {
     File file = new File(filename);
 
     // Small minimum bundle size
-    AvroSource<Bird> source =
+    AvroSource<Bird, Bird> source =
         AvroSource.from(filename).withSchema(Bird.class).withMinBundleSize(100L);
 
     // Assert that the source produces the expected records
@@ -439,7 +445,7 @@ public class AvroSourceTest {
           DataFileConstants.NULL_CODEC);
     }
 
-    AvroSource<Bird> source =
+    AvroSource<Bird, Bird> source =
         AvroSource.from(new File(tmpFolder.getRoot().toString(), baseName + "*").toString())
             .withSchema(Bird.class);
     List<Bird> actual = SourceTestUtils.readFromSource(source, null);
@@ -460,7 +466,7 @@ public class AvroSourceTest {
 
     // Create a source with a schema object
     Schema schema = ReflectData.get().getSchema(Bird.class);
-    AvroSource<GenericRecord> source = AvroSource.from(filename).withSchema(schema);
+    AvroSource<GenericRecord, GenericRecord> source = AvroSource.from(filename).withSchema(schema);
     List<GenericRecord> records = SourceTestUtils.readFromSource(source, null);
     assertEqualsWithGeneric(expected, records);
 
@@ -483,7 +489,7 @@ public class AvroSourceTest {
             AvroCoder.of(Bird.class),
             DataFileConstants.NULL_CODEC);
 
-    AvroSource<FancyBird> source = AvroSource.from(filename).withSchema(FancyBird.class);
+    AvroSource<FancyBird, FancyBird> source = AvroSource.from(filename).withSchema(FancyBird.class);
     List<FancyBird> actual = SourceTestUtils.readFromSource(source, null);
 
     List<FancyBird> expected = new ArrayList<>();
@@ -510,12 +516,14 @@ public class AvroSourceTest {
     Metadata fileMetadata = FileSystems.matchSingleFileSpec(filename);
     String schema = AvroSource.readMetadataFromFile(fileMetadata.resourceId()).getSchemaString();
     // Add "" to the schema to make sure it is not interned.
-    AvroSource<GenericRecord> sourceA = AvroSource.from(filename).withSchema("" + schema);
-    AvroSource<GenericRecord> sourceB = AvroSource.from(filename).withSchema("" + schema);
+    AvroSource<GenericRecord, GenericRecord> sourceA =
+        AvroSource.from(filename).withSchema("" + schema);
+    AvroSource<GenericRecord, GenericRecord> sourceB =
+        AvroSource.from(filename).withSchema("" + schema);
     assertSame(sourceA.getReaderSchemaString(), sourceB.getReaderSchemaString());
 
     // Ensure that deserialization still goes through interning
-    AvroSource<GenericRecord> sourceC = SerializableUtils.clone(sourceB);
+    AvroSource<GenericRecord, GenericRecord> sourceC = SerializableUtils.clone(sourceB);
     assertSame(sourceA.getReaderSchemaString(), sourceC.getReaderSchemaString());
   }
 
@@ -531,7 +539,7 @@ public class AvroSourceTest {
             AvroCoder.of(Bird.class),
             DataFileConstants.NULL_CODEC);
 
-    AvroSource<Bird> source =
+    AvroSource<GenericRecord, Bird> source =
         AvroSource.from(filename)
             .withParseFn(
                 input ->
@@ -567,7 +575,7 @@ public class AvroSourceTest {
               }
             };
 
-    AvroSource<Bird> source =
+    AvroSource<GenericRecord, Bird> source =
         AvroSource.from(filename)
             .withParseFn(
                 input ->
@@ -601,7 +609,7 @@ public class AvroSourceTest {
 
   @Test
   public void testDisplayData() {
-    AvroSource<Bird> source =
+    AvroSource<Bird, Bird> source =
         AvroSource.from("foobar.txt").withSchema(Bird.class).withMinBundleSize(1234);
 
     DisplayData displayData = DisplayData.from(source);
@@ -647,9 +655,10 @@ public class AvroSourceTest {
             codec, expected, SyncBehavior.SYNC_DEFAULT, 0, AvroCoder.of(Bird.class), codec);
     Metadata fileMeta = FileSystems.matchSingleFileSpec(filename);
 
-    AvroSource<GenericRecord> source = AvroSource.from(fileMeta);
-    AvroSource<Bird> sourceWithSchema = source.withSchema(Bird.class);
-    AvroSource<Bird> sourceWithSchemaWithMinBundleSize = sourceWithSchema.withMinBundleSize(1234);
+    AvroSource<GenericRecord, GenericRecord> source = AvroSource.from(fileMeta);
+    AvroSource<Bird, Bird> sourceWithSchema = source.withSchema(Bird.class);
+    AvroSource<Bird, Bird> sourceWithSchemaWithMinBundleSize =
+        sourceWithSchema.withMinBundleSize(1234);
 
     assertEquals(FileBasedSource.Mode.SINGLE_FILE_OR_SUBRANGE, source.getMode());
     assertEquals(FileBasedSource.Mode.SINGLE_FILE_OR_SUBRANGE, sourceWithSchema.getMode());

--- a/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/schemas/utils/AvroUtilsTest.java
+++ b/sdks/java/extensions/avro/src/test/java/org/apache/beam/sdk/extensions/avro/schemas/utils/AvroUtilsTest.java
@@ -828,7 +828,7 @@ public class AvroUtilsTest {
     assertTrue(records.hasSchema());
     CoderProperties.coderSerializable(records.getCoder());
 
-    AvroGeneratedUser user = AvroGeneratedUserFactory.newInstance("foo", 42, "green");
+    AvroGeneratedUser user = AvroGeneratedUserFactory.newInstance("foo", 42L, "green");
     PCollection<AvroGeneratedUser> users =
         pipeline.apply(Create.of(user).withCoder(AvroCoder.of(AvroGeneratedUser.class)));
     assertFalse(users.hasSchema());

--- a/sdks/java/extensions/zetasketch/build.gradle
+++ b/sdks/java/extensions/zetasketch/build.gradle
@@ -38,6 +38,7 @@ dependencies {
     implementation "com.google.zetasketch:zetasketch:$zetasketch_version"
     testImplementation library.java.junit
     testImplementation library.java.hamcrest
+    testImplementation project(":sdks:java:extensions:avro")
     testImplementation project(":sdks:java:io:google-cloud-platform")
     testImplementation project(":sdks:java:extensions:google-cloud-platform-core")
     testImplementation library.java.google_api_services_bigquery

--- a/sdks/java/extensions/zetasketch/src/test/java/org/apache/beam/sdk/extensions/zetasketch/BigQueryHllSketchCompatibilityIT.java
+++ b/sdks/java/extensions/zetasketch/src/test/java/org/apache/beam/sdk/extensions/zetasketch/BigQueryHllSketchCompatibilityIT.java
@@ -34,12 +34,12 @@ import java.util.Date;
 import java.util.List;
 import java.util.Map;
 import java.util.stream.Collectors;
+import org.apache.avro.generic.GenericRecord;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.TypedRead.Method;
-import org.apache.beam.sdk.io.gcp.bigquery.SchemaAndRecord;
 import org.apache.beam.sdk.io.gcp.testing.BigqueryClient;
 import org.apache.beam.sdk.options.ApplicationNameOptions;
 import org.apache.beam.sdk.testing.PAssert;
@@ -179,11 +179,10 @@ public class BigQueryHllSketchCompatibilityIT {
             "SELECT HLL_COUNT.INIT(%s) AS %s FROM %s",
             DATA_FIELD_NAME, QUERY_RESULT_FIELD_NAME, tableSpec);
 
-    SerializableFunction<SchemaAndRecord, byte[]> parseQueryResultToByteArray =
-        input ->
+    SerializableFunction<GenericRecord, byte[]> parseQueryResultToByteArray =
+        record ->
             // BigQuery BYTES type corresponds to Java java.nio.ByteBuffer type
-            HllCount.getSketchFromByteBuffer(
-                (ByteBuffer) input.getRecord().get(QUERY_RESULT_FIELD_NAME));
+            HllCount.getSketchFromByteBuffer((ByteBuffer) record.get(QUERY_RESULT_FIELD_NAME));
 
     TestPipelineOptions options =
         TestPipeline.testingPipelineOptions().as(TestPipelineOptions.class);
@@ -191,12 +190,11 @@ public class BigQueryHllSketchCompatibilityIT {
     Pipeline p = Pipeline.create(options);
     PCollection<Long> result =
         p.apply(
-                BigQueryIO.read(parseQueryResultToByteArray)
+                BigQueryIO.read(parseQueryResultToByteArray, ByteArrayCoder.of())
                     .withFormat(DataFormat.AVRO)
                     .fromQuery(query)
                     .usingStandardSql()
-                    .withMethod(Method.DIRECT_READ)
-                    .withCoder(ByteArrayCoder.of()))
+                    .withMethod(Method.DIRECT_READ))
             .apply(HllCount.MergePartial.globally()) // no-op, only for testing MergePartial
             .apply(HllCount.Extract.globally());
     PAssert.thatSingleton(result).isEqualTo(expectedCount);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryQuerySource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryQuerySource.java
@@ -23,7 +23,7 @@ import java.io.IOException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.extensions.avro.io.AvroSource;
 import org.apache.beam.sdk.options.PipelineOptions;
-import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.SerializableBiFunction;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
 
@@ -35,11 +35,20 @@ class BigQueryQuerySource<T> extends BigQuerySourceBase<T> {
       String stepUuid,
       BigQueryQuerySourceDef queryDef,
       BigQueryServices bqServices,
-      Coder<T> coder,
-      SerializableFunction<TableSchema, AvroSource.DatumReaderFactory<T>> readerFactory,
-      boolean useAvroLogicalTypes) {
+      boolean useAvroLogicalTypes,
+      String avroSchema,
+      AvroSource.DatumReaderFactory<Object> readerFactory,
+      SerializableBiFunction<TableSchema, Object, T> parseFn,
+      Coder<T> coder) {
     return new BigQueryQuerySource<>(
-        stepUuid, queryDef, bqServices, coder, readerFactory, useAvroLogicalTypes);
+        stepUuid,
+        queryDef,
+        bqServices,
+        useAvroLogicalTypes,
+        avroSchema,
+        readerFactory,
+        parseFn,
+        coder);
   }
 
   private final BigQueryQuerySourceDef queryDef;
@@ -48,10 +57,12 @@ class BigQueryQuerySource<T> extends BigQuerySourceBase<T> {
       String stepUuid,
       BigQueryQuerySourceDef queryDef,
       BigQueryServices bqServices,
-      Coder<T> coder,
-      SerializableFunction<TableSchema, AvroSource.DatumReaderFactory<T>> readerFactory,
-      boolean useAvroLogicalTypes) {
-    super(stepUuid, bqServices, coder, readerFactory, useAvroLogicalTypes);
+      boolean useAvroLogicalTypes,
+      String avroSchema,
+      AvroSource.DatumReaderFactory<Object> readerFactory,
+      SerializableBiFunction<TableSchema, Object, T> parseFn,
+      Coder<T> coder) {
+    super(stepUuid, bqServices, useAvroLogicalTypes, avroSchema, readerFactory, parseFn, coder);
     this.queryDef = queryDef;
   }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryQuerySourceDef.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryQuerySourceDef.java
@@ -32,7 +32,7 @@ import org.apache.beam.sdk.extensions.avro.io.AvroSource;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryResourceNaming.JobType;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.schemas.Schema;
-import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.SerializableBiFunction;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -151,11 +151,13 @@ class BigQueryQuerySourceDef implements BigQuerySourceDef {
   @Override
   public <T> BigQuerySourceBase<T> toSource(
       String stepUuid,
-      Coder<T> coder,
-      SerializableFunction<TableSchema, AvroSource.DatumReaderFactory<T>> readerFactory,
-      boolean useAvroLogicalTypes) {
+      boolean useAvroLogicalTypes,
+      String avroSchema,
+      AvroSource.DatumReaderFactory<Object> readerFactory,
+      SerializableBiFunction<TableSchema, Object, T> parseFn,
+      Coder<T> coder) {
     return BigQueryQuerySource.create(
-        stepUuid, this, bqServices, coder, readerFactory, useAvroLogicalTypes);
+        stepUuid, this, bqServices, useAvroLogicalTypes, avroSchema, readerFactory, parseFn, coder);
   }
 
   /** {@inheritDoc} */

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySourceDef.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySourceDef.java
@@ -22,6 +22,7 @@ import java.io.Serializable;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.extensions.avro.io.AvroSource;
 import org.apache.beam.sdk.schemas.Schema;
+import org.apache.beam.sdk.transforms.SerializableBiFunction;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 
 /**
@@ -41,9 +42,11 @@ interface BigQuerySourceDef extends Serializable {
    */
   <T> BigQuerySourceBase<T> toSource(
       String stepUuid,
-      Coder<T> coder,
-      SerializableFunction<TableSchema, AvroSource.DatumReaderFactory<T>> readerFactory,
-      boolean useAvroLogicalTypes);
+      boolean useAvroLogicalTypes,
+      String avroSchema,
+      AvroSource.DatumReaderFactory<Object> readerFactory,
+      SerializableBiFunction<TableSchema, Object, T> parseFn,
+      Coder<T> coder);
 
   /**
    * Extract the Beam {@link Schema} corresponding to this source.

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryTableSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryTableSource.java
@@ -26,7 +26,7 @@ import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.extensions.avro.io.AvroSource;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices.DatasetService;
 import org.apache.beam.sdk.options.PipelineOptions;
-import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.SerializableBiFunction;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -39,11 +39,20 @@ class BigQueryTableSource<T> extends BigQuerySourceBase<T> {
       String stepUuid,
       BigQueryTableSourceDef tableDef,
       BigQueryServices bqServices,
-      Coder<T> coder,
-      SerializableFunction<TableSchema, AvroSource.DatumReaderFactory<T>> readerFactory,
-      boolean useAvroLogicalTypes) {
+      boolean useAvroLogicalTypes,
+      String avroSchema,
+      AvroSource.DatumReaderFactory<Object> readerFactory,
+      SerializableBiFunction<TableSchema, Object, T> parseFn,
+      Coder<T> coder) {
     return new BigQueryTableSource<>(
-        stepUuid, tableDef, bqServices, coder, readerFactory, useAvroLogicalTypes);
+        stepUuid,
+        tableDef,
+        bqServices,
+        useAvroLogicalTypes,
+        avroSchema,
+        readerFactory,
+        parseFn,
+        coder);
   }
 
   private final BigQueryTableSourceDef tableDef;
@@ -53,10 +62,12 @@ class BigQueryTableSource<T> extends BigQuerySourceBase<T> {
       String stepUuid,
       BigQueryTableSourceDef tableDef,
       BigQueryServices bqServices,
-      Coder<T> coder,
-      SerializableFunction<TableSchema, AvroSource.DatumReaderFactory<T>> readerFactory,
-      boolean useAvroLogicalTypes) {
-    super(stepUuid, bqServices, coder, readerFactory, useAvroLogicalTypes);
+      boolean useAvroLogicalTypes,
+      String avroSchema,
+      AvroSource.DatumReaderFactory<Object> readerFactory,
+      SerializableBiFunction<TableSchema, Object, T> parseFn,
+      Coder<T> coder) {
+    super(stepUuid, bqServices, useAvroLogicalTypes, avroSchema, readerFactory, parseFn, coder);
     this.tableDef = tableDef;
     this.tableSizeBytes = new AtomicReference<>();
   }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryTableSourceDef.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryTableSourceDef.java
@@ -29,7 +29,7 @@ import org.apache.beam.sdk.extensions.avro.io.AvroSource;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices.DatasetService;
 import org.apache.beam.sdk.options.ValueProvider;
 import org.apache.beam.sdk.schemas.Schema;
-import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.transforms.SerializableBiFunction;
 import org.apache.beam.sdk.util.Preconditions;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Strings;
 import org.slf4j.Logger;
@@ -93,11 +93,13 @@ class BigQueryTableSourceDef implements BigQuerySourceDef {
   @Override
   public <T> BigQuerySourceBase<T> toSource(
       String stepUuid,
-      Coder<T> coder,
-      SerializableFunction<TableSchema, AvroSource.DatumReaderFactory<T>> readerFactory,
-      boolean useAvroLogicalTypes) {
+      boolean useAvroLogicalTypes,
+      String avroSchema,
+      AvroSource.DatumReaderFactory<Object> readerFactory,
+      SerializableBiFunction<TableSchema, Object, T> parseFn,
+      Coder<T> coder) {
     return BigQueryTableSource.create(
-        stepUuid, this, bqServices, coder, readerFactory, useAvroLogicalTypes);
+        stepUuid, this, bqServices, useAvroLogicalTypes, avroSchema, readerFactory, parseFn, coder);
   }
 
   /** {@inheritDoc} */

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOReadIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOReadIT.java
@@ -79,7 +79,7 @@ public class BigQueryIOReadIT {
   private void runBigQueryIOReadPipeline() {
     Pipeline p = Pipeline.create(options);
     PCollection<Long> count =
-        p.apply("Read", BigQueryIO.read().from(options.getInputTable()))
+        p.apply("Read", BigQueryIO.readTableRows().from(options.getInputTable()))
             .apply("Count", Count.globally());
     PAssert.thatSingleton(count).isEqualTo(options.getNumRecords());
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOReadTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOReadTest.java
@@ -251,7 +251,7 @@ public class BigQueryIOReadTest implements Serializable {
     TableReference tableRef = new TableReference().setDatasetId("dataset-id").setTableId(tableId);
 
     PCollection<MyData> output =
-        p.apply(BigQueryIO.read().from(tableRef).withTestServices(fakeBqServices))
+        p.apply(BigQueryIO.readTableRows().from(tableRef).withTestServices(fakeBqServices))
             .apply(
                 ParDo.of(
                     new DoFn<TableRow, MyData>() {

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageQueryIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageQueryIT.java
@@ -20,7 +20,6 @@ package org.apache.beam.sdk.io.gcp.bigquery;
 import java.util.Map;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
-import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.TableRowParser;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO.TypedRead.Method;
 import org.apache.beam.sdk.options.Description;
 import org.apache.beam.sdk.options.ExperimentalOptions;
@@ -85,7 +84,7 @@ public class BigQueryIOStorageQueryIT {
     PCollection<Long> count =
         p.apply(
                 "Query",
-                BigQueryIO.read(TableRowParser.INSTANCE)
+                BigQueryIO.readTableRows()
                     .fromQuery("SELECT * FROM `" + options.getInputTable() + "`")
                     .usingStandardSql()
                     .withMethod(Method.DIRECT_READ))

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageQueryTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageQueryTest.java
@@ -166,7 +166,7 @@ public class BigQueryIOStorageQueryTest {
   @Test
   public void testQueryBasedSourceWithCustomQuery() throws Exception {
     TypedRead<TableRow> typedRead =
-        BigQueryIO.read(new TableRowParser())
+        BigQueryIO.readTableRows()
             .fromQuery("SELECT * FROM `google.com:project.dataset.table`")
             .withCoder(TableRowJsonCoder.of());
     checkTypedReadQueryObject(typedRead, "SELECT * FROM `google.com:project.dataset.table`");
@@ -223,10 +223,7 @@ public class BigQueryIOStorageQueryTest {
   }
 
   private TypedRead<TableRow> getDefaultTypedRead() {
-    return BigQueryIO.read(new TableRowParser())
-        .fromQuery(DEFAULT_QUERY)
-        .withCoder(TableRowJsonCoder.of())
-        .withMethod(Method.DIRECT_READ);
+    return BigQueryIO.readTableRows().fromQuery(DEFAULT_QUERY).withMethod(Method.DIRECT_READ);
   }
 
   private void checkTypedReadQueryObject(TypedRead<?> typedRead, String query) {
@@ -305,7 +302,7 @@ public class BigQueryIOStorageQueryTest {
             /* queryTempDataset = */ null,
             /* kmsKey = */ null,
             null,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             fakeBigQueryServices);
 
@@ -417,7 +414,7 @@ public class BigQueryIOStorageQueryTest {
             /* queryTempDataset = */ null,
             /* kmsKey = */ null,
             null,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices()
                 .withDatasetService(fakeDatasetService)
@@ -511,7 +508,7 @@ public class BigQueryIOStorageQueryTest {
             /* queryTempDataset = */ null,
             /* kmsKey = */ null,
             null,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices()
                 .withDatasetService(fakeDatasetService)
@@ -652,7 +649,7 @@ public class BigQueryIOStorageQueryTest {
             /* queryTempDataset = */ null,
             /* kmsKey = */ null,
             DataFormat.AVRO,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices()
                 .withDatasetService(fakeDatasetService)
@@ -723,7 +720,7 @@ public class BigQueryIOStorageQueryTest {
             /* queryTempDataset = */ null,
             /* kmsKey = */ null,
             null,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices()
                 .withDatasetService(fakeDatasetService)
@@ -747,7 +744,7 @@ public class BigQueryIOStorageQueryTest {
             /* queryTempDataset = */ null,
             /* kmsKey = */ null,
             null,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             fakeBigQueryServices);
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageReadTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageReadTest.java
@@ -189,8 +189,7 @@ public class BigQueryIOStorageReadTest {
   @Test
   public void testBuildTableBasedSource() {
     BigQueryIO.TypedRead<TableRow> typedRead =
-        BigQueryIO.read(new TableRowParser())
-            .withCoder(TableRowJsonCoder.of())
+        BigQueryIO.readTableRows()
             .withMethod(Method.DIRECT_READ)
             .from("foo.com:project:dataset.table");
     checkTypedReadTableObject(typedRead, "foo.com:project", "dataset", "table");
@@ -200,8 +199,7 @@ public class BigQueryIOStorageReadTest {
   @Test
   public void testBuildTableBasedSourceWithoutValidation() {
     BigQueryIO.TypedRead<TableRow> typedRead =
-        BigQueryIO.read(new TableRowParser())
-            .withCoder(TableRowJsonCoder.of())
+        BigQueryIO.readTableRows()
             .withMethod(Method.DIRECT_READ)
             .from("foo.com:project:dataset.table")
             .withoutValidation();
@@ -212,10 +210,7 @@ public class BigQueryIOStorageReadTest {
   @Test
   public void testBuildTableBasedSourceWithDefaultProject() {
     BigQueryIO.TypedRead<TableRow> typedRead =
-        BigQueryIO.read(new TableRowParser())
-            .withCoder(TableRowJsonCoder.of())
-            .withMethod(Method.DIRECT_READ)
-            .from("myDataset.myTable");
+        BigQueryIO.readTableRows().withMethod(Method.DIRECT_READ).from("myDataset.myTable");
     checkTypedReadTableObject(typedRead, null, "myDataset", "myTable");
   }
 
@@ -227,10 +222,7 @@ public class BigQueryIOStorageReadTest {
             .setDatasetId("dataset")
             .setTableId("table");
     BigQueryIO.TypedRead<TableRow> typedRead =
-        BigQueryIO.read(new TableRowParser())
-            .withCoder(TableRowJsonCoder.of())
-            .withMethod(Method.DIRECT_READ)
-            .from(tableReference);
+        BigQueryIO.readTableRows().withMethod(Method.DIRECT_READ).from(tableReference);
     checkTypedReadTableObject(typedRead, "foo.com:project", "dataset", "table");
   }
 
@@ -251,8 +243,7 @@ public class BigQueryIOStorageReadTest {
             + " which only applies to queries");
     p.apply(
         "ReadMyTable",
-        BigQueryIO.read(new TableRowParser())
-            .withCoder(TableRowJsonCoder.of())
+        BigQueryIO.readTableRows()
             .withMethod(Method.DIRECT_READ)
             .from("foo.com:project:dataset.table")
             .withoutResultFlattening());
@@ -267,8 +258,7 @@ public class BigQueryIOStorageReadTest {
             + " which only applies to queries");
     p.apply(
         "ReadMyTable",
-        BigQueryIO.read(new TableRowParser())
-            .withCoder(TableRowJsonCoder.of())
+        BigQueryIO.readTableRows()
             .withMethod(Method.DIRECT_READ)
             .from("foo.com:project:dataset.table")
             .usingStandardSql());
@@ -279,8 +269,7 @@ public class BigQueryIOStorageReadTest {
   public void testDisplayData() {
     String tableSpec = "foo.com:project:dataset.table";
     BigQueryIO.TypedRead<TableRow> typedRead =
-        BigQueryIO.read(new TableRowParser())
-            .withCoder(TableRowJsonCoder.of())
+        BigQueryIO.readTableRows()
             .withMethod(Method.DIRECT_READ)
             .withSelectedFields(ImmutableList.of("foo", "bar"))
             .withProjectionPushdownApplied()
@@ -295,8 +284,7 @@ public class BigQueryIOStorageReadTest {
   public void testName() {
     assertEquals(
         "BigQueryIO.TypedRead",
-        BigQueryIO.read(new TableRowParser())
-            .withCoder(TableRowJsonCoder.of())
+        BigQueryIO.readTableRows()
             .withMethod(Method.DIRECT_READ)
             .from("foo.com:project:dataset.table")
             .getName());
@@ -343,7 +331,7 @@ public class BigQueryIOStorageReadTest {
             ValueProvider.StaticValueProvider.of(tableRef),
             null,
             null,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withDatasetService(fakeDatasetService));
 
@@ -363,7 +351,7 @@ public class BigQueryIOStorageReadTest {
             ValueProvider.StaticValueProvider.of(BigQueryHelpers.parseTableSpec("dataset.table")),
             null,
             null,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withDatasetService(fakeDatasetService));
 
@@ -382,7 +370,7 @@ public class BigQueryIOStorageReadTest {
             ValueProvider.StaticValueProvider.of(BigQueryHelpers.parseTableSpec("dataset.table")),
             null,
             null,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withDatasetService(fakeDatasetService));
 
@@ -474,7 +462,7 @@ public class BigQueryIOStorageReadTest {
             ValueProvider.StaticValueProvider.of(tableRef),
             null,
             null,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices()
                 .withDatasetService(fakeDatasetService)
@@ -522,7 +510,7 @@ public class BigQueryIOStorageReadTest {
             ValueProvider.StaticValueProvider.of(tableRef),
             StaticValueProvider.of(Lists.newArrayList("name")),
             StaticValueProvider.of("number > 5"),
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices()
                 .withDatasetService(fakeDatasetService)
@@ -567,7 +555,7 @@ public class BigQueryIOStorageReadTest {
             ValueProvider.StaticValueProvider.of(BigQueryHelpers.parseTableSpec("dataset.table")),
             null,
             null,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices()
                 .withDatasetService(fakeDatasetService)
@@ -608,7 +596,7 @@ public class BigQueryIOStorageReadTest {
             ValueProvider.StaticValueProvider.of(tableRef),
             null,
             null,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices()
                 .withDatasetService(fakeDatasetService)
@@ -626,7 +614,7 @@ public class BigQueryIOStorageReadTest {
                 BigQueryHelpers.parseTableSpec("foo.com:project:dataset.table")),
             null,
             null,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withDatasetService(fakeDatasetService));
 
@@ -745,7 +733,7 @@ public class BigQueryIOStorageReadTest {
             ReadSession.getDefaultInstance(),
             ReadStream.getDefaultInstance(),
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices());
 
@@ -760,7 +748,7 @@ public class BigQueryIOStorageReadTest {
             ReadSession.getDefaultInstance(),
             ReadStream.getDefaultInstance(),
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices());
 
@@ -799,7 +787,7 @@ public class BigQueryIOStorageReadTest {
             readSession,
             ReadStream.newBuilder().setName("readStream").build(),
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient));
 
@@ -855,7 +843,7 @@ public class BigQueryIOStorageReadTest {
             readSession,
             ReadStream.newBuilder().setName("readStream").build(),
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient));
 
@@ -940,7 +928,7 @@ public class BigQueryIOStorageReadTest {
             readSession,
             ReadStream.newBuilder().setName("parentStream").build(),
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient));
 
@@ -1025,7 +1013,7 @@ public class BigQueryIOStorageReadTest {
                 .build(),
             ReadStream.newBuilder().setName("parentStream").build(),
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient));
 
@@ -1162,7 +1150,7 @@ public class BigQueryIOStorageReadTest {
                 .build(),
             readStreams.get(0),
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient));
 
@@ -1226,7 +1214,7 @@ public class BigQueryIOStorageReadTest {
                 .build(),
             ReadStream.newBuilder().setName("parentStream").build(),
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient));
 
@@ -1315,7 +1303,7 @@ public class BigQueryIOStorageReadTest {
                 .build(),
             ReadStream.newBuilder().setName("parentStream").build(),
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient));
 
@@ -1656,7 +1644,7 @@ public class BigQueryIOStorageReadTest {
             readSession,
             ReadStream.newBuilder().setName("readStream").build(),
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient));
 
@@ -1705,7 +1693,7 @@ public class BigQueryIOStorageReadTest {
             readSession,
             ReadStream.newBuilder().setName("readStream").build(),
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient));
 
@@ -1787,7 +1775,7 @@ public class BigQueryIOStorageReadTest {
             readSession,
             ReadStream.newBuilder().setName("parentStream").build(),
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient));
 
@@ -1868,7 +1856,7 @@ public class BigQueryIOStorageReadTest {
                 .build(),
             ReadStream.newBuilder().setName("parentStream").build(),
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient));
 
@@ -1987,7 +1975,7 @@ public class BigQueryIOStorageReadTest {
                 .build(),
             readStreams.get(0),
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient));
 
@@ -2047,7 +2035,7 @@ public class BigQueryIOStorageReadTest {
                 .build(),
             ReadStream.newBuilder().setName("parentStream").build(),
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient));
 
@@ -2133,7 +2121,7 @@ public class BigQueryIOStorageReadTest {
                 .build(),
             ReadStream.newBuilder().setName("parentStream").build(),
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient));
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageReadWithStreamBundleSourceTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageReadWithStreamBundleSourceTest.java
@@ -74,8 +74,11 @@ import org.apache.avro.generic.GenericDatumWriter;
 import org.apache.avro.generic.GenericRecord;
 import org.apache.avro.io.Encoder;
 import org.apache.avro.io.EncoderFactory;
+import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderRegistry;
 import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.coders.VarLongCoder;
 import org.apache.beam.sdk.extensions.protobuf.ByteStringCoder;
 import org.apache.beam.sdk.extensions.protobuf.ProtoCoder;
 import org.apache.beam.sdk.io.BoundedSource;
@@ -1300,15 +1303,10 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
     assertFalse(primary.advance());
   }
 
-  private static final class ParseKeyValue
-      implements SerializableFunction<SchemaAndRecord, KV<String, Long>> {
-
-    @Override
-    public KV<String, Long> apply(SchemaAndRecord input) {
-      return KV.of(
-          input.getRecord().get("name").toString(), (Long) input.getRecord().get("number"));
-    }
-  }
+  private final SerializableFunction<GenericRecord, KV<String, Long>> parseKeyValue =
+      (record) -> KV.of(record.get("name").toString(), (Long) record.get("number"));
+  private final Coder<KV<String, Long>> keyValueCoder =
+      KvCoder.of(StringUtf8Coder.of(), VarLongCoder.of());
 
   @Test
   public void testReadFromBigQueryIO() throws Exception {
@@ -1371,7 +1369,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
 
     PCollection<KV<String, Long>> output =
         p.apply(
-            BigQueryIO.read(new ParseKeyValue())
+            BigQueryIO.read(parseKeyValue, keyValueCoder)
                 .from("foo.com:project:dataset.table")
                 .withMethod(Method.DIRECT_READ)
                 .withFormat(DataFormat.AVRO)
@@ -1630,7 +1628,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
 
     PCollection<KV<String, Long>> output =
         p.apply(
-            BigQueryIO.read(new ParseKeyValue())
+            BigQueryIO.read(parseKeyValue, keyValueCoder)
                 .from("foo.com:project:dataset.table")
                 .withMethod(Method.DIRECT_READ)
                 .withFormat(DataFormat.ARROW)

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageReadWithStreamBundleSourceTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageReadWithStreamBundleSourceTest.java
@@ -182,8 +182,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
   @Test
   public void testBuildTableBasedSource() {
     BigQueryIO.TypedRead<TableRow> typedRead =
-        BigQueryIO.read(new TableRowParser())
-            .withCoder(TableRowJsonCoder.of())
+        BigQueryIO.readTableRows()
             .withMethod(Method.DIRECT_READ)
             .from("foo.com:project:dataset.table");
     checkTypedReadTableObject(typedRead, "foo.com:project", "dataset", "table");
@@ -193,8 +192,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
   @Test
   public void testBuildTableBasedSourceWithoutValidation() {
     BigQueryIO.TypedRead<TableRow> typedRead =
-        BigQueryIO.read(new TableRowParser())
-            .withCoder(TableRowJsonCoder.of())
+        BigQueryIO.readTableRows()
             .withMethod(Method.DIRECT_READ)
             .from("foo.com:project:dataset.table")
             .withoutValidation();
@@ -205,10 +203,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
   @Test
   public void testBuildTableBasedSourceWithDefaultProject() {
     BigQueryIO.TypedRead<TableRow> typedRead =
-        BigQueryIO.read(new TableRowParser())
-            .withCoder(TableRowJsonCoder.of())
-            .withMethod(Method.DIRECT_READ)
-            .from("myDataset.myTable");
+        BigQueryIO.readTableRows().withMethod(Method.DIRECT_READ).from("myDataset.myTable");
     checkTypedReadTableObject(typedRead, null, "myDataset", "myTable");
   }
 
@@ -220,10 +215,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
             .setDatasetId("dataset")
             .setTableId("table");
     BigQueryIO.TypedRead<TableRow> typedRead =
-        BigQueryIO.read(new TableRowParser())
-            .withCoder(TableRowJsonCoder.of())
-            .withMethod(Method.DIRECT_READ)
-            .from(tableReference);
+        BigQueryIO.readTableRows().withMethod(Method.DIRECT_READ).from(tableReference);
     checkTypedReadTableObject(typedRead, "foo.com:project", "dataset", "table");
   }
 
@@ -244,8 +236,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
             + " which only applies to queries");
     p.apply(
         "ReadMyTable",
-        BigQueryIO.read(new TableRowParser())
-            .withCoder(TableRowJsonCoder.of())
+        BigQueryIO.readTableRows()
             .withMethod(Method.DIRECT_READ)
             .from("foo.com:project:dataset.table")
             .withoutResultFlattening());
@@ -260,8 +251,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
             + " which only applies to queries");
     p.apply(
         "ReadMyTable",
-        BigQueryIO.read(new TableRowParser())
-            .withCoder(TableRowJsonCoder.of())
+        BigQueryIO.readTableRows()
             .withMethod(Method.DIRECT_READ)
             .from("foo.com:project:dataset.table")
             .usingStandardSql());
@@ -272,8 +262,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
   public void testDisplayData() {
     String tableSpec = "foo.com:project:dataset.table";
     BigQueryIO.TypedRead<TableRow> typedRead =
-        BigQueryIO.read(new TableRowParser())
-            .withCoder(TableRowJsonCoder.of())
+        BigQueryIO.readTableRows()
             .withMethod(Method.DIRECT_READ)
             .withSelectedFields(ImmutableList.of("foo", "bar"))
             .withProjectionPushdownApplied()
@@ -288,8 +277,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
   public void testName() {
     assertEquals(
         "BigQueryIO.TypedRead",
-        BigQueryIO.read(new TableRowParser())
-            .withCoder(TableRowJsonCoder.of())
+        BigQueryIO.readTableRows()
             .withMethod(Method.DIRECT_READ)
             .from("foo.com:project:dataset.table")
             .getName());
@@ -336,7 +324,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
             ValueProvider.StaticValueProvider.of(tableRef),
             null,
             null,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withDatasetService(fakeDatasetService));
 
@@ -356,7 +344,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
             ValueProvider.StaticValueProvider.of(BigQueryHelpers.parseTableSpec("dataset.table")),
             null,
             null,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withDatasetService(fakeDatasetService));
 
@@ -375,7 +363,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
             ValueProvider.StaticValueProvider.of(BigQueryHelpers.parseTableSpec("dataset.table")),
             null,
             null,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withDatasetService(fakeDatasetService));
 
@@ -454,7 +442,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
             ValueProvider.StaticValueProvider.of(tableRef),
             null,
             null,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices()
                 .withDatasetService(fakeDatasetService)
@@ -519,7 +507,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
             ValueProvider.StaticValueProvider.of(tableRef),
             StaticValueProvider.of(Lists.newArrayList("name")),
             StaticValueProvider.of("number > 5"),
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices()
                 .withDatasetService(fakeDatasetService)
@@ -565,7 +553,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
             ValueProvider.StaticValueProvider.of(BigQueryHelpers.parseTableSpec("dataset.table")),
             null,
             null,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices()
                 .withDatasetService(fakeDatasetService)
@@ -607,7 +595,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
             ValueProvider.StaticValueProvider.of(tableRef),
             null,
             null,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices()
                 .withDatasetService(fakeDatasetService)
@@ -625,7 +613,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
                 BigQueryHelpers.parseTableSpec("foo.com:project:dataset.table")),
             null,
             null,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withDatasetService(fakeDatasetService));
 
@@ -744,7 +732,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
             ReadSession.getDefaultInstance(),
             streamBundle,
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices(),
             1L);
@@ -760,7 +748,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
             ReadSession.getDefaultInstance(),
             streamBundle,
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices(),
             1L);
@@ -814,7 +802,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
             readSession,
             streamBundle,
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient),
             1L);
@@ -873,7 +861,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
             readSession,
             streamBundle,
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient),
             1L);
@@ -956,7 +944,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
             readSession,
             streamBundle,
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient),
             1L);
@@ -1023,7 +1011,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
                 .build(),
             parentStreamBundle,
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient),
             1L);
@@ -1098,7 +1086,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
                 .build(),
             primaryStreamBundle,
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient),
             1L);
@@ -1195,7 +1183,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
                 .build(),
             primaryStreamBundle,
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient),
             1L);
@@ -1285,7 +1273,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
                 .build(),
             parentStreamBundle,
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient),
             1L);
@@ -1700,7 +1688,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
             readSession,
             streamBundle,
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient),
             1L);
@@ -1752,7 +1740,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
             readSession,
             streamBundle,
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient),
             1L);
@@ -1830,7 +1818,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
             readSession,
             streamBundle,
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient),
             1L);
@@ -1904,7 +1892,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
                 .build(),
             primaryStreamBundle,
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient),
             1L);
@@ -1979,7 +1967,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
                 .build(),
             primaryStreamBundle,
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient),
             1L);
@@ -2060,7 +2048,7 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
                 .build(),
             parentStreamBundle,
             TABLE_SCHEMA,
-            new TableRowParser(),
+            TableRowParser.INSTANCE,
             TableRowJsonCoder.of(),
             new FakeBigQueryServices().withStorageClient(fakeStorageClient),
             1L);
@@ -2097,10 +2085,9 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
     TypedRead<Row> read =
         BigQueryIO.read(
                 record ->
-                    BigQueryUtils.toBeamRow(
-                        record.getRecord(), schema, ConversionOptions.builder().build()))
-            .withMethod(Method.DIRECT_READ)
-            .withCoder(SchemaCoder.of(schema));
+                    BigQueryUtils.toBeamRow(record, schema, ConversionOptions.builder().build()),
+                SchemaCoder.of(schema))
+            .withMethod(Method.DIRECT_READ);
 
     assertTrue(read.supportsProjectionPushdown());
     PTransform<PBegin, PCollection<Row>> pushdownT =
@@ -2123,11 +2110,10 @@ public class BigQueryIOStorageReadWithStreamBundleSourceTest {
     TypedRead<Row> read =
         BigQueryIO.read(
                 record ->
-                    BigQueryUtils.toBeamRow(
-                        record.getRecord(), schema, ConversionOptions.builder().build()))
+                    BigQueryUtils.toBeamRow(record, schema, ConversionOptions.builder().build()),
+                SchemaCoder.of(schema))
             .fromQuery("SELECT bar FROM `dataset.table`")
-            .withMethod(Method.DIRECT_READ)
-            .withCoder(SchemaCoder.of(schema));
+            .withMethod(Method.DIRECT_READ);
 
     assertFalse(read.supportsProjectionPushdown());
     assertThrows(

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryToTableIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryToTableIT.java
@@ -94,7 +94,8 @@ public class BigQueryToTableIT {
 
   private void runBigQueryToTablePipeline(BigQueryToTableOptions options) {
     Pipeline p = Pipeline.create(options);
-    BigQueryIO.Read bigQueryRead = BigQueryIO.read().fromQuery(options.getQuery());
+    BigQueryIO.TypedRead<TableRow> bigQueryRead =
+        BigQueryIO.readTableRows().fromQuery(options.getQuery());
     if (options.getUsingStandardSql()) {
       bigQueryRead = bigQueryRead.usingStandardSql();
     }

--- a/website/www/site/content/en/documentation/io/built-in/google-bigquery.md
+++ b/website/www/site/content/en/documentation/io/built-in/google-bigquery.md
@@ -244,7 +244,7 @@ allow you to read from a table, or read fields using a query string.
 
 {{< paragraph class="language-java" >}}
 ***Note:*** `BigQueryIO.read()` is deprecated as of Beam SDK 2.2.0. Instead, use
-`read(SerializableFunction<SchemaAndRecord, T>)` to parse BigQuery rows from
+`read(SerializableFunction<GenericRecord, T>, Coder<T>)` to parse BigQuery rows from
 Avro `GenericRecord` into your custom type, or use `readTableRows()` to parse
 them into JSON `TableRow` objects.
 {{< /paragraph >}}


### PR DESCRIPTION
Fix https://github.com/apache/beam/issues/26329

- Add extra `AvroT`  type parameter in `AvroSource` to memorize the materialized avro record type (the one produced by the avro reading).
- Add possibility to combine both `AvroDatumReader` and `parseFn` in the source.
- Add back `parseFn` to `BigqueryIO.TypedRead` so it behaves as the `AvroSource`.
- Require coder in the API when reading custom types.