### PR TITLE
Fix stale dataflow prebuilt image cleaner

### DIFF
--- a/.test-infra/tools/stale_dataflow_prebuilt_image_cleaner.sh
+++ b/.test-infra/tools/stale_dataflow_prebuilt_image_cleaner.sh
@@ -27,9 +27,11 @@ PRIVATE_REPOSITORIES=(java-postcommit-it python-postcommit-it jenkins github-act
 # set as the same as 6-week release period
 if [[ $OSTYPE == "linux-gnu"* ]]; then
   # date command usage depending on OS
-  DELETE_BEFORE_DAY=$(date --iso-8601=s -d '6 weeks ago')
+  DELETE_BEFORE_PUBLIC=$(date --iso-8601=s -d '6 weeks ago')
+  DELETE_BEFORE_PRIVATE=$(date --iso-8601=s -d '3 days ago')
 elif [[ $OSTYPE == "darwin"* ]]; then
-  DELETE_BEFORE_DAY=$(date -j -v-6w '+%Y-%m-%dT%H:%M:%S')
+  DELETE_BEFORE_PUBLIC=$(date -j -v-6w '+%Y-%m-%dT%H:%M:%S')
+  DELETE_BEFORE_PRIVATE=$(date -j -v-3d '+%Y-%m-%dT%H:%M:%S')
 fi
 
 REPOSITORIES=("${PUBLIC_REPOSITORIES[@]/#/gcr.io/apache-beam-testing/}" "${PRIVATE_REPOSITORIES[@]/#/us.gcr.io/apache-beam-testing/}")
@@ -54,7 +56,7 @@ while [ -n "$REPOSITORIES" ]; do
   REPOSITORIES=("${PENDING_REPOSITORIES[@]}")
 done
 
-STALE_IMAGES=""
+HAS_STALE_IMAGES=""
 FAILED_INSPECT=""
 
 for image_name in ${IMAGE_NAMES[@]}; do
@@ -64,22 +66,31 @@ for image_name in ${IMAGE_NAMES[@]}; do
   LATEST_IN_TIME=$(gcloud container images list-tags \
      ${image_name} --sort-by="~TIMESTAMP"  --filter="NOT tags:latest " --format="get(digest)" --limit=1)
   if [ -n "$LATEST_IN_TIME" ]; then
+    # decide timestamp cutoff
+    if [[ $image_name =~ 'us.gcr.io' ]]; then
+      DELETE_BEFORE_DAY=$DELETE_BEFORE_PRIVATE
+    else
+      DELETE_BEFORE_DAY=$DELETE_BEFORE_PUBLIC
+    fi
     # list containers of the image name
     echo "Command" gcloud container images list-tags \
     ${image_name} \
     --sort-by=TIMESTAMP  --filter="NOT tags:latest AND timestamp.datetime < $DELETE_BEFORE_DAY" \
-    --format="get(digest)"
-    STALE_IMAGES_CURRENT=$(gcloud container images list-tags \
+    --format="get(digest,timestamp.year)"
+    STALE_IMAGES=$(gcloud container images list-tags \
      ${image_name} \
       --sort-by=TIMESTAMP  --filter="NOT tags:latest AND timestamp.datetime < $DELETE_BEFORE_DAY" \
-      --format="get(digest)")
-    STALE_IMAGES+=$STALE_IMAGES_CURRENT
-    for current in ${STALE_IMAGES_CURRENT[@]}; do
+      --format="get(digest,timestamp.year)")
+
+    STALE_IMAGES_CURRENT=($STALE_IMAGES)
+    for (( i_stale_images_current=0; i_stale_images_current<${#STALE_IMAGES_CURRENT[@]} ; i_stale_images_current+=2 )) ; do
+      current=${STALE_IMAGES_CURRENT[i_stale_images_current]}
+      currentyear=${STALE_IMAGES_CURRENT[i_stale_images_current+1]}
       # do not delete the one with latest label and the newest image without latest label
       # this make sure we leave at least one container under each image name, either labelled "latest" or not
       if [ "$LATEST_IN_TIME" != "$current" ]; then
-        if [[ $image_name =~ 'beamgrafana' || $image_name =~ 'beammetricssyncjenkins' || $image_name =~ 'beammetricssyncgithub' ]]; then
-          # Skip docker manifest inspect for known single arch images, workaround permission issue & saving API call
+        if [[ $currentyear > 1970 ]]; then
+          # Skip docker manifest inspect for those not in epoch to save API call
           SHOULD_DELETE=0
         else
           # Check to see if this image is built on top of earlier images. This is the case for multiarch images,
@@ -96,8 +107,8 @@ for image_name in ${IMAGE_NAMES[@]}; do
           DIGEST=$(echo $MANIFEST |  jq -r '.manifests[0].digest')
           if [ "$DIGEST" != "null" ]; then
             SHOULD_DELETE=1
-            for i in ${STALE_IMAGES_CURRENT[@]}; do
-              if [ "$i" = "$DIGEST" ]; then
+            for (( j_stale_images_current=0; j_stale_images_current<${#STALE_IMAGES_CURRENT[@]} ; j_stale_images_current+=2 )) ; do
+              if [ "${STALE_IMAGES_CURRENT[j_stale_images_current]}" = "$DIGEST" ]; then
                 SHOULD_DELETE=0
                 break
               fi
@@ -105,8 +116,8 @@ for image_name in ${IMAGE_NAMES[@]}; do
           fi
         fi
 
-        if [ $SHOULD_DELETE = 0 ]
-        then
+        if [ $SHOULD_DELETE = 0 ]; then
+          HAS_STALE_IMAGES="true"
           echo "Deleting image. Command: gcloud container images delete ${image_name}@"${current}" --force-delete-tags -q"
           gcloud container images delete ${image_name}@"${current}" --force-delete-tags -q || FAILED_TO_DELETE+="${current} "
         fi
@@ -125,7 +136,7 @@ for image_name in ${IMAGE_NAMES[@]}; do
   fi
 done
 
-if [[ ${STALE_IMAGES} ]]; then
+if [[ -n "$HAS_STALE_IMAGES" ]]; then
   echo "Deleted multiple images"
 else
   echo "No stale prebuilt container images found."

--- a/.test-infra/tools/stale_dataflow_prebuilt_image_cleaner.sh
+++ b/.test-infra/tools/stale_dataflow_prebuilt_image_cleaner.sh
@@ -34,9 +34,7 @@ elif [[ $OSTYPE == "darwin"* ]]; then
   DELETE_BEFORE_PRIVATE=$(date -j -v-3d '+%Y-%m-%dT%H:%M:%S')
 fi
 
-REPOSITORIES=("${PUBLIC_REPOSITORIES[@]/#/gcr.io/apache-beam-testing/}" "${PRIVATE_REPOSITORIES[@]/#/us.gcr.io/apache-beam-testing/}")
-
-echo $REPOSITORIES
+REPOSITORIES=("${PRIVATE_REPOSITORIES[@]/#/us.gcr.io/apache-beam-testing/}" "${PUBLIC_REPOSITORIES[@]/#/gcr.io/apache-beam-testing/}")
 
 # walk repos recursively
 IMAGE_NAMES=""


### PR DESCRIPTION
Two efficiency improvement

- For the nonzero sized images themself (creation time not in epoch), do not invoke `docker manifest inspect`
- For images in us.gcr.io (that are for testing purpose), decrease the retention time to 3 days so there are fewer zero-sized image that need to check digest and decide the actual creation time each time the workflow is run

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
