### PR TITLE
Revert "assign highmem runner to beam_PostCommit_Python and to beam_PreCommit…"

### DIFF
--- a/.github/workflows/beam_PostCommit_Python.yml
+++ b/.github/workflows/beam_PostCommit_Python.yml
@@ -53,7 +53,7 @@ env:
 jobs:
   beam_PostCommit_Python:
     name: ${{matrix.job_name}} (${{matrix.job_phrase}} ${{matrix.python_version}})
-    runs-on: [self-hosted, ubuntu-20.04, highmem]
+    runs-on: [self-hosted, ubuntu-20.04, main]
     timeout-minutes: 240
     strategy:
       fail-fast: false

--- a/.github/workflows/beam_PreCommit_Java_GCP_IO_Direct.yml
+++ b/.github/workflows/beam_PreCommit_Java_GCP_IO_Direct.yml
@@ -90,7 +90,7 @@ jobs:
       github.event_name == 'schedule' ||
       github.event_name == 'workflow_dispatch' ||
       github.event.comment.body == 'Run Java_GCP_IO_Direct PreCommit'
-    runs-on: [self-hosted, ubuntu-20.04, highmem]
+    runs-on: [self-hosted, ubuntu-20.04, main]
     steps:
       - uses: actions/checkout@v4
       - name: Setup repository


### PR DESCRIPTION
Reverts apache/beam#28719

We have disabled the offending test that causing OOM. And the highmem cluster seems missing some credential and causing this workflow continuously failing: #28803