### PR TITLE
Allow stale_bq_datasets_cleaner.sh to run to completion, even when there are failures to grab a dataset

### DIFF
--- a/.test-infra/tools/stale_bq_datasets_cleaner.sh
+++ b/.test-infra/tools/stale_bq_datasets_cleaner.sh
@@ -37,7 +37,7 @@ for dataset in ${BQ_DATASETS[@]}; do
       # The BQ API reports LAST MODIFIED TIME in miliseconds, while unix works in seconds since epoch
       # thus why we need to convert to seconds.
 
-      failed = 0
+      failed=0
       ds=`bq --format=json --project_id=$PROJECT show $dataset` || failed=1
       if [[ $failed -eq 1 ]]; then
         echo "Could not find dataset $dataset - it may have already been deleted, skipping"

--- a/.test-infra/tools/stale_bq_datasets_cleaner.sh
+++ b/.test-infra/tools/stale_bq_datasets_cleaner.sh
@@ -18,7 +18,7 @@
 #    Deletes stale and old BQ datasets that are left after tests.
 #
 
-set -euo pipefail
+set -xuo pipefail
 
 PROJECT=apache-beam-testing
 MAX_RESULT=1500

--- a/.test-infra/tools/stale_bq_datasets_cleaner.sh
+++ b/.test-infra/tools/stale_bq_datasets_cleaner.sh
@@ -36,20 +36,27 @@ for dataset in ${BQ_DATASETS[@]}; do
     if [[ $dataset =~ $template ]]; then
       # The BQ API reports LAST MODIFIED TIME in miliseconds, while unix works in seconds since epoch
       # thus why we need to convert to seconds.
-      [[ `bq --format=json --project_id=$PROJECT show $dataset` =~ \"lastModifiedTime\":\"([0-9]+)\" ]]
-      LAST_MODIFIED_MS=${BASH_REMATCH[1]}
-      LAST_MODIFIED=$(($LAST_MODIFIED_MS / 1000))
-      if [[ $GRACE_PERIOD -gt $LAST_MODIFIED ]]; then
-        if bq --project_id=$PROJECT rm -r -f $dataset; then
-          if [[ $OSTYPE == "linux-gnu"* ]]; then
-            # date command usage depending on OS
-            echo "Deleted $dataset (modified `date -d @$LAST_MODIFIED`)"
-          elif [[ $OSTYPE == "darwin"* ]]; then
-            echo "Deleted $dataset (modified `date -r @$LAST_MODIFIED`)"
+
+      failed = 0
+      ds=`bq --format=json --project_id=$PROJECT show $dataset` || failed=1
+      if [[ $failed -eq 1 ]]; then
+        echo "Could not find dataset $dataset - it may have already been deleted, skipping"
+      else
+        [[ $ds =~ \"lastModifiedTime\":\"([0-9]+)\" ]]
+        LAST_MODIFIED_MS=${BASH_REMATCH[1]}
+        LAST_MODIFIED=$(($LAST_MODIFIED_MS / 1000))
+        if [[ $GRACE_PERIOD -gt $LAST_MODIFIED ]]; then
+          if bq --project_id=$PROJECT rm -r -f $dataset; then
+            if [[ $OSTYPE == "linux-gnu"* ]]; then
+              # date command usage depending on OS
+              echo "Deleted $dataset (modified `date -d @$LAST_MODIFIED`)"
+            elif [[ $OSTYPE == "darwin"* ]]; then
+              echo "Deleted $dataset (modified `date -r @$LAST_MODIFIED`)"
+            fi
+          else
+            echo "Tried and failed to delete $dataset"
+            failed_calls+=1
           fi
-        else
-          echo "Tried and failed to delete $dataset"
-          failed_calls+=1
         fi
       fi
       break

--- a/.test-infra/tools/stale_bq_datasets_cleaner.sh
+++ b/.test-infra/tools/stale_bq_datasets_cleaner.sh
@@ -18,7 +18,7 @@
 #    Deletes stale and old BQ datasets that are left after tests.
 #
 
-set -uo pipefail
+set -exuo pipefail
 
 PROJECT=apache-beam-testing
 MAX_RESULT=1500

--- a/.test-infra/tools/stale_bq_datasets_cleaner.sh
+++ b/.test-infra/tools/stale_bq_datasets_cleaner.sh
@@ -18,7 +18,7 @@
 #    Deletes stale and old BQ datasets that are left after tests.
 #
 
-set -xuo pipefail
+set -uo pipefail
 
 PROJECT=apache-beam-testing
 MAX_RESULT=1500
@@ -48,6 +48,7 @@ for dataset in ${BQ_DATASETS[@]}; do
             echo "Deleted $dataset (modified `date -r @$LAST_MODIFIED`)"
           fi
         else
+          echo "Tried and failed to delete $dataset"
           failed_calls+=1
         fi
       fi


### PR DESCRIPTION
Also, add a little more logging on failed commands.

Right now, its common for a dataset to be present at the start of the run and then to disappear by the time the cleaner gets to it (for ephemeral test datasets). This will allow those to be skipped.

This was permared before this change - https://github.com/apache/beam/actions/workflows/beam_CleanUpGCPResources.yml

Example run with this change - https://github.com/apache/beam/actions/runs/7731108048

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
