### PR TITLE
Add options giving more isolation between grpc streaming rpcs.

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/build.gradle
+++ b/runners/google-cloud-dataflow-java/worker/build.gradle
@@ -90,7 +90,8 @@ applyJavaNature(
                 "org/slf4j/impl/**"
         ],
         generatedClassPatterns: [
-                /^org\.apache\.beam\.runners\.dataflow\.worker\.windmill.*/
+                /^org\.apache\.beam\.runners\.dataflow\.worker\.windmill.*/,
+                /^org\.apache\.beam\.runners\.dataflow\.worker\..*AutoBuilder.*/,
         ],
         shadowClosure: {
             // Each included dependency must also include all of its necessary transitive dependencies

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/MetricTrackingWindmillServerStub.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/MetricTrackingWindmillServerStub.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.dataflow.worker;
 
+import com.google.auto.value.AutoBuilder;
 import java.io.PrintWriter;
 import java.util.ArrayList;
 import java.util.HashMap;
@@ -31,6 +32,7 @@ import org.apache.beam.runners.dataflow.worker.windmill.Windmill.HeartbeatReques
 import org.apache.beam.runners.dataflow.worker.windmill.WindmillServerStub;
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStream.GetDataStream;
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStreamPool;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.SettableFuture;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.Duration;
@@ -50,7 +52,6 @@ public class MetricTrackingWindmillServerStub {
 
   private static final int MAX_READS_PER_BATCH = 60;
   private static final int MAX_ACTIVE_READS = 10;
-  private static final int NUM_STREAMS = 1;
   private static final Duration STREAM_TIMEOUT = Duration.standardSeconds(30);
   private final AtomicInteger activeSideInputs = new AtomicInteger();
   private final AtomicInteger activeStateReads = new AtomicInteger();
@@ -59,28 +60,66 @@ public class MetricTrackingWindmillServerStub {
   private final MemoryMonitor gcThrashingMonitor;
   private final boolean useStreamingRequests;
 
+  private final WindmillStreamPool<GetDataStream> getDataStreamPool;
+
+  // May be the same instance as getDataStreamPool based upon options.
+  private final WindmillStreamPool<GetDataStream> heartbeatStreamPool;
+
   @GuardedBy("this")
   private final List<ReadBatch> pendingReadBatches;
 
   @GuardedBy("this")
   private int activeReadThreads = 0;
 
-  private WindmillStreamPool<GetDataStream> streamPool;
+  @Internal
+  @AutoBuilder(ofClass = MetricTrackingWindmillServerStub.class)
+  public abstract static class Builder {
 
-  public MetricTrackingWindmillServerStub(
-      WindmillServerStub server, MemoryMonitor gcThrashingMonitor, boolean useStreamingRequests) {
-    this.server = server;
-    this.gcThrashingMonitor = gcThrashingMonitor;
-    // This is used as a queue but is expected to be less than 10 batches.
-    this.pendingReadBatches = new ArrayList<>();
-    this.useStreamingRequests = useStreamingRequests;
+    abstract Builder setServer(WindmillServerStub server);
+
+    abstract Builder setGcThrashingMonitor(MemoryMonitor gcThrashingMonitor);
+
+    abstract Builder setUseStreamingRequests(boolean useStreamingRequests);
+
+    abstract Builder setUseSeparateHeartbeatStreams(boolean useSeparateHeartbeatStreams);
+
+    abstract Builder setNumGetDataStreams(int numGetDataStreams);
+
+    abstract MetricTrackingWindmillServerStub build();
   }
 
-  public void start() {
+  public static Builder builder(WindmillServerStub server, MemoryMonitor gcThrashingMonitor) {
+    return new AutoBuilder_MetricTrackingWindmillServerStub_Builder()
+        .setServer(server)
+        .setGcThrashingMonitor(gcThrashingMonitor)
+        .setUseStreamingRequests(false)
+        .setUseSeparateHeartbeatStreams(false)
+        .setNumGetDataStreams(1);
+  }
+
+  MetricTrackingWindmillServerStub(
+      WindmillServerStub server,
+      MemoryMonitor gcThrashingMonitor,
+      boolean useStreamingRequests,
+      boolean useSeparateHeartbeatStreams,
+      int numGetDataStreams) {
+    this.server = server;
+    this.gcThrashingMonitor = gcThrashingMonitor;
+    this.useStreamingRequests = useStreamingRequests;
     if (useStreamingRequests) {
-      streamPool =
-          WindmillStreamPool.create(NUM_STREAMS, STREAM_TIMEOUT, this.server::getDataStream);
+      getDataStreamPool =
+          WindmillStreamPool.create(numGetDataStreams, STREAM_TIMEOUT, this.server::getDataStream);
+      if (useSeparateHeartbeatStreams) {
+        heartbeatStreamPool =
+            WindmillStreamPool.create(1, STREAM_TIMEOUT, this.server::getDataStream);
+      } else {
+        heartbeatStreamPool = getDataStreamPool;
+      }
+    } else {
+      getDataStreamPool = heartbeatStreamPool = null;
     }
+    // This is used as a queue but is expected to be less than 10 batches.
+    this.pendingReadBatches = new ArrayList<>();
   }
 
   // Adds the entry to a read batch for sending to the windmill server. If a non-null batch is
@@ -193,11 +232,11 @@ public class MetricTrackingWindmillServerStub {
 
     try {
       if (useStreamingRequests) {
-        GetDataStream stream = streamPool.getStream();
+        GetDataStream stream = getDataStreamPool.getStream();
         try {
           return stream.requestKeyedData(computation, request);
         } finally {
-          streamPool.releaseStream(stream);
+          getDataStreamPool.releaseStream(stream);
         }
       } else {
         SettableFuture<Windmill.KeyedGetDataResponse> response = SettableFuture.create();
@@ -219,11 +258,11 @@ public class MetricTrackingWindmillServerStub {
     activeSideInputs.getAndIncrement();
     try {
       if (useStreamingRequests) {
-        GetDataStream stream = streamPool.getStream();
+        GetDataStream stream = getDataStreamPool.getStream();
         try {
           return stream.requestGlobalData(request);
         } finally {
-          streamPool.releaseStream(stream);
+          getDataStreamPool.releaseStream(stream);
         }
       } else {
         return server
@@ -245,11 +284,11 @@ public class MetricTrackingWindmillServerStub {
       if (useStreamingRequests) {
         // With streaming requests, always send the request even when it is empty, to ensure that
         // we trigger health checks for the stream even when it is idle.
-        GetDataStream stream = streamPool.getStream();
+        GetDataStream stream = heartbeatStreamPool.getStream();
         try {
           stream.refreshActiveWork(heartbeats);
         } finally {
-          streamPool.releaseStream(stream);
+          heartbeatStreamPool.releaseStream(stream);
         }
       } else if (!heartbeats.isEmpty()) {
         // This code path is only used by appliance which sends heartbeats (used to refresh active

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -433,8 +433,8 @@ public class StreamingDataflowWorker {
     this.metricTrackingWindmillServer =
         MetricTrackingWindmillServerStub.builder(windmillServer, memoryMonitor)
             .setUseStreamingRequests(windmillServiceEnabled)
-            .setUseSeparateHeartbeatStreams(options.getUseSeparateHeartbeatStreams())
-            .setNumGetDataStreams(options.getGetDataStreamCount())
+            .setUseSeparateHeartbeatStreams(options.getUseSeparateWindmillHeartbeatStreams())
+            .setNumGetDataStreams(options.getWindmillGetDataStreamCount())
             .build();
     this.sideInputStateFetcher = new SideInputStateFetcher(metricTrackingWindmillServer, options);
     this.clientId = clientIdGenerator.nextLong();

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -431,8 +431,11 @@ public class StreamingDataflowWorker {
     this.windmillServer = options.getWindmillServerStub();
     this.windmillServer.setProcessHeartbeatResponses(this::handleHeartbeatResponses);
     this.metricTrackingWindmillServer =
-        new MetricTrackingWindmillServerStub(windmillServer, memoryMonitor, windmillServiceEnabled);
-    this.metricTrackingWindmillServer.start();
+        MetricTrackingWindmillServerStub.builder(windmillServer, memoryMonitor)
+            .setUseStreamingRequests(windmillServiceEnabled)
+            .setUseSeparateHeartbeatStreams(options.getUseSeparateHeartbeatStreams())
+            .setNumGetDataStreams(options.getGetDataStreamCount())
+            .build();
     this.sideInputStateFetcher = new SideInputStateFetcher(metricTrackingWindmillServer, options);
     this.clientId = clientIdGenerator.nextLong();
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/options/StreamingDataflowWorkerOptions.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/options/StreamingDataflowWorkerOptions.java
@@ -130,6 +130,24 @@ public interface StreamingDataflowWorkerOptions extends DataflowWorkerHarnessOpt
 
   void setWindmillMessagesBetweenIsReadyChecks(int value);
 
+  @Description("If true, a most a single active rpc will be used per channel.")
+  @Default.Boolean(false)
+  boolean getUseIsolatedChannels();
+
+  void setUseIsolatedChannels(boolean value);
+
+  @Description("If true, separate streaming rpcs will be used for heartbeats instead of sharing streams with state reads.")
+  @Default.Boolean(false)
+  boolean getUseSeparateHeartbeatStreams();
+
+  void setUseSeparateHeartbeatStreams(boolean value);
+
+  @Description("The number of streams to use for GetData requests.")
+  @Default.Integer(1)
+  int getGetDataStreamCount();
+
+  void setGetDataStreamCount(int value);
+
   /**
    * Factory for creating local Windmill address. Reads from system propery 'windmill.hostport' for
    * backwards compatibility.

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/options/StreamingDataflowWorkerOptions.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/options/StreamingDataflowWorkerOptions.java
@@ -132,21 +132,22 @@ public interface StreamingDataflowWorkerOptions extends DataflowWorkerHarnessOpt
 
   @Description("If true, a most a single active rpc will be used per channel.")
   @Default.Boolean(false)
-  boolean getUseIsolatedChannels();
+  boolean getUseWindmillIsolatedChannels();
 
-  void setUseIsolatedChannels(boolean value);
+  void setUseWindmillIsolatedChannels(boolean value);
 
-  @Description("If true, separate streaming rpcs will be used for heartbeats instead of sharing streams with state reads.")
+  @Description(
+      "If true, separate streaming rpcs will be used for heartbeats instead of sharing streams with state reads.")
   @Default.Boolean(false)
-  boolean getUseSeparateHeartbeatStreams();
+  boolean getUseSeparateWindmillHeartbeatStreams();
 
-  void setUseSeparateHeartbeatStreams(boolean value);
+  void setUseSeparateWindmillHeartbeatStreams(boolean value);
 
   @Description("The number of streams to use for GetData requests.")
   @Default.Integer(1)
-  int getGetDataStreamCount();
+  int getWindmillGetDataStreamCount();
 
-  void setGetDataStreamCount(int value);
+  void setWindmillGetDataStreamCount(int value);
 
   /**
    * Factory for creating local Windmill address. Reads from system propery 'windmill.hostport' for

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillServer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillServer.java
@@ -171,7 +171,8 @@ public final class GrpcWindmillServer extends WindmillServerStub {
             GrpcDispatcherClient.create(
                 WindmillStubFactory.remoteStubFactory(
                     workerOptions.getWindmillServiceRpcChannelAliveTimeoutSec(),
-                    workerOptions.getGcpCredential())));
+                    workerOptions.getGcpCredential(),
+                    workerOptions.getUseIsolatedChannels())));
     if (workerOptions.getWindmillServiceEndpoint() != null) {
       grpcWindmillServer.configureWindmillServiceEndpoints();
     } else if (!workerOptions.isEnableStreamingEngine()

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillServer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcWindmillServer.java
@@ -172,7 +172,7 @@ public final class GrpcWindmillServer extends WindmillServerStub {
                 WindmillStubFactory.remoteStubFactory(
                     workerOptions.getWindmillServiceRpcChannelAliveTimeoutSec(),
                     workerOptions.getGcpCredential(),
-                    workerOptions.getUseIsolatedChannels())));
+                    workerOptions.getUseWindmillIsolatedChannels())));
     if (workerOptions.getWindmillServiceEndpoint() != null) {
       grpcWindmillServer.configureWindmillServiceEndpoints();
     } else if (!workerOptions.isEnableStreamingEngine()

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/stubs/IsolationChannel.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/stubs/IsolationChannel.java
@@ -1,0 +1,243 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs;
+
+import java.util.ArrayList;
+import java.util.HashSet;
+import java.util.List;
+import java.util.Set;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.function.Supplier;
+import java.util.logging.Level;
+import java.util.logging.Logger;
+import javax.annotation.concurrent.GuardedBy;
+import org.apache.beam.sdk.annotations.Internal;
+import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.CallOptions;
+import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.ClientCall;
+import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.ForwardingClientCall.SimpleForwardingClientCall;
+import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.ForwardingClientCallListener.SimpleForwardingClientCallListener;
+import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.ManagedChannel;
+import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.Metadata;
+import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.MethodDescriptor;
+import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.Status;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
+
+/**
+ * A {@link ManagedChannel} that creates a dynamic # of cached channels to the same endpoint such
+ * that each active rpc has its own channel.
+ */
+@Internal
+class IsolationChannel extends ManagedChannel {
+  static final Logger LOG = Logger.getLogger(IsolationChannel.class.getName());
+
+  private final Supplier<ManagedChannel> channelFactory;
+
+  @GuardedBy("channelCache")
+  private final List<ManagedChannel> channelCache;
+
+  @GuardedBy("channelCache")
+  private final Set<ManagedChannel> usedChannels;
+
+  @GuardedBy("channelCache")
+  private boolean shutdownStarted = false;
+
+  private final String authority;
+
+  // Expected that supplier returns channels to the same endpoint with the same authority.
+  public static IsolationChannel create(Supplier<ManagedChannel> channelFactory) {
+    return new IsolationChannel(channelFactory);
+  }
+
+  @VisibleForTesting
+  IsolationChannel(Supplier<ManagedChannel> channelFactory) {
+    this.channelFactory = channelFactory;
+    this.channelCache = new ArrayList<>();
+    ManagedChannel channel = channelFactory.get();
+    this.authority = channel.authority();
+    this.channelCache.add(channel);
+    this.usedChannels = new HashSet<>();
+  }
+
+  @Override
+  public String authority() {
+    return authority;
+  }
+
+  /** Pick an unused channel from the set or create one and then create a {@link ClientCall}. */
+  @Override
+  public <ReqT, RespT> ClientCall<ReqT, RespT> newCall(
+      MethodDescriptor<ReqT, RespT> methodDescriptor, CallOptions callOptions) {
+    ManagedChannel channel = getChannel();
+    return new ReleasingClientCall<>(this, channel, channel.newCall(methodDescriptor, callOptions));
+  }
+
+  private ManagedChannel getChannel() {
+    synchronized (channelCache) {
+      if (!channelCache.isEmpty()) {
+        ManagedChannel result = channelCache.remove(channelCache.size() - 1);
+        usedChannels.add(result);
+        return result;
+      }
+    }
+    ManagedChannel result = channelFactory.get();
+    synchronized (channelCache) {
+      usedChannels.add(result);
+      if (shutdownStarted) result.shutdown();
+    }
+    return result;
+  }
+
+  @Override
+  public ManagedChannel shutdown() {
+    synchronized (channelCache) {
+      shutdownStarted = true;
+      for (ManagedChannel channel : usedChannels) {
+        channel.shutdown();
+      }
+      for (ManagedChannel channel : channelCache) {
+        channel.shutdown();
+      }
+    }
+    return this;
+  }
+
+  @Override
+  public boolean isShutdown() {
+    synchronized (channelCache) {
+      if (!shutdownStarted) return false;
+      for (ManagedChannel channel : usedChannels) {
+        if (!channel.isShutdown()) return false;
+      }
+      for (ManagedChannel channel : channelCache) {
+        if (!channel.isShutdown()) return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public boolean isTerminated() {
+    synchronized (channelCache) {
+      if (!shutdownStarted) return false;
+      for (ManagedChannel channel : usedChannels) {
+        if (!channel.isTerminated()) return false;
+      }
+      for (ManagedChannel channel : channelCache) {
+        if (!channel.isTerminated()) return false;
+      }
+    }
+    return true;
+  }
+
+  @Override
+  public ManagedChannel shutdownNow() {
+    synchronized (channelCache) {
+      shutdownStarted = true;
+      for (ManagedChannel channel : usedChannels) {
+        channel.shutdownNow();
+      }
+      for (ManagedChannel channel : channelCache) {
+        channel.shutdownNow();
+      }
+    }
+    return this;
+  }
+
+  @Override
+  public boolean awaitTermination(long timeout, TimeUnit unit) throws InterruptedException {
+    long endTimeNanos = System.nanoTime() + unit.toNanos(timeout);
+    if (isTerminated()) return true;
+    synchronized (channelCache) {
+      if (!shutdownStarted) return false;
+      for (ManagedChannel channel : usedChannels) {
+        long awaitTimeNanos = endTimeNanos - System.nanoTime();
+        if (awaitTimeNanos <= 0) {
+          break;
+        }
+        channel.awaitTermination(awaitTimeNanos, TimeUnit.NANOSECONDS);
+      }
+      for (ManagedChannel channel : channelCache) {
+        long awaitTimeNanos = endTimeNanos - System.nanoTime();
+        if (awaitTimeNanos <= 0) {
+          break;
+        }
+        channel.awaitTermination(awaitTimeNanos, TimeUnit.NANOSECONDS);
+      }
+    }
+    return isTerminated();
+  }
+
+  void releaseChannelAfterCall(ManagedChannel managedChannel) {
+    synchronized (channelCache) {
+      Preconditions.checkState(
+          usedChannels.remove(managedChannel), "Channel released that was not used");
+      channelCache.add(managedChannel);
+    }
+  }
+
+  /** ClientCall wrapper that adds channel back to the cache on completion. */
+  private static class ReleasingClientCall<ReqT, RespT>
+      extends SimpleForwardingClientCall<ReqT, RespT> {
+    private final IsolationChannel isolationChannel;
+
+    private final ManagedChannel channel;
+    private final AtomicBoolean wasReleased = new AtomicBoolean();
+
+    public ReleasingClientCall(
+        IsolationChannel isolationChannel,
+        ManagedChannel channel,
+        ClientCall<ReqT, RespT> delegate) {
+      super(delegate);
+      this.isolationChannel = isolationChannel;
+      this.channel = channel;
+    }
+
+    @Override
+    public void start(Listener<RespT> responseListener, Metadata headers) {
+      try {
+        super.start(
+            new SimpleForwardingClientCallListener<RespT>(responseListener) {
+              @Override
+              public void onClose(Status status, Metadata trailers) {
+                try {
+                  super.onClose(status, trailers);
+                } finally {
+                  releaseChannelOnce();
+                }
+              }
+            },
+            headers);
+      } catch (Exception e) {
+        releaseChannelOnce();
+        throw e;
+      }
+    }
+
+    private void releaseChannelOnce() {
+      if (!wasReleased.getAndSet(true)) {
+        isolationChannel.releaseChannelAfterCall(channel);
+      } else {
+        LOG.log(
+            Level.WARNING,
+            "The entry is already released. This indicates that onClose() has already been called previously");
+      }
+    }
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/stubs/WindmillChannelFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/stubs/WindmillChannelFactory.java
@@ -48,7 +48,7 @@ public final class WindmillChannelFactory {
         .build();
   }
 
-  static Channel remoteChannel(
+  static ManagedChannel remoteChannel(
       WindmillServiceAddress windmillServiceAddress, int windmillServiceRpcChannelTimeoutSec) {
     switch (windmillServiceAddress.getKind()) {
       case IPV6:
@@ -63,7 +63,7 @@ public final class WindmillChannelFactory {
     }
   }
 
-  public static Channel remoteChannel(
+  public static ManagedChannel remoteChannel(
       HostAndPort endpoint, int windmillServiceRpcChannelTimeoutSec) {
     try {
       return createRemoteChannel(
@@ -85,7 +85,7 @@ public final class WindmillChannelFactory {
     }
   }
 
-  public static Channel remoteChannel(
+  public static ManagedChannel remoteChannel(
       Inet6Address directEndpoint, int windmillServiceRpcChannelTimeoutSec) {
     try {
       return createRemoteChannel(
@@ -97,7 +97,7 @@ public final class WindmillChannelFactory {
   }
 
   @SuppressWarnings("nullness")
-  private static Channel createRemoteChannel(
+  private static ManagedChannel createRemoteChannel(
       NettyChannelBuilder channelBuilder, int windmillServiceRpcChannelTimeoutSec)
       throws SSLException {
     if (windmillServiceRpcChannelTimeoutSec > 0) {

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/stubs/IsolationChannelTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/stubs/IsolationChannelTest.java
@@ -1,0 +1,298 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs;
+
+import static org.junit.Assert.assertThrows;
+import static org.junit.Assert.assertTrue;
+import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.same;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.times;
+import static org.mockito.Mockito.verify;
+import static org.mockito.Mockito.when;
+import static org.mockito.Mockito.inOrder;
+
+import java.io.IOException;
+import java.io.InputStream;
+import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.CallOptions;
+import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.ClientCall;
+import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.ClientCall.Listener;
+import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.ManagedChannel;
+import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.Metadata;
+import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.MethodDescriptor;
+import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.MethodDescriptor.Marshaller;
+import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.Status;
+import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.internal.NoopClientCall;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Supplier;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+import org.mockito.ArgumentCaptor;
+import org.mockito.InOrder;
+
+@RunWith(JUnit4.class)
+public class IsolationChannelTest {
+
+  private Supplier<ManagedChannel> channelSupplier = mock(Supplier.class);
+
+  private static class NoopMarshaller implements Marshaller<Object> {
+
+    @Override
+    public InputStream stream(Object o) {
+      return new InputStream() {
+        @Override
+        public int read() throws IOException {
+          return 0;
+        }
+      };
+    }
+
+    @Override
+    public Object parse(InputStream inputStream) {
+      return null;
+    }
+  };
+
+  private MethodDescriptor<Object, Object> methodDescriptor =
+      MethodDescriptor.newBuilder()
+          .setType(MethodDescriptor.MethodType.UNARY)
+          .setFullMethodName(MethodDescriptor.generateFullMethodName("test", "test"))
+          .setRequestMarshaller(new NoopMarshaller())
+          .setResponseMarshaller(new NoopMarshaller())
+          .build();
+
+  @Test
+  public void singleChannelAuthority() throws Exception {
+    ManagedChannel mockChannel = mock(ManagedChannel.class);
+    when(mockChannel.authority()).thenReturn("TEST_AUTHORITY");
+    when(channelSupplier.get()).thenReturn(mockChannel);
+
+    IsolationChannel isolationChannel = IsolationChannel.create(channelSupplier);
+    assertTrue(isolationChannel.authority().equals("TEST_AUTHORITY"));
+    verify(channelSupplier, times(1)).get();
+  }
+
+  @Test
+  public void singleChannelSuccessReuse() throws Exception {
+    ManagedChannel mockChannel = mock(ManagedChannel.class);
+    when(channelSupplier.get()).thenReturn(mockChannel);
+    ClientCall<Object, Object> underlyingCall = mock(ClientCall.class);
+    when(mockChannel.newCall(any(), any())).thenReturn(underlyingCall);
+
+    IsolationChannel isolationChannel = IsolationChannel.create(channelSupplier);
+    ClientCall<Object, Object> call1 = isolationChannel.newCall(
+        methodDescriptor,
+        CallOptions.DEFAULT);
+
+    Metadata metadata1 = new Metadata();
+    call1.start(new NoopClientCall.NoopClientCallListener<>(), metadata1);
+
+    InOrder inOrder = inOrder(underlyingCall);
+
+    ArgumentCaptor<Listener<Object>> captor =
+      ArgumentCaptor.forClass(ClientCall.Listener.class);
+    inOrder.verify(underlyingCall).start(captor.capture(), same(metadata1));
+    captor.getValue().onClose(Status.OK, new Metadata());
+
+    ClientCall<Object, Object> call2 = isolationChannel.newCall(
+        methodDescriptor,
+        CallOptions.DEFAULT);
+
+    Metadata metadata2 = new Metadata();
+    call2.start(new NoopClientCall.NoopClientCallListener<>(), metadata2);
+    captor = ArgumentCaptor.forClass(ClientCall.Listener.class);
+    inOrder.verify(underlyingCall).start(captor.capture(), same(metadata2));
+    captor.getValue().onClose(Status.OK, new Metadata());
+
+    verify(channelSupplier, times(1)).get();
+    verify(mockChannel, times(2)).newCall(any(), any());
+  }
+
+  @Test
+  public void singleChannelErrorReused() throws Exception {
+    ManagedChannel mockChannel = mock(ManagedChannel.class);
+    when(channelSupplier.get()).thenReturn(mockChannel);
+    ClientCall<Object, Object> underlyingCall = mock(ClientCall.class);
+    when(mockChannel.newCall(any(), any())).thenReturn(underlyingCall);
+
+    IsolationChannel isolationChannel = IsolationChannel.create(channelSupplier);
+    ClientCall<Object, Object> call1 = isolationChannel.newCall(
+        methodDescriptor,
+        CallOptions.DEFAULT);
+
+    Metadata metadata1 = new Metadata();
+    call1.start(new NoopClientCall.NoopClientCallListener<>(), metadata1);
+
+    InOrder inOrder = inOrder(underlyingCall);
+
+    ArgumentCaptor<Listener<Object>> captor =
+        ArgumentCaptor.forClass(ClientCall.Listener.class);
+    inOrder.verify(underlyingCall).start(captor.capture(), same(metadata1));
+    captor.getValue().onClose(Status.OK, new Metadata());
+
+    ClientCall<Object, Object> call2 = isolationChannel.newCall(
+        methodDescriptor,
+        CallOptions.DEFAULT);
+
+    Metadata metadata2 = new Metadata();
+    call2.start(new NoopClientCall.NoopClientCallListener<>(), metadata2);
+    captor = ArgumentCaptor.forClass(ClientCall.Listener.class);
+    inOrder.verify(underlyingCall).start(captor.capture(), same(metadata2));
+    captor.getValue().onClose(Status.ABORTED, new Metadata());
+
+    verify(channelSupplier, times(1)).get();
+    verify(mockChannel, times(2)).newCall(any(), any());
+  }
+
+  @Test
+  public void singleChannelStartExceptionReused() throws Exception {
+    ManagedChannel mockChannel = mock(ManagedChannel.class);
+    when(channelSupplier.get()).thenReturn(mockChannel);
+    ClientCall<Object, Object> exceptionCall = mock(ClientCall.class);
+    ClientCall<Object, Object> successCall = mock(ClientCall.class);
+    when(mockChannel.newCall(any(), any())).thenReturn(exceptionCall, successCall);
+    doThrow(new IllegalStateException("Test start error")).when(
+        exceptionCall).start(any(), any());
+
+    IsolationChannel isolationChannel = IsolationChannel.create(channelSupplier);
+    ClientCall<Object, Object> call1 = isolationChannel.newCall(
+        methodDescriptor,
+        CallOptions.DEFAULT);
+
+    Metadata metadata1 = new Metadata();
+    assertThrows(
+        IllegalStateException.class,
+        ()->       call1.start(new NoopClientCall.NoopClientCallListener<>(), metadata1));
+
+    ClientCall<Object, Object> call2 = isolationChannel.newCall(
+        methodDescriptor,
+        CallOptions.DEFAULT);
+
+    call2.start(new NoopClientCall.NoopClientCallListener<>(), new Metadata());
+    ArgumentCaptor<Listener<Object>> captor = ArgumentCaptor.forClass(ClientCall.Listener.class);
+    verify(successCall).start(captor.capture(), any());
+    captor.getValue().onClose(Status.ABORTED, new Metadata());
+
+    verify(channelSupplier, times(1)).get();
+    verify(mockChannel, times(2)).newCall(any(), any());
+  }
+
+  @Test
+  public void multipleChannelsCreated() throws Exception {
+    ManagedChannel mockChannel1 = mock(ManagedChannel.class);
+    ManagedChannel mockChannel2 = mock(ManagedChannel.class);
+    ManagedChannel mockChannel3 = mock(ManagedChannel.class);
+    when(channelSupplier.get()).thenReturn(mockChannel1, mockChannel2, mockChannel3);
+    ClientCall<Object, Object> mockCall1 = mock(ClientCall.class);
+    when(mockChannel1.newCall(any(), any())).thenReturn(mockCall1);
+    ClientCall<Object, Object> mockCall2 = mock(ClientCall.class);
+    when(mockChannel2.newCall(any(), any())).thenReturn(mockCall2);
+    ClientCall<Object, Object> mockCall3 = mock(ClientCall.class);
+    when(mockChannel3.newCall(any(), any())).thenReturn(mockCall3);
+
+    IsolationChannel isolationChannel = IsolationChannel.create(channelSupplier);
+
+    ClientCall<Object, Object> call1 = isolationChannel.newCall(
+        methodDescriptor,
+        CallOptions.DEFAULT);
+    call1.start(new NoopClientCall.NoopClientCallListener<>(), new Metadata());
+
+    ArgumentCaptor<Listener<Object>> captor1 =
+        ArgumentCaptor.forClass(ClientCall.Listener.class);
+    verify(mockCall1).start(captor1.capture(), any());
+
+    ClientCall<Object, Object> call2 = isolationChannel.newCall(
+        methodDescriptor,
+        CallOptions.DEFAULT);
+    call2.start(new NoopClientCall.NoopClientCallListener<>(), new Metadata());
+
+    ArgumentCaptor<Listener<Object>> captor2 =
+        ArgumentCaptor.forClass(ClientCall.Listener.class);
+    verify(mockCall2).start(captor2.capture(), any());
+
+    ClientCall<Object, Object> call3 = isolationChannel.newCall(
+        methodDescriptor,
+        CallOptions.DEFAULT);
+    call3.start(new NoopClientCall.NoopClientCallListener<>(), new Metadata());
+
+    ArgumentCaptor<Listener<Object>> captor3 =
+        ArgumentCaptor.forClass(ClientCall.Listener.class);
+    verify(mockCall3).start(captor3.capture(), any());
+
+    captor1.getValue().onClose(Status.OK, new Metadata());
+    captor2.getValue().onClose(Status.OK, new Metadata());
+    captor3.getValue().onClose(Status.OK, new Metadata());
+
+    verify(channelSupplier, times(3)).get();
+    verify(mockChannel1, times(1)).newCall(any(), any());
+    verify(mockChannel2, times(1)).newCall(any(), any());
+    verify(mockChannel3, times(1)).newCall(any(), any());
+  }
+
+  @Test
+  public void interleavedReuse() throws Exception {
+    ManagedChannel mockChannel1 = mock(ManagedChannel.class);
+    ManagedChannel mockChannel2 = mock(ManagedChannel.class);
+    when(channelSupplier.get()).thenReturn(mockChannel1, mockChannel2);
+    ClientCall<Object, Object> mockCall1 = mock(ClientCall.class);
+    when(mockChannel1.newCall(any(), any())).thenReturn(mockCall1);
+    ClientCall<Object, Object> mockCall2 = mock(ClientCall.class);
+    ClientCall<Object, Object> mockCall3 = mock(ClientCall.class);
+    when(mockChannel2.newCall(any(), any())).thenReturn(mockCall2, mockCall3);
+
+    IsolationChannel isolationChannel = IsolationChannel.create(channelSupplier);
+
+    ClientCall<Object, Object> call1 = isolationChannel.newCall(
+        methodDescriptor,
+        CallOptions.DEFAULT);
+    call1.start(new NoopClientCall.NoopClientCallListener<>(), new Metadata());
+
+    ArgumentCaptor<Listener<Object>> captor1 =
+        ArgumentCaptor.forClass(ClientCall.Listener.class);
+    verify(mockCall1).start(captor1.capture(), any());
+
+    ClientCall<Object, Object> call2 = isolationChannel.newCall(
+        methodDescriptor,
+        CallOptions.DEFAULT);
+    call2.start(new NoopClientCall.NoopClientCallListener<>(), new Metadata());
+
+    ArgumentCaptor<Listener<Object>> captor2 =
+        ArgumentCaptor.forClass(ClientCall.Listener.class);
+    verify(mockCall2).start(captor2.capture(), any());
+
+    // Finish call2, freeing up the channel
+    captor2.getValue().onClose(Status.OK, new Metadata());
+
+    ClientCall<Object, Object> call3 = isolationChannel.newCall(
+        methodDescriptor,
+        CallOptions.DEFAULT);
+    call3.start(new NoopClientCall.NoopClientCallListener<>(), new Metadata());
+
+    ArgumentCaptor<Listener<Object>> captor3 =
+        ArgumentCaptor.forClass(ClientCall.Listener.class);
+    verify(mockCall3).start(captor3.capture(), any());
+
+    captor1.getValue().onClose(Status.OK, new Metadata());
+    captor3.getValue().onClose(Status.OK, new Metadata());
+
+    verify(channelSupplier, times(2)).get();
+    verify(mockChannel1, times(1)).newCall(any(), any());
+    verify(mockChannel2, times(2)).newCall(any(), any());
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/stubs/IsolationChannelTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/stubs/IsolationChannelTest.java
@@ -17,19 +17,23 @@
  */
 package org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs;
 
+import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertThrows;
 import static org.junit.Assert.assertTrue;
 import static org.mockito.ArgumentMatchers.any;
+import static org.mockito.ArgumentMatchers.eq;
+import static org.mockito.ArgumentMatchers.longThat;
 import static org.mockito.ArgumentMatchers.same;
 import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.inOrder;
 import static org.mockito.Mockito.mock;
 import static org.mockito.Mockito.times;
 import static org.mockito.Mockito.verify;
 import static org.mockito.Mockito.when;
-import static org.mockito.Mockito.inOrder;
 
 import java.io.IOException;
 import java.io.InputStream;
+import java.util.concurrent.TimeUnit;
 import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.CallOptions;
 import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.ClientCall;
 import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.ClientCall.Listener;
@@ -96,23 +100,20 @@ public class IsolationChannelTest {
     when(mockChannel.newCall(any(), any())).thenReturn(underlyingCall);
 
     IsolationChannel isolationChannel = IsolationChannel.create(channelSupplier);
-    ClientCall<Object, Object> call1 = isolationChannel.newCall(
-        methodDescriptor,
-        CallOptions.DEFAULT);
+    ClientCall<Object, Object> call1 =
+        isolationChannel.newCall(methodDescriptor, CallOptions.DEFAULT);
 
     Metadata metadata1 = new Metadata();
     call1.start(new NoopClientCall.NoopClientCallListener<>(), metadata1);
 
     InOrder inOrder = inOrder(underlyingCall);
 
-    ArgumentCaptor<Listener<Object>> captor =
-      ArgumentCaptor.forClass(ClientCall.Listener.class);
+    ArgumentCaptor<Listener<Object>> captor = ArgumentCaptor.forClass(ClientCall.Listener.class);
     inOrder.verify(underlyingCall).start(captor.capture(), same(metadata1));
     captor.getValue().onClose(Status.OK, new Metadata());
 
-    ClientCall<Object, Object> call2 = isolationChannel.newCall(
-        methodDescriptor,
-        CallOptions.DEFAULT);
+    ClientCall<Object, Object> call2 =
+        isolationChannel.newCall(methodDescriptor, CallOptions.DEFAULT);
 
     Metadata metadata2 = new Metadata();
     call2.start(new NoopClientCall.NoopClientCallListener<>(), metadata2);
@@ -132,23 +133,20 @@ public class IsolationChannelTest {
     when(mockChannel.newCall(any(), any())).thenReturn(underlyingCall);
 
     IsolationChannel isolationChannel = IsolationChannel.create(channelSupplier);
-    ClientCall<Object, Object> call1 = isolationChannel.newCall(
-        methodDescriptor,
-        CallOptions.DEFAULT);
+    ClientCall<Object, Object> call1 =
+        isolationChannel.newCall(methodDescriptor, CallOptions.DEFAULT);
 
     Metadata metadata1 = new Metadata();
     call1.start(new NoopClientCall.NoopClientCallListener<>(), metadata1);
 
     InOrder inOrder = inOrder(underlyingCall);
 
-    ArgumentCaptor<Listener<Object>> captor =
-        ArgumentCaptor.forClass(ClientCall.Listener.class);
+    ArgumentCaptor<Listener<Object>> captor = ArgumentCaptor.forClass(ClientCall.Listener.class);
     inOrder.verify(underlyingCall).start(captor.capture(), same(metadata1));
     captor.getValue().onClose(Status.OK, new Metadata());
 
-    ClientCall<Object, Object> call2 = isolationChannel.newCall(
-        methodDescriptor,
-        CallOptions.DEFAULT);
+    ClientCall<Object, Object> call2 =
+        isolationChannel.newCall(methodDescriptor, CallOptions.DEFAULT);
 
     Metadata metadata2 = new Metadata();
     call2.start(new NoopClientCall.NoopClientCallListener<>(), metadata2);
@@ -167,22 +165,19 @@ public class IsolationChannelTest {
     ClientCall<Object, Object> exceptionCall = mock(ClientCall.class);
     ClientCall<Object, Object> successCall = mock(ClientCall.class);
     when(mockChannel.newCall(any(), any())).thenReturn(exceptionCall, successCall);
-    doThrow(new IllegalStateException("Test start error")).when(
-        exceptionCall).start(any(), any());
+    doThrow(new IllegalStateException("Test start error")).when(exceptionCall).start(any(), any());
 
     IsolationChannel isolationChannel = IsolationChannel.create(channelSupplier);
-    ClientCall<Object, Object> call1 = isolationChannel.newCall(
-        methodDescriptor,
-        CallOptions.DEFAULT);
+    ClientCall<Object, Object> call1 =
+        isolationChannel.newCall(methodDescriptor, CallOptions.DEFAULT);
 
     Metadata metadata1 = new Metadata();
     assertThrows(
         IllegalStateException.class,
-        ()->       call1.start(new NoopClientCall.NoopClientCallListener<>(), metadata1));
+        () -> call1.start(new NoopClientCall.NoopClientCallListener<>(), metadata1));
 
-    ClientCall<Object, Object> call2 = isolationChannel.newCall(
-        methodDescriptor,
-        CallOptions.DEFAULT);
+    ClientCall<Object, Object> call2 =
+        isolationChannel.newCall(methodDescriptor, CallOptions.DEFAULT);
 
     call2.start(new NoopClientCall.NoopClientCallListener<>(), new Metadata());
     ArgumentCaptor<Listener<Object>> captor = ArgumentCaptor.forClass(ClientCall.Listener.class);
@@ -208,31 +203,25 @@ public class IsolationChannelTest {
 
     IsolationChannel isolationChannel = IsolationChannel.create(channelSupplier);
 
-    ClientCall<Object, Object> call1 = isolationChannel.newCall(
-        methodDescriptor,
-        CallOptions.DEFAULT);
+    ClientCall<Object, Object> call1 =
+        isolationChannel.newCall(methodDescriptor, CallOptions.DEFAULT);
     call1.start(new NoopClientCall.NoopClientCallListener<>(), new Metadata());
 
-    ArgumentCaptor<Listener<Object>> captor1 =
-        ArgumentCaptor.forClass(ClientCall.Listener.class);
+    ArgumentCaptor<Listener<Object>> captor1 = ArgumentCaptor.forClass(ClientCall.Listener.class);
     verify(mockCall1).start(captor1.capture(), any());
 
-    ClientCall<Object, Object> call2 = isolationChannel.newCall(
-        methodDescriptor,
-        CallOptions.DEFAULT);
+    ClientCall<Object, Object> call2 =
+        isolationChannel.newCall(methodDescriptor, CallOptions.DEFAULT);
     call2.start(new NoopClientCall.NoopClientCallListener<>(), new Metadata());
 
-    ArgumentCaptor<Listener<Object>> captor2 =
-        ArgumentCaptor.forClass(ClientCall.Listener.class);
+    ArgumentCaptor<Listener<Object>> captor2 = ArgumentCaptor.forClass(ClientCall.Listener.class);
     verify(mockCall2).start(captor2.capture(), any());
 
-    ClientCall<Object, Object> call3 = isolationChannel.newCall(
-        methodDescriptor,
-        CallOptions.DEFAULT);
+    ClientCall<Object, Object> call3 =
+        isolationChannel.newCall(methodDescriptor, CallOptions.DEFAULT);
     call3.start(new NoopClientCall.NoopClientCallListener<>(), new Metadata());
 
-    ArgumentCaptor<Listener<Object>> captor3 =
-        ArgumentCaptor.forClass(ClientCall.Listener.class);
+    ArgumentCaptor<Listener<Object>> captor3 = ArgumentCaptor.forClass(ClientCall.Listener.class);
     verify(mockCall3).start(captor3.capture(), any());
 
     captor1.getValue().onClose(Status.OK, new Metadata());
@@ -258,34 +247,28 @@ public class IsolationChannelTest {
 
     IsolationChannel isolationChannel = IsolationChannel.create(channelSupplier);
 
-    ClientCall<Object, Object> call1 = isolationChannel.newCall(
-        methodDescriptor,
-        CallOptions.DEFAULT);
+    ClientCall<Object, Object> call1 =
+        isolationChannel.newCall(methodDescriptor, CallOptions.DEFAULT);
     call1.start(new NoopClientCall.NoopClientCallListener<>(), new Metadata());
 
-    ArgumentCaptor<Listener<Object>> captor1 =
-        ArgumentCaptor.forClass(ClientCall.Listener.class);
+    ArgumentCaptor<Listener<Object>> captor1 = ArgumentCaptor.forClass(ClientCall.Listener.class);
     verify(mockCall1).start(captor1.capture(), any());
 
-    ClientCall<Object, Object> call2 = isolationChannel.newCall(
-        methodDescriptor,
-        CallOptions.DEFAULT);
+    ClientCall<Object, Object> call2 =
+        isolationChannel.newCall(methodDescriptor, CallOptions.DEFAULT);
     call2.start(new NoopClientCall.NoopClientCallListener<>(), new Metadata());
 
-    ArgumentCaptor<Listener<Object>> captor2 =
-        ArgumentCaptor.forClass(ClientCall.Listener.class);
+    ArgumentCaptor<Listener<Object>> captor2 = ArgumentCaptor.forClass(ClientCall.Listener.class);
     verify(mockCall2).start(captor2.capture(), any());
 
     // Finish call2, freeing up the channel
     captor2.getValue().onClose(Status.OK, new Metadata());
 
-    ClientCall<Object, Object> call3 = isolationChannel.newCall(
-        methodDescriptor,
-        CallOptions.DEFAULT);
+    ClientCall<Object, Object> call3 =
+        isolationChannel.newCall(methodDescriptor, CallOptions.DEFAULT);
     call3.start(new NoopClientCall.NoopClientCallListener<>(), new Metadata());
 
-    ArgumentCaptor<Listener<Object>> captor3 =
-        ArgumentCaptor.forClass(ClientCall.Listener.class);
+    ArgumentCaptor<Listener<Object>> captor3 = ArgumentCaptor.forClass(ClientCall.Listener.class);
     verify(mockCall3).start(captor3.capture(), any());
 
     captor1.getValue().onClose(Status.OK, new Metadata());
@@ -294,5 +277,127 @@ public class IsolationChannelTest {
     verify(channelSupplier, times(2)).get();
     verify(mockChannel1, times(1)).newCall(any(), any());
     verify(mockChannel2, times(2)).newCall(any(), any());
+  }
+
+  @Test
+  public void testShutdown() throws Exception {
+    ManagedChannel mockChannel = mock(ManagedChannel.class);
+    when(channelSupplier.get()).thenReturn(mockChannel);
+    ClientCall<Object, Object> mockCall1 = mock(ClientCall.class);
+    ClientCall<Object, Object> mockCall2 = mock(ClientCall.class);
+    when(mockChannel.newCall(any(), any())).thenReturn(mockCall1, mockCall2);
+
+    IsolationChannel isolationChannel = IsolationChannel.create(channelSupplier);
+    ClientCall<Object, Object> call1 =
+        isolationChannel.newCall(methodDescriptor, CallOptions.DEFAULT);
+    call1.start(new NoopClientCall.NoopClientCallListener<>(), new Metadata());
+    ArgumentCaptor<Listener<Object>> captor1 = ArgumentCaptor.forClass(ClientCall.Listener.class);
+    verify(mockCall1).start(captor1.capture(), any());
+
+    when(mockChannel.shutdown()).thenReturn(mockChannel);
+    when(mockChannel.isShutdown()).thenReturn(false, true);
+
+    isolationChannel.shutdown();
+    assertFalse(isolationChannel.isShutdown());
+
+    ClientCall<Object, Object> call2 =
+        isolationChannel.newCall(methodDescriptor, CallOptions.DEFAULT);
+    call2.start(new NoopClientCall.NoopClientCallListener<>(), new Metadata());
+    ArgumentCaptor<Listener<Object>> captor2 = ArgumentCaptor.forClass(ClientCall.Listener.class);
+    verify(mockCall2).start(captor2.capture(), any());
+
+    captor1.getValue().onClose(Status.CANCELLED, new Metadata());
+    captor2.getValue().onClose(Status.CANCELLED, new Metadata());
+
+    assertTrue(isolationChannel.isShutdown());
+
+    verify(channelSupplier, times(1)).get();
+    verify(mockChannel, times(2)).newCall(any(), any());
+    verify(mockChannel, times(1)).shutdown();
+    verify(mockChannel, times(2)).isShutdown();
+  }
+
+  @Test
+  public void testShutdownNow() throws Exception {
+    ManagedChannel mockChannel = mock(ManagedChannel.class);
+    when(channelSupplier.get()).thenReturn(mockChannel);
+    ClientCall<Object, Object> mockCall1 = mock(ClientCall.class);
+    ClientCall<Object, Object> mockCall2 = mock(ClientCall.class);
+    when(mockChannel.newCall(any(), any())).thenReturn(mockCall1, mockCall2);
+
+    IsolationChannel isolationChannel = IsolationChannel.create(channelSupplier);
+    ClientCall<Object, Object> call1 =
+        isolationChannel.newCall(methodDescriptor, CallOptions.DEFAULT);
+    call1.start(new NoopClientCall.NoopClientCallListener<>(), new Metadata());
+    ArgumentCaptor<Listener<Object>> captor1 = ArgumentCaptor.forClass(ClientCall.Listener.class);
+    verify(mockCall1).start(captor1.capture(), any());
+
+    when(mockChannel.shutdownNow()).thenReturn(mockChannel);
+    when(mockChannel.isShutdown()).thenReturn(false, true);
+
+    isolationChannel.shutdownNow();
+    assertFalse(isolationChannel.isShutdown());
+
+    ClientCall<Object, Object> call2 =
+        isolationChannel.newCall(methodDescriptor, CallOptions.DEFAULT);
+    call2.start(new NoopClientCall.NoopClientCallListener<>(), new Metadata());
+    ArgumentCaptor<Listener<Object>> captor2 = ArgumentCaptor.forClass(ClientCall.Listener.class);
+    verify(mockCall2).start(captor2.capture(), any());
+
+    captor1.getValue().onClose(Status.CANCELLED, new Metadata());
+    captor2.getValue().onClose(Status.CANCELLED, new Metadata());
+
+    assertTrue(isolationChannel.isShutdown());
+
+    verify(channelSupplier, times(1)).get();
+    verify(mockChannel, times(2)).newCall(any(), any());
+    verify(mockChannel, times(1)).shutdownNow();
+    verify(mockChannel, times(2)).isShutdown();
+  }
+
+  @Test
+  public void testIsTerminated() throws Exception {
+    ManagedChannel mockChannel = mock(ManagedChannel.class);
+    when(channelSupplier.get()).thenReturn(mockChannel);
+
+    IsolationChannel isolationChannel = IsolationChannel.create(channelSupplier);
+
+    when(mockChannel.shutdown()).thenReturn(mockChannel);
+    when(mockChannel.isTerminated()).thenReturn(false, true);
+
+    isolationChannel.shutdown();
+    assertFalse(isolationChannel.isTerminated());
+    assertTrue(isolationChannel.isTerminated());
+
+    verify(channelSupplier, times(1)).get();
+    verify(mockChannel, times(1)).shutdown();
+    verify(mockChannel, times(2)).isTerminated();
+  }
+
+  @Test
+  public void testAwaitTermination() throws Exception {
+    ManagedChannel mockChannel = mock(ManagedChannel.class);
+    when(channelSupplier.get()).thenReturn(mockChannel);
+
+    IsolationChannel isolationChannel = IsolationChannel.create(channelSupplier);
+
+    assertFalse(isolationChannel.awaitTermination(1, TimeUnit.MILLISECONDS));
+
+    when(mockChannel.shutdown()).thenReturn(mockChannel);
+    when(mockChannel.isTerminated()).thenReturn(false, false, false, true, true);
+    when(mockChannel.awaitTermination(longThat(l -> l < 2_000_000), eq(TimeUnit.NANOSECONDS)))
+        .thenReturn(false, true);
+
+    isolationChannel.shutdown();
+    assertFalse(isolationChannel.awaitTermination(1, TimeUnit.MILLISECONDS));
+    assertTrue(isolationChannel.awaitTermination(1, TimeUnit.MILLISECONDS));
+
+    assertTrue(isolationChannel.isTerminated());
+
+    verify(channelSupplier, times(1)).get();
+    verify(mockChannel, times(1)).shutdown();
+    verify(mockChannel, times(5)).isTerminated();
+    verify(mockChannel, times(2))
+        .awaitTermination(longThat(l -> l < 2_000_000), eq(TimeUnit.NANOSECONDS));
   }
 }


### PR DESCRIPTION
- introduce an IsolationChannel class that uses a separate channel per-rpc. As rpcs complete, the channel will be available for subsequent rpcs. This isn't a good idea in general but given we have a few long-lived rpcs in the streaming client.
- use a separate GetDataStream rpc for heartbeats from read requests. This ensures that heartbeats are not delayed by other read requests.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
