### PR TITLE
Per DoFn latency instrumentation

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/ExecutionStateSampler.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/ExecutionStateSampler.java
@@ -34,9 +34,7 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurren
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.DateTimeUtils.MillisProvider;
 
-/**
- * Monitors the execution of one or more execution threads.
- */
+/** Monitors the execution of one or more execution threads. */
 public class ExecutionStateSampler {
 
   private final Set<ExecutionStateTracker> activeTrackers = ConcurrentHashMap.newKeySet();
@@ -47,8 +45,7 @@ public class ExecutionStateSampler {
       new ExecutionStateSampler(SYSTEM_MILLIS_PROVIDER);
 
   protected final MillisProvider clock;
-  @VisibleForTesting
-  protected volatile long lastSampleTimeMillis;
+  @VisibleForTesting protected volatile long lastSampleTimeMillis;
 
   protected ExecutionStateSampler(MillisProvider clock) {
     this.clock = clock;
@@ -149,16 +146,12 @@ public class ExecutionStateSampler {
     }
   }
 
-  /**
-   * Add the tracker to the sampling set.
-   */
+  /** Add the tracker to the sampling set. */
   protected void addTracker(ExecutionStateTracker tracker) {
     this.activeTrackers.add(tracker);
   }
 
-  /**
-   * Remove the tracker from the sampling set.
-   */
+  /** Remove the tracker from the sampling set. */
   protected void removeTracker(ExecutionStateTracker tracker) {
     activeTrackers.remove(tracker);
 

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/ExecutionStateSampler.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/ExecutionStateSampler.java
@@ -34,7 +34,9 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurren
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.DateTimeUtils.MillisProvider;
 
-/** Monitors the execution of one or more execution threads. */
+/**
+ * Monitors the execution of one or more execution threads.
+ */
 public class ExecutionStateSampler {
 
   private final Set<ExecutionStateTracker> activeTrackers = ConcurrentHashMap.newKeySet();
@@ -44,10 +46,11 @@ public class ExecutionStateSampler {
   private static final ExecutionStateSampler INSTANCE =
       new ExecutionStateSampler(SYSTEM_MILLIS_PROVIDER);
 
-  private final MillisProvider clock;
-  @VisibleForTesting volatile long lastSampleTimeMillis;
+  protected final MillisProvider clock;
+  @VisibleForTesting
+  protected volatile long lastSampleTimeMillis;
 
-  private ExecutionStateSampler(MillisProvider clock) {
+  protected ExecutionStateSampler(MillisProvider clock) {
     this.clock = clock;
   }
 
@@ -146,13 +149,17 @@ public class ExecutionStateSampler {
     }
   }
 
-  /** Add the tracker to the sampling set. */
-  void addTracker(ExecutionStateTracker tracker) {
+  /**
+   * Add the tracker to the sampling set.
+   */
+  protected void addTracker(ExecutionStateTracker tracker) {
     this.activeTrackers.add(tracker);
   }
 
-  /** Remove the tracker from the sampling set. */
-  void removeTracker(ExecutionStateTracker tracker) {
+  /**
+   * Remove the tracker from the sampling set.
+   */
+  protected void removeTracker(ExecutionStateTracker tracker) {
     activeTrackers.remove(tracker);
 
     // Attribute any remaining time since the last sampling while removing the tracker.

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/ExecutionStateTracker.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/ExecutionStateTracker.java
@@ -304,7 +304,7 @@ public class ExecutionStateTracker implements Comparable<ExecutionStateTracker> 
     return nextLullReportMs;
   }
 
-  void takeSample(long millisSinceLastSample) {
+  public void takeSample(long millisSinceLastSample) {
     if (SAMPLING_UPDATER.compareAndSet(this, 0, 1)) {
       try {
         takeSampleOnce(millisSinceLastSample);

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/ExecutionStateTracker.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/ExecutionStateTracker.java
@@ -284,30 +284,22 @@ public class ExecutionStateTracker implements Comparable<ExecutionStateTracker> 
     numTransitions++;
   }
 
-  /**
-   * Return the number of transitions that have been observed by this state tracker.
-   */
+  /** Return the number of transitions that have been observed by this state tracker. */
   public long getNumTransitions() {
     return numTransitions;
   }
 
-  /**
-   * Return the time since the last transition.
-   */
+  /** Return the time since the last transition. */
   public long getMillisSinceLastTransition() {
     return millisSinceLastTransition;
   }
 
-  /**
-   * Return the number of transitions since the last sample.
-   */
+  /** Return the number of transitions since the last sample. */
   public long getTransitionsAtLastSample() {
     return transitionsAtLastSample;
   }
 
-  /**
-   * Return the time of the next lull report.
-   */
+  /** Return the time of the next lull report. */
   public long getNextLullReportMs() {
     return nextLullReportMs;
   }
@@ -316,8 +308,8 @@ public class ExecutionStateTracker implements Comparable<ExecutionStateTracker> 
    * Called periodically by the {@link ExecutionStateSampler} to report time recorded by the
    * tracker.
    *
-   * @param millisSinceLastSample the time since the last sample was reported. As an
-   *     approximation, all of that time should be associated with this tracker.
+   * @param millisSinceLastSample the time since the last sample was reported. As an approximation,
+   *     all of that time should be associated with this tracker.
    */
   public void takeSample(long millisSinceLastSample) {
     if (SAMPLING_UPDATER.compareAndSet(this, 0, 1)) {

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/ExecutionStateTracker.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/metrics/ExecutionStateTracker.java
@@ -284,26 +284,41 @@ public class ExecutionStateTracker implements Comparable<ExecutionStateTracker> 
     numTransitions++;
   }
 
-  /** Return the number of transitions that have been observed by this state tracker. */
+  /**
+   * Return the number of transitions that have been observed by this state tracker.
+   */
   public long getNumTransitions() {
     return numTransitions;
   }
 
-  /** Return the time since the last transition. */
+  /**
+   * Return the time since the last transition.
+   */
   public long getMillisSinceLastTransition() {
     return millisSinceLastTransition;
   }
 
-  /** Return the number of transitions since the last sample. */
+  /**
+   * Return the number of transitions since the last sample.
+   */
   public long getTransitionsAtLastSample() {
     return transitionsAtLastSample;
   }
 
-  /** Return the time of the next lull report. */
+  /**
+   * Return the time of the next lull report.
+   */
   public long getNextLullReportMs() {
     return nextLullReportMs;
   }
 
+  /**
+   * Called periodically by the {@link ExecutionStateSampler} to report time recorded by the
+   * tracker.
+   *
+   * @param millisSinceLastSample the time since the last sample was reported. As an
+   *     approximation, all of that time should be associated with this tracker.
+   */
   public void takeSample(long millisSinceLastSample) {
     if (SAMPLING_UPDATER.compareAndSet(this, 0, 1)) {
       try {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ActiveMessageMetadata.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ActiveMessageMetadata.java
@@ -1,0 +1,12 @@
+package org.apache.beam.runners.dataflow.worker;
+
+public class ActiveMessageMetadata {
+
+  public String userStepName;
+  public Long startTime;
+
+  public ActiveMessageMetadata(String userStepName, Long startTime) {
+    this.userStepName = userStepName;
+    this.startTime = startTime;
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ActiveMessageMetadata.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ActiveMessageMetadata.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.beam.runners.dataflow.worker;
 
 public class ActiveMessageMetadata {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ActiveMessageMetadata.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ActiveMessageMetadata.java
@@ -24,7 +24,7 @@ public abstract class ActiveMessageMetadata {
 
   public abstract String userStepName();
 
-  public abstract Long startTime();
+  public abstract long startTime();
 
   static ActiveMessageMetadata create(String userStepName, Long startTime) {
     return new AutoValue_ActiveMessageMetadata(userStepName, startTime);

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ActiveMessageMetadata.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/ActiveMessageMetadata.java
@@ -17,13 +17,16 @@
  */
 package org.apache.beam.runners.dataflow.worker;
 
-public class ActiveMessageMetadata {
+import com.google.auto.value.AutoValue;
 
-  public String userStepName;
-  public Long startTime;
+@AutoValue
+public abstract class ActiveMessageMetadata {
 
-  public ActiveMessageMetadata(String userStepName, Long startTime) {
-    this.userStepName = userStepName;
-    this.startTime = startTime;
+  public abstract String userStepName();
+
+  public abstract Long startTime();
+
+  static ActiveMessageMetadata create(String userStepName, Long startTime) {
+    return new AutoValue_ActiveMessageMetadata(userStepName, startTime);
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionContext.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionContext.java
@@ -315,8 +315,8 @@ public abstract class DataflowExecutionContext<T extends DataflowStepContext> {
           if (this.activeMessageMetadata != null) {
             recordActiveMessageInProcessingTimesMap();
           }
-          this.activeMessageMetadata = new ActiveMessageMetadata(
-              newDFState.getStepName().userName(), clock.getMillis());
+          this.activeMessageMetadata =
+              new ActiveMessageMetadata(newDFState.getStepName().userName(), clock.getMillis());
         }
         elementExecutionTracker.enter(newDFState.getStepName());
       }
@@ -343,7 +343,7 @@ public abstract class DataflowExecutionContext<T extends DataflowStepContext> {
     public Map<String, IntSummaryStatistics> getProcessingTimesByStep() {
       return processingTimesByStep;
     }
-    
+
     /**
      * Transitions the metadata for the currently active message to an entry in the completed
      * processing times map. Sets the activeMessageMetadata to null after the entry has been
@@ -354,12 +354,12 @@ public abstract class DataflowExecutionContext<T extends DataflowStepContext> {
         return;
       }
       this.processingTimesByStep.compute(
-          this.activeMessageMetadata.userStepName, (k, v) -> {
+          this.activeMessageMetadata.userStepName,
+          (k, v) -> {
             if (v == null) {
               v = new IntSummaryStatistics();
             }
-            v.accept(
-                (int) (System.currentTimeMillis() - this.activeMessageMetadata.startTime));
+            v.accept((int) (System.currentTimeMillis() - this.activeMessageMetadata.startTime));
             return v;
           });
       this.activeMessageMetadata = null;

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionContext.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionContext.java
@@ -256,9 +256,9 @@ public abstract class DataflowExecutionContext<T extends DataflowStepContext> {
     @Nullable
     private ActiveMessageMetadata activeMessageMetadata = null;
 
-    private MillisProvider clock = System::currentTimeMillis;
+    private final MillisProvider clock = System::currentTimeMillis;
 
-    private Map<String, IntSummaryStatistics> processingTimesByStep = new HashMap<>();
+    private final Map<String, IntSummaryStatistics> processingTimesByStep = new HashMap<>();
 
     public DataflowExecutionStateTracker(
         ExecutionStateSampler sampler,

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionContext.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionContext.java
@@ -22,6 +22,7 @@ import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Pr
 import com.google.api.services.dataflow.model.SideInputInfo;
 import java.io.Closeable;
 import java.io.IOException;
+import java.util.Optional;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
@@ -252,6 +253,7 @@ public abstract class DataflowExecutionContext<T extends DataflowStepContext> {
      * Metadata on the message whose processing is currently being managed by this tracker. If no
      * message is actively being processed, activeMessageMetadata will be null.
      */
+    @Nullable
     private ActiveMessageMetadata activeMessageMetadata = null;
 
     private MillisProvider clock = System::currentTimeMillis;
@@ -336,8 +338,8 @@ public abstract class DataflowExecutionContext<T extends DataflowStepContext> {
       return this.workItemId;
     }
 
-    public ActiveMessageMetadata getActiveMessageMetadata() {
-      return activeMessageMetadata;
+    public Optional<ActiveMessageMetadata> getActiveMessageMetadata() {
+      return Optional.ofNullable(activeMessageMetadata);
     }
 
     public Map<String, IntSummaryStatistics> getProcessingTimesByStep() {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionContext.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionContext.java
@@ -22,13 +22,13 @@ import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Pr
 import com.google.api.services.dataflow.model.SideInputInfo;
 import java.io.Closeable;
 import java.io.IOException;
-import java.util.Optional;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashMap;
 import java.util.IntSummaryStatistics;
 import java.util.LinkedHashMap;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.beam.runners.core.NullSideInputReader;
 import org.apache.beam.runners.core.SideInputReader;
 import org.apache.beam.runners.core.StepContext;
@@ -253,8 +253,7 @@ public abstract class DataflowExecutionContext<T extends DataflowStepContext> {
      * Metadata on the message whose processing is currently being managed by this tracker. If no
      * message is actively being processed, activeMessageMetadata will be null.
      */
-    @Nullable
-    private ActiveMessageMetadata activeMessageMetadata = null;
+    @Nullable private ActiveMessageMetadata activeMessageMetadata = null;
 
     private final MillisProvider clock = System::currentTimeMillis;
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionContext.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionContext.java
@@ -343,7 +343,7 @@ public abstract class DataflowExecutionContext<T extends DataflowStepContext> {
     }
 
     public Map<String, IntSummaryStatistics> getProcessingTimesByStep() {
-      return processingTimesByStep;
+      return Collections.unmodifiableMap(processingTimesByStep);
     }
 
     /**

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionContext.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionContext.java
@@ -316,7 +316,7 @@ public abstract class DataflowExecutionContext<T extends DataflowStepContext> {
             recordActiveMessageInProcessingTimesMap();
           }
           this.activeMessageMetadata =
-              new ActiveMessageMetadata(newDFState.getStepName().userName(), clock.getMillis());
+              ActiveMessageMetadata.create(newDFState.getStepName().userName(), clock.getMillis());
         }
         elementExecutionTracker.enter(newDFState.getStepName());
       }
@@ -354,12 +354,12 @@ public abstract class DataflowExecutionContext<T extends DataflowStepContext> {
         return;
       }
       this.processingTimesByStep.compute(
-          this.activeMessageMetadata.userStepName,
+          this.activeMessageMetadata.userStepName(),
           (k, v) -> {
             if (v == null) {
               v = new IntSummaryStatistics();
             }
-            v.accept((int) (System.currentTimeMillis() - this.activeMessageMetadata.startTime));
+            v.accept((int) (System.currentTimeMillis() - this.activeMessageMetadata.startTime()));
             return v;
           });
       this.activeMessageMetadata = null;

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
@@ -1,3 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.beam.runners.dataflow.worker;
 
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkNotNull;
@@ -20,7 +37,8 @@ public class DataflowExecutionStateSampler extends ExecutionStateSampler {
       new DataflowExecutionStateSampler(SYSTEM_MILLIS_PROVIDER);
 
   private HashMap<String, DataflowExecutionStateTracker> activeTrackersByWorkId = new HashMap<>();
-  private HashMap<String, Map<String, IntSummaryStatistics>> completedProcessingMetrics = new HashMap<>();
+  private HashMap<String, Map<String, IntSummaryStatistics>> completedProcessingMetrics =
+      new HashMap<>();
 
   public static DataflowExecutionStateSampler instance() {
     return INSTANCE;
@@ -46,15 +64,16 @@ public class DataflowExecutionStateSampler extends ExecutionStateSampler {
 
   private Map<String, IntSummaryStatistics> mergeStepStatsMaps(
       Map<String, IntSummaryStatistics> map1, Map<String, IntSummaryStatistics> map2) {
-    for (Entry<String, IntSummaryStatistics> steps : map2
-        .entrySet()) {
-      map1.compute(steps.getKey(), (k, v) -> {
-        if (v == null) {
-          return steps.getValue();
-        }
-        v.combine(steps.getValue());
-        return v;
-      });
+    for (Entry<String, IntSummaryStatistics> steps : map2.entrySet()) {
+      map1.compute(
+          steps.getKey(),
+          (k, v) -> {
+            if (v == null) {
+              return steps.getValue();
+            }
+            v.combine(steps.getValue());
+            return v;
+          });
     }
     return map1;
   }
@@ -96,8 +115,7 @@ public class DataflowExecutionStateSampler extends ExecutionStateSampler {
   }
 
   @Nullable
-  public Map<String, IntSummaryStatistics> getProcessingDistributionsForWorkId(
-      String workId) {
+  public Map<String, IntSummaryStatistics> getProcessingDistributionsForWorkId(String workId) {
     if (!activeTrackersByWorkId.containsKey(workId)) {
       if (completedProcessingMetrics.containsKey(workId)) {
         return completedProcessingMetrics.get(workId);
@@ -105,7 +123,8 @@ public class DataflowExecutionStateSampler extends ExecutionStateSampler {
       return null;
     }
     DataflowExecutionStateTracker tracker = activeTrackersByWorkId.get(workId);
-    return mergeStepStatsMaps(completedProcessingMetrics.getOrDefault(workId, new HashMap<>()),
+    return mergeStepStatsMaps(
+        completedProcessingMetrics.getOrDefault(workId, new HashMap<>()),
         tracker.getProcessingTimesByStep());
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
@@ -30,7 +30,7 @@ import org.apache.beam.runners.dataflow.worker.DataflowExecutionContext.Dataflow
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
 import org.joda.time.DateTimeUtils.MillisProvider;
 
-public class DataflowExecutionStateSampler extends ExecutionStateSampler {
+public final class DataflowExecutionStateSampler extends ExecutionStateSampler {
 
   private static final MillisProvider SYSTEM_MILLIS_PROVIDER = System::currentTimeMillis;
   private static final DataflowExecutionStateSampler INSTANCE =

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
@@ -117,13 +117,12 @@ public final class DataflowExecutionStateSampler extends ExecutionStateSampler {
     return Optional.ofNullable(null);
   }
 
-  @Nullable
   public Map<String, IntSummaryStatistics> getProcessingDistributionsForWorkId(String workId) {
     if (!activeTrackersByWorkId.containsKey(workId)) {
       if (completedProcessingMetrics.containsKey(workId)) {
         return completedProcessingMetrics.get(workId);
       }
-      return null;
+      return new HashMap<>();
     }
     DataflowExecutionStateTracker tracker = activeTrackersByWorkId.get(workId);
     return mergeStepStatsMaps(

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
@@ -25,7 +25,6 @@ import java.util.Map;
 import java.util.Map.Entry;
 import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
-import javax.annotation.Nullable;
 import org.apache.beam.runners.core.metrics.ExecutionStateSampler;
 import org.apache.beam.runners.core.metrics.ExecutionStateTracker;
 import org.apache.beam.runners.dataflow.worker.DataflowExecutionContext.DataflowExecutionStateTracker;
@@ -111,8 +110,8 @@ public final class DataflowExecutionStateSampler extends ExecutionStateSampler {
 
   public Optional<ActiveMessageMetadata> getActiveMessageMetadataForWorkId(String workId) {
     if (activeTrackersByWorkId.containsKey(workId)) {
-      return Optional.ofNullable(activeTrackersByWorkId.get(workId).getActiveMessageMetadata()
-          .orElse(null));
+      return Optional.ofNullable(
+          activeTrackersByWorkId.get(workId).getActiveMessageMetadata().orElse(null));
     }
     return Optional.ofNullable(null);
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
@@ -62,7 +62,7 @@ public final class DataflowExecutionStateSampler extends ExecutionStateSampler {
     this.activeTrackersByWorkId.put(dfTracker.getWorkItemId(), dfTracker);
   }
 
-  private Map<String, IntSummaryStatistics> mergeStepStatsMaps(
+  private static Map<String, IntSummaryStatistics> mergeStepStatsMaps(
       Map<String, IntSummaryStatistics> map1, Map<String, IntSummaryStatistics> map2) {
     for (Entry<String, IntSummaryStatistics> steps : map2.entrySet()) {
       map1.compute(

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
@@ -19,6 +19,7 @@ package org.apache.beam.runners.dataflow.worker;
 
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkNotNull;
 
+import java.util.HashMap;
 import java.util.IntSummaryStatistics;
 import java.util.Map;
 import java.util.Map.Entry;
@@ -125,7 +126,7 @@ public final class DataflowExecutionStateSampler extends ExecutionStateSampler {
     }
     DataflowExecutionStateTracker tracker = activeTrackersByWorkId.get(workId);
     return mergeStepStatsMaps(
-        completedProcessingMetrics.getOrDefault(workId, new ConcurrentHashMap<>()),
+        completedProcessingMetrics.getOrDefault(workId, new HashMap<>()),
         tracker.getProcessingTimesByStep());
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
@@ -36,8 +36,8 @@ public final class DataflowExecutionStateSampler extends ExecutionStateSampler {
   private static final DataflowExecutionStateSampler INSTANCE =
       new DataflowExecutionStateSampler(SYSTEM_MILLIS_PROVIDER);
 
-  private HashMap<String, DataflowExecutionStateTracker> activeTrackersByWorkId = new HashMap<>();
-  private HashMap<String, Map<String, IntSummaryStatistics>> completedProcessingMetrics =
+  private final HashMap<String, DataflowExecutionStateTracker> activeTrackersByWorkId = new HashMap<>();
+  private final HashMap<String, Map<String, IntSummaryStatistics>> completedProcessingMetrics =
       new HashMap<>();
 
   public static DataflowExecutionStateSampler instance() {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
@@ -36,7 +36,8 @@ public final class DataflowExecutionStateSampler extends ExecutionStateSampler {
   private static final DataflowExecutionStateSampler INSTANCE =
       new DataflowExecutionStateSampler(SYSTEM_MILLIS_PROVIDER);
 
-  private final HashMap<String, DataflowExecutionStateTracker> activeTrackersByWorkId = new HashMap<>();
+  private final HashMap<String, DataflowExecutionStateTracker> activeTrackersByWorkId =
+      new HashMap<>();
   private final HashMap<String, Map<String, IntSummaryStatistics>> completedProcessingMetrics =
       new HashMap<>();
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
@@ -109,7 +109,7 @@ public final class DataflowExecutionStateSampler extends ExecutionStateSampler {
   @Nullable
   public ActiveMessageMetadata getActiveMessageMetadataForWorkId(String workId) {
     if (activeTrackersByWorkId.containsKey(workId)) {
-      return activeTrackersByWorkId.get(workId).getActiveMessageMetadata();
+      return activeTrackersByWorkId.get(workId).getActiveMessageMetadata().orElse(null);
     }
     return null;
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
@@ -23,6 +23,7 @@ import java.util.HashMap;
 import java.util.IntSummaryStatistics;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 import org.apache.beam.runners.core.metrics.ExecutionStateSampler;
@@ -108,12 +109,12 @@ public final class DataflowExecutionStateSampler extends ExecutionStateSampler {
     }
   }
 
-  @Nullable
-  public ActiveMessageMetadata getActiveMessageMetadataForWorkId(String workId) {
+  public Optional<ActiveMessageMetadata> getActiveMessageMetadataForWorkId(String workId) {
     if (activeTrackersByWorkId.containsKey(workId)) {
-      return activeTrackersByWorkId.get(workId).getActiveMessageMetadata().orElse(null);
+      return Optional.ofNullable(activeTrackersByWorkId.get(workId).getActiveMessageMetadata()
+          .orElse(null));
     }
-    return null;
+    return Optional.ofNullable(null);
   }
 
   @Nullable

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
@@ -38,8 +38,8 @@ public final class DataflowExecutionStateSampler extends ExecutionStateSampler {
 
   private final ConcurrentHashMap<String, DataflowExecutionStateTracker> activeTrackersByWorkId =
       new ConcurrentHashMap<>();
-  private final ConcurrentHashMap<String, Map<String, IntSummaryStatistics>> completedProcessingMetrics =
-      new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, Map<String, IntSummaryStatistics>>
+      completedProcessingMetrics = new ConcurrentHashMap<>();
 
   public static DataflowExecutionStateSampler instance() {
     return INSTANCE;

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
@@ -19,10 +19,10 @@ package org.apache.beam.runners.dataflow.worker;
 
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkNotNull;
 
-import java.util.HashMap;
 import java.util.IntSummaryStatistics;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.concurrent.ConcurrentHashMap;
 import javax.annotation.Nullable;
 import org.apache.beam.runners.core.metrics.ExecutionStateSampler;
 import org.apache.beam.runners.core.metrics.ExecutionStateTracker;
@@ -36,10 +36,10 @@ public final class DataflowExecutionStateSampler extends ExecutionStateSampler {
   private static final DataflowExecutionStateSampler INSTANCE =
       new DataflowExecutionStateSampler(SYSTEM_MILLIS_PROVIDER);
 
-  private final HashMap<String, DataflowExecutionStateTracker> activeTrackersByWorkId =
-      new HashMap<>();
-  private final HashMap<String, Map<String, IntSummaryStatistics>> completedProcessingMetrics =
-      new HashMap<>();
+  private final ConcurrentHashMap<String, DataflowExecutionStateTracker> activeTrackersByWorkId =
+      new ConcurrentHashMap<>();
+  private final ConcurrentHashMap<String, Map<String, IntSummaryStatistics>> completedProcessingMetrics =
+      new ConcurrentHashMap<>();
 
   public static DataflowExecutionStateSampler instance() {
     return INSTANCE;
@@ -125,11 +125,11 @@ public final class DataflowExecutionStateSampler extends ExecutionStateSampler {
     }
     DataflowExecutionStateTracker tracker = activeTrackersByWorkId.get(workId);
     return mergeStepStatsMaps(
-        completedProcessingMetrics.getOrDefault(workId, new HashMap<>()),
+        completedProcessingMetrics.getOrDefault(workId, new ConcurrentHashMap<>()),
         tracker.getProcessingTimesByStep());
   }
 
-  public synchronized void resetForWorkId(String workId) {
+  public void resetForWorkId(String workId) {
     completedProcessingMetrics.remove(workId);
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -1877,7 +1877,7 @@ public class StreamingDataflowWorker {
         clock.get().minus(Duration.millis(options.getActiveWorkRefreshPeriodMillis()));
 
     for (Map.Entry<String, ComputationState> entry : computationMap.entrySet()) {
-      active.put(entry.getKey(), entry.getValue().getKeysToRefresh(refreshDeadline));
+      active.put(entry.getKey(), entry.getValue().getKeysToRefresh(refreshDeadline, sampler));
     }
 
     metricTrackingWindmillServer.refreshActiveWork(active);
@@ -1891,7 +1891,7 @@ public class StreamingDataflowWorker {
     }
   }
 
-  private static String constructWorkId(Windmill.WorkItem workItem) {
+  public static String constructWorkId(Windmill.WorkItem workItem) {
     StringBuilder workIdBuilder = new StringBuilder(33);
     workIdBuilder.append(Long.toHexString(workItem.getShardingKey()));
     workIdBuilder.append('-');

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -1163,7 +1163,8 @@ public class StreamingDataflowWorker {
 
       // Add the output to the commit queue.
       work.setState(State.COMMIT_QUEUED);
-      outputBuilder.addAllPerWorkItemLatencyAttributions(work.getLatencyAttributions());
+      outputBuilder.addAllPerWorkItemLatencyAttributions(
+          work.getLatencyAttributions(false, constructWorkId(workItem), sampler));
 
       WorkItemCommitRequest commitRequest = outputBuilder.build();
       int byteLimit = maxWorkItemCommitBytes;

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -57,7 +57,6 @@ import java.util.function.Function;
 import java.util.function.Supplier;
 import javax.servlet.http.HttpServletRequest;
 import javax.servlet.http.HttpServletResponse;
-import org.apache.beam.runners.core.metrics.ExecutionStateSampler;
 import org.apache.beam.runners.core.metrics.MetricsLogger;
 import org.apache.beam.runners.dataflow.DataflowRunner;
 import org.apache.beam.runners.dataflow.internal.CustomSources;
@@ -286,6 +285,8 @@ public class StreamingDataflowWorker {
   private ScheduledExecutorService globalConfigRefreshTimer;
   // Possibly overridden by streaming engine config.
   private int maxWorkItemCommitBytes = Integer.MAX_VALUE;
+
+  private DataflowExecutionStateSampler sampler = DataflowExecutionStateSampler.instance();
 
   @VisibleForTesting
   StreamingDataflowWorker(
@@ -575,7 +576,7 @@ public class StreamingDataflowWorker {
     memoryMonitorThread.start();
     dispatchThread.start();
     commitThread.start();
-    ExecutionStateSampler.instance().start();
+    sampler.start();
 
     // Periodically report workers counters and other updates.
     globalWorkerUpdatesTimer = executorSupplier.apply("GlobalWorkerUpdatesTimer");
@@ -993,7 +994,7 @@ public class StreamingDataflowWorker {
             (InstructionOutputNode) Iterables.getOnlyElement(mapTaskNetwork.successors(readNode));
         DataflowExecutionContext.DataflowExecutionStateTracker executionStateTracker =
             new DataflowExecutionContext.DataflowExecutionStateTracker(
-                ExecutionStateSampler.instance(),
+                sampler,
                 stageInfo
                     .executionStateRegistry()
                     .getState(
@@ -1292,6 +1293,7 @@ public class StreamingDataflowWorker {
         stageInfo.timerProcessingMsecs().addValue(processingTimeMsecs);
       }
 
+      sampler.resetForWorkId(constructWorkId(work.getWorkItem()));
       DataflowWorkerLoggingMDC.setWorkId(null);
       DataflowWorkerLoggingMDC.setStageName(null);
     }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -513,9 +513,7 @@ public class StreamingDataflowWorker {
     Uninterruptibles.sleepUninterruptibly(millis, TimeUnit.MILLISECONDS);
   }
 
-  /**
-   * Sets the stage name and workId of the current Thread for logging.
-   */
+  /** Sets the stage name and workId of the current Thread for logging. */
   private static void setUpWorkLoggingContext(String workId, String computationId) {
     DataflowWorkerLoggingMDC.setWorkId(workId);
     DataflowWorkerLoggingMDC.setStageName(computationId);

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -286,7 +286,7 @@ public class StreamingDataflowWorker {
   // Possibly overridden by streaming engine config.
   private int maxWorkItemCommitBytes = Integer.MAX_VALUE;
 
-  private DataflowExecutionStateSampler sampler = DataflowExecutionStateSampler.instance();
+  private final DataflowExecutionStateSampler sampler = DataflowExecutionStateSampler.instance();
 
   @VisibleForTesting
   StreamingDataflowWorker(

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -514,11 +514,7 @@ public class StreamingDataflowWorker {
 
   /** Sets the stage name and workId of the current Thread for logging. */
   private static void setUpWorkLoggingContext(Windmill.WorkItem workItem, String computationId) {
-    String workIdBuilder =
-        Long.toHexString(workItem.getShardingKey())
-            + '-'
-            + Long.toHexString(workItem.getWorkToken());
-    DataflowWorkerLoggingMDC.setWorkId(workIdBuilder);
+    DataflowWorkerLoggingMDC.setWorkId(constructWorkId(workItem));
     DataflowWorkerLoggingMDC.setStageName(computationId);
   }
 
@@ -1007,7 +1003,7 @@ public class StreamingDataflowWorker {
                         ScopedProfiler.INSTANCE.emptyScope()),
                 stageInfo.deltaCounters(),
                 options,
-                computationId);
+                constructWorkId(workItem));
         StreamingModeExecutionContext context =
             new StreamingModeExecutionContext(
                 pendingDeltaCounters,
@@ -1890,6 +1886,14 @@ public class StreamingDataflowWorker {
     for (Map.Entry<String, ComputationState> entry : computationMap.entrySet()) {
       entry.getValue().invalidateStuckCommits(stuckCommitDeadline);
     }
+  }
+
+  private static String constructWorkId(Windmill.WorkItem workItem) {
+    StringBuilder workIdBuilder = new StringBuilder(33);
+    workIdBuilder.append(Long.toHexString(workItem.getShardingKey()));
+    workIdBuilder.append('-');
+    workIdBuilder.append(Long.toHexString(workItem.getWorkToken()));
+    return workIdBuilder.toString();
   }
 
   private class HarnessDataProvider implements StatusDataProvider {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/ActiveWorkState.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/ActiveWorkState.java
@@ -212,15 +212,16 @@ final class ActiveWorkState {
     return stuckCommits.build();
   }
 
-  synchronized ImmutableList<KeyedGetDataRequest> getKeysToRefresh(Instant refreshDeadline,
-      DataflowExecutionStateSampler sampler) {
+  synchronized ImmutableList<KeyedGetDataRequest> getKeysToRefresh(
+      Instant refreshDeadline, DataflowExecutionStateSampler sampler) {
     return activeWork.entrySet().stream()
         .flatMap(entry -> toKeyedGetDataRequestStream(entry, refreshDeadline, sampler))
         .collect(toImmutableList());
   }
 
   private static Stream<KeyedGetDataRequest> toKeyedGetDataRequestStream(
-      Entry<ShardedKey, Deque<Work>> shardedKeyAndWorkQueue, Instant refreshDeadline,
+      Entry<ShardedKey, Deque<Work>> shardedKeyAndWorkQueue,
+      Instant refreshDeadline,
       DataflowExecutionStateSampler sampler) {
     ShardedKey shardedKey = shardedKeyAndWorkQueue.getKey();
     Deque<Work> workQueue = shardedKeyAndWorkQueue.getValue();
@@ -234,8 +235,8 @@ final class ActiveWorkState {
                     .setShardingKey(shardedKey.shardingKey())
                     .setWorkToken(work.getWorkItem().getWorkToken())
                     .addAllLatencyAttribution(
-                        work.getLatencyAttributions(true, constructWorkId(work.getWorkItem()),
-                            sampler))
+                        work.getLatencyAttributions(
+                            true, constructWorkId(work.getWorkItem()), sampler))
                     .build());
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/ActiveWorkState.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/ActiveWorkState.java
@@ -32,6 +32,7 @@ import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import javax.annotation.concurrent.GuardedBy;
 import javax.annotation.concurrent.ThreadSafe;
+import org.apache.beam.runners.dataflow.worker.DataflowExecutionStateSampler;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.KeyedGetDataRequest;
 import org.apache.beam.runners.dataflow.worker.windmill.state.WindmillStateCache;
@@ -229,7 +230,9 @@ final class ActiveWorkState {
                     .setKey(shardedKey.key())
                     .setShardingKey(shardedKey.shardingKey())
                     .setWorkToken(work.getWorkItem().getWorkToken())
-                    .addAllLatencyAttribution(work.getLatencyAttributions())
+                    // TODO(clairemccarthy): plumb real values.
+                    .addAllLatencyAttribution(work.getLatencyAttributions(true, "",
+                        DataflowExecutionStateSampler.instance()))
                     .build());
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/ActiveWorkState.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/ActiveWorkState.java
@@ -234,8 +234,7 @@ final class ActiveWorkState {
                     .setShardingKey(shardedKey.shardingKey())
                     .setWorkToken(work.getWorkItem().getWorkToken())
                     .addAllLatencyAttribution(
-                        work.getLatencyAttributions(
-                            true, work.getLatencyTrackingId(), sampler))
+                        work.getLatencyAttributions(true, work.getLatencyTrackingId(), sampler))
                     .build());
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/ActiveWorkState.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/ActiveWorkState.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.runners.dataflow.worker.streaming;
 
-import static org.apache.beam.runners.dataflow.worker.StreamingDataflowWorker.constructWorkId;
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList.toImmutableList;
 
 import java.io.PrintWriter;
@@ -236,7 +235,7 @@ final class ActiveWorkState {
                     .setWorkToken(work.getWorkItem().getWorkToken())
                     .addAllLatencyAttribution(
                         work.getLatencyAttributions(
-                            true, constructWorkId(work.getWorkItem()), sampler))
+                            true, work.getLatencyTrackingId(), sampler))
                     .build());
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/ComputationState.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/ComputationState.java
@@ -120,11 +120,9 @@ public class ComputationState implements AutoCloseable {
     executor.forceExecute(work, work.getWorkItem().getSerializedSize());
   }
 
-  /**
-   * Adds any work started before the refreshDeadline to the GetDataRequest builder.
-   */
-  public List<Windmill.KeyedGetDataRequest> getKeysToRefresh(Instant refreshDeadline,
-      DataflowExecutionStateSampler sampler) {
+  /** Adds any work started before the refreshDeadline to the GetDataRequest builder. */
+  public List<Windmill.KeyedGetDataRequest> getKeysToRefresh(
+      Instant refreshDeadline, DataflowExecutionStateSampler sampler) {
     return activeWorkState.getKeysToRefresh(refreshDeadline, sampler);
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/ComputationState.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/ComputationState.java
@@ -23,6 +23,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import javax.annotation.Nullable;
+import org.apache.beam.runners.dataflow.worker.DataflowExecutionStateSampler;
 import org.apache.beam.runners.dataflow.worker.util.BoundedQueueExecutor;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
 import org.apache.beam.runners.dataflow.worker.windmill.state.WindmillStateCache;
@@ -119,9 +120,12 @@ public class ComputationState implements AutoCloseable {
     executor.forceExecute(work, work.getWorkItem().getSerializedSize());
   }
 
-  /** Adds any work started before the refreshDeadline to the GetDataRequest builder. */
-  public List<Windmill.KeyedGetDataRequest> getKeysToRefresh(Instant refreshDeadline) {
-    return activeWorkState.getKeysToRefresh(refreshDeadline);
+  /**
+   * Adds any work started before the refreshDeadline to the GetDataRequest builder.
+   */
+  public List<Windmill.KeyedGetDataRequest> getKeysToRefresh(Instant refreshDeadline,
+      DataflowExecutionStateSampler sampler) {
+    return activeWorkState.getKeysToRefresh(refreshDeadline, sampler);
   }
 
   public void printActiveWork(PrintWriter writer) {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/ComputationState.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/ComputationState.java
@@ -24,7 +24,6 @@ import java.util.concurrent.ConcurrentLinkedQueue;
 import javax.annotation.Nullable;
 import org.apache.beam.runners.dataflow.worker.DataflowExecutionStateSampler;
 import org.apache.beam.runners.dataflow.worker.util.BoundedQueueExecutor;
-import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.KeyedGetDataRequest;
 import org.apache.beam.runners.dataflow.worker.windmill.state.WindmillStateCache;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
@@ -121,9 +120,7 @@ public class ComputationState implements AutoCloseable {
     executor.forceExecute(work, work.getWorkItem().getSerializedSize());
   }
 
-  /**
-   * Adds any work started before the refreshDeadline to the GetDataRequest builder.
-   */
+  /** Adds any work started before the refreshDeadline to the GetDataRequest builder. */
   public ImmutableList<KeyedGetDataRequest> getKeysToRefresh(
       Instant refreshDeadline, DataflowExecutionStateSampler sampler) {
     return activeWorkState.getKeysToRefresh(refreshDeadline, sampler);

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/ComputationState.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/ComputationState.java
@@ -19,15 +19,16 @@ package org.apache.beam.runners.dataflow.worker.streaming;
 
 import com.google.api.services.dataflow.model.MapTask;
 import java.io.PrintWriter;
-import java.util.List;
 import java.util.Map;
 import java.util.concurrent.ConcurrentLinkedQueue;
 import javax.annotation.Nullable;
 import org.apache.beam.runners.dataflow.worker.DataflowExecutionStateSampler;
 import org.apache.beam.runners.dataflow.worker.util.BoundedQueueExecutor;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
+import org.apache.beam.runners.dataflow.worker.windmill.Windmill.KeyedGetDataRequest;
 import org.apache.beam.runners.dataflow.worker.windmill.state.WindmillStateCache;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.joda.time.Instant;
 
@@ -120,8 +121,10 @@ public class ComputationState implements AutoCloseable {
     executor.forceExecute(work, work.getWorkItem().getSerializedSize());
   }
 
-  /** Adds any work started before the refreshDeadline to the GetDataRequest builder. */
-  public List<Windmill.KeyedGetDataRequest> getKeysToRefresh(
+  /**
+   * Adds any work started before the refreshDeadline to the GetDataRequest builder.
+   */
+  public ImmutableList<KeyedGetDataRequest> getKeysToRefresh(
       Instant refreshDeadline, DataflowExecutionStateSampler sampler) {
     return activeWorkState.getKeysToRefresh(refreshDeadline, sampler);
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/Work.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/Work.java
@@ -109,8 +109,8 @@ public class Work implements Runnable {
     }
   }
 
-  public Collection<Windmill.LatencyAttribution> getLatencyAttributions(Boolean isHeartbeat,
-      String workId, DataflowExecutionStateSampler sampler) {
+  public Collection<Windmill.LatencyAttribution> getLatencyAttributions(
+      Boolean isHeartbeat, String workId, DataflowExecutionStateSampler sampler) {
     List<Windmill.LatencyAttribution> list = new ArrayList<>();
     for (Windmill.LatencyAttribution.State state : Windmill.LatencyAttribution.State.values()) {
       Duration duration = totalDurationPerState.getOrDefault(state, Duration.ZERO);
@@ -122,24 +122,23 @@ public class Work implements Runnable {
       }
       LatencyAttribution.Builder laBuilder = Windmill.LatencyAttribution.newBuilder();
       if (state == LatencyAttribution.State.ACTIVE) {
-        laBuilder = addActiveLatencyBreakdownToBuilder(isHeartbeat, laBuilder,
-            workId, sampler);
+        laBuilder = addActiveLatencyBreakdownToBuilder(isHeartbeat, laBuilder, workId, sampler);
       }
-      Windmill.LatencyAttribution la = laBuilder
-          .setState(state)
-          .setTotalDurationMillis(duration.getMillis())
-          .build();
+      Windmill.LatencyAttribution la =
+          laBuilder.setState(state).setTotalDurationMillis(duration.getMillis()).build();
       list.add(la);
     }
     return list;
   }
 
-  private static LatencyAttribution.Builder addActiveLatencyBreakdownToBuilder(Boolean isHeartbeat,
-      LatencyAttribution.Builder builder, String workId, DataflowExecutionStateSampler sampler) {
+  private static LatencyAttribution.Builder addActiveLatencyBreakdownToBuilder(
+      Boolean isHeartbeat,
+      LatencyAttribution.Builder builder,
+      String workId,
+      DataflowExecutionStateSampler sampler) {
     if (isHeartbeat) {
       ActiveLatencyBreakdown.Builder stepBuilder = ActiveLatencyBreakdown.newBuilder();
-      ActiveMessageMetadata activeMessage = sampler.getActiveMessageMetadataForWorkId(
-          workId);
+      ActiveMessageMetadata activeMessage = sampler.getActiveMessageMetadataForWorkId(workId);
       if (activeMessage == null) {
         return builder;
       }
@@ -151,20 +150,22 @@ public class Work implements Runnable {
       builder.addActiveLatencyBreakdown(stepBuilder.build());
       return builder;
     }
-    
-    Map<String, IntSummaryStatistics> processingDistributions = sampler.getProcessingDistributionsForWorkId(
-        workId);
+
+    Map<String, IntSummaryStatistics> processingDistributions =
+        sampler.getProcessingDistributionsForWorkId(workId);
     if (processingDistributions == null) {
       return builder;
     }
     for (Entry<String, IntSummaryStatistics> entry : processingDistributions.entrySet()) {
       ActiveLatencyBreakdown.Builder stepBuilder = ActiveLatencyBreakdown.newBuilder();
       stepBuilder.setUserStepName(entry.getKey());
-      Distribution.Builder distributionBuilder = Distribution.newBuilder()
-          .setCount(entry.getValue().getCount())
-          .setMin(entry.getValue().getMin()).setMax(entry.getValue()
-              .getMax()).setMean((long) entry.getValue().getAverage())
-          .setSum(entry.getValue().getSum());
+      Distribution.Builder distributionBuilder =
+          Distribution.newBuilder()
+              .setCount(entry.getValue().getCount())
+              .setMin(entry.getValue().getMin())
+              .setMax(entry.getValue().getMax())
+              .setMean((long) entry.getValue().getAverage())
+              .setSum(entry.getValue().getSum());
       stepBuilder.setProcessingTimesDistribution(distributionBuilder.build());
       builder.addActiveLatencyBreakdown(stepBuilder.build());
     }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/Work.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/Work.java
@@ -136,6 +136,22 @@ public class Work implements Runnable {
 
   private static LatencyAttribution.Builder addActiveLatencyBreakdownToBuilder(Boolean isHeartbeat,
       LatencyAttribution.Builder builder, String workId, DataflowExecutionStateSampler sampler) {
+    if (isHeartbeat) {
+      ActiveLatencyBreakdown.Builder stepBuilder = ActiveLatencyBreakdown.newBuilder();
+      ActiveMessageMetadata activeMessage = sampler.getActiveMessageMetadataForWorkId(
+          workId);
+      if (activeMessage == null) {
+        return builder;
+      }
+      stepBuilder.setUserStepName(activeMessage.userStepName);
+      ActiveElementMetadata.Builder activeElementBuilder = ActiveElementMetadata.newBuilder();
+      activeElementBuilder.setProcessingTimeMillis(
+          System.currentTimeMillis() - activeMessage.startTime);
+      stepBuilder.setActiveMessageMetadata(activeElementBuilder);
+      builder.addActiveLatencyBreakdown(stepBuilder.build());
+      return builder;
+    }
+    
     Map<String, IntSummaryStatistics> processingDistributions = sampler.getProcessingDistributionsForWorkId(
         workId);
     if (processingDistributions == null) {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/Work.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/Work.java
@@ -110,7 +110,7 @@ public class Work implements Runnable {
   }
 
   public Collection<Windmill.LatencyAttribution> getLatencyAttributions(
-      Boolean isHeartbeat, String workId, DataflowExecutionStateSampler sampler) {
+      boolean isHeartbeat, String workId, DataflowExecutionStateSampler sampler) {
     List<Windmill.LatencyAttribution> list = new ArrayList<>();
     for (Windmill.LatencyAttribution.State state : Windmill.LatencyAttribution.State.values()) {
       Duration duration = totalDurationPerState.getOrDefault(state, Duration.ZERO);
@@ -132,7 +132,7 @@ public class Work implements Runnable {
   }
 
   private static LatencyAttribution.Builder addActiveLatencyBreakdownToBuilder(
-      Boolean isHeartbeat,
+      boolean isHeartbeat,
       LatencyAttribution.Builder builder,
       String workId,
       DataflowExecutionStateSampler sampler) {
@@ -142,10 +142,10 @@ public class Work implements Runnable {
       if (activeMessage == null) {
         return builder;
       }
-      stepBuilder.setUserStepName(activeMessage.userStepName);
+      stepBuilder.setUserStepName(activeMessage.userStepName());
       ActiveElementMetadata.Builder activeElementBuilder = ActiveElementMetadata.newBuilder();
       activeElementBuilder.setProcessingTimeMillis(
-          System.currentTimeMillis() - activeMessage.startTime);
+          System.currentTimeMillis() - activeMessage.startTime());
       stepBuilder.setActiveMessageMetadata(activeElementBuilder);
       builder.addActiveLatencyBreakdown(stepBuilder.build());
       return builder;

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/Work.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/Work.java
@@ -101,6 +101,14 @@ public class Work implements Runnable {
     return currentState.startTime();
   }
 
+  public String getLatencyTrackingId() {
+    StringBuilder workIdBuilder = new StringBuilder(33);
+    workIdBuilder.append(Long.toHexString(workItem.getShardingKey()));
+    workIdBuilder.append('-');
+    workIdBuilder.append(Long.toHexString(workItem.getWorkToken()));
+    return workIdBuilder.toString();
+  }
+
   private void recordGetWorkStreamLatencies(
       Collection<Windmill.LatencyAttribution> getWorkStreamLatencies) {
     for (Windmill.LatencyAttribution latency : getWorkStreamLatencies) {

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/Work.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/Work.java
@@ -163,9 +163,6 @@ public class Work implements Runnable {
 
     Map<String, IntSummaryStatistics> processingDistributions =
         sampler.getProcessingDistributionsForWorkId(workId);
-    if (processingDistributions == null) {
-      return builder;
-    }
     for (Entry<String, IntSummaryStatistics> entry : processingDistributions.entrySet()) {
       ActiveLatencyBreakdown.Builder stepBuilder = ActiveLatencyBreakdown.newBuilder();
       stepBuilder.setUserStepName(entry.getKey());

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/Work.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/Work.java
@@ -25,6 +25,7 @@ import java.util.IntSummaryStatistics;
 import java.util.List;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Optional;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import javax.annotation.concurrent.NotThreadSafe;
@@ -146,14 +147,15 @@ public class Work implements Runnable {
       DataflowExecutionStateSampler sampler) {
     if (isHeartbeat) {
       ActiveLatencyBreakdown.Builder stepBuilder = ActiveLatencyBreakdown.newBuilder();
-      ActiveMessageMetadata activeMessage = sampler.getActiveMessageMetadataForWorkId(workId);
-      if (activeMessage == null) {
+      Optional<ActiveMessageMetadata> activeMessage = sampler.getActiveMessageMetadataForWorkId(
+          workId);
+      if (!activeMessage.isPresent()) {
         return builder;
       }
-      stepBuilder.setUserStepName(activeMessage.userStepName());
+      stepBuilder.setUserStepName(activeMessage.get().userStepName());
       ActiveElementMetadata.Builder activeElementBuilder = ActiveElementMetadata.newBuilder();
       activeElementBuilder.setProcessingTimeMillis(
-          System.currentTimeMillis() - activeMessage.startTime());
+          System.currentTimeMillis() - activeMessage.get().startTime());
       stepBuilder.setActiveMessageMetadata(activeElementBuilder);
       builder.addActiveLatencyBreakdown(stepBuilder.build());
       return builder;

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/Work.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/Work.java
@@ -18,7 +18,6 @@
 package org.apache.beam.runners.dataflow.worker.streaming;
 
 import com.google.auto.value.AutoValue;
-import java.util.Collections;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumMap;
@@ -149,8 +148,8 @@ public class Work implements Runnable {
       DataflowExecutionStateSampler sampler) {
     if (isHeartbeat) {
       ActiveLatencyBreakdown.Builder stepBuilder = ActiveLatencyBreakdown.newBuilder();
-      Optional<ActiveMessageMetadata> activeMessage = sampler.getActiveMessageMetadataForWorkId(
-          workId);
+      Optional<ActiveMessageMetadata> activeMessage =
+          sampler.getActiveMessageMetadataForWorkId(workId);
       if (!activeMessage.isPresent()) {
         return builder;
       }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/Work.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/Work.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.dataflow.worker.streaming;
 
 import com.google.auto.value.AutoValue;
+import java.util.Collections;
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.EnumMap;
@@ -36,6 +37,7 @@ import org.apache.beam.runners.dataflow.worker.windmill.Windmill.LatencyAttribut
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.LatencyAttribution.ActiveLatencyBreakdown;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.LatencyAttribution.ActiveLatencyBreakdown.ActiveElementMetadata;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.LatencyAttribution.ActiveLatencyBreakdown.Distribution;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 
@@ -118,7 +120,7 @@ public class Work implements Runnable {
     }
   }
 
-  public Collection<Windmill.LatencyAttribution> getLatencyAttributions(
+  public ImmutableList<LatencyAttribution> getLatencyAttributions(
       boolean isHeartbeat, String workId, DataflowExecutionStateSampler sampler) {
     List<Windmill.LatencyAttribution> list = new ArrayList<>();
     for (Windmill.LatencyAttribution.State state : Windmill.LatencyAttribution.State.values()) {
@@ -137,7 +139,7 @@ public class Work implements Runnable {
           laBuilder.setState(state).setTotalDurationMillis(duration.getMillis()).build();
       list.add(la);
     }
-    return list;
+    return ImmutableList.copyOf(list);
   }
 
   private static LatencyAttribution.Builder addActiveLatencyBreakdownToBuilder(

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionContextTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionContextTest.java
@@ -138,9 +138,9 @@ public class DataflowExecutionContextTest {
 
     // After entering a process state, we should have an active message tracked.
     ActiveMessageMetadata expectedMetadata =
-        new ActiveMessageMetadata(NameContextsForTests.nameContextForTest().userName(), 1l);
+        ActiveMessageMetadata.create(NameContextsForTests.nameContextForTest().userName(), 1l);
     Assert.assertEquals(
-        expectedMetadata.userStepName, tracker.getActiveMessageMetadata().userStepName);
+        expectedMetadata.userStepName(), tracker.getActiveMessageMetadata().userStepName());
 
     closure.close();
 
@@ -181,8 +181,8 @@ public class DataflowExecutionContextTest {
         new HashSet<>(Arrays.asList(NameContextsForTests.nameContextForTest().userName())),
         gotProcessingTimes.keySet());
     ActiveMessageMetadata expectedMetadata =
-        new ActiveMessageMetadata(NameContextsForTests.nameContextForTest().userName(), 1l);
+        ActiveMessageMetadata.create(NameContextsForTests.nameContextForTest().userName(), 1l);
     Assert.assertEquals(
-        expectedMetadata.userStepName, tracker.getActiveMessageMetadata().userStepName);
+        expectedMetadata.userStepName(), tracker.getActiveMessageMetadata().userStepName());
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionContextTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionContextTest.java
@@ -139,13 +139,14 @@ public class DataflowExecutionContextTest {
     // After entering a process state, we should have an active message tracked.
     ActiveMessageMetadata expectedMetadata =
         ActiveMessageMetadata.create(NameContextsForTests.nameContextForTest().userName(), 1l);
+    assertTrue(tracker.getActiveMessageMetadata().isPresent());
     Assert.assertEquals(
-        expectedMetadata.userStepName(), tracker.getActiveMessageMetadata().userStepName());
+        expectedMetadata.userStepName(), tracker.getActiveMessageMetadata().get().userStepName());
 
     closure.close();
 
     // Once the state closes, the active message should get cleared.
-    Assert.assertEquals(null, tracker.getActiveMessageMetadata());
+    assertFalse(tracker.getActiveMessageMetadata().isPresent());
   }
 
   @Test
@@ -182,7 +183,8 @@ public class DataflowExecutionContextTest {
         gotProcessingTimes.keySet());
     ActiveMessageMetadata expectedMetadata =
         ActiveMessageMetadata.create(NameContextsForTests.nameContextForTest().userName(), 1l);
+    assertTrue(tracker.getActiveMessageMetadata().isPresent());
     Assert.assertEquals(
-        expectedMetadata.userStepName(), tracker.getActiveMessageMetadata().userStepName());
+        expectedMetadata.userStepName(), tracker.getActiveMessageMetadata().get().userStepName());
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSamplerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSamplerTest.java
@@ -1,8 +1,23 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.beam.runners.dataflow.worker;
 
 import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.anEmptyMap;
-import static org.hamcrest.Matchers.empty;
 import static org.hamcrest.Matchers.equalTo;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.when;
@@ -31,8 +46,9 @@ public class DataflowExecutionStateSamplerTest {
     sampler = DataflowExecutionStateSampler.newForTest(clock);
   }
 
-  private final TestOperationContext.TestDataflowExecutionState step1act1 = new TestOperationContext.TestDataflowExecutionState(
-      createNameContext("test-stage1"), "activity1");
+  private final TestOperationContext.TestDataflowExecutionState step1act1 =
+      new TestOperationContext.TestDataflowExecutionState(
+          createNameContext("test-stage1"), "activity1");
 
   private NameContext createNameContext(String userName) {
     return NameContext.create("", "", "", userName);
@@ -41,15 +57,13 @@ public class DataflowExecutionStateSamplerTest {
   @Test
   public void testAddTrackerRemoveTrackerActiveMessageMetadataGetsUpdated() {
     String workId = "work-item-id1";
-    ActiveMessageMetadata testMetadata = new ActiveMessageMetadata(
-        step1act1.getStepName().userName(),
-        clock.getMillis());
+    ActiveMessageMetadata testMetadata =
+        new ActiveMessageMetadata(step1act1.getStepName().userName(), clock.getMillis());
     DataflowExecutionStateTracker trackerMock = createMockTracker(workId);
     when(trackerMock.getActiveMessageMetadata()).thenReturn(testMetadata);
 
     sampler.addTracker(trackerMock);
-    assertThat(sampler.getActiveMessageMetadataForWorkId(workId),
-        equalTo(testMetadata));
+    assertThat(sampler.getActiveMessageMetadataForWorkId(workId), equalTo(testMetadata));
 
     sampler.removeTracker(trackerMock);
     Assert.assertNull(sampler.getActiveMessageMetadataForWorkId(workId));
@@ -66,8 +80,8 @@ public class DataflowExecutionStateSamplerTest {
     sampler.addTracker(trackerMock);
     sampler.removeTracker(trackerMock);
 
-    assertThat(sampler.getProcessingDistributionsForWorkId(workId),
-        equalTo(testCompletedProcessingTimes));
+    assertThat(
+        sampler.getProcessingDistributionsForWorkId(workId), equalTo(testCompletedProcessingTimes));
   }
 
   @Test
@@ -79,19 +93,17 @@ public class DataflowExecutionStateSamplerTest {
     testSummaryStats.accept(3);
     testSummaryStats.accept(5);
     testCompletedProcessingTimes.put("some-step", testSummaryStats);
-    ActiveMessageMetadata testMetadata = new ActiveMessageMetadata(
-        step1act1.getStepName().userName(),
-        clock.getMillis());
+    ActiveMessageMetadata testMetadata =
+        new ActiveMessageMetadata(step1act1.getStepName().userName(), clock.getMillis());
     DataflowExecutionStateTracker trackerMock = createMockTracker(workId);
     when(trackerMock.getActiveMessageMetadata()).thenReturn(testMetadata);
     when(trackerMock.getProcessingTimesByStep()).thenReturn(testCompletedProcessingTimes);
 
     sampler.addTracker(trackerMock);
 
-    assertThat(sampler.getActiveMessageMetadataForWorkId(workId),
-        equalTo(testMetadata));
-    assertThat(sampler.getProcessingDistributionsForWorkId(workId),
-        equalTo(testCompletedProcessingTimes));
+    assertThat(sampler.getActiveMessageMetadataForWorkId(workId), equalTo(testMetadata));
+    assertThat(
+        sampler.getProcessingDistributionsForWorkId(workId), equalTo(testCompletedProcessingTimes));
   }
 
   @Test
@@ -104,20 +116,25 @@ public class DataflowExecutionStateSamplerTest {
     sampler.addTracker(tracker1Mock);
     sampler.addTracker(tracker2Mock);
 
-    assertThat(sampler.getActiveMessageMetadataForWorkId(workId1),
+    assertThat(
+        sampler.getActiveMessageMetadataForWorkId(workId1),
         equalTo(tracker1Mock.getActiveMessageMetadata()));
-    assertThat(sampler.getProcessingDistributionsForWorkId(workId1),
+    assertThat(
+        sampler.getProcessingDistributionsForWorkId(workId1),
         equalTo(tracker1Mock.getProcessingTimesByStep()));
-    assertThat(sampler.getActiveMessageMetadataForWorkId(workId2),
+    assertThat(
+        sampler.getActiveMessageMetadataForWorkId(workId2),
         equalTo(tracker2Mock.getActiveMessageMetadata()));
-    assertThat(sampler.getProcessingDistributionsForWorkId(workId2),
+    assertThat(
+        sampler.getProcessingDistributionsForWorkId(workId2),
         equalTo(tracker2Mock.getProcessingTimesByStep()));
 
     sampler.removeTracker(tracker1Mock);
     sampler.removeTracker(tracker2Mock);
     sampler.resetForWorkId(workId2);
 
-    assertThat(sampler.getProcessingDistributionsForWorkId(workId1),
+    assertThat(
+        sampler.getProcessingDistributionsForWorkId(workId1),
         equalTo(tracker1Mock.getProcessingTimesByStep()));
     Assert.assertNull(sampler.getProcessingDistributionsForWorkId(workId2));
   }

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSamplerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSamplerTest.java
@@ -58,7 +58,7 @@ public class DataflowExecutionStateSamplerTest {
   public void testAddTrackerRemoveTrackerActiveMessageMetadataGetsUpdated() {
     String workId = "work-item-id1";
     ActiveMessageMetadata testMetadata =
-        new ActiveMessageMetadata(step1act1.getStepName().userName(), clock.getMillis());
+        ActiveMessageMetadata.create(step1act1.getStepName().userName(), clock.getMillis());
     DataflowExecutionStateTracker trackerMock = createMockTracker(workId);
     when(trackerMock.getActiveMessageMetadata()).thenReturn(testMetadata);
 
@@ -94,7 +94,7 @@ public class DataflowExecutionStateSamplerTest {
     testSummaryStats.accept(5);
     testCompletedProcessingTimes.put("some-step", testSummaryStats);
     ActiveMessageMetadata testMetadata =
-        new ActiveMessageMetadata(step1act1.getStepName().userName(), clock.getMillis());
+        ActiveMessageMetadata.create(step1act1.getStepName().userName(), clock.getMillis());
     DataflowExecutionStateTracker trackerMock = createMockTracker(workId);
     when(trackerMock.getActiveMessageMetadata()).thenReturn(testMetadata);
     when(trackerMock.getProcessingTimesByStep()).thenReturn(testCompletedProcessingTimes);

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSamplerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSamplerTest.java
@@ -137,7 +137,7 @@ public class DataflowExecutionStateSamplerTest {
     assertThat(
         sampler.getProcessingDistributionsForWorkId(workId1),
         equalTo(tracker1Mock.getProcessingTimesByStep()));
-    Assert.assertNull(sampler.getProcessingDistributionsForWorkId(workId2));
+    Assert.assertTrue(sampler.getProcessingDistributionsForWorkId(workId2).isEmpty());
   }
 
   private DataflowExecutionStateTracker createMockTracker(String workItemId) {

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSamplerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSamplerTest.java
@@ -64,10 +64,10 @@ public class DataflowExecutionStateSamplerTest {
     when(trackerMock.getActiveMessageMetadata()).thenReturn(Optional.of(testMetadata));
 
     sampler.addTracker(trackerMock);
-    assertThat(sampler.getActiveMessageMetadataForWorkId(workId), equalTo(testMetadata));
+    assertThat(sampler.getActiveMessageMetadataForWorkId(workId).get(), equalTo(testMetadata));
 
     sampler.removeTracker(trackerMock);
-    Assert.assertNull(sampler.getActiveMessageMetadataForWorkId(workId));
+    Assert.assertFalse(sampler.getActiveMessageMetadataForWorkId(workId).isPresent());
   }
 
   @Test
@@ -102,7 +102,7 @@ public class DataflowExecutionStateSamplerTest {
 
     sampler.addTracker(trackerMock);
 
-    assertThat(sampler.getActiveMessageMetadataForWorkId(workId), equalTo(testMetadata));
+    assertThat(sampler.getActiveMessageMetadataForWorkId(workId).get(), equalTo(testMetadata));
     assertThat(
         sampler.getProcessingDistributionsForWorkId(workId), equalTo(testCompletedProcessingTimes));
   }
@@ -119,13 +119,13 @@ public class DataflowExecutionStateSamplerTest {
 
     assertThat(
         sampler.getActiveMessageMetadataForWorkId(workId1),
-        equalTo(tracker1Mock.getActiveMessageMetadata().orElse(null)));
+        equalTo(tracker1Mock.getActiveMessageMetadata()));
     assertThat(
         sampler.getProcessingDistributionsForWorkId(workId1),
         equalTo(tracker1Mock.getProcessingTimesByStep()));
     assertThat(
         sampler.getActiveMessageMetadataForWorkId(workId2),
-        equalTo(tracker2Mock.getActiveMessageMetadata().orElse(null)));
+        equalTo(tracker2Mock.getActiveMessageMetadata()));
     assertThat(
         sampler.getProcessingDistributionsForWorkId(workId2),
         equalTo(tracker2Mock.getProcessingTimesByStep()));

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSamplerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSamplerTest.java
@@ -1,0 +1,130 @@
+package org.apache.beam.runners.dataflow.worker;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.anEmptyMap;
+import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.equalTo;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.when;
+
+import java.util.HashMap;
+import java.util.IntSummaryStatistics;
+import java.util.Map;
+import org.apache.beam.runners.dataflow.worker.DataflowExecutionContext.DataflowExecutionStateTracker;
+import org.apache.beam.runners.dataflow.worker.counters.NameContext;
+import org.joda.time.DateTimeUtils.MillisProvider;
+import org.junit.Assert;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.mockito.junit.MockitoJUnitRunner;
+
+@RunWith(MockitoJUnitRunner.class)
+public class DataflowExecutionStateSamplerTest {
+
+  private MillisProvider clock;
+  private DataflowExecutionStateSampler sampler;
+
+  @Before
+  public void setUp() {
+    clock = mock(MillisProvider.class);
+    sampler = DataflowExecutionStateSampler.newForTest(clock);
+  }
+
+  private final TestOperationContext.TestDataflowExecutionState step1act1 = new TestOperationContext.TestDataflowExecutionState(
+      createNameContext("test-stage1"), "activity1");
+
+  private NameContext createNameContext(String userName) {
+    return NameContext.create("", "", "", userName);
+  }
+
+  @Test
+  public void testAddTrackerRemoveTrackerActiveMessageMetadataGetsUpdated() {
+    String workId = "work-item-id1";
+    ActiveMessageMetadata testMetadata = new ActiveMessageMetadata(
+        step1act1.getStepName().userName(),
+        clock.getMillis());
+    DataflowExecutionStateTracker trackerMock = createMockTracker(workId);
+    when(trackerMock.getActiveMessageMetadata()).thenReturn(testMetadata);
+
+    sampler.addTracker(trackerMock);
+    assertThat(sampler.getActiveMessageMetadataForWorkId(workId),
+        equalTo(testMetadata));
+
+    sampler.removeTracker(trackerMock);
+    Assert.assertNull(sampler.getActiveMessageMetadataForWorkId(workId));
+  }
+
+  @Test
+  public void testRemoveTrackerCompletedProcessingTimesGetsUpdated() {
+    String workId = "work-item-id1";
+    Map<String, IntSummaryStatistics> testCompletedProcessingTimes = new HashMap<>();
+    testCompletedProcessingTimes.put("some-step", new IntSummaryStatistics());
+    DataflowExecutionStateTracker trackerMock = createMockTracker(workId);
+    when(trackerMock.getProcessingTimesByStep()).thenReturn(testCompletedProcessingTimes);
+
+    sampler.addTracker(trackerMock);
+    sampler.removeTracker(trackerMock);
+
+    assertThat(sampler.getProcessingDistributionsForWorkId(workId),
+        equalTo(testCompletedProcessingTimes));
+  }
+
+  @Test
+  public void testGetCompletedProcessingTimesAndActiveMessageFromActiveTracker() {
+    String workId = "work-item-id1";
+    Map<String, IntSummaryStatistics> testCompletedProcessingTimes = new HashMap<>();
+    IntSummaryStatistics testSummaryStats = new IntSummaryStatistics();
+    testSummaryStats.accept(1);
+    testSummaryStats.accept(3);
+    testSummaryStats.accept(5);
+    testCompletedProcessingTimes.put("some-step", testSummaryStats);
+    ActiveMessageMetadata testMetadata = new ActiveMessageMetadata(
+        step1act1.getStepName().userName(),
+        clock.getMillis());
+    DataflowExecutionStateTracker trackerMock = createMockTracker(workId);
+    when(trackerMock.getActiveMessageMetadata()).thenReturn(testMetadata);
+    when(trackerMock.getProcessingTimesByStep()).thenReturn(testCompletedProcessingTimes);
+
+    sampler.addTracker(trackerMock);
+
+    assertThat(sampler.getActiveMessageMetadataForWorkId(workId),
+        equalTo(testMetadata));
+    assertThat(sampler.getProcessingDistributionsForWorkId(workId),
+        equalTo(testCompletedProcessingTimes));
+  }
+
+  @Test
+  public void testResetForWorkIdClearsMaps() {
+    String workId1 = "work-item-id1";
+    String workId2 = "work-item-id2";
+    DataflowExecutionStateTracker tracker1Mock = createMockTracker(workId1);
+    DataflowExecutionStateTracker tracker2Mock = createMockTracker(workId2);
+
+    sampler.addTracker(tracker1Mock);
+    sampler.addTracker(tracker2Mock);
+
+    assertThat(sampler.getActiveMessageMetadataForWorkId(workId1),
+        equalTo(tracker1Mock.getActiveMessageMetadata()));
+    assertThat(sampler.getProcessingDistributionsForWorkId(workId1),
+        equalTo(tracker1Mock.getProcessingTimesByStep()));
+    assertThat(sampler.getActiveMessageMetadataForWorkId(workId2),
+        equalTo(tracker2Mock.getActiveMessageMetadata()));
+    assertThat(sampler.getProcessingDistributionsForWorkId(workId2),
+        equalTo(tracker2Mock.getProcessingTimesByStep()));
+
+    sampler.removeTracker(tracker1Mock);
+    sampler.removeTracker(tracker2Mock);
+    sampler.resetForWorkId(workId2);
+
+    assertThat(sampler.getProcessingDistributionsForWorkId(workId1),
+        equalTo(tracker1Mock.getProcessingTimesByStep()));
+    Assert.assertNull(sampler.getProcessingDistributionsForWorkId(workId2));
+  }
+
+  private DataflowExecutionStateTracker createMockTracker(String workItemId) {
+    DataflowExecutionStateTracker trackerMock = mock(DataflowExecutionStateTracker.class);
+    when(trackerMock.getWorkItemId()).thenReturn(workItemId);
+    return trackerMock;
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSamplerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSamplerTest.java
@@ -25,6 +25,7 @@ import static org.mockito.Mockito.when;
 import java.util.HashMap;
 import java.util.IntSummaryStatistics;
 import java.util.Map;
+import java.util.Optional;
 import org.apache.beam.runners.dataflow.worker.DataflowExecutionContext.DataflowExecutionStateTracker;
 import org.apache.beam.runners.dataflow.worker.counters.NameContext;
 import org.joda.time.DateTimeUtils.MillisProvider;
@@ -60,7 +61,7 @@ public class DataflowExecutionStateSamplerTest {
     ActiveMessageMetadata testMetadata =
         ActiveMessageMetadata.create(step1act1.getStepName().userName(), clock.getMillis());
     DataflowExecutionStateTracker trackerMock = createMockTracker(workId);
-    when(trackerMock.getActiveMessageMetadata()).thenReturn(testMetadata);
+    when(trackerMock.getActiveMessageMetadata()).thenReturn(Optional.of(testMetadata));
 
     sampler.addTracker(trackerMock);
     assertThat(sampler.getActiveMessageMetadataForWorkId(workId), equalTo(testMetadata));
@@ -96,7 +97,7 @@ public class DataflowExecutionStateSamplerTest {
     ActiveMessageMetadata testMetadata =
         ActiveMessageMetadata.create(step1act1.getStepName().userName(), clock.getMillis());
     DataflowExecutionStateTracker trackerMock = createMockTracker(workId);
-    when(trackerMock.getActiveMessageMetadata()).thenReturn(testMetadata);
+    when(trackerMock.getActiveMessageMetadata()).thenReturn(Optional.of(testMetadata));
     when(trackerMock.getProcessingTimesByStep()).thenReturn(testCompletedProcessingTimes);
 
     sampler.addTracker(trackerMock);
@@ -118,13 +119,13 @@ public class DataflowExecutionStateSamplerTest {
 
     assertThat(
         sampler.getActiveMessageMetadataForWorkId(workId1),
-        equalTo(tracker1Mock.getActiveMessageMetadata()));
+        equalTo(tracker1Mock.getActiveMessageMetadata().orElse(null)));
     assertThat(
         sampler.getProcessingDistributionsForWorkId(workId1),
         equalTo(tracker1Mock.getProcessingTimesByStep()));
     assertThat(
         sampler.getActiveMessageMetadataForWorkId(workId2),
-        equalTo(tracker2Mock.getActiveMessageMetadata()));
+        equalTo(tracker2Mock.getActiveMessageMetadata().orElse(null)));
     assertThat(
         sampler.getProcessingDistributionsForWorkId(workId2),
         equalTo(tracker2Mock.getProcessingTimesByStep()));

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/FakeWindmillServer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/FakeWindmillServer.java
@@ -80,7 +80,7 @@ class FakeWindmillServer extends WindmillServerStub {
   private final ErrorCollector errorCollector;
   private final ConcurrentHashMap<Long, Consumer<Windmill.CommitStatus>> droppedStreamingCommits;
   private int commitsRequested = 0;
-  private int numGetDataRequests = 0;
+  private List<Windmill.GetDataRequest> getDataRequests = new ArrayList<>();
   private boolean isReady = true;
   private boolean dropStreamingCommits = false;
 
@@ -144,7 +144,7 @@ class FakeWindmillServer extends WindmillServerStub {
   public Windmill.GetDataResponse getData(Windmill.GetDataRequest request) {
     LOG.info("getDataRequest: {}", request.toString());
     validateGetDataRequest(request);
-    ++numGetDataRequests;
+    getDataRequests.add(request);
     GetDataResponse response = dataToOffer.getOrDefault(request);
     LOG.debug("getDataResponse: {}", response.toString());
     return response;
@@ -431,7 +431,11 @@ class FakeWindmillServer extends WindmillServerStub {
   }
 
   public int numGetDataRequests() {
-    return numGetDataRequests;
+    return getDataRequests.size();
+  }
+
+  public List<Windmill.GetDataRequest> getGetDataRequests() {
+    return getDataRequests;
   }
 
   public ArrayList<Windmill.ReportStatsRequest> getStatsReceived() {

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorkerTest.java
@@ -117,7 +117,6 @@ import org.apache.beam.runners.dataflow.worker.windmill.Windmill.KeyedGetDataReq
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.KeyedGetDataResponse;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.KeyedMessageBundle;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.LatencyAttribution;
-import org.apache.beam.runners.dataflow.worker.windmill.Windmill.LatencyAttribution.ActiveLatencyBreakdown.Distribution;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.LatencyAttribution.State;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.Timer;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.Timer.Type;
@@ -3277,8 +3276,8 @@ public class StreamingDataflowWorkerTest {
     work.setState(Work.State.COMMITTING);
     clock.sleep(Duration.millis(60));
 
-    Iterator<LatencyAttribution> it = work.getLatencyAttributions(false,
-        "", DataflowExecutionStateSampler.instance()).iterator();
+    Iterator<LatencyAttribution> it =
+        work.getLatencyAttributions(false, "", DataflowExecutionStateSampler.instance()).iterator();
     assertTrue(it.hasNext());
     LatencyAttribution lat = it.next();
     assertSame(State.QUEUED, lat.getState());
@@ -3491,14 +3490,18 @@ public class StreamingDataflowWorkerTest {
 
     worker.stop();
 
-    LatencyAttribution.Builder expectedActiveLA = LatencyAttribution.newBuilder()
-        .setState(State.ACTIVE)
-        .setTotalDurationMillis(dofnWaitTimeMs);
-    assertThat(workItemCommitRequest.get((long) workToken).getPerWorkItemLatencyAttributions(0),
+    LatencyAttribution.Builder expectedActiveLA =
+        LatencyAttribution.newBuilder()
+            .setState(State.ACTIVE)
+            .setTotalDurationMillis(dofnWaitTimeMs);
+    assertThat(
+        workItemCommitRequest.get((long) workToken).getPerWorkItemLatencyAttributions(0),
         hasProperty("state", Matchers.equalTo(State.ACTIVE)));
-    assertThat(workItemCommitRequest.get((long) workToken).getPerWorkItemLatencyAttributions(0),
+    assertThat(
+        workItemCommitRequest.get((long) workToken).getPerWorkItemLatencyAttributions(0),
         hasProperty("totalDurationMillis", Matchers.equalTo(1000L)));
-    assertThat(workItemCommitRequest.get((long) workToken).getPerWorkItemLatencyAttributions(0),
+    assertThat(
+        workItemCommitRequest.get((long) workToken).getPerWorkItemLatencyAttributions(0),
         hasProperty("activeLatencyBreakdown"));
     if (streamingEngine) {
       // Initial fake latency provided to FakeWindmillServer when invoke receiveWork in
@@ -3531,14 +3534,13 @@ public class StreamingDataflowWorkerTest {
     Map<Long, Windmill.WorkItemCommitRequest> result = server.waitForAndGetCommits(1);
     Windmill.WorkItemCommitRequest commit = result.get(0L);
 
-    Windmill.LatencyAttribution.Builder laBuilder = LatencyAttribution.newBuilder()
-        .setState(State.ACTIVE)
-        .setTotalDurationMillis(100);
+    Windmill.LatencyAttribution.Builder laBuilder =
+        LatencyAttribution.newBuilder().setState(State.ACTIVE).setTotalDurationMillis(100);
     for (LatencyAttribution la : commit.getPerWorkItemLatencyAttributionsList()) {
       if (la.getState() == State.ACTIVE) {
         assertThat(la.getActiveLatencyBreakdownCount(), equalTo(1));
-        assertThat(la.getActiveLatencyBreakdown(0).getUserStepName(),
-            equalTo(DEFAULT_PARDO_USER_NAME));
+        assertThat(
+            la.getActiveLatencyBreakdown(0).getUserStepName(), equalTo(DEFAULT_PARDO_USER_NAME));
         Assert.assertTrue(la.getActiveLatencyBreakdown(0).hasProcessingTimesDistribution());
         Assert.assertFalse(la.getActiveLatencyBreakdown(0).hasActiveMessageMetadata());
       }
@@ -3571,8 +3573,8 @@ public class StreamingDataflowWorkerTest {
     assertThat(server.numGetDataRequests(), greaterThan(0));
     Windmill.GetDataRequest heartbeat = server.getGetDataRequests().get(2);
 
-    for (LatencyAttribution la : heartbeat.getRequests(0).getRequests(0)
-        .getLatencyAttributionList()) {
+    for (LatencyAttribution la :
+        heartbeat.getRequests(0).getRequests(0).getLatencyAttributionList()) {
       if (la.getState() == State.ACTIVE) {
         assertTrue(la.getActiveLatencyBreakdownCount() > 0);
         assertTrue(la.getActiveLatencyBreakdown(0).hasActiveMessageMetadata());

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/ActiveWorkStateTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/ActiveWorkStateTest.java
@@ -252,8 +252,8 @@ public class ActiveWorkStateTest {
     activeWorkState.activateWorkForKey(shardedKey1, freshWork);
     activeWorkState.activateWorkForKey(shardedKey2, refreshableWork2);
 
-    ImmutableList<KeyedGetDataRequest> requests = activeWorkState.getKeysToRefresh(refreshDeadline,
-        DataflowExecutionStateSampler.instance());
+    ImmutableList<KeyedGetDataRequest> requests =
+        activeWorkState.getKeysToRefresh(refreshDeadline, DataflowExecutionStateSampler.instance());
 
     ImmutableList<GetDataRequestKeyShardingKeyAndWorkToken> expected =
         ImmutableList.of(

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/ActiveWorkStateTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/ActiveWorkStateTest.java
@@ -33,6 +33,7 @@ import java.util.HashMap;
 import java.util.Map;
 import java.util.Optional;
 import javax.annotation.Nullable;
+import org.apache.beam.runners.dataflow.worker.DataflowExecutionStateSampler;
 import org.apache.beam.runners.dataflow.worker.streaming.ActiveWorkState.ActivateWorkResult;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill;
 import org.apache.beam.runners.dataflow.worker.windmill.Windmill.KeyedGetDataRequest;
@@ -251,7 +252,8 @@ public class ActiveWorkStateTest {
     activeWorkState.activateWorkForKey(shardedKey1, freshWork);
     activeWorkState.activateWorkForKey(shardedKey2, refreshableWork2);
 
-    ImmutableList<KeyedGetDataRequest> requests = activeWorkState.getKeysToRefresh(refreshDeadline);
+    ImmutableList<KeyedGetDataRequest> requests = activeWorkState.getKeysToRefresh(refreshDeadline,
+        DataflowExecutionStateSampler.instance());
 
     ImmutableList<GetDataRequestKeyShardingKeyAndWorkToken> expected =
         ImmutableList.of(

--- a/runners/google-cloud-dataflow-java/worker/windmill/src/main/proto/windmill.proto
+++ b/runners/google-cloud-dataflow-java/worker/windmill/src/main/proto/windmill.proto
@@ -59,6 +59,21 @@ message KeyedMessageBundle {
 }
 
 message LatencyAttribution {
+  message ActiveLatencyBreakdown {
+    message Distribution {
+      optional int64 count = 1;
+      optional int64 sum = 2;
+      optional int64 min = 3;
+      optional int64 max = 4;
+      optional int64 mean = 5;
+    }
+    message ActiveElementMetadata {
+      optional int64 processing_time_millis = 1;
+    }
+    optional string user_step_name = 1;
+    optional Distribution processing_times_distribution = 2;
+    optional ActiveElementMetadata active_message_metadata = 3;
+  }
   enum State {
     UNKNOWN = 0;
     QUEUED = 1;
@@ -79,6 +94,7 @@ message LatencyAttribution {
   }
   optional State state = 1;
   optional int64 total_duration_millis = 2;
+  repeated ActiveLatencyBreakdown active_latency_breakdown = 3;
 }
 
 message PerStepNamespaceMetrics {


### PR DESCRIPTION
Tracks the amount of time dofn processing takes for individual messages run on the StreamingDataflowWorker.

Changes:
- modifies the DataflowExecutionStateTracker to record processing times per message per DoFn.
    - When the tracker transitions state, the time spent in state is recorded in an in-memory map (keyed by DoFn name) 
    - Trackers are now identified by shardingkey-worktoken.
- adds a DataflowExecutionStateSampler (extension of existing ExecutionStateSampler) that is responsible for managing ExecutionStateTrackers over the lifetime of the StreamingDataflowWorker.
    - When trackers get removed (ie, processing has completed for the thread / work item it was responsible for), synthesized summary statistics from the tracker are held onto inside of the sampler until the work item has been committed (at which point the in-memory map is cleared for that work item).
- adds a message to the windmill API proto for sending dofn latency info back to windmill
    - On the heartbeats: sends the DoFn name that the currently active message is in and how long it has been there for
    - On commits: sends the mean, min, max, count, and sum of individual message processing times for each DoFn

Load testing has been performed to ensure these changes do not introduce significant changes in user worker memory usage or windmill API bytes transferred. 

addresses #29602 
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
