### PR TITLE
Fix sorting for Pandas 2.1

### DIFF
--- a/sdks/python/apache_beam/dataframe/partitionings.py
+++ b/sdks/python/apache_beam/dataframe/partitionings.py
@@ -135,15 +135,12 @@ class Index(Partitioning):
       # Apply consistent order within dataframe with sort_index()
       # Also drops any empty dataframes.
 
-      # This is a workaround for
+      # Doing it this way instead of just df.sort_index() is a workaround for
       # https://github.com/pandas-dev/pandas/issues/55379.
       # Since this is just for checking, performance shouldn't be an issue.
-      def sort_index(df):
-        df.index = df.index.sort_values()
-        return df
-
-      return sorted((sort_index(df) for df in dfs if len(df)),
-                    key=lambda df: sum(self._hash_index(df)))
+      return sorted(
+          (df.reindex(df.index.sort_values()) for df in dfs if len(df)),
+          key=lambda df: sum(self._hash_index(df)))
 
     dfs = apply_consistent_order(dfs)
     repartitioned_dfs = apply_consistent_order(

--- a/sdks/python/apache_beam/dataframe/partitionings.py
+++ b/sdks/python/apache_beam/dataframe/partitionings.py
@@ -134,7 +134,15 @@ class Index(Partitioning):
       # hash.
       # Apply consistent order within dataframe with sort_index()
       # Also drops any empty dataframes.
-      return sorted((df.sort_index() for df in dfs if len(df)),
+
+      # This is a workaround for
+      # https://github.com/pandas-dev/pandas/issues/55379.
+      # Since this is just for checking, performance shouldn't be an issue.
+      def sort_index(df):
+        df.index = df.index.sort_values()
+        return df
+
+      return sorted((sort_index(df) for df in dfs if len(df)),
                     key=lambda df: sum(self._hash_index(df)))
 
     dfs = apply_consistent_order(dfs)


### PR DESCRIPTION
Due to https://github.com/pandas-dev/pandas/issues/55379, Pandas 2.1 fails some tests because things don't sort right. This work around fixes it, and since it is only for checks it shouldn't be any sort of big performance impact.