### PR TITLE
[prism] Fix downstream side input computations.

### DIFF
--- a/sdks/go/pkg/beam/io/fileio/read_test.go
+++ b/sdks/go/pkg/beam/io/fileio/read_test.go
@@ -134,17 +134,15 @@ func TestReadMatches(t *testing.T) {
 	}
 	for _, tt := range tests {
 		t.Run(tt.name, func(t *testing.T) {
-			t.Run(tt.name, func(t *testing.T) {
-				p, s := beam.NewPipelineWithRoot()
+			p, s := beam.NewPipelineWithRoot()
 
-				col := beam.Create(s, tt.input...)
-				got := ReadMatches(s, col, tt.opts...)
+			col := beam.Create(s, tt.input...)
+			got := ReadMatches(s, col, tt.opts...)
 
-				passert.Equals(s, got, tt.want...)
-				if err := ptest.Run(p); (err != nil) != tt.wantErr {
-					t.Errorf("ReadMatches() error = %v, wantErr %v", err, tt.wantErr)
-				}
-			})
+			passert.Equals(s, got, tt.want...)
+			if err := ptest.Run(p); (err != nil) != tt.wantErr {
+				t.Errorf("ReadMatches() error = %v, wantErr %v", err, tt.wantErr)
+			}
 		})
 	}
 }

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
@@ -156,8 +156,8 @@ func (em *ElementManager) AddStage(ID string, inputIDs, outputIDs []string, side
 	ss := makeStageState(ID, inputIDs, outputIDs, sides)
 
 	em.stages[ss.ID] = ss
-	for _, outputIDs := range ss.outputIDs {
-		em.pcolParents[outputIDs] = ss.ID
+	for _, outputID := range ss.outputIDs {
+		em.pcolParents[outputID] = ss.ID
 	}
 	for _, input := range inputIDs {
 		em.consumers[input] = append(em.consumers[input], ss.ID)
@@ -266,6 +266,13 @@ func (em *ElementManager) Bundles(ctx context.Context, nextBundID func() string)
 					}
 					em.refreshCond.L.Lock()
 				}
+			}
+			if len(em.inprogressBundles) == 0 && len(em.watermarkRefreshes) == 0 {
+				slog.Debug("Bundles: nothing in progress and no refreshes")
+			} else if len(em.inprogressBundles) == 0 {
+				slog.Debug("Bundles: nothing in progress after advance",
+					slog.Any("advanced", advanced),
+					slog.Int("refreshCount", len(em.watermarkRefreshes)))
 			}
 			em.refreshCond.L.Unlock()
 		}

--- a/sdks/go/pkg/beam/runners/prism/internal/execute.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/execute.go
@@ -146,7 +146,7 @@ func executePipeline(ctx context.Context, wks map[string]*worker.W, j *jobservic
 
 	prepro := newPreprocessor(preppers)
 
-	topo := prepro.preProcessGraph(comps)
+	topo := prepro.preProcessGraph(comps, j)
 	ts := comps.GetTransforms()
 
 	em := engine.NewElementManager(engine.Config{})

--- a/sdks/go/pkg/beam/runners/prism/internal/execute.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/execute.go
@@ -32,6 +32,7 @@ import (
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/runners/prism/internal/worker"
 	"golang.org/x/exp/maps"
 	"golang.org/x/exp/slog"
+	"golang.org/x/sync/errgroup"
 	"google.golang.org/protobuf/proto"
 )
 
@@ -245,38 +246,34 @@ func executePipeline(ctx context.Context, wks map[string]*worker.W, j *jobservic
 		em.Impulse(id)
 	}
 
-	// Use a channel to limit max parallelism for the pipeline.
-	maxParallelism := make(chan struct{}, 8)
-	// Execute stages here
-	bundleFailed := make(chan error)
+	// Use an errgroup to limit max parallelism for the pipeline.
+	eg, egctx := errgroup.WithContext(ctx)
+	eg.SetLimit(8)
 
 	var instID uint64
-	bundles := em.Bundles(ctx, func() string {
+	bundles := em.Bundles(egctx, func() string {
 		return fmt.Sprintf("inst%03d", atomic.AddUint64(&instID, 1))
 	})
-
 	for {
 		select {
 		case <-ctx.Done():
 			return context.Cause(ctx)
 		case rb, ok := <-bundles:
 			if !ok {
-				slog.Debug("pipeline done!", slog.String("job", j.String()))
-				return nil
+				err := eg.Wait()
+				slog.Debug("pipeline done!", slog.String("job", j.String()), slog.Any("error", err))
+				return err
 			}
-			maxParallelism <- struct{}{}
-			go func(rb engine.RunBundle) {
-				defer func() { <-maxParallelism }()
+			eg.Go(func() error {
 				s := stages[rb.StageID]
 				wk := wks[s.envID]
 				if err := s.Execute(ctx, j, wk, comps, em, rb); err != nil {
 					// Ensure we clean up on bundle failure
 					em.FailBundle(rb)
-					bundleFailed <- err
+					return err
 				}
-			}(rb)
-		case err := <-bundleFailed:
-			return err
+				return nil
+			})
 		}
 	}
 }

--- a/sdks/go/pkg/beam/runners/prism/internal/handlecombine.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/handlecombine.go
@@ -141,7 +141,7 @@ func (h *combine) PrepareTransform(tid string, t *pipepb.PTransform, comps *pipe
 
 	// Now we need the output collection ID
 	var pcolOutID string
-	// There's only one input.
+	// There's only one output.
 	for _, pcol := range t.GetOutputs() {
 		pcolOutID = pcol
 	}
@@ -207,12 +207,10 @@ func (h *combine) PrepareTransform(tid string, t *pipepb.PTransform, comps *pipe
 		},
 	}
 
-	// Now we return everything!
-	// TODO recurse through sub transforms to remove?
 	// We don't need to remove the composite, since we don't add it in
 	// when we return the new transforms, so it's not in the topology.
 	return prepareResult{
 		SubbedComps:   newComps,
-		RemovedLeaves: t.GetSubtransforms(),
+		RemovedLeaves: removeSubTransforms(comps, t.GetSubtransforms()),
 	}
 }

--- a/sdks/go/pkg/beam/runners/prism/internal/handlecombine_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/handlecombine_test.go
@@ -1,0 +1,212 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package internal
+
+import (
+	"testing"
+
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/util/protox"
+	pipepb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/pipeline_v1"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/runners/prism/internal/urns"
+	"github.com/google/go-cmp/cmp"
+	"google.golang.org/protobuf/testing/protocmp"
+)
+
+func TestHandleCombine(t *testing.T) {
+	undertest := "UnderTest"
+
+	combineTransform := &pipepb.PTransform{
+		UniqueName: "COMBINE",
+		Spec: &pipepb.FunctionSpec{
+			Urn: urns.TransformCombinePerKey,
+			Payload: protox.MustEncode(&pipepb.CombinePayload{
+				CombineFn: &pipepb.FunctionSpec{
+					Urn:     "foo",
+					Payload: []byte("bar"),
+				},
+				AccumulatorCoderId: "AccumID",
+			}),
+		},
+		Inputs: map[string]string{
+			"input": "combineIn",
+		},
+		Outputs: map[string]string{
+			"input": "combineOut",
+		},
+		Subtransforms: []string{
+			"gbk",
+			"combine_values",
+		},
+	}
+	combineValuesTransform := &pipepb.PTransform{
+		UniqueName: "combine_values",
+		Subtransforms: []string{
+			"bonus_leaf",
+		},
+	}
+	basePCollectionMap := map[string]*pipepb.PCollection{
+		"combineIn": {
+			CoderId: "inputCoder",
+		},
+		"combineOut": {
+			CoderId: "outputCoder",
+		},
+	}
+	baseCoderMap := map[string]*pipepb.Coder{
+		"int": {
+			Spec: &pipepb.FunctionSpec{Urn: urns.CoderVarInt},
+		},
+		"string": {
+			Spec: &pipepb.FunctionSpec{Urn: urns.CoderStringUTF8},
+		},
+		"AccumID": {
+			Spec: &pipepb.FunctionSpec{Urn: urns.CoderBytes},
+		},
+		"inputCoder": {
+			Spec:              &pipepb.FunctionSpec{Urn: urns.CoderKV},
+			ComponentCoderIds: []string{"int", "int"},
+		},
+		"outputCoder": {
+			Spec:              &pipepb.FunctionSpec{Urn: urns.CoderKV},
+			ComponentCoderIds: []string{"int", "string"},
+		},
+	}
+
+	tests := []struct {
+		name   string
+		lifted bool
+		comps  *pipepb.Components
+
+		want prepareResult
+	}{
+		{
+			name:   "unlifted",
+			lifted: false,
+			comps: &pipepb.Components{
+				Transforms: map[string]*pipepb.PTransform{
+					undertest: combineTransform,
+					"combine_values": combineValuesTransform,
+				},
+				Pcollections: basePCollectionMap,
+				Coders:       baseCoderMap,
+			},
+			want: prepareResult{
+				SubbedComps: &pipepb.Components{
+					Transforms: map[string]*pipepb.PTransform{
+						undertest: combineTransform,
+					},
+				},
+			},
+		}, {
+			name:   "lifted",
+			lifted: true,
+			comps: &pipepb.Components{
+				Transforms: map[string]*pipepb.PTransform{
+					undertest: combineTransform,
+					"combine_values": combineValuesTransform,
+				},
+				Pcollections: basePCollectionMap,
+				Coders:       baseCoderMap,
+			},
+			want: prepareResult{
+				RemovedLeaves: []string{"gbk", "combine_values", "bonus_leaf"},
+				SubbedComps: &pipepb.Components{
+					Coders: map[string]*pipepb.Coder{
+						"cUnderTest_iter_AccumID": {
+							Spec:              &pipepb.FunctionSpec{Urn: urns.CoderIterable},
+							ComponentCoderIds: []string{"AccumID"},
+						},
+						"cUnderTest_kv_int_AccumID": {
+							Spec:              &pipepb.FunctionSpec{Urn: urns.CoderKV},
+							ComponentCoderIds: []string{"int", "AccumID"},
+						},
+						"cUnderTest_kv_int_iterAccumID": {
+							Spec:              &pipepb.FunctionSpec{Urn: urns.CoderKV},
+							ComponentCoderIds: []string{"int", "cUnderTest_iter_AccumID"},
+						},
+					},
+					Pcollections: map[string]*pipepb.PCollection{
+						"nUnderTest_lifted": {
+							UniqueName: "nUnderTest_lifted",
+							CoderId:    "cUnderTest_kv_int_AccumID",
+						},
+						"nUnderTest_grouped": {
+							UniqueName: "nUnderTest_grouped",
+							CoderId:    "cUnderTest_kv_int_iterAccumID",
+						},
+						"nUnderTest_merged": {
+							UniqueName: "nUnderTest_merged",
+							CoderId:    "cUnderTest_kv_int_AccumID",
+						},
+					},
+					Transforms: map[string]*pipepb.PTransform{
+						"eUnderTest_lift": {
+							UniqueName: "eUnderTest_lift",
+							Spec: &pipepb.FunctionSpec{
+								Urn:     urns.TransformPreCombine,
+								Payload: combineTransform.GetSpec().GetPayload(),
+							},
+							Inputs:  map[string]string{"i0": "combineIn"},
+							Outputs: map[string]string{"i0": "nUnderTest_lifted"},
+						},
+						"eUnderTest_gbk": {
+							UniqueName: "eUnderTest_gbk",
+							Spec: &pipepb.FunctionSpec{
+								Urn: urns.TransformGBK,
+								// Technically shouldn't be here, but since GBK execution doesn't escape the runner
+								// this never gets examined.
+								Payload: combineTransform.GetSpec().GetPayload(),
+							},
+							Inputs:  map[string]string{"i0": "nUnderTest_lifted"},
+							Outputs: map[string]string{"i0": "nUnderTest_grouped"},
+						},
+						"eUnderTest_merge": {
+							UniqueName: "eUnderTest_merge",
+							Spec: &pipepb.FunctionSpec{
+								Urn:     urns.TransformMerge,
+								Payload: combineTransform.GetSpec().GetPayload(),
+							},
+							Inputs:  map[string]string{"i0": "nUnderTest_grouped"},
+							Outputs: map[string]string{"i0": "nUnderTest_merged"},
+						},
+						"eUnderTest_extract": {
+							UniqueName: "eUnderTest_extract",
+							Spec: &pipepb.FunctionSpec{
+								Urn:     urns.TransformExtract,
+								Payload: combineTransform.GetSpec().GetPayload(),
+							},
+							Inputs:  map[string]string{"i0": "nUnderTest_merged"},
+							Outputs: map[string]string{"i0": "combineOut"},
+						},
+					},
+				},
+			},
+		},
+	}
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			handler := combine{
+				config: CombineCharacteristic{
+					EnableLifting: test.lifted,
+				},
+			}
+			got := handler.PrepareTransform(undertest, test.comps.GetTransforms()[undertest], test.comps)
+			if d := cmp.Diff(test.want, got, protocmp.Transform()); d != "" {
+				t.Errorf("combine.PrepareTransform diff (-want, +got):\n%v", d)
+			}
+		})
+	}
+}

--- a/sdks/go/pkg/beam/runners/prism/internal/handlecombine_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/handlecombine_test.go
@@ -97,7 +97,7 @@ func TestHandleCombine(t *testing.T) {
 			lifted: false,
 			comps: &pipepb.Components{
 				Transforms: map[string]*pipepb.PTransform{
-					undertest: combineTransform,
+					undertest:        combineTransform,
 					"combine_values": combineValuesTransform,
 				},
 				Pcollections: basePCollectionMap,
@@ -115,7 +115,7 @@ func TestHandleCombine(t *testing.T) {
 			lifted: true,
 			comps: &pipepb.Components{
 				Transforms: map[string]*pipepb.PTransform{
-					undertest: combineTransform,
+					undertest:        combineTransform,
 					"combine_values": combineValuesTransform,
 				},
 				Pcollections: basePCollectionMap,

--- a/sdks/go/pkg/beam/runners/prism/internal/handlepardo.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/handlepardo.go
@@ -242,7 +242,7 @@ func (h *pardo) PrepareTransform(tid string, t *pipepb.PTransform, comps *pipepb
 			Pcollections: pcols,
 			Transforms:   tforms,
 		},
-		RemovedLeaves: t.GetSubtransforms(),
+		RemovedLeaves: removeSubTransforms(comps, t.GetSubtransforms()),
 		// Force ProcessSized to be a root to ensure SDFs are able to split
 		// between elements or within elements.
 		// Also this is where a transform would be stateful anyway.

--- a/sdks/go/pkg/beam/runners/prism/internal/preprocess.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/preprocess.go
@@ -154,7 +154,7 @@ func (p *preprocessor) preProcessGraph(comps *pipepb.Components, j *jobservices.
 
 	facts, err := computeFacts(topological, comps)
 	if err != nil {
-		fmt.Errorf("error computing pipeline facts: %w", err)
+		err = fmt.Errorf("error computing pipeline facts: %w", err)
 		j.SendMsg(err.Error())
 		j.Failed(err)
 		return nil

--- a/sdks/go/pkg/beam/runners/prism/internal/preprocess.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/preprocess.go
@@ -169,13 +169,8 @@ func (p *preprocessor) preProcessGraph(comps *pipepb.Components, j *jobservices.
 
 	for i, stg := range stages {
 		err := finalizeStage(stg, comps, facts)
-
-		var uniques []string
-		for _, tid := range stg.transforms {
-			uniques = append(uniques, comps.Transforms[tid].UniqueName)
-		}
 		if err != nil {
-			err = fmt.Errorf("ERROR ON VALIDATION of stage %v: %v", i, err)
+			err = fmt.Errorf("preprocess validation failure of stage %v: %v", i, err)
 			j.SendMsg(err.Error())
 			j.Failed(err)
 			return nil

--- a/sdks/go/pkg/beam/runners/prism/internal/preprocess.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/preprocess.go
@@ -154,10 +154,10 @@ func (p *preprocessor) preProcessGraph(comps *pipepb.Components) []*stage {
 	slog.Debug("topological transform ordering", slog.Any("topological", topological))
 
 	facts := computeFacts(topological, comps)
-	facts.forcedRoots = forcedRoots
+	facts.ForcedRoots = forcedRoots
 
-	_ = greedyFusion // avoid "unused" warnings.
-	return defaultFusion(topological, comps, facts)
+	_ = defaultFusion // avoid "unused" warnings while keeping the older default approach available.
+	return greedyFusion(topological, comps, facts)
 }
 
 // TODO(lostluck): Be able to toggle this in variants.
@@ -221,9 +221,9 @@ func defaultFusion(topological []string, comps *pipepb.Components, facts fusionF
 		inputID := getOnlyValue(t.GetInputs())
 		outputID := getOnlyValue(t.GetOutputs())
 
-		producerLink := facts.pcolProducers[inputID]
+		producerLink := facts.PcolProducers[inputID]
 
-		producer := comps.GetTransforms()[producerLink.transform]
+		producer := comps.GetTransforms()[producerLink.Transform]
 
 		// Check if the input source is a GBK
 		if producer.GetSpec().GetUrn() != urns.TransformGBK {
@@ -258,11 +258,11 @@ func defaultFusion(topological []string, comps *pipepb.Components, facts fusionF
 		if !ok {
 			continue
 		}
-		cs := facts.pcolConsumers[pcolID]
+		cs := facts.PcolConsumers[pcolID]
 
 		for _, c := range cs {
-			stg.transforms = append(stg.transforms, c.transform)
-			consumed[c.transform] = true
+			stg.transforms = append(stg.transforms, c.Transform)
+			consumed[c.Transform] = true
 		}
 	}
 
@@ -299,25 +299,25 @@ func checkForExpandCoderPattern(in, out string, comps *pipepb.Components) bool {
 }
 
 type fusionFacts struct {
-	pcolProducers   map[string]link   // global pcol ID to transform link that produces it.
-	pcolConsumers   map[string][]link // global pcol ID to all consumers of that pcollection
-	usedAsSideInput map[string]bool   // global pcol ID and if it's used as a side input
+	PcolProducers   map[string]link   // global pcol ID to transform link that produces it.
+	PcolConsumers   map[string][]link // global pcol ID to all consumers of that pcollection
+	UsedAsSideInput map[string]bool   // global pcol ID and if it's used as a side input
 
-	directSideInputs     map[string]map[string]bool // global transform ID and all direct side input pcollections.
-	downstreamSideInputs map[string]map[string]bool // global transform ID and all transitive side input pcollections.
+	DirectSideInputs     map[string]map[string]bool // global transform ID and all direct side input pcollections.
+	DownstreamSideInputs map[string]map[string]bool // global transform ID and all transitive side input pcollections.
 
-	forcedRoots map[string]bool // transforms forced to be roots (not computed in computeFacts)
+	ForcedRoots map[string]bool // transforms forced to be roots (not computed in computeFacts)
 }
 
 // computeFacts computes facts about the given set of transforms and components that
 // are useful for fusion.
 func computeFacts(topological []string, comps *pipepb.Components) fusionFacts {
 	ret := fusionFacts{
-		pcolProducers:        map[string]link{},
-		pcolConsumers:        map[string][]link{},
-		usedAsSideInput:      map[string]bool{},
-		directSideInputs:     map[string]map[string]bool{}, // direct set
-		downstreamSideInputs: map[string]map[string]bool{}, // transitive set
+		PcolProducers:        map[string]link{},
+		PcolConsumers:        map[string][]link{},
+		UsedAsSideInput:      map[string]bool{},
+		DirectSideInputs:     map[string]map[string]bool{}, // direct set
+		DownstreamSideInputs: map[string]map[string]bool{}, // transitive set
 	}
 
 	// Use the topological ids so each PCollection only has a single
@@ -325,45 +325,45 @@ func computeFacts(topological []string, comps *pipepb.Components) fusionFacts {
 	for _, tID := range topological {
 		t := comps.GetTransforms()[tID]
 		for local, global := range t.GetOutputs() {
-			ret.pcolProducers[global] = link{transform: tID, local: local, global: global}
+			ret.PcolProducers[global] = link{Transform: tID, Local: local, Global: global}
 		}
 		sis, err := getSideInputs(t)
 		if err != nil {
 			panic(err)
 		}
 		directSIs := map[string]bool{}
-		ret.directSideInputs[tID] = directSIs
+		ret.DirectSideInputs[tID] = directSIs
 		for local, global := range t.GetInputs() {
-			ret.pcolConsumers[global] = append(ret.pcolConsumers[global], link{transform: tID, local: local, global: global})
+			ret.PcolConsumers[global] = append(ret.PcolConsumers[global], link{Transform: tID, Local: local, Global: global})
 			if _, ok := sis[local]; ok {
-				ret.usedAsSideInput[global] = true
+				ret.UsedAsSideInput[global] = true
 				directSIs[global] = true
 			}
 		}
 	}
 
 	for _, tID := range topological {
-		computeDownstreamSideInputs(tID, comps, ret)
+		computeDownstreamSideInputs(tID, comps, &ret)
 	}
 
 	return ret
 }
 
-func computeDownstreamSideInputs(tID string, comps *pipepb.Components, facts fusionFacts) map[string]bool {
-	if dssi, ok := facts.downstreamSideInputs[tID]; ok {
+func computeDownstreamSideInputs(tID string, comps *pipepb.Components, facts *fusionFacts) map[string]bool {
+	if dssi, ok := facts.DownstreamSideInputs[tID]; ok {
 		return dssi
 	}
 	dssi := map[string]bool{}
 	for _, o := range comps.GetTransforms()[tID].GetOutputs() {
-		if facts.usedAsSideInput[o] {
+		if facts.UsedAsSideInput[o] {
 			dssi[o] = true
 		}
-		for _, consumer := range facts.pcolConsumers[o] {
-			cdssi := computeDownstreamSideInputs(consumer.global, comps, facts)
+		for _, consumer := range facts.PcolConsumers[o] {
+			cdssi := computeDownstreamSideInputs(consumer.Transform, comps, facts)
 			maps.Copy(dssi, cdssi)
 		}
 	}
-	facts.downstreamSideInputs[tID] = dssi
+	facts.DownstreamSideInputs[tID] = dssi
 	return dssi
 }
 
@@ -396,33 +396,33 @@ func prepareStage(stg *stage, comps *pipepb.Components, pipelineFacts fusionFact
 	mainInputs := map[string]string{}
 	var sideInputs []engine.LinkID
 	inputs := map[string]bool{}
-	for pid, plinks := range stageFacts.pcolConsumers {
+	for pid, plinks := range stageFacts.PcolConsumers {
 		// Check if this PCollection is generated in this bundle.
-		if _, ok := stageFacts.pcolProducers[pid]; ok {
+		if _, ok := stageFacts.PcolProducers[pid]; ok {
 			// It is, so we will ignore for now.
 			continue
 		}
 		// Add this collection to our input set.
 		inputs[pid] = true
 		for _, link := range plinks {
-			t := comps.GetTransforms()[link.transform]
+			t := comps.GetTransforms()[link.Transform]
 			sis, _ := getSideInputs(t)
-			if _, ok := sis[link.local]; ok {
-				sideInputs = append(sideInputs, engine.LinkID{Transform: link.transform, Global: link.global, Local: link.local})
+			if _, ok := sis[link.Local]; ok {
+				sideInputs = append(sideInputs, engine.LinkID{Transform: link.Transform, Global: link.Global, Local: link.Local})
 			} else {
-				mainInputs[link.global] = link.global
+				mainInputs[link.Global] = link.Global
 			}
 		}
 	}
 	outputs := map[string]link{}
 	var internal []string
 	// Look at all PCollections produced in this stage.
-	for pid, link := range stageFacts.pcolProducers {
+	for pid, link := range stageFacts.PcolProducers {
 		// Look at all consumers of this PCollection in the pipeline
 		isInternal := true
-		for _, l := range pipelineFacts.pcolConsumers[pid] {
+		for _, l := range pipelineFacts.PcolConsumers[pid] {
 			// If the consuming transform isn't in the stage, it's an output.
-			if !transformSet[l.transform] {
+			if !transformSet[l.Transform] {
 				isInternal = false
 				outputs[pid] = link
 			}
@@ -505,9 +505,9 @@ func greedyFusion(topological []string, comps *pipepb.Components, facts fusionFa
 			t := comps.GetTransforms()[tID]
 			stageAssignments[tID] = sID
 			stageEnvs[sID] = t.GetEnvironmentId()
-			forcedRoots[sID] = facts.forcedRoots[tID]
-			directSIs[sID] = maps.Clone(facts.directSideInputs[tID])
-			downstreamSIs[sID] = maps.Clone(facts.downstreamSideInputs[tID])
+			forcedRoots[sID] = facts.ForcedRoots[tID]
+			directSIs[sID] = maps.Clone(facts.DirectSideInputs[tID])
+			downstreamSIs[sID] = maps.Clone(facts.DownstreamSideInputs[tID])
 		}
 
 		var oldIDs []int
@@ -544,13 +544,13 @@ func greedyFusion(topological []string, comps *pipepb.Components, facts fusionFa
 
 	// Use the topological sort instead?
 
-	keys := maps.Keys(facts.pcolProducers)
+	keys := maps.Keys(facts.PcolProducers)
 	slices.Sort(keys)
 	for _, pcol := range keys {
-		producer := facts.pcolProducers[pcol]
-		for _, consumer := range facts.pcolConsumers[pcol] {
-			pID := replacements(producer.transform) // Get current stage for producer
-			cID := replacements(consumer.transform) // Get current stage for consumer
+		producer := facts.PcolProducers[pcol]
+		for _, consumer := range facts.PcolConsumers[pcol] {
+			pID := replacements(producer.Transform) // Get current stage for producer
+			cID := replacements(consumer.Transform) // Get current stage for consumer
 
 			// See if there's anything preventing fusion:
 			if pID == cID {

--- a/sdks/go/pkg/beam/runners/prism/internal/preprocess_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/preprocess_test.go
@@ -133,7 +133,7 @@ func Test_preprocessor_preProcessGraph(t *testing.T) {
 				ForcedRoots: test.forcedRoots,
 			}})
 
-			gotStages := pre.preProcessGraph(test.input)
+			gotStages := pre.preProcessGraph(test.input, nil)
 			if diff := cmp.Diff(test.wantStages, gotStages, cmp.AllowUnexported(stage{}, link{}), cmpopts.EquateEmpty()); diff != "" {
 				t.Errorf("preProcessGraph(%q) stages diff (-want,+got)\n%v", test.name, diff)
 			}
@@ -211,7 +211,7 @@ func TestComputeFacts(t *testing.T) {
 		topological []string
 		comps       *pipepb.Components
 
-		want fusionFacts
+		want *fusionFacts
 	}{
 		{
 			name:        "single_transform",
@@ -224,7 +224,7 @@ func TestComputeFacts(t *testing.T) {
 					},
 				},
 			},
-			want: fusionFacts{
+			want: &fusionFacts{
 				PcolProducers:   map[string]link{},
 				PcolConsumers:   map[string][]link{},
 				UsedAsSideInput: map[string]bool{},
@@ -250,7 +250,7 @@ func TestComputeFacts(t *testing.T) {
 					},
 				},
 			},
-			want: fusionFacts{
+			want: &fusionFacts{
 				PcolProducers: map[string]link{
 					"n1": {Transform: "t1", Local: "o0", Global: "n1"},
 				},
@@ -285,7 +285,7 @@ func TestComputeFacts(t *testing.T) {
 					},
 				},
 			},
-			want: fusionFacts{
+			want: &fusionFacts{
 				PcolProducers: map[string]link{
 					"n1": {Transform: "t1", Local: "o0", Global: "n1"},
 				},
@@ -326,7 +326,7 @@ func TestComputeFacts(t *testing.T) {
 					},
 				},
 			},
-			want: fusionFacts{
+			want: &fusionFacts{
 				PcolProducers: map[string]link{
 					"n1": {Transform: "t1", Local: "o0", Global: "n1"},
 					"n2": {Transform: "t2", Local: "o0", Global: "n2"},
@@ -371,7 +371,7 @@ func TestComputeFacts(t *testing.T) {
 					},
 				},
 			},
-			want: fusionFacts{
+			want: &fusionFacts{
 				PcolProducers: map[string]link{
 					"n1": {Transform: "t1", Local: "o0", Global: "n1"},
 					"n2": {Transform: "t2", Local: "o0", Global: "n2"},
@@ -416,7 +416,7 @@ func TestComputeFacts(t *testing.T) {
 					},
 				},
 			},
-			want: fusionFacts{
+			want: &fusionFacts{
 				PcolProducers: map[string]link{
 					"n1": {Transform: "t1", Local: "o0", Global: "n1"},
 					"n2": {Transform: "t2", Local: "o0", Global: "n2"},
@@ -468,7 +468,7 @@ func TestComputeFacts(t *testing.T) {
 					},
 				},
 			},
-			want: fusionFacts{
+			want: &fusionFacts{
 				PcolProducers: map[string]link{
 					"n1": {Transform: "t1", Local: "o0", Global: "n1"},
 					"n2": {Transform: "t2", Local: "o0", Global: "n2"},
@@ -539,7 +539,7 @@ func TestComputeFacts(t *testing.T) {
 					},
 				},
 			},
-			want: fusionFacts{
+			want: &fusionFacts{
 				PcolProducers: map[string]link{
 					"n1": {Transform: "r1", Local: "o0", Global: "n1"},
 					"n2": {Transform: "r2", Local: "o0", Global: "n2"},
@@ -626,7 +626,7 @@ func TestComputeFacts(t *testing.T) {
 					},
 				},
 			},
-			want: fusionFacts{
+			want: &fusionFacts{
 				PcolProducers: map[string]link{
 					"n1": {Transform: "r1", Local: "o0", Global: "n1"},
 					"n2": {Transform: "r2", Local: "o0", Global: "n2"},
@@ -683,7 +683,10 @@ func TestComputeFacts(t *testing.T) {
 
 	for _, test := range tests {
 		t.Run(test.name, func(t *testing.T) {
-			got := computeFacts(test.topological, test.comps)
+			got, err := computeFacts(test.topological, test.comps)
+			if err != nil {
+				t.Fatalf("computeFacts: error: %v", err)
+			}
 			if d := cmp.Diff(test.want, got, cmp.AllowUnexported(), cmpopts.EquateEmpty(), cmpopts.SortSlices(linkLess)); d != "" {
 				t.Errorf("computeFacts diff (-want, +got):\n%v", d)
 			}

--- a/sdks/go/pkg/beam/runners/prism/internal/preprocess_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/preprocess_test.go
@@ -18,7 +18,9 @@ package internal
 import (
 	"testing"
 
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/util/protox"
 	pipepb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/pipeline_v1"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/runners/prism/internal/urns"
 	"github.com/google/go-cmp/cmp"
 	"github.com/google/go-cmp/cmp/cmpopts"
 	"google.golang.org/protobuf/testing/protocmp"
@@ -78,7 +80,7 @@ func Test_preprocessor_preProcessGraph(t *testing.T) {
 
 			wantStages: []*stage{
 				{transforms: []string{"e1_early"}, envID: "env1",
-					outputs: []link{{transform: "e1_early", local: "i0", global: "pcol1"}}},
+					outputs: []link{{Transform: "e1_early", Local: "i0", Global: "pcol1"}}},
 				{transforms: []string{"e1_late"}, envID: "env1", primaryInput: "pcol1"}},
 			wantComponents: &pipepb.Components{
 				Transforms: map[string]*pipepb.PTransform{
@@ -191,5 +193,500 @@ func (p *testPreparer) PrepareTransform(tid string, t *pipepb.PTransform, comps 
 			},
 		},
 		RemovedLeaves: []string{"e1"},
+	}
+}
+
+func TestComputeFacts(t *testing.T) {
+	sideInputSpec := func(sis map[string]*pipepb.SideInput) *pipepb.FunctionSpec {
+		return &pipepb.FunctionSpec{
+			Urn: urns.TransformParDo,
+			Payload: protox.MustEncode(&pipepb.ParDoPayload{
+				SideInputs: sis,
+			}),
+		}
+	}
+
+	tests := []struct {
+		name        string
+		topological []string
+		comps       *pipepb.Components
+
+		want fusionFacts
+	}{
+		{
+			name:        "single_transform",
+			topological: []string{"t1"},
+			comps: &pipepb.Components{
+				Transforms: map[string]*pipepb.PTransform{
+					"t1": {
+						Inputs:  map[string]string{},
+						Outputs: map[string]string{},
+					},
+				},
+			},
+			want: fusionFacts{
+				PcolProducers:   map[string]link{},
+				PcolConsumers:   map[string][]link{},
+				UsedAsSideInput: map[string]bool{},
+				DirectSideInputs: map[string]map[string]bool{
+					"t1": nil,
+				},
+				DownstreamSideInputs: map[string]map[string]bool{
+					"t1": nil,
+				},
+			},
+		}, {
+			name:        "t2_consumes_n1_as_primary",
+			topological: []string{"t1", "t2"},
+			comps: &pipepb.Components{
+				Transforms: map[string]*pipepb.PTransform{
+					"t1": {
+						Inputs:  map[string]string{},
+						Outputs: map[string]string{"o0": "n1"},
+					},
+					"t2": {
+						Inputs:  map[string]string{"i0": "n1"},
+						Outputs: map[string]string{},
+					},
+				},
+			},
+			want: fusionFacts{
+				PcolProducers: map[string]link{
+					"n1": {Transform: "t1", Local: "o0", Global: "n1"},
+				},
+				PcolConsumers: map[string][]link{
+					"n1": {{Transform: "t2", Local: "i0", Global: "n1"}},
+				},
+				UsedAsSideInput: map[string]bool{},
+				DirectSideInputs: map[string]map[string]bool{
+					"t1": nil,
+					"t2": nil,
+				},
+				DownstreamSideInputs: map[string]map[string]bool{
+					"t1": nil,
+					"t2": nil,
+				},
+			},
+		}, {
+			name:        "t2_consumes_n1_as_side",
+			topological: []string{"t1", "t2"},
+			comps: &pipepb.Components{
+				Transforms: map[string]*pipepb.PTransform{
+					"t1": {
+						Inputs:  map[string]string{},
+						Outputs: map[string]string{"o0": "n1"},
+					},
+					"t2": {
+						Inputs:  map[string]string{"i0": "n1"},
+						Outputs: map[string]string{},
+						Spec: sideInputSpec(map[string]*pipepb.SideInput{
+							"i0": {},
+						}),
+					},
+				},
+			},
+			want: fusionFacts{
+				PcolProducers: map[string]link{
+					"n1": {Transform: "t1", Local: "o0", Global: "n1"},
+				},
+				PcolConsumers: map[string][]link{
+					"n1": {{Transform: "t2", Local: "i0", Global: "n1"}},
+				},
+				UsedAsSideInput: map[string]bool{
+					"n1": true,
+				},
+				DirectSideInputs: map[string]map[string]bool{
+					"t1": nil,
+					"t2": {"n1": true},
+				},
+				DownstreamSideInputs: map[string]map[string]bool{
+					"t1": {"n1": true},
+					"t2": nil,
+				},
+			},
+		}, {
+			name:        "t2_consumes_n2_as_side_n1_as_primary_produces_n2",
+			topological: []string{"t1", "t2", "t3"},
+			comps: &pipepb.Components{
+				Transforms: map[string]*pipepb.PTransform{
+					"t1": {
+						Inputs:  map[string]string{},
+						Outputs: map[string]string{"o0": "n1"},
+					},
+					"t2": {
+						Inputs:  map[string]string{"i0": "n1"},
+						Outputs: map[string]string{"o0": "n2"},
+						Spec: sideInputSpec(map[string]*pipepb.SideInput{
+							"i0": {},
+						}),
+					},
+					"t3": {
+						Inputs:  map[string]string{"i0": "n2"},
+						Outputs: map[string]string{},
+					},
+				},
+			},
+			want: fusionFacts{
+				PcolProducers: map[string]link{
+					"n1": {Transform: "t1", Local: "o0", Global: "n1"},
+					"n2": {Transform: "t2", Local: "o0", Global: "n2"},
+				},
+				PcolConsumers: map[string][]link{
+					"n1": {{Transform: "t2", Local: "i0", Global: "n1"}},
+					"n2": {{Transform: "t3", Local: "i0", Global: "n2"}},
+				},
+				UsedAsSideInput: map[string]bool{
+					"n1": true,
+				},
+				DirectSideInputs: map[string]map[string]bool{
+					"t1": nil,
+					"t2": {"n1": true},
+					"t3": nil,
+				},
+				DownstreamSideInputs: map[string]map[string]bool{
+					"t1": {"n1": true},
+					"t2": nil,
+					"t3": nil,
+				},
+			},
+		}, {
+			name:        "t3_consumes_n1_as_side_n2_as_primary",
+			topological: []string{"t1", "t2", "t3"},
+			comps: &pipepb.Components{
+				Transforms: map[string]*pipepb.PTransform{
+					"t1": {
+						Inputs:  map[string]string{},
+						Outputs: map[string]string{"o0": "n1"},
+					},
+					"t2": {
+						Inputs:  map[string]string{},
+						Outputs: map[string]string{"o0": "n2"},
+					},
+					"t3": {
+						Inputs:  map[string]string{"i0": "n2", "i1": "n1"},
+						Outputs: map[string]string{},
+						Spec: sideInputSpec(map[string]*pipepb.SideInput{
+							"i1": {},
+						}),
+					},
+				},
+			},
+			want: fusionFacts{
+				PcolProducers: map[string]link{
+					"n1": {Transform: "t1", Local: "o0", Global: "n1"},
+					"n2": {Transform: "t2", Local: "o0", Global: "n2"},
+				},
+				PcolConsumers: map[string][]link{
+					"n1": {{Transform: "t3", Local: "i1", Global: "n1"}},
+					"n2": {{Transform: "t3", Local: "i0", Global: "n2"}},
+				},
+				UsedAsSideInput: map[string]bool{
+					"n1": true,
+				},
+				DirectSideInputs: map[string]map[string]bool{
+					"t1": nil,
+					"t2": nil,
+					"t3": {"n1": true},
+				},
+				DownstreamSideInputs: map[string]map[string]bool{
+					"t1": {"n1": true},
+					"t2": nil,
+					"t3": nil,
+				},
+			},
+		}, {
+			name:        "t3_consumes_n2_as_side",
+			topological: []string{"t1", "t2", "t3"},
+			comps: &pipepb.Components{
+				Transforms: map[string]*pipepb.PTransform{
+					"t1": {
+						Inputs:  map[string]string{},
+						Outputs: map[string]string{"o0": "n1"},
+					},
+					"t2": {
+						Inputs:  map[string]string{"i0": "n1"},
+						Outputs: map[string]string{"o0": "n2"},
+					},
+					"t3": {
+						Inputs:  map[string]string{"i1": "n2"},
+						Outputs: map[string]string{},
+						Spec: sideInputSpec(map[string]*pipepb.SideInput{
+							"i1": {},
+						}),
+					},
+				},
+			},
+			want: fusionFacts{
+				PcolProducers: map[string]link{
+					"n1": {Transform: "t1", Local: "o0", Global: "n1"},
+					"n2": {Transform: "t2", Local: "o0", Global: "n2"},
+				},
+				PcolConsumers: map[string][]link{
+					"n1": {{Transform: "t2", Local: "i0", Global: "n1"}},
+					"n2": {{Transform: "t3", Local: "i1", Global: "n2"}},
+				},
+				UsedAsSideInput: map[string]bool{
+					"n2": true,
+				},
+				DirectSideInputs: map[string]map[string]bool{
+					"t1": nil,
+					"t2": nil,
+					"t3": {"n2": true},
+				},
+				DownstreamSideInputs: map[string]map[string]bool{
+					"t1": {"n2": true},
+					"t2": {"n2": true},
+					"t3": nil,
+				},
+			},
+		}, {
+			name:        "criss_cross",
+			topological: []string{"t1", "t2", "t3", "t4"},
+			comps: &pipepb.Components{
+				Transforms: map[string]*pipepb.PTransform{
+					"t1": {
+						Inputs:  map[string]string{},
+						Outputs: map[string]string{"o0": "n1"},
+					},
+					"t2": {
+						Inputs:  map[string]string{},
+						Outputs: map[string]string{"o0": "n2"},
+					},
+					"t3": {
+						Inputs:  map[string]string{"i0": "n1", "i1": "n2"},
+						Outputs: map[string]string{},
+						Spec: sideInputSpec(map[string]*pipepb.SideInput{
+							"i1": {},
+						}),
+					},
+					"t4": {
+						Inputs:  map[string]string{"i0": "n2", "i1": "n1"},
+						Outputs: map[string]string{},
+						Spec: sideInputSpec(map[string]*pipepb.SideInput{
+							"i1": {},
+						}),
+					},
+				},
+			},
+			want: fusionFacts{
+				PcolProducers: map[string]link{
+					"n1": {Transform: "t1", Local: "o0", Global: "n1"},
+					"n2": {Transform: "t2", Local: "o0", Global: "n2"},
+				},
+				PcolConsumers: map[string][]link{
+					"n1": {{Transform: "t3", Local: "i0", Global: "n1"}, {Transform: "t4", Local: "i1", Global: "n1"}},
+					"n2": {{Transform: "t3", Local: "i1", Global: "n2"}, {Transform: "t4", Local: "i0", Global: "n2"}},
+				},
+				UsedAsSideInput: map[string]bool{
+					"n1": true,
+					"n2": true,
+				},
+				DirectSideInputs: map[string]map[string]bool{
+					"t1": nil,
+					"t2": nil,
+					"t3": {"n2": true},
+					"t4": {"n1": true},
+				},
+				DownstreamSideInputs: map[string]map[string]bool{
+					"t1": {"n1": true},
+					"t2": {"n2": true},
+					"t3": nil,
+					"t4": nil,
+				},
+			},
+		}, {
+			name:        "long_criss_cross_tail_cross",
+			topological: []string{"r1", "r2", "r3", "l1", "l2", "l3", "r4", "l4"},
+			comps: &pipepb.Components{
+				Transforms: map[string]*pipepb.PTransform{
+					"r1": {
+						Inputs:  map[string]string{},
+						Outputs: map[string]string{"o0": "n1"},
+					},
+					"r2": {
+						Inputs:  map[string]string{"i0": "n1"},
+						Outputs: map[string]string{"o0": "n2"},
+					},
+					"r3": {
+						Inputs:  map[string]string{"i0": "n2"},
+						Outputs: map[string]string{"o0": "n3"},
+					},
+					"l1": {
+						Inputs:  map[string]string{},
+						Outputs: map[string]string{"o0": "n4"},
+					},
+					"l2": {
+						Inputs:  map[string]string{"i0": "n4"},
+						Outputs: map[string]string{"o0": "n5"},
+					},
+					"l3": {
+						Inputs:  map[string]string{"i0": "n5"},
+						Outputs: map[string]string{"o0": "n6"},
+					},
+					"r4": {
+						Inputs:  map[string]string{"i0": "n3", "i1": "n6"},
+						Outputs: map[string]string{},
+						Spec: sideInputSpec(map[string]*pipepb.SideInput{
+							"i1": {},
+						}),
+					},
+					"l4": {
+						Inputs:  map[string]string{"i0": "n6", "i1": "n3"},
+						Outputs: map[string]string{},
+						Spec: sideInputSpec(map[string]*pipepb.SideInput{
+							"i1": {},
+						}),
+					},
+				},
+			},
+			want: fusionFacts{
+				PcolProducers: map[string]link{
+					"n1": {Transform: "r1", Local: "o0", Global: "n1"},
+					"n2": {Transform: "r2", Local: "o0", Global: "n2"},
+					"n3": {Transform: "r3", Local: "o0", Global: "n3"},
+					"n4": {Transform: "l1", Local: "o0", Global: "n4"},
+					"n5": {Transform: "l2", Local: "o0", Global: "n5"},
+					"n6": {Transform: "l3", Local: "o0", Global: "n6"},
+				},
+				PcolConsumers: map[string][]link{
+					"n1": {{Transform: "r2", Local: "i0", Global: "n1"}},
+					"n2": {{Transform: "r3", Local: "i0", Global: "n2"}},
+					"n3": {{Transform: "r4", Local: "i0", Global: "n3"}, {Transform: "l4", Local: "i1", Global: "n3"}},
+					"n4": {{Transform: "l2", Local: "i0", Global: "n4"}},
+					"n5": {{Transform: "l3", Local: "i0", Global: "n5"}},
+					"n6": {{Transform: "l4", Local: "i0", Global: "n6"}, {Transform: "r4", Local: "i1", Global: "n6"}},
+				},
+				UsedAsSideInput: map[string]bool{
+					"n3": true,
+					"n6": true,
+				},
+				DirectSideInputs: map[string]map[string]bool{
+					"r1": nil,
+					"r2": nil,
+					"r3": nil,
+					"r4": {"n6": true},
+					"l1": nil,
+					"l2": nil,
+					"l3": nil,
+					"l4": {"n3": true},
+				},
+				DownstreamSideInputs: map[string]map[string]bool{
+					"r1": {"n3": true},
+					"r2": {"n3": true},
+					"r3": {"n3": true},
+					"r4": nil,
+					"l1": {"n6": true},
+					"l2": {"n6": true},
+					"l3": {"n6": true},
+					"l4": nil,
+				},
+			},
+		}, {
+			name:        "long_criss_cross_head_cross",
+			topological: []string{"r1", "r2", "r3", "l1", "l2", "l3", "r4", "l4"},
+			comps: &pipepb.Components{
+				Transforms: map[string]*pipepb.PTransform{
+					"r1": {
+						Inputs:  map[string]string{},
+						Outputs: map[string]string{"o0": "n1"},
+					},
+					"r2": {
+						Inputs:  map[string]string{"i0": "n1"},
+						Outputs: map[string]string{"o0": "n2"},
+					},
+					"r3": {
+						Inputs:  map[string]string{"i0": "n2"},
+						Outputs: map[string]string{"o0": "n3"},
+					},
+					"l1": {
+						Inputs:  map[string]string{},
+						Outputs: map[string]string{"o0": "n4"},
+					},
+					"l2": {
+						Inputs:  map[string]string{"i0": "n4"},
+						Outputs: map[string]string{"o0": "n5"},
+					},
+					"l3": {
+						Inputs:  map[string]string{"i0": "n5"},
+						Outputs: map[string]string{"o0": "n6"},
+					},
+					"r4": {
+						Inputs:  map[string]string{"i0": "n3", "i1": "n4"},
+						Outputs: map[string]string{},
+						Spec: sideInputSpec(map[string]*pipepb.SideInput{
+							"i1": {},
+						}),
+					},
+					"l4": {
+						Inputs:  map[string]string{"i0": "n6", "i1": "n1"},
+						Outputs: map[string]string{},
+						Spec: sideInputSpec(map[string]*pipepb.SideInput{
+							"i1": {},
+						}),
+					},
+				},
+			},
+			want: fusionFacts{
+				PcolProducers: map[string]link{
+					"n1": {Transform: "r1", Local: "o0", Global: "n1"},
+					"n2": {Transform: "r2", Local: "o0", Global: "n2"},
+					"n3": {Transform: "r3", Local: "o0", Global: "n3"},
+					"n4": {Transform: "l1", Local: "o0", Global: "n4"},
+					"n5": {Transform: "l2", Local: "o0", Global: "n5"},
+					"n6": {Transform: "l3", Local: "o0", Global: "n6"},
+				},
+				PcolConsumers: map[string][]link{
+					"n1": {{Transform: "r2", Local: "i0", Global: "n1"}, {Transform: "l4", Local: "i1", Global: "n1"}},
+					"n2": {{Transform: "r3", Local: "i0", Global: "n2"}},
+					"n3": {{Transform: "r4", Local: "i0", Global: "n3"}},
+					"n4": {{Transform: "l2", Local: "i0", Global: "n4"}, {Transform: "r4", Local: "i1", Global: "n4"}},
+					"n5": {{Transform: "l3", Local: "i0", Global: "n5"}},
+					"n6": {{Transform: "l4", Local: "i0", Global: "n6"}},
+				},
+				UsedAsSideInput: map[string]bool{
+					"n1": true,
+					"n4": true,
+				},
+				DirectSideInputs: map[string]map[string]bool{
+					"r1": nil,
+					"r2": nil,
+					"r3": nil,
+					"r4": {"n4": true},
+					"l1": nil,
+					"l2": nil,
+					"l3": nil,
+					"l4": {"n1": true},
+				},
+				DownstreamSideInputs: map[string]map[string]bool{
+					"r1": {"n1": true},
+					"r2": nil,
+					"r3": nil,
+					"r4": nil,
+					"l1": {"n4": true},
+					"l2": nil,
+					"l3": nil,
+					"l4": nil,
+				},
+			},
+		},
+	}
+
+	linkLess := func(a link, b link) bool {
+		if a.Transform != b.Transform {
+			return a.Transform < b.Transform
+		}
+		if a.Local != b.Local {
+			return a.Local < b.Local
+		}
+		return a.Global < b.Global
+	}
+
+	for _, test := range tests {
+		t.Run(test.name, func(t *testing.T) {
+			got := computeFacts(test.topological, test.comps)
+			if d := cmp.Diff(test.want, got, cmp.AllowUnexported(), cmpopts.EquateEmpty(), cmpopts.SortSlices(linkLess)); d != "" {
+				t.Errorf("computeFacts diff (-want, +got):\n%v", d)
+			}
+		})
 	}
 }

--- a/sdks/go/pkg/beam/runners/prism/internal/stage.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/stage.go
@@ -39,7 +39,7 @@ import (
 // that transform's respective input or output. Which it is, is context dependant,
 // and not knowable from just the link itself, but can be verified against the transform proto.
 type link struct {
-	transform, local, global string
+	Transform, Local, Global string
 }
 
 // stage represents a fused subgraph executed in a single environment.
@@ -293,22 +293,22 @@ func buildDescriptor(stg *stage, comps *pipepb.Components, wk *worker.W, em *eng
 	sink2Col := map[string]string{}
 	col2Coders := map[string]engine.PColInfo{}
 	for _, o := range stg.outputs {
-		col := comps.GetPcollections()[o.global]
-		wOutCid, err := makeWindowedValueCoder(o.global, comps, coders)
+		col := comps.GetPcollections()[o.Global]
+		wOutCid, err := makeWindowedValueCoder(o.Global, comps, coders)
 		if err != nil {
-			return fmt.Errorf("buildDescriptor: failed to handle coder on stage %v for output %+v, pcol %q %v:\n%w %v", stg.ID, o, o.global, prototext.Format(col), err, stg.transforms)
+			return fmt.Errorf("buildDescriptor: failed to handle coder on stage %v for output %+v, pcol %q %v:\n%w %v", stg.ID, o, o.Global, prototext.Format(col), err, stg.transforms)
 		}
-		sinkID := o.transform + "_" + o.local
+		sinkID := o.Transform + "_" + o.Local
 		ed := collectionPullDecoder(col.GetCoderId(), coders, comps)
 		wDec, wEnc := getWindowValueCoders(comps, col, coders)
-		sink2Col[sinkID] = o.global
-		col2Coders[o.global] = engine.PColInfo{
-			GlobalID: o.global,
+		sink2Col[sinkID] = o.Global
+		col2Coders[o.Global] = engine.PColInfo{
+			GlobalID: o.Global,
 			WDec:     wDec,
 			WEnc:     wEnc,
 			EDec:     ed,
 		}
-		transforms[sinkID] = sinkTransform(sinkID, portFor(wOutCid, wk), o.global)
+		transforms[sinkID] = sinkTransform(sinkID, portFor(wOutCid, wk), o.Global)
 	}
 
 	var prepareSides []func(b *worker.B, watermark mtime.Time)

--- a/sdks/go/pkg/beam/util/pubsubx/pubsub_test.go
+++ b/sdks/go/pkg/beam/util/pubsubx/pubsub_test.go
@@ -19,6 +19,7 @@ import (
 	"context"
 	"fmt"
 	"sort"
+	"sync"
 	"testing"
 
 	"cloud.google.com/go/pubsub"
@@ -172,8 +173,11 @@ func TestPublish(t *testing.T) {
 		t.Fatalf("publish failed: %v", err)
 	}
 	cctx, cancel := context.WithCancel(ctx)
+	var mu sync.Mutex
 	var got []string
 	sub.Receive(cctx, func(_ context.Context, msg *pubsub.Message) {
+		mu.Lock()
+		defer mu.Unlock()
 		got = append(got, string(msg.Data))
 		msg.Ack()
 		if len(got) >= len(want) {


### PR DESCRIPTION
Fix error in prism's fusion handling. Re-instates fusion.

Instead of passing the consuming transform ID to get the downstream side inputs, we passed the PCollection ID, causing the computation to fail. Ultimately, the hangs were because there was a stage that depended on it's own produced side input.

Adds unit sufficient testing to avoid replicating the issue, and fixes the issue.
Exported fields on `link` and `fusionFacts` types to let them be compared for diffs by cmp. 
Adds additional debug logging for the resulting hang that was occurring.

(Long due to the unit tests, and necessary renames, the actual fix is a single line that I've commented to point out.)

---

Addendum: There was another bug in prism that when combined with fusion prevented one of the xlang tests from passing. In particular, the combiner lifting handler was not removing subtransforms recursively from lifted combines, leading to additional transforms being left in the graph.

This caused some interesting downstream mayhem: multiple producers for a single pcollection (pcollections only have one producer), and incorrect fusions, leading to the runner to hang, but *only* for certain topological orderings.

A unit test was added for the combine handler to validate the fix. 
Prism has also been made a bit more eager to fail when  it gets into those bad states, in particular when it notices that there is outstanding data to process, but nothing that would trigger it. Now prism crashes, which avoids indefinite hangs and timeouts.

----

Addendum 2.

Fixed a race condition in the pubsubx test, causing flakes.
Fixed an extra t.Run wrapping in the fileio.Match tests, which i assume caused flakes somehow.

Updated prisms bundle execution to use an errgroup to manage bundle failures, context cancellation, and limit parallelism, simplifying that code. This better addresses flakey handling of failures and pipeline completion.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
