### PR TITLE
Change level of initialization exception to error, make errors obvious

### DIFF
--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnHarness.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnHarness.java
@@ -384,9 +384,10 @@ public class FnHarness {
       }
       processBundleHandler.shutdown();
     } catch (Exception e) {
-      System.out.println("Shutting down harness due to exception: " + e.toString());
+      LOG.error("Shutting down harness due to exception", e);
+      e.printStackTrace();
     } finally {
-      System.out.println("Shutting SDK harness down.");
+      LOG.info("Shutting SDK harness down.");
       executionStateSampler.stop();
       executorService.shutdown();
     }


### PR DESCRIPTION
Exceptions in JvmInitializers were being printed in the STDOUT by the FnHarness, so handled/displayed on Dataflow as an info log:

<img width="1467" alt="image" src="https://github.com/apache/beam/assets/3207647/ae9f2490-9d4b-483c-bfd6-1261bf57043f">


This change should help making errors more obvious, and allow users to leverage Error Reporting.

I still kept `e.printStackTrace();` in case there was someone relies on looking at errors on STDOUT/STDERR (happy to remove if seen as a bad practice).