### PR TITLE
Remove INFO from playground python logger

### DIFF
--- a/playground/infrastructure/logger.py
+++ b/playground/infrastructure/logger.py
@@ -37,7 +37,7 @@ def setup_logger():
     )
 
     stdout_handler = logging.StreamHandler(sys.stdout)
-    stdout_handler.addFilter(lambda record: record.levelno in (INFO, WARNING))
+    stdout_handler.addFilter(lambda record: record.levelno in (WARNING,))
     stdout_handler.setFormatter(formatter)
 
     stderr_handler = logging.StreamHandler(sys.stderr)


### PR DESCRIPTION
Beam Playground currently outputs a ton of info messages when you run a python example. In my experience with showing people the examples, new users got a bit overwhelmed by the logging and it made it harder to pick out the actual expected input.

I tried to change the log level here to just WARNING for stdout. I looked a little at the playground local deployment docs but got a bit overwhelmed. I'd appreciate if someone with more experience with playground local deployments could give this a review / test, as I don't expect to make many changes like this so I'm not sure it's worth figuring it out for my own environment