### PR TITLE
Propagate annotations of CombinePerKey transforms to resulting component transforms

### DIFF
--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
@@ -1367,6 +1367,7 @@ def lift_combiners(stages, context):
                 payload=transform.spec.payload),
             inputs={'in': grouped_pcoll_id},
             outputs={'out': merged_pcoll_id},
+            annotations=transform.annotations,
             environment_id=transform.environment_id))
 
     yield make_stage(

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
@@ -1346,6 +1346,7 @@ def lift_combiners(stages, context):
                 payload=transform.spec.payload),
             inputs=transform.inputs,
             outputs={'out': precombined_pcoll_id},
+            annotations=transform.annotations,
             environment_id=transform.environment_id))
 
     yield make_stage(
@@ -1355,6 +1356,7 @@ def lift_combiners(stages, context):
             spec=beam_runner_api_pb2.FunctionSpec(
                 urn=common_urns.primitives.GROUP_BY_KEY.urn),
             inputs={'in': precombined_pcoll_id},
+            annotations=transform.annotations,
             outputs={'out': grouped_pcoll_id}))
 
     yield make_stage(
@@ -1380,6 +1382,7 @@ def lift_combiners(stages, context):
                 payload=transform.spec.payload),
             inputs={'in': merged_pcoll_id},
             outputs=transform.outputs,
+            annotations=transform.annotations,
             environment_id=transform.environment_id))
 
   def unlifted_stages(stage):

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
@@ -384,6 +384,35 @@ class TranslationsTest(unittest.TestCase):
         'multiple-small-combines/min-4-globally/CombinePerKey',
         optimized_stage_names)
 
+  def test_combineperkey_annotation_propagation(self):
+    """
+    Test that the CPK component transforms inherit annotations from the
+    source CPK
+    """
+    class MyCombinePerKey(beam.CombinePerKey):
+      def annotations(self):
+        return {"my_annotation":b""}
+    # Verify the results are as expected.
+    with TestPipeline() as pipeline:
+      pipeline | beam.Create([(1, 2)]) | MyCombinePerKey(min)
+
+    # Verify the optimization is as expected.
+    proto = pipeline.to_runner_api(
+        default_environment=environments.EmbeddedPythonEnvironment(
+            capabilities=environments.python_sdk_capabilities()))
+    optimized = translations.optimize_pipeline(
+        proto,
+        phases=[translations.lift_combiners],
+        known_runner_urns=frozenset(),
+        partial=True)
+    for transform_id in [
+        'MyCombinePerKey(min)/Precombine',
+        'MyCombinePerKey(min)/Group',
+        'MyCombinePerKey(min)/Merge',
+        'MyCombinePerKey(min)/ExtractOutputs']:
+      assert ("my_annotation" in
+              optimized.components.transforms[transform_id].annotations)
+
   def test_conditionally_packed_combiners(self):
     class RecursiveCombine(beam.PTransform):
       def __init__(self, labels):


### PR DESCRIPTION
**Please** add a meaningful description for your change here

------------------------
Issue:
------
If somehow you have an annotation(s) on a `CombinePerKey` transform (e.g. because you subclass it and add annotations or a runner adds annotations), the annotations end up disappearing after getting translated by `lifted_stages`. 

Considerations:
----------------
I don't think it's super obvious what the correct behavior is here. It's a bit surprising the annotation disappears but it may also be surprising for someone who meant to signal some behavior for one transform to suddenly have it for the four resulting component transforms. I put up this PR in case it does make sense to propagate the annotations since for our use case it simplifies things a lot

Context:
--------
We're writing a runner and we'd like to be able to save the top level user labels that users assign to their transforms so we can nicely log which user transform is being run at every phase. The most obvious way to me to do this was to create some custom annotations and then search for them at phase execution time. I was surprised when the CPK annotations were missing. Open to other ways to do this though

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
