### PR TITLE
Make ReadFromBigQueryRequest id more randomized

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -356,13 +356,12 @@ https://github.com/apache/beam/blob/master/sdks/python/OWNERS
 # pytype: skip-file
 
 import collections
-import secrets
-
 import io
 import itertools
 import json
 import logging
 import random
+import secrets
 import time
 import uuid
 import warnings

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -356,6 +356,8 @@ https://github.com/apache/beam/blob/master/sdks/python/OWNERS
 # pytype: skip-file
 
 import collections
+import secrets
+
 import io
 import itertools
 import json
@@ -2926,7 +2928,7 @@ class ReadFromBigQueryRequest:
     self.validate()
 
     # We use this internal object ID to generate BigQuery export directories.
-    self.obj_id = random.randint(0, 100000)
+    self.obj_id = '%d_%s' % (int(time.time()), secrets.token_hex(3))
 
   def validate(self):
     if self.table is not None and self.query is not None:

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -2926,7 +2926,8 @@ class ReadFromBigQueryRequest:
     self.table = table
     self.validate()
 
-    # We use this internal object ID to generate BigQuery export directories.
+    # We use this internal object ID to generate BigQuery export directories
+    # and to create BigQuery job names
     self.obj_id = '%d_%s' % (int(time.time()), secrets.token_hex(3))
 
   def validate(self):


### PR DESCRIPTION
Request ID is just a random number between (0, 100,000). For long streaming jobs, this will inevitably create requests with identical ID's. This becomes a problem because query jobs are created from these IDs and BQ ignores identical job names. 