### PR TITLE
Updating Storage API Autosharding documentation to include that it doesn't work on Runner V2

### DIFF
--- a/website/www/site/content/en/documentation/io/built-in/google-bigquery.md
+++ b/website/www/site/content/en/documentation/io/built-in/google-bigquery.md
@@ -788,6 +788,8 @@ BigQuery Storage Write API for Python SDK currently has some limitations on supp
 {{< paragraph class="language-py" >}}
 **Note:** If you want to run WriteToBigQuery with Storage Write API from the source code, you need to run `./gradlew :sdks:java:io:google-cloud-platform:expansion-service:build` to build the expansion-service jar. If you are running from a released Beam SDK, the jar will already be included.
 
+**Note:** Auto sharding is not currently supported for Python's Storage Write API.
+
 {{< /paragraph >}}
 
 #### Exactly-once semantics

--- a/website/www/site/content/en/documentation/io/built-in/google-bigquery.md
+++ b/website/www/site/content/en/documentation/io/built-in/google-bigquery.md
@@ -877,6 +877,8 @@ explicitly enable this using [`withAutoSharding`](https://beam.apache.org/releas
 
 ***Note:*** `STORAGE_WRITE_API` will default to dynamic sharding when
 `numStorageWriteApiStreams` is set to 0 or is unspecified.
+
+***Note:*** Auto sharding with `STORAGE_WRITE_API` is supported on Dataflow's legacy runner, but **not** on Runner V2
 {{< /paragraph >}}
 
 When using `STORAGE_WRITE_API`, the PCollection returned by


### PR DESCRIPTION
Found when looking at a number of Runner V2 pipelines that stream to BQ with Storage Write API (including #28168)