### PR TITLE
Make BigtableChangeStreamIT less flaky by adding a short sleep

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/it/BigtableChangeStreamIT.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/it/BigtableChangeStreamIT.java
@@ -145,13 +145,16 @@ public class BigtableChangeStreamIT {
 
   @Test
   public void testReadBigtableChangeStream() throws InterruptedException {
+    // Sleep to ensure clock discrepancy between client and server don't affect the start time.
+    Thread.sleep(500);
     Instant startTime = Instant.now();
+    Thread.sleep(500);
     String rowKey = "rowKeySetCell";
     RowMutationEntry setCellEntry =
         RowMutationEntry.create(rowKey).setCell(COLUMN_FAMILY1, COLUMN_QUALIFIER, "cell value 1");
     mutationBatcher.add(setCellEntry);
     mutationBatcher.flush();
-    Instant endTime = Instant.now().plus(Duration.standardSeconds(1));
+    Instant endTime = Instant.now().plus(Duration.standardSeconds(10));
 
     PCollection<MutateRowsRequest.Entry> changeStream = buildPipeline(startTime, endTime);
     PAssert.that(changeStream).containsInAnyOrder(setCellEntry.toProto());
@@ -160,7 +163,10 @@ public class BigtableChangeStreamIT {
 
   @Test
   public void testDeleteRow() throws InterruptedException {
+    // Sleep to ensure clock discrepancy between client and server don't affect the start time.
+    Thread.sleep(500);
     Instant startTime = Instant.now();
+    Thread.sleep(500);
     String rowKeyToDelete = "rowKeyToDelete";
     RowMutationEntry setCellMutationToDelete =
         RowMutationEntry.create(rowKeyToDelete)
@@ -170,7 +176,7 @@ public class BigtableChangeStreamIT {
     mutationBatcher.flush();
     mutationBatcher.add(deleteRowMutation);
     mutationBatcher.flush();
-    Instant endTime = Instant.now().plus(Duration.standardSeconds(1));
+    Instant endTime = Instant.now().plus(Duration.standardSeconds(10));
 
     PCollection<MutateRowsRequest.Entry> changeStream = buildPipeline(startTime, endTime);
     PAssert.that(changeStream)
@@ -186,7 +192,10 @@ public class BigtableChangeStreamIT {
 
   @Test
   public void testDeleteColumnFamily() throws InterruptedException {
+    // Sleep to ensure clock discrepancy between client and server don't affect the start time.
+    Thread.sleep(500);
     Instant startTime = Instant.now();
+    Thread.sleep(500);
     String cellValue = "cell value 1";
     String rowKeyMultiFamily = "rowKeyMultiFamily";
     RowMutationEntry setCells =
@@ -199,7 +208,7 @@ public class BigtableChangeStreamIT {
         RowMutationEntry.create(rowKeyMultiFamily).deleteFamily(COLUMN_FAMILY2);
     mutationBatcher.add(deleteCF2);
     mutationBatcher.flush();
-    Instant endTime = Instant.now().plus(Duration.standardSeconds(1));
+    Instant endTime = Instant.now().plus(Duration.standardSeconds(10));
 
     PCollection<MutateRowsRequest.Entry> changeStream = buildPipeline(startTime, endTime);
     PAssert.that(changeStream).containsInAnyOrder(setCells.toProto(), deleteCF2.toProto());
@@ -208,7 +217,10 @@ public class BigtableChangeStreamIT {
 
   @Test
   public void testDeleteCell() throws InterruptedException {
+    // Sleep to ensure clock discrepancy between client and server don't affect the start time.
+    Thread.sleep(500);
     Instant startTime = Instant.now();
+    Thread.sleep(500);
     String cellValue = "cell value 1";
     String rowKeyMultiCell = "rowKeyMultiCell";
     RowMutationEntry setCells =
@@ -228,7 +240,7 @@ public class BigtableChangeStreamIT {
                     startTime.plus(Duration.standardMinutes(2)).getMillis() * 1000));
     mutationBatcher.add(deleteCQ2);
     mutationBatcher.flush();
-    Instant endTime = Instant.now().plus(Duration.standardSeconds(1));
+    Instant endTime = Instant.now().plus(Duration.standardSeconds(10));
 
     PCollection<MutateRowsRequest.Entry> changeStream = buildPipeline(startTime, endTime);
     PAssert.that(changeStream).containsInAnyOrder(setCells.toProto(), deleteCQ2.toProto());
@@ -237,7 +249,10 @@ public class BigtableChangeStreamIT {
 
   @Test
   public void testComplexMutation() throws InterruptedException {
+    // Sleep to ensure clock discrepancy between client and server don't affect the start time.
+    Thread.sleep(500);
     Instant startTime = Instant.now();
+    Thread.sleep(500);
     String rowKey = "rowKeyComplex";
     // We'll delete this in the next mutation
     RowMutationEntry setCell =
@@ -257,7 +272,7 @@ public class BigtableChangeStreamIT {
                     startTime.plus(Duration.standardMinutes(2)).getMillis() * 1000));
     mutationBatcher.add(complexMutation);
     mutationBatcher.flush();
-    Instant endTime = Instant.now().plus(Duration.standardSeconds(1));
+    Instant endTime = Instant.now().plus(Duration.standardSeconds(10));
 
     PCollection<MutateRowsRequest.Entry> changeStream = buildPipeline(startTime, endTime);
     PAssert.that(changeStream).containsInAnyOrder(setCell.toProto(), complexMutation.toProto());
@@ -266,7 +281,10 @@ public class BigtableChangeStreamIT {
 
   @Test
   public void testLargeMutation() throws InterruptedException {
+    // Sleep to ensure clock discrepancy between client and server don't affect the start time.
+    Thread.sleep(500);
     Instant startTime = Instant.now();
+    Thread.sleep(500);
     // test set cell w size > 1MB so it triggers chunking
     char[] chars = new char[1024 * 1500];
     Arrays.fill(chars, '\u200B'); // zero-width space
@@ -277,7 +295,7 @@ public class BigtableChangeStreamIT {
             .setCell(COLUMN_FAMILY1, COLUMN_QUALIFIER, largeString);
     mutationBatcher.add(setLargeCell);
     mutationBatcher.flush();
-    Instant endTime = Instant.now().plus(Duration.standardSeconds(1));
+    Instant endTime = Instant.now().plus(Duration.standardSeconds(10));
 
     PCollection<MutateRowsRequest.Entry> changeStream = buildPipeline(startTime, endTime);
     PAssert.that(changeStream).containsInAnyOrder(setLargeCell.toProto());
@@ -286,7 +304,10 @@ public class BigtableChangeStreamIT {
 
   @Test
   public void testManyMutations() throws InterruptedException {
+    // Sleep to ensure clock discrepancy between client and server don't affect the start time.
+    Thread.sleep(500);
     Instant startTime = Instant.now();
+    Thread.sleep(500);
     // test set cell w size > 1MB so it triggers chunking
     char[] chars = new char[1024 * 3];
     Arrays.fill(chars, '\u200B'); // zero-width space
@@ -323,7 +344,7 @@ public class BigtableChangeStreamIT {
       mutationBatcher.add(deleteCells);
       mutationBatcher.flush();
     }
-    Instant endTime = Instant.now().plus(Duration.standardSeconds(1));
+    Instant endTime = Instant.now().plus(Duration.standardSeconds(10));
 
     PCollection<MutateRowsRequest.Entry> changeStream = buildPipeline(startTime, endTime);
     PAssert.that(changeStream)


### PR DESCRIPTION
BigtableChangeStreamIT explicitly specifies a start time that is sent to the server. Sometimes, the test code runs so fast that a small discrepancy in system clock between the test runner and Bigtable backend results in missing results.

For example

Time since epoch. There's a 10ms difference between system clocks.
Test runner: r=1000
Bigtable server: b=990

1. Test runner sets start time to 1000 (r=1000, b=990)
1. Test runner sends a write to Bigtable (r=1000, b=990)
1. Bigtable receives the write at 999 and records the write time (r=1009, b=999)
1. Test runner sends a ReadChangeStreamRequest at 1010 (r=1010, b=1000)
1. Bigtable receives ReadChangeStreamRequest at 1003 and returns changes starting at 1000. (r=1013, b=1003)

The write was recorded at 999, so Bigtable does not return the write.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
