### PR TITLE
Fix launcher artifact gradle configuration name conflict

### DIFF
--- a/sdks/java/container/build.gradle
+++ b/sdks/java/container/build.gradle
@@ -31,7 +31,7 @@ description = "Apache Beam :: SDKs :: Java :: Container"
 
 configurations {
   dockerDependency
-  sdkHarnessLauncher
+  javaHarnessLauncher
 }
 
 dependencies {
@@ -76,7 +76,7 @@ task downloadCloudProfilerAgent(type: Exec) {
 }
 
 artifacts {
-  sdkHarnessLauncher file: file('./build/target'), builtBy: goBuild
+  javaHarnessLauncher file: file('./build/target'), builtBy: goBuild
 }
 
 task pushAll {

--- a/sdks/java/container/common.gradle
+++ b/sdks/java/container/common.gradle
@@ -36,13 +36,13 @@ description = "Apache Beam :: SDKs :: Java :: Container :: Java ${imageJavaVersi
 
 configurations {
     dockerDependency
-    sdkHarnessLauncher
+    javaHarnessLauncher
     pulledLicenses
 }
 
 dependencies {
     dockerDependency project(path: ":sdks:java:container", configuration: "dockerDependency")
-    sdkHarnessLauncher project(path: ":sdks:java:container", configuration: "sdkHarnessLauncher")
+    javaHarnessLauncher project(path: ":sdks:java:container", configuration: "javaHarnessLauncher")
 }
 
 task copyDockerfileDependencies(type: Copy) {
@@ -67,7 +67,7 @@ task copySdkHarnessLauncher(type: Copy) {
     // if licenses are required, they should be present before this task run.
     mustRunAfter ":sdks:java:container:pullLicenses"
 
-    from configurations.sdkHarnessLauncher
+    from configurations.javaHarnessLauncher
     into "build/target"
 }
 

--- a/sdks/python/container/build.gradle
+++ b/sdks/python/container/build.gradle
@@ -25,7 +25,7 @@ int max_python_version=11
 
 configurations {
   sdkSourceTarball
-  sdkHarnessLauncher
+  pythonHarnessLauncher
 }
 
 dependencies {
@@ -82,5 +82,5 @@ tasks.register("generatePythonRequirementsAll") {
 }
 
 artifacts {
-  sdkHarnessLauncher file: file('./build/target/launcher'), builtBy: goBuild
+  pythonHarnessLauncher file: file('./build/target/launcher'), builtBy: goBuild
 }

--- a/sdks/python/container/common.gradle
+++ b/sdks/python/container/common.gradle
@@ -22,12 +22,12 @@ description = "Apache Beam :: SDKs :: Python :: Container :: Python ${pythonVers
 
 configurations {
   sdkSourceTarball
-  sdkHarnessLauncher
+  pythonHarnessLauncher
 }
 
 dependencies {
   sdkSourceTarball project(path: ":sdks:python", configuration: "distTarBall")
-  sdkHarnessLauncher project(path: ":sdks:python:container", configuration: "sdkHarnessLauncher")
+  pythonHarnessLauncher project(path: ":sdks:python:container", configuration: "pythonHarnessLauncher")
 }
 
 def generatePythonRequirements = tasks.register("generatePythonRequirements") {
@@ -59,9 +59,9 @@ def copyLicenseScripts = tasks.register("copyLicenseScripts", Copy){
 }
 
 def copyLauncherDependencies = tasks.register("copyLauncherDependencies", Copy) {
-  from configurations.sdkHarnessLauncher
+  from configurations.pythonHarnessLauncher
   into "build/target/launcher"
-  if(configurations.sdkHarnessLauncher.isEmpty()) {
+  if(configurations.pythonHarnessLauncher.isEmpty()) {
       throw new StopExecutionException();
   }
 }


### PR DESCRIPTION
Fixes #29220

When `:sdks:java:container:goBuild` executes before  `:sdks:python:container:goBuild`, XVR tests fail at build python container due to missing launcher binary because both launcher shared the same gradle configuration.

* Rename sdkHarnessLauncher in java container and python container gradle project

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
