### PR TITLE
More efficient map side inputs for small maps.

### DIFF
--- a/model/fn-execution/src/main/proto/org/apache/beam/model/fn_execution/v1/beam_fn_api.proto
+++ b/model/fn-execution/src/main/proto/org/apache/beam/model/fn_execution/v1/beam_fn_api.proto
@@ -52,7 +52,7 @@ import "google/protobuf/duration.proto";
 message FnApiTransforms {
   enum Runner {
     // DataSource is a Root Transform, and a source of data for downstream
-    // transforms in the same ProcessBundleDescriptor. 
+    // transforms in the same ProcessBundleDescriptor.
     // It represents a stream of values coming in from an external source/over
     // a data channel, typically from the runner. It's not the PCollection itself
     // but a description of how to get the portion of the PCollection for a given
@@ -82,7 +82,7 @@ message FnApiTransforms {
     // request will be sent with the matching instruction ID and transform ID.
     // Each PCollection that exits the ProcessBundleDescriptor subgraph will have
     // it's own DataSink, keyed by a transform ID determined by the runner.
-    //  
+    //
     // The DataSink will take in a stream of elements for a given instruction ID
     // and encode them for transmission to the remote sink. The coder ID must be
     // for a windowed value coder.
@@ -924,6 +924,35 @@ message StateKey {
     bytes window = 3;
   }
 
+  // Represents a request for the keys and values associated with a specified window in a PCollection. See
+  // https://s.apache.org/beam-fn-state-api-and-bundle-processing for further
+  // details.
+  //
+  // This is expected to be more efficient than iterating over they keys and
+  // looking up the values one at a time.  If a runner chooses not to implement
+  // this protocol, or a key has too many values to fit into a single response,
+  // the runner is free to fail the request and a fallback to point lookups
+  // will be performed by the SDK.
+  //
+  // Can only be used to perform StateGetRequests on side inputs of the URN
+  // beam:side_input:multimap:v1.
+  //
+  // For a PCollection<KV<K, V>>, the response data stream will be a
+  // concatenation of all KVs associated with the specified window,
+  // encoded with the the KV<K, Iterable<V>> coder.
+  // See
+  // https://s.apache.org/beam-fn-api-send-and-receive-data for further
+  // details.
+  message MultimapKeysValuesSideInput {
+    // (Required) The id of the PTransform containing a side input.
+    string transform_id = 1;
+    // (Required) The id of the side input.
+    string side_input_id = 2;
+    // (Required) The window (after mapping the currently executing elements
+    // window into the side input windows domain) encoded in a nested context.
+    bytes window = 3;
+  }
+
   // Represents a request for an unordered set of values associated with a
   // specified user key and window for a PTransform. See
   // https://s.apache.org/beam-fn-state-api-and-bundle-processing for further
@@ -999,6 +1028,7 @@ message StateKey {
     BagUserState bag_user_state = 3;
     IterableSideInput iterable_side_input = 4;
     MultimapKeysSideInput multimap_keys_side_input = 5;
+    MultimapKeysValuesSideInput multimap_keys_values_side_input = 8;
     MultimapKeysUserState multimap_keys_user_state = 6;
     MultimapUserState multimap_user_state = 7;
   }

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
@@ -915,9 +915,10 @@ public class RemoteExecutionTest implements Serializable {
     // Expect the following requests for the first bundle:
     //   * one to read iterable side input
     //   * one to read keys from multimap side input
+    //   * one to attempt multimap side input bulk read
     //   * one to read key1 iterable from multimap side input
     //   * one to read key2 iterable from multimap side input
-    assertEquals(4, stateRequestHandler.receivedRequests.size());
+    assertEquals(5, stateRequestHandler.receivedRequests.size());
     assertEquals(
         stateRequestHandler.receivedRequests.get(0).getStateKey().getIterableSideInput(),
         BeamFnApi.StateKey.IterableSideInput.newBuilder()
@@ -931,14 +932,20 @@ public class RemoteExecutionTest implements Serializable {
             .setTransformId(transformId)
             .build());
     assertEquals(
-        stateRequestHandler.receivedRequests.get(2).getStateKey().getMultimapSideInput(),
+            stateRequestHandler.receivedRequests.get(2).getStateKey().getMultimapKeysValuesSideInput(),
+            BeamFnApi.StateKey.MultimapKeysValuesSideInput.newBuilder()
+                    .setSideInputId(multimapView.getTagInternal().getId())
+                    .setTransformId(transformId)
+                    .build());
+    assertEquals(
+        stateRequestHandler.receivedRequests.get(3).getStateKey().getMultimapSideInput(),
         BeamFnApi.StateKey.MultimapSideInput.newBuilder()
             .setSideInputId(multimapView.getTagInternal().getId())
             .setTransformId(transformId)
             .setKey(encode("key1"))
             .build());
     assertEquals(
-        stateRequestHandler.receivedRequests.get(3).getStateKey().getMultimapSideInput(),
+        stateRequestHandler.receivedRequests.get(4).getStateKey().getMultimapSideInput(),
         BeamFnApi.StateKey.MultimapSideInput.newBuilder()
             .setSideInputId(multimapView.getTagInternal().getId())
             .setTransformId(transformId)

--- a/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
+++ b/runners/java-fn-execution/src/test/java/org/apache/beam/runners/fnexecution/control/RemoteExecutionTest.java
@@ -932,11 +932,11 @@ public class RemoteExecutionTest implements Serializable {
             .setTransformId(transformId)
             .build());
     assertEquals(
-            stateRequestHandler.receivedRequests.get(2).getStateKey().getMultimapKeysValuesSideInput(),
-            BeamFnApi.StateKey.MultimapKeysValuesSideInput.newBuilder()
-                    .setSideInputId(multimapView.getTagInternal().getId())
-                    .setTransformId(transformId)
-                    .build());
+        stateRequestHandler.receivedRequests.get(2).getStateKey().getMultimapKeysValuesSideInput(),
+        BeamFnApi.StateKey.MultimapKeysValuesSideInput.newBuilder()
+            .setSideInputId(multimapView.getTagInternal().getId())
+            .setTransformId(transformId)
+            .build());
     assertEquals(
         stateRequestHandler.receivedRequests.get(3).getStateKey().getMultimapSideInput(),
         BeamFnApi.StateKey.MultimapSideInput.newBuilder()

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/MultimapSideInput.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/state/MultimapSideInput.java
@@ -20,13 +20,20 @@ package org.apache.beam.fn.harness.state;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
 
 import java.io.IOException;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.Map;
 import org.apache.beam.fn.harness.Cache;
 import org.apache.beam.fn.harness.Caches;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.StateKey;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.StateRequest;
 import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.IterableCoder;
+import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.transforms.Materializations.MultimapView;
 import org.apache.beam.sdk.util.ByteStringOutputStream;
+import org.apache.beam.sdk.values.KV;
 import org.apache.beam.vendor.grpc.v1p54p0.com.google.protobuf.ByteString;
 
 /**
@@ -38,11 +45,15 @@ import org.apache.beam.vendor.grpc.v1p54p0.com.google.protobuf.ByteString;
 })
 public class MultimapSideInput<K, V> implements MultimapView<K, V> {
 
+  private static final int BULK_READ_SIZE = 100;
+
   private final Cache<?, ?> cache;
   private final BeamFnStateClient beamFnStateClient;
   private final StateRequest keysRequest;
   private final Coder<K> keyCoder;
   private final Coder<V> valueCoder;
+  private volatile Map<ByteString, Iterable<V>> bulkRead;
+  private boolean bulkReadIsComplete = false;
 
   public MultimapSideInput(
       Cache<?, ?> cache,
@@ -71,17 +82,52 @@ public class MultimapSideInput<K, V> implements MultimapView<K, V> {
 
   @Override
   public Iterable<V> get(K k) {
-    ByteStringOutputStream output = new ByteStringOutputStream();
-    try {
-      keyCoder.encode(k, output);
-    } catch (IOException e) {
-      throw new IllegalStateException(
-          String.format(
-              "Failed to encode key %s for side input id %s.",
-              k, keysRequest.getStateKey().getMultimapKeysSideInput().getSideInputId()),
-          e);
+    ByteString encodedKey = encodeKey(k);
+
+    if (bulkRead == null) {
+      synchronized (this) {
+        if (bulkRead == null) {
+          bulkRead = new HashMap<>();
+          StateKey bulkReadStateKey =
+              StateKey.newBuilder()
+                  .setMultimapKeysValuesSideInput(
+                      StateKey.MultimapKeysValuesSideInput.newBuilder()
+                          .setTransformId(
+                              keysRequest.getStateKey().getMultimapKeysSideInput().getTransformId())
+                          .setSideInputId(
+                              keysRequest.getStateKey().getMultimapKeysSideInput().getSideInputId())
+                          .setWindow(
+                              keysRequest.getStateKey().getMultimapKeysSideInput().getWindow()))
+                  .build();
+
+          StateRequest bulkReadRequest =
+              keysRequest.toBuilder().setStateKey(bulkReadStateKey).build();
+          try {
+            Iterator<KV<K, Iterable<V>>> entries =
+                StateFetchingIterators.readAllAndDecodeStartingFrom(
+                        Caches.subCache(cache, "ValuesForKey", encodedKey),
+                        beamFnStateClient,
+                        bulkReadRequest,
+                        KvCoder.of(keyCoder, IterableCoder.of(valueCoder)))
+                    .iterator();
+            while (bulkRead.size() < BULK_READ_SIZE && entries.hasNext()) {
+              KV<K, Iterable<V>> entry = entries.next();
+              bulkRead.put(encodeKey(entry.getKey()), entry.getValue());
+            }
+            bulkReadIsComplete = !entries.hasNext();
+          } catch (Exception exn) {
+            bulkReadIsComplete = false;
+          }
+        }
+      }
     }
-    ByteString encodedKey = output.toByteString();
+
+    if (bulkRead.containsKey(encodedKey)) {
+      return bulkRead.get(encodedKey);
+    } else if (bulkReadIsComplete) {
+      return Collections.emptyList();
+    }
+
     StateKey stateKey =
         StateKey.newBuilder()
             .setMultimapSideInput(
@@ -97,5 +143,19 @@ public class MultimapSideInput<K, V> implements MultimapView<K, V> {
     StateRequest request = keysRequest.toBuilder().setStateKey(stateKey).build();
     return StateFetchingIterators.readAllAndDecodeStartingFrom(
         Caches.subCache(cache, "ValuesForKey", encodedKey), beamFnStateClient, request, valueCoder);
+  }
+
+  private ByteString encodeKey(K k) {
+    ByteStringOutputStream output = new ByteStringOutputStream();
+    try {
+      keyCoder.encode(k, output);
+    } catch (IOException e) {
+      throw new IllegalStateException(
+          String.format(
+              "Failed to encode key %s for side input id %s.",
+              k, keysRequest.getStateKey().getMultimapKeysSideInput().getSideInputId()),
+          e);
+    }
+    return output.toByteString();
   }
 }

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/FakeBeamFnStateClient.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/FakeBeamFnStateClient.java
@@ -136,6 +136,10 @@ public class FakeBeamFnStateClient implements BeamFnStateClient {
     if (key.getTypeCase() == TypeCase.MULTIMAP_SIDE_INPUT || key.getTypeCase() == TypeCase.RUNNER) {
       assertEquals(RequestCase.GET, request.getRequestCase());
     }
+    if (key.getTypeCase() == TypeCase.MULTIMAP_KEYS_VALUES_SIDE_INPUT && !data.containsKey(key)) {
+      // Allow testing this not being supported rather than blindly returning the empty list.
+      throw new UnsupportedOperationException("No multimap keys values states provided.");
+    }
 
     switch (request.getRequestCase()) {
       case GET:

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/MultimapSideInputTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/state/MultimapSideInputTest.java
@@ -27,6 +27,8 @@ import org.apache.beam.fn.harness.Caches;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.StateKey;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
 import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.IterableCoder;
+import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.util.ByteStringOutputStream;
 import org.apache.beam.sdk.values.KV;
@@ -51,11 +53,37 @@ public class MultimapSideInputTest {
   private static final byte[] UNKNOWN = "UNKNOWN".getBytes(StandardCharsets.UTF_8);
 
   @Test
+  public void testGetWithBulkRead() throws Exception {
+    FakeBeamFnStateClient fakeBeamFnStateClient =
+        new FakeBeamFnStateClient(
+            ImmutableMap.of(
+                keysValuesStateKey(),
+                KV.of(
+                    KvCoder.of(ByteArrayCoder.of(), IterableCoder.of(StringUtf8Coder.of())),
+                    asList(KV.of(A, asList("A1", "A2", "A3")), KV.of(B, asList("B1", "B2"))))));
+
+    MultimapSideInput<byte[], String> multimapSideInput =
+        new MultimapSideInput<>(
+            Caches.noop(),
+            fakeBeamFnStateClient,
+            "instructionId",
+            keysStateKey(),
+            ByteArrayCoder.of(),
+            StringUtf8Coder.of());
+    assertArrayEquals(
+        new String[] {"A1", "A2", "A3"}, Iterables.toArray(multimapSideInput.get(A), String.class));
+    assertArrayEquals(
+        new String[] {"B1", "B2"}, Iterables.toArray(multimapSideInput.get(B), String.class));
+    assertArrayEquals(
+        new String[] {}, Iterables.toArray(multimapSideInput.get(UNKNOWN), String.class));
+  }
+
+  @Test
   public void testGet() throws Exception {
     FakeBeamFnStateClient fakeBeamFnStateClient =
         new FakeBeamFnStateClient(
             ImmutableMap.of(
-                stateKey(), KV.of(ByteArrayCoder.of(), asList(A, B)),
+                keysStateKey(), KV.of(ByteArrayCoder.of(), asList(A, B)),
                 key(A), KV.of(StringUtf8Coder.of(), asList("A1", "A2", "A3")),
                 key(B), KV.of(StringUtf8Coder.of(), asList("B1", "B2"))));
 
@@ -64,7 +92,7 @@ public class MultimapSideInputTest {
             Caches.noop(),
             fakeBeamFnStateClient,
             "instructionId",
-            stateKey(),
+            keysStateKey(),
             ByteArrayCoder.of(),
             StringUtf8Coder.of());
     assertArrayEquals(
@@ -82,7 +110,7 @@ public class MultimapSideInputTest {
     FakeBeamFnStateClient fakeBeamFnStateClient =
         new FakeBeamFnStateClient(
             ImmutableMap.of(
-                stateKey(), KV.of(ByteArrayCoder.of(), asList(A, B)),
+                keysStateKey(), KV.of(ByteArrayCoder.of(), asList(A, B)),
                 key(A), KV.of(StringUtf8Coder.of(), asList("A1", "A2", "A3")),
                 key(B), KV.of(StringUtf8Coder.of(), asList("B1", "B2"))));
 
@@ -94,7 +122,7 @@ public class MultimapSideInputTest {
               cache,
               fakeBeamFnStateClient,
               "instructionId",
-              stateKey(),
+              keysStateKey(),
               ByteArrayCoder.of(),
               StringUtf8Coder.of());
       assertArrayEquals(
@@ -117,7 +145,7 @@ public class MultimapSideInputTest {
                 throw new IllegalStateException("Unexpected call for test.");
               },
               "instructionId",
-              stateKey(),
+              keysStateKey(),
               ByteArrayCoder.of(),
               StringUtf8Coder.of());
       assertArrayEquals(
@@ -132,10 +160,20 @@ public class MultimapSideInputTest {
     }
   }
 
-  private StateKey stateKey() throws IOException {
+  private StateKey keysStateKey() throws IOException {
     return StateKey.newBuilder()
         .setMultimapKeysSideInput(
             StateKey.MultimapKeysSideInput.newBuilder()
+                .setTransformId("ptransformId")
+                .setSideInputId("sideInputId")
+                .setWindow(ByteString.copyFromUtf8("encodedWindow")))
+        .build();
+  }
+
+  private StateKey keysValuesStateKey() throws IOException {
+    return StateKey.newBuilder()
+        .setMultimapKeysValuesSideInput(
+            StateKey.MultimapKeysValuesSideInput.newBuilder()
                 .setTransformId("ptransformId")
                 .setSideInputId("sideInputId")
                 .setWindow(ByteString.copyFromUtf8("encodedWindow")))

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/execution.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/execution.py
@@ -352,7 +352,7 @@ class WindowGroupingBuffer(object):
         self._values_by_window[key, window].append(value)
 
   def encoded_items(self):
-    # type: () -> Iterator[Tuple[bytes, bytes, bytes]]
+    # type: () -> Iterator[Tuple[bytes, bytes, bytes, int]]
     value_coder_impl = self._value_coder.get_impl()
     key_coder_impl = self._key_coder.get_impl()
     for (key, window), values in self._values_by_window.items():

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/execution.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/execution.py
@@ -23,6 +23,7 @@ import collections
 import copy
 import itertools
 import logging
+import struct
 import typing
 import uuid
 import weakref
@@ -360,7 +361,7 @@ class WindowGroupingBuffer(object):
       output_stream = create_OutputStream()
       for value in values:
         value_coder_impl.encode_to_stream(value, output_stream, True)
-      yield encoded_key, encoded_window, output_stream.get()
+      yield encoded_key, encoded_window, output_stream.get(), len(values)
 
 
 class GenericNonMergingWindowFn(window.NonMergingWindowFn):
@@ -979,7 +980,7 @@ class FnApiRunnerExecutionContext(object):
         elements_by_window.append(element_data)
 
       if func_spec.urn == common_urns.side_inputs.ITERABLE.urn:
-        for _, window, elements_data in elements_by_window.encoded_items():
+        for _, window, elements_data, _ in elements_by_window.encoded_items():
           state_key = beam_fn_api_pb2.StateKey(
               iterable_side_input=beam_fn_api_pb2.StateKey.IterableSideInput(
                   transform_id=consuming_transform_id,
@@ -987,7 +988,8 @@ class FnApiRunnerExecutionContext(object):
                   window=window))
           self.state_servicer.append_raw(state_key, elements_data)
       elif func_spec.urn == common_urns.side_inputs.MULTIMAP.urn:
-        for key, window, elements_data in elements_by_window.encoded_items():
+        for (key, window, elements_data,
+             elements_count) in elements_by_window.encoded_items():
           state_key = beam_fn_api_pb2.StateKey(
               multimap_side_input=beam_fn_api_pb2.StateKey.MultimapSideInput(
                   transform_id=consuming_transform_id,
@@ -995,6 +997,17 @@ class FnApiRunnerExecutionContext(object):
                   window=window,
                   key=key))
           self.state_servicer.append_raw(state_key, elements_data)
+
+          kv_iter_state_key = beam_fn_api_pb2.StateKey(
+              multimap_keys_values_side_input=beam_fn_api_pb2.StateKey.
+              MultimapKeysValuesSideInput(
+                  transform_id=consuming_transform_id,
+                  side_input_id=tag,
+                  window=window))
+          self.state_servicer.append_raw(
+              kv_iter_state_key,
+              # KV<K, Iterable<V>> encoding.
+              key + struct.pack('>i', elements_count) + elements_data)
       else:
         raise ValueError("Unknown access pattern: '%s'" % func_spec.urn)
 

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/worker_handlers.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/worker_handlers.py
@@ -1046,12 +1046,12 @@ class StateServicer(beam_fn_api_pb2_grpc.BeamFnStateServicer,
       state_key,  # type: beam_fn_api_pb2.StateKey
       continuation_token=None  # type: Optional[bytes]
               ):
+    # type: (...) -> Tuple[bytes, Optional[bytes]]
 
     if state_key.WhichOneof('type') not in self._SUPPORTED_STATE_TYPES:
       raise NotImplementedError(
           'Unknown state type: ' + state_key.WhichOneof('type'))
 
-    # type: (...) -> Tuple[bytes, Optional[bytes]]
     with self._lock:
       full_state = self._state[self._to_key(state_key)]
       if self._use_continuation_tokens:

--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -445,7 +445,6 @@ class StateBackedSideInputMap(object):
                     # Attempt to bulk read the key-values over the iterable
                     # protocol which, if supported, can be much more efficient
                     # than point lookups if it fits into memory.
-                    full_map = collections.defaultdict(list)
                     for ix, (k, vs) in enumerate(_StateBackedIterable(
                         state_handler,
                         kv_iter_state_key,


### PR DESCRIPTION
The ability to perform point lookups for multi-map side inputs is great for maps that are too large to fit into memory, but can be very inefficient in requiring an entire state request per key for small maps.

This change adds an optional protocol to request an entire map as a stream of key-values in one (possibly paginated) API call, and uses this to bulk pre-fetch an initial set of values from the map before falling back to point lookups.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
