### PR TITLE
[JdbcIO] Allow fetchSize to be set for partitioned reads

### DIFF
--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
@@ -360,6 +360,7 @@ public class JdbcIO {
     return new AutoValue_JdbcIO_ReadWithPartitions.Builder<T, PartitionColumnT>()
         .setPartitionColumnType(partitioningColumnType)
         .setNumPartitions(DEFAULT_NUM_PARTITIONS)
+        .setFetchSize(DEFAULT_FETCH_SIZE)
         .setUseBeamSchema(false)
         .build();
   }
@@ -1196,6 +1197,9 @@ public class JdbcIO {
     abstract @Nullable String getPartitionColumn();
 
     @Pure
+    abstract int getFetchSize();
+
+    @Pure
     abstract boolean getUseBeamSchema();
 
     @Pure
@@ -1232,6 +1236,8 @@ public class JdbcIO {
       abstract Builder<T, PartitionColumnT> setUpperBound(PartitionColumnT upperBound);
 
       abstract Builder<T, PartitionColumnT> setUseBeamSchema(boolean useBeamSchema);
+
+      abstract Builder<T, PartitionColumnT> setFetchSize(int fetchSize);
 
       abstract Builder<T, PartitionColumnT> setTable(String tableName);
 
@@ -1357,7 +1363,8 @@ public class JdbcIO {
                         .withRowMapper(
                             checkStateNotNull(
                                 JdbcUtil.JdbcReadWithPartitionsHelper.getPartitionsHelper(
-                                    getPartitionColumnType()))))
+                                    getPartitionColumnType())))
+                        .withFetchSize(getFetchSize()))
                 .apply(
                     MapElements.via(
                         new SimpleFunction<
@@ -1421,6 +1428,7 @@ public class JdbcIO {
                   String.format(
                       "select * from %1$s where %2$s >= ? and %2$s < ?", table, partitionColumn))
               .withRowMapper(rowMapper)
+              .withFetchSize(getFetchSize())
               .withParameterSetter(
                   checkStateNotNull(
                           JdbcUtil.JdbcReadWithPartitionsHelper.getPartitionsHelper(


### PR DESCRIPTION
The default for fetchSize is 50000 (https://github.com/apache/beam/blob/master/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java#L372), which is not even supported by some databases. 

For example, DB2 limits to 32767 (source: https://knowledge.informatica.com/s/article/000205468?language=en_US). 


This change will not only allow performance tuning when needed, but will enable usage of partitions on specific databases.


