### PR TITLE
Followup #29353 fix several test failures

### DIFF
--- a/.github/workflows/beam_PreCommit_Spotless.yml
+++ b/.github/workflows/beam_PreCommit_Spotless.yml
@@ -97,7 +97,7 @@ jobs:
       - name: run Spotless PreCommit script
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:
-          gradle-command: spotlessCheck checkStyleMain checkStyleTest
+          gradle-command: spotlessCheck checkStyleMain checkStyleTest :buildSrc:spotlessCheck
       - name: Upload test report
         uses: actions/upload-artifact@v3
         with:

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -970,7 +970,10 @@ class BeamModulePlugin implements Plugin<Project> {
         def java21Home = project.findProperty("java21Home")
         options.fork = true
         options.forkOptions.javaHome = java21Home as File
-        options.compilerArgs += ['-Xlint:-path', '-Xlint:-this-escape']
+        options.compilerArgs += [
+          '-Xlint:-path',
+          '-Xlint:-this-escape'
+        ]
         // Error prone requires some packages to be exported/opened for Java 17+
         // Disabling checks since this property is only used for tests
         options.errorprone.errorproneArgs.add("-XepDisableAllChecks")

--- a/runners/google-cloud-dataflow-java/arm/build.gradle
+++ b/runners/google-cloud-dataflow-java/arm/build.gradle
@@ -152,6 +152,7 @@ def cleanUpDockerJavaImages = tasks.register("cleanUpDockerJavaImages") {
       commandLine "gcloud", "--quiet", "container", "images", "untag", "${DockerJavaMultiarchImageName}"
     }
     exec {
+      ignoreExitValue true
       commandLine "./../scripts/cleanup_untagged_gcr_images.sh", "${DockerJavaMultiarchImageContainer}"
     }
   }

--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -308,6 +308,7 @@ def cleanUpDockerJavaImages = tasks.register("cleanUpDockerJavaImages") {
       commandLine "gcloud", "--quiet", "container", "images", "untag", "${dockerJavaImageName}"
     }
     exec {
+      ignoreExitValue true
       commandLine "./scripts/cleanup_untagged_gcr_images.sh", "${dockerJavaImageContainer}"
     }
   }
@@ -346,9 +347,11 @@ def cleanUpDockerPythonImages = tasks.register("cleanUpDockerPythonImages") {
       commandLine "docker", "rmi", "--force", "${dockerPythonImageName}"
     }
     exec {
+      ignoreExitValue true
       commandLine "gcloud", "--quiet", "container", "images", "untag", "${dockerPythonImageName}"
     }
     exec {
+      ignoreExitValue true
       commandLine "./scripts/cleanup_untagged_gcr_images.sh", "${dockerPythonImageContainer}"
     }
   }

--- a/runners/google-cloud-dataflow-java/examples/build.gradle
+++ b/runners/google-cloud-dataflow-java/examples/build.gradle
@@ -36,7 +36,7 @@ dependencies {
 
 def gcpProject = project.findProperty('gcpProject') ?: 'apache-beam-testing'
 def gcpRegion = project.findProperty('gcpRegion') ?: 'us-central1'
-def gcsTempRoot = project.findProperty('gcsTempRoot') ?: 'gs://temp-storage-for-end-to-end-tests/'
+def gcsTempRoot = project.findProperty('gcsTempRoot') ?: 'gs://temp-storage-for-end-to-end-tests'
 def dockerJavaImageName = project(':runners:google-cloud-dataflow-java').ext.dockerJavaImageName
 // If -PuseExecutableStage is set, the use_executable_stage_bundle_execution wil be enabled.
 def fnapiExperiments = project.hasProperty('useExecutableStage') ? 'beam_fn_api_use_deprecated_read,use_executable_stage_bundle_execution' : "beam_fn_api,beam_fn_api_use_deprecated_read"


### PR DESCRIPTION
#29353 introduced several test failures. However, I would argue a forward fix because these failures was due to existing problem of build.gradle get revealed

- Fixes #29386 . It get revealed because these test were missed previously, and then exposes a problem in runner-cloud-dataflow-java/example/build.gradle that is affected by #19191. It was not found during the work of #29353 because I use a custom tempLocation so the default (having a trailing slash) was not used.
- Fixes `./gradlew :buildSrc:spotlessApply`.  Apparently `./gradlew spotlessCheck` does not run buildSrc's spotless check, nor `./gradlew spotlessApply` applies to buildSrc. #29353 introduced spotless violation that not caught by beam precommit test, and failing internal tests on import. This may originate from gradle timing.
- Fixes ARM tests failing at clean up container image. Previously ARM test do not clean up container image after test run, causing leaked resources.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
