### PR TITLE
Revert "Enable remote gradle cache and build scan for GitHub Actions workflows"

### DIFF
--- a/.github/actions/setup-action/action.yml
+++ b/.github/actions/setup-action/action.yml
@@ -70,5 +70,3 @@ runs:
       shell: bash
       run: |
         echo KUBELET_GCLOUD_CONFIG_PATH=/var/lib/kubelet/pods/$POD_UID/volumes/kubernetes.io~empty-dir/gcloud >> $GITHUB_ENV
-    - name: Setup environment
-      uses: ./.github/actions/setup-environment-action

--- a/.github/actions/setup-self-hosted-action/action.yml
+++ b/.github/actions/setup-self-hosted-action/action.yml
@@ -15,42 +15,47 @@
 # specific language governing permissions and limitations
 # under the License.
 
-name: 'Setup environment action'
-description: 'Setup environment to run jobs'
+name: 'Setup environment for self-hosted runners'
+description: 'Setup action to run jobs in a self-hosted runner'
 inputs:
-  python-version:
+  requires-py-38:
     required: false
-    description: 'Install Python version'
-    default: ''
-  java-version:
+    description: 'Set as false if does not require py38 setup'
+    default: 'true'
+  requires-py-39:
     required: false
-    description: 'Install Java version'
-    default: ''
-  go-version:
+    description: 'Set as false if does not require py39 setup'
+    default: 'true'
+  requires-java-8:
     required: false
-    description: 'Install Go version'
-    default: ''
+    description: 'Set as false if does not require java-8 setup'
+    default: 'true'
+  requires-go:
+    required: false
+    description: 'Set as false if does not require go setup'
+    default: 'true'
 
 runs:
   using: "composite"
   steps:
-    - name: Install Python
-      if: ${{ inputs.python-version != '' }}
+    - name: Install python 3.8
+      if: ${{ inputs.requires-py-38 == 'true'  }}
       uses: actions/setup-python@v4
       with:
-        python-version: ${{ inputs.python-version }}
-    - name: Install Java
-      if: ${{ inputs.java-version != '' }}
+        python-version: "3.8"
+    - name: Install python 3.9
+      if: ${{ inputs.requires-py-39 == 'true'  }}
+      uses: actions/setup-python@v4
+      with:
+        python-version: "3.9"
+    - name: Set Java Version
+      if: ${{ inputs.requires-java-8 == 'true'  }}
       uses: actions/setup-java@v3
       with:
         distribution: 'temurin'
-        java-version: ${{ inputs.java-version }}
-    - name: Setup Gradle
-      uses: gradle/gradle-build-action@v2
-      with:
-        cache-read-only: false
-    - name: Install Go
-      if: ${{ inputs.go-version != '' }}
+        java-version: 8
+    - name: Set Go Version
+      if: ${{ inputs.requires-go == 'true'  }}
       uses: actions/setup-go@v3
       with:
-        go-version: ${{ inputs.go-version }} # never set patch, to get latest patch releases.
+        go-version: '1.21' # never set patch, to get latest patch releases.

--- a/.github/workflows/beam_PostCommit_Go_Dataflow_ARM.yml
+++ b/.github/workflows/beam_PostCommit_Go_Dataflow_ARM.yml
@@ -73,11 +73,19 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Java
+        uses: actions/setup-java@v3.8.0
         with:
-          java-version: 8
-          go-version: 1.21
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v1
       - name: Authenticate on GCP

--- a/.github/workflows/beam_PostCommit_Java_Avro_Versions.yml
+++ b/.github/workflows/beam_PostCommit_Java_Avro_Versions.yml
@@ -45,11 +45,6 @@ permissions:
   security-events: read
   statuses: read
 
-env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
-  GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
-  GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
-
 jobs:
   beam_PostCommit_Java_Avro_Versions:
     name: ${{matrix.job_name}} (${{matrix.job_phrase}})

--- a/.github/workflows/beam_PostCommit_Java_Examples_Dataflow_ARM.yml
+++ b/.github/workflows/beam_PostCommit_Java_Examples_Dataflow_ARM.yml
@@ -85,10 +85,21 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }} ${{matrix.java_version}}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }} ${{matrix.java_version}})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Setup self-hosted
+        uses: ./.github/actions/setup-self-hosted-action
         with:
+          requires-py-38: false
+          requires-py-39: false
+          requires-go: false
+      - name: Set up Java${{ matrix.java_version }}
+        uses: actions/setup-java@v3.8.0
+        with:
+          distribution: 'temurin'
           java-version: ${{ matrix.java_version }}
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Authenticate on GCP

--- a/.github/workflows/beam_PostCommit_Java_Examples_Flink.yml
+++ b/.github/workflows/beam_PostCommit_Java_Examples_Flink.yml
@@ -71,11 +71,19 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Java
+        uses: actions/setup-java@v3.8.0
         with:
-          java-version: 8
-          python-version: 3.8
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: run examplesIntegrationTest script
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:

--- a/.github/workflows/beam_PostCommit_Java_IO_Performance_Tests.yml
+++ b/.github/workflows/beam_PostCommit_Java_IO_Performance_Tests.yml
@@ -80,10 +80,15 @@ jobs:
       with:
         ref: v2.50.0 #TODO(https://github.com/apache/beam/issues/28330) automate updating this
         repository: apache/beam
-    - name: Setup environment
-      uses: ./.github/actions/setup-environment-action
+    - name: Install Java
+      uses: actions/setup-java@v3.8.0
       with:
-        java-version: 8
+        distribution: 'zulu'
+        java-version: '8'
+    - name: Setup Gradle
+      uses: gradle/gradle-build-action@v2
+      with:
+        cache-read-only: false
     - name: Authenticate on GCP
       uses: google-github-actions/setup-gcloud@v0
       with:

--- a/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Flink.yml
+++ b/.github/workflows/beam_PostCommit_Java_ValidatesRunner_Flink.yml
@@ -69,11 +69,19 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Java
+        uses: actions/setup-java@v3.8.0
         with:
-          java-version: 8
-          python-version: 3.8
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: run validatesRunner script
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:

--- a/.github/workflows/beam_PostCommit_Python_Examples_Dataflow.yml
+++ b/.github/workflows/beam_PostCommit_Python_Examples_Dataflow.yml
@@ -69,11 +69,19 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Python
+        uses: actions/setup-python@v4
         with:
-          java-version: 8
           python-version: 3.11
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Run examplesPostCommit script
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:

--- a/.github/workflows/beam_PostCommit_Python_Examples_Direct.yml
+++ b/.github/workflows/beam_PostCommit_Python_Examples_Direct.yml
@@ -71,11 +71,19 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }} ${{ matrix.python_version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }} ${{ matrix.python_version }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Python
+        uses: actions/setup-python@v4
         with:
-          java-version: 8
           python-version: ${{ matrix.python_version }}
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Set PY_VER_CLEAN
         id: set_py_ver_clean
         run: |

--- a/.github/workflows/beam_PostCommit_Python_Examples_Flink.yml
+++ b/.github/workflows/beam_PostCommit_Python_Examples_Flink.yml
@@ -71,11 +71,19 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }} ${{ matrix.python_version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }} ${{ matrix.python_version }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Python
+        uses: actions/setup-python@v4
         with:
-          java-version: 8
           python-version: ${{ matrix.python_version }}
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Set PY_VER_CLEAN
         id: set_py_ver_clean
         run: |

--- a/.github/workflows/beam_PostCommit_Python_Examples_Spark.yml
+++ b/.github/workflows/beam_PostCommit_Python_Examples_Spark.yml
@@ -71,11 +71,19 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }} ${{ matrix.python_version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }} ${{ matrix.python_version }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Python
+        uses: actions/setup-python@v4
         with:
-          java-version: 8
           python-version: ${{ matrix.python_version }}
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Set PY_VER_CLEAN
         id: set_py_ver_clean
         run: |

--- a/.github/workflows/beam_PostCommit_Python_MongoDBIO_IT.yml
+++ b/.github/workflows/beam_PostCommit_Python_MongoDBIO_IT.yml
@@ -69,11 +69,19 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Python
+        uses: actions/setup-python@v4
         with:
-          java-version: 8
           python-version: 3.11
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Run mongodbioIT script
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:

--- a/.github/workflows/beam_PostCommit_Python_ValidatesContainer_Dataflow.yml
+++ b/.github/workflows/beam_PostCommit_Python_ValidatesContainer_Dataflow.yml
@@ -71,11 +71,19 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }} ${{ matrix.python_version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }} ${{ matrix.python_version }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Python
+        uses: actions/setup-python@v4
         with:
-          java-version: 8
           python-version: ${{ matrix.python_version }}
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Set PY_VER_CLEAN
         id: set_py_ver_clean
         run: |

--- a/.github/workflows/beam_PostCommit_Python_ValidatesContainer_Dataflow_With_RC.yml
+++ b/.github/workflows/beam_PostCommit_Python_ValidatesContainer_Dataflow_With_RC.yml
@@ -71,11 +71,19 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }} ${{ matrix.python_version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }} ${{ matrix.python_version }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Python
+        uses: actions/setup-python@v4
         with:
-          java-version: 8
           python-version: ${{ matrix.python_version }}
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Set PY_VER_CLEAN
         id: set_py_ver_clean
         run: |
@@ -89,7 +97,7 @@ jobs:
         with:
           gradle-command: :sdks:python:test-suites:dataflow:py${{steps.set_py_ver_clean.outputs.py_ver_clean}}:validatesContainer
           arguments: |
-            -PtestRCDependencies=true
+            -PtestRCDependencies=true \
             -PpythonVersion=${{ matrix.python_version }} \
       - name: Archive code coverage results
         uses: actions/upload-artifact@v3

--- a/.github/workflows/beam_PostCommit_Python_ValidatesRunner_Dataflow.yml
+++ b/.github/workflows/beam_PostCommit_Python_ValidatesRunner_Dataflow.yml
@@ -71,11 +71,19 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }} ${{ matrix.python_version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }} ${{ matrix.python_version }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Python
+        uses: actions/setup-python@v4
         with:
-          java-version: 8
           python-version: ${{ matrix.python_version }}
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Set PY_VER_CLEAN
         id: set_py_ver_clean
         run: |

--- a/.github/workflows/beam_PostCommit_Python_ValidatesRunner_Flink.yml
+++ b/.github/workflows/beam_PostCommit_Python_ValidatesRunner_Flink.yml
@@ -71,11 +71,19 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }} ${{ matrix.python_version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }} ${{ matrix.python_version }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Python
+        uses: actions/setup-python@v4
         with:
-          java-version: 8
           python-version: ${{ matrix.python_version }}
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Set PY_VER_CLEAN
         id: set_py_ver_clean
         run: |

--- a/.github/workflows/beam_PostCommit_Python_ValidatesRunner_Samza.yml
+++ b/.github/workflows/beam_PostCommit_Python_ValidatesRunner_Samza.yml
@@ -71,11 +71,19 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }} ${{ matrix.python_version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }} ${{ matrix.python_version }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Python
+        uses: actions/setup-python@v4
         with:
-          java-version: 8
           python-version: ${{ matrix.python_version }}
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Set PY_VER_CLEAN
         id: set_py_ver_clean
         run: |

--- a/.github/workflows/beam_PostCommit_Python_ValidatesRunner_Spark.yml
+++ b/.github/workflows/beam_PostCommit_Python_ValidatesRunner_Spark.yml
@@ -71,11 +71,19 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }} ${{ matrix.python_version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }} ${{ matrix.python_version }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Python
+        uses: actions/setup-python@v4
         with:
-          java-version: 8
           python-version: ${{ matrix.python_version }}
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Set PY_VER_CLEAN
         id: set_py_ver_clean
         run: |

--- a/.github/workflows/beam_PreCommit_CommunityMetrics.yml
+++ b/.github/workflows/beam_PreCommit_CommunityMetrics.yml
@@ -78,10 +78,15 @@ jobs:
           comment_phrase: ${{matrix.job_phrase}}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Java
+        uses: actions/setup-java@v3.8.0
         with:
-          java-version: 8
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Remove default github maven configuration

--- a/.github/workflows/beam_PreCommit_Go.yml
+++ b/.github/workflows/beam_PreCommit_Go.yml
@@ -78,11 +78,19 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Java
+        uses: actions/setup-java@v3.8.0
         with:
-          java-version: 8
-          go-version: 1.21
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.21'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: run goPreCommit script
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:

--- a/.github/workflows/beam_PreCommit_GoPortable.yml
+++ b/.github/workflows/beam_PreCommit_GoPortable.yml
@@ -78,11 +78,11 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Setup self-hosted
+        uses: ./.github/actions/setup-self-hosted-action
         with:
-          python-version: 3.8
-          java-version: 8
+          requires-py-39: false
+          requires-go: false
       - name: Run goPortablePreCommit script
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:

--- a/.github/workflows/beam_PreCommit_GoPrism.yml
+++ b/.github/workflows/beam_PreCommit_GoPrism.yml
@@ -78,11 +78,11 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Setup self-hosted
+        uses: ./.github/actions/setup-self-hosted-action
         with:
-          python-version: 3.8
-          java-version: 8
+          requires-py-39: false
+          requires-go: false
       - name: Run goPrismPreCommit script
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:

--- a/.github/workflows/beam_PreCommit_ItFramework.yml
+++ b/.github/workflows/beam_PreCommit_ItFramework.yml
@@ -81,10 +81,16 @@ jobs:
           comment_phrase: ${{matrix.job_phrase}}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Setup self-hosted
+        uses: ./.github/actions/setup-self-hosted-action
         with:
-          java-version: 8
+          requires-py-38: false
+          requires-py-39: false
+          requires-go: false
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: run ItFrameworkPrecommit script
         run: ./gradlew -p it build
       - name: Archive JUnit Test Results

--- a/.github/workflows/beam_PreCommit_Java.yml
+++ b/.github/workflows/beam_PreCommit_Java.yml
@@ -141,11 +141,6 @@ permissions:
   security-events: read
   statuses: read
 
-env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
-  GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
-  GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
-
 jobs:
   beam_PreCommit_Java:
     name: ${{matrix.job_name}} (${{matrix.job_phrase}})

--- a/.github/workflows/beam_PreCommit_Java_Debezium_IO_Direct.yml
+++ b/.github/workflows/beam_PreCommit_Java_Debezium_IO_Direct.yml
@@ -53,11 +53,6 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.issue.number || github.event.pull_request.head.label || github.sha || github.head_ref || github.ref }}-${{ github.event.schedule || github.event.comment.body || github.event.sender.login}}'
   cancel-in-progress: true
 
-env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
-  GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
-  GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
-
 jobs:
   beam_PreCommit_Java_Debezium_IO_Direct:
     name: ${{ matrix.job_name }} (${{ matrix.job_phrase }})

--- a/.github/workflows/beam_PreCommit_Java_ElasticSearch_IO_Direct.yml
+++ b/.github/workflows/beam_PreCommit_Java_ElasticSearch_IO_Direct.yml
@@ -55,11 +55,6 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.issue.number || github.event.pull_request.head.label || github.sha || github.head_ref || github.ref }}-${{ github.event.schedule || github.event.comment.body || github.event.sender.login}}'
   cancel-in-progress: true
 
-env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
-  GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
-  GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
-
 jobs:
   beam_PreCommit_Java_ElasticSearch_IO_Direct:
     name: ${{ matrix.job_name }} (${{ matrix.job_phrase }})

--- a/.github/workflows/beam_PreCommit_Java_Examples_Dataflow.yml
+++ b/.github/workflows/beam_PreCommit_Java_Examples_Dataflow.yml
@@ -92,10 +92,16 @@ jobs:
           comment_phrase: ${{matrix.job_phrase}}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Setup self-hosted
+        uses: ./.github/actions/setup-self-hosted-action
         with:
-          java-version: 8
+          requires-py-38: false
+          requires-py-39: false
+          requires-go: false
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Authenticate on GCP
         uses: google-github-actions/setup-gcloud@v0
         with:

--- a/.github/workflows/beam_PreCommit_Java_Examples_Dataflow_Java17.yml
+++ b/.github/workflows/beam_PreCommit_Java_Examples_Dataflow_Java17.yml
@@ -63,11 +63,6 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.issue.number || github.event.pull_request.head.label || github.sha || github.head_ref || github.ref }}-${{ github.event.schedule || github.event.comment.body || github.event.sender.login}}'
   cancel-in-progress: true
 
-env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
-  GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
-  GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
-
 jobs:
   beam_PreCommit_Java_Examples_Dataflow_Java17:
     name: ${{ matrix.job_name }} (${{ matrix.job_phrase }})

--- a/.github/workflows/beam_PreCommit_Java_File-schema-transform_IO_Direct.yml
+++ b/.github/workflows/beam_PreCommit_Java_File-schema-transform_IO_Direct.yml
@@ -53,11 +53,6 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.issue.number || github.event.pull_request.head.label || github.sha || github.head_ref || github.ref }}-${{ github.event.schedule || github.event.comment.body || github.event.sender.login}}'
   cancel-in-progress: true
 
-env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
-  GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
-  GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
-
 jobs:
   beam_PreCommit_Java_File-schema-transform_IO_Direct:
     name: ${{ matrix.job_name }} (${{ matrix.job_phrase }})

--- a/.github/workflows/beam_PreCommit_Java_Flink_Versions.yml
+++ b/.github/workflows/beam_PreCommit_Java_Flink_Versions.yml
@@ -79,11 +79,19 @@ jobs:
         with:
           comment_phrase: 'Run Java_Flink_Versions PreCommit'
           github_token: ${{ secrets.GITHUB_TOKEN }}
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Java
+        uses: actions/setup-java@v3.8.0
         with:
-          java-version: 8
-          python-version: 3.8
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: run Java Flink Versions PreCommit script
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:

--- a/.github/workflows/beam_PreCommit_Java_PVR_Flink_Batch.yml
+++ b/.github/workflows/beam_PreCommit_Java_PVR_Flink_Batch.yml
@@ -59,11 +59,6 @@ permissions:
   security-events: read
   statuses: read
 
-env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
-  GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
-  GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
-
 jobs:
   beam_PreCommit_Java_PVR_Flink_Batch:
     name: ${{ matrix.job_name }} (${{ matrix.job_phrase }})

--- a/.github/workflows/beam_PreCommit_Python.yml
+++ b/.github/workflows/beam_PreCommit_Python.yml
@@ -79,11 +79,19 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }} ${{ matrix.python_version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }} ${{ matrix.python_version }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Python
+        uses: actions/setup-python@v4
         with:
-          java-version: 8
           python-version: ${{ matrix.python_version }}
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Set PY_VER_CLEAN
         id: set_py_ver_clean
         run: |

--- a/.github/workflows/beam_PreCommit_PythonDocker.yml
+++ b/.github/workflows/beam_PreCommit_PythonDocker.yml
@@ -78,12 +78,23 @@ jobs:
           comment_phrase: ${{matrix.job_phrase}} ${{ matrix.python_version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }} ${{ matrix.python_version }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Java
+        uses: actions/setup-java@v3
         with:
-          java-version: 8
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.16'
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
           python-version: ${{ matrix.python_version }}
-          go-version: 1.16
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Setup Buildx
         uses: docker/setup-buildx-action@v2
         with:

--- a/.github/workflows/beam_PreCommit_PythonDocs.yml
+++ b/.github/workflows/beam_PreCommit_PythonDocs.yml
@@ -78,11 +78,19 @@ jobs:
           comment_phrase: ${{matrix.job_phrase}}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Java
+        uses: actions/setup-java@v3.8.0
         with:
-          java-version: 8
-          python-version: 3.8
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: run pythonDocsPreCommit script
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:

--- a/.github/workflows/beam_PreCommit_PythonFormatter.yml
+++ b/.github/workflows/beam_PreCommit_PythonFormatter.yml
@@ -77,11 +77,19 @@ jobs:
           comment_phrase: ${{matrix.job_phrase}}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Java
+        uses: actions/setup-java@v3.8.0
         with:
-          java-version: 8
-          python-version: 3.8
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: run pythonFormatterPreCommit script
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:

--- a/.github/workflows/beam_PreCommit_PythonLint.yml
+++ b/.github/workflows/beam_PreCommit_PythonLint.yml
@@ -77,12 +77,23 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Java
+        uses: actions/setup-java@v3.8.0
         with:
-          java-version: 8
-          python-version: 3.8
-          go-version: 1.16
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Install Go
+        uses: actions/setup-go@v4
+        with:
+          go-version: '1.16'
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: run pythonLintPreCommit script
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:

--- a/.github/workflows/beam_PreCommit_Python_Coverage.yml
+++ b/.github/workflows/beam_PreCommit_Python_Coverage.yml
@@ -77,11 +77,19 @@ jobs:
           comment_phrase: ${{matrix.job_phrase}}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Python
+        uses: actions/setup-python@v4
         with:
-          java-version: 8
-          python-version: 3.8
+          python-version: '3.8'
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Run preCommitPyCoverage
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:

--- a/.github/workflows/beam_PreCommit_Python_Dataframes.yml
+++ b/.github/workflows/beam_PreCommit_Python_Dataframes.yml
@@ -79,11 +79,19 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase}} ${{ matrix.python_version}}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name}} (${{ matrix.job_phrase}} ${{ matrix.python_version}})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Python
+        uses: actions/setup-python@v4
         with:
-          java-version: 8
           python-version: ${{ matrix.python_version }}
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Set PY_VER_CLEAN
         id: set_py_ver_clean
         run: |

--- a/.github/workflows/beam_PreCommit_Python_Examples.yml
+++ b/.github/workflows/beam_PreCommit_Python_Examples.yml
@@ -79,11 +79,19 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }} ${{ matrix.python_version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }} ${{ matrix.python_version }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Python
+        uses: actions/setup-python@v4
         with:
-          java-version: 8
           python-version: ${{ matrix.python_version }}
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Set PY_VER_CLEAN
         id: set_py_ver_clean
         run: |

--- a/.github/workflows/beam_PreCommit_Python_Integration.yml
+++ b/.github/workflows/beam_PreCommit_Python_Integration.yml
@@ -79,11 +79,19 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }} ${{ matrix.python_version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }} ${{ matrix.python_version }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Python
+        uses: actions/setup-python@v4
         with:
-          java-version: 8
           python-version: ${{ matrix.python_version }}
+      - name: Install Java
+        uses: actions/setup-java@v3.8.0
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Set PY_VER_CLEAN
         id: set_py_ver_clean
         run: |

--- a/.github/workflows/beam_PreCommit_Python_PVR_Flink.yml
+++ b/.github/workflows/beam_PreCommit_Python_PVR_Flink.yml
@@ -71,11 +71,6 @@ concurrency:
   group: '${{ github.workflow }} @ ${{ github.event.issue.number || github.event.pull_request.head.label || github.sha || github.head_ref || github.ref }}-${{ github.event.schedule || github.event.comment.body || github.event.sender.login}}'
   cancel-in-progress: true
 
-env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
-  GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
-  GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
-
 jobs:
   beam_PreCommit_Python_PVR_Flink:
     name: ${{ matrix.job_name }} (${{ matrix.job_phrase }})

--- a/.github/workflows/beam_PreCommit_Python_Runners.yml
+++ b/.github/workflows/beam_PreCommit_Python_Runners.yml
@@ -79,11 +79,19 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }} ${{ matrix.python_version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }} ${{ matrix.python_version }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Python
+        uses: actions/setup-python@v4
         with:
-          java-version: 8
           python-version: ${{ matrix.python_version }}
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Set PY_VER_CLEAN
         id: set_py_ver_clean
         run: |

--- a/.github/workflows/beam_PreCommit_Python_Transforms.yml
+++ b/.github/workflows/beam_PreCommit_Python_Transforms.yml
@@ -79,11 +79,19 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }} ${{ matrix.python_version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }} ${{ matrix.python_version }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Python
+        uses: actions/setup-python@v4
         with:
-          java-version: 8
           python-version: ${{ matrix.python_version }}
+      - name: Install Java
+        uses: actions/setup-java@v3
+        with:
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Set PY_VER_CLEAN
         id: set_py_ver_clean
         run: |

--- a/.github/workflows/beam_PreCommit_RAT.yml
+++ b/.github/workflows/beam_PreCommit_RAT.yml
@@ -76,10 +76,15 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Java
+        uses: actions/setup-java@v3.8.0
         with:
-          java-version: 8
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: run RAT script
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:

--- a/.github/workflows/beam_PreCommit_Spotless.yml
+++ b/.github/workflows/beam_PreCommit_Spotless.yml
@@ -62,11 +62,6 @@ permissions:
   security-events: read
   statuses: read
 
-env:
-  GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
-  GRADLE_ENTERPRISE_CACHE_USERNAME: ${{ secrets.GE_CACHE_USERNAME }}
-  GRADLE_ENTERPRISE_CACHE_PASSWORD: ${{ secrets.GE_CACHE_PASSWORD }}
-
 jobs:
   beam_PreCommit_Spotless:
     name: ${{matrix.job_name}} (${{matrix.job_phrase}})

--- a/.github/workflows/beam_PreCommit_Typescript.yml
+++ b/.github/workflows/beam_PreCommit_Typescript.yml
@@ -79,11 +79,15 @@ jobs:
           comment_phrase: ${{matrix.job_phrase}}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Setup self-hosted
+        uses: ./.github/actions/setup-self-hosted-action
         with:
-          python-version: 3.8
-          java-version: 8
+          requires-py-39: false
+          requires-go: false
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: run typescriptPreCommit script
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:

--- a/.github/workflows/beam_PreCommit_Website.yml
+++ b/.github/workflows/beam_PreCommit_Website.yml
@@ -78,10 +78,15 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Java
+        uses: actions/setup-java@v3.8.0
         with:
-          java-version: 8
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: run websitePreCommit script
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:

--- a/.github/workflows/beam_PreCommit_Website_Stage_GCS.yml
+++ b/.github/workflows/beam_PreCommit_Website_Stage_GCS.yml
@@ -82,11 +82,15 @@ jobs:
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
       - name: Echo PR number
         run: echo "ghprbPullId=${{ github.event.pull_request.number || github.event.issue.number }}" >> $GITHUB_ENV
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Setup self-hosted
+        uses: ./.github/actions/setup-self-hosted-action
         with:
-          python-version: 3.8
-          java-version: 8
+          requires-py-39: false
+          requires-go: false
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Authenticate on GCP
         uses: google-github-actions/setup-gcloud@v0
         with:

--- a/.github/workflows/beam_PreCommit_Whitespace.yml
+++ b/.github/workflows/beam_PreCommit_Whitespace.yml
@@ -77,11 +77,19 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Java
+        uses: actions/setup-java@v3.8.0
         with:
-          java-version: 8
-          python-version: 3.8
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Install Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: run whitespacePreCommit script
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:

--- a/.github/workflows/beam_Python_ValidatesContainer_Dataflow_ARM.yml
+++ b/.github/workflows/beam_Python_ValidatesContainer_Dataflow_ARM.yml
@@ -76,10 +76,14 @@ jobs:
           comment_phrase: ${{ matrix.job_phrase }} ${{ matrix.python_version }}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }} ${{ matrix.python_version }})
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Python
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python_version }}
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Set up Docker Buildx
         uses: docker/setup-buildx-action@v2
       - name: Authenticate on GCP

--- a/.github/workflows/beam_Release_NightlySnapshot.yml
+++ b/.github/workflows/beam_Release_NightlySnapshot.yml
@@ -61,10 +61,15 @@ jobs:
           github_job: ${{matrix.job_name}}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           comment_phrase: "Release Nightly Snapshot"
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Java
+        uses: actions/setup-java@v3.8.0
         with:
-          java-version: 8
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
       - name: Auth on snapshot repository
         run: |
           mkdir -p ${HOME}/.m2

--- a/.github/workflows/beam_Release_Python_NightlySnapshot.yml
+++ b/.github/workflows/beam_Release_Python_NightlySnapshot.yml
@@ -60,11 +60,19 @@ jobs:
           github_job: ${{matrix.job_name}}
           github_token: ${{ secrets.GITHUB_TOKEN }}
           comment_phrase: ${{matrix.job_phrase}}
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Install Java
+        uses: actions/setup-java@v3.8.0
         with:
-          java-version: 8
-          python-version: 3.8
+          distribution: 'zulu'
+          java-version: '8'
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
+      - name: Setup Python
+        uses: actions/setup-python@v4
+        with:
+          python-version: '3.8'
       - name: Authenticate on GCP
         uses: google-github-actions/setup-gcloud@v0
         with:

--- a/.github/workflows/java_tests.yml
+++ b/.github/workflows/java_tests.yml
@@ -77,11 +77,11 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Setup self-hosted
+        uses: ./.github/actions/setup-self-hosted-action
         with:
-          java-version: 8
-          go-version: 1.21
+          requires-py-38: false
+          requires-py-39: false
       - name: Remove default github maven configuration
         # This step is a workaround to avoid a decryption issue of Beam's
         # net.linguica.gradle.maven.settings plugin and github's provided maven
@@ -136,11 +136,12 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - name: Setup self-hosted
+        uses: ./.github/actions/setup-self-hosted-action
         with:
-          java-version: 8
-          go-version: 1.21
+          requires-py-38: false
+          requires-py-39: false
+
       - name: Remove default github maven configuration
         # This step is a workaround to avoid a decryption issue of Beam's
         # net.linguica.gradle.maven.settings plugin and github's provided maven
@@ -179,11 +180,11 @@ jobs:
         with:
           persist-credentials: false
           submodules: recursive
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
-        with:
-          java-version: 8
-          go-version: 1.21
+      - name: Setup self-hosted
+        uses: ./.github/actions/setup-self-hosted-action
+        with: 
+          requires-py-38: false
+          requires-py-39: false
       - name: Authenticate on GCP
         uses: google-github-actions/setup-gcloud@v0
         with:

--- a/.github/workflows/playground_backend_precommit.yml
+++ b/.github/workflows/playground_backend_precommit.yml
@@ -38,12 +38,19 @@ jobs:
     steps:
       - name: Check out the repo
         uses: actions/checkout@v4
-      
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+
+      - uses: actions/setup-python@v4
         with:
-          java-version: '${{ env.JAVA_VERSION }}'
           python-version: '${{ env.PYTHON_VERSION }}'
+      - uses: actions/setup-java@v3.8.0
+        with:
+          distribution: 'zulu'
+          java-version: '${{ env.JAVA_VERSION }}'
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+          cache-read-only: false
 
       - name: Add GOPATH/bin to PATH
         run: echo "PATH=$PATH:$(go env GOPATH)/bin" >> $GITHUB_ENV

--- a/.github/workflows/tour_of_beam_backend_integration.yml
+++ b/.github/workflows/tour_of_beam_backend_integration.yml
@@ -75,12 +75,15 @@ jobs:
         working-directory: ./learning/tour-of-beam/backend
     steps:
       - uses: actions/checkout@v4
-
-      - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
+      - uses: actions/setup-go@v4
         with:
           # pin to the biggest Go version supported by Cloud Functions runtime
           go-version: '1.16'
+
+      - name: Setup Gradle
+        uses: gradle/gradle-build-action@v2
+        with:
+            cache-read-only: false
 
       - name: Build Playground router image
         run: ./gradlew -i playground:backend:containers:router:docker

--- a/.github/workflows/update_python_dependencies.yml
+++ b/.github/workflows/update_python_dependencies.yml
@@ -50,13 +50,7 @@ jobs:
       - name: Checkout code
         uses: actions/checkout@v4
       - name: Setup environment
-        uses: ./.github/actions/setup-environment-action
-        with:
-          python-version: |
-            3.8
-            3.9
-          java-version: 8
-          go-version: 1.21
+        uses: ./.github/actions/setup-self-hosted-action
       - name: Update Python Dependencies
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:


### PR DESCRIPTION
Reverts apache/beam#28539

Suspecting this has caused may flakes in GHA suites due to `Index was out of range. Must be non-negative and less than the size of the collection. (Parameter 'index')`, see: https://github.com/apache/beam/pull/28539#issuecomment-1728049974



