### PR TITLE
Remove beam-artifact temp files when submission JVMs exit

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/External.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/External.java
@@ -19,6 +19,7 @@ package org.apache.beam.runners.core.construction;
 
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
 
+import java.io.File;
 import java.io.FileOutputStream;
 import java.io.IOException;
 import java.nio.file.Files;
@@ -391,7 +392,12 @@ public class External {
                       .build())
               .getReplacementsList()) {
         Path path = Files.createTempFile("beam-artifact", "");
-        try (FileOutputStream fout = new FileOutputStream(path.toFile())) {
+        File artifactFile = path.toFile();
+
+        // Mark the temp file for deletion after submission completes.
+        artifactFile.deleteOnExit();
+
+        try (FileOutputStream fout = new FileOutputStream(artifactFile)) {
           for (Iterator<ArtifactApi.GetArtifactResponse> it =
                   retrievalStub.getArtifact(
                       ArtifactApi.GetArtifactRequest.newBuilder().setArtifact(artifact).build());


### PR DESCRIPTION

This should reduce temp disk space utilization, especially in test VMs that run xlang pipelines hundreds of times per day.
