### PR TITLE
Add map function and skip applymap for 2.1

### DIFF
--- a/sdks/python/apache_beam/dataframe/frames.py
+++ b/sdks/python/apache_beam/dataframe/frames.py
@@ -2978,6 +2978,8 @@ class DeferredDataFrame(DeferredDataFrameOrSeries):
   agg = aggregate
 
   applymap = frame_base._elementwise_method('applymap', base=pd.DataFrame)
+  if PD_VERSION >= (2, 1):
+    map = frame_base._elementwise_method('map', base=pd.DataFrame)
   add_prefix = frame_base._elementwise_method('add_prefix', base=pd.DataFrame)
   add_suffix = frame_base._elementwise_method('add_suffix', base=pd.DataFrame)
 

--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -865,12 +865,25 @@ class DeferredFrameTest(_AbstractFrameTest):
     self._run_error_test(lambda df: df.corrwith(df, axis=5), df)
 
   @unittest.skipIf(PD_VERSION < (1, 2), "na_action added in pandas 1.2.0")
+  @pytest.mark.filterwarnings(
+      "ignore:The default of observed=False is deprecated:FutureWarning")
   def test_applymap_na_action(self):
     # Replicates a doctest for na_action which is incompatible with
     # doctest framework
     df = pd.DataFrame([[pd.NA, 2.12], [3.356, 4.567]])
     self._run_test(
         lambda df: df.applymap(lambda x: len(str(x)), na_action='ignore'),
+        df,
+        # TODO: generate proxy using naive type inference on fn
+        check_proxy=False)
+
+  @unittest.skipIf(PD_VERSION < (2, 1), "map added in 2.1.0")
+  def test_map_na_action(self):
+    # Replicates a doctest for na_action which is incompatible with
+    # doctest framework
+    df = pd.DataFrame([[pd.NA, 2.12], [3.356, 4.567]])
+    self._run_test(
+        lambda df: df.map(lambda x: len(str(x)), na_action='ignore'),
         df,
         # TODO: generate proxy using naive type inference on fn
         check_proxy=False)


### PR DESCRIPTION
In Pandas 2.1, applymap is deprecated and map is the replacement. Fix it here for those