### PR TITLE
Invoke pyarrow_hotfix to alleviate concerns due to CVE-2023-47248.

### DIFF
--- a/sdks/python/apache_beam/__init__.py
+++ b/sdks/python/apache_beam/__init__.py
@@ -94,6 +94,14 @@ from apache_beam.transforms import *
 from apache_beam.pvalue import PCollection
 from apache_beam.pvalue import Row
 from apache_beam.pvalue import TaggedOutput
+
+try:
+  # Add mitigation for CVE-2023-47248 while Beam allows affected versions
+  # of pyarrow. (https://github.com/apache/beam/issues/29392)
+  import pyarrow_hotfix
+except ImportError:
+  pass
+
 # pylint: enable=wrong-import-position
 
 __version__ = version.__version__

--- a/sdks/python/container/py310/base_image_requirements.txt
+++ b/sdks/python/container/py310/base_image_requirements.txt
@@ -101,6 +101,7 @@ proto-plus==1.22.3
 protobuf==4.25.0
 psycopg2-binary==2.9.9
 pyarrow==11.0.0
+pyarrow-hotfix==0.4
 pyasn1==0.5.0
 pyasn1-modules==0.3.0
 pycparser==2.21

--- a/sdks/python/container/py311/base_image_requirements.txt
+++ b/sdks/python/container/py311/base_image_requirements.txt
@@ -98,6 +98,7 @@ proto-plus==1.22.3
 protobuf==4.25.0
 psycopg2-binary==2.9.9
 pyarrow==11.0.0
+pyarrow-hotfix==0.4
 pyasn1==0.5.0
 pyasn1-modules==0.3.0
 pycparser==2.21

--- a/sdks/python/container/py38/base_image_requirements.txt
+++ b/sdks/python/container/py38/base_image_requirements.txt
@@ -105,6 +105,7 @@ proto-plus==1.22.3
 protobuf==4.25.0
 psycopg2-binary==2.9.9
 pyarrow==11.0.0
+pyarrow-hotfix==0.4
 pyasn1==0.5.0
 pyasn1-modules==0.3.0
 pycparser==2.21

--- a/sdks/python/container/py39/base_image_requirements.txt
+++ b/sdks/python/container/py39/base_image_requirements.txt
@@ -102,6 +102,7 @@ proto-plus==1.22.3
 protobuf==4.25.0
 psycopg2-binary==2.9.9
 pyarrow==11.0.0
+pyarrow-hotfix==0.4
 pyasn1==0.5.0
 pyasn1-modules==0.3.0
 pycparser==2.21

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -140,9 +140,15 @@ except ImportError:
 
 # [BEAM-8181] pyarrow cannot be installed on 32-bit Windows platforms.
 if sys.platform == 'win32' and sys.maxsize <= 2**32:
-  pyarrow_dependency = ''
+  pyarrow_dependency = ['']
 else:
-  pyarrow_dependency = 'pyarrow>=3.0.0,<12.0.0'
+  pyarrow_dependency = [
+      'pyarrow>=3.0.0,<12.0.0',
+      # NOTE(https://github.com/apache/beam/issues/29392): We can remove this
+      # once Beam increases the pyarrow lower bound to a version that fixes CVE.
+      'pyarrow-hotfix<1'
+  ]
+
 
 # Exclude pandas<=1.4.2 since it doesn't work with numpy 1.24.x.
 # Exclude 1.5.0 and 1.5.1 because of
@@ -308,7 +314,7 @@ if __name__ == '__main__':
           # Dynamic dependencies must be specified in a separate list, otherwise
           # Dependabot won't be able to parse the main list. Any dynamic
           # dependencies will not receive updates from Dependabot.
-      ] + [pyarrow_dependency],
+      ] + pyarrow_dependency,
       python_requires=python_requires,
       # BEAM-8840: Do NOT use tests_require or setup_requires.
       extras_require={


### PR DESCRIPTION
Address #29392 until we upgrade to newer version of pyarrow.

Note that `import apache_beam` already imports pyarrow, therefore invoking the patch in top-level `__init__.py`