### PR TITLE
Remove CoGBK in MLTransform's TFTProcessHandler

### DIFF
--- a/sdks/python/apache_beam/ml/transforms/handlers.py
+++ b/sdks/python/apache_beam/ml/transforms/handlers.py
@@ -92,7 +92,7 @@ class DataCoder:
       coder=coders.registry.get_coder(Any),
   ):
     """
-    Uses PickleCoder to encode/decode the dictonaries.
+    Encodes/decodes items of a dictionary into a single element.
     Args:
       exclude_columns: list of columns to exclude from the encoding.
     """

--- a/sdks/python/apache_beam/ml/transforms/handlers.py
+++ b/sdks/python/apache_beam/ml/transforms/handlers.py
@@ -419,7 +419,6 @@ class TFTProcessHandler(ProcessHandler[tft_process_handler_input_type,
     # numpy array all the time.
     raw_data_list = (
         keyed_raw_data
-        # | beam.ParDo(_EncodeDict(exclude_columns=feature_set)))
         | beam.Map(lambda elem: self.data_coder.encode(elem)))
 
     keyed_raw_data = keyed_raw_data | beam.ParDo(
@@ -460,7 +459,6 @@ class TFTProcessHandler(ProcessHandler[tft_process_handler_input_type,
 
       transformed_dataset = (
           transformed_dataset
-          # | "DecodeDict" >> beam.ParDo(_DecodeDict()))
           | "DecodeDict" >> beam.Map(lambda x: self.data_coder.decode(x)))
       # The schema only contains the columns that are transformed.
       transformed_dataset = (

--- a/sdks/python/apache_beam/ml/transforms/handlers.py
+++ b/sdks/python/apache_beam/ml/transforms/handlers.py
@@ -100,8 +100,6 @@ class DataCoder:
     self.exclude_columns = exclude_columns
 
   def encode(self, element):
-    # if not set(element.keys()) - set(self.exclude_columns):
-    #   return element
     data_to_encode = element.copy()
     for key in self.exclude_columns:
       if key in data_to_encode:

--- a/sdks/python/apache_beam/ml/transforms/handlers.py
+++ b/sdks/python/apache_beam/ml/transforms/handlers.py
@@ -19,7 +19,7 @@
 import collections
 import os
 import typing
-import uuid
+from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -31,6 +31,7 @@ import numpy as np
 import apache_beam as beam
 import tensorflow as tf
 import tensorflow_transform.beam as tft_beam
+from apache_beam.internal import pickler
 from apache_beam.io.filesystems import FileSystems
 from apache_beam.ml.transforms.base import ArtifactMode
 from apache_beam.ml.transforms.base import ProcessHandler
@@ -50,7 +51,7 @@ __all__ = [
     'TFTProcessHandler',
 ]
 
-_ID_COLUMN = 'tmp_uuid'  # Name for a temporary column.
+_TEMP_KEY = 'CODED_SAMPLE'  # key for the encoded sample
 
 RAW_DATA_METADATA_DIR = 'raw_data_metadata'
 SCHEMA_FILE = 'schema.pbtxt'
@@ -129,7 +130,7 @@ class _ConvertScalarValuesToListValues(beam.DoFn):
         new_dict[key] = [value]
       else:
         new_dict[key] = value
-    yield (id, new_dict)
+    yield new_dict
 
 
 class _ConvertNamedTupleToDict(
@@ -155,79 +156,6 @@ class _ConvertNamedTupleToDict(
     else:
       # named tuple
       return pcoll | beam.Map(lambda x: x._asdict())
-
-
-class _ComputeAndAttachUniqueID(beam.DoFn):
-  """
-  Computes and attaches a unique id to each element in the PCollection.
-  """
-  def process(self, element):
-    # UUID1 includes machine-specific bits and has a counter. As long as not too
-    # many are generated at the same time, they should be unique.
-    # UUID4 generation should be unique in practice as long as underlying random
-    # number generation is not compromised.
-    # A combintation of both should avoid the anecdotal pitfalls where
-    # replacing one with the other has helped some users.
-    # UUID collision will result in data loss, but we can detect that and fail.
-
-    # TODO(https://github.com/apache/beam/issues/29593): Evaluate MLTransform
-    # implementation without CoGBK.
-    unique_key = uuid.uuid1().bytes + uuid.uuid4().bytes
-    yield (unique_key, element)
-
-
-class _GetMissingColumns(beam.DoFn):
-  """
-  Returns data containing only the columns that are not
-  present in the schema. This is needed since TFT only outputs
-  columns that are transformed by any of the data processing transforms.
-  """
-  def __init__(self, existing_columns):
-    self.existing_columns = existing_columns
-
-  def process(self, element):
-    id, row_dict = element
-    new_dict = {
-        k: v
-        for k, v in row_dict.items() if k not in self.existing_columns
-    }
-    yield (id, new_dict)
-
-
-class _MakeIdAsColumn(beam.DoFn):
-  """
-  Extracts the id from the element and adds it as a column instead.
-  """
-  def process(self, element):
-    id, element = element
-    element[_ID_COLUMN] = id
-    yield element
-
-
-class _ExtractIdAndKeyPColl(beam.DoFn):
-  """
-  Extracts the id and return id and element as a tuple.
-  """
-  def process(self, element):
-    id = element[_ID_COLUMN][0]
-    del element[_ID_COLUMN]
-    yield (id, element)
-
-
-class _MergeDicts(beam.DoFn):
-  """
-  Merges processed and unprocessed columns from CoGBK result into a single row.
-  """
-  def process(self, element):
-    unused_row_id, row_dicts_tuple = element
-    new_dict = {}
-    for d in row_dicts_tuple:
-      # After CoGBK, dicts with processed and unprocessed portions of each row
-      # are wrapped in 1-element lists, since all rows have a unique id.
-      # Assertion could fail due to UUID collision.
-      assert len(d) == 1, f"Expected 1 element, got: {len(d)}."
-      new_dict.update(d[0])
-    yield new_dict
 
 
 class TFTProcessHandler(ProcessHandler[tft_process_handler_input_type,
@@ -358,7 +286,7 @@ class TFTProcessHandler(ProcessHandler[tft_process_handler_input_type,
   def get_raw_data_metadata(
       self, input_types: Dict[str, type]) -> dataset_metadata.DatasetMetadata:
     raw_data_feature_spec = self.get_raw_data_feature_spec(input_types)
-    raw_data_feature_spec[_ID_COLUMN] = tf.io.VarLenFeature(dtype=tf.string)
+    raw_data_feature_spec[_TEMP_KEY] = tf.io.VarLenFeature(dtype=tf.string)
     return self.convert_raw_data_feature_spec_to_dataset_metadata(
         raw_data_feature_spec)
 
@@ -480,21 +408,20 @@ class TFTProcessHandler(ProcessHandler[tft_process_handler_input_type,
       raw_data_metadata = metadata_io.read_metadata(
           os.path.join(self.artifact_location, RAW_DATA_METADATA_DIR))
 
-    keyed_raw_data = (raw_data | beam.ParDo(_ComputeAndAttachUniqueID()))
+    keyed_raw_data = (raw_data)  #  | beam.ParDo(_ComputeAndAttachUniqueID()))
 
     feature_set = [feature.name for feature in raw_data_metadata.schema.feature]
-    keyed_columns_not_in_schema = (
-        keyed_raw_data
-        | beam.ParDo(_GetMissingColumns(feature_set)))
 
     # To maintain consistency by outputting numpy array all the time,
     # whether a scalar value or list or np array is passed as input,
     #  we will convert scalar values to list values and TFT will ouput
     # numpy array all the time.
+    raw_data_list = (
+        keyed_raw_data
+        | beam.ParDo(_EncodeDict(exclude_columns=feature_set)))
+
     keyed_raw_data = keyed_raw_data | beam.ParDo(
         _ConvertScalarValuesToListValues())
-
-    raw_data_list = (keyed_raw_data | beam.ParDo(_MakeIdAsColumn()))
 
     with tft_beam.Context(temp_dir=self.artifact_location):
       data = (raw_data_list, raw_data_metadata)
@@ -525,26 +452,13 @@ class TFTProcessHandler(ProcessHandler[tft_process_handler_input_type,
       # So we will use a RowTypeConstraint to create a schema'd PCollection.
       # this is needed since new columns are included in the
       # transformed_dataset.
-      del self.transformed_schema[_ID_COLUMN]
+      del self.transformed_schema[_TEMP_KEY]
       row_type = RowTypeConstraint.from_fields(
           list(self.transformed_schema.items()))
 
-      # If a non schema PCollection is passed, and one of the input columns
-      # is not transformed by any of the transforms, then the output will
-      # not have that column. So we will join the missing columns from the
-      # raw_data to the transformed_dataset.
-      keyed_transformed_dataset = (
-          transformed_dataset | beam.ParDo(_ExtractIdAndKeyPColl()))
-
-      # The grouping is needed here since tensorflow transform only outputs
-      # columns that are transformed by any of the transforms. So we will
-      # join the missing columns from the raw_data to the transformed_dataset
-      # using the id.
       transformed_dataset = (
-          (keyed_transformed_dataset, keyed_columns_not_in_schema)
-          | beam.CoGroupByKey()
-          | beam.ParDo(_MergeDicts()))
-
+          transformed_dataset
+          | "DecodeDict" >> beam.ParDo(_DecodeDict()))
       # The schema only contains the columns that are transformed.
       transformed_dataset = (
           transformed_dataset

--- a/sdks/python/apache_beam/ml/transforms/handlers.py
+++ b/sdks/python/apache_beam/ml/transforms/handlers.py
@@ -85,7 +85,7 @@ tft_process_handler_input_type = typing.Union[typing.NamedTuple,
 tft_process_handler_output_type = typing.Union[beam.Row, Dict[str, np.ndarray]]
 
 
-class DataCoder:
+class _DataCoder:
   def __init__(
       self,
       exclude_columns,
@@ -101,11 +101,12 @@ class DataCoder:
 
   def encode(self, element):
     data_to_encode = element.copy()
+    element_to_return = element.copy()
     for key in self.exclude_columns:
       if key in data_to_encode:
         del data_to_encode[key]
-    element[_TEMP_KEY] = self.coder.encode(data_to_encode)
-    return element
+    element_to_return[_TEMP_KEY] = self.coder.encode(data_to_encode)
+    return element_to_return
 
   def decode(self, element):
     clone = copy.copy(element)
@@ -411,7 +412,7 @@ class TFTProcessHandler(ProcessHandler[tft_process_handler_input_type,
     # To preserve these extra columns without disrupting TFT processing,
     # they are temporarily encoded as bytes and added to the PCollection with
     # a unique identifier
-    data_coder = DataCoder(exclude_columns=feature_set)
+    data_coder = _DataCoder(exclude_columns=feature_set)
     data_with_encoded_columns = (
         raw_data
         | "EncodeUnmodifiedColumns" >>

--- a/sdks/python/apache_beam/ml/transforms/handlers.py
+++ b/sdks/python/apache_beam/ml/transforms/handlers.py
@@ -20,6 +20,7 @@ import collections
 import copy
 import os
 import typing
+from typing import Any
 from typing import Dict
 from typing import List
 from typing import Optional
@@ -31,7 +32,7 @@ import numpy as np
 import apache_beam as beam
 import tensorflow as tf
 import tensorflow_transform.beam as tft_beam
-from apache_beam.coders.coders import PickleCoder
+from apache_beam import coders
 from apache_beam.io.filesystems import FileSystems
 from apache_beam.ml.transforms.base import ArtifactMode
 from apache_beam.ml.transforms.base import ProcessHandler
@@ -91,7 +92,7 @@ class DataCoder:
     Args:
       exclude_columns: list of columns to exclude from the encoding.
     """
-    self.coder = PickleCoder()
+    self.coder = coders.registry.get_coder(Any)
     self.exclude_columns = exclude_columns
 
   def set_unused_columns(self, exclude_columns):


### PR DESCRIPTION
This PR attempts to remove CoGBK from MLTransform's TFTProcessHandler. 

Instead of using CoGBK, encode the dict of columns not specified by the user into bytes and pass them in the original dict with a temporary key specified in the schema for TFT. In the TFT `AnalyzeDataset` or `TransformDataset`, this temp column would be a no-op. Once TFT is done processing data, decode the bytes into their actual format.

This only affects the data processing operations specified at `apache_beam/ml/transforms/tft.py`. The operations support float and string data. We have tests for them already. 

For encoding and decoding purposes, I used `apache_beam/pickler` for now. 

Fixes: https://github.com/apache/beam/issues/29593



------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
