### PR TITLE
Add GoogleAdsIO to the list of built-in connectors

### DIFF
--- a/website/www/site/content/en/documentation/io/connectors.md
+++ b/website/www/site/content/en/documentation/io/connectors.md
@@ -938,6 +938,20 @@ This table provides a consolidated, at-a-glance overview of the available built-
     <td class="present">✔</td>
     <td class="absent">✘</td>
   </tr>
+  <tr>
+    <td>GoogleAdsIO</td>
+    <td class="present">✔</td>
+    <td class="present">✔</td>
+    <td class="present">
+      ✔
+      <a href="https://beam.apache.org/releases/javadoc/current/org/apache/beam/sdk/io/googleads/GoogleAdsIO.html">native</a>
+    </td>
+    <td>Not available</td>
+    <td>Not available</td>
+    <td>Not available</td>
+    <td class="present">✔</td>
+    <td class="present">✔</td>
+  </tr>
 </table>
 </div>
 


### PR DESCRIPTION
GoogleAdsIO was added by @sjvanrossum at https://github.com/apache/beam/pull/27681, but it wasn't added to the list.

Fixing the gap here