### PR TITLE
[release automation] Add documentation building job to build_release_candidate.yml workflow

### DIFF
--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -204,6 +204,8 @@ jobs:
           repository: apache/beam-site
           path: beam-site
           fetch-depth: 0
+          token: ${{ github.event.inputs.BEAM_SITE_TOKEN }}
+          ref: release-docs
       - name: Install Python 3.8
         uses: actions/setup-python@v4
         with:
@@ -257,7 +259,6 @@ jobs:
              
             echo "------------------Updating Release Docs---------------------"
             cd ${SITE_ROOT_DIR}
-            git checkout release-docs
             git checkout -b updates_release_${{ github.event.inputs.RELEASE }} release-docs
              
             # echo "..........Copying generated javadoc into beam-site.........."
@@ -284,6 +285,7 @@ jobs:
             git config user.email actions@"$RUNNER_NAME".local
             git add -A
             git commit -m "Update beam-site for release ${{ github.event.inputs.RELEASE }}." -m "Content generated from commit ${RELEASE_COMMIT}."
+            git push -f
             
             echo "............Creating PR.........."
             gh pr create -f --base release-docs --head ${{ github.actor }}:updates_release_${{ github.event.inputs.RELEASE }}

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -287,4 +287,7 @@ jobs:
             git push -f --set-upstream origin $BRANCH_NAME
             
             echo "............Creating PR.........."
-            gh pr create --title "Publish docs for ${RELEASE} release}" --body "Content generated from commit ${RELEASE_COMMIT}." --base release-docs
+            PR_TITLE="Publish docs for ${RELEASE} release}"
+            PR_BODY="Content generated from commit ${RELEASE_COMMIT}."
+            # Update the title and body if the PR already exists and reopen it. Create it otherwise.
+            gh pr edit $BRANCH_NAME -t $PR_TITLE -b $PR_BODY  && gh pr reopen $BRANCH_NAME || gh pr create -t $PR_TITLE -b $PR_BODY --base release-docs

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -286,4 +286,4 @@ jobs:
             git commit -m "Update beam-site for release ${{ github.event.inputs.RELEASE }}." -m "Content generated from commit ${RELEASE_COMMIT}."
             
             echo "............Creating PR.........."
-            gh pr create -f --head ${{ github.actor }}:updates_release_${{ github.event.inputs.RELEASE }}
+            gh pr create -f --base release-docs --head ${{ github.actor }}:updates_release_${{ github.event.inputs.RELEASE }}

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -234,13 +234,12 @@ jobs:
       - name: Build Python Docs
         working-directory: beam/sdks/python
         run: |
-            echo "------------------Building Python Doc------------------------"
-            # pip install --upgrade pip setuptools wheel
-            # pip install -U pip
-            # pip install tox
-            # # TODO(https://github.com/apache/beam/issues/20209): Don't hardcode py version in this file.
-            # pip install -r build-requirements.txt && tox -e py38-docs
-            # rm -rf target/docs/_build/.doctrees
+            pip install --upgrade pip setuptools wheel
+            pip install -U pip
+            pip install tox
+            # TODO(https://github.com/apache/beam/issues/20209): Don't hardcode py version in this file.
+            pip install -r build-requirements.txt && tox -e py38-docs
+            rm -rf target/docs/_build/.doctrees
       - name: Build Typescript Docs
         working-directory: beam/sdks/typescript
         run: |
@@ -248,24 +247,23 @@ jobs:
       - name: Build Java Docs
         working-directory: beam
         run: |
-            echo "----------------------Building Java Doc----------------------"
-            # ./gradlew :sdks:java:javadoc:aggregateJavadoc -PisRelease --no-daemon --no-parallel
-      - name: Update Release Docs
+            ./gradlew :sdks:java:javadoc:aggregateJavadoc -PisRelease --no-daemon --no-parallel
+      - name: Consolidate Release Docs to beam-site branch with symlinks
         working-directory: beam-site
         run: |
             git checkout -b $BRANCH_NAME release-docs
              
-            # echo "..........Copying generated javadoc into beam-site.........."
-            # cp -r ${BEAM_ROOT_DIR}/sdks/java/javadoc/build/docs/javadoc/ javadoc/${{ github.event.inputs.RELEASE }}
-            # # Update current symlink to point to the latest release
-            # unlink javadoc/current
-            # ln -s ${{ github.event.inputs.RELEASE }} javadoc/current
+            echo "..........Copying generated javadoc into beam-site.........."
+            cp -r ${BEAM_ROOT_DIR}/sdks/java/javadoc/build/docs/javadoc/ javadoc/${{ github.event.inputs.RELEASE }}
+            # Update current symlink to point to the latest release
+            unlink javadoc/current
+            ln -s ${{ github.event.inputs.RELEASE }} javadoc/current
              
-            # echo "............Copying generated pydoc into beam-site.........."
-            # cp -r ${BEAM_ROOT_DIR}/sdks/python/target/docs/_build pydoc/${{  github.event.inputs.RELEASE }}
-            # # Update current symlink to point to the latest release
-            # unlink pydoc/current
-            # ln -s ${{ github.event.inputs.RELEASE }} pydoc/current
+            echo "............Copying generated pydoc into beam-site.........."
+            cp -r ${BEAM_ROOT_DIR}/sdks/python/target/docs/_build pydoc/${{  github.event.inputs.RELEASE }}
+            # Update current symlink to point to the latest release
+            unlink pydoc/current
+            ln -s ${{ github.event.inputs.RELEASE }} pydoc/current
              
             echo "............Copying generated typedoc into beam-site.........."
             mkdir -p typedoc

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -273,7 +273,7 @@ jobs:
             # Update current symlink to point to the latest release
             unlink typedoc/current | true
             ln -s ${{ github.event.inputs.RELEASE }} typedoc/current
-      - name: Create beam-site PR
+      - name: Create commit on beam-site branch
         working-directory: beam
         run: |
             # Get the commit from the beam repo, not the beam-site repo.
@@ -285,7 +285,7 @@ jobs:
             git commit -m "Update beam-site for release ${{ github.event.inputs.RELEASE }}." -m "Content generated from commit ${RELEASE_COMMIT}."
             git push -f --set-upstream origin $BRANCH_NAME
       - name: Create beam-site PR
-        working-directory: ${SITE_ROOT_DIR}
+        working-directory: beam-site
         env:
           GH_TOKEN: ${{ github.event.inputs.BEAM_SITE_TOKEN }}
           PR_TITLE: "Publish docs for ${{ github.event.inputs.RELEASE }} release}"

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -219,6 +219,8 @@ jobs:
         # settings.xml file
         run: rm ~/.m2/settings.xml || true
       - name: create documentation pr for website
+        env:
+          GH_TOKEN: ${{ github.token }}
         run: |
             BEAM_ROOT_DIR=${{ github.workspace }}/beam
             SITE_ROOT_DIR=${{ github.workspace }}/beam-site
@@ -275,23 +277,5 @@ jobs:
              
             git add -A
             git commit -m "Update beam-site for release ${{ github.event.inputs.RELEASE }}." -m "Content generated from commit ${RELEASE_COMMIT}."
-            git push -f ${USER_REMOTE_URL}
-             
-            # Check if hub is installed. See https://stackoverflow.com/a/677212
-            if ! hash hub 2> /dev/null; then
-              echo "installing hub with sudo permission"
-              HUB_VERSION=2.5.0
-              HUB_ARTIFACTS_NAME=hub-linux-amd64-${HUB_VERSION}
-              wget https://github.com/github/hub/releases/download/v${HUB_VERSION}/${HUB_ARTIFACTS_NAME}.tgz
-              tar zvxvf ${HUB_ARTIFACTS_NAME}.tgz
-              sudo ./${HUB_ARTIFACTS_NAME}/install
-              echo "eval "$(hub alias -s)"" >> ~/.bashrc
-              rm -rf ${HUB_ARTIFACTS_NAME}*
-            fi
-            if hash hub 2> /dev/null; then
-              hub pull-request -m "Publish ${{ github.event.inputs.RELEASE }} release" -h ${{ github.actor }}:updates_release_${{ github.event.inputs.RELEASE }} -b apache:release-docs \
-               || echo "Pull request creation did not succeed. If you created the website PR earlier it may have been updated via force-push."
-            else
-              echo "Without hub, you need to create PR manually."
-            fi
-            echo "Finished ${ RC_TAG } doc creation."
+           
+            gh pr create -f

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -275,10 +275,14 @@ jobs:
             unlink typedoc/current | true
             ln -s ${{ github.event.inputs.RELEASE }} typedoc/current
              
-            echo "............Creating PR.........."
+            echo "............Creating Commit.........."
             git config user.name $GITHUB_ACTOR
             git config user.email actions@"$RUNNER_NAME".local
             git add -A
             git commit -m "Update beam-site for release ${{ github.event.inputs.RELEASE }}." -m "Content generated from commit ${RELEASE_COMMIT}."
            
+            echo "............Pushing to remote ${USER_REMOTE_URL}.........."
+            git push -f ${USER_REMOTE_URL}
+            
+            echo "............Creating PR.........."
             gh pr create -f

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -288,4 +288,4 @@ jobs:
             git push -f --set-upstream origin $BRANCH_NAME
             
             echo "............Creating PR.........."
-            gh pr create -f --base release-docs --head ${{ github.actor }}:$BRANCH_NAME
+            gh pr create -f

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -291,5 +291,4 @@ jobs:
           PR_TITLE: "Publish docs for ${{ github.event.inputs.RELEASE }} release}"
           PR_BODY: "Content generated from  https://github.com/apache/beam/tree/v${RC_TAG}."
         run: |
-            # Update the body if the PR already exists and reopen it. Create it otherwise.
-            gh pr edit $BRANCH_NAME -b "$PR_BODY"  && gh pr reopen $BRANCH_NAME || gh pr create -t "$PR_TITLE" -b "$PR_BODY" --base release-docs
+            gh pr create -t "$PR_TITLE" -b "$PR_BODY" --base release-docs || echo "PR likely already exists, but has been updated."

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -31,6 +31,10 @@ on:
         description: Whether to stage SDK docker images to docker hub Apache organization
         required: true
         default: 'no'
+      CREATE_BEAM_SITE_PR:
+        description: Whether to create the documentation update PR against apache/beam-site.
+        required: true
+        default: 'no'
 
 jobs:
   publish_java_artifacts:
@@ -177,3 +181,108 @@ jobs:
           password: ${{ secrets.DOCKERHUB_TOKEN }}
       - name: Push docker images
         run: ./gradlew :pushAllDockerImages -PisRelease -Pdocker-pull-licenses -Pprune-images -Pdocker-tag=${{ github.event.inputs.RELEASE }}rc${{ github.event.inputs.RC }} -Pjava11Home=${{steps.export-java11.outputs.JAVA11_HOME}} --no-daemon --no-parallel
+
+
+  beam_site_pr:
+    if: ${{github.event.inputs.CREATE_BEAM_SITE_PR == 'yes'}}
+    runs-on: [self-hosted, ubuntu-20.04, main]
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v3
+        with:
+          ref: "v${{ github.event.inputs.RELEASE }}-RC${{ github.event.inputs.RC }}"
+          repository: apache/beam
+          path: beam
+      - name: Checkout tools repo
+        uses: actions/checkout@v3
+        with:
+          repository: apache/beam-site
+          path: beam-site
+          fetch-depth: 0
+      - name: Install Python 3.8
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+      - name: Install Java 8
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+      - name: Install node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
+      - name: create documentation pr for website
+        run: |
+            BEAM_ROOT_DIR=${GITHUB_WORKSPACE}/beam
+            SITE_ROOT_DIR=${GITHUB_WORKSPACE}/beam-site
+            USER_REMOTE_URL=git@github.com:${ github.actor }/beam-site
+            RC_TAG="v${{ github.event.inputs.RELEASE }}-RC${{ github.event.inputs.RC }}"
+             
+            echo "------------------Building Python Doc------------------------"
+            pip install --upgrade pip setuptools wheel
+            pip install -U pip
+            pip install tox
+            cd ${BEAM_ROOT_DIR}
+            # TODO(https://github.com/apache/beam/issues/20209): Don't hardcode py version in this file.
+            cd sdks/python && pip install -r build-requirements.txt && tox -e py38-docs
+            GENERATED_PYDOC=${BEAM_ROOT_DIR}/sdks/python/target/docs/_build
+            rm -rf ${GENERATED_PYDOC}/.doctrees
+             
+            echo "------------------Building Typescript Doc------------------------"
+            cd ${BEAM_ROOT_DIR}
+            cd sdks/typescript && npm ci && npm run docs
+            GENERATED_TYPEDOC=${BEAM_ROOT_DIR}/sdks/typescript/docs
+             
+            echo "----------------------Building Java Doc----------------------"
+            cd ${BEAM_ROOT_DIR}
+            ./gradlew :sdks:java:javadoc:aggregateJavadoc -PisRelease --no-daemon --no-parallel
+            GENERATE_JAVADOC=${BEAM_ROOT_DIR}/sdks/java/javadoc/build/docs/javadoc/
+             
+            echo "------------------Updating Release Docs---------------------"
+            cd ${SITE_ROOT_DIR}
+            git checkout release-docs
+            git checkout -b updates_release_${ github.event.inputs.RELEASE } release-docs
+             
+            echo "..........Copying generated javadoc into beam-site.........."
+            cp -r ${GENERATE_JAVADOC} javadoc/${ github.event.inputs.RELEASE }
+            # Update current symlink to point to the latest release
+            unlink javadoc/current
+            ln -s ${ github.event.inputs.RELEASE } javadoc/current
+             
+            echo "............Copying generated pydoc into beam-site.........."
+            cp -r ${GENERATED_PYDOC} pydoc/${  github.event.inputs.RELEASE }
+            # Update current symlink to point to the latest release
+            unlink pydoc/current
+            ln -s ${ github.event.inputs.RELEASE } pydoc/current
+             
+            echo "............Copying generated typedoc into beam-site.........."
+            mkdir -p typedoc
+            cp -r ${GENERATED_TYPEDOC} typedoc/${ github.event.inputs.RELEASE }
+            # Update current symlink to point to the latest release
+            unlink typedoc/current | true
+            ln -s ${ github.event.inputs.RELEASE } typedoc/current
+             
+            git add -A
+            RELEASE_COMMIT=$(git rev-list -n 1 "tags/${RC_TAG}")
+            git commit -m "Update beam-site for release ${ github.event.inputs.RELEASE }." -m "Content generated from commit ${RELEASE_COMMIT}."
+            git push -f ${USER_REMOTE_URL}
+             
+            # Check if hub is installed. See https://stackoverflow.com/a/677212
+            if ! hash hub 2> /dev/null; then
+              echo "installing hub with sudo permission"
+              HUB_VERSION=2.5.0
+              HUB_ARTIFACTS_NAME=hub-linux-amd64-${HUB_VERSION}
+              wget https://github.com/github/hub/releases/download/v${HUB_VERSION}/${HUB_ARTIFACTS_NAME}.tgz
+              tar zvxvf ${HUB_ARTIFACTS_NAME}.tgz
+              sudo ./${HUB_ARTIFACTS_NAME}/install
+              echo "eval "$(hub alias -s)"" >> ~/.bashrc
+              rm -rf ${HUB_ARTIFACTS_NAME}*
+            fi
+            if hash hub 2> /dev/null; then
+              hub pull-request -m "Publish ${ github.event.inputs.RELEASE } release" -h ${ github.actor }:updates_release_${ github.event.inputs.RELEASE } -b apache:release-docs \
+               || echo "Pull request creation did not succeed. If you created the website PR earlier it may have been updated via force-push."
+            else
+              echo "Without hub, you need to create PR manually."
+            fi
+            echo "Finished ${ RC_TAG } doc creation."

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -242,7 +242,7 @@ jobs:
       - name: Build Typescript Docs
         working-directory: beam/sdks/typescript
         run: |
-            npm install ttypescript@1.5.15 && npm ci && npm run docs
+            npm ci && npm run docs
       - name: Build Java Docs
         working-directory: beam
         run: |

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -214,9 +214,9 @@ jobs:
           node-version: '16'
       - name: create documentation pr for website
         run: |
-            BEAM_ROOT_DIR=${GITHUB_WORKSPACE}/beam
-            SITE_ROOT_DIR=${GITHUB_WORKSPACE}/beam-site
-            USER_REMOTE_URL=git@github.com:${ github.actor }/beam-site
+            BEAM_ROOT_DIR=${{ github.workspace }}/beam
+            SITE_ROOT_DIR=${{ github.workspace }}/beam-site
+            USER_REMOTE_URL=git@github.com:${{} github.actor }}/beam-site
             RC_TAG="v${{ github.event.inputs.RELEASE }}-RC${{ github.event.inputs.RC }}"
              
             echo "------------------Building Python Doc------------------------"
@@ -242,30 +242,30 @@ jobs:
             echo "------------------Updating Release Docs---------------------"
             cd ${SITE_ROOT_DIR}
             git checkout release-docs
-            git checkout -b updates_release_${ github.event.inputs.RELEASE } release-docs
+            git checkout -b updates_release_${{ github.event.inputs.RELEASE }} release-docs
              
             echo "..........Copying generated javadoc into beam-site.........."
-            cp -r ${GENERATE_JAVADOC} javadoc/${ github.event.inputs.RELEASE }
+            cp -r ${GENERATE_JAVADOC} javadoc/${{ github.event.inputs.RELEASE }}
             # Update current symlink to point to the latest release
             unlink javadoc/current
-            ln -s ${ github.event.inputs.RELEASE } javadoc/current
+            ln -s ${{ github.event.inputs.RELEASE }} javadoc/current
              
             echo "............Copying generated pydoc into beam-site.........."
-            cp -r ${GENERATED_PYDOC} pydoc/${  github.event.inputs.RELEASE }
+            cp -r ${GENERATED_PYDOC} pydoc/${{  github.event.inputs.RELEASE }}
             # Update current symlink to point to the latest release
             unlink pydoc/current
-            ln -s ${ github.event.inputs.RELEASE } pydoc/current
+            ln -s ${{ github.event.inputs.RELEASE }} pydoc/current
              
             echo "............Copying generated typedoc into beam-site.........."
             mkdir -p typedoc
-            cp -r ${GENERATED_TYPEDOC} typedoc/${ github.event.inputs.RELEASE }
+            cp -r ${GENERATED_TYPEDOC} typedoc/${{ github.event.inputs.RELEASE }}
             # Update current symlink to point to the latest release
             unlink typedoc/current | true
-            ln -s ${ github.event.inputs.RELEASE } typedoc/current
+            ln -s ${{ github.event.inputs.RELEASE }} typedoc/current
              
             git add -A
             RELEASE_COMMIT=$(git rev-list -n 1 "tags/${RC_TAG}")
-            git commit -m "Update beam-site for release ${ github.event.inputs.RELEASE }." -m "Content generated from commit ${RELEASE_COMMIT}."
+            git commit -m "Update beam-site for release ${{ github.event.inputs.RELEASE }}." -m "Content generated from commit ${RELEASE_COMMIT}."
             git push -f ${USER_REMOTE_URL}
              
             # Check if hub is installed. See https://stackoverflow.com/a/677212
@@ -280,7 +280,7 @@ jobs:
               rm -rf ${HUB_ARTIFACTS_NAME}*
             fi
             if hash hub 2> /dev/null; then
-              hub pull-request -m "Publish ${ github.event.inputs.RELEASE } release" -h ${ github.actor }:updates_release_${ github.event.inputs.RELEASE } -b apache:release-docs \
+              hub pull-request -m "Publish ${{ github.event.inputs.RELEASE }} release" -h ${{ github.actor }}:updates_release_${{ github.event.inputs.RELEASE }} -b apache:release-docs \
                || echo "Pull request creation did not succeed. If you created the website PR earlier it may have been updated via force-push."
             else
               echo "Without hub, you need to create PR manually."

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -216,7 +216,7 @@ jobs:
         run: |
             BEAM_ROOT_DIR=${{ github.workspace }}/beam
             SITE_ROOT_DIR=${{ github.workspace }}/beam-site
-            USER_REMOTE_URL=git@github.com:${{} github.actor }}/beam-site
+            USER_REMOTE_URL=git@github.com:${{ github.actor }}/beam-site
             RC_TAG="v${{ github.event.inputs.RELEASE }}-RC${{ github.event.inputs.RC }}"
              
             echo "------------------Building Python Doc------------------------"

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -288,4 +288,4 @@ jobs:
             git push -f --set-upstream origin $BRANCH_NAME
             
             echo "............Creating PR.........."
-            gh pr create -f
+            gh pr create --title "Update beam-site for release ${{ github.event.inputs.RELEASE }} --body "Content generated from commit ${RELEASE_COMMIT}."

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -288,4 +288,4 @@ jobs:
             git push -f --set-upstream origin $BRANCH_NAME
             
             echo "............Creating PR.........."
-            gh pr create --title "Update beam-site for release ${{ github.event.inputs.RELEASE }} --body "Content generated from commit ${RELEASE_COMMIT}."
+            gh pr create --title "Update beam-site for release ${{ github.event.inputs.RELEASE }}" --body "Content generated from commit ${RELEASE_COMMIT}."

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -185,15 +185,16 @@ jobs:
 
   beam_site_pr:
     if: ${{github.event.inputs.CREATE_BEAM_SITE_PR == 'yes'}}
-    runs-on: [self-hosted, ubuntu-20.04, main]
+    # Note: if this ever changes to self-hosted, remove the "Remove default github maven configuration" step
+    runs-on: ubuntu-latest
     steps:
-      - name: Checkout
+      - name: Checkout Beam Repo
         uses: actions/checkout@v3
         with:
           ref: "v${{ github.event.inputs.RELEASE }}-RC${{ github.event.inputs.RC }}"
           repository: apache/beam
           path: beam
-      - name: Checkout tools repo
+      - name: Checkout Beam Site Repo
         uses: actions/checkout@v3
         with:
           repository: apache/beam-site
@@ -203,15 +204,20 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: '3.8'
+      - name: Install node
+        uses: actions/setup-node@v3
+        with:
+          node-version: '16'
       - name: Install Java 8
         uses: actions/setup-java@v3
         with:
           distribution: 'temurin'
           java-version: '8'
-      - name: Install node
-        uses: actions/setup-node@v3
-        with:
-          node-version: '16'
+      - name: Remove default github maven configuration
+        # This step is a workaround to avoid a decryption issue of Beam's
+        # net.linguica.gradle.maven.settings plugin and github's provided maven
+        # settings.xml file
+        run: rm ~/.m2/settings.xml || true
       - name: create documentation pr for website
         run: |
             BEAM_ROOT_DIR=${{ github.workspace }}/beam

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -19,6 +19,9 @@ on:
       APACHE_PASSWORD:
         description: Your Apache password. Required if you want to stage artifacts into https://dist.apache.org/repos/dist/dev/beam/
         required: false
+      BEAM_SITE_TOKEN:
+        description:  Required if you want to create the beam-site docs PR.
+        default: ''
       PUBLISH_JAVA_ARTIFACTS:
         description: Whether to publish java artifacts to https://repository.apache.org/#stagingRepositories (yes/no)
         required: true
@@ -35,10 +38,6 @@ on:
         description: Whether to create the documentation update PR against apache/beam-site.
         required: true
         default: 'no'
-      BEAM_SITE_TOKEN:
-        description: Github token with permissions to create prs on your beam-site fork.
-        required: true
-        default: ''
 
 jobs:
   publish_java_artifacts:
@@ -287,6 +286,6 @@ jobs:
         env:
           GH_TOKEN: ${{ github.event.inputs.BEAM_SITE_TOKEN }}
           PR_TITLE: "Publish docs for ${{ github.event.inputs.RELEASE }} release"
-          PR_BODY: "Content generated from https://github.com/apache/beam/tree/v${{ env.RC_TAG }}."
+          PR_BODY: "Content generated from https://github.com/apache/beam/tree/${{ env.RC_TAG }}."
         run: |
             gh pr create -t "$PR_TITLE" -b "$PR_BODY" --base release-docs

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -230,6 +230,10 @@ jobs:
             pip install -U pip
             pip install tox
             cd ${BEAM_ROOT_DIR}
+
+            # Get the commit from the beam repo, not the beam-site repo.
+            RELEASE_COMMIT=$(git rev-list -n 1 "tags/${RC_TAG}")
+
             # TODO(https://github.com/apache/beam/issues/20209): Don't hardcode py version in this file.
             cd sdks/python && pip install -r build-requirements.txt && tox -e py38-docs
             GENERATED_PYDOC=${BEAM_ROOT_DIR}/sdks/python/target/docs/_build
@@ -270,7 +274,6 @@ jobs:
             ln -s ${{ github.event.inputs.RELEASE }} typedoc/current
              
             git add -A
-            RELEASE_COMMIT=$(git rev-list -n 1 "tags/${RC_TAG}")
             git commit -m "Update beam-site for release ${{ github.event.inputs.RELEASE }}." -m "Content generated from commit ${RELEASE_COMMIT}."
             git push -f ${USER_REMOTE_URL}
              

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -20,7 +20,7 @@ on:
         description: Your Apache password. Required if you want to stage artifacts into https://dist.apache.org/repos/dist/dev/beam/
         required: false
       BEAM_SITE_TOKEN:
-        description:  Required if you want to create the beam-site docs PR.
+        description:  Github Personal Access Token with repo permission if you want to create the beam-site docs PR. See https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens.
         default: ''
       PUBLISH_JAVA_ARTIFACTS:
         description: Whether to publish java artifacts to https://repository.apache.org/#stagingRepositories (yes/no)

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -230,7 +230,6 @@ jobs:
             BEAM_ROOT_DIR=${{ github.workspace }}/beam
             SITE_ROOT_DIR=${{ github.workspace }}/beam-site
             BRANCH_NAME=updates_release_${{ github.event.inputs.RELEASE }}
-            USER_REMOTE_URL=git@github.com:${{ github.actor }}/beam-site
             RC_TAG="v${{ github.event.inputs.RELEASE }}-RC${{ github.event.inputs.RC }}"
              
             echo "------------------Building Python Doc------------------------"
@@ -288,4 +287,4 @@ jobs:
             git push -f --set-upstream origin $BRANCH_NAME
             
             echo "............Creating PR.........."
-            gh pr create --title "Update beam-site for release ${{ github.event.inputs.RELEASE }}" --body "Content generated from commit ${RELEASE_COMMIT}."
+            gh pr create --title "Update beam-site for release ${{ github.event.inputs.RELEASE }}" --body "Content generated from commit ${RELEASE_COMMIT}." --base release-docs

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -194,6 +194,8 @@ jobs:
     env:
       RC_TAG: "v${{ github.event.inputs.RELEASE }}-RC${{ github.event.inputs.RC }}"
       BRANCH_NAME: updates_release_${{ github.event.inputs.RELEASE }}
+      BEAM_ROOT_DIR: ${{ github.workspace }}/beam
+      SITE_ROOT_DIR: ${{ github.workspace }}/beam-site
     steps:
       - name: Checkout Beam Repo
         uses: actions/checkout@v3
@@ -226,32 +228,30 @@ jobs:
         # net.linguica.gradle.maven.settings plugin and github's provided maven
         # settings.xml file
         run: rm ~/.m2/settings.xml || true
-      - name: create documentation commit for website
+      - name: Create documentation commit for website
         run: |
-            BEAM_ROOT_DIR=${{ github.workspace }}/beam
-            SITE_ROOT_DIR=${{ github.workspace }}/beam-site
-             
-            # Get the commit from the beam repo, not the beam-site repo.
-            cd ${BEAM_ROOT_DIR}
-            RELEASE_COMMIT=$(git rev-list -n 1 "tags/${RC_TAG}")
-
-            # echo "------------------Building Python Doc------------------------"
+            echo "OK!"
+      - name: Build Python Docs
+        working-directory: beam/sdks/python
+        run: |
+            echo "------------------Building Python Doc------------------------"
             # pip install --upgrade pip setuptools wheel
             # pip install -U pip
             # pip install tox
-
             # # TODO(https://github.com/apache/beam/issues/20209): Don't hardcode py version in this file.
-            # cd sdks/python && pip install -r build-requirements.txt && tox -e py38-docs
+            # pip install -r build-requirements.txt && tox -e py38-docs
             # GENERATED_PYDOC=${BEAM_ROOT_DIR}/sdks/python/target/docs/_build
             # rm -rf ${GENERATED_PYDOC}/.doctrees
-             
+      - name: Build Typescript Docs
+        working-directory: beam/sdks/typescript
+        run: |
             echo "------------------Building Typescript Doc------------------------"
-            cd ${BEAM_ROOT_DIR}
-            cd sdks/typescript && npm install ttypescript@1.5.15 && npm ci && npm run docs
+            npm install ttypescript@1.5.15 && npm ci && npm run docs
             GENERATED_TYPEDOC=${BEAM_ROOT_DIR}/sdks/typescript/docs
-             
-            # echo "----------------------Building Java Doc----------------------"
-            # cd ${BEAM_ROOT_DIR}
+      - name: Build Java Docs
+        working-directory: beam
+        run: |
+            echo "----------------------Building Java Doc----------------------"
             # ./gradlew :sdks:java:javadoc:aggregateJavadoc -PisRelease --no-daemon --no-parallel
             # GENERATE_JAVADOC=${BEAM_ROOT_DIR}/sdks/java/javadoc/build/docs/javadoc/
              
@@ -277,18 +277,22 @@ jobs:
             # Update current symlink to point to the latest release
             unlink typedoc/current | true
             ln -s ${{ github.event.inputs.RELEASE }} typedoc/current
-             
-            echo "............Creating Commit.........."
+      - name: Create beam-site PR
+        working-directory: ${BEAM_ROOT_DIR}
+        run: |
+            # Get the commit from the beam repo, not the beam-site repo.
+            RELEASE_COMMIT=$(git rev-list -n 1 "tags/${RC_TAG}")
+            cd ${SITE_ROOT_DIR}
             git config user.name $GITHUB_ACTOR
             git config user.email actions@"$RUNNER_NAME".local
             git add -A
             git commit -m "Update beam-site for release ${{ github.event.inputs.RELEASE }}." -m "Content generated from commit ${RELEASE_COMMIT}."
             git push -f --set-upstream origin $BRANCH_NAME
       - name: Create beam-site PR
-        working-directory: beam-site
+        working-directory: ${SITE_ROOT_DIR}
         env:
           GH_TOKEN: ${{ github.event.inputs.BEAM_SITE_TOKEN }}
           PR_TITLE: "Publish docs for ${{ github.event.inputs.RELEASE }} release}"
           PR_BODY: "Content generated from  https://github.com/apache/beam/tree/v${RC_TAG}."
         run: |
-            gh pr create -t "$PR_TITLE" -b "$PR_BODY" --base release-docs || echo "PR likely already exists, but has been updated."
+            gh pr create -t "$PR_TITLE" -b "$PR_BODY" --base release-docs

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -232,14 +232,15 @@ jobs:
             BRANCH_NAME=updates_release_${{ github.event.inputs.RELEASE }}
             RC_TAG="v${{ github.event.inputs.RELEASE }}-RC${{ github.event.inputs.RC }}"
              
-            echo "------------------Building Python Doc------------------------"
-            pip install --upgrade pip setuptools wheel
-            pip install -U pip
-            pip install tox
-            cd ${BEAM_ROOT_DIR}
-
             # Get the commit from the beam repo, not the beam-site repo.
+            cd ${BEAM_ROOT_DIR}
             RELEASE_COMMIT=$(git rev-list -n 1 "tags/${RC_TAG}")
+
+            # echo "------------------Building Python Doc------------------------"
+            # pip install --upgrade pip setuptools wheel
+            # pip install -U pip
+            # pip install tox
+
 
             # # TODO(https://github.com/apache/beam/issues/20209): Don't hardcode py version in this file.
             # cd sdks/python && pip install -r build-requirements.txt && tox -e py38-docs

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -240,40 +240,36 @@ jobs:
             # pip install tox
             # # TODO(https://github.com/apache/beam/issues/20209): Don't hardcode py version in this file.
             # pip install -r build-requirements.txt && tox -e py38-docs
-            # GENERATED_PYDOC=${BEAM_ROOT_DIR}/sdks/python/target/docs/_build
-            # rm -rf ${GENERATED_PYDOC}/.doctrees
+            # rm -rf target/docs/_build/.doctrees
       - name: Build Typescript Docs
         working-directory: beam/sdks/typescript
         run: |
-            echo "------------------Building Typescript Doc------------------------"
             npm install ttypescript@1.5.15 && npm ci && npm run docs
-            GENERATED_TYPEDOC=${BEAM_ROOT_DIR}/sdks/typescript/docs
       - name: Build Java Docs
         working-directory: beam
         run: |
             echo "----------------------Building Java Doc----------------------"
             # ./gradlew :sdks:java:javadoc:aggregateJavadoc -PisRelease --no-daemon --no-parallel
-            # GENERATE_JAVADOC=${BEAM_ROOT_DIR}/sdks/java/javadoc/build/docs/javadoc/
-             
-            echo "------------------Updating Release Docs---------------------"
-            cd ${SITE_ROOT_DIR}
+      - name: Update Release Docs
+        working-directory: beam-site
+        run: |
             git checkout -b $BRANCH_NAME release-docs
              
             # echo "..........Copying generated javadoc into beam-site.........."
-            # cp -r ${GENERATE_JAVADOC} javadoc/${{ github.event.inputs.RELEASE }}
+            # cp -r ${BEAM_ROOT_DIR}/sdks/java/javadoc/build/docs/javadoc/ javadoc/${{ github.event.inputs.RELEASE }}
             # # Update current symlink to point to the latest release
             # unlink javadoc/current
             # ln -s ${{ github.event.inputs.RELEASE }} javadoc/current
              
             # echo "............Copying generated pydoc into beam-site.........."
-            # cp -r ${GENERATED_PYDOC} pydoc/${{  github.event.inputs.RELEASE }}
+            # cp -r ${BEAM_ROOT_DIR}/sdks/python/target/docs/_build pydoc/${{  github.event.inputs.RELEASE }}
             # # Update current symlink to point to the latest release
             # unlink pydoc/current
             # ln -s ${{ github.event.inputs.RELEASE }} pydoc/current
              
             echo "............Copying generated typedoc into beam-site.........."
             mkdir -p typedoc
-            cp -r ${GENERATED_TYPEDOC} typedoc/${{ github.event.inputs.RELEASE }}
+            cp -r ${BEAM_ROOT_DIR}/sdks/typescript/docs typedoc/${{ github.event.inputs.RELEASE }}
             # Update current symlink to point to the latest release
             unlink typedoc/current | true
             ln -s ${{ github.event.inputs.RELEASE }} typedoc/current

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -231,7 +231,7 @@ jobs:
              
             echo "------------------Building Typescript Doc------------------------"
             cd ${BEAM_ROOT_DIR}
-            cd sdks/typescript && npm ci && npm run docs
+            cd sdks/typescript && npm install ttypescript@1.5.15 && npm ci && npm run docs
             GENERATED_TYPEDOC=${BEAM_ROOT_DIR}/sdks/typescript/docs
              
             echo "----------------------Building Java Doc----------------------"

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -192,6 +192,7 @@ jobs:
     # Note: if this ever changes to self-hosted, remove the "Remove default github maven configuration" step
     runs-on: ubuntu-latest
     env:
+      RC_TAG: "v${{ github.event.inputs.RELEASE }}-RC${{ github.event.inputs.RC }}"
       BRANCH_NAME: updates_release_${{ github.event.inputs.RELEASE }}
     steps:
       - name: Checkout Beam Repo
@@ -229,7 +230,6 @@ jobs:
         run: |
             BEAM_ROOT_DIR=${{ github.workspace }}/beam
             SITE_ROOT_DIR=${{ github.workspace }}/beam-site
-            RC_TAG="v${{ github.event.inputs.RELEASE }}-RC${{ github.event.inputs.RC }}"
              
             # Get the commit from the beam repo, not the beam-site repo.
             cd ${BEAM_ROOT_DIR}
@@ -285,10 +285,11 @@ jobs:
             git commit -m "Update beam-site for release ${{ github.event.inputs.RELEASE }}." -m "Content generated from commit ${RELEASE_COMMIT}."
             git push -f --set-upstream origin $BRANCH_NAME
       - name: Create beam-site PR
+        working-directory: beam-site
         env:
           GH_TOKEN: ${{ github.event.inputs.BEAM_SITE_TOKEN }}
+          PR_TITLE: "Publish docs for ${{ github.event.inputs.RELEASE }} release}"
+          PR_BODY: "Content generated from  https://github.com/apache/beam/tree/v${RC_TAG}."
         run: |
-            PR_TITLE="Publish docs for ${{ github.event.inputs.RELEASE }} release}"
-            PR_BODY="Content generated from commit https://github.com/apache/beam/tree/${RELEASE_COMMIT}."
             # Update the body if the PR already exists and reopen it. Create it otherwise.
             gh pr edit $BRANCH_NAME -b "$PR_BODY"  && gh pr reopen $BRANCH_NAME || gh pr create -t "$PR_TITLE" -b "$PR_BODY" --base release-docs

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -288,7 +288,7 @@ jobs:
         working-directory: beam-site
         env:
           GH_TOKEN: ${{ github.event.inputs.BEAM_SITE_TOKEN }}
-          PR_TITLE: "Publish docs for ${{ github.event.inputs.RELEASE }} release}"
-          PR_BODY: "Content generated from  https://github.com/apache/beam/tree/v${RC_TAG}."
+          PR_TITLE: "Publish docs for ${{ github.event.inputs.RELEASE }} release"
+          PR_BODY: "Content generated from https://github.com/apache/beam/tree/v${{ env.RC_TAG }}."
         run: |
             gh pr create -t "$PR_TITLE" -b "$PR_BODY" --base release-docs

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -288,6 +288,6 @@ jobs:
             
             echo "............Creating PR.........."
             PR_TITLE="Publish docs for ${RELEASE} release}"
-            PR_BODY="Content generated from commit ${RELEASE_COMMIT}."
+            PR_BODY="Content generated from commit https://github.com/apache/beam/tree/${RELEASE_COMMIT}."
             # Update the title and body if the PR already exists and reopen it. Create it otherwise.
             gh pr edit $BRANCH_NAME -t $PR_TITLE -b $PR_BODY  && gh pr reopen $BRANCH_NAME || gh pr create -t $PR_TITLE -b $PR_BODY --base release-docs

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -191,6 +191,8 @@ jobs:
     if: ${{github.event.inputs.CREATE_BEAM_SITE_PR == 'yes'}}
     # Note: if this ever changes to self-hosted, remove the "Remove default github maven configuration" step
     runs-on: ubuntu-latest
+    env:
+      BRANCH_NAME: updates_release_${{ github.event.inputs.RELEASE }}
     steps:
       - name: Checkout Beam Repo
         uses: actions/checkout@v3
@@ -223,13 +225,10 @@ jobs:
         # net.linguica.gradle.maven.settings plugin and github's provided maven
         # settings.xml file
         run: rm ~/.m2/settings.xml || true
-      - name: create documentation pr for website
-        env:
-          GH_TOKEN: ${{ github.event.inputs.BEAM_SITE_TOKEN }}
+      - name: create documentation commit for website
         run: |
             BEAM_ROOT_DIR=${{ github.workspace }}/beam
             SITE_ROOT_DIR=${{ github.workspace }}/beam-site
-            BRANCH_NAME=updates_release_${{ github.event.inputs.RELEASE }}
             RC_TAG="v${{ github.event.inputs.RELEASE }}-RC${{ github.event.inputs.RC }}"
              
             # Get the commit from the beam repo, not the beam-site repo.
@@ -285,9 +284,11 @@ jobs:
             git add -A
             git commit -m "Update beam-site for release ${{ github.event.inputs.RELEASE }}." -m "Content generated from commit ${RELEASE_COMMIT}."
             git push -f --set-upstream origin $BRANCH_NAME
-            
-            echo "............Creating PR.........."
-            PR_TITLE="Publish docs for ${RELEASE} release}"
+      - name: Create beam-site PR
+        env:
+          GH_TOKEN: ${{ github.event.inputs.BEAM_SITE_TOKEN }}
+        run: |
+            PR_TITLE="Publish docs for ${{ github.event.inputs.RELEASE }} release}"
             PR_BODY="Content generated from commit https://github.com/apache/beam/tree/${RELEASE_COMMIT}."
-            # Update the title and body if the PR already exists and reopen it. Create it otherwise.
-            gh pr edit $BRANCH_NAME -t "$PR_TITLE" -b "$PR_BODY"  && gh pr reopen $BRANCH_NAME || gh pr create -t "$PR_TITLE" -b "$PR_BODY" --base release-docs
+            # Update the body if the PR already exists and reopen it. Create it otherwise.
+            gh pr edit $BRANCH_NAME -b "$PR_BODY"  && gh pr reopen $BRANCH_NAME || gh pr create -t "$PR_TITLE" -b "$PR_BODY" --base release-docs

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -290,4 +290,4 @@ jobs:
             PR_TITLE="Publish docs for ${RELEASE} release}"
             PR_BODY="Content generated from commit https://github.com/apache/beam/tree/${RELEASE_COMMIT}."
             # Update the title and body if the PR already exists and reopen it. Create it otherwise.
-            gh pr edit $BRANCH_NAME -t $PR_TITLE -b $PR_BODY  && gh pr reopen $BRANCH_NAME || gh pr create -t $PR_TITLE -b $PR_BODY --base release-docs
+            gh pr edit $BRANCH_NAME -t "$PR_TITLE" -b "$PR_BODY"  && gh pr reopen $BRANCH_NAME || gh pr create -t "$PR_TITLE" -b "$PR_BODY" --base release-docs

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -35,6 +35,10 @@ on:
         description: Whether to create the documentation update PR against apache/beam-site.
         required: true
         default: 'no'
+      BEAM_SITE_TOKEN:
+        description: Github token with permissions to create prs on your beam-site fork.
+        required: true
+        default: ''
 
 jobs:
   publish_java_artifacts:
@@ -220,7 +224,7 @@ jobs:
         run: rm ~/.m2/settings.xml || true
       - name: create documentation pr for website
         env:
-          GH_TOKEN: ${{ github.token }}
+          GH_TOKEN: ${{ github.event.inputs.BEAM_SITE_TOKEN }}
         run: |
             BEAM_ROOT_DIR=${{ github.workspace }}/beam
             SITE_ROOT_DIR=${{ github.workspace }}/beam-site
@@ -280,9 +284,6 @@ jobs:
             git config user.email actions@"$RUNNER_NAME".local
             git add -A
             git commit -m "Update beam-site for release ${{ github.event.inputs.RELEASE }}." -m "Content generated from commit ${RELEASE_COMMIT}."
-           
-            echo "............Pushing to remote ${USER_REMOTE_URL}.........."
-            git push -f ${USER_REMOTE_URL}
             
             echo "............Creating PR.........."
-            gh pr create -f
+            gh pr create -f --head ${{ github.actor }}:updates_release_${{ github.event.inputs.RELEASE }}

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -275,6 +275,9 @@ jobs:
             unlink typedoc/current | true
             ln -s ${{ github.event.inputs.RELEASE }} typedoc/current
              
+            echo "............Creating PR.........."
+            git config user.name $GITHUB_ACTOR
+            git config user.email actions@"$RUNNER_NAME".local
             git add -A
             git commit -m "Update beam-site for release ${{ github.event.inputs.RELEASE }}." -m "Content generated from commit ${RELEASE_COMMIT}."
            

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -236,37 +236,37 @@ jobs:
             # Get the commit from the beam repo, not the beam-site repo.
             RELEASE_COMMIT=$(git rev-list -n 1 "tags/${RC_TAG}")
 
-            # TODO(https://github.com/apache/beam/issues/20209): Don't hardcode py version in this file.
-            cd sdks/python && pip install -r build-requirements.txt && tox -e py38-docs
-            GENERATED_PYDOC=${BEAM_ROOT_DIR}/sdks/python/target/docs/_build
-            rm -rf ${GENERATED_PYDOC}/.doctrees
+            # # TODO(https://github.com/apache/beam/issues/20209): Don't hardcode py version in this file.
+            # cd sdks/python && pip install -r build-requirements.txt && tox -e py38-docs
+            # GENERATED_PYDOC=${BEAM_ROOT_DIR}/sdks/python/target/docs/_build
+            # rm -rf ${GENERATED_PYDOC}/.doctrees
              
             echo "------------------Building Typescript Doc------------------------"
             cd ${BEAM_ROOT_DIR}
             cd sdks/typescript && npm install ttypescript@1.5.15 && npm ci && npm run docs
             GENERATED_TYPEDOC=${BEAM_ROOT_DIR}/sdks/typescript/docs
              
-            echo "----------------------Building Java Doc----------------------"
-            cd ${BEAM_ROOT_DIR}
-            ./gradlew :sdks:java:javadoc:aggregateJavadoc -PisRelease --no-daemon --no-parallel
-            GENERATE_JAVADOC=${BEAM_ROOT_DIR}/sdks/java/javadoc/build/docs/javadoc/
+            # echo "----------------------Building Java Doc----------------------"
+            # cd ${BEAM_ROOT_DIR}
+            # ./gradlew :sdks:java:javadoc:aggregateJavadoc -PisRelease --no-daemon --no-parallel
+            # GENERATE_JAVADOC=${BEAM_ROOT_DIR}/sdks/java/javadoc/build/docs/javadoc/
              
             echo "------------------Updating Release Docs---------------------"
             cd ${SITE_ROOT_DIR}
             git checkout release-docs
             git checkout -b updates_release_${{ github.event.inputs.RELEASE }} release-docs
              
-            echo "..........Copying generated javadoc into beam-site.........."
-            cp -r ${GENERATE_JAVADOC} javadoc/${{ github.event.inputs.RELEASE }}
-            # Update current symlink to point to the latest release
-            unlink javadoc/current
-            ln -s ${{ github.event.inputs.RELEASE }} javadoc/current
+            # echo "..........Copying generated javadoc into beam-site.........."
+            # cp -r ${GENERATE_JAVADOC} javadoc/${{ github.event.inputs.RELEASE }}
+            # # Update current symlink to point to the latest release
+            # unlink javadoc/current
+            # ln -s ${{ github.event.inputs.RELEASE }} javadoc/current
              
-            echo "............Copying generated pydoc into beam-site.........."
-            cp -r ${GENERATED_PYDOC} pydoc/${{  github.event.inputs.RELEASE }}
-            # Update current symlink to point to the latest release
-            unlink pydoc/current
-            ln -s ${{ github.event.inputs.RELEASE }} pydoc/current
+            # echo "............Copying generated pydoc into beam-site.........."
+            # cp -r ${GENERATED_PYDOC} pydoc/${{  github.event.inputs.RELEASE }}
+            # # Update current symlink to point to the latest release
+            # unlink pydoc/current
+            # ln -s ${{ github.event.inputs.RELEASE }} pydoc/current
              
             echo "............Copying generated typedoc into beam-site.........."
             mkdir -p typedoc

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -241,7 +241,6 @@ jobs:
             # pip install -U pip
             # pip install tox
 
-
             # # TODO(https://github.com/apache/beam/issues/20209): Don't hardcode py version in this file.
             # cd sdks/python && pip install -r build-requirements.txt && tox -e py38-docs
             # GENERATED_PYDOC=${BEAM_ROOT_DIR}/sdks/python/target/docs/_build
@@ -288,4 +287,4 @@ jobs:
             git push -f --set-upstream origin $BRANCH_NAME
             
             echo "............Creating PR.........."
-            gh pr create --title "Update beam-site for release ${{ github.event.inputs.RELEASE }}" --body "Content generated from commit ${RELEASE_COMMIT}." --base release-docs
+            gh pr create --title "Publish docs for ${RELEASE} release}" --body "Content generated from commit ${RELEASE_COMMIT}." --base release-docs

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -203,7 +203,6 @@ jobs:
         with:
           repository: apache/beam-site
           path: beam-site
-          fetch-depth: 0
           token: ${{ github.event.inputs.BEAM_SITE_TOKEN }}
           ref: release-docs
       - name: Install Python 3.8
@@ -230,6 +229,7 @@ jobs:
         run: |
             BEAM_ROOT_DIR=${{ github.workspace }}/beam
             SITE_ROOT_DIR=${{ github.workspace }}/beam-site
+            BRANCH_NAME=updates_release_${{ github.event.inputs.RELEASE }}
             USER_REMOTE_URL=git@github.com:${{ github.actor }}/beam-site
             RC_TAG="v${{ github.event.inputs.RELEASE }}-RC${{ github.event.inputs.RC }}"
              
@@ -259,7 +259,7 @@ jobs:
              
             echo "------------------Updating Release Docs---------------------"
             cd ${SITE_ROOT_DIR}
-            git checkout -b updates_release_${{ github.event.inputs.RELEASE }} release-docs
+            git checkout -b $BRANCH_NAME release-docs
              
             # echo "..........Copying generated javadoc into beam-site.........."
             # cp -r ${GENERATE_JAVADOC} javadoc/${{ github.event.inputs.RELEASE }}
@@ -285,7 +285,7 @@ jobs:
             git config user.email actions@"$RUNNER_NAME".local
             git add -A
             git commit -m "Update beam-site for release ${{ github.event.inputs.RELEASE }}." -m "Content generated from commit ${RELEASE_COMMIT}."
-            git push -f
+            git push -f --set-upstream origin $BRANCH_NAME
             
             echo "............Creating PR.........."
-            gh pr create -f --base release-docs --head ${{ github.actor }}:updates_release_${{ github.event.inputs.RELEASE }}
+            gh pr create -f --base release-docs --head ${{ github.actor }}:$BRANCH_NAME

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -274,7 +274,7 @@ jobs:
             unlink typedoc/current | true
             ln -s ${{ github.event.inputs.RELEASE }} typedoc/current
       - name: Create beam-site PR
-        working-directory: ${BEAM_ROOT_DIR}
+        working-directory: beam
         run: |
             # Get the commit from the beam repo, not the beam-site repo.
             RELEASE_COMMIT=$(git rev-list -n 1 "tags/${RC_TAG}")

--- a/website/www/site/content/en/contribute/release-guide.md
+++ b/website/www/site/content/en/contribute/release-guide.md
@@ -456,7 +456,7 @@ Consider adding known issues there for minor issues instead of accepting cherry 
 
 ## 8. Build a release candidate
 
-### Checklist before proceeding
+## Checklist before proceeding
 
 * Release Manager’s GPG key is published to `dist.apache.org`;
 * Release Manager’s GPG key is configured in `git` configuration;
@@ -509,7 +509,7 @@ is perfectly safe since the script does not depend on the current working tree.
 
 See the source of the script for more details, or to run commands manually in case of a problem.
 
-### Run build_release_candidate GitHub Action to create a release candidate
+## Run build_release_candidate GitHub Action to create a release candidate
 
 Note: This step is partially automated (in progress), so part of the rc creation is done by GitHub Actions and the rest is done by a script.
 You don't need to wait for the action to complete to start running the script.
@@ -520,6 +520,8 @@ You don't need to wait for the action to complete to start running the script.
   1. Clone the repo at the selected RC tag.
   1. Run gradle publish to push java artifacts into Maven staging repo.
   1. Stage SDK docker images to [docker hub Apache organization](https://hub.docker.com/search?q=apache%2Fbeam&type=image).
+  1. Build javadoc, pydoc, typedocs for a PR to update beam-site.
+     * **NOTE**: Do not merge this PR until after an RC has been approved (see "Finalize the Release").
 
 #### Tasks you need to do manually
 
@@ -556,6 +558,7 @@ help with this step. Please email `dev@` and ask a member of the `beam` DockerHu
      * Copy python doc into beam-site
      * Copy java doc into beam-site
      * **NOTE**: Do not merge this PR until after an RC has been approved (see "Finalize the Release").
+Skip this step if you already did it with the build_release_candidate GitHub Actions workflow.
 
 #### Tasks you need to do manually
   1. Verify the script worked.

--- a/website/www/site/content/en/contribute/release-guide.md
+++ b/website/www/site/content/en/contribute/release-guide.md
@@ -456,7 +456,7 @@ Consider adding known issues there for minor issues instead of accepting cherry 
 
 ## 8. Build a release candidate
 
-## Checklist before proceeding
+#### Checklist before proceeding
 
 * Release Manager’s GPG key is published to `dist.apache.org`;
 * Release Manager’s GPG key is configured in `git` configuration;
@@ -509,7 +509,7 @@ is perfectly safe since the script does not depend on the current working tree.
 
 See the source of the script for more details, or to run commands manually in case of a problem.
 
-## Run build_release_candidate GitHub Action to create a release candidate
+### Run build_release_candidate GitHub Action to create a release candidate
 
 Note: This step is partially automated (in progress), so part of the rc creation is done by GitHub Actions and the rest is done by a script.
 You don't need to wait for the action to complete to start running the script.


### PR DESCRIPTION
Create Docs PR with a Github Action for building release artifacts.

Based largely on the existing build_release_candidate.sh script, but with the following changes:

* No longer quarantine each doc generator into it's own clone.
* Leverage available steps for checking out code instead.
* Use `gh` instead of `hub`.
* Adds a use of the release managers' github token.
* Converts parts to steps to clarify logging and failures.
  * Uses local envs, and working directory to clarify where we're working. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
