### PR TITLE
Add observed=False to be explicit for Pandas 2.1

### DIFF
--- a/sdks/python/apache_beam/dataframe/frames_test.py
+++ b/sdks/python/apache_beam/dataframe/frames_test.py
@@ -1021,8 +1021,14 @@ class DeferredFrameTest(_AbstractFrameTest):
     df = df.set_index('B')
     # TODO(BEAM-11190): These aggregations can be done in index partitions, but
     # it will require a little more complex logic
-    self._run_test(lambda df: df.groupby(level=0).sum(), df, nonparallel=True)
-    self._run_test(lambda df: df.groupby(level=0).mean(), df, nonparallel=True)
+    self._run_test(
+        lambda df: df.groupby(level=0, observed=False).sum(),
+        df,
+        nonparallel=True)
+    self._run_test(
+        lambda df: df.groupby(level=0, observed=False).mean(),
+        df,
+        nonparallel=True)
 
   def test_astype_categorical(self):
     df = pd.DataFrame({'A': np.arange(6), 'B': list('aabbca')})


### PR DESCRIPTION
Starting with Pandas 2.1, observed=False is deprecated as the default for groupby, and raises warnings when grouping on categoricals. Explicitly set observed=False in these tests to stop that.