### PR TITLE
Add WindmillConnectionsCache used to consume GetWorkerMetadata response and updates

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/WindmillStream.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/WindmillStream.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.dataflow.worker.windmill;
 
+import com.google.auto.value.AutoValue;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
@@ -50,6 +51,30 @@ public interface WindmillStream {
           @Nullable Instant synchronizedProcessingTime,
           Windmill.WorkItem workItem,
           Collection<Windmill.LatencyAttribution> getWorkStreamLatencies);
+    }
+
+    @AutoValue
+    abstract class GetWorkBudget {
+      public static GetWorkBudget.Builder builder() {
+        return new AutoValue_WindmillStream_GetWorkStream_GetWorkBudget.Builder();
+      }
+
+      public GetWorkBudget consumeBudgetUpdate(long bytes, long items) {
+        return GetWorkBudget.builder().setBytes(bytes() + bytes).setItems(items() + items).build();
+      }
+
+      public abstract long bytes();
+
+      public abstract long items();
+
+      @AutoValue.Builder
+      public abstract static class Builder {
+        public abstract Builder setBytes(long bytes);
+
+        public abstract Builder setItems(long budget);
+
+        public abstract GetWorkBudget build();
+      }
     }
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/connectionscache/ReadOnlyWindmillConnectionsCache.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/connectionscache/ReadOnlyWindmillConnectionsCache.java
@@ -1,0 +1,55 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.windmill.connectionscache;
+
+import java.util.Optional;
+import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc;
+import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
+import org.apache.beam.runners.dataflow.worker.windmill.WindmillApplianceGrpc;
+
+/** Read only interface for {@link WindmillConnectionsCache}. */
+public interface ReadOnlyWindmillConnectionsCache {
+
+  /**
+   * Used by GetDataStream and CommitWorkStream calls inorder to make sure Windmill API calls get
+   * routed to the same workers that GetWork was initiated on. If no {@link WindmillConnection} is
+   * found, it means that the windmill worker working on the key range has moved on (ranges have
+   * moved to other workers, worker crash, etc.).
+   *
+   * @see <a
+   *     href=https://medium.com/google-cloud/streaming-engine-execution-model-1eb2eef69a8e>Windmill
+   *     API</a>
+   */
+  Optional<WindmillConnection> getWindmillWorkerConnection(WindmillConnectionCacheToken token);
+
+  /**
+   * Used by GetWorkStream to initiate the Windmill API calls and fetch Work items.
+   *
+   * @see <a
+   *     href=https://medium.com/google-cloud/streaming-engine-execution-model-1eb2eef69a8e>Windmill
+   *     API</a>
+   */
+  WindmillConnection getNewWindmillWorkerConnection();
+
+  CloudWindmillServiceV1Alpha1Grpc.CloudWindmillServiceV1Alpha1Stub getDispatcherStub();
+
+  Optional<CloudWindmillServiceV1Alpha1Grpc.CloudWindmillServiceV1Alpha1Stub> getGlobalDataStub(
+      Windmill.GlobalDataId globalDataId);
+
+  Optional<WindmillApplianceGrpc.WindmillApplianceBlockingStub> getWindmillApplianceStub();
+}

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/connectionscache/ReadWriteWindmillConnectionsCache.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/connectionscache/ReadWriteWindmillConnectionsCache.java
@@ -1,0 +1,40 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.windmill.connectionscache;
+
+import org.apache.beam.runners.dataflow.worker.windmill.WindmillEndpoints;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableSet;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.net.HostAndPort;
+
+public interface ReadWriteWindmillConnectionsCache extends ReadOnlyWindmillConnectionsCache {
+  void consumeWindmillDispatcherEndpoints(ImmutableSet<HostAndPort> dispatcherEndpoints);
+
+  void consumeWindmillWorkerEndpoints(WindmillEndpoints windmillEndpoints);
+
+  /**
+   * To pass as {@link ReadOnlyWindmillConnectionsCache} to enforce read only interface. This allows
+   * optimization for many concurrent readers. {@link
+   * org.apache.beam.runners.dataflow.worker.windmill.WindmillStream}(s) will hold a reference to
+   * the read-only interface, with updates coming from the consumer of the worker metadata produced
+   * in {@link
+   * org.apache.beam.runners.dataflow.worker.windmill.WindmillStream.GetWorkerMetadataStream}.
+   */
+  default ReadOnlyWindmillConnectionsCache asReadOnlyCache() {
+    return this;
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/connectionscache/VendoredCredentialsAdapter.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/connectionscache/VendoredCredentialsAdapter.java
@@ -1,0 +1,110 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.windmill.connectionscache;
+
+import java.io.IOException;
+import java.net.URI;
+import java.util.List;
+import java.util.Map;
+import java.util.concurrent.Executor;
+import javax.annotation.Nullable;
+import org.apache.beam.vendor.grpc.v1p54p0.com.google.auth.Credentials;
+import org.apache.beam.vendor.grpc.v1p54p0.com.google.auth.RequestMetadataCallback;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
+
+/**
+ * Create a wrapper around credentials that delegates to the underlying {@link
+ * com.google.auth.Credentials}. Note that this class should override every method that is not final
+ * and not static and call the delegate directly.
+ *
+ * <p>TODO: Replace this with an auto generated proxy which calls the underlying implementation
+ * delegate to reduce maintenance burden.
+ */
+class VendoredCredentialsAdapter extends Credentials {
+
+  private final Credentials credentials;
+
+  VendoredCredentialsAdapter(@Nullable Credentials credentials) {
+    this.credentials =
+        Preconditions.checkNotNull(
+            credentials, "gcpCredentials are required to communicate with Streaming Engine.");
+  }
+
+  @Override
+  public String getAuthenticationType() {
+    return credentials.getAuthenticationType();
+  }
+
+  @Override
+  public Map<String, List<String>> getRequestMetadata() throws IOException {
+    return credentials.getRequestMetadata();
+  }
+
+  @Override
+  public void getRequestMetadata(URI uri, Executor executor, RequestMetadataCallback callback) {
+    credentials.getRequestMetadata(
+        uri, executor, new VendoredRequestMetadataCallbackAdapter(callback));
+  }
+
+  @Override
+  public Map<String, List<String>> getRequestMetadata(URI uri) throws IOException {
+    return credentials.getRequestMetadata(uri);
+  }
+
+  @Override
+  public boolean hasRequestMetadata() {
+    return credentials.hasRequestMetadata();
+  }
+
+  @Override
+  public boolean hasRequestMetadataOnly() {
+    return credentials.hasRequestMetadataOnly();
+  }
+
+  @Override
+  public void refresh() throws IOException {
+    credentials.refresh();
+  }
+
+  /**
+   * Create a wrapper around credentials callback that delegates to the underlying vendored {@link
+   * com.google.auth.RequestMetadataCallback}. Note that this class should override every method
+   * that is not final and not static and call the delegate directly.
+   *
+   * <p>TODO: Replace this with an auto generated proxy which calls the underlying implementation
+   * delegate to reduce maintenance burden.
+   */
+  private static class VendoredRequestMetadataCallbackAdapter implements RequestMetadataCallback {
+
+    private final RequestMetadataCallback callback;
+
+    private VendoredRequestMetadataCallbackAdapter(RequestMetadataCallback callback) {
+      this.callback = callback;
+    }
+
+    @Override
+    public void onSuccess(Map<String, List<String>> metadata) {
+      callback.onSuccess(metadata);
+    }
+
+    @Override
+    public void onFailure(Throwable exception) {
+      callback.onFailure(exception);
+    }
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/connectionscache/WindmillChannelFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/connectionscache/WindmillChannelFactory.java
@@ -1,0 +1,135 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.windmill.connectionscache;
+
+import java.net.Inet6Address;
+import java.net.InetSocketAddress;
+import java.util.concurrent.TimeUnit;
+import javax.net.ssl.SSLException;
+import org.apache.beam.runners.dataflow.worker.windmill.WindmillServiceAddress;
+import org.apache.beam.vendor.grpc.v1p54p0.io.grpc.Channel;
+import org.apache.beam.vendor.grpc.v1p54p0.io.grpc.inprocess.InProcessChannelBuilder;
+import org.apache.beam.vendor.grpc.v1p54p0.io.grpc.netty.GrpcSslContexts;
+import org.apache.beam.vendor.grpc.v1p54p0.io.grpc.netty.NegotiationType;
+import org.apache.beam.vendor.grpc.v1p54p0.io.grpc.netty.NettyChannelBuilder;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.net.HostAndPort;
+
+/** Utilities for creating {@link Channel} for gRPC stubs. */
+final class WindmillChannelFactory {
+  static final String LOCALHOST = "localhost";
+  private static final int DEFAULT_GRPC_PORT = 443;
+
+  private WindmillChannelFactory() {}
+
+  static Channel inProcessChannel(String channelName) {
+    return InProcessChannelBuilder.forName(channelName).directExecutor().build();
+  }
+
+  static Channel localhostChannel(int port) {
+    return NettyChannelBuilder.forAddress(LOCALHOST, port)
+        .maxInboundMessageSize(Integer.MAX_VALUE)
+        .negotiationType(NegotiationType.PLAINTEXT)
+        .build();
+  }
+
+  static Channel remoteChannel(
+      WindmillServiceAddress windmillServiceAddress, int windmillServiceRpcChannelTimeoutSec) {
+    switch (windmillServiceAddress.getKind()) {
+      case IPV6:
+        return remoteChannel(windmillServiceAddress.ipv6(), windmillServiceRpcChannelTimeoutSec);
+      case GCP_SERVICE_ADDRESS:
+        return remoteChannel(
+            windmillServiceAddress.gcpServiceAddress(), windmillServiceRpcChannelTimeoutSec);
+        // switch is exhaustive will never happen.
+      default:
+        throw new UnsupportedOperationException(
+            "Only IPV6 and GCP_SERVICE_ADDRESS are supported WindmillServiceAddresses.");
+    }
+  }
+
+  static Channel remoteChannel(HostAndPort endpoint, int windmillServiceRpcChannelTimeoutSec) {
+    try {
+      return createRemoteChannel(
+          NettyChannelBuilder.forAddress(endpoint.getHost(), endpoint.getPort()),
+          windmillServiceRpcChannelTimeoutSec);
+    } catch (SSLException sslException) {
+      throw new WindmillChannelCreationException(endpoint, sslException);
+    }
+  }
+
+  static Channel remoteChannel(
+      Inet6Address directEndpoint, int port, int windmillServiceRpcChannelTimeoutSec) {
+    try {
+      return createRemoteChannel(
+          NettyChannelBuilder.forAddress(new InetSocketAddress(directEndpoint, port)),
+          windmillServiceRpcChannelTimeoutSec);
+    } catch (SSLException sslException) {
+      throw new WindmillChannelCreationException(directEndpoint.toString(), sslException);
+    }
+  }
+
+  static Channel remoteChannel(
+      Inet6Address directEndpoint, int windmillServiceRpcChannelTimeoutSec) {
+    try {
+      return createRemoteChannel(
+          NettyChannelBuilder.forAddress(new InetSocketAddress(directEndpoint, DEFAULT_GRPC_PORT)),
+          windmillServiceRpcChannelTimeoutSec);
+    } catch (SSLException sslException) {
+      throw new WindmillChannelCreationException(directEndpoint.toString(), sslException);
+    }
+  }
+
+  @SuppressWarnings("nullness")
+  private static Channel createRemoteChannel(
+      NettyChannelBuilder channelBuilder, int windmillServiceRpcChannelTimeoutSec)
+      throws SSLException {
+    if (windmillServiceRpcChannelTimeoutSec > 0) {
+      channelBuilder
+          .keepAliveTime(windmillServiceRpcChannelTimeoutSec, TimeUnit.SECONDS)
+          .keepAliveTimeout(windmillServiceRpcChannelTimeoutSec, TimeUnit.SECONDS)
+          .keepAliveWithoutCalls(true);
+    }
+
+    return channelBuilder
+        .flowControlWindow(10 * 1024 * 1024)
+        .maxInboundMessageSize(Integer.MAX_VALUE)
+        .maxInboundMetadataSize(1024 * 1024)
+        .negotiationType(NegotiationType.TLS)
+        // Set ciphers(null) to not use GCM, which is disabled for Dataflow
+        // due to it being horribly slow.
+        .sslContext(GrpcSslContexts.forClient().ciphers(null).build())
+        .build();
+  }
+
+  public static class WindmillChannelCreationException extends IllegalStateException {
+    private WindmillChannelCreationException(HostAndPort endpoint, SSLException sourceException) {
+      super(
+          String.format(
+              "Exception thrown when trying to create channel to endpoint={host:%s; port:%d}",
+              endpoint.getHost(), endpoint.getPort()),
+          sourceException);
+    }
+
+    WindmillChannelCreationException(String directEndpoint, Throwable sourceException) {
+      super(
+          String.format(
+              "Exception thrown when trying to create channel to endpoint={%s}", directEndpoint),
+          sourceException);
+    }
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/connectionscache/WindmillConnection.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/connectionscache/WindmillConnection.java
@@ -1,0 +1,64 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.windmill.connectionscache;
+
+import com.google.auto.value.AutoValue;
+import java.util.Optional;
+import java.util.function.Function;
+import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc;
+import org.apache.beam.runners.dataflow.worker.windmill.WindmillEndpoints;
+
+@AutoValue
+public abstract class WindmillConnection {
+  static WindmillConnection.Builder from(
+      WindmillEndpoints.Endpoint windmillEndpoint,
+      Function<
+              WindmillEndpoints.Endpoint,
+              CloudWindmillServiceV1Alpha1Grpc.CloudWindmillServiceV1Alpha1Stub>
+          endpointToStubFn) {
+    WindmillConnection.Builder windmillWorkerConnection = WindmillConnection.builder();
+
+    windmillEndpoint.workerToken().ifPresent(windmillWorkerConnection::setBackendWorkerToken);
+    windmillWorkerConnection.setDirectStub(endpointToStubFn.apply(windmillEndpoint));
+
+    return windmillWorkerConnection;
+  }
+
+  public static Builder builder() {
+    return new AutoValue_WindmillConnection.Builder();
+  }
+
+  public abstract WindmillConnectionCacheToken cacheToken();
+
+  public abstract Optional<String> backendWorkerToken();
+
+  public abstract Optional<CloudWindmillServiceV1Alpha1Grpc.CloudWindmillServiceV1Alpha1Stub>
+      directStub();
+
+  @AutoValue.Builder
+  abstract static class Builder {
+    abstract Builder setCacheToken(WindmillConnectionCacheToken cacheToken);
+
+    abstract Builder setBackendWorkerToken(String backendWorkerToken);
+
+    abstract Builder setDirectStub(
+        CloudWindmillServiceV1Alpha1Grpc.CloudWindmillServiceV1Alpha1Stub directStub);
+
+    abstract WindmillConnection build();
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/connectionscache/WindmillConnectionCacheToken.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/connectionscache/WindmillConnectionCacheToken.java
@@ -1,0 +1,34 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.windmill.connectionscache;
+
+import com.google.auto.value.AutoValue;
+import java.util.UUID;
+
+@AutoValue
+public abstract class WindmillConnectionCacheToken {
+  static WindmillConnectionCacheToken create(String token) {
+    return new AutoValue_WindmillConnectionCacheToken(token);
+  }
+
+  static WindmillConnectionCacheToken generateRandomToken() {
+    return create(UUID.randomUUID().toString());
+  }
+
+  public abstract String token();
+}

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/connectionscache/WindmillConnectionsCache.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/connectionscache/WindmillConnectionsCache.java
@@ -1,0 +1,455 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.windmill.connectionscache;
+
+import static org.apache.beam.runners.dataflow.worker.windmill.connectionscache.WindmillChannelFactory.LOCALHOST;
+import static org.apache.beam.runners.dataflow.worker.windmill.connectionscache.WindmillChannelFactory.localhostChannel;
+import static org.apache.beam.runners.dataflow.worker.windmill.connectionscache.WindmillChannelFactory.remoteChannel;
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap.toImmutableMap;
+
+import com.google.auto.value.AutoValue;
+import com.google.errorprone.annotations.concurrent.GuardedBy;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+import java.util.Random;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.function.Function;
+import javax.annotation.Nullable;
+import javax.annotation.concurrent.ThreadSafe;
+import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc;
+import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc.CloudWindmillServiceV1Alpha1Stub;
+import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
+import org.apache.beam.runners.dataflow.worker.windmill.WindmillApplianceGrpc;
+import org.apache.beam.runners.dataflow.worker.windmill.WindmillEndpoints;
+import org.apache.beam.runners.dataflow.worker.windmill.WindmillEndpoints.Endpoint;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableSet;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.net.HostAndPort;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+@ThreadSafe
+final class WindmillConnectionsCache implements ReadWriteWindmillConnectionsCache {
+  private static final Logger LOG = LoggerFactory.getLogger(WindmillConnectionsCache.class);
+
+  private final Object dispatcherConnectionLock;
+
+  @GuardedBy("dispatcherConnectionLock")
+  private final List<CloudWindmillServiceV1Alpha1Stub> dispatcherStubs;
+
+  @GuardedBy("dispatcherConnectionLock")
+  private final Set<HostAndPort> dispatcherEndpoints;
+
+  @GuardedBy("dispatcherConnectionLock")
+  private final Random rand;
+
+  /**
+   * Writes are guarded by synchronization on "this". Reads are done grabbing the {@link
+   * AtomicReference#get()} before reading the state. Writes are all or nothing since this will get
+   * set only after the new state is computed. Reads may be stale, and in that case the work item
+   * may be retried later with a fresh connection since Windmill operations on the work item will
+   * fail.
+   */
+  private final AtomicReference<WindmillWorkerConnections> windmillWorkerConnectionsState;
+
+  private final WindmillGrpcStubFactory windmillGrpcStubFactory;
+  private final @Nullable WindmillApplianceGrpc.WindmillApplianceBlockingStub syncApplianceStub;
+  private final int windmillServiceRpcChannelTimeoutSec;
+
+  WindmillConnectionsCache(
+      List<CloudWindmillServiceV1Alpha1Stub> dispatcherStubs,
+      Set<HostAndPort> dispatcherEndpoints,
+      AtomicReference<WindmillWorkerConnections> windmillWorkerConnectionsState,
+      @Nullable WindmillApplianceGrpc.WindmillApplianceBlockingStub syncApplianceStub,
+      int windmillServiceRpcChannelTimeoutSec,
+      WindmillGrpcStubFactory windmillGrpcStubFactory) {
+    this.dispatcherConnectionLock = new Object();
+    this.dispatcherStubs = dispatcherStubs;
+    this.dispatcherEndpoints = dispatcherEndpoints;
+    this.syncApplianceStub = syncApplianceStub;
+    this.rand = new Random();
+    this.windmillServiceRpcChannelTimeoutSec = windmillServiceRpcChannelTimeoutSec;
+    this.windmillGrpcStubFactory = windmillGrpcStubFactory;
+    this.windmillWorkerConnectionsState = windmillWorkerConnectionsState;
+  }
+
+  /** Returns a stub for Windmill dispatcher. */
+  @Override
+  public CloudWindmillServiceV1Alpha1Stub getDispatcherStub() {
+    synchronized (dispatcherConnectionLock) {
+      if (dispatcherStubs.isEmpty()) {
+        throw new IllegalStateException("windmillServiceEndpoint has not been set");
+      }
+
+      return (dispatcherStubs.size() == 1
+          ? dispatcherStubs.get(0)
+          : dispatcherStubs.get(rand.nextInt(dispatcherStubs.size())));
+    }
+  }
+
+  @Override
+  public void consumeWindmillDispatcherEndpoints(ImmutableSet<HostAndPort> dispatcherEndpoints) {
+    Preconditions.checkArgument(
+        dispatcherEndpoints != null && !dispatcherEndpoints.isEmpty(),
+        "Cannot set dispatcher endpoints to nothing.");
+    synchronized (dispatcherConnectionLock) {
+      if (this.dispatcherEndpoints.equals(dispatcherEndpoints)) {
+        // The endpoints are equal don't recreate the stubs.
+        return;
+      }
+
+      LOG.info("Creating a new windmill stub, endpoints: {}", dispatcherEndpoints);
+      if (!this.dispatcherEndpoints.isEmpty()) {
+        LOG.info("Previous windmill stub endpoints: {}", this.dispatcherEndpoints);
+      }
+
+      resetDispatcherEndpoints(dispatcherEndpoints);
+    }
+  }
+
+  private void resetDispatcherEndpoints(ImmutableSet<HostAndPort> newDispatcherEndpoints) {
+    synchronized (dispatcherConnectionLock) {
+      LOG.info(
+          "Initializing Streaming Engine GRPC client for endpoints: {}", newDispatcherEndpoints);
+      this.dispatcherStubs.clear();
+      this.dispatcherEndpoints.clear();
+      this.dispatcherEndpoints.addAll(newDispatcherEndpoints);
+
+      dispatcherEndpoints.stream()
+          .map(this::createDispatcherStubForWindmillService)
+          .forEach(dispatcherStubs::add);
+    }
+  }
+
+  /**
+   * Used by GetDataStream and CommitWorkStream calls inorder to make sure Windmill API calls get
+   * routed to the same workers that GetWork was initiated on. If no {@link WindmillConnection} is
+   * found, it means that the windmill worker working on the key range has moved on (ranges have
+   * moved to other windmill workers, windmill worker crash, etc.).
+   *
+   * @see <a
+   *     href=https://medium.com/google-cloud/streaming-engine-execution-model-1eb2eef69a8e>Windmill
+   *     API</a>
+   */
+  @Override
+  public Optional<WindmillConnection> getWindmillWorkerConnection(
+      WindmillConnectionCacheToken key) {
+    WindmillWorkerConnections currentWindmillWorkerConnections =
+        Optional.ofNullable(windmillWorkerConnectionsState.get())
+            .orElseThrow(UninitializedWindmillConnectionsException::new);
+
+    Optional<WindmillConnection> windmillWorkerConnection =
+        Optional.ofNullable(currentWindmillWorkerConnections.windmillWorkerStubs().get(key));
+
+    if (!windmillWorkerConnection.isPresent()) {
+      LOG.warn("Attempted to fetch WindmillWorkerConnection for {}, but none exist.", key);
+    }
+
+    return windmillWorkerConnection;
+  }
+
+  /**
+   * Used by GetWorkStream to initiate the Windmill API calls and fetch Work items.
+   *
+   * @see <a
+   *     href=https://medium.com/google-cloud/streaming-engine-execution-model-1eb2eef69a8e>Windmill
+   *     API</a>
+   */
+  @Override
+  public WindmillConnection getNewWindmillWorkerConnection() {
+    WindmillWorkerConnections currentWindmillWorkerConnections =
+        Optional.ofNullable(windmillWorkerConnectionsState.get())
+            .orElseThrow(UninitializedWindmillConnectionsException::new);
+
+    return currentWindmillWorkerConnections
+        .roundRobinGetWorkStubSelector()
+        .pickNextGetWorkServer()
+        .flatMap(this::getWindmillWorkerConnection)
+        .orElseThrow(
+            () -> new IllegalStateException("No windmill connections have been initiated."));
+  }
+
+  /**
+   * Acquires a lock and creates a new {@link WindmillWorkerConnections} view derived from the new
+   * {@link WindmillEndpoints} and the current {@link WindmillWorkerConnections} view in {@link
+   * #windmillWorkerConnectionsState}.
+   *
+   * <p>Read-only {@link ReadOnlyWindmillConnectionsCache} and Read-write {@link
+   * ReadWriteWindmillConnectionsCache} interfaces are separated to allow for different read/write
+   * paths.
+   */
+  @Override
+  public synchronized void consumeWindmillWorkerEndpoints(WindmillEndpoints windmillEndpoints) {
+    Preconditions.checkNotNull(windmillEndpoints, "Cannot consume null endpoints.");
+    Preconditions.checkArgument(
+        !windmillEndpoints.globalDataEndpoints().isEmpty(),
+        "Cannot consume empty global_data_endpoints.");
+    Preconditions.checkArgument(
+        !windmillEndpoints.windmillEndpoints().isEmpty(),
+        "Cannot consume empty windmill_endpoints.");
+
+    LOG.info("Consuming new windmill endpoints: {}", windmillEndpoints);
+    // This is null when it is the 1st time the windmillEndpoints are being consumed.
+    Optional<WindmillWorkerConnections> currentWindmillWorkerConnections =
+        Optional.ofNullable(windmillWorkerConnectionsState.get());
+    LOG.info("Current windmillWorkerConnectionsState: {}", currentWindmillWorkerConnections);
+    ImmutableMap<Endpoint, WindmillConnectionCacheToken> newEndpointToCacheTokenMap =
+        createEndpointToCacheTokenMap(
+            windmillEndpoints.windmillEndpoints(),
+            currentWindmillWorkerConnections
+                .map(WindmillWorkerConnections::endpointToCacheTokenMap)
+                .orElseGet(ImmutableMap::of));
+    LOG.info("Mapped endpoints to tokens. {}", newEndpointToCacheTokenMap);
+    ImmutableList<WindmillConnectionCacheToken> cacheTokensForRandomAccess =
+        ImmutableList.copyOf(newEndpointToCacheTokenMap.values());
+
+    WindmillWorkerConnections newWindmillWorkerConnections =
+        WindmillWorkerConnections.builder()
+            .setEndpointToCacheTokenMap(newEndpointToCacheTokenMap)
+            .setWindmillWorkerStubs(
+                currentWindmillWorkerConnections
+                    .map(WindmillWorkerConnections::windmillWorkerStubs)
+                    .map(
+                        existingStubs ->
+                            createNewWindmillWorkerStubs(newEndpointToCacheTokenMap, existingStubs))
+                    // There are no existing stubs since this is the first time metadata is being
+                    // consumed.
+                    .orElseGet(
+                        () ->
+                            createNewWindmillWorkerStubs(
+                                newEndpointToCacheTokenMap, ImmutableMap.of())))
+            .setGlobalDataStubs(createGlobalDataStubs(windmillEndpoints.globalDataEndpoints()))
+            .setRoundRobinGetWorkStubSelector(
+                currentWindmillWorkerConnections
+                    .map(WindmillWorkerConnections::roundRobinGetWorkStubSelector)
+                    .map(
+                        stubSelector ->
+                            RoundRobinGetWorkStubSelector.next(
+                                stubSelector, cacheTokensForRandomAccess))
+                    .orElseGet(
+                        () -> RoundRobinGetWorkStubSelector.create(cacheTokensForRandomAccess)))
+            .build();
+
+    LOG.info("New windmillWorkerConnectionsState: {}", newWindmillWorkerConnections);
+    windmillWorkerConnectionsState.set(newWindmillWorkerConnections);
+  }
+
+  private ImmutableMap<Endpoint, WindmillConnectionCacheToken> createEndpointToCacheTokenMap(
+      ImmutableList<Endpoint> newEndpoints,
+      ImmutableMap<Endpoint, WindmillConnectionCacheToken> currentEndpointsToCacheTokens) {
+    return newEndpoints.stream()
+        .collect(
+            toImmutableMap(
+                Function.identity(),
+                endpoint ->
+                    Optional.ofNullable(currentEndpointsToCacheTokens.get(endpoint))
+                        .orElseGet(WindmillConnectionCacheToken::generateRandomToken)));
+  }
+
+  private ImmutableMap<WindmillConnectionCacheToken, WindmillConnection>
+      createNewWindmillWorkerStubs(
+          ImmutableMap<Endpoint, WindmillConnectionCacheToken> newEndpointToCacheTokenMap,
+          ImmutableMap<WindmillConnectionCacheToken, WindmillConnection>
+              currentWindmillWorkerConnections) {
+    return newEndpointToCacheTokenMap.entrySet().stream()
+        .collect(
+            toImmutableMap(
+                Map.Entry::getValue,
+                entry ->
+                    // If a connection for the endpoint already exists, just reuse the connection,
+                    // else make a new one.
+                    Optional.ofNullable(currentWindmillWorkerConnections.get(entry.getValue()))
+                        .orElseGet(() -> createNewWindmillConnection(entry))));
+  }
+
+  private WindmillConnection createNewWindmillConnection(
+      Map.Entry<Endpoint, WindmillConnectionCacheToken> endpointAndCacheToken) {
+    return WindmillConnection.from(endpointAndCacheToken.getKey(), this::newWindmillStub)
+        .setCacheToken(endpointAndCacheToken.getValue())
+        .build();
+  }
+
+  private ImmutableMap<String, CloudWindmillServiceV1Alpha1Stub> createGlobalDataStubs(
+      ImmutableMap<String, Endpoint> newGlobalDataEndpoints) {
+    return newGlobalDataEndpoints.entrySet().stream()
+        .collect(
+            toImmutableMap(
+                Map.Entry::getKey, // global data tag
+                entry -> newWindmillStub(entry.getValue())));
+  }
+
+  @Override
+  public Optional<CloudWindmillServiceV1Alpha1Stub> getGlobalDataStub(
+      Windmill.GlobalDataId globalDataId) {
+    WindmillWorkerConnections currentWindmillWorkerConnections =
+        Optional.ofNullable(windmillWorkerConnectionsState.get())
+            .orElseThrow(UninitializedWindmillConnectionsException::new);
+
+    return Optional.ofNullable(
+        currentWindmillWorkerConnections.globalDataStubs().get(globalDataId.getTag()));
+  }
+
+  private CloudWindmillServiceV1Alpha1Stub newWindmillStub(Endpoint endpoint) {
+    switch (windmillGrpcStubFactory.getKind()) {
+        // This is only used in tests.
+      case INPROCESS:
+        return windmillGrpcStubFactory.inProcess().get();
+        // Create stub for direct_endpoint or just default to Dispatcher stub.
+      case REMOTE:
+        return endpoint
+            .directEndpoint()
+            .map(windmillGrpcStubFactory.remote())
+            .orElseGet(this::getDispatcherStub);
+        // Should never be called, this switch statement is exhaustive.
+      default:
+        throw new UnsupportedOperationException(
+            "Only remote or in-process stub factories are available.");
+    }
+  }
+
+  private CloudWindmillServiceV1Alpha1Stub createDispatcherStubForWindmillService(
+      HostAndPort endpoint) {
+    if (LOCALHOST.equals(endpoint.getHost())) {
+      return CloudWindmillServiceV1Alpha1Grpc.newStub(localhostChannel(endpoint.getPort()));
+    }
+
+    // Use an in-process stub if testing.
+    return windmillGrpcStubFactory.getKind() == WindmillGrpcStubFactory.Kind.INPROCESS
+        ? windmillGrpcStubFactory.inProcess().get()
+        : CloudWindmillServiceV1Alpha1Grpc.newStub(
+            remoteChannel(endpoint, windmillServiceRpcChannelTimeoutSec));
+  }
+
+  @Override
+  public Optional<WindmillApplianceGrpc.WindmillApplianceBlockingStub> getWindmillApplianceStub() {
+    return Optional.ofNullable(syncApplianceStub);
+  }
+
+  @AutoValue
+  abstract static class WindmillWorkerConnections {
+    private static WindmillWorkerConnections.Builder builder() {
+      return new AutoValue_WindmillConnectionsCache_WindmillWorkerConnections.Builder();
+    }
+
+    abstract ImmutableMap<Endpoint, WindmillConnectionCacheToken> endpointToCacheTokenMap();
+
+    abstract ImmutableMap<WindmillConnectionCacheToken, WindmillConnection> windmillWorkerStubs();
+
+    abstract RoundRobinGetWorkStubSelector roundRobinGetWorkStubSelector();
+
+    abstract ImmutableMap<String, CloudWindmillServiceV1Alpha1Stub> globalDataStubs();
+
+    @AutoValue.Builder
+    abstract static class Builder {
+      abstract Builder setEndpointToCacheTokenMap(
+          Map<Endpoint, WindmillConnectionCacheToken> endpointToCacheTokenMap);
+
+      abstract Builder setWindmillWorkerStubs(
+          ImmutableMap<WindmillConnectionCacheToken, WindmillConnection> windmillWorkerStubs);
+
+      abstract Builder setRoundRobinGetWorkStubSelector(
+          RoundRobinGetWorkStubSelector roundRobinGetWorkStubSelector);
+
+      abstract Builder setGlobalDataStubs(
+          ImmutableMap<String, CloudWindmillServiceV1Alpha1Stub> globalDataStubs);
+
+      abstract WindmillWorkerConnections build();
+    }
+  }
+
+  /**
+   * Naive round-robin {@link
+   * org.apache.beam.runners.dataflow.worker.windmill.WindmillStream.GetWorkStream} stub selector.
+   * This is only used for {@link
+   * org.apache.beam.runners.dataflow.worker.windmill.WindmillStream.GetWorkStream} because {@link
+   * org.apache.beam.runners.dataflow.worker.windmill.WindmillStream.GetDataStream} and {@link
+   * org.apache.beam.runners.dataflow.worker.windmill.WindmillStream.CommitWorkStream} know which
+   * Windmill workers to communicate with, and {@link
+   * org.apache.beam.runners.dataflow.worker.windmill.WindmillStream.GetWorkerMetadataStream}
+   * communicates with the Windmill Dispatcher.
+   *
+   * @implNote Package private for {@link AutoValue} visibility.
+   */
+  @ThreadSafe
+  static class RoundRobinGetWorkStubSelector {
+    private static final String GET_WORK_STUB_SELECTOR_LOCK = "RoundRobinGetWorkStubSelector.this";
+    private static final int INITIAL_INDEX = -1;
+
+    @GuardedBy(GET_WORK_STUB_SELECTOR_LOCK)
+    private final ImmutableList<WindmillConnectionCacheToken> windmillConnectionCacheTokens;
+
+    @GuardedBy(GET_WORK_STUB_SELECTOR_LOCK)
+    private int lastSelectedStubIndex;
+
+    private RoundRobinGetWorkStubSelector(
+        int lastSelectedStubIndex,
+        ImmutableList<WindmillConnectionCacheToken> windmillConnectionCacheTokens) {
+      this.lastSelectedStubIndex = lastSelectedStubIndex;
+      this.windmillConnectionCacheTokens = windmillConnectionCacheTokens;
+    }
+
+    private static RoundRobinGetWorkStubSelector create(
+        ImmutableList<WindmillConnectionCacheToken> cacheTokens) {
+      return new RoundRobinGetWorkStubSelector(INITIAL_INDEX, cacheTokens);
+    }
+
+    private static RoundRobinGetWorkStubSelector next(
+        RoundRobinGetWorkStubSelector prev,
+        ImmutableList<WindmillConnectionCacheToken> newCacheTokens) {
+      // If it getNextValidIndex returns 0, it means that we have either reached the bounds, or
+      // pickNextGetWorkServer() was never called on the previous stubSelector. In that case just
+      // create a fresh stubSelector with the new cacheTokens, else keep the lastSelectedStubIndex
+      // incrementing if valid.
+      int nextValidStubSelectorIndex = prev.getNextValidIndex(newCacheTokens.size());
+      return nextValidStubSelectorIndex > 0
+          // Keep the lastSelectedStubIndex moving
+          ? new RoundRobinGetWorkStubSelector(nextValidStubSelectorIndex, newCacheTokens)
+          : create(newCacheTokens);
+    }
+
+    private synchronized Optional<WindmillConnectionCacheToken> pickNextGetWorkServer() {
+      if (windmillConnectionCacheTokens.isEmpty()) {
+        return Optional.empty();
+      }
+
+      int nextSelectedStubIndex = getNextValidIndex(windmillConnectionCacheTokens.size());
+      lastSelectedStubIndex = nextSelectedStubIndex;
+      return Optional.of(windmillConnectionCacheTokens.get(nextSelectedStubIndex));
+    }
+
+    private synchronized int getNextValidIndex(int bounds) {
+      return lastSelectedStubIndex == INITIAL_INDEX || lastSelectedStubIndex == bounds
+          ? 0
+          : lastSelectedStubIndex + 1;
+    }
+  }
+
+  @VisibleForTesting
+  static class UninitializedWindmillConnectionsException extends IllegalStateException {
+    private UninitializedWindmillConnectionsException() {
+      super(
+          "Attempted to fetch a new windmill worker connection when no windmill connections"
+              + " have been initiated.");
+    }
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/connectionscache/WindmillConnectionsCacheFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/connectionscache/WindmillConnectionsCacheFactory.java
@@ -1,0 +1,60 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.windmill.connectionscache;
+
+import static org.apache.beam.runners.dataflow.worker.windmill.connectionscache.WindmillChannelFactory.localhostChannel;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.concurrent.atomic.AtomicReference;
+import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc;
+import org.apache.beam.runners.dataflow.worker.windmill.WindmillApplianceGrpc;
+import org.apache.beam.vendor.grpc.v1p54p0.com.google.auth.Credentials;
+import org.apache.beam.vendor.grpc.v1p54p0.io.grpc.Channel;
+
+public final class WindmillConnectionsCacheFactory {
+  private WindmillConnectionsCacheFactory() {}
+
+  public static ReadWriteWindmillConnectionsCache forStreamingEngine(
+      List<CloudWindmillServiceV1Alpha1Grpc.CloudWindmillServiceV1Alpha1Stub> dispatcherStubs,
+      int windmillServiceRpcChannelTimeoutSec,
+      Credentials gcpCredentials) {
+    return new WindmillConnectionsCache(
+        new ArrayList<>(dispatcherStubs),
+        /* dispatcherEndpoints= */ new HashSet<>(),
+        /* windmillWorkerConnectionsState= */ new AtomicReference<>(),
+        /* syncApplianceStub= */ null,
+        windmillServiceRpcChannelTimeoutSec,
+        WindmillGrpcStubFactory.remoteStubFactory(
+            windmillServiceRpcChannelTimeoutSec, gcpCredentials));
+  }
+
+  /** Returns a connections cache for windmill Appliance. */
+  public static ReadOnlyWindmillConnectionsCache forAppliance(int localhostPort) {
+    Channel localChannel = localhostChannel(localhostPort);
+    return new WindmillConnectionsCache(
+        /* dispatcherStubs= */ new ArrayList<>(),
+        /* dispatcherEndpoints= */ new HashSet<>(),
+        /* windmillWorkerConnectionsState= */ new AtomicReference<>(),
+        WindmillApplianceGrpc.newBlockingStub(localChannel),
+        // Appliance just uses localhost channel. This is a no-op.
+        /*windmillServiceRpcChannelTimeoutSec*/ -1,
+        WindmillGrpcStubFactory.inProcessStubFactory(""));
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/connectionscache/WindmillGrpcStubFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/connectionscache/WindmillGrpcStubFactory.java
@@ -1,0 +1,65 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.windmill.connectionscache;
+
+import static org.apache.beam.runners.dataflow.worker.windmill.connectionscache.WindmillChannelFactory.inProcessChannel;
+import static org.apache.beam.runners.dataflow.worker.windmill.connectionscache.WindmillChannelFactory.remoteChannel;
+
+import com.google.auto.value.AutoOneOf;
+import java.util.function.Function;
+import java.util.function.Supplier;
+import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc;
+import org.apache.beam.runners.dataflow.worker.windmill.WindmillServiceAddress;
+import org.apache.beam.vendor.grpc.v1p54p0.com.google.auth.Credentials;
+import org.apache.beam.vendor.grpc.v1p54p0.io.grpc.auth.MoreCallCredentials;
+
+/**
+ * Used to create stubs to talk to Streaming Engine. Stubs are either in-process for testing, or
+ * remote.
+ */
+@AutoOneOf(WindmillGrpcStubFactory.Kind.class)
+abstract class WindmillGrpcStubFactory {
+
+  static WindmillGrpcStubFactory inProcessStubFactory(String testName) {
+    return AutoOneOf_WindmillGrpcStubFactory.inProcess(
+        () -> CloudWindmillServiceV1Alpha1Grpc.newStub(inProcessChannel(testName)));
+  }
+
+  static WindmillGrpcStubFactory remoteStubFactory(
+      int rpcChannelTimeoutSec, Credentials gcpCredentials) {
+    return AutoOneOf_WindmillGrpcStubFactory.remote(
+        directEndpoint ->
+            CloudWindmillServiceV1Alpha1Grpc.newStub(
+                    remoteChannel(directEndpoint, rpcChannelTimeoutSec))
+                .withCallCredentials(
+                    MoreCallCredentials.from(new VendoredCredentialsAdapter(gcpCredentials))));
+  }
+
+  abstract Kind getKind();
+
+  abstract Supplier<CloudWindmillServiceV1Alpha1Grpc.CloudWindmillServiceV1Alpha1Stub> inProcess();
+
+  abstract Function<
+          WindmillServiceAddress, CloudWindmillServiceV1Alpha1Grpc.CloudWindmillServiceV1Alpha1Stub>
+      remote();
+
+  enum Kind {
+    INPROCESS,
+    REMOTE
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/connectionscache/WindmillConnectionsCacheTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/connectionscache/WindmillConnectionsCacheTest.java
@@ -1,0 +1,430 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.windmill.connectionscache;
+
+import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertFalse;
+import static org.junit.Assert.assertNotNull;
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Optional;
+import java.util.Set;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import org.apache.beam.runners.dataflow.worker.windmill.CloudWindmillServiceV1Alpha1Grpc.CloudWindmillServiceV1Alpha1Stub;
+import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
+import org.apache.beam.runners.dataflow.worker.windmill.WindmillEndpoints;
+import org.apache.beam.runners.dataflow.worker.windmill.WindmillEndpoints.Endpoint;
+import org.apache.beam.runners.dataflow.worker.windmill.WindmillServiceAddress;
+import org.apache.beam.runners.dataflow.worker.windmill.connectionscache.WindmillConnectionsCache.WindmillWorkerConnections;
+import org.apache.beam.vendor.grpc.v1p54p0.com.google.protobuf.ByteString;
+import org.apache.beam.vendor.grpc.v1p54p0.io.grpc.Server;
+import org.apache.beam.vendor.grpc.v1p54p0.io.grpc.inprocess.InProcessServerBuilder;
+import org.apache.beam.vendor.grpc.v1p54p0.io.grpc.testing.GrpcCleanupRule;
+import org.apache.beam.vendor.grpc.v1p54p0.io.grpc.util.MutableHandlerRegistry;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableSet;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.net.HostAndPort;
+import org.junit.After;
+import org.junit.Before;
+import org.junit.Rule;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class WindmillConnectionsCacheTest {
+
+  private static final String FAKE_SERVER_NAME = "Fake server for GrpcGetWorkerMetadataStreamTest";
+  private static final WindmillServiceAddress DEFAULT_WINDMILL_SERVICE_ADDRESS =
+      WindmillServiceAddress.create(HostAndPort.fromParts(WindmillChannelFactory.LOCALHOST, 443));
+  private static final Endpoint DEFAULT_ENDPOINT =
+      Endpoint.builder().setDirectEndpoint(DEFAULT_WINDMILL_SERVICE_ADDRESS).build();
+  private static final ImmutableMap<String, Endpoint> DEFAULT_GLOBAL_DATA_ENDPOINTS =
+      ImmutableMap.of("global_data", DEFAULT_ENDPOINT);
+
+  @Rule public final GrpcCleanupRule grpcCleanup = new GrpcCleanupRule();
+  private final MutableHandlerRegistry serviceRegistry = new MutableHandlerRegistry();
+  private final List<CloudWindmillServiceV1Alpha1Stub> dispatcherStubs = new ArrayList<>();
+  private final Set<HostAndPort> dispatcherEndpoints = new HashSet<>();
+  private final AtomicReference<WindmillWorkerConnections> windmillWorkerConnectionsState =
+      new AtomicReference<>();
+  private Server server;
+
+  @Before
+  public void setUp() throws IOException {
+    server =
+        InProcessServerBuilder.forName(FAKE_SERVER_NAME)
+            .fallbackHandlerRegistry(serviceRegistry)
+            .directExecutor()
+            .build()
+            .start();
+
+    grpcCleanup.register(server);
+    dispatcherStubs.clear();
+    dispatcherEndpoints.clear();
+    windmillWorkerConnectionsState.set(null);
+  }
+
+  @After
+  public void tearDown() {
+    server.shutdownNow();
+  }
+
+  private ReadWriteWindmillConnectionsCache newWindmillConnectionsCache() {
+    return new WindmillConnectionsCache(
+        dispatcherStubs,
+        dispatcherEndpoints,
+        windmillWorkerConnectionsState,
+        null,
+        /* windmillServiceRpcChannelTimeoutSec= */ -1,
+        WindmillGrpcStubFactory.inProcessStubFactory(FAKE_SERVER_NAME));
+  }
+
+  @Test
+  public void testGetDispatcherStub() {
+    ReadWriteWindmillConnectionsCache windmillConnectionsCache = newWindmillConnectionsCache();
+    HostAndPort dispatcherEndpoint = DEFAULT_WINDMILL_SERVICE_ADDRESS.gcpServiceAddress();
+    windmillConnectionsCache.consumeWindmillDispatcherEndpoints(
+        ImmutableSet.of(dispatcherEndpoint));
+    assertNotNull(windmillConnectionsCache.getDispatcherStub());
+    assertEquals(1, dispatcherStubs.size());
+    assertEquals(1, dispatcherEndpoints.size());
+    HostAndPort cachedDispatcherEndpoint = new ArrayList<>(dispatcherEndpoints).get(0);
+    assertEquals(dispatcherEndpoint.getHost(), cachedDispatcherEndpoint.getHost());
+    assertEquals(dispatcherEndpoint.getPort(), cachedDispatcherEndpoint.getPort());
+  }
+
+  @Test
+  public void testGetDispatcherStub_throwsIllegalStateExceptionIfDispatcherEndpointsNotSet() {
+    ReadWriteWindmillConnectionsCache windmillConnectionsCache = newWindmillConnectionsCache();
+    assertThrows(IllegalStateException.class, windmillConnectionsCache::getDispatcherStub);
+  }
+
+  @Test
+  public void testConsumeWindmillDispatcherEndpoints_correctlySetsDispatcherStubs() {
+    ReadWriteWindmillConnectionsCache windmillConnectionsCache = newWindmillConnectionsCache();
+    HostAndPort hostAndPort = DEFAULT_WINDMILL_SERVICE_ADDRESS.gcpServiceAddress();
+    windmillConnectionsCache.consumeWindmillDispatcherEndpoints(ImmutableSet.of(hostAndPort));
+    assertTrue(dispatcherEndpoints.contains(hostAndPort));
+    assertEquals(1, dispatcherEndpoints.size());
+    assertEquals(1, dispatcherStubs.size());
+  }
+
+  @Test
+  public void testConsumeWindmillDispatcherEndpoints_doesNothingIfNewEndpointsIdentical() {
+    ReadWriteWindmillConnectionsCache windmillConnectionsCache = newWindmillConnectionsCache();
+    HostAndPort hostAndPort = DEFAULT_WINDMILL_SERVICE_ADDRESS.gcpServiceAddress();
+    windmillConnectionsCache.consumeWindmillDispatcherEndpoints(ImmutableSet.of(hostAndPort));
+    assertTrue(dispatcherEndpoints.contains(hostAndPort));
+    assertEquals(1, dispatcherEndpoints.size());
+    assertEquals(1, dispatcherStubs.size());
+  }
+
+  @Test
+  public void testConsumeWindmillDispatcherEndpoints_errorIfNewEndpointsEmptyOrNull() {
+    ReadWriteWindmillConnectionsCache windmillConnectionsCache = newWindmillConnectionsCache();
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> windmillConnectionsCache.consumeWindmillDispatcherEndpoints(ImmutableSet.of()));
+    assertThrows(
+        IllegalArgumentException.class,
+        () -> windmillConnectionsCache.consumeWindmillDispatcherEndpoints(null));
+  }
+
+  @Test
+  public void testGetNewWindmillWorkerConnection() {
+    ReadWriteWindmillConnectionsCache windmillConnectionsCache = newWindmillConnectionsCache();
+    String workerToken = "workerToken";
+    ImmutableList<Endpoint> windmillEndpoints =
+        ImmutableList.of(Endpoint.builder().setWorkerToken(workerToken).build());
+    windmillConnectionsCache.consumeWindmillWorkerEndpoints(
+        WindmillEndpoints.builder()
+            .setWindmillEndpoints(windmillEndpoints)
+            .setGlobalDataEndpoints(DEFAULT_GLOBAL_DATA_ENDPOINTS)
+            .build());
+    WindmillConnection windmillWorkerConnection =
+        windmillConnectionsCache.getNewWindmillWorkerConnection();
+
+    assertTrue(windmillWorkerConnection.backendWorkerToken().isPresent());
+    assertEquals(workerToken, windmillWorkerConnection.backendWorkerToken().get());
+    assertTrue(windmillWorkerConnection.directStub().isPresent());
+    assertTrue(
+        windmillWorkerConnectionsState
+            .get()
+            .windmillWorkerStubs()
+            .containsKey(windmillWorkerConnection.cacheToken()));
+    assertTrue(
+        windmillWorkerConnectionsState
+            .get()
+            .windmillWorkerStubs()
+            .containsValue(windmillWorkerConnection));
+  }
+
+  @Test
+  public void testGetNewWindmillWorkerConnectionConcurrentReads() throws InterruptedException {
+    ReadWriteWindmillConnectionsCache windmillConnectionsCache = newWindmillConnectionsCache();
+    String workerToken = "workerToken1";
+    String workerToken2 = "workerToken2";
+
+    windmillConnectionsCache.consumeWindmillWorkerEndpoints(
+        WindmillEndpoints.builder()
+            .addWindmillEndpoint(Endpoint.builder().setWorkerToken(workerToken).build())
+            .addWindmillEndpoint(Endpoint.builder().setWorkerToken(workerToken2).build())
+            .setGlobalDataEndpoints(DEFAULT_GLOBAL_DATA_ENDPOINTS)
+            .build());
+
+    AtomicReference<WindmillConnection> windmillWorkerConnection = new AtomicReference<>();
+    AtomicReference<WindmillConnection> windmillWorkerConnection2 = new AtomicReference<>();
+
+    Thread getWindmillWorkerEndpoint1 =
+        new Thread(
+            () ->
+                windmillWorkerConnection.set(
+                    windmillConnectionsCache.getNewWindmillWorkerConnection()));
+
+    Thread getWindmillWorkerEndpoint2 =
+        new Thread(
+            () ->
+                windmillWorkerConnection2.set(
+                    windmillConnectionsCache.getNewWindmillWorkerConnection()));
+
+    getWindmillWorkerEndpoint1.start();
+    getWindmillWorkerEndpoint2.start();
+
+    // Wait for threads to complete executing before assertions.
+    getWindmillWorkerEndpoint1.join();
+    getWindmillWorkerEndpoint2.join();
+
+    // Assert all expected values are present since the order of execution is non-deterministic.
+    assertTrue(windmillWorkerConnection.get().backendWorkerToken().isPresent());
+    assertTrue(windmillWorkerConnection2.get().backendWorkerToken().isPresent());
+
+    assertTrue(windmillWorkerConnection.get().directStub().isPresent());
+    assertTrue(windmillWorkerConnection2.get().directStub().isPresent());
+
+    assertTrue(
+        windmillWorkerConnectionsState
+            .get()
+            .windmillWorkerStubs()
+            .containsKey(windmillWorkerConnection.get().cacheToken()));
+    assertTrue(
+        windmillWorkerConnectionsState
+            .get()
+            .windmillWorkerStubs()
+            .containsKey(windmillWorkerConnection2.get().cacheToken()));
+
+    assertTrue(
+        windmillWorkerConnectionsState
+            .get()
+            .windmillWorkerStubs()
+            .containsValue(windmillWorkerConnection.get()));
+    assertTrue(
+        windmillWorkerConnectionsState
+            .get()
+            .windmillWorkerStubs()
+            .containsValue(windmillWorkerConnection2.get()));
+  }
+
+  @Test
+  public void
+      testGetNewWindmillWorkerConnection_throwsUninitializedWindmillConnectionsException_ifConnectionsNeverConsumed() {
+    assertThrows(
+        WindmillConnectionsCache.UninitializedWindmillConnectionsException.class,
+        newWindmillConnectionsCache()::getNewWindmillWorkerConnection);
+  }
+
+  @Test
+  public void testGetWindmillWorkerConnection_returnsEmptyOptionalIfConnectionNotPresent() {
+    ReadWriteWindmillConnectionsCache windmillConnectionsCache = newWindmillConnectionsCache();
+    windmillConnectionsCache.consumeWindmillWorkerEndpoints(
+        WindmillEndpoints.builder()
+            .addWindmillEndpoint(Endpoint.builder().setWorkerToken("workerToken").build())
+            .setGlobalDataEndpoints(DEFAULT_GLOBAL_DATA_ENDPOINTS)
+            .build());
+
+    windmillConnectionsCache.getNewWindmillWorkerConnection();
+
+    assertFalse(
+        newWindmillConnectionsCache()
+            .getWindmillWorkerConnection(WindmillConnectionCacheToken.create("thisDoesNotExist"))
+            .isPresent());
+  }
+
+  @Test
+  public void testGetWindmillWorkerConnection() {
+    ReadWriteWindmillConnectionsCache windmillConnectionsCache = newWindmillConnectionsCache();
+    windmillConnectionsCache.consumeWindmillWorkerEndpoints(
+        WindmillEndpoints.builder()
+            .addWindmillEndpoint(Endpoint.builder().setWorkerToken("workerToken").build())
+            .setGlobalDataEndpoints(DEFAULT_GLOBAL_DATA_ENDPOINTS)
+            .build());
+
+    WindmillConnection connection = windmillConnectionsCache.getNewWindmillWorkerConnection();
+    Optional<WindmillConnection> cachedConnection =
+        windmillConnectionsCache.getWindmillWorkerConnection(connection.cacheToken());
+
+    assertTrue(cachedConnection.isPresent());
+    assertEquals(connection, cachedConnection.get());
+  }
+
+  @Test
+  public void
+      testGetWindmillWorkerConnection_throwsUninitializedWindmillConnectionsException_ifConnectionsNeverConsumed() {
+    assertThrows(
+        WindmillConnectionsCache.UninitializedWindmillConnectionsException.class,
+        () ->
+            newWindmillConnectionsCache()
+                .getWindmillWorkerConnection(WindmillConnectionCacheToken.create("doesn't exist")));
+  }
+
+  @Test
+  public void testConsumeWindmillWorkerEndpoints_correctlyRemovesStaleWindmillServers() {
+    ReadWriteWindmillConnectionsCache windmillConnectionsCache = newWindmillConnectionsCache();
+    String workerToken = "workerToken1";
+    String workerToken2 = "workerToken2";
+    String workerToken3 = "workerToken3";
+
+    windmillConnectionsCache.consumeWindmillWorkerEndpoints(
+        WindmillEndpoints.builder()
+            .addWindmillEndpoint(Endpoint.builder().setWorkerToken(workerToken).build())
+            .addWindmillEndpoint(Endpoint.builder().setWorkerToken(workerToken2).build())
+            .setGlobalDataEndpoints(DEFAULT_GLOBAL_DATA_ENDPOINTS)
+            .build());
+
+    windmillConnectionsCache.consumeWindmillWorkerEndpoints(
+        WindmillEndpoints.builder()
+            .addWindmillEndpoint(Endpoint.builder().setWorkerToken(workerToken3).build())
+            .setGlobalDataEndpoints(DEFAULT_GLOBAL_DATA_ENDPOINTS)
+            .build());
+
+    assertEquals(1, windmillWorkerConnectionsState.get().windmillWorkerStubs().size());
+    Set<String> workerTokens =
+        windmillWorkerConnectionsState.get().windmillWorkerStubs().values().stream()
+            .map(WindmillConnection::backendWorkerToken)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(Collectors.toSet());
+
+    assertFalse(workerTokens.contains(workerToken));
+    assertFalse(workerTokens.contains(workerToken2));
+  }
+
+  @Test
+  public void testConsumeWindmillWorkerEndpoints_correctlyAddsNewWindmillServers() {
+    ReadWriteWindmillConnectionsCache windmillConnectionsCache = newWindmillConnectionsCache();
+    String workerToken = "workerToken1";
+    String workerToken2 = "workerToken2";
+    String workerToken3 = "workerToken3";
+
+    windmillConnectionsCache.consumeWindmillWorkerEndpoints(
+        WindmillEndpoints.builder()
+            .addWindmillEndpoint(Endpoint.builder().setWorkerToken(workerToken).build())
+            .addWindmillEndpoint(Endpoint.builder().setWorkerToken(workerToken2).build())
+            .setGlobalDataEndpoints(DEFAULT_GLOBAL_DATA_ENDPOINTS)
+            .build());
+
+    windmillConnectionsCache.consumeWindmillWorkerEndpoints(
+        WindmillEndpoints.builder()
+            .addWindmillEndpoint(Endpoint.builder().setWorkerToken(workerToken3).build())
+            .setGlobalDataEndpoints(DEFAULT_GLOBAL_DATA_ENDPOINTS)
+            .build());
+
+    assertEquals(1, windmillWorkerConnectionsState.get().windmillWorkerStubs().size());
+    Set<String> workerTokens =
+        windmillWorkerConnectionsState.get().windmillWorkerStubs().values().stream()
+            .map(WindmillConnection::backendWorkerToken)
+            .filter(Optional::isPresent)
+            .map(Optional::get)
+            .collect(Collectors.toSet());
+
+    assertTrue(workerTokens.contains(workerToken3));
+  }
+
+  @Test
+  public void testConsumeWindmillWorkerEndpoints_correctlyConsumesGlobalDataServers() {
+    ReadWriteWindmillConnectionsCache windmillConnectionsCache = newWindmillConnectionsCache();
+    String globalDataKey = "globalDataKey";
+    windmillConnectionsCache.consumeWindmillWorkerEndpoints(
+        WindmillEndpoints.builder()
+            .addWindmillEndpoint(DEFAULT_ENDPOINT)
+            .addGlobalDataEndpoint(globalDataKey, Endpoint.builder().build())
+            .build());
+
+    assertTrue(windmillWorkerConnectionsState.get().globalDataStubs().containsKey(globalDataKey));
+  }
+
+  @Test
+  public void testGetGlobalDataStub_returnsGlobalDataStubIfPresent() {
+    ReadWriteWindmillConnectionsCache windmillConnectionsCache = newWindmillConnectionsCache();
+    String globalDataKey = "globalDataKey";
+    windmillConnectionsCache.consumeWindmillWorkerEndpoints(
+        WindmillEndpoints.builder()
+            .addWindmillEndpoint(Endpoint.builder().setWorkerToken("workerToken").build())
+            .addGlobalDataEndpoint(globalDataKey, Endpoint.builder().build())
+            .build());
+
+    assertTrue(
+        windmillConnectionsCache
+            .getGlobalDataStub(
+                Windmill.GlobalDataId.newBuilder()
+                    .setTag(globalDataKey)
+                    .setVersion(ByteString.fromHex(""))
+                    .build())
+            .isPresent());
+  }
+
+  @Test
+  public void testGetGlobalDataStub_returnsEmptyOptionalIfNoStubs() {
+    ReadWriteWindmillConnectionsCache windmillConnectionsCache = newWindmillConnectionsCache();
+    windmillConnectionsCache.consumeWindmillWorkerEndpoints(
+        WindmillEndpoints.builder()
+            .addWindmillEndpoint(Endpoint.builder().setWorkerToken("workerToken").build())
+            .addGlobalDataEndpoint("globalDataKey", Endpoint.builder().build())
+            .build());
+
+    assertFalse(
+        windmillConnectionsCache
+            .getGlobalDataStub(
+                Windmill.GlobalDataId.newBuilder()
+                    .setTag("nonExistentKey")
+                    .setVersion(ByteString.fromHex(""))
+                    .build())
+            .isPresent());
+  }
+
+  @Test
+  public void
+      testGetGlobalDataStub_throwsUninitializedWindmillConnectionsException_ifConnectionsNeverConsumed() {
+    assertThrows(
+        WindmillConnectionsCache.UninitializedWindmillConnectionsException.class,
+        () ->
+            newWindmillConnectionsCache()
+                .getGlobalDataStub(
+                    Windmill.GlobalDataId.newBuilder()
+                        .setTag("nonExistentKey")
+                        .setVersion(ByteString.fromHex(""))
+                        .build()));
+  }
+}


### PR DESCRIPTION
WindmillConnectionsCache will be used to consume GetWorkerMetadata response and updates.

It exposes a separate read and write interface.  The write interface will be used for the caller of GetWorkerMetadata stream to be able to pass the response along to the cache to consume.  The read interface will be vended out to GetWorkStream, GetDataStream, and CommitWorkStream call sites in order to fetch connections directly to Streaming Engine Windmill Workers, or the Dispatcher.

WindmillConnectionCacheTokens will be used to attach to WorkItems to correctly call GetDataStream and CommitWorkStream.  

Since the WindmillConnectionsCache's will be shared, it uses AtomicReference and synchronization around writes to the cache.  Updates are all or nothing and done under a lock/synchronization, and reads fetch a snapshot of the of the AtomicReference's value to serve reads without locking.

r: @scwhittle 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
