### PR TITLE
add canonical link into javadocs when running post commit

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -155,6 +155,17 @@ If you are testing on a fork, you likely will not have self-hosted runners set u
 To work around this, you can start using hosted runners and then switch over when you're ready to create a PR.
 You can do this by changing `runs-on: [self-hosted, ubuntu-20.04, main]` (self-hosted, use in your PR) to `runs-on: ubuntu-20.04` (GitHub hosted, use for local testing).
 
+Note when using `ubuntu-20.04` as the host, you might need to choose the Java version since some gradle tasks only work with a certain Java version.
+One example is below to use Java 8 when testing your workflow:
+```
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
+```
+
 ## Testing Workflow Updates
 
 If you need to make more changes to the workflow yaml file after it has been added to the repo, you can develop normally on a branch (using your fork or the main Beam repo if you are a committer). If you are a non-committer, this flow has several caveats mentioned below.

--- a/.github/workflows/beam_PostCommit_Javadoc.yml
+++ b/.github/workflows/beam_PostCommit_Javadoc.yml
@@ -53,7 +53,7 @@ env:
 jobs:
   beam_PostCommit_Javadoc:
     name: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
-    runs-on: ubuntu-20.04
+    runs-on: [self-hosted, ubuntu-20.04, main]
     timeout-minutes: 240
     strategy:
       matrix:
@@ -66,10 +66,6 @@ jobs:
       github.event.comment.body == 'Run Javadoc PostCommit'
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
-        with:
-          distribution: 'temurin'
-          java-version: '8'
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PostCommit_Javadoc.yml
+++ b/.github/workflows/beam_PostCommit_Javadoc.yml
@@ -66,6 +66,10 @@ jobs:
       github.event.comment.body == 'Run Javadoc PostCommit'
     steps:
       - uses: actions/checkout@v4
+      - uses: actions/setup-java@v3
+        with:
+          distribution: 'temurin'
+          java-version: '8'
       - name: Setup repository
         uses: ./.github/actions/setup-action
         with:

--- a/.github/workflows/beam_PostCommit_Javadoc.yml
+++ b/.github/workflows/beam_PostCommit_Javadoc.yml
@@ -78,6 +78,11 @@ jobs:
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:
           gradle-command: :sdks:java:javadoc:aggregateJavadoc
+      - name: Add canonical link into javadocs
+        uses: cicirello/javadoc-cleanup@v1
+        with:
+          path-to-root: sdks/java/javadoc/build/docs/javadoc
+          base-url-path: beam.apache.org/releases/javadoc/current/
       - name: Upload Javadoc Results
         uses: actions/upload-artifact@v3
         with:

--- a/.github/workflows/beam_PostCommit_Javadoc.yml
+++ b/.github/workflows/beam_PostCommit_Javadoc.yml
@@ -53,7 +53,7 @@ env:
 jobs:
   beam_PostCommit_Javadoc:
     name: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
-    runs-on: [self-hosted, ubuntu-20.04, main]
+    runs-on: ubuntu-20.04
     timeout-minutes: 240
     strategy:
       matrix:

--- a/.github/workflows/beam_PostCommit_Javadoc.yml
+++ b/.github/workflows/beam_PostCommit_Javadoc.yml
@@ -86,7 +86,7 @@ jobs:
         uses: cicirello/javadoc-cleanup@v1
         with:
           path-to-root: sdks/java/javadoc/build/docs/javadoc
-          base-url-path: beam.apache.org/releases/javadoc/current/
+          base-url-path: https://beam.apache.org/releases/javadoc/current/
       - name: Upload Javadoc Results
         uses: actions/upload-artifact@v3
         with:


### PR DESCRIPTION
Following https://github.com/apache/beam/tree/master/.github/workflows#testing-workflow-updates to test.

Fixes https://github.com/apache/beam/issues/26445

Tested this using my own fork: 

The job ran fine: https://github.com/liferoad/beam/actions/runs/6914434714/job/18812289459

The generated html now has the canonical link. One example is:

<img width="1211" alt="image" src="https://github.com/apache/beam/assets/7833268/939c9526-77af-4461-a6a4-8ea92c866253">



------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
