### PR TITLE
Replace usage of deprecated pandas.Int64Index()

### DIFF
--- a/sdks/python/apache_beam/typehints/pandas_type_compatibility_test.py
+++ b/sdks/python/apache_beam/typehints/pandas_type_compatibility_test.py
@@ -64,7 +64,7 @@ from apache_beam.typehints.batch import BatchConverter
             'bar': pd.Series([i / 100 for i in range(100)], dtype='float64'),
             'baz': pd.Series([str(i) for i in range(100)],
                              dtype=pd.StringDtype()),
-        }).set_index(pd.Int64Index(range(123, 223), name='an_index')),
+        }).set_index(pd.Index(range(123, 223), dtype='int64', name='an_index')),
     },
     {
         'batch_typehint': pd.DataFrame,
@@ -87,8 +87,8 @@ from apache_beam.typehints.batch import BatchConverter
             'baz': pd.Series([str(i) for i in range(100)],
                              dtype=pd.StringDtype()),
         }).set_index([
-            pd.Int64Index(range(123, 223), name='an_index'),
-            pd.Int64Index(range(475, 575), name='another_index'),
+            pd.Index(range(123, 223), dtype='int64', name='an_index'),
+            pd.Index(range(475, 575), dtype='int64', name='another_index'),
         ]),
     },
     {


### PR DESCRIPTION
`pandas.Int64Index()` has been deprecated in favor of using `pandas.Index(dtype='int64')` and the deprecation warnings are clogging testing output. This resolves that issue and should reduce test log noise.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
