### PR TITLE
Add Java 17 to docker image for self-hosted runners

### DIFF
--- a/.github/gh-actions-self-hosted-runners/arc/images/Dockerfile
+++ b/.github/gh-actions-self-hosted-runners/arc/images/Dockerfile
@@ -41,6 +41,9 @@ RUN curl -OL https://cdn.azul.com/zulu/bin/zulu8.70.0.23-ca-jdk8.0.372-linux_x64
     tar -C /usr/local -xzf zulu8.70.0.23-ca-jdk8.0.372-linux_x64.tar.gz && \
     rm zulu8.70.0.23-ca-jdk8.0.372-linux_x64.tar.gz && \
     mv /usr/local/zulu8.70.0.23-ca-jdk8.0.372-linux_x64 /usr/local/java
+RUN curl -OL https://cdn.azul.com/zulu/bin/zulu17.46.19-ca-jdk17.0.9-linux_x64.tar.gz && \
+    tar -C /usr/local -xzf zulu17.46.19-ca-jdk17.0.9-linux_x64.tar.gz && \
+    rm zulu17.46.19-ca-jdk17.0.9-linux_x64.tar.gz
 ENV PATH="${PATH}:/usr/local/java/bin"
 #Install Gradle
 RUN curl -OL https://services.gradle.org/distributions/gradle-7.3.3-bin.zip && \


### PR DESCRIPTION
This should make Java 17 available for java jobs to use without an extra download step. Then we can migrate them and remove Java 8 from the image. The goal is to build with gradle and plugins using this version of Java, and probably javac and all that also using this version but targeting Java 8 platform.

Feedback welcome on the tradeoff between preloading this stuff onto the image vs downloading dynamically (as we seem to do for non-default versions), how to migrate to it being default, etc.

Particularly I might eliminate the concept of it being symlinked to /usr/local/java and always use explicit versions when it comes to the filesystem layer.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
