### PR TITLE
[#29772][prism] Handle EventTime Timers.

### DIFF
--- a/sdks/go/pkg/beam/core/timers/timers.go
+++ b/sdks/go/pkg/beam/core/timers/timers.go
@@ -51,9 +51,10 @@ type TimerMap struct {
 	FireTimestamp, HoldTimestamp mtime.Time
 }
 
+// timerConfig is used transiently to hold configuration from the functional options.
 type timerConfig struct {
 	Tag           string
-	HoldSet       bool
+	HoldSet       bool // Whether the HoldTimestamp was set.
 	HoldTimestamp mtime.Time
 }
 

--- a/sdks/go/pkg/beam/core/timers/timers.go
+++ b/sdks/go/pkg/beam/core/timers/timers.go
@@ -53,6 +53,7 @@ type TimerMap struct {
 
 type timerConfig struct {
 	Tag           string
+	HoldSet       bool
 	HoldTimestamp mtime.Time
 }
 
@@ -68,6 +69,7 @@ func WithTag(tag string) timerOptions {
 // WithOutputTimestamp sets the output timestamp for the timer.
 func WithOutputTimestamp(outputTimestamp time.Time) timerOptions {
 	return func(tm *timerConfig) {
+		tm.HoldSet = true
 		tm.HoldTimestamp = mtime.FromTime(outputTimestamp)
 	}
 }
@@ -108,7 +110,7 @@ func (et EventTime) Set(p Provider, FiringTimestamp time.Time, opts ...timerOpti
 		opt(&tc)
 	}
 	tm := TimerMap{Family: et.Family, Tag: tc.Tag, FireTimestamp: mtime.FromTime(FiringTimestamp), HoldTimestamp: mtime.FromTime(FiringTimestamp)}
-	if !tc.HoldTimestamp.ToTime().IsZero() {
+	if tc.HoldSet {
 		tm.HoldTimestamp = tc.HoldTimestamp
 	}
 	p.Set(tm)
@@ -142,7 +144,7 @@ func (pt ProcessingTime) Set(p Provider, FiringTimestamp time.Time, opts ...time
 		opt(&tc)
 	}
 	tm := TimerMap{Family: pt.Family, Tag: tc.Tag, FireTimestamp: mtime.FromTime(FiringTimestamp), HoldTimestamp: mtime.FromTime(FiringTimestamp)}
-	if !tc.HoldTimestamp.ToTime().IsZero() {
+	if tc.HoldSet {
 		tm.HoldTimestamp = tc.HoldTimestamp
 	}
 

--- a/sdks/go/pkg/beam/runners/prism/internal/coders.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/coders.go
@@ -242,14 +242,6 @@ func pullDecoderNoAlloc(c *pipepb.Coder, coders map[string]*pipepb.Coder) func(i
 			kd(r)
 			vd(r)
 		}
-	case urns.CoderTimer:
-		ccids := c.GetComponentCoderIds()
-		kd := pullDecoderNoAlloc(coders[ccids[0]], coders)
-		wd := pullDecoderNoAlloc(coders[ccids[1]], coders)
-		return func(r io.Reader) {
-			kd(r)
-			wd(r)
-		}
 	case urns.CoderRow:
 		panic(fmt.Sprintf("Runner forgot to LP this Row Coder. %v", prototext.Format(c)))
 	default:

--- a/sdks/go/pkg/beam/runners/prism/internal/coders.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/coders.go
@@ -200,7 +200,7 @@ func pullDecoder(c *pipepb.Coder, coders map[string]*pipepb.Coder) func(io.Reade
 	}
 }
 
-// pullDecoderNoAlloc returns a function that decodes a single eleemnt of the given coder.
+// pullDecoderNoAlloc returns a function that decodes a single element of the given coder.
 // Intended to only be used as an internal function for pullDecoder, which will use a io.TeeReader
 // to extract the bytes.
 func pullDecoderNoAlloc(c *pipepb.Coder, coders map[string]*pipepb.Coder) func(io.Reader) {
@@ -241,6 +241,14 @@ func pullDecoderNoAlloc(c *pipepb.Coder, coders map[string]*pipepb.Coder) func(i
 		return func(r io.Reader) {
 			kd(r)
 			vd(r)
+		}
+	case urns.CoderTimer:
+		ccids := c.GetComponentCoderIds()
+		kd := pullDecoderNoAlloc(coders[ccids[0]], coders)
+		wd := pullDecoderNoAlloc(coders[ccids[1]], coders)
+		return func(r io.Reader) {
+			kd(r)
+			wd(r)
 		}
 	case urns.CoderRow:
 		panic(fmt.Sprintf("Runner forgot to LP this Row Coder. %v", prototext.Format(c)))

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/data.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/data.go
@@ -32,6 +32,11 @@ type StateData struct {
 	Multimap map[string][][]byte
 }
 
+// TimerKey is for use as a key for timers.
+type TimerKey struct {
+	Transform, Family string
+}
+
 // TentativeData is where data for in progress bundles is put
 // until the bundle executes successfully.
 type TentativeData struct {
@@ -39,8 +44,8 @@ type TentativeData struct {
 
 	// state is a map from transformID + UserStateID, to window, to userKey, to datavalues.
 	state map[LinkID]map[typex.Window]map[string]StateData
-	// timers is a map from transformID + UserStateID, to window, to userKey, to datavalues.
-	timers map[LinkID][][]byte
+	// timers is a map from the Timer transform+family to the encoded timer.
+	timers map[TimerKey][][]byte
 }
 
 // WriteData adds data to a given global collectionID.
@@ -54,9 +59,9 @@ func (d *TentativeData) WriteData(colID string, data []byte) {
 // WriteTimers adds timers to the associated transform handler.
 func (d *TentativeData) WriteTimers(transformID, familyID string, timers []byte) {
 	if d.timers == nil {
-		d.timers = map[LinkID][][]byte{}
+		d.timers = map[TimerKey][][]byte{}
 	}
-	link := LinkID{Transform: transformID, Local: familyID}
+	link := TimerKey{Transform: transformID, Family: familyID}
 	d.timers[link] = append(d.timers[link], timers)
 }
 

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/data.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/data.go
@@ -39,6 +39,8 @@ type TentativeData struct {
 
 	// state is a map from transformID + UserStateID, to window, to userKey, to datavalues.
 	state map[LinkID]map[typex.Window]map[string]StateData
+	// timers is a map from transformID + UserStateID, to window, to userKey, to datavalues.
+	timers map[LinkID][][]byte
 }
 
 // WriteData adds data to a given global collectionID.
@@ -47,6 +49,15 @@ func (d *TentativeData) WriteData(colID string, data []byte) {
 		d.Raw = map[string][][]byte{}
 	}
 	d.Raw[colID] = append(d.Raw[colID], data)
+}
+
+// WriteTimers adds timers to the associated transform handler.
+func (d *TentativeData) WriteTimers(transformID, familyID string, timers []byte) {
+	if d.timers == nil {
+		d.timers = map[LinkID][][]byte{}
+	}
+	link := LinkID{Transform: transformID, Local: familyID}
+	d.timers[link] = append(d.timers[link], timers)
 }
 
 func (d *TentativeData) toWindow(wKey []byte) typex.Window {

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
@@ -604,7 +604,7 @@ func (em *ElementManager) PersistBundle(rb RunBundle, col2Coders map[string]PCol
 	}
 
 	var pendingTimers []element
-	for family, timers := range d.timers {
+	for tentativeKey, timers := range d.timers {
 		keyToTimers := map[timerKey]element{}
 		for _, t := range timers {
 			key, tag, elms := decodeTimer(inputInfo.KeyDec, true, t)
@@ -618,8 +618,8 @@ func (em *ElementManager) PersistBundle(rb RunBundle, col2Coders map[string]PCol
 		}
 
 		for _, elm := range keyToTimers {
-			elm.transform = family.Transform
-			elm.family = family.Local
+			elm.transform = tentativeKey.Transform
+			elm.family = tentativeKey.Family
 			pendingTimers = append(pendingTimers, elm)
 		}
 	}

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
@@ -607,7 +607,7 @@ func (em *ElementManager) PersistBundle(rb RunBundle, col2Coders map[string]PCol
 	for family, timers := range d.timers {
 		keyToTimers := map[timerKey]element{}
 		for _, t := range timers {
-			key, tag, elms := decodeTimer(nil, true, t)
+			key, tag, elms := decodeTimer(inputInfo.KeyDec, true, t)
 			for _, e := range elms {
 				keyToTimers[timerKey{key: string(key), tag: tag, win: e.window}] = e
 			}

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager_test.go
@@ -294,7 +294,9 @@ func TestStageState_updateWatermarks(t *testing.T) {
 			ss.input = test.initInput
 			ss.output = test.initOutput
 			ss.updateUpstreamWatermark(inputCol, test.upstream)
-			ss.updateWatermarks(test.minPending, test.minStateHold, em)
+			ss.pending = append(ss.pending, element{timestamp: test.minPending})
+			ss.watermarkHoldHeap = append(ss.watermarkHoldHeap, test.minStateHold)
+			ss.updateWatermarks(em)
 			if got, want := ss.input, test.wantInput; got != want {
 				pcol, up := ss.UpstreamWatermark()
 				t.Errorf("ss.updateWatermarks(%v,%v); ss.input = %v, want %v (upstream %v %v)", test.minPending, test.minStateHold, got, want, pcol, up)

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/engine_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/engine_test.go
@@ -89,7 +89,17 @@ func initTestName(fn any) string {
 	return name[n+1:]
 }
 
-func TestStateAPI(t *testing.T) {
+// TestStatefulStages validates that stateful transform execution is correct in
+// four different modes for producing bundles:
+//
+//   - Greedily batching all ready keys and elements.
+//   - All elements for a single key.
+//   - Only one element for each available key.
+//   - Only one element.
+//
+// Executing these pipeline here ensures their coverage is reflected in the
+// engine package.
+func TestStatefulStages(t *testing.T) {
 	initRunner(t)
 
 	tests := []struct {
@@ -105,6 +115,8 @@ func TestStateAPI(t *testing.T) {
 		{pipeline: primitives.MapStateParDoClear},
 		{pipeline: primitives.SetStateParDo},
 		{pipeline: primitives.SetStateParDoClear},
+		{pipeline: primitives.TimersEventTimeBounded},
+		{pipeline: primitives.TimersEventTimeUnbounded},
 	}
 
 	configs := []struct {

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/timers.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/timers.go
@@ -33,7 +33,7 @@ import (
 // Returns the key bytes, tag, window exploded elements, and the hold timestamp.
 // If the timer has been cleared, no elements will be returned. Any existing timers
 // for the tag *must* be cleared from the pending queue.
-func decodeTimer(keyDec func(io.Reader) []byte, globalWindow bool, raw []byte) ([]byte, string, []element) {
+func decodeTimer(keyDec func(io.Reader) []byte, usesGlobalWindow bool, raw []byte) ([]byte, string, []element) {
 	keyBytes := keyDec(bytes.NewBuffer(raw))
 
 	d := decoder{raw: raw, cursor: len(keyBytes)}
@@ -41,7 +41,7 @@ func decodeTimer(keyDec func(io.Reader) []byte, globalWindow bool, raw []byte) (
 
 	var ws []typex.Window
 	numWin := d.Fixed32()
-	if globalWindow {
+	if usesGlobalWindow {
 		for i := 0; i < int(numWin); i++ {
 			ws = append(ws, window.GlobalWindow{})
 		}

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/timers.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/timers.go
@@ -137,15 +137,6 @@ func (d *decoder) Bytes() []byte {
 	return b
 }
 
-func (d *decoder) LPKeyBytes() []byte {
-	start := d.cursor
-	l := d.Varint()
-	end := d.cursor + int(l)
-	b := d.raw[start:end]
-	d.cursor = end
-	return b
-}
-
 func (d *decoder) Bool() bool {
 	if b := d.Byte(); b == 0 {
 		return false

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/timers.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/timers.go
@@ -1,0 +1,185 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"encoding/binary"
+	"fmt"
+	"math"
+
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/coder"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/mtime"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/window"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/typex"
+	"google.golang.org/protobuf/encoding/protowire"
+)
+
+// DecodeTimer extracts timers to elements for insertion into their keyed queues.
+// Returns the key bytes, tag, window exploded elements, and the hold timestamp.
+// If the timer has been cleared, no elements will be returned. Any existing timers
+// for the tag *must* be cleared from the pending queue.
+func decodeTimer(keyDec func([]byte) int, globalWindow bool, raw []byte) ([]byte, string, []element) {
+	// keyDec returns the index n of the first byte of the tag from the raw, such that the key bytes are raw[:n]
+	//n := keyDec(raw)
+	d := decoder{raw: raw}
+
+	// DO NOT SUBMIT THIS HACK: Just assume length prefix for now.
+	keyBytes := d.LPKeyBytes()
+
+	tag := string(d.Bytes())
+
+	var ws []typex.Window
+	numWin := d.Fixed32()
+	if globalWindow {
+		for i := 0; i < int(numWin); i++ {
+			ws = append(ws, window.GlobalWindow{})
+		}
+	} else {
+		// Assume interval windows here, otherwise *shrug*.
+		for i := 0; i < int(numWin); i++ {
+			ws = append(ws, d.IntervalWindow())
+		}
+	}
+
+	clear := d.Bool()
+	hold := mtime.MaxTimestamp
+	if clear {
+		return keyBytes, tag, nil
+	}
+
+	firing := d.Timestamp()
+	hold = d.Timestamp()
+	pane := d.Pane()
+
+	var ret []element
+	for _, w := range ws {
+		ret = append(ret, element{
+			tag:           tag,
+			elmBytes:      nil, // indicates this is a timer.
+			keyBytes:      keyBytes,
+			window:        w,
+			timestamp:     firing,
+			holdTimestamp: hold,
+			pane:          pane,
+		})
+	}
+	return keyBytes, tag, ret
+}
+
+type decoder struct {
+	raw    []byte
+	cursor int
+}
+
+// Varint consumes a varint from the bytes, returning the decoded length.
+func (d *decoder) Varint() (l int64) {
+	v, n := protowire.ConsumeVarint(d.raw[d.cursor:])
+	if n < 0 {
+		panic("invalid varint")
+	}
+	d.cursor += n
+	return int64(v)
+}
+
+// Uint64 decodes a value of type uint64.
+func (d *decoder) Uint64() uint64 {
+	defer func() {
+		d.cursor += 8
+	}()
+	return binary.BigEndian.Uint64(d.raw[d.cursor : d.cursor+8])
+}
+
+func (d *decoder) Timestamp() mtime.Time {
+	msec := d.Uint64()
+	return mtime.Time((int64)(msec) + math.MinInt64)
+}
+
+// Fixed32 decodes a fixed length encoding of uint32, for window decoding.
+func (d *decoder) Fixed32() uint32 {
+	defer func() {
+		d.cursor += 4
+	}()
+	return binary.BigEndian.Uint32(d.raw[d.cursor : d.cursor+4])
+}
+
+func (d *decoder) IntervalWindow() window.IntervalWindow {
+	end := d.Timestamp()
+	dur := d.Varint()
+	return window.IntervalWindow{
+		End:   end,
+		Start: mtime.FromMilliseconds(end.Milliseconds() - dur),
+	}
+}
+
+func (d *decoder) Byte() byte {
+	defer func() {
+		d.cursor += 1
+	}()
+	return d.raw[d.cursor]
+}
+
+func (d *decoder) Bytes() []byte {
+	l := d.Varint()
+	end := d.cursor + int(l)
+	b := d.raw[d.cursor:end]
+	d.cursor = end
+	return b
+}
+
+func (d *decoder) LPKeyBytes() []byte {
+	start := d.cursor
+	l := d.Varint()
+	end := d.cursor + int(l)
+	b := d.raw[start:end]
+	d.cursor = end
+	return b
+}
+
+func (d *decoder) Bool() bool {
+	if b := d.Byte(); b == 0 {
+		return false
+	} else if b == 1 {
+		return true
+	} else {
+		panic(fmt.Sprintf("unable to decode bool; expected {0, 1} got %v", b))
+	}
+}
+
+func (d *decoder) Pane() typex.PaneInfo {
+	first := d.Byte()
+	pn := coder.NewPane(first & 0x0f)
+
+	switch first >> 4 {
+	case 0:
+		// Result encoded in only one pane.
+		return pn
+	case 1:
+		// Result encoded in one pane plus a VarInt encoded integer.
+		index := d.Varint()
+		pn.Index = index
+		if pn.Timing == typex.PaneEarly {
+			pn.NonSpeculativeIndex = -1
+		} else {
+			pn.NonSpeculativeIndex = pn.Index
+		}
+	case 2:
+		// Result encoded in one pane plus two VarInt encoded integer.
+		index := d.Varint()
+		pn.Index = index
+		pn.NonSpeculativeIndex = d.Varint()
+	}
+	return pn
+}

--- a/sdks/go/pkg/beam/runners/prism/internal/handlepardo.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/handlepardo.go
@@ -82,7 +82,6 @@ func (h *pardo) PrepareTransform(tid string, t *pipepb.PTransform, comps *pipepb
 		!pdo.RequestsFinalization &&
 		!pdo.RequiresStableInput &&
 		!pdo.RequiresTimeSortedInput &&
-		len(pdo.TimerFamilySpecs) == 0 &&
 		pdo.RestrictionCoderId == "" {
 		// Which inputs are Side inputs don't change the graph further,
 		// so they're not included here. Any nearly any ParDo can have them.

--- a/sdks/go/pkg/beam/runners/prism/internal/jobservices/management.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/jobservices/management.go
@@ -153,8 +153,10 @@ func (s *Server) Prepare(ctx context.Context, req *jobpb.PrepareJobRequest) (*jo
 			}
 			// Validate all the timer features
 			for _, spec := range pardo.GetTimerFamilySpecs() {
-				check("TimerFamilySpecs.TimeDomain.Urn", spec.GetTimeDomain())
+				check("TimerFamilySpecs.TimeDomain.Urn", spec.GetTimeDomain(), pipepb.TimeDomain_EVENT_TIME)
 			}
+
+			check("OnWindowExpirationTimerFamily", pardo.GetOnWindowExpirationTimerFamilySpec(), "") // Unsupported for now.
 
 		case "":
 			// Composites can often have no spec

--- a/sdks/go/pkg/beam/runners/prism/internal/preprocess.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/preprocess.go
@@ -448,7 +448,7 @@ func finalizeStage(stg *stage, comps *pipepb.Components, pipelineFacts *fusionFa
 				if err := (proto.UnmarshalOptions{}).Unmarshal(t.GetSpec().GetPayload(), pardo); err != nil {
 					return fmt.Errorf("unable to decode ParDoPayload for %v", link.Transform)
 				}
-				if len(pardo.GetTimerFamilySpecs())+len(pardo.GetStateSpecs()) > 0 {
+				if len(pardo.GetTimerFamilySpecs())+len(pardo.GetStateSpecs())+len(pardo.GetOnWindowExpirationTimerFamilySpec()) > 0 {
 					stg.stateful = true
 				}
 				sis = pardo.GetSideInputs()

--- a/sdks/go/pkg/beam/runners/prism/internal/stage.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/stage.go
@@ -303,7 +303,6 @@ func buildDescriptor(stg *stage, comps *pipepb.Components, wk *worker.W, em *eng
 		if err := (proto.UnmarshalOptions{}).Unmarshal(t.GetSpec().GetPayload(), pardo); err != nil {
 			return fmt.Errorf("unable to decode ParDoPayload for %v in stage %v", tid, stg.ID)
 		}
-		before := prototext.Format(pardo)
 
 		// We need to ensure the coders can be handled by prism, and are available in the bundle descriptor.
 		// So we rewrite the transform's Payload with updated coder ids here.

--- a/sdks/go/pkg/beam/runners/prism/internal/stage.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/stage.go
@@ -63,6 +63,7 @@ type stage struct {
 	internalCols []string        // PCollections that escape. Used for precise coder sending.
 	envID        string
 	stateful     bool
+	hasTimers    []string
 
 	exe              transformExecuter
 	inputTransformID string
@@ -78,7 +79,6 @@ func (s *stage) Execute(ctx context.Context, j *jobservices.Job, wk *worker.W, c
 	slog.Debug("Execute: starting bundle", "bundle", rb)
 
 	var b *worker.B
-	inputData := em.InputForBundle(rb, s.inputInfo)
 	initialState := em.StateForBundle(rb)
 	var dataReady <-chan struct{}
 	switch s.envID {
@@ -88,7 +88,7 @@ func (s *stage) Execute(ctx context.Context, j *jobservices.Job, wk *worker.W, c
 		}
 		tid := s.transforms[0]
 		// Runner transforms are processed immeadiately.
-		b = s.exe.ExecuteTransform(s.ID, tid, comps.GetTransforms()[tid], comps, rb.Watermark, inputData)
+		b = s.exe.ExecuteTransform(s.ID, tid, comps.GetTransforms()[tid], comps, rb.Watermark, em.InputForBundle(rb, s.inputInfo))
 		b.InstID = rb.BundleID
 		slog.Debug("Execute: runner transform", "bundle", rb, slog.String("tid", tid))
 
@@ -99,14 +99,18 @@ func (s *stage) Execute(ctx context.Context, j *jobservices.Job, wk *worker.W, c
 		close(closed)
 		dataReady = closed
 	case wk.Env:
+		input, estimatedElements := em.DataAndTimerInputForBundle(rb, s.inputInfo)
 		b = &worker.B{
 			PBDID:  s.ID,
 			InstID: rb.BundleID,
 
 			InputTransformID: s.inputTransformID,
 
-			InputData:  inputData,
+			Input:                  input,
+			EstimatedInputElements: estimatedElements,
+
 			OutputData: initialState,
+			HasTimers:  s.hasTimers,
 
 			SinkToPCollection: s.SinkToPCollection,
 			OutputCount:       len(s.outputs),
@@ -196,8 +200,9 @@ progress:
 				cs := sr.GetChannelSplits()[0]
 				fr := cs.GetFirstResidualElement()
 				// The first residual can be after the end of data, so filter out those cases.
-				if len(b.InputData) >= int(fr) {
-					b.InputData = b.InputData[:int(fr)]
+				if b.EstimatedInputElements >= int(fr) {
+					b.EstimatedInputElements = int(fr) // Update the estimate for the next split.
+					// Residuals are returned right away for rescheduling.
 					em.ReturnResiduals(rb, int(fr), s.inputInfo, residualData)
 				}
 			} else {
@@ -286,7 +291,72 @@ func buildDescriptor(stg *stage, comps *pipepb.Components, wk *worker.W, em *eng
 	transforms := map[string]*pipepb.PTransform{}
 
 	for _, tid := range stg.transforms {
-		transforms[tid] = comps.GetTransforms()[tid]
+		t := comps.GetTransforms()[tid]
+
+		transforms[tid] = t
+
+		if t.GetSpec().GetUrn() != urns.TransformParDo {
+			continue
+		}
+
+		pardo := &pipepb.ParDoPayload{}
+		if err := (proto.UnmarshalOptions{}).Unmarshal(t.GetSpec().GetPayload(), pardo); err != nil {
+			return fmt.Errorf("unable to decode ParDoPayload for %v in stage %v", tid, stg.ID)
+		}
+		before := prototext.Format(pardo)
+
+		// We need to ensure the coders can be handled by prism, and are available in the bundle descriptor.
+		// So we rewrite the transform's Payload with updated coder ids here.
+		var rewrite bool
+		var rewriteErr error
+		for stateID, s := range pardo.GetStateSpecs() {
+			rewrite = true
+			rewriteCoder := func(cid *string) {
+				newCid, err := lpUnknownCoders(*cid, coders, comps.GetCoders())
+				if err != nil {
+					rewriteErr = fmt.Errorf("unable to rewrite coder %v for state %v for transform %v in stage %v:%w", *cid, stateID, tid, stg.ID, err)
+					return
+				}
+				*cid = newCid
+			}
+			switch s := s.GetSpec().(type) {
+			case *pipepb.StateSpec_BagSpec:
+				rewriteCoder(&s.BagSpec.ElementCoderId)
+			case *pipepb.StateSpec_SetSpec:
+				rewriteCoder(&s.SetSpec.ElementCoderId)
+			case *pipepb.StateSpec_OrderedListSpec:
+				rewriteCoder(&s.OrderedListSpec.ElementCoderId)
+			case *pipepb.StateSpec_CombiningSpec:
+				rewriteCoder(&s.CombiningSpec.AccumulatorCoderId)
+			case *pipepb.StateSpec_MapSpec:
+				rewriteCoder(&s.MapSpec.KeyCoderId)
+				rewriteCoder(&s.MapSpec.ValueCoderId)
+			case *pipepb.StateSpec_MultimapSpec:
+				rewriteCoder(&s.MultimapSpec.KeyCoderId)
+				rewriteCoder(&s.MultimapSpec.ValueCoderId)
+			case *pipepb.StateSpec_ReadModifyWriteSpec:
+				rewriteCoder(&s.ReadModifyWriteSpec.CoderId)
+			}
+			if rewriteErr != nil {
+				return rewriteErr
+			}
+		}
+		for timerID, v := range pardo.GetTimerFamilySpecs() {
+			stg.hasTimers = append(stg.hasTimers, tid)
+			rewrite = true
+			newCid, err := lpUnknownCoders(v.GetTimerFamilyCoderId(), coders, comps.GetCoders())
+			if err != nil {
+				return fmt.Errorf("unable to rewrite coder %v for timer %v for transform %v in stage %v: %w", v.GetTimerFamilyCoderId(), timerID, tid, stg.ID, err)
+			}
+			v.TimerFamilyCoderId = newCid
+		}
+		if rewrite {
+			pyld, err := proto.MarshalOptions{}.Marshal(pardo)
+			if err != nil {
+				return fmt.Errorf("unable to encode ParDoPayload for %v in stage %v after rewrite", tid, stg.ID)
+			}
+			t.Spec.Payload = pyld
+		}
 	}
 	if len(transforms) == 0 {
 		return fmt.Errorf("buildDescriptor: invalid stage - no transforms at all %v", stg.ID)
@@ -386,6 +456,13 @@ func buildDescriptor(stg *stage, comps *pipepb.Components, wk *worker.W, em *eng
 
 	reconcileCoders(coders, comps.GetCoders())
 
+	var timerServiceDescriptor *pipepb.ApiServiceDescriptor
+	if len(stg.hasTimers) > 0 {
+		timerServiceDescriptor = &pipepb.ApiServiceDescriptor{
+			Url: wk.Endpoint(),
+		}
+	}
+
 	desc := &fnpb.ProcessBundleDescriptor{
 		Id:                  stg.ID,
 		Transforms:          transforms,
@@ -395,6 +472,7 @@ func buildDescriptor(stg *stage, comps *pipepb.Components, wk *worker.W, em *eng
 		StateApiServiceDescriptor: &pipepb.ApiServiceDescriptor{
 			Url: wk.Endpoint(),
 		},
+		TimerApiServiceDescriptor: timerServiceDescriptor,
 	}
 
 	stg.desc = desc

--- a/sdks/go/pkg/beam/runners/prism/internal/unimplemented_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/unimplemented_test.go
@@ -141,3 +141,25 @@ func TestStateAPI(t *testing.T) {
 		})
 	}
 }
+
+func TestTimers(t *testing.T) {
+	initRunner(t)
+
+	tests := []struct {
+		pipeline func(s beam.Scope)
+	}{
+		{pipeline: primitives.TimersEventTimeBounded},
+		{pipeline: primitives.TimersEventTimeUnbounded},
+	}
+
+	for _, test := range tests {
+		t.Run(initTestName(test.pipeline), func(t *testing.T) {
+			p, s := beam.NewPipelineWithRoot()
+			test.pipeline(s)
+			_, err := executeWithT(context.Background(), t, p)
+			if err != nil {
+				t.Fatalf("pipeline failed, but feature should be implemented in Prism: %v", err)
+			}
+		})
+	}
+}

--- a/sdks/go/pkg/beam/runners/prism/internal/worker/bundle.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/bundle.go
@@ -32,17 +32,6 @@ type SideInputKey struct {
 	TransformID, Local string
 }
 
-type E struct {
-	Data   [][]byte
-	Timers *T
-}
-
-type T struct {
-	TransformID string
-	Family      string
-	Timers      [][]byte
-}
-
 // B represents an extant ProcessBundle instruction sent to an SDK worker.
 // Generally manipulated by another package to interact with a worker.
 type B struct {
@@ -53,7 +42,7 @@ type B struct {
 	InputTransformID       string
 	Input                  []*engine.Block // Data and Timers for this bundle.
 	EstimatedInputElements int
-	HasTimers              []string // Hack so we can start from the "write side"
+	HasTimers              []string
 
 	// IterableSideInputData is a map from transformID + inputID, to window, to data.
 	IterableSideInputData map[SideInputKey]map[typex.Window][][]byte

--- a/sdks/go/pkg/beam/runners/prism/internal/worker/bundle.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/bundle.go
@@ -32,15 +32,28 @@ type SideInputKey struct {
 	TransformID, Local string
 }
 
+type E struct {
+	Data   [][]byte
+	Timers *T
+}
+
+type T struct {
+	TransformID string
+	Family      string
+	Timers      [][]byte
+}
+
 // B represents an extant ProcessBundle instruction sent to an SDK worker.
 // Generally manipulated by another package to interact with a worker.
 type B struct {
 	InstID string // ID for the instruction processing this bundle.
 	PBDID  string // ID for the ProcessBundleDescriptor
 
-	// InputTransformID is data being sent to the SDK.
-	InputTransformID string
-	InputData        [][]byte // Data specifically for this bundle.
+	// InputTransformID is where data is being sent to in the SDK.
+	InputTransformID       string
+	Input                  []*engine.Block // Data and Timers for this bundle.
+	EstimatedInputElements int
+	HasTimers              []string // Hack so we can start from the "write side"
 
 	// IterableSideInputData is a map from transformID + inputID, to window, to data.
 	IterableSideInputData map[SideInputKey]map[typex.Window][][]byte
@@ -69,9 +82,9 @@ type B struct {
 // Init initializes the bundle's internal state for waiting on all
 // data and for relaying a response back.
 func (b *B) Init() {
-	// We need to see final data signals that match the number of
+	// We need to see final data and timer signals that match the number of
 	// outputs the stage this bundle executes posesses
-	b.dataSema.Store(int32(b.OutputCount))
+	b.dataSema.Store(int32(b.OutputCount + len(b.HasTimers)))
 	b.DataWait = make(chan struct{})
 	if b.OutputCount == 0 {
 		close(b.DataWait) // Can happen if there are no outputs for the bundle.
@@ -79,8 +92,8 @@ func (b *B) Init() {
 	b.Resp = make(chan *fnpb.ProcessBundleResponse, 1)
 }
 
-// DataDone indicates a final element has been received from a Data or Timer output.
-func (b *B) DataDone() {
+// DataOrTimerDone indicates a final element has been received from a Data or Timer output.
+func (b *B) DataOrTimerDone() {
 	sema := b.dataSema.Add(-1)
 	if sema == 0 {
 		close(b.DataWait)
@@ -132,23 +145,67 @@ func (b *B) ProcessOn(ctx context.Context, wk *W) <-chan struct{} {
 		},
 	}
 
-	// TODO: make batching decisions.
-	dataBuf := bytes.Join(b.InputData, []byte{})
+	// TODO: make sending cap decisions, to reduce processing time overhead.
+	for _, block := range b.Input {
+		elms := &fnpb.Elements{}
+
+		dataBuf := bytes.Join(block.Bytes, []byte{})
+		switch block.Kind {
+		case engine.BlockData:
+			elms.Data = []*fnpb.Elements_Data{
+				{
+					InstructionId: b.InstID,
+					TransformId:   b.InputTransformID,
+					Data:          dataBuf,
+				},
+			}
+		case engine.BlockTimer:
+			elms.Timers = []*fnpb.Elements_Timers{
+				{
+					InstructionId: b.InstID,
+					TransformId:   block.Transform,
+					TimerFamilyId: block.Family,
+					Timers:        dataBuf,
+				},
+			}
+			fmt.Println("SendingTimer:", b.InstID, block.Transform, block.Family, dataBuf)
+		default:
+			panic("unknown engine.Block kind")
+		}
+
+		select {
+		case wk.DataReqs <- elms:
+		case <-ctx.Done():
+			b.DataOrTimerDone()
+			return b.DataWait
+		}
+	}
+
+	// Send last of everything for now.
+	timers := make([]*fnpb.Elements_Timers, 0, len(b.HasTimers))
+	for _, tid := range b.HasTimers {
+		timers = append(timers, &fnpb.Elements_Timers{
+			InstructionId: b.InstID,
+			TransformId:   tid,
+			IsLast:        true,
+		})
+	}
 	select {
 	case wk.DataReqs <- &fnpb.Elements{
+		Timers: timers,
 		Data: []*fnpb.Elements_Data{
 			{
 				InstructionId: b.InstID,
 				TransformId:   b.InputTransformID,
-				Data:          dataBuf,
 				IsLast:        true,
 			},
 		},
 	}:
 	case <-ctx.Done():
-		b.DataDone()
+		b.DataOrTimerDone()
 		return b.DataWait
 	}
+
 	return b.DataWait
 }
 
@@ -184,7 +241,7 @@ func (b *B) Split(ctx context.Context, wk *W, fraction float64, allowedSplits []
 					b.InputTransformID: {
 						FractionOfRemainder:    fraction,
 						AllowedSplitPoints:     allowedSplits,
-						EstimatedInputElements: int64(len(b.InputData)),
+						EstimatedInputElements: int64(b.EstimatedInputElements),
 					},
 				},
 			},

--- a/sdks/go/pkg/beam/runners/prism/internal/worker/bundle.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/bundle.go
@@ -168,7 +168,6 @@ func (b *B) ProcessOn(ctx context.Context, wk *W) <-chan struct{} {
 					Timers:        dataBuf,
 				},
 			}
-			fmt.Println("SendingTimer:", b.InstID, block.Transform, block.Family, dataBuf)
 		default:
 			panic("unknown engine.Block kind")
 		}

--- a/sdks/go/pkg/beam/runners/prism/internal/worker/bundle.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/bundle.go
@@ -134,7 +134,7 @@ func (b *B) ProcessOn(ctx context.Context, wk *W) <-chan struct{} {
 		},
 	}
 
-	// TODO: make sending cap decisions, to reduce processing time overhead.
+	// TODO: make batching decisions on the maxium to send per elements block, to reduce processing time overhead.
 	for _, block := range b.Input {
 		elms := &fnpb.Elements{}
 

--- a/sdks/go/pkg/beam/runners/prism/internal/worker/bundle_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/bundle_test.go
@@ -20,6 +20,8 @@ import (
 	"context"
 	"sync"
 	"testing"
+
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/runners/prism/internal/engine"
 )
 
 func TestBundle_ProcessOn(t *testing.T) {
@@ -28,7 +30,11 @@ func TestBundle_ProcessOn(t *testing.T) {
 		InstID:      "testInst",
 		PBDID:       "testPBDID",
 		OutputCount: 1,
-		InputData:   [][]byte{{1, 2, 3}},
+		Input: []*engine.Block{
+			{
+				Kind:  engine.BlockData,
+				Bytes: [][]byte{{1, 2, 3}},
+			}},
 	}
 	b.Init()
 	var completed sync.WaitGroup
@@ -37,7 +43,7 @@ func TestBundle_ProcessOn(t *testing.T) {
 		b.ProcessOn(context.Background(), wk)
 		completed.Done()
 	}()
-	b.DataDone()
+	b.DataOrTimerDone()
 	gotData := <-wk.DataReqs
 	if got, want := gotData.GetData()[0].GetData(), []byte{1, 2, 3}; !bytes.EqualFold(got, want) {
 		t.Errorf("ProcessOn(): data not sent; got %v, want %v", got, want)

--- a/sdks/go/pkg/beam/runners/prism/internal/worker/worker_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/worker_test.go
@@ -26,6 +26,7 @@ import (
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/window"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/typex"
 	fnpb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/fnexecution_v1"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/runners/prism/internal/engine"
 	"google.golang.org/grpc"
 	"google.golang.org/grpc/credentials/insecure"
 	"google.golang.org/grpc/test/bufconn"
@@ -178,9 +179,11 @@ func TestWorker_Data_HappyPath(t *testing.T) {
 	b := &B{
 		InstID: instID,
 		PBDID:  "teststageID",
-		InputData: [][]byte{
-			{1, 1, 1, 1, 1, 1},
-		},
+		Input: []*engine.Block{
+			{
+				Kind:  engine.BlockData,
+				Bytes: [][]byte{{1, 1, 1, 1, 1, 1}},
+			}},
 		OutputCount: 1,
 	}
 	b.Init()

--- a/sdks/go/pkg/beam/runners/prism/internal/worker/worker_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/worker_test.go
@@ -211,8 +211,22 @@ func TestWorker_Data_HappyPath(t *testing.T) {
 	if got, want := elements.GetData()[0].GetData(), []byte{1, 1, 1, 1, 1, 1}; !bytes.Equal(got, want) {
 		t.Fatalf("client Data received %v, want %v", got, want)
 	}
+	if got, want := elements.GetData()[0].GetIsLast(), false; got != want {
+		t.Fatalf("client Data received was last: got %v, want %v", got, want)
+	}
+
+	elements, err = dataStream.Recv()
+	if err != nil {
+		t.Fatal("expected 2nd data elements:", err)
+	}
+	if got, want := elements.GetData()[0].GetInstructionId(), b.InstID; got != want {
+		t.Fatalf("couldn't receive data elements ID: got %v, want %v", got, want)
+	}
+	if got, want := elements.GetData()[0].GetData(), []byte(nil); !bytes.Equal(got, want) {
+		t.Fatalf("client Data received %v, want %v", got, want)
+	}
 	if got, want := elements.GetData()[0].GetIsLast(), true; got != want {
-		t.Fatalf("client Data received wasn't last: got %v, want %v", got, want)
+		t.Fatalf("client Data received was last: got %v, want %v", got, want)
 	}
 
 	dataStream.Send(elements)

--- a/sdks/go/pkg/beam/runners/prism/internal/worker/worker_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/worker_test.go
@@ -226,7 +226,7 @@ func TestWorker_Data_HappyPath(t *testing.T) {
 		t.Fatalf("client Data received %v, want %v", got, want)
 	}
 	if got, want := elements.GetData()[0].GetIsLast(), true; got != want {
-		t.Fatalf("client Data received was last: got %v, want %v", got, want)
+		t.Fatalf("client Data received wasn't last: got %v, want %v", got, want)
 	}
 
 	dataStream.Send(elements)

--- a/sdks/go/test/integration/integration.go
+++ b/sdks/go/test/integration/integration.go
@@ -157,8 +157,8 @@ var prismFilters = []string{
 	// OOMs currently only lead to heap dumps on Dataflow runner
 	"TestOomParDo",
 
-	// The prism runner does not support timers https://github.com/apache/beam/issues/29772.
-	"TestTimers.*",
+	// The prism runner does not support processing time timers https://github.com/apache/beam/issues/29772.
+	"TestTimers_ProcessingTime.*",
 }
 
 var flinkFilters = []string{


### PR DESCRIPTION
Updates Prism to support EventTime Timers.

Fixes a bug in Go SDK timer handling unset watermark holds would have the wrong default hold. They should default to the firing time.

Timer implementation tracked in #29772.

Largely handles event time timers by treating them as data elements in the processing, with the goal of minimizing unique handling of timers vs data.
Timers with the same event time must always sort *after* data elements with the same event time, so they can be reasonably be consolidated when firing.

Since only a single timer can be set for a [window, user key, timerfamily, tag] tuple we track the last set EventTime + Hold. This avoids scanning the element queue for a key every time a timer is written at the expense that more timers are retained in memory (a "spend RAM to save CPU" trade off). This requires managing the remaining "pending elements" properly as well, as a timer may be written, but it may not affect size of the pending queue.

WatermarkHolds are tracked on a per Hold basis. Each stage maintains a heap of their holds, and a map of how many timers are using that hold. When the count goes to 0, we remove the hold from the map, and the heap. This approach avoids tracking holds on a per timer basis, which would mean a much larger hold heap. 

Aside: A general improvement that could be made to the Element Manager would be to "intern" the user key bytes, tags, and various other strings when persisting the data. This would avoid retaining several copies of each set of bytes in memory between stages (this is a "spend CPU to save RAM" trade off). There's also likely opportunity to clean up "leaked" tails of large byte buffers when a key prefix is being held (a similar CPU for RAM tradeoff).

---- 

Deferred to a later PR, related to EventTime timers:
* Handling Cleared timers correctly.
  * Fired timers *are* cleared, but a user clearing a timer (eg. because a batch is determined complete, so a GC timer isn't needed) isn't tested yet. It's expected that such a timer will simply fire.
* Handling OnWindowExpiration, because it's not implemented in the Go SDK yet, so it's hard to test.

Both are likely to be handled in the process of cleaning up prism for the Java and Python Validates Runner tests.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
