### PR TITLE
Use RemoveSafeDeltaCounterCell for PerWorker counters

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/RemoveSafeDeltaCounterCell.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/RemoveSafeDeltaCounterCell.java
@@ -45,7 +45,7 @@ public class RemoveSafeDeltaCounterCell implements Counter, MetricCell<Long> {
    * @param countersMap The underlying {@code map} used to store this metric.
    */
   public RemoveSafeDeltaCounterCell(
-      @Nonnull MetricName metricName, ConcurrentHashMap<MetricName, AtomicLong> countersMap) {
+      MetricName metricName, ConcurrentHashMap<MetricName, AtomicLong> countersMap) {
     this.metricName = metricName;
     this.countersMap = countersMap;
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/RemoveSafeDeltaCounterCell.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/RemoveSafeDeltaCounterCell.java
@@ -19,7 +19,6 @@ package org.apache.beam.runners.dataflow.worker;
 
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
-import javax.annotation.Nonnull;
 import org.apache.beam.runners.core.metrics.CounterCell;
 import org.apache.beam.runners.core.metrics.DirtyState;
 import org.apache.beam.runners.core.metrics.MetricCell;
@@ -34,8 +33,17 @@ import org.apache.beam.sdk.metrics.MetricName;
 public class RemoveSafeDeltaCounterCell implements Counter, MetricCell<Long> {
 
   private final MetricName metricName;
+  /**
+   * This class does not own {@code countersMap} and only operates on a single key in the map
+   * specified by {@code metricName}. These opeations include the {@link Counter} interface along
+   * with the {@code deleteIfZero} method.
+   */
   private final ConcurrentHashMap<MetricName, AtomicLong> countersMap;
 
+  /**
+   * @param metricName Specifies which metric this counter refers to.
+   * @param countersMap The underlying {@code map} used to store this metric.
+   */
   public RemoveSafeDeltaCounterCell(
       @Nonnull MetricName metricName, ConcurrentHashMap<MetricName, AtomicLong> countersMap) {
     this.metricName = metricName;

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/RemoveSafeDeltaCounterCell.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/RemoveSafeDeltaCounterCell.java
@@ -1,0 +1,109 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import javax.annotation.Nonnull;
+import org.apache.beam.runners.core.metrics.CounterCell;
+import org.apache.beam.runners.core.metrics.DirtyState;
+import org.apache.beam.runners.core.metrics.MetricCell;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.MetricName;
+
+/**
+ * Version of {@link CounterCell} supporting multi-thread safe mutations and extraction of delta
+ * values. {@link RemoveSafeDeltaCounterCell} allows safe deletions from the underlying {@code
+ * countersMap} through the {@code deleteIfZero} method.
+ */
+public class RemoveSafeDeltaCounterCell implements Counter, MetricCell<Long> {
+
+  private final MetricName metricName;
+  private final ConcurrentHashMap<MetricName, AtomicLong> countersMap;
+
+  public RemoveSafeDeltaCounterCell(
+      @Nonnull MetricName metricName, ConcurrentHashMap<MetricName, AtomicLong> countersMap) {
+    this.metricName = metricName;
+    this.countersMap = countersMap;
+  }
+
+  @Override
+  public void reset() {
+    countersMap.computeIfPresent(
+        metricName,
+        (unusedName, value) -> {
+          value.set(0);
+          return value;
+        });
+  }
+
+  @Override
+  public void inc(long n) {
+    countersMap.compute(
+        metricName,
+        (name, value) -> {
+          if (value == null) {
+            return new AtomicLong(n);
+          }
+          value.addAndGet(n);
+          return value;
+        });
+  }
+
+  @Override
+  public void inc() {
+    inc(1);
+  }
+
+  @Override
+  public void dec() {
+    inc(-1);
+  }
+
+  @Override
+  public void dec(long n) {
+    inc(-1 * n);
+  }
+
+  @Override
+  public MetricName getName() {
+    return metricName;
+  }
+
+  @Override
+  public DirtyState getDirty() {
+    throw new UnsupportedOperationException(
+        String.format("%s doesn't support the getDirty", getClass().getSimpleName()));
+  }
+
+  @Override
+  public Long getCumulative() {
+    throw new UnsupportedOperationException("getCumulative is not supported by Streaming Metrics");
+  }
+
+  /** Remove the metric from the {@code countersMap} if the the metric is zero valued. */
+  @SuppressWarnings(
+      "nullness") // computeIfPresent's remapping function can return null to remove the entry.
+  public void deleteIfZero() {
+    countersMap.computeIfPresent(
+        metricName,
+        (name, value) -> {
+          return value.get() == 0L ? null : value;
+        });
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/RemoveSafeDeltaCounterCellTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/RemoveSafeDeltaCounterCellTest.java
@@ -1,0 +1,102 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker;
+
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.equalTo;
+import static org.hamcrest.Matchers.is;
+import static org.hamcrest.Matchers.nullValue;
+
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.atomic.AtomicLong;
+import org.apache.beam.sdk.metrics.MetricName;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link RemoveSafeDeltaCounterCell}. */
+@RunWith(JUnit4.class)
+public class RemoveSafeDeltaCounterCellTest {
+
+  @Test
+  public void testRemoveSafeDeltaCounterCell_deleteZero() throws Exception {
+    ConcurrentHashMap<MetricName, AtomicLong> metric_map = new ConcurrentHashMap<>();
+    MetricName metric1 = MetricName.named("namespace", "name_1");
+
+    RemoveSafeDeltaCounterCell cell_1 = new RemoveSafeDeltaCounterCell(metric1, metric_map);
+    RemoveSafeDeltaCounterCell cell_2 = new RemoveSafeDeltaCounterCell(metric1, metric_map);
+
+    cell_2.inc(10);
+    assertThat(metric_map.get(metric1).get(), equalTo(10L));
+
+    cell_2.reset();
+    assertThat(metric_map.get(metric1).get(), equalTo(0L));
+    cell_2.deleteIfZero();
+
+    assertThat(metric_map.get(metric1), is(nullValue()));
+
+    // Incrementing a deleted counter will recreate it.
+    cell_1.inc(20);
+    assertThat(metric_map.get(metric1).get(), equalTo(20L));
+  }
+
+  @Test
+  public void testRemoveSafeDeltaCounterCell_deleteNonZero() throws Exception {
+    ConcurrentHashMap<MetricName, AtomicLong> metric_map = new ConcurrentHashMap<>();
+    MetricName metric1 = MetricName.named("namespace", "name_1");
+
+    RemoveSafeDeltaCounterCell cell_1 = new RemoveSafeDeltaCounterCell(metric1, metric_map);
+    cell_1.inc(10);
+
+    cell_1.deleteIfZero();
+    assertThat(metric_map.size(), equalTo(1));
+    assertThat(metric_map.get(metric1).get(), equalTo(10L));
+  }
+
+  @Test
+  public void testRemoveSafeDeltaCounterCell_multipleUpdates() throws Exception {
+    ConcurrentHashMap<MetricName, AtomicLong> metric_map = new ConcurrentHashMap<>();
+    MetricName metric1 = MetricName.named("namespace", "name_1");
+
+    RemoveSafeDeltaCounterCell cell_1 = new RemoveSafeDeltaCounterCell(metric1, metric_map);
+
+    cell_1.inc();
+    assertThat(metric_map.get(metric1).get(), equalTo(1L));
+
+    cell_1.inc(5);
+    assertThat(metric_map.get(metric1).get(), equalTo(6L));
+
+    cell_1.dec(10);
+    assertThat(metric_map.get(metric1).get(), equalTo(-4L));
+
+    cell_1.dec();
+    assertThat(metric_map.get(metric1).get(), equalTo(-5L));
+  }
+
+  @Test
+  public void testRemoveSafeDeltaCounterCell_resetNonExistant() throws Exception {
+    ConcurrentHashMap<MetricName, AtomicLong> metric_map = new ConcurrentHashMap<>();
+    MetricName metric1 = MetricName.named("namespace", "name_1");
+
+    RemoveSafeDeltaCounterCell cell_1 = new RemoveSafeDeltaCounterCell(metric1, metric_map);
+    assertThat(metric_map.size(), equalTo(0));
+
+    cell_1.reset();
+    assertThat(metric_map.size(), equalTo(0));
+  }
+}


### PR DESCRIPTION
Dataflow Streaming harness's metrics container will store `per worker counters` in a new `RemoveSafeDeltaCounterCell`.

For the new `PerWorkerMetrics` we want to support dynamically creating metrics that may not live the lifetime of the job, therefore we need to implement garbage collection for stale metrics.

E.g. We want to support BigQuery Metrics on a per-bigquery-table basis. If the pipeline uses dynamic destinations to write to 100 tables at 12:00 and at 15:00 is only writing to a few tables, the underlying MetricsContainer should not hold on to metrics for all 100 tables.

In`RemoveSafeDeltaCounterCell` metric updates and deletions are handled atomically - using `ConcurrentHashMap::compute` and `ConcurrentHashMap::remove` respectively - ensuring safe garbage collection.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
