### PR TITLE
[BEAM-11151]Adds the ToStringFn Bundle Processor to Golang

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/to_string.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/to_string.go
@@ -35,13 +35,11 @@ func (m *ToString) Up(ctx context.Context) error {
 	return nil
 }
 
-func (m *ToString) StartBundle(ctx context.Context, id string,
-	data DataContext) error {
+func (m *ToString) StartBundle(ctx context.Context, id string, data DataContext) error {
 	return m.Out.StartBundle(ctx, id, data)
 }
 
-func (m *ToString) ProcessElement(ctx context.Context, elm *FullValue,
-	values ...ReStream) error {
+func (m *ToString) ProcessElement(ctx context.Context, elm *FullValue, values ...ReStream) error {
 	ret := FullValue{
 		Windows:   elm.Windows,
 		Elm:       elm.Elm,

--- a/sdks/go/pkg/beam/core/runtime/exec/to_string.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/to_string.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package exec
 
 import (

--- a/sdks/go/pkg/beam/core/runtime/exec/to_string.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/to_string.go
@@ -1,0 +1,50 @@
+package exec
+
+import (
+	"context"
+	"fmt"
+)
+
+type ToString struct {
+	// UID is the unit identifier.
+	UID UnitID
+	// Out is the output node.
+	Out Node
+}
+
+func (m *ToString) ID() UnitID {
+	return m.UID
+}
+
+func (m *ToString) Up(ctx context.Context) error {
+	return nil
+}
+
+func (m *ToString) StartBundle(ctx context.Context, id string,
+	data DataContext) error {
+	return m.Out.StartBundle(ctx, id, data)
+}
+
+func (m *ToString) ProcessElement(ctx context.Context, elm *FullValue,
+	values ...ReStream) error {
+	ret := FullValue{
+		Windows:   elm.Windows,
+		Elm:       elm.Elm,
+		Elm2:      fmt.Sprintf("%v", elm.Elm2),
+		Timestamp: elm.Timestamp,
+	}
+
+	return m.Out.ProcessElement(ctx, &ret, values...)
+}
+
+func (m *ToString) FinishBundle(ctx context.Context) error {
+	return m.Out.FinishBundle(ctx)
+}
+
+func (m *ToString) Down(ctx context.Context) error {
+	return nil
+}
+
+func (m *ToString) String() string {
+	return fmt.Sprintf("ToStringFn. Out:%v", m.Out)
+}

--- a/sdks/go/pkg/beam/core/runtime/exec/to_string_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/to_string_test.go
@@ -31,6 +31,7 @@ var toStringTestCases = []struct {
 
 func TestToString(t *testing.T) {
 	for _, testCase := range toStringTestCases {
+		ctx := context.Background()
 		out := &CaptureNode{UID: 1}
 		toString := &ToString{UID: 2, Out: out}
 		a := &FixedRoot{UID: 3, Elements: makeKVInput("key", testCase.Input...), Out: toString}
@@ -40,11 +41,11 @@ func TestToString(t *testing.T) {
 			t.Fatalf("failed to construct plan: %v", err)
 		}
 
-		if err := p.Execute(context.Background(), "1", DataContext{}); err != nil {
+		if err := p.Execute(ctx, "1", DataContext{}); err != nil {
 			t.Fatalf("execute failed: %v", err)
 		}
 
-		if err := p.Down(context.Background()); err != nil {
+		if err := p.Down(ctx); err != nil {
 			t.Fatalf("down failed: %v", err)
 		}
 

--- a/sdks/go/pkg/beam/core/runtime/exec/to_string_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/to_string_test.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package exec
 
 import (

--- a/sdks/go/pkg/beam/core/runtime/exec/to_string_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/to_string_test.go
@@ -20,7 +20,7 @@ func TestToString(t *testing.T) {
 		toString := &ToString{UID: 2, Out: out}
 		a := &FixedRoot{UID: 3, Elements: makeKVInput("key", testCase.Input...), Out: toString}
 
-		p, err := NewPlan("a", []Unit{a, toString, out}) // order matters in this test
+		p, err := NewPlan("a", []Unit{a, toString, out})
 		if err != nil {
 			t.Fatalf("failed to construct plan: %v", err)
 		}

--- a/sdks/go/pkg/beam/core/runtime/exec/to_string_test.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/to_string_test.go
@@ -1,0 +1,41 @@
+package exec
+
+import (
+	"context"
+	"testing"
+)
+
+var toStringTestCases = []struct {
+	Input    []any
+	Expected []any
+}{
+	{Input: strInput, Expected: strInput},
+	{Input: intInput, Expected: strInput},
+	{Input: int64Input, Expected: strInput},
+}
+
+func TestToString(t *testing.T) {
+	for _, testCase := range toStringTestCases {
+		out := &CaptureNode{UID: 1}
+		toString := &ToString{UID: 2, Out: out}
+		a := &FixedRoot{UID: 3, Elements: makeKVInput("key", testCase.Input...), Out: toString}
+
+		p, err := NewPlan("a", []Unit{a, toString, out}) // order matters in this test
+		if err != nil {
+			t.Fatalf("failed to construct plan: %v", err)
+		}
+
+		if err := p.Execute(context.Background(), "1", DataContext{}); err != nil {
+			t.Fatalf("execute failed: %v", err)
+		}
+
+		if err := p.Down(context.Background()); err != nil {
+			t.Fatalf("down failed: %v", err)
+		}
+
+		expected := makeKVValues("key", testCase.Expected...)
+		if !equalList(out.Elements, expected) {
+			t.Errorf("tostring returned %v, want %v", extractKeyedValues(out.Elements...), extractKeyedValues(expected...))
+		}
+	}
+}

--- a/sdks/go/pkg/beam/core/runtime/exec/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/translate.go
@@ -823,6 +823,9 @@ func (b *builder) makeLink(from string, id linkID) (Node, error) {
 		}
 		u = sink
 
+	case graphx.URNToString:
+		u = &ToString{UID: b.idgen.New(), Out: out[0]}
+
 	default:
 		panic(fmt.Sprintf("Unexpected transform URN: %v", urn))
 	}

--- a/sdks/go/pkg/beam/core/runtime/graphx/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/graphx/translate.go
@@ -47,6 +47,7 @@ const (
 	URNCombinePerKey = "beam:transform:combine_per_key:v1"
 	URNWindow        = "beam:transform:window_into:v1"
 	URNMapWindows    = "beam:transform:map_windows:v1"
+	URNToString      = "beam:transform:to_string:v1"
 
 	URNIterableSideInput = "beam:side_input:iterable:v1"
 	URNMultimapSideInput = "beam:side_input:multimap:v1"
@@ -106,6 +107,7 @@ func goCapabilities() []string {
 		URNWorkerStatus,
 		URNMonitoringInfoShortID,
 		URNBaseVersionGo,
+		URNToString,
 	}
 	return append(capabilities, knownStandardCoders()...)
 }


### PR DESCRIPTION
This adds the ToStringFn implementation to Golang. This allows Runners to call the SDK to translate an element to a human-readable representation.

Design-doc:
https://s.apache.org/data-sampling-go-sdk-design 

See https://issues.apache.org/jira/browse/BEAM-11151

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
