### PR TITLE
Remove SuppressWarnings nullness from JsonMatcher

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/JsonMatcher.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/JsonMatcher.java
@@ -17,12 +17,14 @@
  */
 package org.apache.beam.sdk.testing;
 
+import static org.apache.beam.sdk.util.Preconditions.checkStateNotNull;
 import static org.hamcrest.Matchers.is;
 
 import com.fasterxml.jackson.core.type.TypeReference;
 import com.fasterxml.jackson.databind.ObjectMapper;
 import java.io.IOException;
 import java.util.Map;
+import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -35,13 +37,10 @@ import org.hamcrest.TypeSafeMatcher;
  *              jsonStringLike("{\"height\": 80, \"name\": \"person\"}"));
  * </pre>
  */
-@SuppressWarnings({
-  "nullness" // TODO(https://github.com/apache/beam/issues/20497)
-})
 public abstract class JsonMatcher<T> extends TypeSafeMatcher<T> {
-  private Matcher<Map<String, Object>> mapMatcher;
+  private final Matcher<Map<String, Object>> mapMatcher;
   private static final ObjectMapper MAPPER = new ObjectMapper();
-  private Map<String, Object> actualMap;
+  private @MonotonicNonNull Map<String, Object> actualMap;
 
   public JsonMatcher(Map<String, Object> expectedMap) {
     this.mapMatcher = is(expectedMap);
@@ -86,7 +85,7 @@ public abstract class JsonMatcher<T> extends TypeSafeMatcher<T> {
     } catch (IOException e) {
       return false;
     }
-    return mapMatcher.matches(actualMap);
+    return mapMatcher.matches(checkStateNotNull(actualMap));
   }
 
   @Override
@@ -96,6 +95,6 @@ public abstract class JsonMatcher<T> extends TypeSafeMatcher<T> {
 
   @Override
   protected void describeMismatchSafely(T item, Description mismatchDescription) {
-    mapMatcher.describeMismatch(actualMap, mismatchDescription);
+    mapMatcher.describeMismatch(checkStateNotNull(actualMap), mismatchDescription);
   }
 }


### PR DESCRIPTION
This PR addresses #20507 by replacing JsonMatcher's use of the SuppressWarnings nullness annotation with:
- Apply `final` to constructor initialized field
- Apply the `@MonotonicNonNull` annotation to a late initialized field `actualMap` that is checked for nullness using `checkStateNotNull`.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
