### PR TITLE
Apply the monkey-patch with backport of newer changes to dill pickler also in Python 3.10.

### DIFF
--- a/sdks/python/apache_beam/internal/dill_pickler.py
+++ b/sdks/python/apache_beam/internal/dill_pickler.py
@@ -46,7 +46,7 @@ import dill
 
 settings = {'dill_byref': None}
 
-if sys.version_info >= (3, 11) and dill.__version__ == "0.3.1.1":
+if sys.version_info >= (3, 10) and dill.__version__ == "0.3.1.1":
   # Let's make dill 0.3.1.1 support Python 3.11.
 
   # The following function is based on 'save_code' from 'dill'


### PR DESCRIPTION
This should help with the segfault portion of https://github.com/apache/beam/issues/27330.