### PR TITLE
Allow dropLataData in GBK for SamzaRunner

### DIFF
--- a/runners/samza/src/main/java/org/apache/beam/runners/samza/SamzaPipelineOptions.java
+++ b/runners/samza/src/main/java/org/apache/beam/runners/samza/SamzaPipelineOptions.java
@@ -173,4 +173,10 @@ public interface SamzaPipelineOptions extends PipelineOptions {
           new ThreadFactoryBuilder().setNameFormat("Process Element Thread-%d").build());
     }
   }
+
+  @Description("Enable/disable late data dropping in GroupByKey/Combine transforms")
+  @Default.Boolean(false)
+  boolean getDropLateData();
+
+  void setDropLateData(boolean dropLateData);
 }

--- a/runners/samza/src/test/java/org/apache/beam/runners/samza/runtime/GroupByKeyOpTest.java
+++ b/runners/samza/src/test/java/org/apache/beam/runners/samza/runtime/GroupByKeyOpTest.java
@@ -1,0 +1,123 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.samza.runtime;
+
+import java.io.Serializable;
+import java.util.Arrays;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
+import org.apache.beam.sdk.coders.VarIntCoder;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.testing.PAssert;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.TestStream;
+import org.apache.beam.sdk.transforms.Combine;
+import org.apache.beam.sdk.transforms.Sum;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.Window;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TimestampedValue;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.junit.Rule;
+import org.junit.Test;
+
+/** Tests for GroupByKeyOp. */
+public class GroupByKeyOpTest implements Serializable {
+  @Rule
+  public final transient TestPipeline pipeline =
+      TestPipeline.fromOptions(
+          PipelineOptionsFactory.fromArgs("--runner=TestSamzaRunner").create());
+
+  @Rule
+  public final transient TestPipeline dropLateDataPipeline =
+      TestPipeline.fromOptions(
+          PipelineOptionsFactory.fromArgs("--runner=TestSamzaRunner", "--dropLateData=true")
+              .create());
+
+  @Test
+  public void testDefaultGbk() {
+    TestStream.Builder<Integer> testStream =
+        TestStream.create(VarIntCoder.of())
+            .addElements(TimestampedValue.of(1, new Instant(1000)))
+            .addElements(TimestampedValue.of(2, new Instant(2000)))
+            .advanceWatermarkTo(new Instant(3000))
+            .addElements(TimestampedValue.of(10, new Instant(1000)))
+            .advanceWatermarkTo(new Instant(10000));
+
+    PCollection<Integer> aggregated =
+        pipeline
+            .apply(testStream.advanceWatermarkToInfinity())
+            .apply(
+                Window.<Integer>into(FixedWindows.of(Duration.standardSeconds(3)))
+                    .accumulatingFiredPanes())
+            .apply(Combine.globally(Sum.ofIntegers()).withoutDefaults());
+
+    PAssert.that(aggregated).containsInAnyOrder(Arrays.asList(3, 10));
+
+    pipeline.run().waitUntilFinish();
+  }
+
+  @Test
+  public void testDropLateDataNonKeyed() {
+    TestStream.Builder<Integer> testStream =
+        TestStream.create(VarIntCoder.of())
+            .addElements(TimestampedValue.of(1, new Instant(1000)))
+            .addElements(TimestampedValue.of(2, new Instant(2000)))
+            .advanceWatermarkTo(new Instant(3000))
+            .addElements(TimestampedValue.of(10, new Instant(1000)))
+            .advanceWatermarkTo(new Instant(10000));
+
+    PCollection<Integer> aggregated =
+        dropLateDataPipeline
+            .apply(testStream.advanceWatermarkToInfinity())
+            .apply(
+                Window.<Integer>into(FixedWindows.of(Duration.standardSeconds(3)))
+                    .accumulatingFiredPanes())
+            .apply(Combine.globally(Sum.ofIntegers()).withoutDefaults());
+
+    PAssert.that(aggregated).containsInAnyOrder(3);
+
+    dropLateDataPipeline.run().waitUntilFinish();
+  }
+
+  @Test
+  public void testDropLateDataKeyed() {
+    TestStream.Builder<KV<String, Integer>> testStream =
+        TestStream.create(KvCoder.of(StringUtf8Coder.of(), VarIntCoder.of()))
+            .addElements(TimestampedValue.of(KV.of("a", 1), new Instant(1000)))
+            .addElements(TimestampedValue.of(KV.of("b", 2), new Instant(2000)))
+            .addElements(TimestampedValue.of(KV.of("a", 3), new Instant(2500)))
+            .advanceWatermarkTo(new Instant(3000))
+            .addElements(TimestampedValue.of(KV.of("a", 10), new Instant(1000)))
+            .advanceWatermarkTo(new Instant(10000));
+
+    PCollection<KV<String, Integer>> aggregated =
+        dropLateDataPipeline
+            .apply(testStream.advanceWatermarkToInfinity())
+            .apply(
+                Window.<KV<String, Integer>>into(FixedWindows.of(Duration.standardSeconds(3)))
+                    .accumulatingFiredPanes())
+            .apply(Sum.integersPerKey());
+
+    PAssert.that(aggregated).containsInAnyOrder(Arrays.asList(KV.of("a", 4), KV.of("b", 2)));
+
+    dropLateDataPipeline.run().waitUntilFinish();
+  }
+}


### PR DESCRIPTION
This patch adds the `DoFnRunners.lateDataDroppingRunner()` in SamzaRunner GroupByKey translation so we allow users to drop late data in windowing when needed. Also add a boolean flag in SamzaPipelineOptions to turn it on/off.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
