### PR TITLE
Support logical types with arguments in Python SDK

### DIFF
--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -711,7 +711,6 @@ class LogicalType(Generic[LanguageT, RepresentationT, ArgT]):
     representing the type parameterized by the argument should be returned.
 
     The returned type should be a subclass of LanguageT"""
-    return type(f'LanguageT.__name__')
     raise NotImplementedError()
 
   @classmethod
@@ -1180,18 +1179,6 @@ class VariableString(PassThroughLogicalType[str, np.int32]):
     return self.max_length
 
 
-class EnumerationTypeValue:
-  def __init__(self, enumeration_type, value):
-    self.typ = enumeration_type
-    self.value = value
-
-  def get_typ(self):
-    return self.typ
-
-  def get_value(self):
-    return self.value
-
-
 class EnumerationTypeType:
   def __init__(self, values: dict):
     self.values = frozenset(values.items())
@@ -1200,9 +1187,6 @@ class EnumerationTypeType:
     """Makes this typing.Callable for <Python3.11
     """
     pass
-
-  def values(self) -> dict:
-    return self.values
 
   def __hash__(self):
     return hash((EnumerationTypeType, self.values))
@@ -1221,11 +1205,8 @@ class EnumerationTypeType:
 
 class EnumerationTypeValue(EnumerationTypeType):
   def __init__(self, values, value):
-    super.__init__(values)
+    super().__init__(values)
     self.value = value
-
-  def value(self):
-    return self.value
 
 
 @LogicalType.register_logical_type

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -343,8 +343,14 @@ class SchemaTranslation(object):
       argument = None
       if logical_type.argument_type() is not None:
         argument_type = self.typing_to_runner_api(logical_type.argument_type())
-        argument = self.value_to_runner_api(
-            argument_type, logical_type.argument())
+        try:
+          argument = self.value_to_runner_api(
+              argument_type, logical_type.argument())
+        except ValueError:
+          # TODO(https://github.com/apache/beam/issues/23373): Complete support
+          # for logical types that require arguments beyond atomic type.
+          # For now, skip arguments.
+          argument = None
       return schema_pb2.FieldType(
           logical_type=schema_pb2.LogicalType(
               urn=logical_type.urn(),

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -813,9 +813,10 @@ class LogicalType(Generic[LanguageT, RepresentationT, ArgT]):
       return logical_type()
     else:
       argument = value_from_runner_api(
-        logical_type_proto.argument_type, logical_type_proto.argument)
+          logical_type_proto.argument_type, logical_type_proto.argument)
       logical_type_instance = logical_type(argument)
-      LogicalType.register_logical_type_with_argument(logical_type, logical_type_instance._language_type())
+      LogicalType.register_logical_type_with_argument(
+          logical_type, logical_type_instance._language_type())
       return logical_type_instance
 
 

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -688,11 +688,6 @@ ArgT = TypeVar('ArgT')
 class LogicalType(Generic[LanguageT, RepresentationT, ArgT]):
   _known_logical_types = LogicalTypeRegistry()
 
-  def __call__(self):
-    """Makes all LogicalType subclasses typing.Callable for <Python3.11
-    """
-    pass
-
   @classmethod
   def urn(cls):
     # type: () -> str
@@ -1199,6 +1194,12 @@ class EnumerationTypeValue:
 class EnumerationTypeType:
   def __init__(self, values: dict):
     self.values = frozenset(values.items())
+
+  def __call__(self):
+    """Makes this typing.Callable to pass runtime typechecks in <Python3.11
+    """
+    pass
+
 
   def values(self) -> dict:
     return self.values

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -688,6 +688,11 @@ ArgT = TypeVar('ArgT')
 class LogicalType(Generic[LanguageT, RepresentationT, ArgT]):
   _known_logical_types = LogicalTypeRegistry()
 
+  def __call__(self):
+    """Makes all LogicalType subclasses typing.Callable for <Python3.11
+    """
+    pass
+
   @classmethod
   def urn(cls):
     # type: () -> str

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -711,7 +711,7 @@ class LogicalType(Generic[LanguageT, RepresentationT, ArgT]):
     representing the type parameterized by the argument should be returned.
 
     The returned type should be a subclass of LanguageT"""
-    raise NotImplementedError()
+    return cls.language_type()
 
   @classmethod
   def representation_type(cls):

--- a/sdks/python/apache_beam/typehints/schemas.py
+++ b/sdks/python/apache_beam/typehints/schemas.py
@@ -711,6 +711,7 @@ class LogicalType(Generic[LanguageT, RepresentationT, ArgT]):
     representing the type parameterized by the argument should be returned.
 
     The returned type should be a subclass of LanguageT"""
+    return type(f'LanguageT.__name__')
     raise NotImplementedError()
 
   @classmethod
@@ -1196,10 +1197,9 @@ class EnumerationTypeType:
     self.values = frozenset(values.items())
 
   def __call__(self):
-    """Makes this typing.Callable to pass runtime typechecks in <Python3.11
+    """Makes this typing.Callable for <Python3.11
     """
     pass
-
 
   def values(self) -> dict:
     return self.values
@@ -1249,7 +1249,7 @@ class EnumerationType(LogicalType[EnumerationTypeValue, np.int32, dict]):
   @classmethod
   def argument_type(cls):
     # type: () -> type
-    return dict[np.int32, str]
+    return Dict[np.int32, str]
 
   def argument(self):
     # type: () -> ArgT

--- a/sdks/python/apache_beam/typehints/schemas_test.py
+++ b/sdks/python/apache_beam/typehints/schemas_test.py
@@ -137,6 +137,40 @@ def get_test_beam_fieldtype_protos():
       schema_pb2.FieldType(
           row_type=schema_pb2.RowType(
               schema=schema_pb2.Schema(
+                  id='logical-map',
+                  fields=[
+                      schema_pb2.Field(
+                          name='logicalmapdict',
+                          type=schema_pb2.FieldType(
+                              nullable=True,
+                              logical_type=schema_pb2.LogicalType(
+                                  urn="beam:logical_type:pythonenum",
+                                  representation=schema_pb2.FieldType(
+                                      atomic_type=schema_pb2.INT32),
+                                  argument=schema_pb2.FieldValue(
+                                      map_value=schema_pb2.MapTypeValue(
+                                          # Use a single value to avoid non-deterministic map ordering
+                                          entries=[
+                                              schema_pb2.MapTypeEntry(
+                                                  key=schema_pb2.FieldValue(
+                                                      atomic_value=schema_pb2.
+                                                      AtomicTypeValue(int32=0)),
+                                                  value=schema_pb2.FieldValue(
+                                                      atomic_value=schema_pb2.
+                                                      AtomicTypeValue(
+                                                          string="A")))
+                                          ])),
+                                  argument_type=schema_pb2.FieldType(
+                                      map_type=schema_pb2.MapType(
+                                          key_type=schema_pb2.FieldType(
+                                              atomic_type=schema_pb2.INT32),
+                                          value_type=schema_pb2.FieldType(
+                                              atomic_type=schema_pb2.STRING)))))
+                      ),
+                  ]))),
+      schema_pb2.FieldType(
+          row_type=schema_pb2.RowType(
+              schema=schema_pb2.Schema(
                   id='32497414-85e8-46b7-9c90-9a9cc62fe390',
                   fields=[
                       schema_pb2.Field(name='field%d' % i, type=typ) for i,

--- a/sdks/python/apache_beam/typehints/schemas_test.py
+++ b/sdks/python/apache_beam/typehints/schemas_test.py
@@ -362,7 +362,7 @@ def get_test_beam_fieldtype_protos_with_logical_types():
               representation=schema_pb2.FieldType(atomic_type=schema_pb2.INT32),
               argument=schema_pb2.FieldValue(
                   map_value=schema_pb2.MapTypeValue(
-                      # Use a single value to avoid non-deterministic map ordering
+                      # avoid non-deterministic map ordering
                       entries=[
                           schema_pb2.MapTypeEntry(
                               key=schema_pb2.FieldValue(
@@ -396,7 +396,7 @@ def get_test_beam_fieldtype_protos_with_logical_types():
                                       atomic_type=schema_pb2.INT32),
                                   argument=schema_pb2.FieldValue(
                                       map_value=schema_pb2.MapTypeValue(
-                                          # Use a single value to avoid non-deterministic map ordering
+                                          # 1 entry; avoid ordering
                                           entries=[
                                               schema_pb2.MapTypeEntry(
                                                   key=schema_pb2.FieldValue(

--- a/sdks/python/apache_beam/typehints/schemas_test.py
+++ b/sdks/python/apache_beam/typehints/schemas_test.py
@@ -133,41 +133,8 @@ def get_test_beam_fieldtype_protos():
       value_type in itertools.product(all_primitives, all_primitives)
   ]
 
+
   selected_schemas = [
-      schema_pb2.FieldType(
-          row_type=schema_pb2.RowType(
-              schema=schema_pb2.Schema(
-                  id='logical-map',
-                  fields=[
-                      schema_pb2.Field(
-                          name='logicalmapdict',
-                          type=schema_pb2.FieldType(
-                              nullable=True,
-                              logical_type=schema_pb2.LogicalType(
-                                  urn="beam:logical_type:pythonenum",
-                                  representation=schema_pb2.FieldType(
-                                      atomic_type=schema_pb2.INT32),
-                                  argument=schema_pb2.FieldValue(
-                                      map_value=schema_pb2.MapTypeValue(
-                                          # Use a single value to avoid non-deterministic map ordering
-                                          entries=[
-                                              schema_pb2.MapTypeEntry(
-                                                  key=schema_pb2.FieldValue(
-                                                      atomic_value=schema_pb2.
-                                                      AtomicTypeValue(int32=0)),
-                                                  value=schema_pb2.FieldValue(
-                                                      atomic_value=schema_pb2.
-                                                      AtomicTypeValue(
-                                                          string="A")))
-                                          ])),
-                                  argument_type=schema_pb2.FieldType(
-                                      map_type=schema_pb2.MapType(
-                                          key_type=schema_pb2.FieldType(
-                                              atomic_type=schema_pb2.INT32),
-                                          value_type=schema_pb2.FieldType(
-                                              atomic_type=schema_pb2.STRING)))))
-                      ),
-                  ]))),
       schema_pb2.FieldType(
           row_type=schema_pb2.RowType(
               schema=schema_pb2.Schema(
@@ -384,6 +351,75 @@ def get_test_beam_fieldtype_protos():
       basic_map_types + \
       selected_schemas
 
+# Separate list of fieldtype_protos including logical types to avoid
+# testing arrow type compatibility
+def get_test_beam_fieldtype_protos_with_logical_types():
+  logical_types = [
+                          schema_pb2.FieldType(
+                              nullable=True,
+                              logical_type=schema_pb2.LogicalType(
+                                  urn="beam:logical_type:pythonenum",
+                                  representation=schema_pb2.FieldType(
+                                      atomic_type=schema_pb2.INT32),
+                                  argument=schema_pb2.FieldValue(
+                                      map_value=schema_pb2.MapTypeValue(
+                                          # Use a single value to avoid non-deterministic map ordering
+                                          entries=[
+                                              schema_pb2.MapTypeEntry(
+                                                  key=schema_pb2.FieldValue(
+                                                      atomic_value=schema_pb2.
+                                                      AtomicTypeValue(int32=0)),
+                                                  value=schema_pb2.FieldValue(
+                                                      atomic_value=schema_pb2.
+                                                      AtomicTypeValue(
+                                                          string="A")))
+                                          ])),
+                                  argument_type=schema_pb2.FieldType(
+                                      map_type=schema_pb2.MapType(
+                                          key_type=schema_pb2.FieldType(
+                                              atomic_type=schema_pb2.INT32),
+                                          value_type=schema_pb2.FieldType(
+                                              atomic_type=schema_pb2.STRING)))))
+
+  ]
+
+  selected_schemas_with_logical_types = [
+      schema_pb2.FieldType(
+          row_type=schema_pb2.RowType(
+              schema=schema_pb2.Schema(
+                  id='logical-map',
+                  fields=[
+                      schema_pb2.Field(
+                          name='logicalmapdict',
+                          type=schema_pb2.FieldType(
+                              nullable=True,
+                              logical_type=schema_pb2.LogicalType(
+                                  urn="beam:logical_type:pythonenum",
+                                  representation=schema_pb2.FieldType(
+                                      atomic_type=schema_pb2.INT32),
+                                  argument=schema_pb2.FieldValue(
+                                      map_value=schema_pb2.MapTypeValue(
+                                          # Use a single value to avoid non-deterministic map ordering
+                                          entries=[
+                                              schema_pb2.MapTypeEntry(
+                                                  key=schema_pb2.FieldValue(
+                                                      atomic_value=schema_pb2.
+                                                      AtomicTypeValue(int32=0)),
+                                                  value=schema_pb2.FieldValue(
+                                                      atomic_value=schema_pb2.
+                                                      AtomicTypeValue(
+                                                          string="A")))
+                                          ])),
+                                  argument_type=schema_pb2.FieldType(
+                                      map_type=schema_pb2.MapType(
+                                          key_type=schema_pb2.FieldType(
+                                              atomic_type=schema_pb2.INT32),
+                                          value_type=schema_pb2.FieldType(
+                                              atomic_type=schema_pb2.STRING)))))
+                      ),
+                  ])))
+  ]
+  return get_test_beam_fieldtype_protos() + selected_schemas_with_logical_types + logical_types
 
 def get_test_beam_schemas_protos():
   return [
@@ -547,7 +583,7 @@ class SchemaTest(unittest.TestCase):
 
   @parameterized.expand([
       (fieldtype_proto, )
-      for fieldtype_proto in get_test_beam_fieldtype_protos()
+      for fieldtype_proto in get_test_beam_fieldtype_protos_with_logical_types()
   ])
   def test_proto_survives_typing_roundtrip(self, fieldtype_proto):
     self.assertEqual(

--- a/sdks/python/apache_beam/typehints/schemas_test.py
+++ b/sdks/python/apache_beam/typehints/schemas_test.py
@@ -133,7 +133,6 @@ def get_test_beam_fieldtype_protos():
       value_type in itertools.product(all_primitives, all_primitives)
   ]
 
-
   selected_schemas = [
       schema_pb2.FieldType(
           row_type=schema_pb2.RowType(
@@ -351,36 +350,34 @@ def get_test_beam_fieldtype_protos():
       basic_map_types + \
       selected_schemas
 
+
 # Separate list of fieldtype_protos including logical types to avoid
 # testing arrow type compatibility
 def get_test_beam_fieldtype_protos_with_logical_types():
   logical_types = [
-                          schema_pb2.FieldType(
-                              nullable=True,
-                              logical_type=schema_pb2.LogicalType(
-                                  urn="beam:logical_type:pythonenum",
-                                  representation=schema_pb2.FieldType(
-                                      atomic_type=schema_pb2.INT32),
-                                  argument=schema_pb2.FieldValue(
-                                      map_value=schema_pb2.MapTypeValue(
-                                          # Use a single value to avoid non-deterministic map ordering
-                                          entries=[
-                                              schema_pb2.MapTypeEntry(
-                                                  key=schema_pb2.FieldValue(
-                                                      atomic_value=schema_pb2.
-                                                      AtomicTypeValue(int32=0)),
-                                                  value=schema_pb2.FieldValue(
-                                                      atomic_value=schema_pb2.
-                                                      AtomicTypeValue(
-                                                          string="A")))
-                                          ])),
-                                  argument_type=schema_pb2.FieldType(
-                                      map_type=schema_pb2.MapType(
-                                          key_type=schema_pb2.FieldType(
-                                              atomic_type=schema_pb2.INT32),
-                                          value_type=schema_pb2.FieldType(
-                                              atomic_type=schema_pb2.STRING)))))
-
+      schema_pb2.FieldType(
+          nullable=True,
+          logical_type=schema_pb2.LogicalType(
+              urn="beam:logical_type:pythonenum",
+              representation=schema_pb2.FieldType(atomic_type=schema_pb2.INT32),
+              argument=schema_pb2.FieldValue(
+                  map_value=schema_pb2.MapTypeValue(
+                      # Use a single value to avoid non-deterministic map ordering
+                      entries=[
+                          schema_pb2.MapTypeEntry(
+                              key=schema_pb2.FieldValue(
+                                  atomic_value=schema_pb2.AtomicTypeValue(
+                                      int32=0)),
+                              value=schema_pb2.FieldValue(
+                                  atomic_value=schema_pb2.AtomicTypeValue(
+                                      string="A")))
+                      ])),
+              argument_type=schema_pb2.FieldType(
+                  map_type=schema_pb2.MapType(
+                      key_type=schema_pb2.FieldType(
+                          atomic_type=schema_pb2.INT32),
+                      value_type=schema_pb2.FieldType(
+                          atomic_type=schema_pb2.STRING)))))
   ]
 
   selected_schemas_with_logical_types = [
@@ -419,7 +416,9 @@ def get_test_beam_fieldtype_protos_with_logical_types():
                       ),
                   ])))
   ]
-  return get_test_beam_fieldtype_protos() + selected_schemas_with_logical_types + logical_types
+  return get_test_beam_fieldtype_protos(
+  ) + selected_schemas_with_logical_types + logical_types
+
 
 def get_test_beam_schemas_protos():
   return [
@@ -581,10 +580,8 @@ class SchemaTest(unittest.TestCase):
     #for attr in dir(expected):
     #  self.assertEqual(getattr(actual, attr), getattr(expected, attr))
 
-  @parameterized.expand([
-      (fieldtype_proto, )
-      for fieldtype_proto in get_test_beam_fieldtype_protos_with_logical_types()
-  ])
+  @parameterized.expand([(fieldtype_proto, ) for fieldtype_proto in
+                         get_test_beam_fieldtype_protos_with_logical_types()])
   def test_proto_survives_typing_roundtrip(self, fieldtype_proto):
     self.assertEqual(
         fieldtype_proto,


### PR DESCRIPTION
Fixes: https://github.com/apache/beam/issues/23373

Possible (partial) implementation of logical types with arguments. Currently, only map and atomic values are supported.

Adds an instance method _language_type() to LogicalType that returns the language type for a specific instance of a logical type, i.e. a logical type with a specific argument. For logical types without arguments, this should just return the existing language_type().

Several downsides:
- Types need to be hashable and in practice should define a hash function that is a combination of the class and the argument. This implies the argument needs to be hashable as well.
- PassThroughLogicalTypes cannot have an argument, as it's impossible for the language type to match the representation type while also acting as a container for the argument that is excluded from the representation (by definition).

I'm not sure if there's a better way to approach this? I can also remove the EnumerationType from schemas.py and use a test specific schema defined/registered in schemas_test.py.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
