### PR TITLE
Route remaining prints in boot.go through logging service if possible, add periodic flush for PIP invocations

### DIFF
--- a/sdks/go/container/tools/buffered_logging.go
+++ b/sdks/go/container/tools/buffered_logging.go
@@ -36,17 +36,18 @@ type BufferedLogger struct {
 	lastFlush            time.Time
 	flushInterval        time.Duration
 	periodicFlushContext context.Context
+	now                  func() time.Time
 }
 
 // NewBufferedLogger returns a new BufferedLogger type by reference.
 func NewBufferedLogger(logger *Logger) *BufferedLogger {
-	return &BufferedLogger{logger: logger, lastFlush: time.Now(), flushInterval: time.Duration(math.MaxInt64), periodicFlushContext: context.Background()}
+	return &BufferedLogger{logger: logger, lastFlush: time.Now(), flushInterval: time.Duration(math.MaxInt64), periodicFlushContext: context.Background(), now: time.Now}
 }
 
 // NewBufferedLoggerWithFlushInterval returns a new BufferedLogger type by reference. This type will
 // flush logs periodically on Write() calls as well as when Flush*() functions are called.
 func NewBufferedLoggerWithFlushInterval(ctx context.Context, logger *Logger, interval time.Duration) *BufferedLogger {
-	return &BufferedLogger{logger: logger, lastFlush: time.Now(), flushInterval: interval, periodicFlushContext: ctx}
+	return &BufferedLogger{logger: logger, lastFlush: time.Now(), flushInterval: interval, periodicFlushContext: ctx, now: time.Now}
 }
 
 // Write implements the io.Writer interface, converting input to a string
@@ -62,7 +63,7 @@ func (b *BufferedLogger) Write(p []byte) (int, error) {
 	}
 	b.logs = append(b.logs, b.builder.String())
 	b.builder.Reset()
-	if time.Since(b.lastFlush) > b.flushInterval {
+	if b.now().Sub(b.lastFlush) > b.flushInterval {
 		b.FlushAtDebug(b.periodicFlushContext)
 	}
 	return n, err

--- a/sdks/go/container/tools/buffered_logging.go
+++ b/sdks/go/container/tools/buffered_logging.go
@@ -78,6 +78,7 @@ func (b *BufferedLogger) FlushAtError(ctx context.Context) {
 		b.logger.Errorf(ctx, message)
 	}
 	b.logs = nil
+	b.lastFlush = time.Now()
 }
 
 // FlushAtDebug flushes the contents of the buffer to the logging
@@ -90,6 +91,7 @@ func (b *BufferedLogger) FlushAtDebug(ctx context.Context) {
 		b.logger.Printf(ctx, message)
 	}
 	b.logs = nil
+	b.lastFlush = time.Now()
 }
 
 // Prints directly to the logging service. If the logger is nil, prints directly to the

--- a/sdks/go/container/tools/buffered_logging.go
+++ b/sdks/go/container/tools/buffered_logging.go
@@ -17,6 +17,7 @@ package tools
 
 import (
 	"context"
+	"log"
 	"os"
 	"strings"
 )
@@ -75,4 +76,14 @@ func (b *BufferedLogger) FlushAtDebug(ctx context.Context) {
 		b.logger.Printf(ctx, message)
 	}
 	b.logs = nil
+}
+
+// Prints directly to the logging service. If the logger is nil, prints directly to the
+// console. Used for the container pre-build workflow.
+func (b *BufferedLogger) Printf(ctx context.Context, format string, args ...any) {
+	if b.logger == nil {
+		log.Printf(format, args...)
+		return
+	}
+	b.logger.Printf(ctx, format, args...)
 }

--- a/sdks/go/container/tools/buffered_logging_test.go
+++ b/sdks/go/container/tools/buffered_logging_test.go
@@ -166,4 +166,22 @@ func TestBufferedLogger(t *testing.T) {
 			}
 		}
 	})
+
+	t.Run("direct print", func(t *testing.T) {
+		catcher := &logCatcher{}
+		l := &Logger{client: catcher}
+		bl := NewBufferedLogger(l)
+
+		bl.Printf(ctx, "foo %v", "bar")
+
+		received := catcher.msgs[0].GetLogEntries()[0]
+
+		if got, want := received.Message, "foo bar"; got != want {
+			t.Errorf("l.Printf(\"foo %%v\", \"bar\"): got message %q, want %q", got, want)
+		}
+
+		if got, want := received.Severity, fnpb.LogEntry_Severity_DEBUG; got != want {
+			t.Errorf("l.Printf(\"foo %%v\", \"bar\"): got severity %v, want %v", got, want)
+		}
+	})
 }

--- a/sdks/python/container/boot.go
+++ b/sdks/python/container/boot.go
@@ -380,10 +380,11 @@ func setupAcceptableWheelSpecs() error {
 
 // installSetupPackages installs Beam SDK and user dependencies.
 func installSetupPackages(ctx context.Context, logger *tools.Logger, files []string, workDir string, requirementsFiles []string) error {
-	log.Printf("Installing setup packages ...")
+	bufLogger := tools.NewBufferedLogger(logger)
+	bufLogger.Printf(ctx, "Installing setup packages ...")
 
 	if err := setupAcceptableWheelSpecs(); err != nil {
-		log.Printf("Failed to setup acceptable wheel specs, leave it as empty: %v", err)
+		bufLogger.Printf(ctx, "Failed to setup acceptable wheel specs, leave it as empty: %v", err)
 	}
 
 	pkgName := "apache-beam"

--- a/sdks/python/container/piputil.go
+++ b/sdks/python/container/piputil.go
@@ -77,7 +77,7 @@ func isPackageInstalled(pkgName string) bool {
 	return true
 }
 
-const pipLogFlushInterval time.Duration = time.Duration(5e9)
+const pipLogFlushInterval time.Duration = 5 * time.Second
 
 // pipInstallPackage installs the given package, if present.
 func pipInstallPackage(ctx context.Context, logger *tools.Logger, files []string, dir, name string, force, optional bool, extras []string) error {

--- a/sdks/python/container/piputil.go
+++ b/sdks/python/container/piputil.go
@@ -47,7 +47,7 @@ func pipInstallRequirements(ctx context.Context, logger *tools.Logger, files []s
 			// used without following their dependencies.
 			args := []string{"-m", "pip", "install", "-q", "-r", filepath.Join(dir, name), "--no-cache-dir", "--disable-pip-version-check", "--no-index", "--no-deps", "--find-links", dir}
 			if err := execx.Execute(pythonVersion, args...); err != nil {
-				fmt.Println("Some packages could not be installed solely from the requirements cache. Installing packages from PyPI.")
+				bufLogger.Printf(ctx, "Some packages could not be installed solely from the requirements cache. Installing packages from PyPI.")
 			}
 			// The second install round opens up the search for packages on PyPI and
 			// also installs dependencies. The key is that if all the packages have
@@ -173,12 +173,13 @@ func installExtraPackages(ctx context.Context, logger *tools.Logger, files []str
 	return nil
 }
 
-func findBeamSdkWhl(files []string, acceptableWhlSpecs []string) string {
+func findBeamSdkWhl(ctx context.Context, logger *tools.Logger, files []string, acceptableWhlSpecs []string) string {
+	bufLogger := tools.NewBufferedLogger(logger)
 	for _, file := range files {
 		if strings.HasPrefix(file, "apache_beam") {
 			for _, s := range acceptableWhlSpecs {
 				if strings.HasSuffix(file, s) {
-					log.Printf("Found Apache Beam SDK wheel: %v", file)
+					bufLogger.Printf(ctx, "Found Apache Beam SDK wheel: %v", file)
 					return file
 				}
 			}
@@ -193,8 +194,8 @@ func findBeamSdkWhl(files []string, acceptableWhlSpecs []string) string {
 // file, and we try to install it. If not successful, we fall back to installing
 // SDK from source tarball provided in sdkSrcFile.
 func installSdk(ctx context.Context, logger *tools.Logger, files []string, workDir string, sdkSrcFile string, acceptableWhlSpecs []string, required bool) error {
-	sdkWhlFile := findBeamSdkWhl(files, acceptableWhlSpecs)
-
+	sdkWhlFile := findBeamSdkWhl(ctx, logger, files, acceptableWhlSpecs)
+	bufLogger := tools.NewBufferedLogger(logger)
 	if sdkWhlFile != "" {
 		// by default, pip rejects to install wheel if same version already installed
 		isDev := strings.Contains(sdkWhlFile, ".dev")
@@ -202,7 +203,7 @@ func installSdk(ctx context.Context, logger *tools.Logger, files []string, workD
 		if err == nil {
 			return nil
 		}
-		log.Printf("Could not install Apache Beam SDK from a wheel: %v, proceeding to install SDK from source tarball.", err)
+		bufLogger.Printf(ctx, "Could not install Apache Beam SDK from a wheel: %v, proceeding to install SDK from source tarball.", err)
 	}
 	if !required {
 		_, err := os.Stat(filepath.Join(workDir, sdkSrcFile))

--- a/sdks/python/container/piputil.go
+++ b/sdks/python/container/piputil.go
@@ -77,7 +77,7 @@ func isPackageInstalled(pkgName string) bool {
 	return true
 }
 
-const pipLogFlushInterval time.Duration = 5 * time.Second
+const pipLogFlushInterval time.Duration = 15 * time.Second
 
 // pipInstallPackage installs the given package, if present.
 func pipInstallPackage(ctx context.Context, logger *tools.Logger, files []string, dir, name string, force, optional bool, extras []string) error {


### PR DESCRIPTION
Adds the capacity for the buffered logger to print directly to the console or write directly over the logging service if available to cover the last print statements in the script. Routes through a buffered logger type to support the container prebuild workflow. Also adds the ability to periodically flush output during long-running operations (like PIP dependency resolution) rather than waiting for the end of the process. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
