### PR TITLE
[#29772][Go SDK] Add EventTime Timer tests.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/translate.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/translate.go
@@ -798,7 +798,7 @@ func (b *builder) makeLink(from string, id linkID) (Node, error) {
 		if err != nil {
 			return nil, err
 		}
-		u = &MapWindows{UID: b.idgen.New(), Fn: mapper, Out: out[0]}
+		u = &MapWindows{UID: b.idgen.New(), Fn: mapper, Out: out[0], FnUrn: fn.GetUrn()}
 
 	case graphx.URNFlatten:
 		u = &Flatten{UID: b.idgen.New(), N: len(transform.Inputs), Out: out[0]}

--- a/sdks/go/test/integration/integration.go
+++ b/sdks/go/test/integration/integration.go
@@ -169,6 +169,9 @@ var prismFilters = []string{
 	"TestMapStateClear",
 	"TestSetState",
 	"TestSetStateClear",
+
+	// The prism runner does not support timers https://github.com/apache/beam/issues/29772.
+	"TestTimers*",
 }
 
 var flinkFilters = []string{

--- a/sdks/go/test/integration/integration.go
+++ b/sdks/go/test/integration/integration.go
@@ -136,6 +136,9 @@ var portableFilters = []string{
 	"TestMapStateClear",
 	"TestSetState",
 	"TestSetStateClear",
+
+	// The portable runner does not appear to support timers. (extra elements)
+	"TestTimers.*",
 }
 
 var prismFilters = []string{
@@ -171,7 +174,7 @@ var prismFilters = []string{
 	"TestSetStateClear",
 
 	// The prism runner does not support timers https://github.com/apache/beam/issues/29772.
-	"TestTimers*",
+	"TestTimers.*",
 }
 
 var flinkFilters = []string{
@@ -195,6 +198,9 @@ var flinkFilters = []string{
 	"TestMapStateClear",
 	"TestSetStateClear",
 	"TestSetState",
+
+	// Flink does not appear to support timers. (missing timer elements)
+	"TestTimers.*",
 }
 
 var samzaFilters = []string{
@@ -233,6 +239,9 @@ var samzaFilters = []string{
 	"TestSetStateClear",
 	// TODO(https://github.com/apache/beam/issues/26126): Java runner issue (AcitveBundle has no regsitered handler)
 	"TestDebeziumIO_BasicRead",
+
+	// Samza does not appear to support timers. (missing timer elements)
+	"TestTimers.*",
 }
 
 var sparkFilters = []string{
@@ -264,6 +273,9 @@ var sparkFilters = []string{
 	"TestMapStateClear",
 	"TestSetStateClear",
 	"TestSetState",
+
+	// Spark does not appear to support timers. (Missing all elements)
+	"TestTimers.*",
 }
 
 var dataflowFilters = []string{

--- a/sdks/go/test/integration/primitives/timers.go
+++ b/sdks/go/test/integration/primitives/timers.go
@@ -1,0 +1,131 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package primitives
+
+import (
+	"context"
+	"strconv"
+
+	"github.com/apache/beam/sdks/v2/go/pkg/beam"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/state"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/timers"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/register"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/testing/passert"
+)
+
+// Based on https://github.com/apache/beam/blob/master/runners/flink/src/test/java/org/apache/beam/runners/flink/PortableTimersExecutionTest.java
+
+func init() {
+	register.DoFn2x0[[]byte, func(string, int)](&inputFn[string, int]{})
+	register.DoFn6x0[beam.Window, state.Provider, timers.Provider, string, int, func(kv[string, int])](&eventTimeFn{})
+	register.Emitter2[string, int]()
+	register.Emitter1[kv[string, int]]()
+}
+
+type kv[K, V any] struct {
+	Key   K
+	Value V
+}
+
+func kvfn[K, V any](k K, v V) kv[K, V] {
+	return kv[K, V]{k, v}
+}
+
+type inputFn[K, V any] struct {
+	Inputs []kv[K, V]
+}
+
+func (fn *inputFn[K, V]) ProcessElement(_ []byte, emit func(K, V)) {
+	for _, in := range fn.Inputs {
+		emit(in.Key, in.Value)
+	}
+}
+
+type eventTimeFn struct {
+	Foo    timers.EventTime
+	Sizzle state.Value[string]
+
+	Offset      int
+	TimerOutput int
+}
+
+func (fn *eventTimeFn) ProcessElement(w beam.Window, sp state.Provider, tp timers.Provider, key string, value int, emit func(kv[string, int])) {
+	fn.Foo.Set(tp, w.MaxTimestamp().ToTime())
+	fn.Sizzle.Write(sp, key)
+	emit(kvfn(key, value+fn.Offset))
+}
+
+func (fn *eventTimeFn) OnTimer(ctx context.Context, ts beam.EventTime, sp state.Provider, tp timers.Provider, key string, timer timers.Context, emit func(kv[string, int])) {
+	switch timer.Family {
+	case fn.Foo.Family:
+		switch timer.Tag {
+		case "":
+			read, ok, err := fn.Sizzle.Read(sp)
+			if err != nil {
+				panic(err)
+			}
+			if !ok {
+				panic("State must be set.")
+			}
+			emit(kvfn(read, fn.TimerOutput))
+		}
+	default:
+		if fn.Foo.Family != timer.Family || timer.Tag != "" {
+			panic("unexpected timer family: " + timer.Family + " tag:" + timer.Tag + " want: " + fn.Foo.Family)
+		}
+	}
+}
+
+// TimersEventTime takes in an impulse transform and then validates
+// event time timer execution.
+//
+// The impulse is provided outside to swap between a bounded impulse, and
+// an unbounded one, because the Go SDK uses that to determine if a pipeline
+// is "streaming" or not. This matters at least for executions on Dataflow.
+//
+// Regardless,the pipelines should pass.
+func TimersEventTime(makeImp func(s beam.Scope) beam.PCollection) func(s beam.Scope) {
+	return func(s beam.Scope) {
+		var inputs, wantOutputs []kv[string, int]
+
+		offset := 5000
+		timerOutput := 4093
+
+		numKeys := 50
+		numDuplicateTimers := 15
+
+		for key := 0; key < numKeys; key++ {
+			k := strconv.Itoa(key)
+			wantOutputs = append(wantOutputs, kvfn(k, timerOutput))
+
+			for i := 0; i < numDuplicateTimers; i++ {
+				inputs = append(inputs, kvfn(k, i))
+				wantOutputs = append(wantOutputs, kvfn(k, i+offset))
+			}
+		}
+
+		imp := makeImp(s)
+
+		keyed := beam.ParDo(s, &inputFn[string, int]{
+			Inputs: inputs,
+		}, imp)
+		times := beam.ParDo(s, &eventTimeFn{
+			Offset:      offset,
+			TimerOutput: timerOutput,
+		}, keyed)
+		passert.EqualsList(s, times, wantOutputs)
+	}
+}

--- a/sdks/go/test/integration/primitives/timers_test.go
+++ b/sdks/go/test/integration/primitives/timers_test.go
@@ -17,25 +17,19 @@ package primitives
 
 import (
 	"testing"
-	"time"
 
-	"github.com/apache/beam/sdks/v2/go/pkg/beam"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/testing/ptest"
-	"github.com/apache/beam/sdks/v2/go/pkg/beam/transforms/periodic"
 	"github.com/apache/beam/sdks/v2/go/test/integration"
 )
 
 func TestTimers_EventTime_Bounded(t *testing.T) {
 	integration.CheckFilters(t)
-	ptest.BuildAndRun(t, TimersEventTime(beam.Impulse))
+	ptest.BuildAndRun(t, TimersEventTime_Bounded)
 }
 
 func TestTimers_EventTime_Unbounded(t *testing.T) {
 	integration.CheckFilters(t)
-	ptest.BuildAndRun(t, TimersEventTime(func(s beam.Scope) beam.PCollection {
-		now := time.Now()
-		return periodic.Impulse(s, now, now.Add(10*time.Second), 0, false)
-	}))
+	ptest.BuildAndRun(t, TimersEventTime_Unbounded)
 }
 
 // TODO(https://github.com/apache/beam/issues/29772): Add ProcessingTime Timer tests.

--- a/sdks/go/test/integration/primitives/timers_test.go
+++ b/sdks/go/test/integration/primitives/timers_test.go
@@ -1,3 +1,18 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
 package primitives
 
 import (

--- a/sdks/go/test/integration/primitives/timers_test.go
+++ b/sdks/go/test/integration/primitives/timers_test.go
@@ -1,0 +1,26 @@
+package primitives
+
+import (
+	"testing"
+	"time"
+
+	"github.com/apache/beam/sdks/v2/go/pkg/beam"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/testing/ptest"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/transforms/periodic"
+	"github.com/apache/beam/sdks/v2/go/test/integration"
+)
+
+func TestTimers_EventTime_Bounded(t *testing.T) {
+	integration.CheckFilters(t)
+	ptest.BuildAndRun(t, TimersEventTime(beam.Impulse))
+}
+
+func TestTimers_EventTime_Unbounded(t *testing.T) {
+	integration.CheckFilters(t)
+	ptest.BuildAndRun(t, TimersEventTime(func(s beam.Scope) beam.PCollection {
+		now := time.Now()
+		return periodic.Impulse(s, now, now.Add(10*time.Second), 0, false)
+	}))
+}
+
+// TODO(https://github.com/apache/beam/issues/29772): Add ProcessingTime Timer tests.


### PR DESCRIPTION
Add event time timer validation tests.

Execute both with bounded, and unbounded modes incase runners execute them differently (namely dataflow).

Fix bug in handling MapWindows, which couldn't map from Global Windows to GlobalWindows properly due to a quirk in the SDK's Window Coder + KV handling.

Pre-Work for #29772

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
