### PR TITLE
[Proposal] Improve DisplayData support in PTransform API

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/PTransform.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/PTransform.java
@@ -221,7 +221,7 @@ public abstract class PTransform<InputT extends PInput, OutputT extends POutput>
   }
 
   /**
-   * Set display data for your PTransform
+   * Set display data for your PTransform.
    *
    * @param displayData a list of {@link ItemSpec} instances.
    * @return a reference to the same transfrom instance.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/PTransform.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/PTransform.java
@@ -20,14 +20,17 @@ package org.apache.beam.sdk.transforms;
 import java.io.ObjectInputStream;
 import java.io.ObjectOutputStream;
 import java.io.Serializable;
+import java.util.ArrayList;
 import java.util.Collections;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.transforms.display.DisplayData;
+import org.apache.beam.sdk.transforms.display.DisplayData.ItemSpec;
 import org.apache.beam.sdk.transforms.display.HasDisplayData;
 import org.apache.beam.sdk.transforms.resourcehints.ResourceHints;
 import org.apache.beam.sdk.util.NameUtils;
@@ -217,6 +220,25 @@ public abstract class PTransform<InputT extends PInput, OutputT extends POutput>
     return resourceHints;
   }
 
+  /**
+   * Set display data for your PTransform
+   *
+   * @param displayData a list of {@link ItemSpec} instances.
+   * @return a reference to the same transfrom instance.
+   *     <p>For example:
+   *     <pre>{@code
+   * Pipeline p = ...
+   * ...
+   * p.apply(new SomeTransform().setDisplayData(ImmutableList.of(DisplayData.item("userFn", userFn.getClass())))
+   * ...
+   *
+   * }</pre>
+   */
+  public PTransform<InputT, OutputT> setDisplayData(@NonNull List<ItemSpec<?>> displayData) {
+    this.displayData = displayData;
+    return this;
+  }
+
   /** Returns annotations map to provide additional hints to the runner. */
   public Map<String, byte[]> getAnnotations() {
     return annotations;
@@ -242,6 +264,8 @@ public abstract class PTransform<InputT extends PInput, OutputT extends POutput>
   protected transient @NonNull ResourceHints resourceHints = ResourceHints.create();
 
   protected transient @NonNull Map<String, byte @NonNull []> annotations = new HashMap<>();
+
+  protected transient @NonNull List<ItemSpec<?>> displayData = new ArrayList<>();
 
   protected PTransform() {
     this.name = null;
@@ -346,7 +370,11 @@ public abstract class PTransform<InputT extends PInput, OutputT extends POutput>
    * provide their own display data.
    */
   @Override
-  public void populateDisplayData(DisplayData.Builder builder) {}
+  public void populateDisplayData(DisplayData.Builder builder) {
+    if (this.displayData != null) {
+      this.displayData.forEach(builder::add);
+    }
+  }
 
   /**
    * For a {@code SerializableFunction<InputT, OutputT>} {@code fn}, returns a {@code PTransform}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/PTransformTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/PTransformTest.java
@@ -17,9 +17,11 @@
  */
 package org.apache.beam.sdk.transforms;
 
+import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
 import static org.apache.beam.sdk.values.TypeDescriptors.integers;
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.empty;
+import static org.hamcrest.Matchers.hasSize;
 import static org.junit.Assert.assertEquals;
 
 import java.io.Serializable;
@@ -29,6 +31,7 @@ import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.display.DisplayData;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionList;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.experimental.categories.Category;
@@ -52,6 +55,24 @@ public class PTransformTest implements Serializable {
         };
     DisplayData displayData = DisplayData.from(transform);
     assertThat(displayData.items(), empty());
+  }
+
+  @Test
+  public void testSetDisplayData() {
+    PTransform<PCollection<String>, PCollection<String>> transform =
+        new PTransform<PCollection<String>, PCollection<String>>() {
+          @Override
+          public PCollection<String> expand(PCollection<String> begin) {
+            throw new IllegalArgumentException("Should never be applied");
+          }
+        };
+    transform.setDisplayData(
+        ImmutableList.of(DisplayData.item("key1", "value1"), DisplayData.item("key2", 2L)));
+
+    final DisplayData displayData = DisplayData.from(transform);
+    assertThat(displayData.items(), hasSize(2));
+    assertThat(displayData, hasDisplayItem("key1", "value1"));
+    assertThat(displayData, hasDisplayItem("key2", 2L));
   }
 
   @Test

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ParDoTest.java
@@ -507,6 +507,10 @@ public class ParDoTest implements Serializable {
                   DisplayDataMatchers.hasValue(fn.getClass().getName()))));
 
       assertThat(displayData, includesDisplayDataFor("fn", fn));
+
+      // Test setting DisplayData through PTransform API
+      parDo.setDisplayData(ImmutableList.of(DisplayData.item("doFnMetadata", "baz")));
+      assertThat(DisplayData.from(parDo), hasDisplayItem("doFnMetadata", "baz"));
     }
 
     @Test


### PR DESCRIPTION
This PR proposes a new PTransform API, `setDisplayData`, for adding DisplayData items to the transform.

Motivation: Adding DisplayData is easy to do via the `HasDisplayData#populateDisplayData` method that most transform-like types inherit. However, as a user and library owner, I don't always have access to the construction of the PTransform or DoFn and can't override `populateDisplayData`. For example, it would be difficult to add custom displayData labels to any of these transforms unless I wrapped them into new PTransforms:

```java
    pipeline
        .apply(Create.of(1, 2, 3))
        .apply("Map Elements", MapElements.via(...))
        .apply("GBK", GroupByKey.create())
```

This PR adds a method `setDisplayData` that can be invoked on any PTransform instance.

Note: I followed the convention of other setter methods in the PTransform class, i.e. [setResourceHints](https://github.com/apache/beam/blob/v2.53.0/sdks/java/core/src/main/java/org/apache/beam/sdk/transforms/PTransform.java#L210), but it might be more intuitive to make it a `withDisplayData` method that returns the PTransform instance, so that users can use it like `pipeline.apply(Create.of(1, 2, 3).withDisplayData(...))` ?

Let me know what you think! :)

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
