### PR TITLE
WIP: Add DefaultProjectId, DefaultDatasetID and Parameters QueryOptions to go bigqueryio.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -64,6 +64,7 @@
 
 * Support for X source added (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
 * TextIO now supports skipping multiple header lines (Java) ([#17990](https://github.com/apache/beam/issues/17990)).
+* BigQueryIO now supports parameters, default project id, and default dataset id (Go) ([#29382](https://github.com/apache/beam/issues/29382)).
 
 ## New Features / Improvements
 

--- a/sdks/go/pkg/beam/io/bigqueryio/bigquery.go
+++ b/sdks/go/pkg/beam/io/bigqueryio/bigquery.go
@@ -113,6 +113,14 @@ func constructSelectStatement(t reflect.Type, tagKey string, table string) strin
 type QueryOptions struct {
 	// UseStandardSQL enables BigQuery's Standard SQL dialect when executing a query.
 	UseStandardSQL bool
+
+	// Parameters are positional or named replacement values put into the query.
+	Parameters []bigquery.QueryParameter
+
+	// DefaultProjectID and DefaultDatasetID allow for unqualified table identifiers
+	// to be used in queries. DefaultDatasetID must be set if DefaultProjectId is set.
+	DefaultProjectID string
+	DefaultDatasetID string
 }
 
 // UseStandardSQL enables BigQuery's Standard SQL dialect when executing a query.
@@ -166,6 +174,9 @@ func (f *queryFn) ProcessElement(ctx context.Context, _ []byte, emit func(beam.X
 	if !f.Options.UseStandardSQL {
 		q.UseLegacySQL = true
 	}
+	q.DefaultProjectID = f.Options.DefaultProjectID
+	q.DefaultDatasetID = f.Options.DefaultDatasetID
+	q.Parameters = f.Options.Parameters
 
 	it, err := q.Read(ctx)
 	if err != nil {


### PR DESCRIPTION
addresses #29382

Exposes options from the underlying go BigQuery sdk to the bigqueryio package, to allow for Parameters, DefaultProjectId and DefaultDatasetID.

This allows for queries that are not susceptible to SQL injection attacks. Most values can be replaced via parameters, but [parameters cannot be used for identifiers](https://cloud.google.com/bigquery/docs/parameterized-queries). DefaultProjectId and DefaultDatasetID help by allowing unqualified table names to be used in the query, reducing the need for string interpolation on queries where table names are known ahead of time and tables share datasets.