### PR TITLE
[#29917][prism] Initial TestStream support

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
@@ -231,7 +231,6 @@ func (em *ElementManager) AddTestStream(id string, tagToPCol map[string]string) 
 	impl := &testStreamImpl{em: em}
 	impl.initHandler(id)
 	impl.TagsToPCollections(tagToPCol)
-	// em.addRefreshes(singleSet(id))
 	return impl
 }
 

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
@@ -330,41 +330,70 @@ func (em *ElementManager) Bundles(ctx context.Context, nextBundID func() string)
 					em.refreshCond.L.Lock()
 				}
 			}
-			if len(em.inprogressBundles) == 0 && len(em.watermarkRefreshes) == 0 {
-				nextEvent := em.testStreamHandler.NextEvent()
-				if nextEvent == nil {
-					v := em.livePending.Load()
-					slog.Debug("Bundles: nothing in progress and no refreshes", slog.Int64("pendingElementCount", v))
-					if v > 0 {
-						var stageState []string
-						ids := maps.Keys(em.stages)
-						sort.Strings(ids)
-						for _, id := range ids {
-							ss := em.stages[id]
-							inW := ss.InputWatermark()
-							outW := ss.OutputWatermark()
-							upPCol, upW := ss.UpstreamWatermark()
-							upS := em.pcolParents[upPCol]
-							stageState = append(stageState, fmt.Sprintln(id, "watermark in", inW, "out", outW, "upstream", upW, "from", upS, "pending", ss.pending, "byKey", ss.pendingByKeys, "inprogressKeys", ss.inprogressKeys, "byBundle", ss.inprogressKeysByBundle, "holds", ss.watermarkHoldHeap, "holdCounts", ss.watermarkHoldsCounts))
-						}
-						panic(fmt.Sprintf("nothing in progress and no refreshes with non zero pending elements: %v\n%v", v, strings.Join(stageState, "")))
-					}
-				} else {
-					nextEvent.Execute(em)
-					em.addPending(-1) // Decrement for the event being processed.
-				}
-			} else if len(em.inprogressBundles) == 0 {
-				v := em.livePending.Load()
-				slog.Debug("Bundles: nothing in progress after advance",
-					slog.Any("advanced", advanced),
-					slog.Int("refreshCount", len(em.watermarkRefreshes)),
-					slog.Int64("pendingElementCount", v),
-				)
-			}
-			em.refreshCond.L.Unlock()
+			em.checkForQuiescence(advanced)
 		}
 	}()
 	return runStageCh
+}
+
+// checkForQuiescence sees if this element manager is no longer able to do any pending work or make progress.
+//
+// Quiescense can happen if there are no inprogress bundles, and there are no further watermark refreshes, which
+// are the only way to access new pending elements. If there are no pending elements, then the pipeline will
+// terminate successfully.
+//
+// Otherwise, produce information for debugging why the pipeline is stuck and take appropriate action, such as
+// executing off the next TestStream event.
+//
+// Must be called while holding em.refreshCond.L.
+func (em *ElementManager) checkForQuiescence(advanced set[string]) {
+	defer em.refreshCond.L.Unlock()
+	if len(em.inprogressBundles) > 0 {
+		// If there are bundles in progress, then there may be watermark refreshes when they terminate.
+		return
+	}
+	if len(em.watermarkRefreshes) > 0 {
+		// If there are watermarks to refresh, we aren't yet stuck.
+		v := em.livePending.Load()
+		slog.Debug("Bundles: nothing in progress after advance",
+			slog.Any("advanced", advanced),
+			slog.Int("refreshCount", len(em.watermarkRefreshes)),
+			slog.Int64("pendingElementCount", v),
+		)
+		return
+	}
+	// The job has quiesced!
+
+	// There are no further incoming watermark changes, see if there are test stream events for this job.
+	nextEvent := em.testStreamHandler.NextEvent()
+	if nextEvent != nil {
+		nextEvent.Execute(em)
+		// Decrement pending for the event being processed.
+		em.addPending(-1)
+		return
+	}
+
+	v := em.livePending.Load()
+	if v == 0 {
+		// Since there are no further pending elements, the job will be terminating successfully.
+		return
+	}
+	// The job is officially stuck. Fail fast and produce debugging information.
+	// Jobs must never get stuck so this indicates a bug in prism to be investigated.
+
+	slog.Debug("Bundles: nothing in progress and no refreshes", slog.Int64("pendingElementCount", v))
+	var stageState []string
+	ids := maps.Keys(em.stages)
+	sort.Strings(ids)
+	for _, id := range ids {
+		ss := em.stages[id]
+		inW := ss.InputWatermark()
+		outW := ss.OutputWatermark()
+		upPCol, upW := ss.UpstreamWatermark()
+		upS := em.pcolParents[upPCol]
+		stageState = append(stageState, fmt.Sprintln(id, "watermark in", inW, "out", outW, "upstream", upW, "from", upS, "pending", ss.pending, "byKey", ss.pendingByKeys, "inprogressKeys", ss.inprogressKeys, "byBundle", ss.inprogressKeysByBundle, "holds", ss.watermarkHoldHeap, "holdCounts", ss.watermarkHoldsCounts))
+	}
+	panic(fmt.Sprintf("nothing in progress and no refreshes with non zero pending elements: %v\n%v", v, strings.Join(stageState, "")))
 }
 
 // InputForBundle returns pre-allocated data for the given bundle, encoding the elements using

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/engine_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/engine_test.go
@@ -184,6 +184,7 @@ func TestTestStream(t *testing.T) {
 		{pipeline: primitives.TestStreamTwoBoolSequences},
 		{pipeline: primitives.TestStreamTwoFloat64Sequences},
 		{pipeline: primitives.TestStreamTwoInt64Sequences},
+		{pipeline: primitives.TestStreamTwoUserTypeSequences},
 	}
 
 	configs := []struct {

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/engine_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/engine_test.go
@@ -169,3 +169,48 @@ func TestElementManagerCoverage(t *testing.T) {
 		})
 	}
 }
+
+func TestTestStream(t *testing.T) {
+	initRunner(t)
+
+	tests := []struct {
+		pipeline func(s beam.Scope)
+	}{
+		{pipeline: primitives.TestStreamBoolSequence},
+		{pipeline: primitives.TestStreamByteSliceSequence},
+		{pipeline: primitives.TestStreamFloat64Sequence},
+		{pipeline: primitives.TestStreamInt64Sequence},
+		{pipeline: primitives.TestStreamStrings},
+		{pipeline: primitives.TestStreamTwoBoolSequences},
+		{pipeline: primitives.TestStreamTwoFloat64Sequences},
+		{pipeline: primitives.TestStreamTwoInt64Sequences},
+	}
+
+	configs := []struct {
+		name                              string
+		OneElementPerKey, OneKeyPerBundle bool
+	}{
+		{"Greedy", false, false},
+		{"AllElementsPerKey", false, true},
+		{"OneElementPerKey", true, false},
+		{"OneElementPerBundle", true, true},
+	}
+	for _, config := range configs {
+		for _, test := range tests {
+			t.Run(initTestName(test.pipeline)+"_"+config.name, func(t *testing.T) {
+				t.Cleanup(func() {
+					engine.OneElementPerKey = false
+					engine.OneKeyPerBundle = false
+				})
+				engine.OneElementPerKey = config.OneElementPerKey
+				engine.OneKeyPerBundle = config.OneKeyPerBundle
+				p, s := beam.NewPipelineWithRoot()
+				test.pipeline(s)
+				_, err := executeWithT(context.Background(), t, p)
+				if err != nil {
+					t.Fatalf("pipeline failed, but feature should be implemented in Prism: %v", err)
+				}
+			})
+		}
+	}
+}

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/engine_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/engine_test.go
@@ -180,6 +180,7 @@ func TestTestStream(t *testing.T) {
 		{pipeline: primitives.TestStreamByteSliceSequence},
 		{pipeline: primitives.TestStreamFloat64Sequence},
 		{pipeline: primitives.TestStreamInt64Sequence},
+		{pipeline: primitives.TestStreamInt16Sequence},
 		{pipeline: primitives.TestStreamStrings},
 		{pipeline: primitives.TestStreamTwoBoolSequences},
 		{pipeline: primitives.TestStreamTwoFloat64Sequences},

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/teststream.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/teststream.go
@@ -1,0 +1,269 @@
+// Licensed to the Apache Software Foundation (ASF) under one or more
+// contributor license agreements.  See the NOTICE file distributed with
+// this work for additional information regarding copyright ownership.
+// The ASF licenses this file to You under the Apache License, Version 2.0
+// (the "License"); you may not use this file except in compliance with
+// the License.  You may obtain a copy of the License at
+//
+//    http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+package engine
+
+import (
+	"time"
+
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/mtime"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/window"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/typex"
+)
+
+// We define our own element wrapper and similar to avoid depending on the protos within the
+// engine package. This improves compile times, and readability of this package.
+
+// TestStreamHandler manages TestStreamEvents for the ElementManager.
+//
+// TestStreams are a pipeline root like an Impulse. They kick off computation, and
+// strictly manage Watermark advancements.
+//
+// A given pipeline can only have a single TestStream due to test streams
+// requiring a single source of truth for Relative Processing Time advancements
+// and ordering emissions of Elements.
+// All operations with testStreamHandler are expected to be in the element manager's
+// refresh lock critical section.
+type testStreamHandler struct {
+	ID string
+
+	nextEventIndex int
+	events         []tsEvent
+	// Initialzed with normal "time.Now", so this does change by relative nature.
+	processingTime time.Time // Override for the processing time clock, for triggers and ProcessContinuations.
+
+	tagState map[string]tagState // Map from event tag to related outputs.
+
+	completed bool // indicates that no further test stream events exist, and all watermarks are advanced to infinity. Used to send the final event, once.
+}
+
+func makeTestStreamHandler(id string) *testStreamHandler {
+	return &testStreamHandler{
+		ID:       id,
+		tagState: map[string]tagState{},
+	}
+}
+
+// tagState tracks state for a given tag.
+type tagState struct {
+	watermark   mtime.Time // Current Watermark for this tag.
+	pcollection string     // ID for the pcollection of this tag to look up consumers.
+}
+
+// Now represents the overridden ProcessingTime, which is only advanced when directed by an event.
+// Overrides the elementManager "clock".
+func (ts *testStreamHandler) Now() time.Time {
+	return ts.processingTime
+}
+
+// TagsToPCollections recieves the map of local output tags to global pcollection ids.
+func (ts *testStreamHandler) TagsToPCollections(tagToPcol map[string]string) {
+	for tag, pcol := range tagToPcol {
+		ts.tagState[tag] = tagState{
+			watermark:   mtime.MinTimestamp,
+			pcollection: pcol,
+		}
+		// If there is only one output pcollection, duplicate initial state to the
+		// empty tag string.
+		if len(tagToPcol) == 1 {
+			ts.tagState[""] = ts.tagState[tag]
+		}
+	}
+}
+
+// AddElementEvent adds an element event to the test stream event queue.
+func (ts *testStreamHandler) AddElementEvent(tag string, elements []TestStreamElement) {
+	ts.events = append(ts.events, tsElementEvent{
+		Tag:      tag,
+		Elements: elements,
+	})
+}
+
+// AddWatermarkEvent adds a watermark event to the test stream event queue.
+func (ts *testStreamHandler) AddWatermarkEvent(tag string, newWatermark mtime.Time) {
+	ts.events = append(ts.events, tsWatermarkEvent{
+		Tag:          tag,
+		NewWatermark: newWatermark,
+	})
+}
+
+// AddProcessingTimeEvent adds a processing time event to the test stream event queue.
+func (ts *testStreamHandler) AddProcessingTimeEvent(d time.Duration) {
+	ts.events = append(ts.events, tsProcessingTimeEvent{
+		AdvanceBy: d,
+	})
+}
+
+// NextEvent returns the next event.
+// If there are no more events, returns nil.
+func (ts *testStreamHandler) NextEvent() tsEvent {
+	if ts == nil {
+		return nil
+	}
+	if ts.nextEventIndex >= len(ts.events) {
+		if !ts.completed {
+			ts.completed = true
+			return tsFinalEvent{stageID: ts.ID}
+		}
+		return nil
+	}
+	ev := ts.events[ts.nextEventIndex]
+	ts.nextEventIndex++
+	return ev
+}
+
+// TestStreamElement wraps the provided bytes and timestamp for ingestion and use.
+type TestStreamElement struct {
+	Encoded   []byte
+	EventTime mtime.Time
+}
+
+// tsEvent abstracts over the different TestStream Event kinds so we can keep
+// them in the same queue.
+type tsEvent interface {
+	// Execute the associated event on this element manager.
+	Execute(*ElementManager)
+}
+
+// tsElementEvent implements an element event, inserting additional elements
+// to be pending for consuming stages.
+type tsElementEvent struct {
+	Tag      string
+	Elements []TestStreamElement
+}
+
+// Execute this ElementEvent by routing pending element to their consuming stages.
+func (ev tsElementEvent) Execute(em *ElementManager) {
+	t := em.testStreamHandler.tagState[ev.Tag]
+
+	var pending []element
+	for _, e := range ev.Elements {
+		pending = append(pending, element{
+			window:    window.GlobalWindow{},
+			timestamp: e.EventTime,
+			elmBytes:  e.Encoded,
+			pane:      typex.NoFiringPane(),
+		})
+	}
+
+	// Update the consuming state.
+	for _, sID := range em.consumers[t.pcollection] {
+		ss := em.stages[sID]
+		added := ss.AddPending(pending)
+		em.addPending(added)
+		em.watermarkRefreshes.insert(sID)
+	}
+
+	for _, link := range em.sideConsumers[t.pcollection] {
+		ss := em.stages[link.Global]
+		ss.AddPendingSide(pending, link.Transform, link.Local)
+		em.watermarkRefreshes.insert(link.Global)
+	}
+}
+
+// tsWatermarkEvent sets the watermark for the new stage.
+type tsWatermarkEvent struct {
+	Tag          string
+	NewWatermark mtime.Time
+}
+
+// Execute this WatermarkEvent by updating the watermark for the tag, and notify affected downstream stages.
+func (ev tsWatermarkEvent) Execute(em *ElementManager) {
+	t := em.testStreamHandler.tagState[ev.Tag]
+
+	if ev.NewWatermark < t.watermark {
+		panic("test stream event decreases watermark. Watermarks cannot go backwards.")
+	}
+	t.watermark = ev.NewWatermark
+	em.testStreamHandler.tagState[ev.Tag] = t
+
+	// Update the upstream watermarks in the consumers.
+	for _, sID := range em.consumers[t.pcollection] {
+		ss := em.stages[sID]
+		ss.updateUpstreamWatermark(ss.inputID, t.watermark)
+		em.watermarkRefreshes.insert(sID)
+	}
+}
+
+// tsProcessingTimeEvent implements advancing the synthetic processing time.
+type tsProcessingTimeEvent struct {
+	AdvanceBy time.Duration
+}
+
+// Execute this ProcessingTime event by advancing the synthetic processing time.
+func (ev tsProcessingTimeEvent) Execute(em *ElementManager) {
+	em.testStreamHandler.processingTime = em.testStreamHandler.processingTime.Add(ev.AdvanceBy)
+}
+
+// tsFinalEvent is the "last" event we perform after all preceeding events.
+// It's automatically inserted once the user defined events have all been executed.
+// It updates the upstream watermarks for all consumers to infinity.
+type tsFinalEvent struct {
+	stageID string
+}
+
+func (ev tsFinalEvent) Execute(em *ElementManager) {
+	em.addPending(1) // We subtrack a pending after event execution, so add one now.
+	ss := em.stages[ev.stageID]
+	kickSet := ss.updateWatermarks(em)
+	kickSet.insert(ev.stageID)
+	em.watermarkRefreshes.merge(kickSet)
+}
+
+// TestStreamBuilder builds a synthetic sequence of events for the engine to execute.
+// A pipeline may only have a single TestStream and may panic.
+type TestStreamBuilder interface {
+	AddElementEvent(tag string, elements []TestStreamElement)
+	AddWatermarkEvent(tag string, newWatermark mtime.Time)
+	AddProcessingTimeEvent(d time.Duration)
+}
+
+type testStreamImpl struct {
+	em *ElementManager
+}
+
+var (
+	_ TestStreamBuilder = (*testStreamImpl)(nil)
+	_ TestStreamBuilder = (*testStreamHandler)(nil)
+)
+
+func (tsi *testStreamImpl) initHandler(id string) {
+	if tsi.em.testStreamHandler == nil {
+		tsi.em.testStreamHandler = makeTestStreamHandler(id)
+	}
+}
+
+// TagsToPCollections recieves the map of local output tags to global pcollection ids.
+func (tsi *testStreamImpl) TagsToPCollections(tagToPcol map[string]string) {
+	tsi.em.testStreamHandler.TagsToPCollections(tagToPcol)
+}
+
+// AddElementEvent adds an element event to the test stream event queue.
+func (tsi *testStreamImpl) AddElementEvent(tag string, elements []TestStreamElement) {
+	tsi.em.testStreamHandler.AddElementEvent(tag, elements)
+	tsi.em.addPending(1)
+}
+
+// AddWatermarkEvent adds a watermark event to the test stream event queue.
+func (tsi *testStreamImpl) AddWatermarkEvent(tag string, newWatermark mtime.Time) {
+	tsi.em.testStreamHandler.AddWatermarkEvent(tag, newWatermark)
+	tsi.em.addPending(1)
+}
+
+// AddProcessingTimeEvent adds a processing time event to the test stream event queue.
+func (tsi *testStreamImpl) AddProcessingTimeEvent(d time.Duration) {
+	tsi.em.testStreamHandler.AddProcessingTimeEvent(d)
+	tsi.em.addPending(1)
+}

--- a/sdks/go/pkg/beam/runners/prism/internal/jobservices/management.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/jobservices/management.go
@@ -117,6 +117,7 @@ func (s *Server) Prepare(ctx context.Context, req *jobpb.PrepareJobRequest) (*jo
 	// Inspect Transforms for unsupported features.
 	bypassedWindowingStrategies := map[string]bool{}
 	ts := job.Pipeline.GetComponents().GetTransforms()
+	var testStreamIds []string
 	for tid, t := range ts {
 		urn := t.GetSpec().GetUrn()
 		switch urn {
@@ -170,9 +171,21 @@ func (s *Server) Prepare(ctx context.Context, req *jobpb.PrepareJobRequest) (*jo
 				continue
 			}
 			fallthrough
+		case urns.TransformTestStream:
+			var testStream pipepb.TestStreamPayload
+			if err := proto.Unmarshal(t.GetSpec().GetPayload(), &testStream); err != nil {
+				return nil, fmt.Errorf("unable to unmarshal TestStreamPayload for %v - %q: %w", tid, t.GetUniqueName(), err)
+			}
+
+			t.EnvironmentId = "" // Unset the environment, to ensure it's handled prism side.
+			testStreamIds = append(testStreamIds, tid)
 		default:
 			check("PTransform.Spec.Urn", urn+" "+t.GetUniqueName(), "<doesn't exist>")
 		}
+	}
+	// At most one test stream per pipeline.
+	if len(testStreamIds) > 1 {
+		check("Multiple TestStream Transforms in Pipeline", testStreamIds)
 	}
 
 	// Inspect Windowing strategies for unsupported features.

--- a/sdks/go/pkg/beam/runners/prism/internal/jobservices/management.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/jobservices/management.go
@@ -176,6 +176,11 @@ func (s *Server) Prepare(ctx context.Context, req *jobpb.PrepareJobRequest) (*jo
 			if err := proto.Unmarshal(t.GetSpec().GetPayload(), &testStream); err != nil {
 				return nil, fmt.Errorf("unable to unmarshal TestStreamPayload for %v - %q: %w", tid, t.GetUniqueName(), err)
 			}
+			for _, ev := range testStream.GetEvents() {
+				if ev.GetProcessingTimeEvent() != nil {
+					check("TestStream.Event - ProcessingTimeEvents unsupported.", ev.GetProcessingTimeEvent())
+				}
+			}
 
 			t.EnvironmentId = "" // Unset the environment, to ensure it's handled prism side.
 			testStreamIds = append(testStreamIds, tid)

--- a/sdks/go/pkg/beam/runners/prism/internal/unimplemented_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/unimplemented_test.go
@@ -43,18 +43,6 @@ func TestUnimplemented(t *testing.T) {
 	}{
 		// {pipeline: primitives.Drain}, // Can't test drain automatically yet.
 
-		{pipeline: primitives.TestStreamBoolSequence},
-		{pipeline: primitives.TestStreamByteSliceSequence},
-		{pipeline: primitives.TestStreamFloat64Sequence},
-		{pipeline: primitives.TestStreamInt64Sequence},
-		{pipeline: primitives.TestStreamStrings},
-		{pipeline: primitives.TestStreamTwoBoolSequences},
-		{pipeline: primitives.TestStreamTwoFloat64Sequences},
-		{pipeline: primitives.TestStreamTwoInt64Sequences},
-
-		// Needs teststream
-		{pipeline: primitives.Panes},
-
 		// Triggers (Need teststream and are unimplemented.)
 		{pipeline: primitives.TriggerAlways},
 		{pipeline: primitives.TriggerAfterAll},
@@ -68,7 +56,8 @@ func TestUnimplemented(t *testing.T) {
 		{pipeline: primitives.TriggerOrFinally},
 		{pipeline: primitives.TriggerRepeat},
 
-		// TODO: Timers integration tests.
+		// Needs triggers.
+		{pipeline: primitives.Panes},
 	}
 
 	for _, test := range tests {
@@ -150,6 +139,34 @@ func TestTimers(t *testing.T) {
 	}{
 		{pipeline: primitives.TimersEventTimeBounded},
 		{pipeline: primitives.TimersEventTimeUnbounded},
+	}
+
+	for _, test := range tests {
+		t.Run(initTestName(test.pipeline), func(t *testing.T) {
+			p, s := beam.NewPipelineWithRoot()
+			test.pipeline(s)
+			_, err := executeWithT(context.Background(), t, p)
+			if err != nil {
+				t.Fatalf("pipeline failed, but feature should be implemented in Prism: %v", err)
+			}
+		})
+	}
+}
+
+func TestTestStream(t *testing.T) {
+	initRunner(t)
+
+	tests := []struct {
+		pipeline func(s beam.Scope)
+	}{
+		{pipeline: primitives.TestStreamBoolSequence},
+		{pipeline: primitives.TestStreamByteSliceSequence},
+		{pipeline: primitives.TestStreamFloat64Sequence},
+		{pipeline: primitives.TestStreamInt64Sequence},
+		{pipeline: primitives.TestStreamStrings},
+		{pipeline: primitives.TestStreamTwoBoolSequences},
+		{pipeline: primitives.TestStreamTwoFloat64Sequences},
+		{pipeline: primitives.TestStreamTwoInt64Sequences},
 	}
 
 	for _, test := range tests {

--- a/sdks/go/pkg/beam/testing/teststream/teststream.go
+++ b/sdks/go/pkg/beam/testing/teststream/teststream.go
@@ -18,11 +18,9 @@
 //
 // See https://beam.apache.org/blog/test-stream/ for more information.
 //
-// TestStream is supported on the Flink runner and currently supports int64,
-// float64, and boolean types.
-//
-// TODO(BEAM-12753): Flink currently displays unexpected behavior with TestStream,
-// should not be used until this issue is resolved.
+// TestStream is supported on the Flink, and Prism runners.
+// Use on Flink currently supports int64, float64, and boolean types, while
+// Prism supports arbitrary types.
 package teststream
 
 import (

--- a/sdks/go/test/integration/integration.go
+++ b/sdks/go/test/integration/integration.go
@@ -108,7 +108,7 @@ var directFilters = []string{
 
 var portableFilters = []string{
 	// The portable runner does not support the TestStream primitive
-	"TestTestStream.*",
+	// "TestTestStream.*",
 	// The trigger and pane tests uses TestStream
 	"TestTrigger.*",
 	"TestPanes",

--- a/sdks/go/test/integration/integration.go
+++ b/sdks/go/test/integration/integration.go
@@ -108,7 +108,7 @@ var directFilters = []string{
 
 var portableFilters = []string{
 	// The portable runner does not support the TestStream primitive
-	// "TestTestStream.*",
+	"TestTestStream.*",
 	// The trigger and pane tests uses TestStream
 	"TestTrigger.*",
 	"TestPanes",

--- a/sdks/go/test/integration/integration.go
+++ b/sdks/go/test/integration/integration.go
@@ -139,8 +139,6 @@ var portableFilters = []string{
 var prismFilters = []string{
 	// The prism runner does not yet support Java's CoGBK.
 	"TestXLang_CoGroupBy",
-	// The prism runner does not support the TestStream primitive
-	"TestTestStream.*",
 	// The trigger and pane tests uses TestStream
 	"TestTrigger.*",
 	"TestPanes",

--- a/sdks/go/test/integration/integration.go
+++ b/sdks/go/test/integration/integration.go
@@ -181,6 +181,11 @@ var flinkFilters = []string{
 	"TestSetStateClear",
 	"TestSetState",
 
+	// With TestStream Flink adds extra length prefixs some data types, causing SDK side failures.
+	"TestTestStreamStrings",
+	"TestTestStreamByteSliceSequence",
+	"TestTestStreamTwoUserTypeSequences",
+
 	"TestTimers_EventTime_Unbounded", // (failure when comparing on side inputs (NPE on window lookup))
 }
 

--- a/sdks/go/test/integration/primitives/teststream.go
+++ b/sdks/go/test/integration/primitives/teststream.go
@@ -31,6 +31,7 @@ func TestStreamStrings(s beam.Scope) {
 	col := teststream.Create(s, con)
 
 	passert.Count(s, col, "teststream strings", 3)
+	passert.Equals(s, col, "a", "b", "c")
 }
 
 // TestStreamByteSliceSequence tests the TestStream primitive by inserting byte slice elements

--- a/sdks/go/test/integration/primitives/teststream.go
+++ b/sdks/go/test/integration/primitives/teststream.go
@@ -31,19 +31,21 @@ func TestStreamStrings(s beam.Scope) {
 	col := teststream.Create(s, con)
 
 	passert.Count(s, col, "teststream strings", 3)
-	passert.Equals(s, col, "a", "b", "c")
 }
 
 // TestStreamByteSliceSequence tests the TestStream primitive by inserting byte slice elements
 // then advancing the watermark to infinity and comparing the output..
 func TestStreamByteSliceSequence(s beam.Scope) {
 	con := teststream.NewConfig()
-	b := []byte{91, 92, 93}
-	con.AddElements(1, b)
+
+	a := []byte{91, 92, 93}
+	b := []byte{94, 95, 96}
+	c := []byte{97, 98, 99}
+	con.AddElements(1, a, b, c)
 	con.AdvanceWatermarkToInfinity()
 	col := teststream.Create(s, con)
-	passert.Count(s, col, "teststream byte", 1)
-	passert.Equals(s, col, b)
+	passert.Count(s, col, "teststream byte", 3)
+	passert.Equals(s, col, a, b, c)
 }
 
 // TestStreamInt64Sequence tests the TestStream primitive by inserting int64 elements
@@ -136,5 +138,22 @@ func TestStreamTwoBoolSequences(s beam.Scope) {
 	col := teststream.Create(s, con)
 
 	passert.Count(s, col, "teststream bool", 6)
+	passert.EqualsList(s, col, append(eo, et...))
+}
+
+// TestStreamTwoUserTypeSequences tests the TestStream primitive by inserting two sets of
+// boolean elements that arrive on-time into the TestStream
+func TestStreamTwoUserTypeSequences(s beam.Scope) {
+	con := teststream.NewConfig()
+	eo := []stringPair{{"a", "b"}, {"b", "c"}, {"c", "a"}}
+	et := []stringPair{{"b", "a"}, {"c", "b"}, {"a", "c"}}
+	con.AddElementList(100, eo)
+	con.AdvanceWatermark(110)
+	con.AddElementList(120, et)
+	con.AdvanceWatermark(130)
+
+	col := teststream.Create(s, con)
+
+	passert.Count(s, col, "teststream usertype", 6)
 	passert.EqualsList(s, col, append(eo, et...))
 }

--- a/sdks/go/test/integration/primitives/teststream.go
+++ b/sdks/go/test/integration/primitives/teststream.go
@@ -31,6 +31,7 @@ func TestStreamStrings(s beam.Scope) {
 	col := teststream.Create(s, con)
 
 	passert.Count(s, col, "teststream strings", 3)
+	passert.Equals(s, col, "a", "b", "c")
 }
 
 // TestStreamByteSliceSequence tests the TestStream primitive by inserting byte slice elements
@@ -42,7 +43,7 @@ func TestStreamByteSliceSequence(s beam.Scope) {
 	con.AdvanceWatermarkToInfinity()
 	col := teststream.Create(s, con)
 	passert.Count(s, col, "teststream byte", 1)
-	passert.Equals(s, col, append([]byte{3}, b...))
+	passert.Equals(s, col, b)
 }
 
 // TestStreamInt64Sequence tests the TestStream primitive by inserting int64 elements

--- a/sdks/go/test/integration/primitives/teststream.go
+++ b/sdks/go/test/integration/primitives/teststream.go
@@ -158,3 +158,17 @@ func TestStreamTwoUserTypeSequences(s beam.Scope) {
 	passert.Count(s, col, "teststream usertype", 6)
 	passert.EqualsList(s, col, append(eo, et...))
 }
+
+// TestStreamInt16Sequence validates that a non-beam standard coder
+// works with test stream.
+func TestStreamInt16Sequence(s beam.Scope) {
+	con := teststream.NewConfig()
+	ele := []int16{91, 92, 93}
+	con.AddElementList(100, ele)
+	con.AdvanceWatermarkToInfinity()
+
+	col := teststream.Create(s, con)
+
+	passert.Count(s, col, "teststream int15", 3)
+	passert.EqualsList(s, col, ele)
+}

--- a/sdks/go/test/integration/primitives/teststream_test.go
+++ b/sdks/go/test/integration/primitives/teststream_test.go
@@ -37,6 +37,11 @@ func TestTestStreamInt64Sequence(t *testing.T) {
 	ptest.BuildAndRun(t, TestStreamInt64Sequence)
 }
 
+func TestTestStreamInt16Sequence(t *testing.T) {
+	integration.CheckFilters(t)
+	ptest.BuildAndRun(t, TestStreamInt16Sequence)
+}
+
 func TestTestStreamTwoInt64Sequences(t *testing.T) {
 	integration.CheckFilters(t)
 	ptest.BuildAndRun(t, TestStreamTwoInt64Sequences)

--- a/sdks/go/test/integration/primitives/teststream_test.go
+++ b/sdks/go/test/integration/primitives/teststream_test.go
@@ -61,3 +61,8 @@ func TestTestStreamTwoBoolSequences(t *testing.T) {
 	integration.CheckFilters(t)
 	ptest.BuildAndRun(t, TestStreamTwoBoolSequences)
 }
+
+func TestTestStreamTwoUserTypeSequences(t *testing.T) {
+	integration.CheckFilters(t)
+	ptest.BuildAndRun(t, TestStreamTwoUserTypeSequences)
+}


### PR DESCRIPTION
Adds initial TestStream support for Prism for #29917.

* Handles watermark advancement.
* Multiple Outputs (though, this is untested until covered by Python, as Go doesn't permit tag specification, however, the same lookup mechanism remains in the single output case)
* Handles arbitrary element bytes.
* Handles being consumed as a side input.

A bit of light experimentation on handling design puts most test stream related code into a single file, and uses an interface to delegate the execution of events to the different events themeselves.

The only easily testable logic outside of a pipeline execution context would be popping events from a queue. But as the alternative to correct popping is a pipeline freeze and crash (pending elements remaining, but nothing to trigger their processing), these are omitted.

The only included logic that isn't currently covered is Processing Time handling, though the core is present in this PR. TestStreams with ProcessingTime events will be hard failed at job submission time for now.  This is no great loss as Prism doesn't meaningfully handle ProcessingTime events at all, and that will require it's own coordination to insert their executions in the queue. Tracking processing time implementation is in #30083.

There was a bit of a delay in finishing this implementation due to the 2.54.0 beam release, and what to do about the Flink quirks. It turns out the Flink TestStream quirks were documented for the Go SDK, and the tests were made to suit them. This PR removes the quirks to validate What You Put In Is What You Get Out, for those tests (no extra length prefixing for example).

Prism also wraps the unknown byte blobs with length prefixes if it is length prefixing that coder in other places. This is simpler than doing an additional conditional re-write of coders in the pipeline graph, just due to test stream. A test that uses a row coder has been added to additionally validate this behavior.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
