### PR TITLE
fix: have a timeout on the wait when closing BigtableIO#Writer

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
@@ -1169,11 +1169,8 @@ public class BigtableIO {
       Duration closeWaitTimeout = null;
       if (closeWaitTimeoutStr != null) {
         long closeWaitTimeoutMs = Long.parseLong(closeWaitTimeoutStr);
-        if (closeWaitTimeoutMs < 0) {
-          throw new RuntimeException("Close wait timeout must be positive " + closeWaitTimeoutMs);
-        } else {
-          closeWaitTimeout = Duration.millis(closeWaitTimeoutMs);
-        }
+        checkState(closeWaitTimeoutMs > 0, "Close wait timeout must be positive");
+        closeWaitTimeout = Duration.millis(closeWaitTimeoutMs);
       }
 
       return input.apply(
@@ -1284,10 +1281,7 @@ public class BigtableIO {
             entry.getKey().maxTimestamp(),
             entry.getKey());
       }
-    }
 
-    @Teardown
-    public void tearDown() throws Exception {
       if (serviceEntry != null) {
         serviceEntry.close();
         serviceEntry = null;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
@@ -1267,24 +1267,26 @@ public class BigtableIO {
 
     @FinishBundle
     public void finishBundle(FinishBundleContext c) throws Exception {
-      if (bigtableWriter != null) {
-        bigtableWriter.close();
-        bigtableWriter = null;
-      }
+      try {
+        if (bigtableWriter != null) {
+          bigtableWriter.close();
+          bigtableWriter = null;
+        }
 
-      checkForFailures();
-      LOG.debug("Wrote {} records", recordsWritten);
+        checkForFailures();
+        LOG.debug("Wrote {} records", recordsWritten);
 
-      for (Map.Entry<BoundedWindow, Long> entry : seenWindows.entrySet()) {
-        c.output(
-            BigtableWriteResult.create(entry.getValue()),
-            entry.getKey().maxTimestamp(),
-            entry.getKey());
-      }
-
-      if (serviceEntry != null) {
-        serviceEntry.close();
-        serviceEntry = null;
+        for (Map.Entry<BoundedWindow, Long> entry : seenWindows.entrySet()) {
+          c.output(
+              BigtableWriteResult.create(entry.getValue()),
+              entry.getKey().maxTimestamp(),
+              entry.getKey());
+        }
+      } finally {
+        if (serviceEntry != null) {
+          serviceEntry.close();
+          serviceEntry = null;
+        }
       }
     }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
@@ -1166,22 +1166,13 @@ public class BigtableIO {
       PipelineOptions pipelineOptions = input.getPipeline().getOptions();
       String closeWaitTimeoutStr =
           ExperimentalOptions.getExperimentValue(pipelineOptions, BIGTABLE_WRITER_WAIT_TIMEOUT_MS);
-      Duration closeWaitTimeout = Duration.ZERO;
+      Duration closeWaitTimeout = null;
       if (closeWaitTimeoutStr != null) {
-        try {
-          long closeWaitTimeoutMs = Long.parseLong(closeWaitTimeoutStr);
-          if (closeWaitTimeoutMs < 0) {
-            LOG.warn(
-                "Invalid close wait timeout {}, will not set a wait timeout on close",
-                closeWaitTimeoutMs);
-          } else {
-            closeWaitTimeout = Duration.millis(closeWaitTimeoutMs);
-          }
-        } catch (NumberFormatException e) {
-          LOG.warn(
-              "Failed to parse close wait timeout {}, will not set a wait timeout on close",
-              closeWaitTimeoutStr,
-              e);
+        long closeWaitTimeoutMs = Long.parseLong(closeWaitTimeoutStr);
+        if (closeWaitTimeoutMs < 0) {
+          throw new RuntimeException("Close wait timeout must be positive " + closeWaitTimeoutMs);
+        } else {
+          closeWaitTimeout = Duration.millis(closeWaitTimeoutMs);
         }
       }
 
@@ -1246,7 +1237,7 @@ public class BigtableIO {
       this.writeOptions = writeOptions;
       this.failures = new ConcurrentLinkedQueue<>();
       this.id = factory.newId();
-      LOG.info("Created Bigtable Write Fn with writeOptions {} ", writeOptions);
+      LOG.debug("Created Bigtable Write Fn with writeOptions {} ", writeOptions);
     }
 
     @StartBundle

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableService.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableService.java
@@ -81,7 +81,7 @@ interface BigtableService extends Serializable {
   Reader createReader(BigtableSource source) throws IOException;
 
   /** Returns a {@link Writer} that will write to the specified table. */
-  Writer openForWriting(String tableId) throws IOException;
+  Writer openForWriting(BigtableWriteOptions writeOptions) throws IOException;
 
   /**
    * Returns a set of row keys sampled from the underlying table. These contain information about

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableService.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableService.java
@@ -46,13 +46,6 @@ interface BigtableService extends Serializable {
         throws IOException;
 
     /**
-     * Flushes the writer.
-     *
-     * @throws IOException if any writes did not succeed
-     */
-    void flush() throws IOException;
-
-    /**
      * Closes the writer.
      *
      * @throws IOException if there is an error closing the writer

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceFactory.java
@@ -30,7 +30,6 @@ import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicInteger;
 import org.apache.beam.sdk.options.ExperimentalOptions;
 import org.apache.beam.sdk.options.PipelineOptions;
-import org.joda.time.Duration;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -52,8 +51,6 @@ class BigtableServiceFactory implements Serializable {
 
   private static final String BIGTABLE_ENABLE_CLIENT_SIDE_METRICS =
       "bigtable_enable_client_side_metrics";
-
-  private static final String BIGTABLE_WRITER_WAIT_TIMEOUT_MS = "bigtable_writer_wait_timeout_ms";
 
   @AutoValue
   abstract static class ConfigId implements Serializable {
@@ -176,26 +173,7 @@ class BigtableServiceFactory implements Serializable {
         BigtableDataSettings.enableBuiltinMetrics();
       }
 
-      String closeWaitTimeoutStr =
-          ExperimentalOptions.getExperimentValue(pipelineOptions, BIGTABLE_WRITER_WAIT_TIMEOUT_MS);
-      Duration closeWaitTimeout = Duration.ZERO;
-      try {
-        long closeWaitTimeoutMs = Long.parseLong(closeWaitTimeoutStr);
-        if (closeWaitTimeoutMs < 0) {
-          LOG.warn(
-              "Invalid close wait timeout {}, will not set a wait timeout on close",
-              closeWaitTimeoutMs);
-        } else {
-          closeWaitTimeout = Duration.millis(closeWaitTimeoutMs);
-        }
-      } catch (NumberFormatException e) {
-        LOG.warn(
-            "Failed to parse close wait timeout {}, will not set a wait timeout on close",
-            closeWaitTimeoutStr,
-            e);
-      }
-
-      BigtableService service = new BigtableServiceImpl(settings, closeWaitTimeout);
+      BigtableService service = new BigtableServiceImpl(settings);
       entry = BigtableServiceEntry.create(configId, service);
       entries.put(configId.id(), entry);
       refCounts.put(configId.id(), new AtomicInteger(1));

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
@@ -127,7 +127,9 @@ class BigtableServiceImpl implements BigtableService {
         projectId,
         instanceId,
         writeOptions.getTableId().get(),
-        writeOptions.getCloseWaitTimeout());
+        writeOptions.getCloseWaitTimeout() != null
+            ? writeOptions.getCloseWaitTimeout()
+            : Duration.ZERO);
   }
 
   @VisibleForTesting

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableWriteOptions.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableWriteOptions.java
@@ -60,6 +60,9 @@ abstract class BigtableWriteOptions implements Serializable {
   /** Returns true if batch write flow control is enabled. Otherwise return false. */
   abstract @Nullable Boolean getFlowControl();
 
+  /** Returns the time to wait when closing the writer. */
+  abstract @Nullable Duration getCloseWaitTimeout();
+
   abstract Builder toBuilder();
 
   static Builder builder() {
@@ -86,6 +89,8 @@ abstract class BigtableWriteOptions implements Serializable {
     abstract Builder setThrottlingTargetMs(int targetMs);
 
     abstract Builder setFlowControl(boolean enableFlowControl);
+
+    abstract Builder setCloseWaitTimeout(Duration timeout);
 
     abstract BigtableWriteOptions build();
   }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
@@ -1695,8 +1695,8 @@ public class BigtableIOTest {
     }
 
     @Override
-    public FakeBigtableWriter openForWriting(String tableId) {
-      return new FakeBigtableWriter(tableId);
+    public FakeBigtableWriter openForWriting(BigtableWriteOptions writeOptions) {
+      return new FakeBigtableWriter(writeOptions.getTableId().get());
     }
 
     @Override
@@ -1748,8 +1748,8 @@ public class BigtableIOTest {
     }
 
     @Override
-    public FailureBigtableWriter openForWriting(String tableId) {
-      return new FailureBigtableWriter(tableId, this, failureOptions);
+    public FailureBigtableWriter openForWriting(BigtableWriteOptions writeOptions) {
+      return new FailureBigtableWriter(writeOptions.getTableId().get(), this, failureOptions);
     }
 
     @Override

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
@@ -1930,9 +1930,6 @@ public class BigtableIOTest {
     }
 
     @Override
-    public void flush() {}
-
-    @Override
     public void close() {}
   }
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImplTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImplTest.java
@@ -73,9 +73,6 @@ import org.apache.beam.sdk.io.gcp.bigtable.BigtableIO.BigtableSource;
 import org.apache.beam.sdk.io.range.ByteKey;
 import org.apache.beam.sdk.io.range.ByteKeyRange;
 import org.apache.beam.sdk.metrics.MetricsEnvironment;
-import org.apache.beam.sdk.options.ExperimentalOptions;
-import org.apache.beam.sdk.options.PipelineOptions;
-import org.apache.beam.sdk.options.PipelineOptionsFactory;
 import org.apache.beam.sdk.options.ValueProvider.StaticValueProvider;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
@@ -791,54 +788,6 @@ public class BigtableServiceImplTest {
     assertEquals(
         "Family", captor.getValue().toProto().getMutations(0).getSetCell().getFamilyName());
     underTest.close();
-  }
-
-  @Test
-  public void testCloseWaitTimeout() throws Exception {
-    BigtableServiceFactory serviceFactory = Mockito.mock(BigtableServiceFactory.class);
-    when(serviceFactory.getServiceForWriting(any(), any(), any(), any())).thenCallRealMethod();
-
-    BigtableConfig config =
-        BigtableConfig.builder()
-            .setProjectId(StaticValueProvider.of("project"))
-            .setInstanceId(StaticValueProvider.of("instance"))
-            .setValidate(true)
-            .build();
-    BigtableWriteOptions writeOptions =
-        BigtableWriteOptions.builder().setTableId(StaticValueProvider.of("table")).build();
-    PipelineOptions options1 = PipelineOptionsFactory.create();
-    options1
-        .as(ExperimentalOptions.class)
-        .setExperiments(Arrays.asList("bigtable_writer_wait_timeout_ms=60000"));
-
-    BigtableServiceFactory.BigtableServiceEntry entry1 =
-        serviceFactory.getServiceForWriting(
-            BigtableServiceFactory.ConfigId.create(), config, writeOptions, options1);
-
-    BigtableServiceImpl service = (BigtableServiceImpl) entry1.getService();
-    assertEquals(service.writeCloseWaitTimeout, Duration.millis(60000));
-
-    PipelineOptions options2 = PipelineOptionsFactory.create();
-    options2
-        .as(ExperimentalOptions.class)
-        .setExperiments(Arrays.asList("bigtable_writer_wait_timeout_ms=-1000"));
-    BigtableServiceFactory.BigtableServiceEntry entry2 =
-        serviceFactory.getServiceForWriting(
-            BigtableServiceFactory.ConfigId.create(), config, writeOptions, options2);
-
-    service = (BigtableServiceImpl) entry2.getService();
-    assertEquals(service.writeCloseWaitTimeout, Duration.ZERO);
-
-    PipelineOptions options3 = PipelineOptionsFactory.create();
-    options3
-        .as(ExperimentalOptions.class)
-        .setExperiments(Arrays.asList("bigtable_writer_wait_timeout_ms=abc"));
-    BigtableServiceFactory.BigtableServiceEntry entry3 =
-        serviceFactory.getServiceForWriting(
-            BigtableServiceFactory.ConfigId.create(), config, writeOptions, options3);
-
-    service = (BigtableServiceImpl) entry3.getService();
-    assertEquals(service.writeCloseWaitTimeout, Duration.ZERO);
   }
 
   private void verifyMetricWasSet(String method, String status, long count) {


### PR DESCRIPTION
Batcher#closeAsync already sends out remaining elements and wait on them to finish before closing. Calling closeAsync let us set a timeout on the future and it should not take longer than the operation timeout. 

Another hang seems to come from calling service.close() in tearDown. Since we create the service in startBundle, closing the service in finishBundle addresses the issue.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
