### PR TITLE
Add StreamingStepMetricsContainer::extractPerWorkerMetrics method.

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingStepMetricsContainer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingStepMetricsContainer.java
@@ -18,9 +18,15 @@
 package org.apache.beam.runners.dataflow.worker;
 
 import com.google.api.services.dataflow.model.CounterUpdate;
+import com.google.api.services.dataflow.model.PerStepNamespaceMetrics;
 import edu.umd.cs.findbugs.annotations.SuppressFBWarnings;
+import java.time.Clock;
+import java.time.Duration;
+import java.time.Instant;
+import java.util.HashSet;
 import java.util.Map;
 import java.util.Map.Entry;
+import java.util.Set;
 import java.util.concurrent.ConcurrentHashMap;
 import java.util.concurrent.atomic.AtomicLong;
 import javax.annotation.Nonnull;
@@ -37,6 +43,7 @@ import org.apache.beam.sdk.metrics.MetricName;
 import org.apache.beam.sdk.metrics.MetricsContainer;
 import org.apache.beam.sdk.util.HistogramData;
 import org.apache.beam.sdk.values.KV;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Function;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Predicates;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.FluentIterable;
@@ -50,10 +57,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
 public class StreamingStepMetricsContainer implements MetricsContainer {
-
   private final String stepName;
 
-  private static Boolean enablePerWorkerMetrics;
+  private static Boolean enablePerWorkerMetrics = false;
 
   private MetricsMap<MetricName, DeltaCounterCell> counters =
       new MetricsMap<>(DeltaCounterCell::new);
@@ -67,6 +73,14 @@ public class StreamingStepMetricsContainer implements MetricsContainer {
 
   private MetricsMap<KV<MetricName, HistogramData.BucketType>, HistogramCell> perWorkerHistograms =
       new MetricsMap<>(HistogramCell::new);
+
+  private Map<MetricName, Instant> perWorkerCountersByFirstStaleTime = new ConcurrentHashMap<>();
+
+  // PerWorkerCounters that have been longer than this value will be removed from the underlying
+  // metrics map.
+  private Duration maximumPerWorkerCounterStaleness = Duration.ofMinutes(5);
+
+  private Clock clock = Clock.systemUTC();
 
   private StreamingStepMetricsContainer(String stepName) {
     this.stepName = stepName;
@@ -177,5 +191,110 @@ public class StreamingStepMetricsContainer implements MetricsContainer {
 
   public static void setEnablePerWorkerMetrics(Boolean enablePerWorkerMetrics) {
     StreamingStepMetricsContainer.enablePerWorkerMetrics = enablePerWorkerMetrics;
+  }
+
+  /**
+   * Updates {@code perWorkerCountersByFirstStaleTime} with the current zero-valued metrics and
+   * removes metrics that have been stale for longer than {@code maximumPerWorkerCounterStaleness}
+   * from {@code perWorkerCounters}.
+   *
+   * @param currentZeroValuedCounters Current zero-valued perworker counters.
+   * @param extractionTime Time {@code currentZeroValuedCounters} were discovered to be zero-valued.
+   */
+  private void deleteStaleCounters(
+      Set<MetricName> currentZeroValuedCounters, Instant extractionTime) {
+    // perWorkerCountersByFirstStaleTime should only contain metrics that are currently zero-valued.
+    perWorkerCountersByFirstStaleTime.keySet().retainAll(currentZeroValuedCounters);
+
+    // Delete metrics that have been longer than 'maximumPerWorkerCounterStaleness'.
+    Set<MetricName> deletedMetricNames = new HashSet<MetricName>();
+    for (Entry<MetricName, Instant> entry : perWorkerCountersByFirstStaleTime.entrySet()) {
+      if (Duration.between(entry.getValue(), extractionTime)
+              .compareTo(maximumPerWorkerCounterStaleness)
+          > 0) {
+        RemoveSafeDeltaCounterCell cell =
+            new RemoveSafeDeltaCounterCell(entry.getKey(), perWorkerCounters);
+        cell.deleteIfZero();
+        deletedMetricNames.add(entry.getKey());
+      }
+    }
+
+    // Insert new zero-valued metrics into `perWorkerCountersByFirstStaleTime`.
+    currentZeroValuedCounters.forEach(
+        name -> perWorkerCountersByFirstStaleTime.putIfAbsent(name, extractionTime));
+
+    // Metrics in 'deletedMetricNames' have either been removed from 'perWorkerCounters' or are no
+    // longer zero-valued.
+    perWorkerCountersByFirstStaleTime.keySet().removeAll(deletedMetricNames);
+  }
+
+  /**
+   * Extracts metric updates for all PerWorker metrics that have changed in this Container since the
+   * last time this function was called. Additionally, deletes any PerWorker counters that have been
+   * zero valued for more than {@code maximumPerWorkerCounterStaleness}.
+   */
+  private Iterable<PerStepNamespaceMetrics> extractPerWorkerMetricUpdates() {
+    ConcurrentHashMap<MetricName, Long> counters = new ConcurrentHashMap<MetricName, Long>();
+    ConcurrentHashMap<MetricName, HistogramData> histograms =
+        new ConcurrentHashMap<MetricName, HistogramData>();
+    HashSet<MetricName> currentZeroValuedCounters = new HashSet<MetricName>();
+
+    // Extract metrics updates.
+    perWorkerCounters.forEach(
+        (k, v) -> {
+          Long val = v.getAndSet(0);
+          if (val == 0) {
+            currentZeroValuedCounters.add(k);
+            return;
+          }
+          counters.put(k, val);
+        });
+    perWorkerHistograms.forEach(
+        (k, v) -> {
+          HistogramData val = v.getCumulative().getAndReset();
+          if (val.getTotalCount() == 0) {
+            return;
+          }
+          histograms.put(k.getKey(), val);
+        });
+
+    deleteStaleCounters(currentZeroValuedCounters, Instant.now(clock));
+
+    return MetricsToPerStepNamespaceMetricsConverter.convert(stepName, counters, histograms);
+  }
+
+  /**
+   * @param metricsContainerRegistry Metrics will be extracted for all containers in this registry.
+   * @return An iterable of {@link PerStepNamespaceMetrics} representing the changes to all
+   *     PerWorkerMetrics that have changed since the last time this function was invoked.
+   */
+  public static Iterable<PerStepNamespaceMetrics> extractPerWorkerMetricUpdates(
+      MetricsContainerRegistry<StreamingStepMetricsContainer> metricsContainerRegistry) {
+    return metricsContainerRegistry
+        .getContainers()
+        .transformAndConcat(StreamingStepMetricsContainer::extractPerWorkerMetricUpdates);
+  }
+
+  // The following methods are used to test that zero-valued perWorkerMetrics metrics are properly
+  // deleted.
+  @VisibleForTesting
+  Map<MetricName, AtomicLong> getPerWorkerCounters() {
+    return perWorkerCounters;
+  }
+
+  @VisibleForTesting
+  Map<MetricName, Instant> getPerWorkerCountersByFirstStaleTime() {
+    return perWorkerCountersByFirstStaleTime;
+  }
+
+  /**
+   * Set the internal clock used to determine how long PerWorker metrics have been zero-valued for.
+   * Should only be used for testing.
+   *
+   * @param clock
+   */
+  @VisibleForTesting
+  void setClock(Clock clock) {
+    this.clock = clock;
   }
 }


### PR DESCRIPTION
This method allows us to periodically extract perWorkerMetric updates for an input `MetricsContainerRegistry`. This is the same pattern we use to support existing DFE counters (see `StreamingStepMetricsContainer::extractMetricUpdates`).

Additionally, this PR adds support to clean up stale PerWorkerCounters. Counters will be removed from the underlying `perWorkerCounters` map if they have been zero valued for longer than 5 minutes. This allows us to create counters with dynamic metric labels that might not last the lifetime of the job, e.g. BQ table IDs set with dynamic destinations.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
