### PR TITLE
Allow using CREATE_IF_NEEDED when writing deletes or updates to BigQuery

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -30,6 +30,7 @@ import com.google.api.services.bigquery.model.JobReference;
 import com.google.api.services.bigquery.model.JobStatistics;
 import com.google.api.services.bigquery.model.Table;
 import com.google.api.services.bigquery.model.TableCell;
+import com.google.api.services.bigquery.model.TableConstraints;
 import com.google.api.services.bigquery.model.TableFieldSchema;
 import com.google.api.services.bigquery.model.TableReference;
 import com.google.api.services.bigquery.model.TableRow;
@@ -510,7 +511,8 @@ import org.slf4j.LoggerFactory;
  *    .apply(BigQueryIO.applyRowMutations()
  *           .to(my_project:my_dataset.my_table)
  *           .withSchema(schema)
- *           .withCreateDisposition(Write.CreateDisposition.CREATE_NEVER));
+ *           .withPrimaryKey(ImmutableList.of("field1", "field2"))
+ *           .withCreateDisposition(Write.CreateDisposition.CREATE_IF_NEEDED));
  * }</pre>
  *
  * <p>If writing a type other than TableRow (e.g. using {@link BigQueryIO#writeGenericRecords} or
@@ -523,12 +525,17 @@ import org.slf4j.LoggerFactory;
  * cdcEvent.apply(BigQueryIO.write()
  *          .to("my-project:my_dataset.my_table")
  *          .withSchema(schema)
+ *          .withPrimaryKey(ImmutableList.of("field1", "field2"))
  *          .withFormatFunction(CdcEvent::getTableRow)
  *          .withRowMutationInformationFn(cdc -> RowMutationInformation.of(cdc.getChangeType(),
  *                                                                         cdc.getSequenceNumber()))
  *          .withMethod(Write.Method.STORAGE_API_AT_LEAST_ONCE)
- *          .withCreateDisposition(Write.CreateDisposition.CREATE_NEVER));
+ *          .withCreateDisposition(Write.CreateDisposition.CREATE_IF_NEEDED));
  * }</pre>
+ *
+ * <p>Note that in order to use inserts or deletes, the table must bet set up with a primary key. If
+ * the table is not previously created and CREATE_IF_NEEDED is used, a primary key must be
+ * specified.
  */
 @SuppressWarnings({
   "nullness" // TODO(https://github.com/apache/beam/issues/20506)
@@ -3325,8 +3332,11 @@ public class BigQueryIO {
         }
         if (getPrimaryKey() != null) {
           dynamicDestinations =
-              new DynamicDestinationsHelpers.ConstantPrimaryKeyDestinations<>(
-                  (DynamicDestinations<T, TableDestination>) dynamicDestinations, getPrimaryKey());
+              new DynamicDestinationsHelpers.ConstantTableConstraintsDestinations<>(
+                  (DynamicDestinations<T, TableDestination>) dynamicDestinations,
+                  new TableConstraints()
+                      .setPrimaryKey(
+                          new TableConstraints.PrimaryKey().setColumns(getPrimaryKey())));
         }
       }
       return expandTyped(input, dynamicDestinations);

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/CreateTables.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/CreateTables.java
@@ -113,10 +113,14 @@ public class CreateTables<DestinationT, ElementT>
                     dest);
                 Supplier<@Nullable TableSchema> schemaSupplier =
                     () -> dynamicDestinations.getSchema(dest);
+                Supplier<@Nullable List<String>> primaryKeySupplier =
+                    () -> dynamicDestinations.getPrimaryKey(dest);
+
                 return CreateTableHelpers.possiblyCreateTable(
                     context.getPipelineOptions().as(BigQueryOptions.class),
                     tableDestination1,
                     schemaSupplier,
+                    primaryKeySupplier,
                     createDisposition,
                     dynamicDestinations.getDestinationCoder(),
                     kmsKey,

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/CreateTables.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/CreateTables.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.io.gcp.bigquery;
 
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
 
+import com.google.api.services.bigquery.model.TableConstraints;
 import com.google.api.services.bigquery.model.TableSchema;
 import java.util.List;
 import java.util.Map;
@@ -113,14 +114,14 @@ public class CreateTables<DestinationT, ElementT>
                     dest);
                 Supplier<@Nullable TableSchema> schemaSupplier =
                     () -> dynamicDestinations.getSchema(dest);
-                Supplier<@Nullable List<String>> primaryKeySupplier =
-                    () -> dynamicDestinations.getPrimaryKey(dest);
+                Supplier<@Nullable TableConstraints> tableConstraintsSupplier =
+                    () -> dynamicDestinations.getTableConstraints(dest);
 
                 return CreateTableHelpers.possiblyCreateTable(
                     context.getPipelineOptions().as(BigQueryOptions.class),
                     tableDestination1,
                     schemaSupplier,
-                    primaryKeySupplier,
+                    tableConstraintsSupplier,
                     createDisposition,
                     dynamicDestinations.getDestinationCoder(),
                     kmsKey,

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/DynamicDestinations.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/DynamicDestinations.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.io.gcp.bigquery;
 import static org.apache.beam.sdk.values.TypeDescriptors.extractFromTypeParameters;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState;
 
+import com.google.api.services.bigquery.model.TableConstraints;
 import com.google.api.services.bigquery.model.TableSchema;
 import java.io.Serializable;
 import java.util.List;
@@ -155,10 +156,10 @@ public abstract class DynamicDestinations<T, DestinationT> implements Serializab
   public abstract @Nullable TableSchema getSchema(DestinationT destination);
 
   /**
-   * Returns a list of field names to be used as a primary key when creating the table. Note: this
-   * is not currently supported when using FILE_LOADS!.
+   * Returns TableConstraints (including primary and foreign key) to be used when creating the
+   * table. Note: this is not currently supported when using FILE_LOADS!.
    */
-  public @Nullable List<String> getPrimaryKey(DestinationT destination) {
+  public @Nullable TableConstraints getTableConstraints(DestinationT destination) {
     return null;
   }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/DynamicDestinations.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/DynamicDestinations.java
@@ -154,6 +154,14 @@ public abstract class DynamicDestinations<T, DestinationT> implements Serializab
   /** Returns the table schema for the destination. */
   public abstract @Nullable TableSchema getSchema(DestinationT destination);
 
+  /**
+   * Returns a list of field names to be used as a primary key when creating the table. Note: this
+   * is not currently supported when using FILE_LOADS!.
+   */
+  public @Nullable List<String> getPrimaryKey(DestinationT destination) {
+    return null;
+  }
+
   // Gets the destination coder. If the user does not provide one, try to find one in the coder
   // registry. If no coder can be found, throws CannotProvideCoderException.
   Coder<DestinationT> getDestinationCoderWithDefault(CoderRegistry registry)

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/DynamicDestinationsHelpers.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/DynamicDestinationsHelpers.java
@@ -178,6 +178,11 @@ class DynamicDestinationsHelpers {
     }
 
     @Override
+    public @Nullable List<String> getPrimaryKey(DestinationT destination) {
+      return inner.getPrimaryKey(destination);
+    }
+
+    @Override
     public TableDestination getTable(DestinationT destination) {
       return inner.getTable(destination);
     }
@@ -211,6 +216,30 @@ class DynamicDestinationsHelpers {
     @Override
     public String toString() {
       return MoreObjects.toStringHelper(this).add("inner", inner).toString();
+    }
+  }
+
+  static class ConstantPrimaryKeyDestinations<T, DestinationT>
+      extends DelegatingDynamicDestinations<T, DestinationT> {
+    private final List<String> primaryKey;
+
+    ConstantPrimaryKeyDestinations(
+        DynamicDestinations<T, DestinationT> inner, List<String> primaryKey) {
+      super(inner);
+      this.primaryKey = primaryKey;
+    }
+
+    @Override
+    public List<String> getPrimaryKey(DestinationT destination) {
+      return primaryKey;
+    }
+
+    @Override
+    public String toString() {
+      return MoreObjects.toStringHelper(this)
+          .add("inner", inner)
+          .add("primaryKey", primaryKey)
+          .toString();
     }
   }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/DynamicDestinationsHelpers.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/DynamicDestinationsHelpers.java
@@ -23,6 +23,7 @@ import com.google.api.client.util.BackOff;
 import com.google.api.client.util.BackOffUtils;
 import com.google.api.client.util.Sleeper;
 import com.google.api.services.bigquery.model.Table;
+import com.google.api.services.bigquery.model.TableConstraints;
 import com.google.api.services.bigquery.model.TableReference;
 import com.google.api.services.bigquery.model.TableSchema;
 import java.io.IOException;
@@ -178,8 +179,8 @@ class DynamicDestinationsHelpers {
     }
 
     @Override
-    public @Nullable List<String> getPrimaryKey(DestinationT destination) {
-      return inner.getPrimaryKey(destination);
+    public @Nullable TableConstraints getTableConstraints(DestinationT destination) {
+      return inner.getTableConstraints(destination);
     }
 
     @Override
@@ -219,26 +220,26 @@ class DynamicDestinationsHelpers {
     }
   }
 
-  static class ConstantPrimaryKeyDestinations<T, DestinationT>
+  static class ConstantTableConstraintsDestinations<T, DestinationT>
       extends DelegatingDynamicDestinations<T, DestinationT> {
-    private final List<String> primaryKey;
+    private final String jsonTableConstraints;
 
-    ConstantPrimaryKeyDestinations(
-        DynamicDestinations<T, DestinationT> inner, List<String> primaryKey) {
+    ConstantTableConstraintsDestinations(
+        DynamicDestinations<T, DestinationT> inner, TableConstraints tableConstraints) {
       super(inner);
-      this.primaryKey = primaryKey;
+      this.jsonTableConstraints = BigQueryHelpers.toJsonString(tableConstraints);
     }
 
     @Override
-    public List<String> getPrimaryKey(DestinationT destination) {
-      return primaryKey;
+    public TableConstraints getTableConstraints(DestinationT destination) {
+      return BigQueryHelpers.fromJsonString(jsonTableConstraints, TableConstraints.class);
     }
 
     @Override
     public String toString() {
       return MoreObjects.toStringHelper(this)
           .add("inner", inner)
-          .add("primaryKey", primaryKey)
+          .add("tableConstraints", jsonTableConstraints)
           .toString();
     }
   }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiDynamicDestinations.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiDynamicDestinations.java
@@ -18,19 +18,14 @@
 package org.apache.beam.sdk.io.gcp.bigquery;
 
 import com.google.api.services.bigquery.model.TableRow;
-import com.google.api.services.bigquery.model.TableSchema;
 import com.google.protobuf.DescriptorProtos;
-import java.util.List;
 import javax.annotation.Nullable;
-import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices.DatasetService;
 import org.apache.beam.sdk.transforms.DoFn;
-import org.apache.beam.sdk.values.PCollectionView;
-import org.apache.beam.sdk.values.ValueInSingleWindow;
 
 /** Base dynamicDestinations class used by the Storage API sink. */
 abstract class StorageApiDynamicDestinations<T, DestinationT>
-    extends DynamicDestinations<T, DestinationT> {
+    extends DynamicDestinationsHelpers.DelegatingDynamicDestinations<T, DestinationT> {
   public interface MessageConverter<T> {
     com.google.cloud.bigquery.storage.v1.TableSchema getTableSchema();
 
@@ -42,39 +37,12 @@ abstract class StorageApiDynamicDestinations<T, DestinationT>
     TableRow toTableRow(T element);
   }
 
-  private DynamicDestinations<T, DestinationT> inner;
-
   StorageApiDynamicDestinations(DynamicDestinations<T, DestinationT> inner) {
-    this.inner = inner;
+    super(inner);
   }
 
   public abstract MessageConverter<T> getMessageConverter(
       DestinationT destination, DatasetService datasetService) throws Exception;
-
-  @Override
-  public DestinationT getDestination(@Nullable ValueInSingleWindow<T> element) {
-    return inner.getDestination(element);
-  }
-
-  @Override
-  public @Nullable Coder<DestinationT> getDestinationCoder() {
-    return inner.getDestinationCoder();
-  }
-
-  @Override
-  public TableDestination getTable(DestinationT destination) {
-    return inner.getTable(destination);
-  }
-
-  @Override
-  public @Nullable TableSchema getSchema(DestinationT destination) {
-    return inner.getSchema(destination);
-  }
-
-  @Override
-  public List<PCollectionView<?>> getSideInputs() {
-    return inner.getSideInputs();
-  }
 
   @Override
   void setSideInputAccessorFromProcessContext(DoFn<?, ?>.ProcessContext context) {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
@@ -939,7 +939,7 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
                 c.getPipelineOptions().as(BigQueryOptions.class),
                 tableDestination1,
                 () -> dynamicDestinations.getSchema(destination),
-                () -> dynamicDestinations.getPrimaryKey(destination),
+                () -> dynamicDestinations.getTableConstraints(destination),
                 createDisposition,
                 destinationCoder,
                 kmsKey,

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
@@ -939,6 +939,7 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
                 c.getPipelineOptions().as(BigQueryOptions.class),
                 tableDestination1,
                 () -> dynamicDestinations.getSchema(destination),
+                () -> dynamicDestinations.getPrimaryKey(destination),
                 createDisposition,
                 destinationCoder,
                 kmsKey,

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWritesShardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWritesShardedRecords.java
@@ -441,10 +441,12 @@ public class StorageApiWritesShardedRecords<DestinationT extends @NonNull Object
       Coder<DestinationT> destinationCoder = dynamicDestinations.getDestinationCoder();
       Callable<Boolean> tryCreateTable =
           () -> {
+            DestinationT dest = element.getKey().getKey();
             CreateTableHelpers.possiblyCreateTable(
                 c.getPipelineOptions().as(BigQueryOptions.class),
                 tableDestination,
-                () -> dynamicDestinations.getSchema(element.getKey().getKey()),
+                () -> dynamicDestinations.getSchema(dest),
+                () -> dynamicDestinations.getPrimaryKey(dest),
                 createDisposition,
                 destinationCoder,
                 kmsKey,

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWritesShardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWritesShardedRecords.java
@@ -446,7 +446,7 @@ public class StorageApiWritesShardedRecords<DestinationT extends @NonNull Object
                 c.getPipelineOptions().as(BigQueryOptions.class),
                 tableDestination,
                 () -> dynamicDestinations.getSchema(dest),
-                () -> dynamicDestinations.getPrimaryKey(dest),
+                () -> dynamicDestinations.getTableConstraints(dest),
                 createDisposition,
                 destinationCoder,
                 kmsKey,


### PR DESCRIPTION
Since tables must be created using a primary key, this PR also adds support for specifying the primary key.

R: @ahmedabu98 