### PR TITLE
[Go SDK] Use distroless:debian12 (no-ssl) as base image.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -82,6 +82,8 @@
 
 ## Security Fixes
 * Fixed (CVE-YYYY-NNNN)[https://www.cve.org/CVERecord?id=CVE-YYYY-NNNN] (Java/Python/Go) ([#X](https://github.com/apache/beam/issues/X)).
+* Go SDK base container image moved to distroless/base-debian12, reducing vulnerable container surface ([#Y](https://github.com/apache/beam/issues/Y)).
+   * Fixes (CVE-YYYY-NNNN)[https://www.cve.org/CVERecord?id=CVE-YYYY-NNNN] (Go) 
 
 ## Known Issues
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -82,7 +82,7 @@
 
 ## Security Fixes
 * Fixed (CVE-YYYY-NNNN)[https://www.cve.org/CVERecord?id=CVE-YYYY-NNNN] (Java/Python/Go) ([#X](https://github.com/apache/beam/issues/X)).
-* Go SDK base container image moved to distroless/base-nossl-debian12, reducing vulnerable container surface to kernel and glibc([#30011](https://github.com/apache/beam/pull/30011)).
+* Go SDK base container image moved to distroless/base-nossl-debian12, reducing vulnerable container surface to kernel and glibc ([#30011](https://github.com/apache/beam/pull/30011)).
 
 ## Known Issues
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -82,8 +82,7 @@
 
 ## Security Fixes
 * Fixed (CVE-YYYY-NNNN)[https://www.cve.org/CVERecord?id=CVE-YYYY-NNNN] (Java/Python/Go) ([#X](https://github.com/apache/beam/issues/X)).
-* Go SDK base container image moved to distroless/base-debian12, reducing vulnerable container surface ([#Y](https://github.com/apache/beam/issues/Y)).
-   * Fixes (CVE-YYYY-NNNN)[https://www.cve.org/CVERecord?id=CVE-YYYY-NNNN] (Go)
+* Go SDK base container image moved to distroless/base-nossl-debian12, reducing vulnerable container surface to kernel and glibc([#30011](https://github.com/apache/beam/pull/30011)).
 
 ## Known Issues
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -83,7 +83,7 @@
 ## Security Fixes
 * Fixed (CVE-YYYY-NNNN)[https://www.cve.org/CVERecord?id=CVE-YYYY-NNNN] (Java/Python/Go) ([#X](https://github.com/apache/beam/issues/X)).
 * Go SDK base container image moved to distroless/base-debian12, reducing vulnerable container surface ([#Y](https://github.com/apache/beam/issues/Y)).
-   * Fixes (CVE-YYYY-NNNN)[https://www.cve.org/CVERecord?id=CVE-YYYY-NNNN] (Go) 
+   * Fixes (CVE-YYYY-NNNN)[https://www.cve.org/CVERecord?id=CVE-YYYY-NNNN] (Go)
 
 ## Known Issues
 

--- a/sdks/go/container/Dockerfile
+++ b/sdks/go/container/Dockerfile
@@ -16,19 +16,11 @@
 # limitations under the License.
 ###############################################################################
 
-FROM debian:bookworm
+FROM gcr.io/distroless/base-nossl-debian12:latest
 LABEL Author "Apache Beam <dev@beam.apache.org>"
 
 ARG TARGETOS
 ARG TARGETARCH
-
-ARG pull_licenses
-
-RUN apt-get update && \
-    DEBIAN_FRONTEND=noninteractive apt-get install -y \
-        ca-certificates \
-        && \
-    rm -rf /var/lib/apt/lists/*
 
 ADD target/${TARGETOS}_${TARGETARCH}/boot /opt/apache/beam/
 
@@ -37,9 +29,4 @@ COPY target/NOTICE /opt/apache/beam/
 
 # Add Go licenses.
 COPY target/go-licenses/* /opt/apache/beam/third_party_licenses/golang/
-RUN if [ "$pull_licenses" = "false" ] ; then \
-    # Remove above golang license and dir if pull licenses false
-    rm -rf /opt/apache/beam/third_party_licenses ; \
-   fi
-
 ENTRYPOINT ["/opt/apache/beam/boot"]


### PR DESCRIPTION
Move Go SDK image to use distroless as the base image, instead of the docker debian image.

Technically, the same version of debian, but with everything but glibc stripped out of it.

Go binaries (Go SDK binaries in particular) don't need external deps or most other parts of the OS toolchains, so this reduces the vulnerabilities to largely intractable to fix glibc issues. 

We could remove glibc as by default the SDK doesn't need to compile with C-go enabled (the only reason to link in glibc for go running binaries) but it is handy for users who would depend on it.

distroless has the ca-certificates pre-installed, and as long as we build against latest, it remains relatively up to date. It's not clear to me why we chose to remove the licenses except when configured, but it's harder to remove things conditionally when the shell tools and bash aren't present.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
