### PR TITLE
[Task] Update document for spark runner on a kubernetes cluster

### DIFF
--- a/website/www/site/content/en/documentation/runners/spark.md
+++ b/website/www/site/content/en/documentation/runners/spark.md
@@ -487,8 +487,8 @@ Provided SparkContext and StreamingListeners are not supported on the Spark port
 {{< /paragraph >}}
 
 ### Kubernetes
-
-To submit a beam job on spark kubernetes cluster, you can do:
+#### Submit beam job without job server
+To submit a beam job directly on spark kubernetes cluster without spinning up an extra job server, you can do:
 ```
 spark-submit --master MASTER_URL \
   --conf spark.kubernetes.driver.podTemplateFile=driver_pod_template.yaml \
@@ -521,4 +521,5 @@ spec:
     emptyDir: {}
 ```
 
-An [example](https://github.com/cometta/python-apache-beam-spark) of configuring Spark to run Apache beam job
+#### Submit beam job with job server
+An [example](https://github.com/cometta/python-apache-beam-spark) of configuring Spark to run Apache beam job with a job server.

--- a/website/www/site/content/en/documentation/runners/spark.md
+++ b/website/www/site/content/en/documentation/runners/spark.md
@@ -497,8 +497,17 @@ spark-submit --master MASTER_URL \
   --conf spark.kubernetes.container.image=apache/spark:v3.3.2 \
   ./wc_job.jar
 ```
+Similar to run the beam job on Dataproc, you can bundle the job jar like below. The example use the `PROCESS` type of [SDK harness](https://beam.apache.org/documentation/runtime/sdk-harness-config/) to execute the job by processes.
+```
+python -m beam_example_wc \
+    --runner=SparkRunner \
+    --output_executable_path=./wc_job.jar \
+    --environment_type=PROCESS \
+    --environment_config='{\"command\": \"/opt/apache/beam/boot\"}' \
+    --spark_version=3
+```
 
-And below is an example of kubernetes executor pod template, the `initContainer` is required to download the beam SDK harness to run the beam pipelines:
+And below is an example of kubernetes executor pod template, the `initContainer` is required to download the beam SDK harness to run the beam pipelines.
 ```
 spec:
   containers:

--- a/website/www/site/content/en/documentation/runners/spark.md
+++ b/website/www/site/content/en/documentation/runners/spark.md
@@ -488,4 +488,37 @@ Provided SparkContext and StreamingListeners are not supported on the Spark port
 
 ### Kubernetes
 
+To submit a beam job on spark kubernetes cluster, you can do:
+```
+spark-submit --master MASTER_URL \
+  --conf spark.kubernetes.driver.podTemplateFile=driver_pod_template.yaml \
+  --conf spark.kubernetes.executor.podTemplateFile=executor_pod_template.yaml \
+  --class org.apache.beam.runners.spark.SparkPipelineRunner \
+  --conf spark.kubernetes.container.image=apache/spark:v3.3.2 \
+  ./wc_job.jar
+```
+
+And below is an example of kubernetes executor pod template, the `initContainer` is required to download the beam SDK harness to run the beam pipelines:
+```
+spec:
+  containers:
+    - name: spark-kubernetes-executor
+      volumeMounts:
+      - name: beam-data
+        mountPath: /opt/apache/beam/
+  initContainers:
+  - name: init-beam
+    image: apache/beam_python3.7_sdk
+    command:
+    - cp
+    - /opt/apache/beam/boot
+    - /init-container/data/boot
+    volumeMounts:
+    - name: beam-data
+      mountPath: /init-container/data
+  volumes:
+  - name: beam-data
+    emptyDir: {}
+```
+
 An [example](https://github.com/cometta/python-apache-beam-spark) of configuring Spark to run Apache beam job


### PR DESCRIPTION
The PR updated the Spark runner document, including the way to run the beam job on a spark kubernetes cluster.
The work at Affirm has verified this.
address #27985

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
