### PR TITLE
Add getters to CheckResult in IT framework

### DIFF
--- a/it/conditions/src/main/java/org/apache/beam/it/conditions/ConditionCheck.java
+++ b/it/conditions/src/main/java/org/apache/beam/it/conditions/ConditionCheck.java
@@ -77,6 +77,14 @@ public abstract class ConditionCheck implements Supplier<Boolean> {
       this.message = message;
     }
 
+    public boolean isSuccess() {
+      return success;
+    }
+
+    public String getMessage() {
+      return message;
+    }
+
     @Override
     public String toString() {
       return "CheckResult{" + "success=" + success + ", message='" + message + '\'' + '}';


### PR DESCRIPTION
I want to use the checker in a specific way, and we didn't expose the `success` or `message`:

```java
    assertThat(pubsubCheck.check().isSuccess()).isTrue();
```

Right now we only have `pubsubCheck.get()` but it's not expressive enough (and wouldn't return the message if it failed).
