### PR TITLE
make getProcessingDistributionsForWorkId threadsafe

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
@@ -117,7 +117,8 @@ public final class DataflowExecutionStateSampler extends ExecutionStateSampler {
     return Optional.ofNullable(null);
   }
 
-  public Map<String, IntSummaryStatistics> getProcessingDistributionsForWorkId(String workId) {
+  public synchronized Map<String, IntSummaryStatistics> getProcessingDistributionsForWorkId(
+      String workId) {
     if (!activeTrackersByWorkId.containsKey(workId)) {
       if (completedProcessingMetrics.containsKey(workId)) {
         return completedProcessingMetrics.get(workId);

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/DataflowExecutionStateSampler.java
@@ -117,15 +117,11 @@ public final class DataflowExecutionStateSampler extends ExecutionStateSampler {
     return Optional.ofNullable(null);
   }
 
-  public synchronized Map<String, IntSummaryStatistics> getProcessingDistributionsForWorkId(
-      String workId) {
-    if (!activeTrackersByWorkId.containsKey(workId)) {
-      if (completedProcessingMetrics.containsKey(workId)) {
-        return completedProcessingMetrics.get(workId);
-      }
-      return new HashMap<>();
-    }
+  public Map<String, IntSummaryStatistics> getProcessingDistributionsForWorkId(String workId) {
     DataflowExecutionStateTracker tracker = activeTrackersByWorkId.get(workId);
+    if (tracker == null) {
+      return completedProcessingMetrics.getOrDefault(workId, new HashMap<>());
+    }
     return mergeStepStatsMaps(
         completedProcessingMetrics.getOrDefault(workId, new HashMap<>()),
         tracker.getProcessingTimesByStepCopy());


### PR DESCRIPTION
make getProcessingDistributionsForWorkId threadsafe to avoid race conditions with remove tracker

the race condition happens in getProcessingDistributionsForWorkId because we check for the existence of the work id in the activeTrackersByWorkId map before retrieving the value from the map. if another thread removes the tracker from the map in-between us checking for its existence and actually grabbing the object, we will get a null tracker that then throws a NullPointerException when we try to access data on it. 

Was able to repro this with a chaos test locally and confirmed that synchronizing the getProcessingDistributionsForWorkId method solves the issue. Decided to not commit the chaos test since it's a bit messy and deviates from test patterns in this repo.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
