### PR TITLE
Deep-copy the process bundle descriptor when creating a new bundle processor.

### DIFF
--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -23,7 +23,6 @@
 import abc
 import collections
 import contextlib
-import copy
 import functools
 import json
 import logging
@@ -490,14 +489,18 @@ class BundleProcessorCache(object):
         pass
 
     # Make sure we instantiate the processor while not holding the lock.
+
+    # Reduce risks of concurrent modifications of the same protos
+    # captured in bundle descriptor when the same bundle descriptor is used
+    # in different instructions.
+    pbd = beam_fn_api_pb2.ProcessBundleDescriptor()
+    pbd.MergeFrom(self.fns[bundle_descriptor_id])
+
     processor = bundle_processor.BundleProcessor(
         self.runner_capabilities,
-        # Reduce risks of concurrent modifications of the same protos
-        # captured in bundle descriptor when the same bundle desciptor is used
-        # in different instructions.
-        copy.deepcopy(self.fns[bundle_descriptor_id]),
+        pbd,
         self.state_handler_factory.create_state_handler(
-            self.fns[bundle_descriptor_id].state_api_service_descriptor),
+            pbd.state_api_service_descriptor),
         self.data_channel_factory,
         self.data_sampler)
     with self._lock:

--- a/sdks/python/apache_beam/runners/worker/sdk_worker.py
+++ b/sdks/python/apache_beam/runners/worker/sdk_worker.py
@@ -23,6 +23,7 @@
 import abc
 import collections
 import contextlib
+import copy
 import functools
 import json
 import logging
@@ -491,7 +492,10 @@ class BundleProcessorCache(object):
     # Make sure we instantiate the processor while not holding the lock.
     processor = bundle_processor.BundleProcessor(
         self.runner_capabilities,
-        self.fns[bundle_descriptor_id],
+        # Reduce risks of concurrent modifications of the same protos
+        # captured in bundle descriptor when the same bundle desciptor is used
+        # in different instructions.
+        copy.deepcopy(self.fns[bundle_descriptor_id]),
         self.state_handler_factory.create_state_handler(
             self.fns[bundle_descriptor_id].state_api_service_descriptor),
         self.data_channel_factory,


### PR DESCRIPTION
After protobuf v4 upgrade we are seeing SDK crashes in #27330 .

A possible reason might be that micro-protobuf protos objects are more sensitive to unsafe concurrent modifications, leading to process memory corruption.

This change should reduce the risk of concurrent modifications.

