### PR TITLE
Propagate correct boundedness when using multiple outputs

### DIFF
--- a/sdks/python/apache_beam/pvalue.py
+++ b/sdks/python/apache_beam/pvalue.py
@@ -304,7 +304,12 @@ class DoOutputsTuple(object):
     assert self.producer is not None
     if tag is not None:
       self._transform.output_tags.add(tag)
-      pcoll = PCollection(self._pipeline, tag=tag, element_type=typehints.Any)
+      is_bounded = all(i.is_bounded for i in self.producer.main_inputs.values())
+      pcoll = PCollection(
+          self._pipeline,
+          tag=tag,
+          element_type=typehints.Any,
+          is_bounded=is_bounded)
       # Transfer the producer from the DoOutputsTuple to the resulting
       # PCollection.
       pcoll.producer = self.producer.parts[0]

--- a/sdks/python/apache_beam/transforms/core_test.py
+++ b/sdks/python/apache_beam/transforms/core_test.py
@@ -119,7 +119,7 @@ class PartitionTest(unittest.TestCase):
         yield element
 
     with beam.testing.test_pipeline.TestPipeline() as p:
-      source = p | beam.Create([1,2,3,4,5])
+      source = p | beam.Create([1, 2, 3, 4, 5])
       p1, p2, p3 = source | "bounded" >> beam.Partition(partition_fn, 3)
 
       self.assertEqual(source.is_bounded, True)
@@ -127,13 +127,14 @@ class PartitionTest(unittest.TestCase):
       self.assertEqual(p2.is_bounded, True)
       self.assertEqual(p3.is_bounded, True)
 
-      unbounded_pcoll = source | beam.ParDo(UnboundedDoFn())
-      p4, p5, p6 = unbounded_pcoll | "unbounded" >> beam.Partition(partition_fn, 3)
+      unbounded = source | beam.ParDo(UnboundedDoFn())
+      p4, p5, p6 = unbounded | "unbounded" >> beam.Partition(partition_fn, 3)
 
-      self.assertEqual(unbounded_pcoll.is_bounded, False)
+      self.assertEqual(unbounded.is_bounded, False)
       self.assertEqual(p4.is_bounded, False)
       self.assertEqual(p5.is_bounded, False)
       self.assertEqual(p6.is_bounded, False)
+
 
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)

--- a/sdks/python/apache_beam/transforms/core_test.py
+++ b/sdks/python/apache_beam/transforms/core_test.py
@@ -108,6 +108,33 @@ class CreateTest(unittest.TestCase):
       assert warning_text in self._caplog.text
 
 
+class PartitionTest(unittest.TestCase):
+  def test_partition_boundedness(self):
+    def partition_fn(val, num_partitions):
+      return val % num_partitions
+
+    class UnboundedDoFn(beam.DoFn):
+      @beam.DoFn.unbounded_per_element()
+      def process(self, element):
+        yield element
+
+    with beam.testing.test_pipeline.TestPipeline() as p:
+      source = p | beam.Create([1,2,3,4,5])
+      p1, p2, p3 = source | "bounded" >> beam.Partition(partition_fn, 3)
+
+      self.assertEqual(source.is_bounded, True)
+      self.assertEqual(p1.is_bounded, True)
+      self.assertEqual(p2.is_bounded, True)
+      self.assertEqual(p3.is_bounded, True)
+
+      unbounded_pcoll = source | beam.ParDo(UnboundedDoFn())
+      p4, p5, p6 = unbounded_pcoll | "unbounded" >> beam.Partition(partition_fn, 3)
+
+      self.assertEqual(unbounded_pcoll.is_bounded, False)
+      self.assertEqual(p4.is_bounded, False)
+      self.assertEqual(p5.is_bounded, False)
+      self.assertEqual(p6.is_bounded, False)
+
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)
   unittest.main()


### PR DESCRIPTION
Right now, if you have a transform with multiple outputs, the tagged outputs lose the boundedness value of their input and default to always be bounded. This was discovered in #29196 with the Partition transform. This fixes the problem.

Example of my test failing before my change (after first commit, before second commit on this PR) - https://github.com/apache/beam/actions/runs/6944498801/job/18891751771?pr=29506

The test is now passing in CI.

Fixes #29196

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
