### PR TITLE
Fix GenerateSequenceSchemaTransformProvider formatting

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/providers/GenerateSequenceSchemaTransformProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/providers/GenerateSequenceSchemaTransformProvider.java
@@ -67,9 +67,9 @@ public class GenerateSequenceSchemaTransformProvider
     return String.format(
         "Outputs a PCollection of Beam Rows, each containing a single INT64 "
             + "number called \"value\". The count is produced from the given \"start\""
-            + "value and either up to the given \"end\" or until 2^63 - 1.\n"
+            + "value and either up to the given \"end\" or until 2^63 - 1.%n"
             + "To produce an unbounded PCollection, simply do not specify an \"end\" value. "
-            + "Unbounded sequences can specify a \"rate\" for output elements.\n"
+            + "Unbounded sequences can specify a \"rate\" for output elements.%n"
             + "In all cases, the sequence of numbers is generated in parallel, so there is no "
             + "inherent ordering between the generated values");
   }


### PR DESCRIPTION
Right now, this is breaking the java precommit because it is causing a spotbugs failure.

Example: https://github.com/apache/beam/actions/runs/7245514035/job/19735677563

From the report:

```
FS | Format string should use %n rather than \n in org.apache.beam.sdk.providers.GenerateSequenceSchemaTransformProvider.description()

  | Bug type VA_FORMAT_STRING_USES_NEWLINE (click for details)In class org.apache.beam.sdk.providers.GenerateSequenceSchemaTransformProviderIn method org.apache.beam.sdk.providers.GenerateSequenceSchemaTransformProvider.description()Called method String.format(String, Object[])Format string "Outputs a PCollection of Beam Rows, each containing a single INT64 number called "value". The count is produced from the given "start"value and either up to the given "end" or until 2^63 - 1.\nTo produce an unbounded PCollection, simply do not specify an "end" value. Unbounded sequences can specify a "rate" for output elements.\nIn all cases, the sequence of numbers is generated in parallel, so there is no inherent ordering between the generated values"At GenerateSequenceSchemaTransformProvider.java:[line 67]
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
