### PR TITLE
[prism] Fail jobs on SDK disconnect.

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
@@ -209,11 +209,11 @@ func (rb RunBundle) LogValue() slog.Value {
 // remaining.
 func (em *ElementManager) Bundles(ctx context.Context, nextBundID func() string) <-chan RunBundle {
 	runStageCh := make(chan RunBundle)
-	ctx, cancelFn := context.WithCancel(ctx)
+	ctx, cancelFn := context.WithCancelCause(ctx)
 	go func() {
 		em.pendingElements.Wait()
 		slog.Debug("no more pending elements: terminating pipeline")
-		cancelFn()
+		cancelFn(fmt.Errorf("elementManager out of elements, cleaning up"))
 		// Ensure the watermark evaluation goroutine exits.
 		em.refreshCond.Broadcast()
 	}()

--- a/sdks/go/pkg/beam/runners/prism/internal/execute.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/execute.go
@@ -105,7 +105,7 @@ func runEnvironment(ctx context.Context, j *jobservices.Job, env string, wk *wor
 			slog.Error("unmarshing environment payload", err, slog.String("envID", wk.ID))
 		}
 		externalEnvironment(ctx, ep, wk)
-		slog.Info("environment stopped", slog.String("envID", wk.String()), slog.String("job", j.String()))
+		slog.Debug("environment stopped", slog.String("envID", wk.String()), slog.String("job", j.String()))
 	default:
 		panic(fmt.Sprintf("environment %v with urn %v unimplemented", env, e.GetUrn()))
 	}
@@ -304,7 +304,7 @@ func executePipeline(ctx context.Context, wk *worker.W, j *jobservices.Job) erro
 			s.Execute(ctx, j, wk, comps, em, rb)
 		}(rb)
 	}
-	slog.Info("pipeline done!", slog.String("job", j.String()))
+	slog.Debug("pipeline done!", slog.String("job", j.String()))
 	return nil
 }
 

--- a/sdks/go/pkg/beam/runners/prism/internal/jobservices/job.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/jobservices/job.go
@@ -137,9 +137,13 @@ func (j *Job) SendMsg(msg string) {
 func (j *Job) sendState(state jobpb.JobState_Enum) {
 	j.streamCond.L.Lock()
 	defer j.streamCond.L.Unlock()
-	j.stateTime = time.Now()
-	j.stateIdx++
-	j.state.Store(state)
+	old := j.state.Load()
+	// Never overwrite a failed state with another one.
+	if old != jobpb.JobState_FAILED {
+		j.state.Store(state)
+		j.stateTime = time.Now()
+		j.stateIdx++
+	}
 	j.streamCond.Broadcast()
 }
 

--- a/sdks/go/pkg/beam/runners/prism/internal/jobservices/job.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/jobservices/job.go
@@ -167,5 +167,5 @@ func (j *Job) Failed(err error) {
 	slog.Error("job failed", slog.Any("job", j), slog.Any("error", err))
 	j.failureErr = err
 	j.sendState(jobpb.JobState_FAILED)
-	j.CancelFn(err)
+	j.CancelFn(fmt.Errorf("jobFailed %v: %w", j, err))
 }

--- a/sdks/go/pkg/beam/runners/prism/internal/jobservices/management.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/jobservices/management.go
@@ -226,7 +226,7 @@ func (s *Server) GetMessageStream(req *jobpb.JobMessagesRequest, stream jobpb.Jo
 			job.streamCond.Wait()
 			select { // Quit out if the external connection is done.
 			case <-stream.Context().Done():
-				return stream.Context().Err()
+				return context.Cause(stream.Context())
 			default:
 			}
 		}

--- a/sdks/go/pkg/beam/runners/prism/internal/stage.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/stage.go
@@ -103,7 +103,7 @@ func (s *stage) Execute(ctx context.Context, j *jobservices.Job, wk *worker.W, c
 		closed := make(chan struct{})
 		close(closed)
 		dataReady = closed
-	case wk.ID:
+	case wk.Env:
 		b = &worker.B{
 			PBDID:  s.ID,
 			InstID: rb.BundleID,

--- a/sdks/go/pkg/beam/runners/prism/internal/stage.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/stage.go
@@ -117,15 +117,10 @@ func (s *stage) Execute(ctx context.Context, j *jobservices.Job, wk *worker.W, c
 
 		slog.Debug("Execute: processing", "bundle", rb)
 		defer b.Cleanup(wk)
-		b.Fail = func(errMsg string) {
-			slog.Debug("job failed", "bundle", rb, "job", j)
-			err := fmt.Errorf("stage exec %v", errMsg)
-			j.Failed(err)
-		}
 		dataReady = b.ProcessOn(ctx, wk)
 	default:
 		err := fmt.Errorf("unknown environment[%v]", s.envID)
-		slog.Error("Execute", err)
+		slog.Error("Execute", "error", err)
 		panic(err)
 	}
 
@@ -195,6 +190,9 @@ progress:
 	var resp *fnpb.ProcessBundleResponse
 	select {
 	case resp = <-b.Resp:
+		if b.BundleErr != nil {
+			return b.BundleErr
+		}
 	case <-ctx.Done():
 		return context.Cause(ctx)
 	}

--- a/sdks/go/pkg/beam/runners/prism/internal/worker/bundle.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/bundle.go
@@ -152,8 +152,8 @@ func (b *B) Cleanup(wk *W) {
 }
 
 // Progress sends a progress request for the given bundle to the passed in worker, blocking on the response.
-func (b *B) Progress(wk *W) (*fnpb.ProcessBundleProgressResponse, error) {
-	resp := wk.sendInstruction(&fnpb.InstructionRequest{
+func (b *B) Progress(ctx context.Context, wk *W) (*fnpb.ProcessBundleProgressResponse, error) {
+	resp := wk.sendInstruction(ctx, &fnpb.InstructionRequest{
 		Request: &fnpb.InstructionRequest_ProcessBundleProgress{
 			ProcessBundleProgress: &fnpb.ProcessBundleProgressRequest{
 				InstructionId: b.InstID,
@@ -167,8 +167,8 @@ func (b *B) Progress(wk *W) (*fnpb.ProcessBundleProgressResponse, error) {
 }
 
 // Split sends a split request for the given bundle to the passed in worker, blocking on the response.
-func (b *B) Split(wk *W, fraction float64, allowedSplits []int64) (*fnpb.ProcessBundleSplitResponse, error) {
-	resp := wk.sendInstruction(&fnpb.InstructionRequest{
+func (b *B) Split(ctx context.Context, wk *W, fraction float64, allowedSplits []int64) (*fnpb.ProcessBundleSplitResponse, error) {
+	resp := wk.sendInstruction(ctx, &fnpb.InstructionRequest{
 		Request: &fnpb.InstructionRequest_ProcessBundleSplit{
 			ProcessBundleSplit: &fnpb.ProcessBundleSplitRequest{
 				InstructionId: b.InstID,

--- a/sdks/go/pkg/beam/runners/prism/internal/worker/bundle_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/bundle_test.go
@@ -23,7 +23,7 @@ import (
 )
 
 func TestBundle_ProcessOn(t *testing.T) {
-	wk := New("test")
+	wk := New("test", "testEnv")
 	b := &B{
 		InstID:      "testInst",
 		PBDID:       "testPBDID",

--- a/sdks/go/pkg/beam/runners/prism/internal/worker/worker.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/worker.go
@@ -248,6 +248,7 @@ func (wk *W) GetProcessBundleDescriptor(ctx context.Context, req *fnpb.GetProces
 	return desc, nil
 }
 
+// Connected indicates whether the worker has connected to the control RPC.
 func (wk *W) Connected() bool {
 	return wk.connected.Load()
 }
@@ -308,7 +309,7 @@ func (wk *W) Control(ctrl fnpb.BeamFnControl_ControlServer) error {
 				})
 			}
 			wk.mu.Unlock()
-			return ctrl.Context().Err()
+			return context.Cause(ctrl.Context())
 		case err := <-done:
 			if err != nil {
 				slog.Warn("Control done", "error", err, "worker", wk)
@@ -374,7 +375,7 @@ func (wk *W) Data(data fnpb.BeamFnData_DataServer) error {
 			}
 		case <-data.Context().Done():
 			slog.Debug("Data context canceled")
-			return data.Context().Err()
+			return context.Cause(data.Context())
 		}
 	}
 }

--- a/sdks/go/pkg/beam/runners/prism/internal/worker/worker_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/worker_test.go
@@ -32,14 +32,14 @@ import (
 )
 
 func TestWorker_New(t *testing.T) {
-	w := New("test")
+	w := New("test", "testEnv")
 	if got, want := w.ID, "test"; got != want {
 		t.Errorf("New(%q) = %v, want %v", want, got, want)
 	}
 }
 
 func TestWorker_NextInst(t *testing.T) {
-	w := New("test")
+	w := New("test", "testEnv")
 
 	instIDs := map[string]struct{}{}
 	for i := 0; i < 100; i++ {
@@ -51,7 +51,7 @@ func TestWorker_NextInst(t *testing.T) {
 }
 
 func TestWorker_NextStage(t *testing.T) {
-	w := New("test")
+	w := New("test", "testEnv")
 
 	stageIDs := map[string]struct{}{}
 	for i := 0; i < 100; i++ {
@@ -63,7 +63,7 @@ func TestWorker_NextStage(t *testing.T) {
 }
 
 func TestWorker_GetProcessBundleDescriptor(t *testing.T) {
-	w := New("test")
+	w := New("test", "testEnv")
 
 	id := "available"
 	w.Descriptors[id] = &fnpb.ProcessBundleDescriptor{
@@ -93,7 +93,7 @@ func serveTestWorker(t *testing.T) (context.Context, *W, *grpc.ClientConn) {
 	ctx, cancelFn := context.WithCancel(context.Background())
 	t.Cleanup(cancelFn)
 
-	w := New("test")
+	w := New("test", "testEnv")
 	lis := bufconn.Listen(2048)
 	w.lis = lis
 	t.Cleanup(func() { w.Stop() })

--- a/sdks/go/pkg/beam/testing/passert/equals_test.go
+++ b/sdks/go/pkg/beam/testing/passert/equals_test.go
@@ -184,7 +184,7 @@ func ExampleEqualsList_mismatch() {
 	err = unwrapError(err)
 
 	// Process error for cleaner example output, demonstrating the diff.
-	processedErr := strings.SplitAfter(err.Error(), "/passert.failIfBadEntries] failed:")
+	processedErr := strings.SplitAfter(err.Error(), ".failIfBadEntries] failed:")
 	fmt.Println(processedErr[1])
 
 	// Output:


### PR DESCRIPTION
If the control connection for a job is lost, eg. by an SDK worker crash (detected via grpc stream context cancel), then fail all extant instructions, and terminate the job, rather than leave it running perpetually.

Further, ensure the extant bundles are cleaned up from the element manager, to allow failed jobs to be properly garbage collected.

Reduce routine log messages to debug to avoid noise.

Use ctx.WithCancelCause properly, which requires calling context.Cause on the context.

Restructures the bundle processing loop in execute.go to better allow for eager bundle splitting. Would need to move bundle data acquisition to be moved out of stage.Execute, and split there.

Special thanks to the Swift SDK for being in a crashing on worker state to reliably validate this.

Related #28187

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
