### PR TITLE
Simplify logic to pass custom requirement files to integration tests.

### DIFF
--- a/sdks/python/scripts/run_integration_test.sh
+++ b/sdks/python/scripts/run_integration_test.sh
@@ -215,17 +215,6 @@ if [[ -z $PIPELINE_OPTS ]]; then
     echo "[WARNING] Could not find SDK tarball in SDK_LOCATION: $SDK_LOCATION."
   fi
 
-  # Install test dependencies for ValidatesRunner tests.
-  # pyhamcrest==1.10.0 doesn't work on Py2.
-  # See: https://github.com/hamcrest/PyHamcrest/issues/131.
-  if [[ -z $REQUIREMENTS_FILE ]]; then
-    echo "pyhamcrest!=1.10.0,<2.0.0" > postcommit_requirements.txt
-    echo "mock<3.0.0" >> postcommit_requirements.txt
-    echo "parameterized>=0.7.1,<0.8.0" >> postcommit_requirements.txt
-  else
-    cp $REQUIREMENTS_FILE postcommit_requirements.txt
-  fi
-
   # Options used to run testing pipeline on Cloud Dataflow Service. Also used for
   # running on DirectRunner (some options ignored).
   opts=(
@@ -236,7 +225,6 @@ if [[ -z $PIPELINE_OPTS ]]; then
     "--temp_location=$GCS_LOCATION/temp-it"
     "--output=$GCS_LOCATION/py-it-cloud/output"
     "--sdk_location=$SDK_LOCATION"
-    "--requirements_file=postcommit_requirements.txt"
     "--num_workers=$NUM_WORKERS"
     "--sleep_secs=$SLEEP_SECS"
   )
@@ -244,6 +232,10 @@ if [[ -z $PIPELINE_OPTS ]]; then
   # Add --streaming if provided
   if [[ "$STREAMING" = true ]]; then
     opts+=("--streaming")
+  fi
+
+  if [[ -n "$REQUIREMENTS_FILE" ]]; then
+    opts+=("--requirements_file=$REQUIREMENTS_FILE")
   fi
 
   if [[ "$ARCH" == "ARM" ]]; then


### PR DESCRIPTION
Default postcommit requirements are already preinstalled in default Beam container images. 

It made sense to keep that logic to have coverage for the --requirements_file pipeline option, but now we have several other test suites to provide that coverage.

Also rewriting requirement files could be racey (https://github.com/apache/beam/issues/29501). 
