### PR TITLE
fix: fix a race condition in BigtableService cache

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceFactory.java
@@ -30,6 +30,7 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.beam.sdk.options.ExperimentalOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -75,15 +76,15 @@ class BigtableServiceFactory implements Serializable {
 
     @Override
     public void close() {
-      int refCount =
-          refCounts.getOrDefault(getConfigId().id(), new AtomicInteger(0)).decrementAndGet();
-      if (refCount < 0) {
-        LOG.error(
-            "close() Ref count is < 0, configId=" + getConfigId().id() + " refCount=" + refCount);
-      }
-      LOG.debug("close() for config id " + getConfigId().id() + ", ref count is " + refCount);
-      if (refCount == 0) {
-        synchronized (lock) {
+      synchronized (lock) {
+        int refCount =
+            refCounts.getOrDefault(getConfigId().id(), new AtomicInteger(0)).decrementAndGet();
+        if (refCount < 0) {
+          LOG.error(
+              "close() Ref count is < 0, configId=" + getConfigId().id() + " refCount=" + refCount);
+        }
+        LOG.debug("close() for config id " + getConfigId().id() + ", ref count is " + refCount);
+        if (refCount == 0) {
           if (refCounts.get(getConfigId().id()).get() <= 0) {
             entries.remove(getConfigId().id());
             refCounts.remove(getConfigId().id());
@@ -105,8 +106,12 @@ class BigtableServiceFactory implements Serializable {
       BigtableServiceEntry entry = entries.get(configId.id());
       if (entry != null) {
         // When entry is not null, refCount.get(configId.id()) should always exist.
-        // Do a getOrDefault to avoid unexpected NPEs.
-        refCounts.getOrDefault(configId.id(), new AtomicInteger(0)).getAndIncrement();
+        Preconditions.checkNotNull(
+            refCounts.get(configId.id()),
+            "Can't find the ref count of the config id "
+                + configId.id()
+                + ", this should never happen.");
+        refCounts.get(configId.id()).getAndIncrement();
         LOG.debug("getServiceForReading() returning an existing service entry");
         return entry;
       }
@@ -150,8 +155,12 @@ class BigtableServiceFactory implements Serializable {
       LOG.debug("getServiceForWriting(), config id: " + configId.id());
       if (entry != null) {
         // When entry is not null, refCount.get(configId.id()) should always exist.
-        // Do a getOrDefault to avoid unexpected NPEs.
-        refCounts.getOrDefault(configId.id(), new AtomicInteger(0)).getAndIncrement();
+        Preconditions.checkNotNull(
+            refCounts.get(configId.id()),
+            "Can't find the ref count of the config id "
+                + configId.id()
+                + ", this should never happen.");
+        refCounts.get(configId.id()).getAndIncrement();
         LOG.debug("getServiceForWriting() returning an existing service entry");
         return entry;
       }


### PR DESCRIPTION
The race condition could cause NPE:

- Thread 1 enters close and get the refCount == 0, the refCount for configId is decremented to 0.
   - Before Thread 1 could remove the configId from entry maps and refCount maps, Thread 2 enters getServiceForReading and get the lock.
   - For thread 2, entry is not null, it increment the counter in refCounts and exit. Now the refCount for configId is 1.
   - Thread 2 finishes the work and also entered close(). gets the ref count again, and refCount is decremented to 0 again.
- Thread 1 gets the lock since refCount is 0, removes configId from the map.
- Thread 2 gets the lock since refCount is 0, tries to removes the configId from the map and gets NPE.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
