### PR TITLE
[Security] Bump org.json:json due to CVE-2022-45688

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -602,7 +602,7 @@ class BeamModulePlugin implements Plugin<Project> {
     def jackson_version = "2.14.1"
     def jaxb_api_version = "2.3.3"
     def jsr305_version = "3.0.2"
-    def everit_json_version = "1.14.1"
+    def everit_json_version = "1.14.2"
     def kafka_version = "2.4.1"
     def log4j2_version = "2.20.0"
     def nemo_version = "0.1"
@@ -809,7 +809,7 @@ class BeamModulePlugin implements Plugin<Project> {
         joda_time                                   : "joda-time:joda-time:2.10.10",
         jsonassert                                  : "org.skyscreamer:jsonassert:1.5.0",
         jsr305                                      : "com.google.code.findbugs:jsr305:$jsr305_version",
-        json_org                                    : "org.json:json:20220320", // Keep in sync with everit-json-schema / google_cloud_platform_libraries_bom transitive deps.
+        json_org                                    : "org.json:json:20230618", // Keep in sync with everit-json-schema / google_cloud_platform_libraries_bom transitive deps.
         everit_json_schema                          : "com.github.erosb:everit-json-schema:${everit_json_version}",
         junit                                       : "junit:junit:4.13.1",
         jupiter_api                                 : "org.junit.jupiter:junit-jupiter-api:$jupiter_version",

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/JsonUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/JsonUtils.java
@@ -58,7 +58,7 @@ import org.json.JSONObject;
  * }</pre>
  *
  * <p><b>Note:</b> This functionality has been tested with {@code everit-json-schema} version
- * 1.14.1.
+ * 1.14.2.
  *
  * <h3>JSON-Schema supported features</h3>
  *


### PR DESCRIPTION
Comments suggested that org.json was in sync with libraries-bom, but when analyzing through

```
cd /tmp; wget https://repo1.maven.org/maven2/com/google/cloud/libraries-bom/26.22.0/libraries-bom-26.22.0.pom -O base.pom && mvn help:effective-pom -f base.pom -Doutput=effective.pom && cat effective.pom | grep -v 'dependencyManagement' > cleanup.pom && mvn dependency:tree -f cleanup.pom
```

We can see that it brings a much newer (and not in the CVE range) version:

```
[INFO] --- dependency:3.6.0:tree (default-cli) @ libraries-bom ---
[INFO] com.google.cloud:libraries-bom:pom:26.22.0
[INFO] +- com.google.cloud:google-cloud-bigquery:jar:2.31.1:compile
[INFO] |  +- org.json:json:jar:20230618:compile
```
