### PR TITLE
[Security] Bump ActiveMQ version due to CVE-2023-46604

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -586,7 +586,7 @@ class BeamModulePlugin implements Plugin<Project> {
     // These versions are defined here because they represent
     // a dependency version which should match across multiple
     // Maven artifacts.
-    def activemq_version = "5.17.6"
+    def activemq_version = "5.15.16"
     def autovalue_version = "1.9"
     def autoservice_version = "1.0.1"
     def aws_java_sdk_version = "1.12.135"

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -586,7 +586,7 @@ class BeamModulePlugin implements Plugin<Project> {
     // These versions are defined here because they represent
     // a dependency version which should match across multiple
     // Maven artifacts.
-    def activemq_version = "5.14.5"
+    def activemq_version = "5.17.6"
     def autovalue_version = "1.9"
     def autoservice_version = "1.0.1"
     def aws_java_sdk_version = "1.12.135"


### PR DESCRIPTION
CVE-2023-46604 is still being evaluated for scores, but it is likely going to be critical due to Remote Code Execution.

I've updated to [5.15.16](https://mvnrepository.com/artifact/org.apache.activemq/activemq-client/5.15.16). It's not the latest, but it's patched. The reason I didn't want to go to latest is that they are based on JMS 2.x instead of JMS 1.1, so it's more likely to bring incompatibilities together.


Reference: https://activemq.apache.org/security-advisories.data/CVE-2023-46604-announcement.txt
