### PR TITLE
[BigQueryIO] Upserts work with CREATE_IF_NEEDED -- doc only PR

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -487,10 +487,10 @@ import org.slf4j.LoggerFactory;
  *
  * The connector also supports streaming row updates to BigQuery, with the following qualifications:
  *
+ * <p>- Only the STORAGE_WRITE_API_AT_LEAST_ONCE method is supported.
+ *
  * <p>- If the table is not previously created and CREATE_IF_NEEDED is used, a primary key must be
  * specified using {@link Write#withPrimaryKey}.
- *
- * <p>- Only the STORAGE_WRITE_API_AT_LEAST_ONCE method is supported.
  *
  * <p>Two types of updates are supported. UPSERT replaces the row with the matching primary key or
  * inserts the row if non exists. DELETE removes the row with the matching primary key. Row inserts

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -486,8 +486,11 @@ import org.slf4j.LoggerFactory;
  * <h3>Upserts and deletes</h3>
  *
  * The connector also supports streaming row updates to BigQuery, with the following qualifications:
- * - The CREATE_IF_NEEDED CreateDisposition is not supported. Tables must be precreated with primary
- * keys. - Only the STORAGE_WRITE_API_AT_LEAST_ONCE method is supported.
+ *
+ * <p>- If the table is not previously created and CREATE_IF_NEEDED is used, a primary key must be
+ * specified using {@link Write#withPrimaryKey}.
+ *
+ * <p>- Only the STORAGE_WRITE_API_AT_LEAST_ONCE method is supported.
  *
  * <p>Two types of updates are supported. UPSERT replaces the row with the matching primary key or
  * inserts the row if non exists. DELETE removes the row with the matching primary key. Row inserts
@@ -535,8 +538,8 @@ import org.slf4j.LoggerFactory;
  * }</pre>
  *
  * <p>Note that in order to use inserts or deletes, the table must bet set up with a primary key. If
- * the table is not previously created and CREATE_IF_NEEDED is used, a primary key must be
- * specified.
+ * the table is not previously created and CREATE_IF_NEEDED is used, a primary key must be specified
+ * using {@link Write#withPrimaryKey}.
  */
 @SuppressWarnings({
   "nullness" // TODO(https://github.com/apache/beam/issues/20506)
@@ -2167,9 +2170,10 @@ public class BigQueryIO {
    * apply row updates; directly calling {@link Write#withRowMutationInformationFn} is preferred
    * when writing non TableRows types (e.g. {@link #writeGenericRecords} or a custom user type).
    *
-   * <p>This is only supported when using the {@link Write.Method#STORAGE_API_AT_LEAST_ONCE} insert
-   * method and {@link Write.CreateDisposition#CREATE_NEVER}. The tables must be precreated with a
-   * primary key.
+   * <p>This is supported when using the {@link Write.Method#STORAGE_API_AT_LEAST_ONCE} insert
+   * method, and with either {@link Write.CreateDisposition#CREATE_NEVER} or {@link
+   * Write.CreateDisposition#CREATE_IF_NEEDED}. For CREATE_IF_NEEDED, a primary key must be
+   * specified using {@link Write#withPrimaryKey}.
    */
   public static Write<RowMutation> applyRowMutations() {
     return BigQueryIO.<RowMutation>write()
@@ -2826,9 +2830,10 @@ public class BigQueryIO {
      * function that determines how a row is applied to BigQuery (upsert, or delete) along with a
      * sequence number for ordering operations.
      *
-     * <p>This is only supported when using the {@link Write.Method#STORAGE_API_AT_LEAST_ONCE}
-     * insert method and {@link Write.CreateDisposition#CREATE_NEVER}. The tables must be precreated
-     * with a primary key.
+     * <p>This is supported when using the {@link Write.Method#STORAGE_API_AT_LEAST_ONCE} insert
+     * method, and with either {@link Write.CreateDisposition#CREATE_NEVER} or {@link
+     * Write.CreateDisposition#CREATE_IF_NEEDED}. For CREATE_IF_NEEDED, a primary key must be
+     * specified using {@link Write#withPrimaryKey}.
      */
     public Write<T> withRowMutationInformationFn(
         SerializableFunction<T, RowMutationInformation> updateFn) {


### PR DESCRIPTION
This is a doc only PR that updates `BigQueryIO` documentation.

Upserts, in streaming, with STORAGE_AT_LEAST_ONCE work also using CREATE_IF_NEEDED if a primary key is specified. Actually, the code examples included in the documentation were already using CREATE_IF_NEEDED, I guess the bits of doc touched in this PR were not updated when the examples were written.

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
