### PR TITLE
Inventory - Update temp files retention to 24h, run more frequently

### DIFF
--- a/.test-infra/jenkins/job_Inventory.groovy
+++ b/.test-infra/jenkins/job_Inventory.groovy
@@ -50,7 +50,7 @@ nums.each {
       }
       stringParam {
         name("tmp_unaccessed_for")
-        defaultValue("48")
+        defaultValue("24")
         description("Files from /tmp dir that were not accessed for last `tmp_unaccessed_for` hours will be deleted.")
         trim(true)
       }

--- a/.test-infra/jenkins/job_Inventory.groovy
+++ b/.test-infra/jenkins/job_Inventory.groovy
@@ -32,7 +32,7 @@ nums.each {
     commonJobProperties.setTopLevelMainJobProperties(delegate)
 
     // Sets that this is a cron job.
-    commonJobProperties.setCronJob(delegate, '45 6,18 * * *')
+    commonJobProperties.setCronJob(delegate, '45 */8 * * *')
 
     // Allows triggering this build against pull requests.
     commonJobProperties.enablePhraseTriggeringFromPullRequest(


### PR DESCRIPTION
There's a high volume of temp files being created, and there are frequent scenarios of full disk errors

```
00:03:28 Caused by: java.lang.RuntimeException: java.io.IOException: No space left on device
```

For example: https://ci-beam.apache.org/job/beam_PreCommit_Python_Commit/31256/console

Based on recent cleanups, temp files are allocated really fast (~15gb per hour).

So changing the retention to 24h, which should reduce the peak from ~700gb to ~350gb, as well as the frequency to run from every 12h to 8h, to make cleanups more consistent & faster.