### PR TITLE
Partially revert changes from #29587

### DIFF
--- a/sdks/python/apache_beam/runners/worker/bundle_processor.py
+++ b/sdks/python/apache_beam/runners/worker/bundle_processor.py
@@ -378,11 +378,6 @@ coder_impl.FastPrimitivesCoderImpl.register_iterable_like_type(
 
 
 class StateBackedSideInputMap(object):
-
-  _BULK_READ_LIMIT = 100
-  _BULK_READ_FULLY = "fully"
-  _BULK_READ_PARTIALLY = "partially"
-
   def __init__(self,
                state_handler,  # type: sdk_worker.CachingStateHandler
                transform_id,  # type: str
@@ -422,53 +417,13 @@ class StateBackedSideInputMap(object):
                 side_input_id=self._tag,
                 window=self._target_window_coder.encode(target_window),
                 key=b''))
-        kv_iter_state_key = beam_fn_api_pb2.StateKey(
-            multimap_keys_values_side_input=beam_fn_api_pb2.StateKey.
-            MultimapKeysValuesSideInput(
-                transform_id=self._transform_id,
-                side_input_id=self._tag,
-                window=self._target_window_coder.encode(target_window)))
         cache = {}
         key_coder = self._element_coder.key_coder()
         key_coder_impl = key_coder.get_impl()
         value_coder = self._element_coder.value_coder()
 
         class MultiMap(object):
-          _bulk_read = None
-          _lock = threading.Lock()
-
           def __getitem__(self, key):
-            if self._bulk_read is None:
-              with self._lock:
-                if self._bulk_read is None:
-                  try:
-                    # Attempt to bulk read the key-values over the iterable
-                    # protocol which, if supported, can be much more efficient
-                    # than point lookups if it fits into memory.
-                    for ix, (k, vs) in enumerate(_StateBackedIterable(
-                        state_handler,
-                        kv_iter_state_key,
-                        coders.TupleCoder(
-                            (key_coder, coders.IterableCoder(value_coder))))):
-                      cache[k] = vs
-                      if ix > StateBackedSideInputMap._BULK_READ_LIMIT:
-                        self._bulk_read = (
-                            StateBackedSideInputMap._BULK_READ_PARTIALLY)
-                        break
-                    else:
-                      # We reached the end of the iteration without breaking.
-                      self._bulk_read = (
-                          StateBackedSideInputMap._BULK_READ_FULLY)
-                  except Exception:
-                    _LOGGER.error(
-                        "Iterable access of map side inputs unsupported.",
-                        exc_info=True)
-                    self._bulk_read = (
-                        StateBackedSideInputMap._BULK_READ_PARTIALLY)
-
-            if (self._bulk_read == StateBackedSideInputMap._BULK_READ_FULLY):
-              return cache.get(key, [])
-
             if key not in cache:
               keyed_state_key = beam_fn_api_pb2.StateKey()
               keyed_state_key.CopyFrom(state_key)


### PR DESCRIPTION
#29587 introduced changes to allow the usage of the multimap_keys_values_side_input state key. Since some runners don't support this key yet, usage was wrapped in a try/except block so that when talking to the runner if an error state response was received then it would no-op. In practice, some runners close the data channel on unknown state keys, so this introduced a regression. This attempts to minimally fix the problem by reverting part of #29587

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
