### PR TITLE
Don't fail to acquire multi_process_shared object if some attributes aren't available on a given platform

### DIFF
--- a/sdks/python/apache_beam/utils/multi_process_shared_test.py
+++ b/sdks/python/apache_beam/utils/multi_process_shared_test.py
@@ -18,8 +18,8 @@
 
 import logging
 import threading
-from typing import Any
 import unittest
+from typing import Any
 
 from apache_beam.utils import multi_process_shared
 

--- a/sdks/python/apache_beam/utils/multi_process_shared_test.py
+++ b/sdks/python/apache_beam/utils/multi_process_shared_test.py
@@ -18,6 +18,7 @@
 
 import logging
 import threading
+from typing import Any
 import unittest
 
 from apache_beam.utils import multi_process_shared
@@ -57,6 +58,30 @@ class Counter(object):
     raise RuntimeError(msg)
 
 
+class CounterWithBadAttr(object):
+  def __init__(self, start=0):
+    self.running = start
+    self.lock = threading.Lock()
+
+  def get(self):
+    return self.running
+
+  def increment(self, value=1):
+    with self.lock:
+      self.running += value
+      return self.running
+
+  def error(self, msg):
+    raise RuntimeError(msg)
+
+  def __getattribute__(self, __name: str) -> Any:
+    if __name == 'error':
+      raise AttributeError('error is not actually supported on this platform')
+    else:
+      # Default behaviour
+      return object.__getattribute__(self, __name)
+
+
 class MultiProcessSharedTest(unittest.TestCase):
   @classmethod
   def setUpClass(cls):
@@ -71,6 +96,15 @@ class MultiProcessSharedTest(unittest.TestCase):
     self.assertEqual(self.shared.increment(10), 11)
     self.assertEqual(self.shared.increment(value=10), 21)
     self.assertEqual(self.shared.get(), 21)
+
+  def test_call_illegal_attr(self):
+    shared_handle = multi_process_shared.MultiProcessShared(
+        CounterWithBadAttr, tag='test_call_illegal_attr', always_proxy=True)
+    shared = shared_handle.acquire()
+
+    self.assertEqual(shared.get(), 0)
+    self.assertEqual(shared.increment(), 1)
+    self.assertEqual(shared.get(), 1)
 
   def test_call_callable(self):
     self.assertEqual(self.sharedCallable(), 0)


### PR DESCRIPTION
Right now, when using multi_process_shared.py if any public member of an object throws an exception when `getattr` is called on it, the whole object cannot be loaded and an exception is thrown. Some objects, however, will return an exception if a certain attribute is not available on a given platform (even if it is not central to that object functioning). This PR fixes that problem and just logs when encountering cases like that.

Example failing test run without the changes to multi_process_shared.py - https://github.com/apache/beam/actions/runs/5859613509/job/15885978842?pr=27995

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
