### PR TITLE
Sets recommended max Xmx 32G when set_recommended_max_xmx experiment is enabled

### DIFF
--- a/sdks/java/container/boot.go
+++ b/sdks/java/container/boot.go
@@ -267,8 +267,10 @@ func makePipelineOptionsFile(options string) error {
 // it returns 70% of the physical memory on the machine. If it cannot determine
 // that value, it returns 1GB. This is an imperfect heuristic. It aims to
 // ensure there is memory for non-heap use and other overhead, while also not
-// underutilizing the machine. if set_recommended_max_xmx experiment is enabled, sets xmx 
-// to 32G
+// underutilizing the machine. if set_recommended_max_xmx experiment is enabled, 
+// sets xmx to 32G. Under 32G JVM enables CompressedOops. CompressedOops 
+// utilizes memory more efficiently, and has positive impact on GC performance 
+// and cache hit rate.
 func heapSizeLimit(info *fnpb.ProvisionInfo, setRecommendedMaxXmx bool) uint64 {
 	if setRecommendedMaxXmx {
 		return 32 << 30

--- a/sdks/java/container/boot.go
+++ b/sdks/java/container/boot.go
@@ -272,8 +272,7 @@ func makePipelineOptionsFile(options string) error {
 func heapSizeLimit(info *fnpb.ProvisionInfo, setRecommendedMaxXmx bool) uint64 {
 	if setRecommendedMaxXmx {
 		return 32 << 30
-	}
-	else if size, err := syscallx.PhysicalMemorySize(); err == nil {
+	} else if size, err := syscallx.PhysicalMemorySize(); err == nil {
 		return (size * 70) / 100
 	}
 	return 1 << 30

--- a/sdks/java/container/boot.go
+++ b/sdks/java/container/boot.go
@@ -159,8 +159,9 @@ func main() {
 		cp = append(cp, filepath.Join(dir, filepath.FromSlash(name)))
 	}
 
+	var setRecommendedMaxXmx = strings.Contains(options, "set_recommended_max_xmx")
 	args := []string{
-		"-Xmx" + strconv.FormatUint(heapSizeLimit(info), 10),
+		"-Xmx" + strconv.FormatUint(heapSizeLimit(info, setRecommendedMaxXmx), 10),
 		// ParallelGC the most adequate for high throughput and lower CPU utilization
 		// It is the default GC in Java 8, but not on newer versions
 		"-XX:+UseParallelGC",
@@ -266,9 +267,13 @@ func makePipelineOptionsFile(options string) error {
 // it returns 70% of the physical memory on the machine. If it cannot determine
 // that value, it returns 1GB. This is an imperfect heuristic. It aims to
 // ensure there is memory for non-heap use and other overhead, while also not
-// underutilizing the machine.
-func heapSizeLimit(info *fnpb.ProvisionInfo) uint64 {
-	if size, err := syscallx.PhysicalMemorySize(); err == nil {
+// underutilizing the machine. if set_recommended_max_xmx experiment is enabled, sets xmx 
+// to 32G
+func heapSizeLimit(info *fnpb.ProvisionInfo, setRecommendedMaxXmx bool) uint64 {
+	if setRecommendedMaxXmx {
+		return 32 << 30
+	}
+	else if size, err := syscallx.PhysicalMemorySize(); err == nil {
 		return (size * 70) / 100
 	}
 	return 1 << 30


### PR DESCRIPTION

We set the Xmx to the recommended max value(32G) with set_recommended_max_xmx is enabled. Under 32G JVM enables CompressedOops. CompressedOops utilizes memory more efficiently, and has positive impact on GC performance and cache hit rate. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
