### PR TITLE
Support legacy DATE and TIME logical types in xlang JdbcIO

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java
@@ -56,6 +56,7 @@ import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.grpc.v1p54p0.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Strings;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Maps;
@@ -74,7 +75,23 @@ public class SchemaTranslation {
   private static final Logger LOG = LoggerFactory.getLogger(SchemaTranslation.class);
 
   private static final String URN_BEAM_LOGICAL_DECIMAL = FixedPrecisionNumeric.BASE_IDENTIFIER;
-  private static final String URN_BEAM_LOGICAL_JAVASDK = "beam:logical_type:javasdk:v1";
+
+  private static String getLogicalTypeUrn(String identifier) {
+    if (identifier.startsWith("beam:logical_type:")) {
+      return identifier;
+    } else {
+      String filtered = identifier.replaceAll("[^0-9A-Za-z_]", "").toLowerCase();
+      if (!Strings.isNullOrEmpty(filtered)) {
+        // urn for non-standard Java SDK logical types are assigned with javasdk_<identifier>
+        return String.format("beam:logical_type:javasdk_%s:v1", filtered);
+      } else {
+        // raw "javasdk" name should only be a last resort. Types defined in Beam should have their
+        // own URN.
+        return "beam:logical_type:javasdk:v1";
+      }
+    }
+  }
+
   private static final String URN_BEAM_LOGICAL_MILLIS_INSTANT =
       SchemaApi.LogicalTypes.Enum.MILLIS_INSTANT
           .getValueDescriptor()
@@ -84,18 +101,18 @@ public class SchemaTranslation {
   // TODO(https://github.com/apache/beam/issues/19715): Populate this with a LogicalTypeRegistrar,
   // which includes a way to construct
   // the LogicalType given an argument.
-  private static final ImmutableMap<String, Class<? extends LogicalType<?, ?>>>
-      STANDARD_LOGICAL_TYPES =
-          ImmutableMap.<String, Class<? extends LogicalType<?, ?>>>builder()
-              .put(FixedPrecisionNumeric.IDENTIFIER, FixedPrecisionNumeric.class)
-              .put(MicrosInstant.IDENTIFIER, MicrosInstant.class)
-              .put(SchemaLogicalType.IDENTIFIER, SchemaLogicalType.class)
-              .put(PythonCallable.IDENTIFIER, PythonCallable.class)
-              .put(FixedBytes.IDENTIFIER, FixedBytes.class)
-              .put(VariableBytes.IDENTIFIER, VariableBytes.class)
-              .put(FixedString.IDENTIFIER, FixedString.class)
-              .put(VariableString.IDENTIFIER, VariableString.class)
-              .build();
+  @VisibleForTesting
+  static final ImmutableMap<String, Class<? extends LogicalType<?, ?>>> STANDARD_LOGICAL_TYPES =
+      ImmutableMap.<String, Class<? extends LogicalType<?, ?>>>builder()
+          .put(FixedPrecisionNumeric.IDENTIFIER, FixedPrecisionNumeric.class)
+          .put(MicrosInstant.IDENTIFIER, MicrosInstant.class)
+          .put(SchemaLogicalType.IDENTIFIER, SchemaLogicalType.class)
+          .put(PythonCallable.IDENTIFIER, PythonCallable.class)
+          .put(FixedBytes.IDENTIFIER, FixedBytes.class)
+          .put(VariableBytes.IDENTIFIER, VariableBytes.class)
+          .put(FixedString.IDENTIFIER, FixedString.class)
+          .put(VariableString.IDENTIFIER, VariableString.class)
+          .build();
 
   public static SchemaApi.Schema schemaToProto(Schema schema, boolean serializeLogicalType) {
     String uuid = schema.getUUID() != null ? schema.getUUID().toString() : "";
@@ -179,11 +196,7 @@ public class SchemaTranslation {
                     fieldValueToProto(logicalType.getArgumentType(), logicalType.getArgument()));
           }
         } else {
-          // TODO(https://github.com/apache/beam/issues/19715): "javasdk" types should only
-          // be a last resort. Types defined in Beam should have their own URN, and there
-          // should be a mechanism for users to register their own types by URN.
-          String urn =
-              identifier.startsWith("beam:logical_type:") ? identifier : URN_BEAM_LOGICAL_JAVASDK;
+          String urn = getLogicalTypeUrn(identifier);
           logicalTypeBuilder =
               SchemaApi.LogicalType.newBuilder()
                   .setRepresentation(
@@ -429,15 +442,19 @@ public class SchemaTranslation {
         } else if (urn.equals(URN_BEAM_LOGICAL_DECIMAL)) {
           return FieldType.DECIMAL;
         } else if (urn.startsWith("beam:logical_type:")) {
-          try {
-            return FieldType.logicalType(
-                (LogicalType)
-                    SerializableUtils.deserializeFromByteArray(
-                        logicalType.getPayload().toByteArray(), "logicalType"));
-          } catch (IllegalArgumentException e) {
-            LOG.warn(
-                "Unable to deserialize the logical type {} from proto. Mark as UnknownLogicalType.",
-                urn);
+          if (!logicalType.getPayload().isEmpty()) {
+            try {
+              return FieldType.logicalType(
+                  (LogicalType)
+                      SerializableUtils.deserializeFromByteArray(
+                          logicalType.getPayload().toByteArray(), "logicalType"));
+            } catch (IllegalArgumentException e) {
+              LOG.warn(
+                  "Unable to deserialize the logical type {} from proto. Mark as UnknownLogicalType.",
+                  urn);
+            }
+          } else {
+            LOG.info("Constructing non-standard logical type {} as UnknownLogicalType", urn);
           }
         }
         // assemble an UnknownLogicalType

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java
@@ -443,6 +443,7 @@ public class SchemaTranslation {
           return FieldType.DECIMAL;
         } else if (urn.startsWith("beam:logical_type:")) {
           if (!logicalType.getPayload().isEmpty()) {
+            // logical type has a payload, try to recover the instance by deserialization
             try {
               return FieldType.logicalType(
                   (LogicalType)
@@ -454,6 +455,8 @@ public class SchemaTranslation {
                   urn);
             }
           } else {
+            // logical type does not have a payload. This happens when it is passed xlang.
+            // TODO(yathu) it appears this path is called heavily, consider cache the instance
             LOG.debug("Constructing non-standard logical type {} as UnknownLogicalType", urn);
           }
         }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaTranslation.java
@@ -454,7 +454,7 @@ public class SchemaTranslation {
                   urn);
             }
           } else {
-            LOG.info("Constructing non-standard logical type {} as UnknownLogicalType", urn);
+            LOG.debug("Constructing non-standard logical type {} as UnknownLogicalType", urn);
           }
         }
         // assemble an UnknownLogicalType

--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/LogicalTypes.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/LogicalTypes.java
@@ -19,7 +19,6 @@ package org.apache.beam.sdk.io.jdbc;
 
 import java.sql.JDBCType;
 import java.time.Instant;
-import java.util.Objects;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.logicaltypes.FixedBytes;
@@ -30,11 +29,11 @@ import org.apache.beam.sdk.schemas.logicaltypes.UuidLogicalType;
 import org.apache.beam.sdk.schemas.logicaltypes.VariableBytes;
 import org.apache.beam.sdk.schemas.logicaltypes.VariableString;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
-import org.checkerframework.checker.nullness.qual.NonNull;
-import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** Beam {@link org.apache.beam.sdk.schemas.Schema.LogicalType} implementations of JDBC types. */
 class LogicalTypes {
+  // Logical types of the following static members are not portable and are preserved for
+  // compatibility reason. Consider using portable logical types when adding new ones.
   static final Schema.FieldType JDBC_BIT_TYPE =
       Schema.FieldType.logicalType(
           new PassThroughLogicalType<Boolean>(
@@ -108,71 +107,6 @@ class LogicalTypes {
       return VariableBytes.of(name, length);
     } else {
       return FixedBytes.of(name, length);
-    }
-  }
-
-  /** Base class for JDBC logical types. */
-  abstract static class JdbcLogicalType<T extends @NonNull Object>
-      implements Schema.LogicalType<T, T> {
-    protected final String identifier;
-    protected final Schema.FieldType argumentType;
-    protected final Schema.FieldType baseType;
-    protected final Object argument;
-
-    protected JdbcLogicalType(
-        String identifier,
-        Schema.FieldType argumentType,
-        Schema.FieldType baseType,
-        Object argument) {
-      this.identifier = identifier;
-      this.argumentType = argumentType;
-      this.baseType = baseType;
-      this.argument = argument;
-    }
-
-    @Override
-    public String getIdentifier() {
-      return identifier;
-    }
-
-    @Override
-    public FieldType getArgumentType() {
-      return argumentType;
-    }
-
-    @Override
-    @SuppressWarnings("TypeParameterUnusedInFormals")
-    public <ArgumentT> ArgumentT getArgument() {
-      return (ArgumentT) argument;
-    }
-
-    @Override
-    public Schema.FieldType getBaseType() {
-      return baseType;
-    }
-
-    @Override
-    public T toBaseType(T input) {
-      return input;
-    }
-
-    @Override
-    public boolean equals(@Nullable Object o) {
-      if (this == o) {
-        return true;
-      }
-      if (!(o instanceof JdbcLogicalType)) {
-        return false;
-      }
-      JdbcLogicalType<?> that = (JdbcLogicalType<?>) o;
-      return Objects.equals(identifier, that.identifier)
-          && Objects.equals(baseType, that.baseType)
-          && Objects.equals(argument, that.argument);
-    }
-
-    @Override
-    public int hashCode() {
-      return Objects.hash(identifier, baseType, argument);
     }
   }
 }

--- a/sdks/python/apache_beam/io/external/xlang_jdbcio_it_test.py
+++ b/sdks/python/apache_beam/io/external/xlang_jdbcio_it_test.py
@@ -17,6 +17,7 @@
 
 # pytype: skip-file
 
+import datetime
 import logging
 import time
 import typing
@@ -60,7 +61,8 @@ JdbcTestRow = typing.NamedTuple(
     "JdbcTestRow",
     [("f_id", int), ("f_float", float), ("f_char", str), ("f_varchar", str),
      ("f_bytes", bytes), ("f_varbytes", bytes), ("f_timestamp", Timestamp),
-     ("f_decimal", Decimal)],
+     ("f_decimal", Decimal), ("f_date", datetime.date),
+     ("f_time", datetime.time)],
 )
 coders.registry.register_coder(JdbcTestRow, coders.RowCoder)
 
@@ -144,7 +146,11 @@ class CrossLanguageJdbcIOTest(unittest.TestCase):
             # In alignment with Java Instant which supports milli precision.
             Timestamp.of(seconds=round(time.time(), 3)),
             # Test both positive and negative numbers.
-            Decimal(f'{i-1}.23')) for i in range(ROW_COUNT)
+            Decimal(f'{i-1}.23'),
+            # Test both date before or after EPOCH
+            datetime.date(1969 + i, i % 12 + 1, i % 31 + 1),
+            datetime.time(i % 24, i % 60, i % 60, (i * 100) % 1_000_000))
+        for i in range(ROW_COUNT)
     ]
     expected_row = []
     for row in inserted_rows:
@@ -163,7 +169,9 @@ class CrossLanguageJdbcIOTest(unittest.TestCase):
               f_bytes,
               row.f_bytes,
               row.f_timestamp,
-              row.f_decimal))
+              row.f_decimal,
+              row.f_date,
+              row.f_time))
 
     with TestPipeline() as p:
       p.not_use_test_runner_api = True

--- a/sdks/python/apache_beam/io/external/xlang_jdbcio_it_test.py
+++ b/sdks/python/apache_beam/io/external/xlang_jdbcio_it_test.py
@@ -134,7 +134,7 @@ class CrossLanguageJdbcIOTest(unittest.TestCase):
         "f_float DOUBLE PRECISION, " + "f_char CHAR(10), " +
         "f_varchar VARCHAR(10), " + f"f_bytes {binary_type[0]}, " +
         f"f_varbytes {binary_type[1]}, " + "f_timestamp TIMESTAMP(3), " +
-        "f_decimal DECIMAL(10, 2), " + "f_date DATE, " + "f_time TIME)")
+        "f_decimal DECIMAL(10, 2), " + "f_date DATE, " + "f_time TIME(3))")
     inserted_rows = [
         JdbcTestRow(
             i,
@@ -149,7 +149,7 @@ class CrossLanguageJdbcIOTest(unittest.TestCase):
             Decimal(f'{i-1}.23'),
             # Test both date before or after EPOCH
             datetime.date(1969 + i, i % 12 + 1, i % 31 + 1),
-            datetime.time(i % 24, i % 60, i % 60, (i * 100) % 1_000_000))
+            datetime.time(i % 24, i % 60, i % 60, (i * 1000) % 1_000_000))
         for i in range(ROW_COUNT)
     ]
     expected_row = []

--- a/sdks/python/apache_beam/io/external/xlang_jdbcio_it_test.py
+++ b/sdks/python/apache_beam/io/external/xlang_jdbcio_it_test.py
@@ -134,7 +134,7 @@ class CrossLanguageJdbcIOTest(unittest.TestCase):
         "f_float DOUBLE PRECISION, " + "f_char CHAR(10), " +
         "f_varchar VARCHAR(10), " + f"f_bytes {binary_type[0]}, " +
         f"f_varbytes {binary_type[1]}, " + "f_timestamp TIMESTAMP(3), " +
-        "f_decimal DECIMAL(10, 2))")
+        "f_decimal DECIMAL(10, 2), " + "f_date DATE, " + "f_time TIME)")
     inserted_rows = [
         JdbcTestRow(
             i,

--- a/sdks/python/apache_beam/io/jdbc.py
+++ b/sdks/python/apache_beam/io/jdbc.py
@@ -86,6 +86,7 @@
 
 # pytype: skip-file
 
+import datetime
 import typing
 
 import numpy as np
@@ -94,7 +95,10 @@ from apache_beam.coders import RowCoder
 from apache_beam.transforms.external import BeamJarExpansionService
 from apache_beam.transforms.external import ExternalTransform
 from apache_beam.transforms.external import NamedTupleBasedPayloadBuilder
+from apache_beam.typehints.schemas import LogicalType
+from apache_beam.typehints.schemas import MillisInstant
 from apache_beam.typehints.schemas import typing_to_runner_api
+from apache_beam.utils.timestamp import Timestamp
 
 __all__ = [
     'WriteToJdbc',
@@ -355,3 +359,89 @@ class ReadFromJdbc(ExternalTransform):
         ),
         expansion_service or default_io_expansion_service(classpath),
     )
+
+
+@LogicalType.register_logical_type
+class JdbcDateType(LogicalType[datetime.date, MillisInstant, str]):
+  """Support of Legacy JdbcIO DATE logical type."""
+  def __init__(self, argument=""):
+    pass
+
+  @classmethod
+  def representation_type(cls):
+    # type: () -> type
+    return Timestamp
+
+  @classmethod
+  def urn(cls):
+    return "beam:logical_type:javasdk_date:v1"
+
+  @classmethod
+  def language_type(cls):
+    return datetime.date
+
+  def to_representation_type(self, value):
+    # type: (datetime.date) -> Timestamp
+    return Timestamp.from_utc_datetime(
+        datetime.datetime.combine(
+            value, datetime.datetime.min.time(), tzinfo=datetime.timezone.utc))
+
+  def to_language_type(self, value):
+    # type: (Timestamp) -> datetime.date
+
+    return value.to_utc_datetime().date()
+
+  @classmethod
+  def argument_type(cls):
+    return str
+
+  def argument(self):
+    return ""
+
+  @classmethod
+  def _from_typing(cls, typ):
+    return cls()
+
+
+@LogicalType.register_logical_type
+class JdbcTimeType(LogicalType[datetime.time, MillisInstant, str]):
+  """Support of Legacy JdbcIO TIME logical type."""
+  def __init__(self, argument=""):
+    pass
+
+  @classmethod
+  def representation_type(cls):
+    # type: () -> type
+    return Timestamp
+
+  @classmethod
+  def urn(cls):
+    return "beam:logical_type:javasdk_time:v1"
+
+  @classmethod
+  def language_type(cls):
+    return datetime.time
+
+  def to_representation_type(self, value):
+    # type: (datetime.date) -> Timestamp
+    return Timestamp.from_utc_datetime(
+        datetime.datetime.combine(
+            datetime.datetime.utcfromtimestamp(0),
+            value,
+            tzinfo=datetime.timezone.utc))
+
+  def to_language_type(self, value):
+    # type: (Timestamp) -> datetime.date
+
+    return value.to_utc_datetime().time()
+
+  @classmethod
+  def argument_type(cls):
+    return str
+
+  def argument(self):
+    return ""
+
+  @classmethod
+  def _from_typing(cls, typ):
+    return cls()

--- a/sdks/python/apache_beam/io/jdbc.py
+++ b/sdks/python/apache_beam/io/jdbc.py
@@ -363,7 +363,12 @@ class ReadFromJdbc(ExternalTransform):
 
 @LogicalType.register_logical_type
 class JdbcDateType(LogicalType[datetime.date, MillisInstant, str]):
-  """Support of Legacy JdbcIO DATE logical type."""
+  """
+  For internal use only; no backwards-compatibility guarantees.
+
+  Support of Legacy JdbcIO DATE logical type. Deemed to change when Java JDBCIO
+  has been migrated to Beam portable logical types.
+  """
   def __init__(self, argument=""):
     pass
 
@@ -405,7 +410,12 @@ class JdbcDateType(LogicalType[datetime.date, MillisInstant, str]):
 
 @LogicalType.register_logical_type
 class JdbcTimeType(LogicalType[datetime.time, MillisInstant, str]):
-  """Support of Legacy JdbcIO TIME logical type."""
+  """
+  For internal use only; no backwards-compatibility guarantees.
+
+  Support of Legacy JdbcIO TIME logical type. . Deemed to change when Java
+  JDBCIO has been migrated to Beam portable logical types.
+  """
   def __init__(self, argument=""):
     pass
 


### PR DESCRIPTION
Part of #28359 (date and time support without breaking change); fixes #19715

* Add identifier to  URN for legacy Java logical types

* Implement JdbcIO logical type javasdk_date and javasdk_time in Python

* Add tests

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
