### PR TITLE
Fix test for new group keys behavior for Pandas 2

### DIFF
--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -1827,8 +1827,8 @@ class GroupByTest(_AbstractFrameTest):
     df = GROUPBY_DF
 
     self._run_test(
-        lambda df: df[['foo', 'group', 'bar']].groupby('group').apply(
-            lambda x: x),
+        lambda df: df[['foo', 'group', 'bar']].groupby(
+            'group', group_keys=False).apply(lambda x: x),
         df)
 
   def test_groupby_transform(self):


### PR DESCRIPTION
In Pandas 2, groupby().apply() will append group keys to an index that already has them in cases where the apply is really a transform (the resulting index is same as the incoming one). This is a change from Pandas 1.5.  

When running the original test with Pandas 1.5, we get the following warning:

```FutureWarning: Not prepending group keys to the result index of transform-like apply. In the future, the group keys will be included in the index, regardless of whether the applied function returns a like-indexed object.
To preserve the previous behavior, use

	>>> .groupby(..., group_keys=False)

To adopt the future behavior and silence this warning, use 

	>>> .groupby(..., group_keys=True)
  df.groupby(['provider']).apply(lambda x: x)
```

So I set group_keys to False to retain the 1.5 behavior.