### PR TITLE
[Go SDK] Don't depend on the go 1.21 standard lib yet

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/contextreg/contextreg.go
+++ b/sdks/go/pkg/beam/core/runtime/contextreg/contextreg.go
@@ -22,8 +22,9 @@ package contextreg
 
 import (
 	"context"
-	"maps"
 	"sync"
+
+	"golang.org/x/exp/maps"
 )
 
 var defaultReg = &Registry{}

--- a/sdks/go/pkg/beam/core/runtime/harness/init/init.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/init/init.go
@@ -22,14 +22,14 @@ import (
 	"context"
 	"encoding/json"
 	"flag"
-	"slices"
 	"strings"
 	"time"
 
 	"fmt"
 	"os"
-
 	"runtime/debug"
+
+	"golang.org/x/exp/slices"
 
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime/graphx"


### PR DESCRIPTION
Beam is currently using go 1.20, but was accidentally depending on the go 1.21 standard libary versions of "maps" and "slices". This changes them to be the compatibility packages.

While beam advocates using the latest release (go 1.21) of Go when using it (which avoids problems when compiling those targets), the occasionally subtle dependency semantics allowed for that mismatch, leading to the compiler error. (IIRC this is not a problem past 1.21, which has better tooling awareness, but won't cause regressions for packages authored before those semantics...)

Going to cherry pick this into the 2.54.0 release to restore the compatibility with go 1.20.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
