### PR TITLE
[YAML] Add support for callable kwargs for Combine, PyTransform and custom python transform providers

### DIFF
--- a/sdks/python/apache_beam/yaml/inline_python.md
+++ b/sdks/python/apache_beam/yaml/inline_python.md
@@ -17,7 +17,7 @@
     under the License.
 -->
 
-# Using PyTransform form YAML
+# Using PyTransform from YAML
 
 Beam YAML provides the ability to easily invoke Python transforms via the
 `PyTransform` type, simply referencing them by fully qualified name.
@@ -35,7 +35,7 @@ For example,
 will invoke the transform `apache_beam.pkg.mod.SomeTransform(1, 'foo', baz=3)`.
 This fully qualified name can be any PTransform class or other callable that
 returns a PTransform. Note, however, that PTransforms that do not accept or
-return schema'd data may not be as useable to use from YAML.
+return schema'd data may not be as usable within YAML.
 Restoring the schema-ness after a non-schema returning transform can be done
 by using the `callable` option on `MapToFields` which takes the entire element
 as an input, e.g.
@@ -155,7 +155,7 @@ In this case one can simply write
 
 # External transforms
 
-One can also invoke PTransforms define elsewhere via a `python` provider,
+One can also invoke PTransforms defined elsewhere via a `python` provider,
 for example
 
 ```
@@ -186,7 +186,8 @@ pipeline:
     - type: ToCase
       input: ...
       config:
-        upper: True
+        case: 
+          callable: str.upper
 
 providers:
   - type: python
@@ -194,9 +195,6 @@ providers:
     transforms:
       'ToCase': |
         @beam.ptransform_fn
-        def ToCase(pcoll, upper):
-          if upper:
-            return pcoll | beam.Map(lambda x: str(x).upper())
-          else:
-            return pcoll | beam.Map(lambda x: str(x).lower())
+        def ToCase(pcoll, case):
+          return pcoll | beam.Map(lambda x: case(x.col1))
 ```

--- a/sdks/python/apache_beam/yaml/yaml_combine.md
+++ b/sdks/python/apache_beam/yaml/yaml_combine.md
@@ -147,6 +147,27 @@ parameter.
             n: 10
 ```
 
+For custom aggregation functions that use python callables as parameters, 
+nesting the function parameter values under a `callable` tag will tell the 
+transform to treat the value as a callable.
+
+```
+- type: Combine
+  config:
+    language: python
+    group_by: col1
+    combine:
+      biggest:
+        value: col2
+        fn:
+          type: 'apache_beam.transforms.combiners.TopCombineFn'
+          config:
+            n: 2
+            key:
+              callable: len
+            reverse: true
+```
+
 ## SQL-style aggregations
 
 By setting the language to SQL, one can provide full SQL snippets as the

--- a/sdks/python/apache_beam/yaml/yaml_combine.md
+++ b/sdks/python/apache_beam/yaml/yaml_combine.md
@@ -148,8 +148,8 @@ parameter.
 ```
 
 For custom aggregation functions that use python callables as parameters, 
-nesting the function parameter values under a `callable` tag will tell the 
-transform to treat the value as a callable.
+nesting the function parameter values under a `__callable__` tag will tell the 
+transform to evaluate the value as a callable rather than a literal string.
 
 ```
 - type: Combine
@@ -164,7 +164,7 @@ transform to treat the value as a callable.
           config:
             n: 2
             key:
-              callable: len
+              __callable__: len
             reverse: true
 ```
 

--- a/sdks/python/apache_beam/yaml/yaml_combine.py
+++ b/sdks/python/apache_beam/yaml/yaml_combine.py
@@ -32,7 +32,7 @@ from apache_beam.utils import python_callable
 from apache_beam.yaml import options
 from apache_beam.yaml import yaml_mapping
 from apache_beam.yaml import yaml_provider
-from apache_beam.yaml.yaml_provider import parse_callable_kwargs
+from apache_beam.yaml.yaml_provider import parse_callable_args
 
 BUILTIN_COMBINE_FNS = {
     'sum': sum,
@@ -114,7 +114,7 @@ class PyJsYamlCombine(beam.PTransform):
         fn = python_callable.PythonCallableWithSource.load_from_source(
             fn_spec['type'])
         if 'config' in fn_spec:
-          fn = fn(**parse_callable_kwargs(fn_spec['config']))
+          fn = fn(**parse_callable_args(fn_spec['config']))
         return fn
       else:
         raise TypeError('Unknown CombineFn: {fn_spec}')

--- a/sdks/python/apache_beam/yaml/yaml_combine.py
+++ b/sdks/python/apache_beam/yaml/yaml_combine.py
@@ -32,6 +32,7 @@ from apache_beam.utils import python_callable
 from apache_beam.yaml import options
 from apache_beam.yaml import yaml_mapping
 from apache_beam.yaml import yaml_provider
+from apache_beam.yaml.yaml_provider import parse_callable_kwargs
 
 BUILTIN_COMBINE_FNS = {
     'sum': sum,
@@ -113,7 +114,7 @@ class PyJsYamlCombine(beam.PTransform):
         fn = python_callable.PythonCallableWithSource.load_from_source(
             fn_spec['type'])
         if 'config' in fn_spec:
-          fn = fn(**fn_spec['config'])
+          fn = fn(**parse_callable_kwargs(fn_spec['config']))
         return fn
       else:
         raise TypeError('Unknown CombineFn: {fn_spec}')

--- a/sdks/python/apache_beam/yaml/yaml_provider_unit_test.py
+++ b/sdks/python/apache_beam/yaml/yaml_provider_unit_test.py
@@ -19,6 +19,7 @@ import logging
 import unittest
 
 from apache_beam.yaml.yaml_provider import YamlProviders
+from apache_beam.yaml.yaml_provider import parse_callable_kwargs
 
 
 class WindowIntoTest(unittest.TestCase):
@@ -61,6 +62,77 @@ class WindowIntoTest(unittest.TestCase):
   def test_parse_duration_with_missing_value(self):
     with self.assertRaises(ValueError):
       self.parse_duration('s', 'size')
+
+
+class CallableKwargsTest(unittest.TestCase):
+  def __init__(self, methodName="runCallableKwargsTest"):
+    unittest.TestCase.__init__(self, methodName)
+
+  def test_parse_callable_kwargs_without_callable(self):
+    kwargs = {'n': 2, 'key': 'a', 'reverse': True}
+    expected = {'n': 2, 'key': 'a', 'reverse': True}
+    actual = parse_callable_kwargs(kwargs)
+    self.assertEqual(expected, actual)
+
+  def test_parse_callable_kwargs_with_callable(self):
+    kwargs = {'n': 2, 'key': {'callable': 'len'}, 'reverse': True}
+    expected = {'n': 2, 'key': len, 'reverse': True}
+    actual = parse_callable_kwargs(kwargs)
+    self.assertEqual(expected, actual)
+
+  def test_parse_callable_kwargs_with_nested_value(self):
+    kwargs = {'n': {'m': 2}, 'key': 'a', 'reverse': True}
+    expected = {'n': {'m': 2}, 'key': 'a', 'reverse': True}
+    actual = parse_callable_kwargs(kwargs)
+    self.assertEqual(expected, actual)
+
+  def test_parse_callable_kwargs_with_nested_callable(self):
+    kwargs = {'n': {'m': {'callable': 'len'}}, 'key': 'a', 'reverse': True}
+    expected = {'n': {'m': len}, 'key': 'a', 'reverse': True}
+    actual = parse_callable_kwargs(kwargs)
+    self.assertEqual(expected, actual)
+
+  def test_parse_callable_kwargs_with_top_level_callable(self):
+    kwargs = {'n': 2, 'callable': 'len', 'reverse': True}
+    expected = {'n': 2, 'callable': 'len', 'reverse': True}
+    actual = parse_callable_kwargs(kwargs)
+    self.assertEqual(expected, actual)
+
+  def test_parse_callable_kwargs_with_double_nested_callable(self):
+    kwargs = {'n': 2, 'callable': {'callable': 'len'}, 'reverse': True}
+    expected = {'n': 2, 'callable': len, 'reverse': True}
+    actual = parse_callable_kwargs(kwargs)
+    self.assertEqual(expected, actual)
+
+  def test_parse_callable_kwargs_with_double_nested_callable_under_value(self):
+    kwargs = {'n': 2, 'key': {'callable': {'callable': 'len'}}, 'reverse': True}
+    expected = {'n': 2, 'key': {'callable': len}, 'reverse': True}
+    actual = parse_callable_kwargs(kwargs)
+    self.assertEqual(expected, actual)
+
+  def test_parse_callable_kwargs_with_multiple_values(self):
+    kwargs = {'n': 2, 'key': {'inner': 2, 'val': 'foo'}, 'reverse': True}
+    expected = {'n': 2, 'key': {'inner': 2, 'val': 'foo'}, 'reverse': True}
+    actual = parse_callable_kwargs(kwargs)
+    self.assertEqual(expected, actual)
+
+  def test_parse_callable_kwargs_with_multiple_values_callable(self):
+    kwargs = {'n': 2, 'key': {'val': 2, 'callable': 'len'}, 'reverse': True}
+    expected = {'n': 2, 'key': {'val': 2, 'callable': 'len'}, 'reverse': True}
+    actual = parse_callable_kwargs(kwargs)
+    self.assertEqual(expected, actual)
+
+  def test_parse_callable_kwargs_with_multiple_values_nested_callable(self):
+    kwargs = {'n': 2, 'key': {'inner': 2, 'callable': {'callable': 'len'}}}
+    expected = {'n': 2, 'key': {'inner': 2, 'callable': len}}
+    actual = parse_callable_kwargs(kwargs)
+    self.assertEqual(expected, actual)
+
+  def test_parse_callable_kwargs_with_only_callable(self):
+    kwargs = {'callable': 'len'}
+    expected = {'callable': 'len'}
+    actual = parse_callable_kwargs(kwargs)
+    self.assertEqual(expected, actual)
 
 
 if __name__ == '__main__':


### PR DESCRIPTION
This PR adds support for defining **python** `callable` parameters for the built-in `Combine` transform as well as any transform defined using `PyTransform` or `ExternalProvider` registered with `python` or `pythonPackage`.

External transforms defined using a `python` registered `ExternalProvider` use the `InlineProvider` when no python packages are defined. In this case, a special flag is passed to `InlineProvider` to tell it to allow `callable` parameters. This is to avoid interfering with built-in transform behavior, while allowing a user to expose the functionality within their own custom transform provider.

This will allow for more complex pipelines to be defined such as the one below:
```
pipeline:
  type: chain
  transforms:
    - type: Create
      config:
        elements:
          - {'season': spring, 'produce': '🥕 Carrot'}
          - {'season': spring, 'produce': '🍓 Strawberry'}
          - {'season': summer, 'produce': '🥕 Carrot'}
          - {'season': summer, 'produce': '🌽 Corn'}
          - {'season': summer, 'produce': '🍏 Green apple'}
          - {'season': fall, 'produce': '🥕 Carrot'}
          - {'season': fall, 'produce': '🍏 Green apple'}
          - {'season': winter, 'produce': '🍆 Eggplant'}
    - type: ToCase
      config:
        fn_map:
          upper:
            __callable__: str.upper
          lower:
            __callable__: str.lower
        suffix: 'x'
    - type: Combine
      config:
        language: python
        group_by: season
        combine:
          shortest:
            value: produce
            fn:
              type: apache_beam.transforms.combiners.TopCombineFn
              config:
                n: 2
                key:
                  __callable__: 'lambda x: len(x)'
                reverse: true
    - type: Explode
      config:
        fields: [ shortest ]
    - type: Filter
      config:
        language: python
        keep:
          callable: "lambda x: x.season == 'SPRINGx'"
    - type: PyTransform
      config:
        constructor: apache_beam.transforms.core.Map
        kwargs:
          fn:
            __callable__: print
options:
  yaml_experimental_features: Combine

providers:
  - type: python
    config: {}
    transforms:
      'ToCase': |
        @beam.ptransform_fn
        def ToCase(pcoll, fn_map, suffix=''):
          return pcoll | beam.Map(lambda x: beam.Row(season=fn_map['upper'](x.season) + suffix, produce=x.produce))
```
Running the above pipeline prints the following output:
```
Row(season='SPRINGx', shortest='🥕 Carrot')
Row(season='SPRINGx', shortest='🍓 Strawberry')
```


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
