### PR TITLE
Reduce the maximum size of input splits in Flink to better distribute work

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
@@ -313,6 +313,12 @@ public interface FlinkPipelineOptions
 
   void setFlinkConfDir(String confDir);
 
+  @Description("Set the maximum size of input split when data is read from a filesystem.")
+  @Default.Long(128 * 1024 * 1024)
+  Long getFileInputSplitMaxSizeBytes();
+
+  void setFileInputSplitMaxSizeBytes(Long inputSplitMaxSizeBytes);
+
   static FlinkPipelineOptions defaults() {
     return PipelineOptionsFactory.as(FlinkPipelineOptions.class);
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
@@ -313,11 +313,11 @@ public interface FlinkPipelineOptions
 
   void setFlinkConfDir(String confDir);
 
-  @Description("Set the maximum size of input split when data is read from a filesystem.")
-  @Default.Long(128 * 1024 * 1024)
-  Long getFileInputSplitMaxSizeBytes();
+  @Description("Set the maximum size of input split when data is read from a filesystem. -1 implies no max size.")
+  @Default.Long(-1)
+  Long getFileInputSplitMaxSizeMB();
 
-  void setFileInputSplitMaxSizeBytes(Long inputSplitMaxSizeBytes);
+  void setFileInputSplitMaxSizeMB(Long inputSplitMaxSizeMB);
 
   static FlinkPipelineOptions defaults() {
     return PipelineOptionsFactory.as(FlinkPipelineOptions.class);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
@@ -313,11 +313,12 @@ public interface FlinkPipelineOptions
 
   void setFlinkConfDir(String confDir);
 
-  @Description("Set the maximum size of input split when data is read from a filesystem. -1 implies no max size.")
-  @Default.Long(-1)
+  @Description(
+      "Set the maximum size of input split when data is read from a filesystem. 0 implies no max size.")
+  @Default.Long(0)
   Long getFileInputSplitMaxSizeMB();
 
-  void setFileInputSplitMaxSizeMB(Long inputSplitMaxSizeMB);
+  void setFileInputSplitMaxSizeMB(Long fileInputSplitMaxSizeMB);
 
   static FlinkPipelineOptions defaults() {
     return PipelineOptionsFactory.as(FlinkPipelineOptions.class);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/SourceInputFormat.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/SourceInputFormat.java
@@ -113,7 +113,10 @@ public class SourceInputFormat<T> extends RichInputFormat<WindowedValue<T>, Sour
   private long getDesiredSizeBytes(int numSplits) throws Exception {
     long totalSize = initialSource.getEstimatedSizeBytes(options);
     long defaultSplitSize = totalSize / numSplits;
-    long maxSplitSize = options.as(FlinkPipelineOptions.class).getFileInputSplitMaxSizeMB();
+    long maxSplitSize = 0;
+    if (options != null) {
+      maxSplitSize = options.as(FlinkPipelineOptions.class).getFileInputSplitMaxSizeMB();
+    }
     if (initialSource instanceof FileBasedSource && maxSplitSize > 0) {
       // Most of the time parallelism is < number of files in source.
       // Each file becomes a unique split which commonly create skew.

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/SourceInputFormat.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/SourceInputFormat.java
@@ -113,12 +113,12 @@ public class SourceInputFormat<T> extends RichInputFormat<WindowedValue<T>, Sour
   private long getDesiredSizeBytes(int numSplits) throws Exception {
     long totalSize = initialSource.getEstimatedSizeBytes(options);
     long defaultSplitSize = totalSize / numSplits;
-    if (initialSource instanceof FileBasedSource) {
-      long maxSplitSize = options.as(FlinkPipelineOptions.class).getFileInputSplitMaxSizeBytes();
+    long maxSplitSize = options.as(FlinkPipelineOptions.class).getFileInputSplitMaxSizeMB();
+    if (initialSource instanceof FileBasedSource && maxSplitSize > 0) {
       // Most of the time parallelism is < number of files in source.
       // Each file becomes a unique split which commonly create skew.
-      // This limits the size of splits to 128Mb to reduce skew.
-      return Math.min(defaultSplitSize, maxSplitSize);
+      // This limits the size of splits to reduce skew.
+      return Math.min(defaultSplitSize, maxSplitSize * 1024 * 1024);
     } else {
       return defaultSplitSize;
     }


### PR DESCRIPTION
In the current implementation of file sources, the Flink runner will try to fix the size of input splits using the formula `source estimated size / parallelism`. Most of the time, the resulting desired split size will be much larger than the size of files read by this source.  In that case each individual file becomes full split, and the number of splits is larger than parallelism. 

This creates an issue when the size of individual files varies a lot. At Spotify we commonly read datasets stored on GCS where individual files range from a few Mb to 1 or 2 Gb. Because of this, work distribution is sub-optimal because some workers will be consuming larges splits while other worker consume smaller splits.  

This PR limits the maximum size of each split to 128Mb (configurable), which is a decent tradeoff between balancing work and limiting the overhead of consuming splits. I believe Dataflow uses the same strategy.

In our test on real workflows, we measured an **improvement in execution time (and therefore resource consumption) of up to 20%**. Of course the overall improvement varies a lot from one workflow to another, but we never encountered a case where performances where noticeably degraded.



------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
