### PR TITLE
Fix Jms drop record

### DIFF
--- a/sdks/java/io/jms/build.gradle
+++ b/sdks/java/io/jms/build.gradle
@@ -48,5 +48,3 @@ dependencies {
   testRuntimeOnly library.java.slf4j_jdk14
   testRuntimeOnly project(path: ":runners:direct-java", configuration: "shadow")
 }
-
-test.outputs.upToDateWhen {false}

--- a/sdks/java/io/jms/build.gradle
+++ b/sdks/java/io/jms/build.gradle
@@ -48,3 +48,5 @@ dependencies {
   testRuntimeOnly library.java.slf4j_jdk14
   testRuntimeOnly project(path: ":runners:direct-java", configuration: "shadow")
 }
+
+test.outputs.upToDateWhen {false}

--- a/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsCheckpointMark.java
+++ b/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsCheckpointMark.java
@@ -66,9 +66,10 @@ class JmsCheckpointMark implements UnboundedSource.CheckpointMark, Serializable 
         lastMessage.acknowledge();
       }
     } catch (JMSException e) {
-      // The effect of this is message not get acknowledged and thus will be redilivered. It is
-      // not fatal so we just raise error log. Similar below.
-      LOG.error("Exception while finalizing message: ", e);
+      // The effect of this is message not get acknowledged and thus will be redelivered. It is
+      // not fatal, so we just raise error log. Similar below.
+      LOG.error(
+          "Failed to acknowledge the message. Will redeliver and might cause duplication.", e);
     }
 
     // session is closed after message acknowledged otherwise other consumer may receive duplicate

--- a/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsIO.java
+++ b/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsIO.java
@@ -609,6 +609,10 @@ public class JmsIO {
 
     @Override
     public CheckpointMark getCheckpointMark() {
+      if (checkpointMarkPreparer.isEmpty()) {
+        return checkpointMarkPreparer.emptyCheckpoint();
+      }
+
       MessageConsumer consumerToClose;
       Session sessionTofinalize;
       synchronized (this) {

--- a/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsIO.java
+++ b/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsIO.java
@@ -515,6 +515,15 @@ public class JmsIO {
     /** recreate session and consumer. */
     private synchronized void recreateSession() throws IOException {
       try {
+        if (consumer != null) {
+          consumer.close();
+          consumer = null;
+        }
+      } catch (JMSException e) {
+        LOG.error("Error closing JMS consumer. It may have already been closed.", e);
+      }
+
+      try {
         this.session = this.connection.createSession(false, Session.CLIENT_ACKNOWLEDGE);
       } catch (Exception e) {
         throw new IOException("Error creating JMS session", e);
@@ -524,9 +533,9 @@ public class JmsIO {
 
       try {
         if (source.spec.getTopic() != null) {
-          this.consumer = this.session.createConsumer(this.session.createTopic(spec.getTopic()));
+          consumer = session.createConsumer(session.createTopic(spec.getTopic()));
         } else {
-          this.consumer = this.session.createConsumer(this.session.createQueue(spec.getQueue()));
+          consumer = session.createConsumer(session.createQueue(spec.getQueue()));
         }
       } catch (Exception e) {
         throw new IOException("Error creating JMS consumer", e);

--- a/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOIT.java
+++ b/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOIT.java
@@ -167,7 +167,7 @@ public class JmsIOIT implements Serializable {
       connectionFactory = this.commonJms.getConnectionFactory();
       connectionFactoryClass = this.commonJms.getConnectionFactoryClass();
       // use a small number of record for local integration test
-      OPTIONS.setNumberOfRecords(10000);
+      OPTIONS.setNumberOfRecords(1000);
     }
   }
 

--- a/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOTest.java
+++ b/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOTest.java
@@ -439,7 +439,7 @@ public class JmsIOTest {
             .withPassword(PASSWORD)
             .withQueue(QUEUE);
     JmsIO.UnboundedJmsSource source = new JmsIO.UnboundedJmsSource(spec);
-    JmsIO.UnboundedJmsReader reader = source.createReader(null, null);
+    JmsIO.UnboundedJmsReader reader = source.createReader(PipelineOptionsFactory.create(), null);
 
     // start the reader and move to the first record
     assertTrue(reader.start());
@@ -545,7 +545,7 @@ public class JmsIOTest {
             .withPassword(PASSWORD)
             .withQueue(QUEUE);
     JmsIO.UnboundedJmsSource source = new JmsIO.UnboundedJmsSource(spec);
-    JmsIO.UnboundedJmsReader reader = source.createReader(null, null);
+    JmsIO.UnboundedJmsReader reader = source.createReader(PipelineOptionsFactory.create(), null);
 
     // start the reader and move to the first record
     assertTrue(reader.start());
@@ -583,7 +583,7 @@ public class JmsIOTest {
   /** Test the checkpoint mark default coder, which is actually AvroCoder. */
   @Test
   public void testCheckpointMarkDefaultCoder() throws Exception {
-    JmsCheckpointMark jmsCheckpointMark = JmsCheckpointMark.newPreparer().newCheckpoint(null);
+    JmsCheckpointMark jmsCheckpointMark = JmsCheckpointMark.newPreparer().newCheckpoint(null, null);
     Coder coder = new JmsIO.UnboundedJmsSource(null).getCheckpointMarkCoder();
     CoderProperties.coderSerializable(coder);
     CoderProperties.coderDecodeEncodeEqual(coder, jmsCheckpointMark);
@@ -598,7 +598,7 @@ public class JmsIOTest {
             .withPassword(PASSWORD)
             .withQueue(QUEUE);
     JmsIO.UnboundedJmsSource source = new JmsIO.UnboundedJmsSource(spec);
-    JmsIO.UnboundedJmsReader reader = source.createReader(null, null);
+    JmsIO.UnboundedJmsReader reader = source.createReader(PipelineOptionsFactory.create(), null);
 
     // start the reader and check getSplitBacklogBytes and getTotalBacklogBytes values
     reader.start();
@@ -622,7 +622,7 @@ public class JmsIOTest {
             .withAutoScaler(autoScaler);
 
     JmsIO.UnboundedJmsSource source = new JmsIO.UnboundedJmsSource(spec);
-    JmsIO.UnboundedJmsReader reader = source.createReader(null, null);
+    JmsIO.UnboundedJmsReader reader = source.createReader(PipelineOptionsFactory.create(), null);
 
     // start the reader and check getSplitBacklogBytes and getTotalBacklogBytes values
     reader.start();
@@ -698,7 +698,7 @@ public class JmsIOTest {
             .withPassword(PASSWORD)
             .withQueue(QUEUE);
     JmsIO.UnboundedJmsSource source = new JmsIO.UnboundedJmsSource(spec);
-    JmsIO.UnboundedJmsReader reader = source.createReader(null, null);
+    JmsIO.UnboundedJmsReader reader = source.createReader(PipelineOptionsFactory.create(), null);
 
     // start the reader and move to the first record
     assertTrue(reader.start());

--- a/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOTest.java
+++ b/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOTest.java
@@ -429,7 +429,7 @@ public class JmsIOTest {
 
     // consume 3 messages (NB: start already consumed the first message)
     for (int i = 0; i < 3; i++) {
-      assertTrue(reader.advance());
+      assertTrue(String.format("Failed at %d-th message", i), reader.advance());
     }
 
     // the messages are still pending in the queue (no ACK yet)
@@ -443,7 +443,7 @@ public class JmsIOTest {
 
     // we read the 6 pending messages
     for (int i = 0; i < 6; i++) {
-      assertTrue(reader.advance());
+      assertTrue(String.format("Failed at %d-th message", i), reader.advance());
     }
 
     // still 6 pending messages as we didn't finalize the checkpoint


### PR DESCRIPTION
Attempt to fix - #30054

# The issue identified

There were two issues in the JmsIO read checkpoint implementation

1. checkpoint was a mutable member of the reader, returned to the runner each time getCheckpointMark is called:

https://github.com/apache/beam/blob/27f1c0774fd93e846de9a8b668e6effc5a41eb10/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsIO.java#L600

This is not correct as the checkpoint by definition should not change after made. Here, record after the checkpoint made still add to the same checkpoint:

https://github.com/apache/beam/blob/27f1c0774fd93e846de9a8b668e6effc5a41eb10/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsIO.java#L566

When checkpoint is finalized (by finalizeCheckpoint call from runner), messages read between the checkpoint made and finalizing the checkpoint incorrectly gets acknowledged

2. Jms specification of message acknowledgement

It is surprising, Jms message acknowledge isn't per message, but per session. The [spec](https://docs.oracle.com/cd/E19798-01/821-1841/bncfw/index.html) states

> acknowledgment takes place on the session level: Acknowledging a consumed message automatically acknowledges the receipt of all messages that have been consumed by its session.

Even if 1 is fixed, the symptom would remain the same as messages between checkpoint being made and the checkpoint finalized would get acknowledged.

# The fix

Corresponding to these two issues, two fixes are made

1. Introduce `Checkpoint.Preparer` class pretty much the same as the original the mutable "checkpoint". Instead, when getCheckpointMark is called, it create an actual checkpoint for later use, and the Preparer is reset.

2. Recreate session at the time checkpoint is made. In this way, the current session won't consume more data before that checkpoint is finalized.


# Caveat

1. Since the message is acknowledged by `finalizeCheckpoint` called anytime later, the current session needs to be alive otherwise the acknowledge will fail (see [diff](https://github.com/apache/beam/pull/30218/files#diff-a63812b51f93708cc60430f314b496ae1110425c6a8ae4c85e59573cfb8f0938R207)). Therefore, the owner of current session is transferred from the Reader to the checkpoint. However, checkpoint finalization is best effort. If it does not happen, duplicate message may seen downstream.

2. reader calls `consumer.receiveNoWait` to get a message. However, the Jms specification does not guarantee a  message will be returned (otherwise null) when there are unacknowledged messages on the server side. From the test, I find `receiveNoWait` of one consumer can return null when there is other consumer active (not closed). This leads to the integration test failing the original assert that all messages received by the sink when streaming pipeline timeout. There are always ~1-9 outstanding messages. Checking unacknowledged messages, there are ~10 unacknowledged. So there is no data loss here, but we have to adjust the test assertion.

On the other hand, if close the consumer immediately after the checkpoint is made (but keep the session active), data gets consumed, not acknowledged, and even the associate session was still open, will get redelivered  into other sessions' consumers, causing a surge of duplication. So we still need to defer closing the consumer after acknowledge messages, along with closing the session


**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
