### PR TITLE
RenderRunner cleanup

### DIFF
--- a/sdks/python/apache_beam/runners/render.py
+++ b/sdks/python/apache_beam/runners/render.py
@@ -78,6 +78,8 @@ try:
 except ImportError:
   gcsio = None  # type: ignore
 
+_LOGGER = logging.getLogger(__name__)
+
 # From the Beam site, circa November 2022.
 DEFAULT_EDGE_STYLE = 'color="#ff570b"'
 DEFAULT_TRANSFORM_STYLE = (
@@ -336,7 +338,7 @@ class PipelineRenderer:
     }
 
   def render_data(self):
-    logging.info("Re-rendering pipeline...")
+    _LOGGER.info("Re-rendering pipeline...")
     layout = self.layout_dot()
     if self.options.render_output:
       for path in self.options.render_output:
@@ -346,10 +348,10 @@ class PipelineRenderer:
             input=layout,
             check=False)
         if result.returncode:
-          logging.error(
+          _LOGGER.error(
               "Failed render pipeline as %r: exit %s", path, result.returncode)
         else:
-          logging.info("Rendered pipeline as %r", path)
+          _LOGGER.info("Rendered pipeline as %r", path)
     return self.page_callback_data(layout)
 
   def render_json(self):
@@ -407,7 +409,7 @@ class RenderRunner(runner.PipelineRunner):
       raise ValueError(
           'At least one of --render_port or --render_output must be provided.')
     if render_options.log_proto:
-      logging.info(pipeline_proto)
+      _LOGGER.info(pipeline_proto)
     renderer = PipelineRenderer(pipeline_proto, render_options)
     try:
       subprocess.run(['dot', '-V'], capture_output=True, check=True)
@@ -420,7 +422,7 @@ class RenderRunner(runner.PipelineRunner):
       for output in dot_files:
         with open(output, 'w') as fout:
           fout.write(renderer.to_dot())
-          logging.info("Wrote pipeline as %s", output)
+          _LOGGER.info("Wrote pipeline as %s", output)
 
       non_dot_files = set(render_options.render_output) - set(dot_files)
       if non_dot_files:

--- a/sdks/python/apache_beam/runners/render.py
+++ b/sdks/python/apache_beam/runners/render.py
@@ -129,12 +129,6 @@ class RenderOptions(pipeline_options.PipelineOptions):
         help='Set to also log input pipeline proto to stdout.')
     return parser
 
-  def __init__(self, *args, render_testing=False, **kwargs):
-    super().__init__(*args, **kwargs)
-    if self.render_port < 0 and not self.render_output and not render_testing:
-      raise ValueError(
-          'At least one of --render_port or --render_output must be provided.')
-
 
 class PipelineRenderer:
   def __init__(self, pipeline, options):
@@ -408,8 +402,10 @@ class RenderRunner(runner.PipelineRunner):
     return self.run_portable_pipeline(pipeline_object.to_runner_api(), options)
 
   def run_portable_pipeline(self, pipeline_proto, options):
-    #render_options = options.view_as(RenderOptions)
-    render_options = options
+    render_options = options.view_as(RenderOptions)
+    if render_options.render_port < 0 and not render_options.render_output:
+      raise ValueError(
+          'At least one of --render_port or --render_output must be provided.')
     if render_options.log_proto:
       logging.info(pipeline_proto)
     renderer = PipelineRenderer(pipeline_proto, render_options)

--- a/sdks/python/apache_beam/runners/render_test.py
+++ b/sdks/python/apache_beam/runners/render_test.py
@@ -39,6 +39,18 @@ class RenderRunnerTest(unittest.TestCase):
     self.assertIn('CustomName', dot)
     self.assertEqual(dot.count('->'), 2)
 
+  def test_run_portable_pipeline(self):
+    p = beam.Pipeline()
+    _ = (
+        p | beam.Impulse() | beam.Map(lambda _: 2)
+        | 'CustomName' >> beam.Map(lambda x: x * x))
+    pipeline_proto = p.to_runner_api()
+    dot = render.RenderRunner().run_portable_pipeline(
+        pipeline_proto, default_options)
+    self.assertIn('digraph', dot)
+    self.assertIn('CustomName', dot)
+    self.assertEqual(dot.count('->'), 2)
+
   def test_side_input(self):
     p = beam.Pipeline()
     pcoll = p | beam.Impulse() | beam.FlatMap(lambda x: [1, 2, 3])

--- a/sdks/python/apache_beam/runners/render_test.py
+++ b/sdks/python/apache_beam/runners/render_test.py
@@ -16,6 +16,7 @@
 #
 # pytype: skip-file
 
+import os
 import argparse
 import logging
 import subprocess
@@ -45,11 +46,11 @@ class RenderRunnerTest(unittest.TestCase):
         p | beam.Impulse() | beam.Map(lambda _: 2)
         | 'CustomName' >> beam.Map(lambda x: x * x))
     pipeline_proto = p.to_runner_api()
-    dot = render.RenderRunner().run_portable_pipeline(
-        pipeline_proto, default_options)
-    self.assertIn('digraph', dot)
-    self.assertIn('CustomName', dot)
-    self.assertEqual(dot.count('->'), 2)
+    render.RenderRunner().run_portable_pipeline(
+        pipeline_proto,
+        render.RenderOptions(
+            render_output=["my_output.svg"], render_testing=True))
+    assert os.path.exists("my_output.svg")
 
   def test_side_input(self):
     p = beam.Pipeline()

--- a/sdks/python/apache_beam/runners/render_test.py
+++ b/sdks/python/apache_beam/runners/render_test.py
@@ -90,7 +90,7 @@ class DotRequiringRenderingTest(unittest.TestCase):
       cls._dot_installed = True
 
   def setUp(self) -> None:
-    if not self._dot_installed:
+    if not self._dot_installed:  # type: ignore[attr-defined]
       self.skipTest('dot executable not installed')
 
   def test_run_portable_pipeline(self):

--- a/sdks/python/apache_beam/runners/render_test.py
+++ b/sdks/python/apache_beam/runners/render_test.py
@@ -100,10 +100,6 @@ class DotRequiringRenderingTest(unittest.TestCase):
         | 'CustomName' >> beam.Map(lambda x: x * x))
     pipeline_proto = p.to_runner_api()
 
-    # In tmpdir:
-    #   - Create a file called "my_output.svg"
-    #   - Run the pipeline
-    #   - Assert that "my_output.svg" exists
     with tempfile.TemporaryDirectory() as tmpdir:
       svg_path = os.path.join(tmpdir, "my_output.svg")
       render.RenderRunner().run_portable_pipeline(


### PR DESCRIPTION
While trying to use the `RenderRunner`, I came across a few warts.
- It accepts a pipeline proto but doesn't use `run_portable_pipeline`
- Not 100% sure about this but it used `dotX` instead of `dot` for one of its subprocess calls
- `RenderOptions` couldn't be used with `.view_as` because the init-time validation
- The `RenderRunner` logging used the root logger instead of the module logger


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.