### PR TITLE
Try a different approach for cibuildwheel flake.

### DIFF
--- a/sdks/python/build.gradle
+++ b/sdks/python/build.gradle
@@ -94,17 +94,32 @@ platform_identifiers_map.each { platform, idsuffix ->
 
       // generated installable Python SDK package
       doLast {
-        exec {
-          environment CIBW_BUILD: "cp${pyversion}-${idsuffix}"
-          environment CIBW_ENVIRONMENT: "SETUPTOOLS_USE_DISTUTILS=stdlib"
-          // note: sync cibuildwheel version with GitHub Action
-          // .github/workflow/build_wheel.yml:build_wheels "Install cibuildwheel" step
-          // note(https://github.com/pypa/cibuildwheel/issues/1692): cibuildwheel appears to timeout occasionally.
-          executable 'sh'
-          args '-c', ". ${envdir}/bin/activate && " +
-              "pip install cibuildwheel==2.9.0 && " +
-              "cibuildwheel --print-build-identifiers --platform ${platform} --archs ${archs} && " +
-              "for i in {1..3}; do cibuildwheel --output-dir ${buildDir} --platform ${platform} --archs ${archs} && break; done"
+        int maxRetries = 3
+        int retryCount = 0
+        // note(https://github.com/pypa/cibuildwheel/issues/1692): cibuildwheel appears to timeout occasionally.
+        while (retryCount < maxRetries) {
+          try {
+            exec {
+             environment CIBW_BUILD: "cp${pyversion}-${idsuffix}"
+             environment CIBW_ENVIRONMENT: "SETUPTOOLS_USE_DISTUTILS=stdlib"
+             executable 'sh'
+             args '-c', ". ${envdir}/bin/activate && " +
+                 // note: sync cibuildwheel version with GitHub Action
+                 // .github/workflows/build_wheel.yml:build_wheels "Install cibuildwheel" step
+                 "pip install cibuildwheel==2.9.0 && " +
+                 "cibuildwheel --print-build-identifiers --platform ${platform} --archs ${archs} && " +
+                 "cibuildwheel --output-dir ${buildDir} --platform ${platform} --archs ${archs} "
+           }
+           break;
+         }
+         catch (Exception e) {
+            retryCount++
+            if (retryCount < maxRetries) {
+                println "cibuildwheel failed on attempt ${retryCount}. Will retry."
+            } else {
+                throw e
+            }
+         }
         }
       }
     }


### PR DESCRIPTION
Another attempt to fix https://github.com/apache/beam/issues/28703

Looks like flakes are still happening and retries not happening:

https://github.com/apache/beam/actions/runs/7757756669/job/21157951160

```
> Task :sdks:python:bdistPy310linux
Collecting cibuildwheel==2.9.0
  Downloading cibuildwheel-2.9.0-py3-none-any.whl (63 kB)
     ...
cibuildwheel version 2.9.0

Build options:
  platform: 'linux'
  architectures: {<Architecture.x86_64: 'x86_64'>, <Architecture.i686: 'i686'>}
  build_selector: {'build_config': 'cp310-manylinux_*64*', 'skip_config': '', 'requires_python': None, 'prerelease_pythons': False}
  container_engine: 'docker'
  output_dir: PosixPath('/runner/_work/beam/beam/sdks/python/build')
  package_dir: PosixPath('/runner/_work/beam/beam/sdks/python')
  test_selector: {'skip_config': ''}
  before_all: ''
  before_build: ''
  before_test: ''
  build_frontend: 'pip'
  build_verbosity: 0
  dependency_constraints: DependencyConstraints(PosixPath('/runner/_work/beam/beam/build/gradleenv/1922375555/lib/python3.10/site-packages/cibuildwheel/resources/constraints.txt'))
  environment: {'assignments': [SETUPTOOLS_USE_DISTUTILS=stdlib]}
    cp310-manylinux_x86_64: ParsedEnvironment(['SETUPTOOLS_USE_DISTUTILS=stdlib'])
    self.process.wait(timeout=30)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/subprocess.py", line 1209, in wait
    return self._wait(timeout=timeout)
  File "/opt/hostedtoolcache/Python/3.10.13/x64/lib/python3.10/subprocess.py", line 1951, in _wait
    raise TimeoutExpired(self.args, timeout)
subprocess.TimeoutExpired: Command '['docker', 'start', '--attach', '--interactive', 'cibuildwheel-5185decf-f8fe-4515-bbca-0fa628587781']' timed out after 30 seconds

> Task :sdks:python:bdistPy310linux FAILED
```