### PR TITLE
Automatically enable Dataflow Runner v2 for pipeliens that use the transform upgrade feature

### DIFF
--- a/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PipelineTranslation.java
+++ b/runners/core-construction-java/src/main/java/org/apache/beam/runners/core/construction/PipelineTranslation.java
@@ -56,6 +56,14 @@ public class PipelineTranslation {
       final Pipeline pipeline,
       final SdkComponents components,
       boolean useDeprecatedViewTransforms) {
+    return toProto(pipeline, components, useDeprecatedViewTransforms, true);
+  }
+
+  public static RunnerApi.Pipeline toProto(
+      final Pipeline pipeline,
+      final SdkComponents components,
+      boolean useDeprecatedViewTransforms,
+      boolean upgradeTransforms) {
     final List<String> rootIds = new ArrayList<>();
     pipeline.traverseTopologically(
         new PipelineVisitor.Defaults() {
@@ -106,7 +114,7 @@ public class PipelineTranslation {
     ExternalTranslationOptions externalTranslationOptions =
         pipeline.getOptions().as(ExternalTranslationOptions.class);
     List<String> urnsToOverride = externalTranslationOptions.getTransformsToOverride();
-    if (urnsToOverride.size() > 0) {
+    if (urnsToOverride.size() > 0 && upgradeTransforms) {
       try (TransformUpgrader upgrader = TransformUpgrader.of()) {
         res =
             upgrader.upgradeTransformsViaTransformService(

--- a/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/TransformUpgraderTest.java
+++ b/runners/core-construction-java/src/test/java/org/apache/beam/runners/core/construction/TransformUpgraderTest.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.core.construction;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertTrue;
 
 import com.google.auto.service.AutoService;
 import java.io.ByteArrayInputStream;
@@ -284,6 +285,9 @@ public class TransformUpgraderTest {
             .get("TransformUpgraderTest-TestTransform");
 
     validateTestParam(upgradedTransform, 4);
+
+    // Confirm that the upgraded transform includes the upgrade annotation.
+    assertTrue(upgradedTransform.getAnnotationsMap().containsKey(TransformUpgrader.UPGRADE_KEY));
   }
 
   @Test


### PR DESCRIPTION
PR Also includes following two updates.

* Add an annotation to upgraded transforms so that they can be easily identified by looking at the pipeline proto.
* Prevent Dataflow from performing upgrading when building the Runner v1 pipeline (otherwise, Dataflow will unnecessarily start/shutdown the transform service twice).

This fixes https://github.com/apache/beam/issues/30060.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
