### PR TITLE
Filter out some warnings that aren't useful in pytest

### DIFF
--- a/sdks/python/pytest.ini
+++ b/sdks/python/pytest.ini
@@ -17,6 +17,9 @@
 
 [pytest]
 junit_family = xunit2
+filterwarnings =
+  ignore:Deprecated call to `pkg_resources.declare_namespace\('.*'\):DeprecationWarning
+  ignore::DeprecationWarning:google.rpc
 
 # Disable class-name-based test discovery.
 python_classes =


### PR DESCRIPTION
Going along with https://github.com/googleapis/google-cloud-python/issues/11184  I want to filter these out for now. It is nothing to do with our code.