### PR TITLE
Generalize file based source output capabilities

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/ReadAllViaFileBasedSource.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/ReadAllViaFileBasedSource.java
@@ -39,7 +39,7 @@ public class ReadAllViaFileBasedSource<T, K> extends ReadAllViaFileBasedSourceTr
 
   private final SerializableFunction<OutputContextFromFile<T>, K> outputFn;
 
-  protected ReadAllViaFileBasedSource(
+  public ReadAllViaFileBasedSource(
       long desiredBundleSizeBytes,
       SerializableFunction<String, ? extends FileBasedSource<T>> createSource,
       Coder<K> coder,
@@ -53,7 +53,7 @@ public class ReadAllViaFileBasedSource<T, K> extends ReadAllViaFileBasedSourceTr
     this.outputFn = outputFn;
   }
 
-  protected ReadAllViaFileBasedSource(
+  public ReadAllViaFileBasedSource(
       long desiredBundleSizeBytes,
       SerializableFunction<String, ? extends FileBasedSource<T>> createSource,
       Coder<K> coder,

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/ReadAllViaFileBasedSourceTransform.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/ReadAllViaFileBasedSourceTransform.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.io;
 
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
 import java.io.IOException;
+import java.io.Serializable;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.io.fs.MatchResult;
 import org.apache.beam.sdk.io.range.OffsetRange;
@@ -101,11 +102,11 @@ public abstract class ReadAllViaFileBasedSourceTransform<InT, T>
   public abstract static class AbstractReadFileRangesFn<InT, T>
       extends DoFn<KV<FileIO.ReadableFile, OffsetRange>, T> {
     private final SerializableFunction<String, ? extends FileBasedSource<InT>> createSource;
-    private final ReadAllViaFileBasedSource.ReadFileRangesFnExceptionHandler exceptionHandler;
+    private final ReadFileRangesFnExceptionHandler exceptionHandler;
 
     public AbstractReadFileRangesFn(
         SerializableFunction<String, ? extends FileBasedSource<InT>> createSource,
-        ReadAllViaFileBasedSource.ReadFileRangesFnExceptionHandler exceptionHandler) {
+        ReadFileRangesFnExceptionHandler exceptionHandler) {
       this.createSource = createSource;
       this.exceptionHandler = exceptionHandler;
     }
@@ -138,6 +139,18 @@ public abstract class ReadAllViaFileBasedSourceTransform<InT, T>
           throw e;
         }
       }
+    }
+  }
+
+  /** A class to handle errors which occur during file reads. */
+  public static class ReadFileRangesFnExceptionHandler implements Serializable {
+
+    /*
+     * Applies the desired handler logic to the given exception and returns
+     * if the exception should be thrown.
+     */
+    public boolean apply(FileIO.ReadableFile file, OffsetRange range, Exception e) {
+      return true;
     }
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/ReadAllViaFileBasedSourceWithFilename.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/ReadAllViaFileBasedSourceWithFilename.java
@@ -19,8 +19,6 @@ package org.apache.beam.sdk.io;
 
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.io.fs.ResourceId;
-import org.apache.beam.sdk.io.range.OffsetRange;
-import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
@@ -37,34 +35,19 @@ import org.apache.beam.sdk.values.PCollection;
  * FileIO#readMatches()}.
  */
 public class ReadAllViaFileBasedSourceWithFilename<T>
-    extends ReadAllViaFileBasedSourceTransform<T, KV<String, T>> {
+    extends ReadAllViaFileBasedSource<T, KV<String, T>> {
 
   public ReadAllViaFileBasedSourceWithFilename(
       final long desiredBundleSizeBytes,
       final SerializableFunction<String, ? extends FileBasedSource<T>> createSource,
       final Coder<KV<String, T>> coder) {
-    super(desiredBundleSizeBytes, createSource, coder);
-  }
-
-  @Override
-  protected DoFn<KV<FileIO.ReadableFile, OffsetRange>, KV<String, T>> readRangesFn() {
-    return new ReadFileRangesFn<>(createSource, exceptionHandler);
-  }
-
-  private static class ReadFileRangesFn<T> extends AbstractReadFileRangesFn<T, KV<String, T>> {
-    public ReadFileRangesFn(
-        final SerializableFunction<String, ? extends FileBasedSource<T>> createSource,
-        final ReadAllViaFileBasedSource.ReadFileRangesFnExceptionHandler exceptionHandler) {
-      super(createSource, exceptionHandler);
-    }
-
-    @Override
-    protected KV<String, T> makeOutput(
-        final FileIO.ReadableFile file,
-        final OffsetRange range,
-        final FileBasedSource<T> fileBasedSource,
-        final BoundedSource.BoundedReader<T> reader) {
-      return KV.of(file.getMetadata().resourceId().toString(), reader.getCurrent());
-    }
+    super(
+        desiredBundleSizeBytes,
+        createSource,
+        coder,
+        outputArguments ->
+            KV.of(
+                outputArguments.file().getMetadata().resourceId().toString(),
+                outputArguments.reader().getCurrent()));
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TFRecordIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TFRecordIO.java
@@ -237,7 +237,7 @@ public class TFRecordIO {
     public PCollection<byte[]> expand(PCollection<FileIO.ReadableFile> input) {
       return input.apply(
           "Read all via FileBasedSource",
-          new ReadAllViaFileBasedSource<>(
+          ReadAllViaFileBasedSource.create(
               Long.MAX_VALUE, new CreateSourceFn(), DEFAULT_BYTE_ARRAY_CODER));
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
@@ -263,6 +263,7 @@ public class TextIO {
         .setDesiredBundleSizeBytes(DEFAULT_BUNDLE_SIZE_BYTES)
         .setSkipHeaderLines(0)
         .setOutputCoder(StringUtf8Coder.of())
+        .setOutputFn(outputArguments -> outputArguments.reader().getCurrent())
         .build();
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
@@ -611,7 +611,7 @@ public class TextIO {
     public PCollection<String> expand(PCollection<FileIO.ReadableFile> input) {
       return input.apply(
           "Read all via FileBasedSource",
-          new ReadAllViaFileBasedSource<>(
+          ReadAllViaFileBasedSource.create(
               getDesiredBundleSizeBytes(),
               new CreateTextSourceFn(getDelimiter(), getSkipHeaderLines()),
               StringUtf8Coder.of()));

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/TextIO.java
@@ -125,7 +125,7 @@ import org.joda.time.Duration;
  * // read from a data source.
  * PCollection<String> filenames = ...;
  *
- * // Read all files in the collection.
+ * // Read data on all files in the collection, including the file name on each read line.
  * PCollection<KV<String, String>> linesWithFileName =
  *     filenames
  *         .apply(FileIO.matchAll())

--- a/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/io/AvroIO.java
+++ b/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/io/AvroIO.java
@@ -924,7 +924,7 @@ public class AvroIO {
       PCollection<T> read =
           input.apply(
               "Read all via FileBasedSource",
-              new ReadAllViaFileBasedSource<>(
+              ReadAllViaFileBasedSource.create(
                   getDesiredBundleSizeBytes(),
                   new CreateSourceFn<>(
                       getRecordClass(), getSchema().toString(), coder, getDatumReaderFactory()),
@@ -1266,7 +1266,7 @@ public class AvroIO {
           new CreateParseSourceFn<>(parseFn, coder);
       return input.apply(
           "Parse Files via FileBasedSource",
-          new ReadAllViaFileBasedSource<>(
+          ReadAllViaFileBasedSource.create(
               getDesiredBundleSizeBytes(),
               createSource,
               coder,

--- a/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/io/AvroIO.java
+++ b/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/io/AvroIO.java
@@ -18,7 +18,7 @@
 package org.apache.beam.sdk.extensions.avro.io;
 
 import static org.apache.beam.sdk.io.FileIO.ReadMatches.DirectoryTreatment;
-import static org.apache.beam.sdk.io.ReadAllViaFileBasedSource.ReadFileRangesFnExceptionHandler;
+import static org.apache.beam.sdk.io.ReadAllViaFileBasedSourceTransform.ReadFileRangesFnExceptionHandler;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkNotNull;
 

--- a/sdks/java/io/contextualtextio/src/main/java/org/apache/beam/sdk/io/contextualtextio/ContextualTextIO.java
+++ b/sdks/java/io/contextualtextio/src/main/java/org/apache/beam/sdk/io/contextualtextio/ContextualTextIO.java
@@ -612,7 +612,7 @@ public class ContextualTextIO {
       PCollection<Row> rows =
           input.apply(
               "Read all via FileBasedSource",
-              new ReadAllViaFileBasedSource<>(
+              ReadAllViaFileBasedSource.create(
                   getDesiredBundleSizeBytes(),
                   new CreateTextSourceFn(getDelimiter(), getHasMultilineCSVRecords()),
                   SchemaCoder.of(RecordWithMetadata.getSchema())));

--- a/sdks/java/io/xml/src/main/java/org/apache/beam/sdk/io/xml/XmlIO.java
+++ b/sdks/java/io/xml/src/main/java/org/apache/beam/sdk/io/xml/XmlIO.java
@@ -437,7 +437,7 @@ public class XmlIO {
     @Override
     public PCollection<T> expand(PCollection<ReadableFile> input) {
       return input.apply(
-          new ReadAllViaFileBasedSource.create(
+          ReadAllViaFileBasedSource.create(
               64 * 1024L * 1024L,
               new CreateSourceFn<>(getConfiguration()),
               JAXBCoder.of(getConfiguration().getRecordClass())));

--- a/sdks/java/io/xml/src/main/java/org/apache/beam/sdk/io/xml/XmlIO.java
+++ b/sdks/java/io/xml/src/main/java/org/apache/beam/sdk/io/xml/XmlIO.java
@@ -437,7 +437,7 @@ public class XmlIO {
     @Override
     public PCollection<T> expand(PCollection<ReadableFile> input) {
       return input.apply(
-          new ReadAllViaFileBasedSource<>(
+          new ReadAllViaFileBasedSource.create(
               64 * 1024L * 1024L,
               new CreateSourceFn<>(getConfiguration()),
               JAXBCoder.of(getConfiguration().getRecordClass())));


### PR DESCRIPTION
Currently, when using a file based source implementation to read data from files we have 2 output options: 
- read only the content of the each line of each file into a PCollection 
- read the content of a file, key each line in the file with the file name and put it into a PCollection (through direct usage of the `ReadAllViaFileBasedSourceWithFilename` PTransform)  

While this cover a large bulk of the desired read operations, we can generalize the current implementation to allow a much larger space of possibilities for the users.

By introducing a serializable lambda as a parameter for the `ReadAllViaFileBasedSource` class, and a data carrier adapter class to simplify the makeOutput method arguments with that one of the provided lambda, we can enable users to make new decisions on how to emit the data read from particular files by making more information accessible about those files their data was extracted from. 

This change adds such generalization to the `ReadAllViaFileBasedSource` class, a new factory method to `TextIO` PTransform (along side documentation on how to use it) and tests that corroborate the changes made.

Subsequent PRs can be done to propagate the functionality to other file base sources (Avro, Parquet, etc). 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
