### PR TITLE
[prism] Add user counters and msec metrics to prism UI.

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/web/web.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/web/web.go
@@ -188,6 +188,10 @@ func (h *jobDetailsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	trs := pipeResp.GetPipeline().GetComponents().GetTransforms()
 	col2T, topo := preprocessTransforms(trs)
 
+	counters := toTransformMap(results.AllMetrics().Counters())
+	distributions := toTransformMap(results.AllMetrics().Distributions())
+	msecs := toTransformMap(results.AllMetrics().Msecs())
+
 	data.Transforms = make([]pTransform, 0, len(trs))
 	for _, id := range topo {
 		pt := trs[id]
@@ -224,6 +228,29 @@ func (h *jobDetailsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 			strMets = append(strMets, outMets...)
 		}
 
+		var msecMets []string
+		// TODO: Figure out where uniquename or id is being used in prism. It should be all global transform ID to faciliate lookups.
+		for _, msec := range msecs[pt.GetUniqueName()] {
+			msecMets = append(msecMets, fmt.Sprintf("\n- %+v", msec.Result()))
+		}
+		if len(msecMets) > 0 {
+			strMets = append(strMets, "Profiling metrics")
+			strMets = append(strMets, msecMets...)
+		}
+
+		var userMetrics []string
+		for _, ctr := range counters[pt.GetUniqueName()] {
+			userMetrics = append(userMetrics, fmt.Sprintf("\n- %s.%s: %v", ctr.Namespace(), ctr.Name(), ctr.Result()))
+		}
+		for _, dist := range distributions[pt.GetUniqueName()] {
+			userMetrics = append(userMetrics, fmt.Sprintf("\n- %s.%s: %+v", dist.Namespace(), dist.Name(), dist.Result()))
+		}
+
+		if len(userMetrics) > 0 {
+			strMets = append(strMets, "User metrics")
+			strMets = append(strMets, userMetrics...)
+		}
+
 		data.Transforms = append(data.Transforms, pTransform{
 			ID:        id,
 			Transform: pt,
@@ -232,6 +259,14 @@ func (h *jobDetailsHandler) ServeHTTP(w http.ResponseWriter, r *http.Request) {
 	}
 
 	renderPage(jobPage, &data, w)
+}
+
+func toTransformMap[E interface{ Transform() string }](mets []E) map[string][]E {
+	ret := map[string][]E{}
+	for _, met := range mets {
+		ret[met.Transform()] = append(ret[met.Transform()], met)
+	}
+	return ret
 }
 
 type pcolParent struct {
@@ -244,7 +279,10 @@ type pcolParent struct {
 func preprocessTransforms(trs map[string]*pipepb.PTransform) (map[string]pcolParent, []string) {
 	ret := map[string]pcolParent{}
 	var leaves []string
-	for id, t := range trs {
+	keys := maps.Keys(trs)
+	sort.Strings(keys)
+	for _, id := range keys {
+		t := trs[id]
 		// Skip composites at this time.
 		if len(t.GetSubtransforms()) > 0 {
 			continue


### PR DESCRIPTION
Add in User counters, user Distributions, and msec samples to Prism UI.

![image](https://github.com/apache/beam/assets/13907733/309de21a-922a-4e0e-be84-340495280628)

Also pre-sort the transform IDs before topological sort so display remains stable on refreshes.

I wasn't expecting the PTransforms keys in the metrics to be the human readable unique names, and instead expected the global ids from the transforms map. This is either prism, or SDK dependent. Any later fix would be to make it consistent for all uses.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
