### PR TITLE
Update BigQueryIO Documentation

### DIFF
--- a/website/www/site/content/en/documentation/io/built-in/google-bigquery.md
+++ b/website/www/site/content/en/documentation/io/built-in/google-bigquery.md
@@ -885,8 +885,7 @@ explicitly enable this using [`withAutoSharding`](https://beam.apache.org/releas
 
 When using `STORAGE_WRITE_API`, the `PCollection` returned by
 [`WriteResult.getFailedStorageApiInserts`](https://beam.apache.org/releases/javadoc/current/org/apache/beam/sdk/io/gcp/bigquery/WriteResult.html#getFailedStorageApiInserts--)
-will contain the rows that failed to be written to the Storage Write API sink. If there are data validation errors, the
-transform will throw a `RuntimeException`.
+will contain the rows that failed to be written to the Storage Write API sink.
 
 #### At-least-once semantics
 
@@ -903,8 +902,7 @@ Auto sharding is not applicable for `STORAGE_API_AT_LEAST_ONCE`.
 
 When using `STORAGE_API_AT_LEAST_ONCE`, the `PCollection` returned by
 [`WriteResult.getFailedStorageApiInserts`](https://beam.apache.org/releases/javadoc/current/org/apache/beam/sdk/io/gcp/bigquery/WriteResult.html#getFailedStorageApiInserts--)
-will contain the rows that failed to be written to the Storage Write API sink. If there are data validation errors, the
-transform will throw a `RuntimeException`.
+will contain the rows that failed to be written to the Storage Write API sink.
 
 #### Quotas
 

--- a/website/www/site/content/en/documentation/io/built-in/google-bigquery.md
+++ b/website/www/site/content/en/documentation/io/built-in/google-bigquery.md
@@ -885,7 +885,7 @@ explicitly enable this using [`withAutoSharding`](https://beam.apache.org/releas
 
 When using `STORAGE_WRITE_API`, the `PCollection` returned by
 [`WriteResult.getFailedStorageApiInserts`](https://beam.apache.org/releases/javadoc/current/org/apache/beam/sdk/io/gcp/bigquery/WriteResult.html#getFailedStorageApiInserts--)
-will contain the rows that failed to be written by the Storage Write API. If there are data validation errors, the
+will contain the rows that failed to be written to the Storage Write API sink. If there are data validation errors, the
 transform will throw a `RuntimeException`.
 
 #### At-least-once semantics

--- a/website/www/site/content/en/documentation/io/built-in/google-bigquery.md
+++ b/website/www/site/content/en/documentation/io/built-in/google-bigquery.md
@@ -883,9 +883,9 @@ explicitly enable this using [`withAutoSharding`](https://beam.apache.org/releas
 ***Note:*** Auto sharding with `STORAGE_WRITE_API` is supported on Dataflow's legacy runner, but **not** on Runner V2
 {{< /paragraph >}}
 
-When using `STORAGE_WRITE_API`, the PCollection returned by
-[`WriteResult.getFailedInserts`](https://beam.apache.org/releases/javadoc/current/org/apache/beam/sdk/io/gcp/bigquery/WriteResult.html#getFailedInserts--)
-will not contain the failed rows. If there are data validation errors, the
+When using `STORAGE_WRITE_API`, the `PCollection` returned by
+[`WriteResult.getFailedStorageApiInserts`](https://beam.apache.org/releases/javadoc/current/org/apache/beam/sdk/io/gcp/bigquery/WriteResult.html#getFailedStorageApiInserts--)
+will contain the rows that failed to be written by the Storage Write API. If there are data validation errors, the
 transform will throw a `RuntimeException`.
 
 #### At-least-once semantics
@@ -901,9 +901,9 @@ specify the number of streams, and you can’t specify the triggering frequency.
 
 Auto sharding is not applicable for `STORAGE_API_AT_LEAST_ONCE`.
 
-When using `STORAGE_API_AT_LEAST_ONCE`, the PCollection returned by
-[`WriteResult.getFailedInserts`](https://beam.apache.org/releases/javadoc/current/org/apache/beam/sdk/io/gcp/bigquery/WriteResult.html#getFailedInserts--)
-will not contain the failed rows. If there are data validation errors, the
+When using `STORAGE_API_AT_LEAST_ONCE`, the `PCollection` returned by
+[`WriteResult.getFailedStorageApiInserts`](https://beam.apache.org/releases/javadoc/current/org/apache/beam/sdk/io/gcp/bigquery/WriteResult.html#getFailedStorageApiInserts--)
+will contain the rows that failed to be written by the Storage Write API. If there are data validation errors, the
 transform will throw a `RuntimeException`.
 
 #### Quotas

--- a/website/www/site/content/en/documentation/io/built-in/google-bigquery.md
+++ b/website/www/site/content/en/documentation/io/built-in/google-bigquery.md
@@ -903,7 +903,7 @@ Auto sharding is not applicable for `STORAGE_API_AT_LEAST_ONCE`.
 
 When using `STORAGE_API_AT_LEAST_ONCE`, the `PCollection` returned by
 [`WriteResult.getFailedStorageApiInserts`](https://beam.apache.org/releases/javadoc/current/org/apache/beam/sdk/io/gcp/bigquery/WriteResult.html#getFailedStorageApiInserts--)
-will contain the rows that failed to be written by the Storage Write API. If there are data validation errors, the
+will contain the rows that failed to be written to the Storage Write API sink. If there are data validation errors, the
 transform will throw a `RuntimeException`.
 
 #### Quotas


### PR DESCRIPTION
- Updated the description regarding failed rows for Storage Write API.
- Made `PCollection` formatting consistent.

**Please** add a meaningful description for your change here

fixes #27298 

Current [documentation](https://beam.apache.org/documentation/io/built-in/google-bigquery/#exactly-once-semantics) mentions `WriteResult.getFailedInserts` does not work for Storage Write API. But now `WriteResult.getFailedStorageApiInserts` will return the failed rows for Storage Write API. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
