### PR TITLE
[PYTHON] Add new `--auto_unique_labels` option to StandardOptions 

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -515,6 +515,14 @@ class StandardOptions(PipelineOptions):
             'at transform level. Interpretation of hints is defined by '
             'Beam runners.'))
 
+    parser.add_argument(
+        '--auto_unique_labels',
+        default=False,
+        action='store_true',
+        help='Whether to automatically generate unique transform labels '
+        'for every transform. The default behavior is to raise an '
+        'exception if a transform is created with a non-unique label.')
+
 
 class CrossLanguageOptions(PipelineOptions):
   @classmethod

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -677,10 +677,18 @@ class Pipeline(object):
         [self._current_transform().full_label, label or
          transform.label]).lstrip('/')
     if full_label in self.applied_labels:
-      raise RuntimeError(
-          'A transform with label "%s" already exists in the pipeline. '
-          'To apply a transform with a specified label write '
-          'pvalue | "label" >> transform' % full_label)
+      auto_unique_labels = self._options.view_as(
+          StandardOptions).auto_unique_labels
+      if auto_unique_labels:
+        # If auto_unique_labels is set, we will append a unique suffix to the
+        # label to make it unique.
+        unique_label = self._generate_unique_label(transform)
+        return self.apply(transform, pvalueish, unique_label)
+      else:
+        raise RuntimeError(
+            'A transform with label "%s" already exists in the pipeline. '
+            'To apply a transform with a specified label write '
+            'pvalue | "label" >> transform' % full_label)
     self.applied_labels.add(full_label)
 
     pvalueish, inputs = transform._extract_input_pvalues(pvalueish)
@@ -755,6 +763,28 @@ class Pipeline(object):
     finally:
       self.transforms_stack.pop()
     return pvalueish_result
+
+  def _generate_unique_label(
+      self,
+      transform  # type: str
+  ):
+    # type: (...) -> str
+
+    """
+    Given a transform, generate a unique label for it based on current label.
+    
+    Note that the generated label is only guaranteed to be unique relative
+    to the current _current_transform()
+    """
+    full_label = '/'.join(
+        [self._current_transform().full_label, transform.label]).lstrip('/')
+    counter = 1
+    while full_label in self.applied_labels:
+      counter += 1
+      full_label = '%s_%d' % (full_label, counter)
+    label = full_label.rsplit('/', maxsplit=1)[-1]
+    return label
+
 
   def _infer_result_type(
       self,

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -674,8 +674,7 @@ class Pipeline(object):
       alter_label_if_ipython(transform, pvalueish)
 
     full_label = '/'.join(
-        [self._current_transform().full_label, label or
-         transform.label]).lstrip('/')
+        [self._current_transform().full_label, transform.label]).lstrip('/')
     if full_label in self.applied_labels:
       auto_unique_labels = self._options.view_as(
           StandardOptions).auto_unique_labels

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -775,12 +775,15 @@ class Pipeline(object):
     Note that the generated label is only guaranteed to be unique relative
     to the current _current_transform()
     """
-    full_label = '/'.join(
-        [self._current_transform().full_label, transform.label]).lstrip('/')
     counter = 1
+
+    full_label_wo_prefix = '/'.join(
+        [self._current_transform().full_label, transform.label]).lstrip('/')
+
+    full_label = '%s_%d' % (full_label_wo_prefix, counter)
     while full_label in self.applied_labels:
       counter += 1
-      full_label = '%s_%d' % (full_label, counter)
+      full_label = '%s_%d' % (full_label_wo_prefix, counter)
     label = full_label.rsplit('/', maxsplit=1)[-1]
     return label
 

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -54,6 +54,7 @@ import re
 import shutil
 import tempfile
 import unicodedata
+import uuid
 from collections import defaultdict
 from typing import TYPE_CHECKING
 from typing import Any
@@ -68,7 +69,6 @@ from typing import Set
 from typing import Tuple
 from typing import Type
 from typing import Union
-import uuid
 
 from google.protobuf import message
 

--- a/sdks/python/apache_beam/pipeline.py
+++ b/sdks/python/apache_beam/pipeline.py
@@ -68,6 +68,7 @@ from typing import Set
 from typing import Tuple
 from typing import Type
 from typing import Union
+import uuid
 
 from google.protobuf import message
 
@@ -771,21 +772,9 @@ class Pipeline(object):
 
     """
     Given a transform, generate a unique label for it based on current label.
-    
-    Note that the generated label is only guaranteed to be unique relative
-    to the current _current_transform()
     """
-    counter = 1
-
-    full_label_wo_prefix = '/'.join(
-        [self._current_transform().full_label, transform.label]).lstrip('/')
-
-    full_label = '%s_%d' % (full_label_wo_prefix, counter)
-    while full_label in self.applied_labels:
-      counter += 1
-      full_label = '%s_%d' % (full_label_wo_prefix, counter)
-    label = full_label.rsplit('/', maxsplit=1)[-1]
-    return label
+    unique_suffix = uuid.uuid4().hex[:6]
+    return '%s_%s' % (transform.label, unique_suffix)
 
 
   def _infer_result_type(

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -273,16 +273,16 @@ class PipelineTest(unittest.TestCase):
     with mock.patch.object(uuid, 'uuid4') as mock_uuid_gen:
       mock_uuids = [mock.Mock(hex='UUID01XXX'), mock.Mock(hex='UUID02XXX')]
       mock_uuid_gen.side_effect = mock_uuids
-    with TestPipeline(options=opts) as pipeline:
-      pcoll = pipeline | 'pcoll' >> Create([1, 2, 3])
+      with TestPipeline(options=opts) as pipeline:
+        pcoll = pipeline | 'pcoll' >> Create([1, 2, 3])
 
-      def identity(x):
-        return x
+        def identity(x):
+          return x
 
-      pcoll2 = pcoll | Map(identity)
-      pcoll3 = pcoll2 | Map(identity)
-      pcoll4 = pcoll3 | Map(identity)
-      assert_that(pcoll4, equal_to([1, 2, 3]))
+        pcoll2 = pcoll | Map(identity)
+        pcoll3 = pcoll2 | Map(identity)
+        pcoll4 = pcoll3 | Map(identity)
+        assert_that(pcoll4, equal_to([1, 2, 3]))
 
     map_id_full_labels = {
         label

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -279,6 +279,14 @@ class PipelineTest(unittest.TestCase):
       pcoll4 = pcoll3 | Map(identity)
       assert_that(pcoll4, equal_to([1, 2, 3]))
 
+    map_id_full_labels = {
+        label
+        for label in pipeline.applied_labels if "Map(identity)" in label
+    }
+    map_id_leaf_labels = {label.split(":")[-1] for label in map_id_full_labels}
+    assert map_id_leaf_labels == set(
+        ["Map(identity)", "Map(identity)_1", "Map(identity)_2"])
+
   def test_reuse_cloned_custom_transform_instance(self):
     with TestPipeline() as pipeline:
       pcoll1 = pipeline | 'pc1' >> Create([1, 2, 3])

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -276,7 +276,8 @@ class PipelineTest(unittest.TestCase):
 
       pcoll2 = pcoll | Map(identity)
       pcoll3 = pcoll2 | Map(identity)
-      assert_that(pcoll3, equal_to([1, 2, 3]))
+      pcoll4 = pcoll3 | Map(identity)
+      assert_that(pcoll4, equal_to([1, 2, 3]))
 
   def test_reuse_cloned_custom_transform_instance(self):
     with TestPipeline() as pipeline:

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -33,7 +33,6 @@ from apache_beam.io import Read
 from apache_beam.io.iobase import SourceBase
 from apache_beam.options.pipeline_options import PortableOptions
 from apache_beam.pipeline import Pipeline
-from apache_beam.pipeline import StandardOptions
 from apache_beam.pipeline import PipelineOptions
 from apache_beam.pipeline import PipelineVisitor
 from apache_beam.pipeline import PTransformOverride
@@ -268,7 +267,7 @@ class PipelineTest(unittest.TestCase):
         'pvalue | "label" >> transform')
 
   def test_auto_unique_labels(self):
-    opts = StandardOptions("--auto_unique_labels")
+    opts = PipelineOptions(["--auto_unique_labels"])
     with TestPipeline(options=opts) as pipeline:
       pcoll = pipeline | 'pcoll' >> Create([1, 2, 3])
 

--- a/sdks/python/apache_beam/pipeline_test.py
+++ b/sdks/python/apache_beam/pipeline_test.py
@@ -33,6 +33,7 @@ from apache_beam.io import Read
 from apache_beam.io.iobase import SourceBase
 from apache_beam.options.pipeline_options import PortableOptions
 from apache_beam.pipeline import Pipeline
+from apache_beam.pipeline import StandardOptions
 from apache_beam.pipeline import PipelineOptions
 from apache_beam.pipeline import PipelineVisitor
 from apache_beam.pipeline import PTransformOverride
@@ -265,6 +266,18 @@ class PipelineTest(unittest.TestCase):
         'A transform with label "CustomTransform" already exists in the '
         'pipeline. To apply a transform with a specified label write '
         'pvalue | "label" >> transform')
+
+  def test_auto_unique_labels(self):
+    opts = StandardOptions("--auto_unique_labels")
+    with TestPipeline(options=opts) as pipeline:
+      pcoll = pipeline | 'pcoll' >> Create([1, 2, 3])
+
+      def identity(x):
+        return x
+
+      pcoll2 = pcoll | Map(identity)
+      pcoll3 = pcoll2 | Map(identity)
+      assert_that(pcoll3, equal_to([1, 2, 3]))
 
   def test_reuse_cloned_custom_transform_instance(self):
     with TestPipeline() as pipeline:


### PR DESCRIPTION
Motivating Issue
----------------
The python SDK requires users specify a unique label for every transform. Often times, the first time a transform is applied there is a default label that will be unique, but any future applications of the transform will require that the user specify a new and unique label. This can be quite tedious since there are many (?) scenarios where a user won't actually care about the labels. A couple scenarios that came up in my experience:

- Writing unit tests with multiple `assert_that()`s requires unique label for each assert
- Writing a pipeline that branches and applies the same transform to each branch
- Writing a linear pipeline where I want to reuse the same transform (e.g. `LogElements` or `Deduplicate`)

Change Summary
------------------
This change adds a new `--auto_unique_labels` standard option. The option defaults to off so there's no change in the default behavior. If the option is set, then whenever a transform is applied with a non-unique label, a new label is generated that includes an automatically incremented suffix. For example, if `Deduplicate` is applied twice, then the second deduplicate will have a label of `Deduplicate_1`. Additional `Deduplicates` would have a label of `Deduplicate_n`.

Testing
-------
Wrote a new unit test that tests the new behavior. The rest of the `pipeline_test.py` tests still pass except for one: `test_display_data`. It also fails on my fork's master though so I'm assuming it's unrelated (EDIT: confirmed unrelated, it's just failing b/c it doesn't expect the URN to change when `pipeline_test.py` is invoked directly, in which case the URN references `__main__`)


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
