### PR TITLE
Bump classgraph version to 4.8.162

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -556,7 +556,7 @@ class BeamModulePlugin implements Plugin<Project> {
     def cassandra_driver_version = "3.10.2"
     def cdap_version = "6.5.1"
     def checkerframework_version = "3.27.0"
-    def classgraph_version = "4.8.104"
+    def classgraph_version = "4.8.162"
     def dbcp2_version = "2.9.0"
     def errorprone_version = "2.10.0"
     // Try to keep gax_version consistent with gax-grpc version in google_cloud_platform_libraries_bom

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/resources/ClasspathScanningResourcesDetectorTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/resources/ClasspathScanningResourcesDetectorTest.java
@@ -120,7 +120,7 @@ public class ClasspathScanningResourcesDetectorTest {
 
   @Test
   public void shouldNotDetectClassPathResourceThatIsNotAFile() throws Exception {
-    String url = "http://www.google.com/all-the-secrets.jar";
+    String url = "http://www.example.com/all-the-secrets.jar";
     ClassLoader classLoader = new URLClassLoader(new URL[] {new URL(url)});
     ClasspathScanningResourcesDetector detector =
         new ClasspathScanningResourcesDetector(new ClassGraph());


### PR DESCRIPTION
I'm helping to investigate a scenario where classpath scanning is taking a lot of time (>10 minutes), and from the logs the only operation between the lines below seem to be classgraph.

> INFO 2023-08-22T01:36:26Z [main] INFO org.apache.beam.runners.dataflow.options.DataflowPipelineOptions$StagingLocationFactory - No stagingLocation provided, falling back to gcpTempLocation
> INFO 2023-08-22T01:49:04Z [main] INFO org.apache.beam.runners.dataflow.DataflowRunner - PipelineOptions.filesToStage was not specified. Defaulting to files from the classpath: will stage 1 files. Enable logging at DEBUG level to see which files will be staged.


Unfortunately I couldn't reproduce locally, but debugging or raising bugs is not likely to go anywhere because the version is over 2 years old, and missing several improvements https://github.com/classgraph/classgraph/compare/classgraph-4.8.104...classgraph-4.8.162.

So bumping it as a mean to reduce tech debt.

It also improves compatibility for JDK 17+,

