### PR TITLE
Use MillisInstant by default when Python JdbcIO is used

### DIFF
--- a/sdks/python/apache_beam/io/external/xlang_jdbcio_it_test.py
+++ b/sdks/python/apache_beam/io/external/xlang_jdbcio_it_test.py
@@ -36,8 +36,6 @@ from apache_beam.options.pipeline_options import StandardOptions
 from apache_beam.testing.test_pipeline import TestPipeline
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
-from apache_beam.typehints.schemas import LogicalType
-from apache_beam.typehints.schemas import MillisInstant
 from apache_beam.utils.timestamp import Timestamp
 
 # pylint: disable=wrong-import-order, wrong-import-position, ungrouped-imports
@@ -188,10 +186,6 @@ class CrossLanguageJdbcIOTest(unittest.TestCase):
               password=self.password,
               classpath=classpath,
           ))
-
-    # Register MillisInstant logical type to override the mapping from Timestamp
-    # originally handled by MicrosInstant.
-    LogicalType.register_logical_type(MillisInstant)
 
     with TestPipeline() as p:
       p.not_use_test_runner_api = True

--- a/sdks/python/apache_beam/io/jdbc.py
+++ b/sdks/python/apache_beam/io/jdbc.py
@@ -360,6 +360,9 @@ class ReadFromJdbc(ExternalTransform):
         expansion_service or default_io_expansion_service(classpath),
     )
 
+# TODO(https://github.com/apache/beam/issues/28359) The following logical type
+# definitions and registrations are workaround for #28359. Remove them when
+# switched to portable Data and Time type for JdbcIO.
 
 @LogicalType.register_logical_type
 class JdbcDateType(LogicalType[datetime.date, MillisInstant, str]):
@@ -455,3 +458,7 @@ class JdbcTimeType(LogicalType[datetime.time, MillisInstant, str]):
   @classmethod
   def _from_typing(cls, typ):
     return cls()
+
+# Register MillisInstant logical type to override the mapping from Timestamp
+# originally handled by MicrosInstant.
+LogicalType.register_logical_type(MillisInstant)


### PR DESCRIPTION
Resolve https://stackoverflow.com/questions/77317904/apache-beam-python-sdk-reading-from-postgres-using-jdbc-io

Some context:

This has been a long-standing issue. MillisInstant is a logical type that backs Java's DATETIME type in schema (in Java side, its language type is a Joda Instant). In Beam portable framework, DATETIME is no longer a primitive type (true for Python, Go but not for Java), but rather a logical type backed by a MicrosInstant. Its language type is a Java.time.Instant (due to joda is in maintenance mode and there is plan to replace to java.time.Instant.

This would be a breaking change and milestoned at next major version). As such, Java SDK still uses DATETIME primitive in schema. MillisInstant logical type was then a workaround introduced, to enable Python xlang JdbcIO to r/w rows contain Timestamps. But it need to register the MillisInstant to overwrite the default mapping (MicrosInstant) --- That is what currently the integration does.

Since this has been a pain point. It may worth to include this line in the jdbc module. It will then make the MillisInstant supersedes MicrosInstant when jdbc module is imported. 


**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
