### PR TITLE
Improve varint encoding throughput by using buffers of approximate size

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/VarInt.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/VarInt.java
@@ -31,22 +31,26 @@ import java.io.OutputStream;
  */
 public class VarInt {
 
+  private static long convertIntToLongNoSignExtend(int v) {
+    return v & 0xFFFFFFFFL;
+  }
+
   /** Encodes the given value onto the stream. */
   public static void encode(int v, OutputStream stream) throws IOException {
-    do {
-      // Encode next 7 bits + terminator bit
-      long bits = v & 0x7F;
-      v >>>= 7;
-      byte b = (byte) (bits | ((v != 0) ? 0x80 : 0));
-      stream.write(b);
-    } while (v != 0);
+    encode(convertIntToLongNoSignExtend(v), stream);
   }
 
   /** Encodes the given value onto the stream. */
   public static void encode(long v, OutputStream stream) throws IOException {
     // Write 1-5 bytes
     if ((v & ~0xFFFFFFFFL) == 0) {
-      encode((int) v, stream);
+      do {
+        // Encode next 7 bits + terminator bit
+        long bits = v & 0x7F;
+        v >>>= 7;
+        byte b = (byte) (bits | ((v != 0) ? 0x80 : 0));
+        stream.write(b);
+      } while (v != 0);
       return;
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/VarInt.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/VarInt.java
@@ -59,7 +59,7 @@ public class VarInt {
     final byte[] buf = new byte[sz];
     int pos = 0;
 
-    // Write 6-10 bytes
+    // Write 5-10 bytes
     do {
       // Encode next 7 bits + terminator bit
       long bits = v & 0x7F;


### PR DESCRIPTION
This change should improve varint encoding throughput by 1.5-6x for multi-byte encodings according to benchmark tests on an Apple M1 Pro machine.
The single byte case is handled by directly writing to the stream, which can't be sped up.
All multi byte cases seem to benefit from using an intermediate buffer and writing the entire buffer to the stream.
When the order of the mask is inversed (i.e. 1-5 writes to array, 5-10 writes to stream) the throughput metrics return to their old state, so this does not seem to be a case of branch prediction playing tricks.

The buffer length is approximated, which improved throughput on size calculation by 1.1x and overall encoding throughput by 1.3x. I am aware that the bit shift loop in getLength is typically faster than constant time tricks (it was hard to beat), but this approximation avoids a divide by 7 which typically causes that to be slower.

I've benchmarked this using JMH with 3 warmups, 5 iterations, and 1 fork on an Apple M1 Pro machine (happy to provide results from other platforms).
The benchmark constructs 2048 random longs and adds bits to produce an even distribution of small and large integers.
- "All" encodes as is to a pre-constructed ByteArrayOutputStream
- "ExtraLarge" marks a bit to force only 10 bytes of output before encoding
- "Large" marks a bit to force only 4 bytes of output before encoding
- "Medium" marks a bit to force only 2 bytes of output before encoding
- "Small" marks a bit to force only 1 byte of output before encoding

```
Benchmark                                      Mode  Cnt       Score       Error  Units
VarIntBenchmark.benchmarkNewVarIntAll         thrpt    5  320828.193 ± 20567.050  ops/s
VarIntBenchmark.benchmarkNewVarIntExtraLarge  thrpt    5  243184.470 ± 31068.177  ops/s
VarIntBenchmark.benchmarkNewVarIntLarge       thrpt    5  373675.092 ±  6412.076  ops/s
VarIntBenchmark.benchmarkNewVarIntMedium      thrpt    5  338347.826 ± 18859.258  ops/s
VarIntBenchmark.benchmarkNewVarIntSmall       thrpt    5  415559.304 ±  8169.027  ops/s
VarIntBenchmark.benchmarkOldVarIntAll         thrpt    5  191424.762 ±  3954.473  ops/s
VarIntBenchmark.benchmarkOldVarIntExtraLarge  thrpt    5   41411.167 ±  1322.300  ops/s
VarIntBenchmark.benchmarkOldVarIntLarge       thrpt    5  102820.015 ±  5414.503  ops/s
VarIntBenchmark.benchmarkOldVarIntMedium      thrpt    5  204669.983 ± 24894.096  ops/s
VarIntBenchmark.benchmarkOldVarIntSmall       thrpt    5  415046.963 ±  9567.074  ops/s

```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
