### PR TITLE
Fix logic for _run_test in frames_test.py

### DIFF
--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -187,6 +187,9 @@ class _AbstractFrameTest(unittest.TestCase):
         if expected.index.is_unique:
           expected = expected.sort_index()
           actual = actual.sort_index()
+        elif isinstance(expected, pd.Series):
+          expected = expected.sort_values()
+          actual = actual.sort_values()
         else:
           expected = expected.sort_values(list(expected.columns))
           actual = actual.sort_values(list(actual.columns))


### PR DESCRIPTION
Came across this while trying to debug other things, but if a series has a non-unique index run_test would fail because ser.columns doesn't exist.

I guess none of our existing tests have non-unique indices for series.

