### PR TITLE
Relocate Avro dependencies in Fn Harness JAR

### DIFF
--- a/sdks/java/harness/build.gradle
+++ b/sdks/java/harness/build.gradle
@@ -52,7 +52,6 @@ applyJavaNature(
     "junit/**",
     "io/github/classgraph/**",
     "nonapi/io/github/classgraph/**",
-    "org/apache/avro/**",
     "org/apache/beam/fn/harness/**",
     "org/apache/beam/model/fnexecution/**",
     "org/apache/beam/runners/core/**",
@@ -75,6 +74,9 @@ applyJavaNature(
         exclude(dependency(it.getModuleGroup() + ":" + it.getModuleName() + ":.*"))
       }
     }
+
+    relocate("org.apache.avro", "org.apache.beam.fn.harness.repackaged.org.apache.avro")
+
   },
 )
 


### PR DESCRIPTION
After https://github.com/apache/beam/pull/27851, user code that depends on versions newer than Avro 1.8.2 are having problems running on Dataflow.

For example in https://github.com/GoogleCloudPlatform/DataflowTemplates, where we moved on to Avro 1.11.3, there were incompatibility errors:

> Caused by: java.io.InvalidClassException: org.apache.avro.specific.SpecificRecordBase; local class incompatible: stream classdesc serialVersionUID = -1463700717714793795, local class serialVersionUID = 189988654766568477

and

> Caused by: java.lang.NoSuchMethodError: 'boolean org.apache.avro.generic.GenericRecord.hasField(java.lang.String)'   com.google.cloud.teleport.v2.transforms.FormatDatastreamRecordToJson.getMetadataIsDeleted(FormatDatastreamRecordToJson.java:258)    com.google.cloud.teleport.v2.transforms.FormatDatastreamRecordToJson.apply(FormatDatastreamRecordToJson.java:123)    com.google.cloud.teleport.v2.transforms.FormatDatastreamRecordToJson.apply(FormatDatastreamRecordToJson.java:51)    org.apache.beam.sdk.extensions.avro.io.AvroSource$AvroBlock.readNextRecord(AvroSource.java:610)

The root cause is that Avro classes are now being shipped along with the `/opt/apache/beam/jars/beam-sdks-java-harness.jar`, which wasn't the case before.

Relocating `org.apache.avro` to `org.apache.beam.fn.harness.repackaged.org.apache.avro` will solve the problem and allow users to control their Avro.

