### PR TITLE
Fix buildx always been true

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamDockerPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamDockerPlugin.groovy
@@ -247,6 +247,9 @@ class BeamDockerPlugin implements Plugin<Project> {
       }
     } else {
       buildCommandLine.add 'build'
+      // TARGETOS and TARGETARCH args not present through `docker build`, add here
+      ext.buildArgs.put('TARGETOS', 'linux')
+      ext.buildArgs.put('TARGETARCH', ext.project.nativeArchitecture())
     }
     if (ext.noCache) {
       buildCommandLine.add '--no-cache'

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -558,7 +558,7 @@ class BeamModulePlugin implements Plugin<Project> {
     project.ext.containerArchitectures = {
       if (isRelease(project)) {
         // Ensure we always publish the expected containers.
-        return ["amd64", "arm64"];
+        return ["amd64", "arm64"]
       } else if (project.rootProject.findProperty("container-architecture-list") != null) {
         def containerArchitectures = project.rootProject.findProperty("container-architecture-list").split(',')
         if (containerArchitectures.size() > 1 && !project.rootProject.hasProperty("push-containers")) {
@@ -572,6 +572,10 @@ class BeamModulePlugin implements Plugin<Project> {
 
     project.ext.containerPlatforms = {
       return project.containerArchitectures().collect { arch -> "linux/" + arch }
+    }
+
+    project.ext.useBuildx = {
+      return project.containerArchitectures() != [project.nativeArchitecture()]
     }
 
     /** ***********************************************************************************************/

--- a/runners/flink/job-server-container/flink_job_server_container.gradle
+++ b/runners/flink/job-server-container/flink_job_server_container.gradle
@@ -52,7 +52,6 @@ task copyDockerfileDependencies(type: Copy) {
   into "build"
 }
 
-def useBuildx = project.containerPlatforms() != [project.nativeArchitecture()]
 def pushContainers = project.rootProject.hasProperty(["isRelease"]) || project.rootProject.hasProperty("push-containers")
 
 docker {
@@ -66,9 +65,9 @@ docker {
   // tags used by dockerTag task
   tags containerImageTags()
   files "./build/"
-  buildx useBuildx
+  buildx project.useBuildx()
   platform(*project.containerPlatforms())
-  load useBuildx && !pushContainers
+  load project.useBuildx() && !pushContainers
   push pushContainers
 }
 

--- a/runners/spark/job-server/container/spark_job_server_container.gradle
+++ b/runners/spark/job-server/container/spark_job_server_container.gradle
@@ -51,7 +51,6 @@ task copyDockerfileDependencies(type: Copy) {
   into "build"
 }
 
-def useBuildx = project.containerPlatforms() != [project.nativeArchitecture()]
 def pushContainers = project.rootProject.hasProperty(["isRelease"]) || project.rootProject.hasProperty("push-containers")
 
 docker {
@@ -64,9 +63,9 @@ docker {
   // tags used by dockerTag task
   tags containerImageTags()
   files "./build/"
-  buildx useBuildx
+  buildx project.useBuildx()
   platform(*project.containerPlatforms())
-  load useBuildx && !pushContainers
+  load project.useBuildx() && !pushContainers
   push pushContainers
 }
 

--- a/sdks/go/container/build.gradle
+++ b/sdks/go/container/build.gradle
@@ -27,7 +27,6 @@ goBuild {
   outputLocation = './build/target/${GOOS}_${GOARCH}/boot'
 }
 
-def useBuildx = project.containerPlatforms() != [project.nativeArchitecture()]
 def pushContainers = project.rootProject.hasProperty(["isRelease"]) || project.rootProject.hasProperty("push-containers")
 
 docker {
@@ -41,9 +40,9 @@ docker {
   files "./build/"
   buildArgs(['pull_licenses': project.rootProject.hasProperty(["docker-pull-licenses"]) ||
                      project.rootProject.hasProperty(["isRelease"])])
-  buildx useBuildx
+  buildx project.useBuildx()
   platform(*project.containerPlatforms())
-  load useBuildx && !pushContainers
+  load project.useBuildx() && !pushContainers
   push pushContainers
 }
 dockerPrepare.dependsOn tasks.named("goBuild")

--- a/sdks/java/container/common.gradle
+++ b/sdks/java/container/common.gradle
@@ -121,7 +121,6 @@ task validateJavaHome {
     }
 }
 
-def useBuildx = project.containerPlatforms() != [project.nativeArchitecture()]
 def pushContainers = project.rootProject.hasProperty(["isRelease"]) || project.rootProject.hasProperty("push-containers")
 
 docker {
@@ -142,9 +141,9 @@ docker {
             'base_image': javaBaseImage,
             'java_version': imageJavaVersion,
     ])
-    buildx useBuildx
+    buildx project.useBuildx()
     platform(*project.containerPlatforms())
-    load useBuildx && !pushContainers
+    load project.useBuildx() && !pushContainers
     push pushContainers
 }
 

--- a/sdks/java/expansion-service/container/build.gradle
+++ b/sdks/java/expansion-service/container/build.gradle
@@ -60,7 +60,6 @@ task copyConfigFile(type: Copy) {
     into "build/target"
 }
 
-def useBuildx = project.containerPlatforms() != [project.nativeArchitecture()]
 def pushContainers = project.rootProject.hasProperty(["isRelease"]) || project.rootProject.hasProperty("push-containers")
 
 docker {
@@ -74,9 +73,9 @@ docker {
     // tags used by dockerTag task
     tags containerImageTags()
     files "./build"
-    buildx useBuildx
+    buildx project.useBuildx()
     platform(*project.containerPlatforms())
-    load useBuildx && !pushContainers
+    load project.useBuildx() && !pushContainers
     push pushContainers
 }
 

--- a/sdks/java/transform-service/controller-container/build.gradle
+++ b/sdks/java/transform-service/controller-container/build.gradle
@@ -49,7 +49,6 @@ task copyConfigFile(type: Copy) {
     into "build/target"
 }
 
-def useBuildx = project.containerPlatforms() != [project.nativeArchitecture()]
 def pushContainers = project.rootProject.hasProperty(["isRelease"]) || project.rootProject.hasProperty("push-containers")
 
 docker {
@@ -63,9 +62,9 @@ docker {
     // tags used by dockerTag task
     tags containerImageTags()
     files "./build"
-    buildx useBuildx
+    buildx project.useBuildx()
     platform(*project.containerPlatforms())
-    load useBuildx && !pushContainers
+    load project.useBuildx() && !pushContainers
     push pushContainers
 }
 

--- a/sdks/python/container/common.gradle
+++ b/sdks/python/container/common.gradle
@@ -70,7 +70,6 @@ def copyLauncherDependencies = tasks.register("copyLauncherDependencies", Copy) 
   }
 }
 
-def useBuildx = project.containerPlatforms() != [project.nativeArchitecture()]
 def pushContainers = project.rootProject.hasProperty(["isRelease"]) || project.rootProject.hasProperty("push-containers")
 
 docker {
@@ -87,9 +86,9 @@ docker {
   buildArgs(['py_version': "${project.ext.pythonVersion}",
              'pull_licenses': project.rootProject.hasProperty(["docker-pull-licenses"]) ||
                      project.rootProject.hasProperty(["isRelease"])])
-  buildx useBuildx
+  buildx project.useBuildx()
   platform(*project.containerPlatforms())
-  load useBuildx && !pushContainers
+  load project.useBuildx() && !pushContainers
   push pushContainers
 }
 

--- a/sdks/python/expansion-service-container/build.gradle
+++ b/sdks/python/expansion-service-container/build.gradle
@@ -57,7 +57,6 @@ def copyLicenseScripts = tasks.register("copyLicenseScripts", Copy){
     into "build/target/license_scripts"
 }
 
-def useBuildx = project.containerPlatforms() != [project.nativeArchitecture()]
 def pushContainers = project.rootProject.hasProperty(["isRelease"]) || project.rootProject.hasProperty("push-containers")
 
 docker {
@@ -71,9 +70,9 @@ docker {
   // tags used by dockerTag task
   tags containerImageTags()
   files "./build"
-  buildx useBuildx
+  buildx project.useBuildx()
   platform(*project.containerPlatforms())
-  load useBuildx && !pushContainers
+  load project.useBuildx() && !pushContainers
   push pushContainers
 }
 

--- a/sdks/typescript/container/build.gradle
+++ b/sdks/typescript/container/build.gradle
@@ -43,7 +43,6 @@ def copyDockerfileDependencies = tasks.register("copyDockerfileDependencies", Co
   }
 }
 
-def useBuildx = project.containerPlatforms() != [project.nativeArchitecture()]
 def pushContainers = project.rootProject.hasProperty(["isRelease"]) || project.rootProject.hasProperty("push-containers")
 
 docker {
@@ -57,9 +56,9 @@ docker {
   // tags used by dockerTag task
   tags containerImageTags()
   files "./build"
-  buildx useBuildx
+  buildx project.useBuildx()
   platform(*project.containerPlatforms())
-  load useBuildx && !pushContainers
+  load project.useBuildx() && !pushContainers
   push pushContainers
 }
 


### PR DESCRIPTION
It has been found `DockerExtension.ext.buildx` parameter is always true even for local testing. The issue is 
```
def useBuildx = project.containerPlatforms() != [project.nativeArchitecture()]
```
this gives
```
"linux/amd64" != "amd64"
```

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
