### PR TITLE
Pin orjson dependency.

### DIFF
--- a/sdks/python/container/py310/base_image_requirements.txt
+++ b/sdks/python/container/py310/base_image_requirements.txt
@@ -100,7 +100,7 @@ oauth2client==4.1.3
 oauthlib==3.2.2
 objsize==0.6.1
 opt-einsum==3.3.0
-orjson==3.9.4
+orjson==3.9.1
 overrides==6.5.0
 packaging==23.1
 pandas==1.5.3

--- a/sdks/python/container/py310/base_image_requirements.txt
+++ b/sdks/python/container/py310/base_image_requirements.txt
@@ -100,7 +100,7 @@ oauth2client==4.1.3
 oauthlib==3.2.2
 objsize==0.6.1
 opt-einsum==3.3.0
-orjson==3.9.1
+orjson==3.9.2
 overrides==6.5.0
 packaging==23.1
 pandas==1.5.3

--- a/sdks/python/container/py311/base_image_requirements.txt
+++ b/sdks/python/container/py311/base_image_requirements.txt
@@ -97,7 +97,7 @@ oauth2client==4.1.3
 oauthlib==3.2.2
 objsize==0.6.1
 opt-einsum==3.3.0
-orjson==3.9.4
+orjson==3.9.1
 overrides==6.5.0
 packaging==23.1
 pandas==1.5.3

--- a/sdks/python/container/py311/base_image_requirements.txt
+++ b/sdks/python/container/py311/base_image_requirements.txt
@@ -97,7 +97,7 @@ oauth2client==4.1.3
 oauthlib==3.2.2
 objsize==0.6.1
 opt-einsum==3.3.0
-orjson==3.9.1
+orjson==3.9.2
 overrides==6.5.0
 packaging==23.1
 pandas==1.5.3

--- a/sdks/python/container/py38/base_image_requirements.txt
+++ b/sdks/python/container/py38/base_image_requirements.txt
@@ -101,7 +101,7 @@ oauth2client==4.1.3
 oauthlib==3.2.2
 objsize==0.6.1
 opt-einsum==3.3.0
-orjson==3.9.4
+orjson==3.9.1
 overrides==6.5.0
 packaging==23.1
 pandas==1.5.3

--- a/sdks/python/container/py38/base_image_requirements.txt
+++ b/sdks/python/container/py38/base_image_requirements.txt
@@ -101,7 +101,7 @@ oauth2client==4.1.3
 oauthlib==3.2.2
 objsize==0.6.1
 opt-einsum==3.3.0
-orjson==3.9.1
+orjson==3.9.2
 overrides==6.5.0
 packaging==23.1
 pandas==1.5.3

--- a/sdks/python/container/py39/base_image_requirements.txt
+++ b/sdks/python/container/py39/base_image_requirements.txt
@@ -101,7 +101,7 @@ oauth2client==4.1.3
 oauthlib==3.2.2
 objsize==0.6.1
 opt-einsum==3.3.0
-orjson==3.9.4
+orjson==3.9.1
 overrides==6.5.0
 packaging==23.1
 pandas==1.5.3

--- a/sdks/python/container/py39/base_image_requirements.txt
+++ b/sdks/python/container/py39/base_image_requirements.txt
@@ -101,7 +101,7 @@ oauth2client==4.1.3
 oauthlib==3.2.2
 objsize==0.6.1
 opt-einsum==3.3.0
-orjson==3.9.1
+orjson==3.9.2
 overrides==6.5.0
 packaging==23.1
 pandas==1.5.3

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -230,7 +230,7 @@ if __name__ == '__main__':
                             language_level=3),
       install_requires=[
           'crcmod>=1.7,<2.0',
-          'orjson<4.0',
+          'orjson<3.9.2',  # https://github.com/ijl/orjson/issues/415
           # Dill doesn't have forwards-compatibility guarantees within minor
           # version. Pickles created with a new version of dill may not unpickle
           # using older version of dill. It is best to use the same version of

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -230,7 +230,7 @@ if __name__ == '__main__':
                             language_level=3),
       install_requires=[
           'crcmod>=1.7,<2.0',
-          'orjson<3.9.2',  # https://github.com/ijl/orjson/issues/415
+          'orjson<3.9.3',  # https://github.com/ijl/orjson/issues/415
           # Dill doesn't have forwards-compatibility guarantees within minor
           # version. Pickles created with a new version of dill may not unpickle
           # using older version of dill. It is best to use the same version of


### PR DESCRIPTION
Remediation for: https://github.com/apache/beam/issues/28318.
If orjson doesn't come up with a fix, we can pin the last tested version.