### PR TITLE
Fix BigQuerySinkMetrics constants and increment metrics in more places. 

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySinkMetrics.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySinkMetrics.java
@@ -53,9 +53,9 @@ public class BigQuerySinkMetrics {
   public static final String PAYLOAD_TOO_LARGE = "PayloadTooLarge";
 
   // Base Metric names
-  private static final String RPC_REQUESTS = "RpcRequests";
+  private static final String RPC_REQUESTS = "RpcRequestsCount";
   private static final String RPC_LATENCY = "RpcLatency";
-  private static final String APPEND_ROWS_ROW_STATUS = "AppendRowsRowStatus";
+  private static final String APPEND_ROWS_ROW_STATUS = "RowsAppendedCount";
   private static final String THROTTLED_TIME = "ThrottledTime";
 
   // StorageWriteAPI Method names
@@ -73,10 +73,10 @@ public class BigQuerySinkMetrics {
   }
 
   // Metric labels
-  private static final String TABLE_ID_LABEL = "TableId";
-  private static final String RPC_STATUS_LABEL = "RpcStatus";
-  private static final String RPC_METHOD = "Method";
-  private static final String ROW_STATUS = "RowStatus";
+  private static final String TABLE_ID_LABEL = "table_id";
+  private static final String RPC_STATUS_LABEL = "rpc_status";
+  private static final String RPC_METHOD = "rpc_method";
+  private static final String ROW_STATUS = "row_status";
 
   // Delimiters
   private static final char LABEL_DELIMITER = ';';

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWritesShardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWritesShardedRecords.java
@@ -652,7 +652,7 @@ public class StorageApiWritesShardedRecords<DestinationT extends @NonNull Object
             AppendRowsContext failedContext =
                 Preconditions.checkStateNotNull(Iterables.getFirst(failedContexts, null));
             BigQuerySinkMetrics.reportFailedRPCMetrics(
-                failedContext, BigQuerySinkMetrics.RpcMethod.APPEND_ROWS);
+                failedContext, BigQuerySinkMetrics.RpcMethod.APPEND_ROWS, shortTableId);
             String errorCode =
                 BigQuerySinkMetrics.throwableToGRPCCodeString(failedContext.getError());
 
@@ -801,7 +801,8 @@ public class StorageApiWritesShardedRecords<DestinationT extends @NonNull Object
             BigQuerySinkMetrics.reportSuccessfulRpcMetrics(
                 context, BigQuerySinkMetrics.RpcMethod.APPEND_ROWS, shortTableId);
             BigQuerySinkMetrics.appendRowsRowStatusCounter(
-                BigQuerySinkMetrics.RowStatus.SUCCESSFUL, BigQuerySinkMetrics.OK, shortTableId);
+                    BigQuerySinkMetrics.RowStatus.SUCCESSFUL, BigQuerySinkMetrics.OK, shortTableId)
+                .inc(flushedRows);
 
             if (successfulRowsTag != null) {
               for (int i = 0; i < context.protoRows.getSerializedRowsCount(); ++i) {
@@ -966,3 +967,4 @@ public class StorageApiWritesShardedRecords<DestinationT extends @NonNull Object
     }
   }
 }
+

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWritesShardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWritesShardedRecords.java
@@ -967,4 +967,3 @@ public class StorageApiWritesShardedRecords<DestinationT extends @NonNull Object
     }
   }
 }
-

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySinkMetricsTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySinkMetricsTest.java
@@ -112,7 +112,7 @@ public class BigQuerySinkMetricsTest {
     deletesDisabledCounter.inc();
     MetricName deletesDisabledCounterName =
         MetricName.named(
-            "BigQuerySink", "AppendRowsRowStatus-RowStatus:SUCCESSFUL;RpcStatus:rpcStatus;");
+            "BigQuerySink", "RowsAppendedCount-row_status:SUCCESSFUL;rpc_status:rpcStatus;");
     assertThat(testContainer.perWorkerCounters, IsMapContaining.hasKey(deletesDisabledCounterName));
     assertThat(
         testContainer.perWorkerCounters.get(deletesDisabledCounterName).getCumulative(),
@@ -127,7 +127,7 @@ public class BigQuerySinkMetricsTest {
     MetricName deletesEnabledCounterName =
         MetricName.named(
             "BigQuerySink",
-            "AppendRowsRowStatus-RowStatus:SUCCESSFUL;RpcStatus:rpcStatus;TableId:tableId;");
+            "RowsAppendedCount-row_status:SUCCESSFUL;rpc_status:rpcStatus;table_id:tableId;");
     assertThat(testContainer.perWorkerCounters, IsMapContaining.hasKey(deletesEnabledCounterName));
     assertThat(
         testContainer.perWorkerCounters.get(deletesEnabledCounterName).getCumulative(),
@@ -160,8 +160,9 @@ public class BigQuerySinkMetricsTest {
     appendRowsThrottleCounter.inc(1);
     assertThat(
         appendRowsThrottleCounter.getName().getName(),
-        equalTo("ThrottledTime-Method:APPEND_ROWS;"));
-    MetricName counterName = MetricName.named("BigQuerySink", "ThrottledTime-Method:APPEND_ROWS;");
+        equalTo("ThrottledTime-rpc_method:APPEND_ROWS;"));
+    MetricName counterName =
+        MetricName.named("BigQuerySink", "ThrottledTime-rpc_method:APPEND_ROWS;");
     assertThat(testContainer.perWorkerCounters, IsMapContaining.hasKey(counterName));
     assertThat(testContainer.perWorkerCounters.get(counterName).getCumulative(), equalTo(1L));
   }
@@ -181,8 +182,9 @@ public class BigQuerySinkMetricsTest {
     BigQuerySinkMetrics.reportSuccessfulRpcMetrics(
         c, BigQuerySinkMetrics.RpcMethod.APPEND_ROWS, "tableId");
     MetricName counterNameDisabledDeletes =
-        MetricName.named("BigQuerySink", "RpcRequests-Method:APPEND_ROWS;RpcStatus:OK;");
-    MetricName histogramName = MetricName.named("BigQuerySink", "RpcLatency-Method:APPEND_ROWS;");
+        MetricName.named("BigQuerySink", "RpcRequestsCount-rpc_method:APPEND_ROWS;rpc_status:OK;");
+    MetricName histogramName =
+        MetricName.named("BigQuerySink", "RpcLatency-rpc_method:APPEND_ROWS;");
     HistogramData.BucketType bucketType = HistogramData.ExponentialBuckets.of(1, 34);
     assertThat(testContainer.perWorkerCounters, IsMapContaining.hasKey(counterNameDisabledDeletes));
     assertThat(
@@ -199,7 +201,8 @@ public class BigQuerySinkMetricsTest {
         c, BigQuerySinkMetrics.RpcMethod.APPEND_ROWS, "tableId");
     MetricName counterNameEnabledDeletes =
         MetricName.named(
-            "BigQuerySink", "RpcRequests-Method:APPEND_ROWS;RpcStatus:OK;TableId:tableId;");
+            "BigQuerySink",
+            "RpcRequestsCount-rpc_method:APPEND_ROWS;rpc_status:OK;table_id:tableId;");
     assertThat(testContainer.perWorkerCounters, IsMapContaining.hasKey(counterNameEnabledDeletes));
     assertThat(
         testContainer.perWorkerCounters.get(counterNameEnabledDeletes).getCumulative(),
@@ -228,8 +231,10 @@ public class BigQuerySinkMetricsTest {
     BigQuerySinkMetrics.reportFailedRPCMetrics(
         c, BigQuerySinkMetrics.RpcMethod.APPEND_ROWS, "tableId");
     MetricName counterNameDisabledDeletes =
-        MetricName.named("BigQuerySink", "RpcRequests-Method:APPEND_ROWS;RpcStatus:NOT_FOUND;");
-    MetricName histogramName = MetricName.named("BigQuerySink", "RpcLatency-Method:APPEND_ROWS;");
+        MetricName.named(
+            "BigQuerySink", "RpcRequestsCount-rpc_method:APPEND_ROWS;rpc_status:NOT_FOUND;");
+    MetricName histogramName =
+        MetricName.named("BigQuerySink", "RpcLatency-rpc_method:APPEND_ROWS;");
     HistogramData.BucketType bucketType = HistogramData.ExponentialBuckets.of(1, 34);
     assertThat(testContainer.perWorkerCounters, IsMapContaining.hasKey(counterNameDisabledDeletes));
     assertThat(
@@ -249,7 +254,8 @@ public class BigQuerySinkMetricsTest {
         c, BigQuerySinkMetrics.RpcMethod.APPEND_ROWS, "tableId");
     MetricName counterNameEnabledDeletes =
         MetricName.named(
-            "BigQuerySink", "RpcRequests-Method:APPEND_ROWS;RpcStatus:NOT_FOUND;TableId:tableId;");
+            "BigQuerySink",
+            "RpcRequestsCount-rpc_method:APPEND_ROWS;rpc_status:NOT_FOUND;table_id:tableId;");
     assertThat(testContainer.perWorkerCounters, IsMapContaining.hasKey(counterNameEnabledDeletes));
     assertThat(
         testContainer.perWorkerCounters.get(counterNameEnabledDeletes).getCumulative(),
@@ -277,8 +283,10 @@ public class BigQuerySinkMetricsTest {
     BigQuerySinkMetrics.reportFailedRPCMetrics(
         c, BigQuerySinkMetrics.RpcMethod.APPEND_ROWS, "tableId");
     MetricName counterNameDisabledDeletes =
-        MetricName.named("BigQuerySink", "RpcRequests-Method:APPEND_ROWS;RpcStatus:UNKNOWN;");
-    MetricName histogramName = MetricName.named("BigQuerySink", "RpcLatency-Method:APPEND_ROWS;");
+        MetricName.named(
+            "BigQuerySink", "RpcRequestsCount-rpc_method:APPEND_ROWS;rpc_status:UNKNOWN;");
+    MetricName histogramName =
+        MetricName.named("BigQuerySink", "RpcLatency-rpc_method:APPEND_ROWS;");
     HistogramData.BucketType bucketType = HistogramData.ExponentialBuckets.of(1, 34);
     assertThat(testContainer.perWorkerCounters, IsMapContaining.hasKey(counterNameDisabledDeletes));
     assertThat(
@@ -295,7 +303,8 @@ public class BigQuerySinkMetricsTest {
         c, BigQuerySinkMetrics.RpcMethod.APPEND_ROWS, "tableId");
     MetricName counterNameEnabledDeletes =
         MetricName.named(
-            "BigQuerySink", "RpcRequests-Method:APPEND_ROWS;RpcStatus:UNKNOWN;TableId:tableId;");
+            "BigQuerySink",
+            "RpcRequestsCount-rpc_method:APPEND_ROWS;rpc_status:UNKNOWN;table_id:tableId;");
     assertThat(testContainer.perWorkerCounters, IsMapContaining.hasKey(counterNameEnabledDeletes));
     assertThat(
         testContainer.perWorkerCounters.get(counterNameEnabledDeletes).getCumulative(),


### PR DESCRIPTION
Expected bq metric names/label names have changed since they were originally implemented.
Additionally, there were a few spots in [StorageApiWritesShardedRecords.java](https://github.com/apache/beam/compare/master...JayajP:beam:Fixbqmetrics3?expand=1#diff-7a37e64a2dd8c51763204b5de1463318e35292177068e8a11ef0cd4764d8b261) where we did not increment metrics or supply the table_id parameter, this PR also fixes this issue.

This is a no-op change since we currently don't send metrics to the backend.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
