### PR TITLE
[prism] Add fusion.

### DIFF
--- a/sdks/go/pkg/beam/runners/direct/direct_test.go
+++ b/sdks/go/pkg/beam/runners/direct/direct_test.go
@@ -29,6 +29,7 @@ import (
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/mtime"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/window"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/metrics"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/register"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/transforms/filter"
 	"github.com/google/go-cmp/cmp"
 )
@@ -541,4 +542,101 @@ func TestMain(m *testing.M) {
 	}
 	beam.Init()
 	os.Exit(m.Run())
+}
+
+func init() {
+	// Basic Registration
+	// 	beam.RegisterFunction(identity)
+	// 	beam.RegisterType(reflect.TypeOf((*source)(nil)))
+	// 	beam.RegisterType(reflect.TypeOf((*discard)(nil)))
+
+	// Generic registration
+	register.Function2x0(identity)
+	register.DoFn2x0[[]byte, func(int)]((*source)(nil))
+	register.DoFn1x0[int]((*discard)(nil))
+	register.Emitter1[int]()
+}
+
+type source struct {
+	Count int
+}
+
+func (fn *source) ProcessElement(_ []byte, emit func(int)) {
+	for i := 0; i < fn.Count; i++ {
+		emit(i)
+	}
+}
+
+func identity(v int, emit func(int)) {
+	emit(v)
+}
+
+type discard struct {
+	processed int
+}
+
+func (fn *discard) ProcessElement(int) {
+	fn.processed++
+}
+
+// BenchmarkPipe checks basic throughput and exec overhead with everything registered.
+//
+// Just registered: ~700-900ns per call, 330B per DoFn, across 5 allocs per DoFn
+//
+// goos: linux
+// goarch: amd64
+// pkg: github.com/apache/beam/sdks/v2/go/pkg/beam/runners/direct
+// cpu: 12th Gen Intel(R) Core(TM) i7-1260P
+// BenchmarkPipe/dofns=0-16         	 1657698	       763.0 ns/op	  10.49 MB/s	       763.0 ns/elm	     320 B/op	       6 allocs/op
+// BenchmarkPipe/dofns=1-16         	  832784	      1294 ns/op	  12.37 MB/s	      1294 ns/elm	     656 B/op	      11 allocs/op
+// BenchmarkPipe/dofns=2-16         	  633345	      1798 ns/op	  13.35 MB/s	       899.0 ns/elm	     992 B/op	      16 allocs/op
+// BenchmarkPipe/dofns=3-16         	  471106	      2446 ns/op	  13.08 MB/s	       815.4 ns/elm	    1329 B/op	      21 allocs/op
+// BenchmarkPipe/dofns=5-16         	  340099	      3634 ns/op	  13.21 MB/s	       726.8 ns/elm	    2001 B/op	      31 allocs/op
+// BenchmarkPipe/dofns=10-16        	  183429	      6957 ns/op	  12.65 MB/s	       695.7 ns/elm	    3683 B/op	      56 allocs/op
+// BenchmarkPipe/dofns=100-16       	   17956	     65986 ns/op	  12.25 MB/s	       659.9 ns/elm	   33975 B/op	     506 allocs/op
+//
+// Optimized w/ Generic reg: ~200-300ns per call, 150B per DoFn, across 2 allocs per DoFn
+//
+// goos: linux
+// goarch: amd64
+// pkg: github.com/apache/beam/sdks/v2/go/pkg/beam/runners/direct
+// cpu: 12th Gen Intel(R) Core(TM) i7-1260P
+// BenchmarkPipe/dofns=0-16         	 9319206	       131.5 ns/op	  60.85 MB/s	       131.5 ns/elm	     152 B/op	       2 allocs/op
+// BenchmarkPipe/dofns=1-16         	 4465477	       268.3 ns/op	  59.63 MB/s	       268.3 ns/elm	     304 B/op	       3 allocs/op
+// BenchmarkPipe/dofns=2-16         	 2876710	       431.9 ns/op	  55.56 MB/s	       216.0 ns/elm	     456 B/op	       5 allocs/op
+// BenchmarkPipe/dofns=3-16         	 2096349	       562.1 ns/op	  56.93 MB/s	       187.4 ns/elm	     608 B/op	       7 allocs/op
+// BenchmarkPipe/dofns=5-16         	 1347927	       823.8 ns/op	  58.27 MB/s	       164.8 ns/elm	     912 B/op	      11 allocs/op
+// BenchmarkPipe/dofns=10-16        	  737594	      1590 ns/op	  55.36 MB/s	       159.0 ns/elm	    1672 B/op	      21 allocs/op
+// BenchmarkPipe/dofns=100-16       	   60728	     19696 ns/op	  41.02 MB/s	       197.0 ns/elm	   15357 B/op	     201 allocs/op
+func BenchmarkPipe(b *testing.B) {
+	makeBench := func(numDoFns int) func(b *testing.B) {
+		return func(b *testing.B) {
+			b.ReportAllocs()
+			b.SetBytes(8 * int64(numDoFns+1))
+
+			disc := &discard{}
+			p, s := beam.NewPipelineWithRoot()
+			imp := beam.Impulse(s)
+			src := beam.ParDo(s, &source{Count: b.N}, imp)
+			iden := src
+			for i := 0; i < numDoFns; i++ {
+				iden = beam.ParDo(s, identity, iden)
+			}
+			beam.ParDo0(s, disc, iden)
+			Execute(context.TODO(), p)
+			if disc.processed != b.N {
+				b.Fatalf("processed dodn't match bench number: got %v want %v", disc.processed, b.N)
+			}
+			d := b.Elapsed()
+			div := numDoFns
+			if div == 0 {
+				div = 1
+			}
+			div = div * b.N
+			b.ReportMetric(float64(d)/float64(div), "ns/elm")
+		}
+	}
+	for _, numDoFns := range []int{0, 1, 2, 3, 5, 10, 100} {
+		b.Run(fmt.Sprintf("dofns=%d", numDoFns), makeBench(numDoFns))
+	}
 }

--- a/sdks/go/pkg/beam/runners/prism/README.md
+++ b/sdks/go/pkg/beam/runners/prism/README.md
@@ -152,6 +152,8 @@ can have features selectively disabled to ensure
 * Progess tracking
     * Channel Splitting
     * Dynamic Splitting
+* FnAPI Optimizations
+  * Fusion
 
 ## Next feature short list (unordered)
 
@@ -165,7 +167,6 @@ See https://github.com/apache/beam/issues/24789 for current status.
 * Support SDK Containers via Testcontainers
   * Cross Language Transforms
 * FnAPI Optimizations
-  * Fusion
   * Data with ProcessBundleRequest & Response
 
 This is not a comprehensive feature set, but a set of goals to best

--- a/sdks/go/pkg/beam/runners/prism/internal/execute.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/execute.go
@@ -104,7 +104,6 @@ func makeWorker(env string, j *jobservices.Job) (*worker.W, error) {
 
 type transformExecuter interface {
 	ExecuteUrns() []string
-	ExecuteWith(t *pipepb.PTransform) string
 	ExecuteTransform(stageID, tid string, t *pipepb.PTransform, comps *pipepb.Components, watermark mtime.Time, data [][]byte) *worker.B
 }
 
@@ -166,11 +165,6 @@ func executePipeline(ctx context.Context, wks map[string]*worker.W, j *jobservic
 		urn := t.GetSpec().GetUrn()
 		stage.exe = proc.transformExecuters[urn]
 
-		// Stopgap until everythinng's moved to handlers.
-		stage.envID = t.GetEnvironmentId()
-		if stage.exe != nil {
-			stage.envID = stage.exe.ExecuteWith(t)
-		}
 		stage.ID = fmt.Sprintf("stage-%03d", i)
 		wk := wks[stage.envID]
 

--- a/sdks/go/pkg/beam/runners/prism/internal/execute_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/execute_test.go
@@ -37,7 +37,7 @@ import (
 	"github.com/apache/beam/sdks/v2/go/test/integration/primitives"
 )
 
-func initRunner(t *testing.T) {
+func initRunner(t testing.TB) {
 	t.Helper()
 	if *jobopts.Endpoint == "" {
 		s := jobservices.NewServer(0, internal.RunPipeline)
@@ -64,7 +64,7 @@ func execute(ctx context.Context, p *beam.Pipeline) (beam.PipelineResult, error)
 	return universal.Execute(ctx, p)
 }
 
-func executeWithT(ctx context.Context, t *testing.T, p *beam.Pipeline) (beam.PipelineResult, error) {
+func executeWithT(ctx context.Context, t testing.TB, p *beam.Pipeline) (beam.PipelineResult, error) {
 	t.Log("startingTest - ", t.Name())
 	s1 := rand.NewSource(time.Now().UnixNano())
 	r1 := rand.New(s1)
@@ -586,4 +586,105 @@ func init() {
 
 func TestMain(m *testing.M) {
 	ptest.MainWithDefault(m, "testlocal")
+}
+
+func init() {
+	// Basic Registration
+	// beam.RegisterFunction(identity)
+	// beam.RegisterType(reflect.TypeOf((*source)(nil)))
+	// beam.RegisterType(reflect.TypeOf((*discard)(nil)))
+
+	// Generic registration
+	register.Function2x0(identity)
+	register.DoFn2x0[[]byte, func(int)]((*source)(nil))
+	register.DoFn1x0[int]((*discard)(nil))
+	register.Emitter1[int]()
+}
+
+type source struct {
+	Count int
+}
+
+func (fn *source) ProcessElement(_ []byte, emit func(int)) {
+	for i := 0; i < fn.Count; i++ {
+		emit(i)
+	}
+}
+
+func identity(v int, emit func(int)) {
+	emit(v)
+}
+
+type discard struct {
+	processed int
+}
+
+func (fn *discard) ProcessElement(int) {
+	fn.processed++
+}
+
+// BenchmarkPipe checks basic throughput and exec overhead with everything registered.
+//
+// No fusion (all elements encoded) (generic registration):
+//
+//		~2000ns per call, 2000B per DoFn, across 22 allocs per DoFn
+//	 (using Basic regsitration adds 3 allocs per DoFn, a ~200 bytes, and ~200-400ns/elm)
+//
+// goos: linux
+// goarch: amd64
+// pkg: github.com/apache/beam/sdks/v2/go/pkg/beam/runners/direct
+// cpu: 12th Gen Intel(R) Core(TM) i7-1260P
+// BenchmarkPipe/dofns=0-16         	  885811	      1333 ns/op	      1333 ns/elm	    1993 B/op	      22 allocs/op
+// BenchmarkPipe/dofns=1-16         	  457683	      2636 ns/op	      2636 ns/elm	    3986 B/op	      44 allocs/op
+// BenchmarkPipe/dofns=2-16         	  283699	      3975 ns/op	      1988 ns/elm	    6138 B/op	      66 allocs/op
+// BenchmarkPipe/dofns=3-16         	  212767	      5689 ns/op	      1896 ns/elm	    8504 B/op	      88 allocs/op
+// BenchmarkPipe/dofns=5-16         	  121842	      8279 ns/op	      1656 ns/elm	   11994 B/op	     132 allocs/op
+// BenchmarkPipe/dofns=10-16        	   22059	     52877 ns/op	      5288 ns/elm	   30614 B/op	     443 allocs/op
+// BenchmarkPipe/dofns=100-16       	    6614	    166364 ns/op	      1664 ns/elm	  192961 B/op	    2261 allocs/op
+//
+// With fusion (generic registration):
+// ~200ns per call, 150B per DoFn, across 2 allocs per DoFn
+// AKA comparible to Direct Runner, as expected.
+//
+// goos: linux
+// goarch: amd64
+// pkg: github.com/apache/beam/sdks/v2/go/pkg/beam/runners/direct
+// cpu: 12th Gen Intel(R) Core(TM) i7-1260P
+// BenchmarkPipe/dofns=0-16         	   7660638	       145.8 ns/op	       145.8 ns/elm	     152 B/op	       2 allocs/op
+// BenchmarkPipe/dofns=1-16         	   3676358	       313.3 ns/op	       313.3 ns/elm	     304 B/op	       4 allocs/op
+// BenchmarkPipe/dofns=2-16         	   2242688	       507.4 ns/op	       253.7 ns/elm	     457 B/op	       6 allocs/op
+// BenchmarkPipe/dofns=3-16         	   1726969	       662.6 ns/op	       220.9 ns/elm	     610 B/op	       8 allocs/op
+// BenchmarkPipe/dofns=5-16         	   1198765	      1005 ns/op	       201.0 ns/elm	     915 B/op	      12 allocs/op
+// BenchmarkPipe/dofns=10-16        	    631459	      1874 ns/op	       187.4 ns/elm	    1679 B/op	      22 allocs/op
+// BenchmarkPipe/dofns=100-16       	     57926	     19890 ns/op	       198.9 ns/elm	   15660 B/op	     206 allocs/op
+func BenchmarkPipe(b *testing.B) {
+	initRunner(b)
+	makeBench := func(numDoFns int) func(b *testing.B) {
+		return func(b *testing.B) {
+			b.ReportAllocs()
+			disc := &discard{}
+			p, s := beam.NewPipelineWithRoot()
+			imp := beam.Impulse(s)
+			src := beam.ParDo(s, &source{Count: b.N}, imp)
+			iden := src
+			for i := 0; i < numDoFns; i++ {
+				iden = beam.ParDo(s, identity, iden)
+			}
+			beam.ParDo0(s, disc, iden)
+			_, err := execute(context.Background(), p)
+			if err != nil {
+				b.Fatal(err)
+			}
+			d := b.Elapsed()
+			div := numDoFns
+			if div == 0 {
+				div = 1
+			}
+			div = div * b.N
+			b.ReportMetric(float64(d)/float64(div), "ns/elm")
+		}
+	}
+	for _, numDoFns := range []int{0, 1, 2, 3, 5, 10, 100} {
+		b.Run(fmt.Sprintf("dofns=%d", numDoFns), makeBench(numDoFns))
+	}
 }

--- a/sdks/go/pkg/beam/runners/prism/internal/handlepardo.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/handlepardo.go
@@ -58,7 +58,7 @@ func (*pardo) PrepareUrns() []string {
 
 // PrepareTransform handles special processing with respect to ParDos, since their handling is dependant on supported features
 // and requirements.
-func (h *pardo) PrepareTransform(tid string, t *pipepb.PTransform, comps *pipepb.Components) (*pipepb.Components, []string) {
+func (h *pardo) PrepareTransform(tid string, t *pipepb.PTransform, comps *pipepb.Components) prepareResult {
 
 	// ParDos are a pain in the butt.
 	// Combines, by comparison, are dramatically simpler.
@@ -89,21 +89,22 @@ func (h *pardo) PrepareTransform(tid string, t *pipepb.PTransform, comps *pipepb
 		// so they're not included here. Any nearly any ParDo can have them.
 
 		// At their simplest, we don't need to do anything special at pre-processing time, and simply pass through as normal.
-		return &pipepb.Components{
-			Transforms: map[string]*pipepb.PTransform{
-				tid: t,
+		return prepareResult{
+			SubbedComps: &pipepb.Components{
+				Transforms: map[string]*pipepb.PTransform{
+					tid: t,
+				},
 			},
-		}, nil
+		}
 	}
 
 	// Side inputs add to topology and make fusion harder to deal with
 	// (side input producers can't be in the same stage as their consumers)
-	// But we don't have fusion yet, so no worries.
 
 	// State, Timers, Stable Input, Time Sorted Input, and some parts of SDF
-	// Are easier to deal including a fusion break. But We can do that with a
-	// runner specific transform for stable input, and another for timesorted
-	// input.
+	// Are easier to deal with by including a fusion break. But we can do that with a
+	// runner specific transform for stable input, and another for time sorted input.
+	// TODO add
 
 	// SplittableDoFns have 3 required phases and a 4th optional phase.
 	//
@@ -235,10 +236,16 @@ func (h *pardo) PrepareTransform(tid string, t *pipepb.PTransform, comps *pipepb
 			EnvironmentId: t.GetEnvironmentId(),
 		},
 	}
-
-	return &pipepb.Components{
-		Coders:       coders,
-		Pcollections: pcols,
-		Transforms:   tforms,
-	}, t.GetSubtransforms()
+	return prepareResult{
+		SubbedComps: &pipepb.Components{
+			Coders:       coders,
+			Pcollections: pcols,
+			Transforms:   tforms,
+		},
+		RemovedLeaves: t.GetSubtransforms(),
+		// Force ProcessSized to be a root to ensure SDFs are able to split
+		// between elements or within elements.
+		// Also this is where a transform would be stateful anyway.
+		ForcedRoots: []string{eProcessID},
+	}
 }

--- a/sdks/go/pkg/beam/runners/prism/internal/preprocess.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/preprocess.go
@@ -463,7 +463,7 @@ func prepareStage(stg *stage, comps *pipepb.Components, pipelineFacts fusionFact
 //
 // # Fusion Restrictions
 //
-// Environments: Transforms that aren't in the same environment can't b
+// Environments: Transforms that aren't in the same environment can't be
 // fused together *unless* their environments can also be fused together.
 // Eg. Resource hints can often be ignored for local runners.
 //

--- a/sdks/go/pkg/beam/runners/prism/internal/preprocess.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/preprocess.go
@@ -297,14 +297,14 @@ func (p *preprocessor) preProcessGraph(comps *pipepb.Components) []*stage {
 // }
 
 type fusionFacts struct {
-	pcolProducers        map[string]link  // global pcol ID to transform link that produces it.
-	pcolConsumers        map[string][]link // global pcol ID to all consumers of that pcollection
-	usedAsSideInput      map[string]bool // global pcol ID and if it's used as a side input
+	pcolProducers   map[string]link   // global pcol ID to transform link that produces it.
+	pcolConsumers   map[string][]link // global pcol ID to all consumers of that pcollection
+	usedAsSideInput map[string]bool   // global pcol ID and if it's used as a side input
 
 	directSideInputs     map[string]map[string]bool // global transform ID and all direct side input pcollections.
 	downstreamSideInputs map[string]map[string]bool // global transform ID and all transitive side input pcollections.
 
-	forcedRoots          map[string]bool // transforms forced to be roots (not computed by pcol facts.)
+	forcedRoots map[string]bool // transforms forced to be roots (not computed in computeFacts)
 }
 
 // computeFacts computes facts about the given set of transforms and components that

--- a/sdks/go/pkg/beam/runners/prism/internal/separate_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/separate_test.go
@@ -141,6 +141,7 @@ func TestSeparation(t *testing.T) {
 				count := 10
 				imp := beam.Impulse(s)
 				ints := beam.ParDo(s, emitTenFn, imp)
+				ints = beam.Reshuffle(s, ints)
 				out := beam.ParDo(s, &sepHarness{
 					Base: sepHarnessBase{
 						WatcherID:         ws.newWatcher(3),
@@ -379,7 +380,7 @@ func (fn *sepHarnessBase) setup() error {
 	sepWaitMap[fn.WatcherID] = c
 	go func(id int, c chan struct{}) {
 		for {
-			time.Sleep(time.Second * 1) // Check counts every second.
+			time.Sleep(time.Millisecond * 50) // Check counts every second.
 			sepClientMu.Lock()
 			var unblock bool
 			err := sepClient.Call("Watchers.Check", &Args{WatcherID: id}, &unblock)

--- a/sdks/go/pkg/beam/runners/prism/internal/unimplemented_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/unimplemented_test.go
@@ -108,7 +108,6 @@ func TestImplemented(t *testing.T) {
 		{pipeline: primitives.Flatten},
 		{pipeline: primitives.FlattenDup},
 		{pipeline: primitives.Checkpoints},
-
 		{pipeline: primitives.CoGBK},
 		{pipeline: primitives.ReshuffleKV},
 	}


### PR DESCRIPTION
Add robust fusion heuristics to Prism's graph Pre-processing, leading to improved performance when it's enabled. In this PR it's enabled by default, but in a subsequent PR, it'll be enabled by default in the stand alone command, and generally all variants except the "test" variant.

* Largely cribbed from Python fn_api_runner/translations.py, which is based on two main heuristics: Avoiding side input conflicts, and indicating situations where a producing transform must not be fused with a consuming transform.
* Updated handlers and fact computation to use return structs.
* Add simple benchmarks for the Go Direct Runner, and Prism to demonstrate fusion was effective.
* Clean up no-longer necessary exec side override for environments (handled in handlers now).
* Fix Bug in ProcessBundle handling where a stage without data outputs would not send progress or split requests. This broke the channel splitting test in particular.
  * As a bonus, this moves that async processing into the progress handling loop, cleaning up that handling. 

Minor fixes:
* Fix Transform UniqueName for Combine extract output.
* Fix channel splitting separation harness test to have an explicit Reshuffle, as it can't be automatically added for that synthetic test.
  * Reduce wait time for separation harness polling.

Note: This can be improved if we add "Flatten Unnzipping/Sinking" where Flattens can be removed from the graph, and executed implicitly. It's a more elaborate graph transformation however, since it involves duplicating downstream transforms, and allowing PCollections to have multiple producers. For now, we ignore SDK side flattens (which are only sometimes permittable), and force Runner side flattens to not be fused, since runner side transforms can't fuse at this time.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
