### PR TITLE
Add package-info to fix checkstyle validation

### DIFF
--- a/sdks/java/container/agent/src/main/java/org/apache/beam/agent/package-info.java
+++ b/sdks/java/container/agent/src/main/java/org/apache/beam/agent/package-info.java
@@ -1,0 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/**
+ * Utilities used by Beam to open modules to JAMM, required to measure object sizes, which are used
+ * to estimate/weigh cache footprints.
+ */
+package org.apache.beam.agent;


### PR DESCRIPTION
Fixes the error:

```
> Task :sdks:java:container:agent:checkstyleMain FAILED
[ant:checkstyle] [ERROR] /usr/local/githubworkspace/beam/sdks/java/container/agent/src/main/java/org/apache/beam/agent/OpenModuleAgent.java:1: Missing package-info.java file. [JavadocPackage]

FAILURE: Build failed with an exception.
```

