### PR TITLE
[JdbcIO] - Adding option for max batch buffering duration

### DIFF
--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
@@ -2065,9 +2065,9 @@ public class JdbcIO {
     }
 
     /**
-     * Provide a maximum size in number of SQL statement for the batch. Default is 1000.
-     * The pipeline will either commit a batch when this maximum is reached or its
-     * maximum buffering time has been reached. See {@link #withMaxBatchBufferingDuration(long)}
+     * Provide a maximum size in number of SQL statement for the batch. Default is 1000. The
+     * pipeline will either commit a batch when this maximum is reached or its maximum buffering
+     * time has been reached. See {@link #withMaxBatchBufferingDuration(long)}
      *
      * @param batchSize maximum batch size in number of statements
      */
@@ -2077,9 +2077,9 @@ public class JdbcIO {
     }
 
     /**
-     * Provide maximum buffering time to batch elements before committing SQL statement. Default is 200
-     * The pipeline will either commit a batch when this maximum buffering time has been reached or the maximum
-     * amount of elements has been collected. See {@link #withBatchSize(long)}
+     * Provide maximum buffering time to batch elements before committing SQL statement. Default is
+     * 200 The pipeline will either commit a batch when this maximum buffering time has been reached
+     * or the maximum amount of elements has been collected. See {@link #withBatchSize(long)}
      *
      * @param maxBatchBufferingDuration maximum time in milliseconds before batch is committed
      */

--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
@@ -1761,7 +1761,10 @@ public class JdbcIO {
   /* The maximum number of elements that will be included in a batch. */
 
   static <T> PCollection<Iterable<T>> batchElements(
-      PCollection<T> input, @Nullable Boolean withAutoSharding, long batchSize, long maxBatchBufferingDuration) {
+      PCollection<T> input,
+      @Nullable Boolean withAutoSharding,
+      long batchSize,
+      long maxBatchBufferingDuration) {
     PCollection<Iterable<T>> iterables;
     if (input.isBounded() == IsBounded.UNBOUNDED) {
       PCollection<KV<String, T>> keyedInput = input.apply(WithKeys.<String, T>of(""));
@@ -1965,7 +1968,8 @@ public class JdbcIO {
           "Autosharding is only supported for streaming pipelines.");
 
       PCollection<Iterable<T>> iterables =
-          JdbcIO.<T>batchElements(input, autoSharding, DEFAULT_BATCH_SIZE, DEFAULT_MAX_BATCH_BUFFERING_DURATION);
+          JdbcIO.<T>batchElements(
+              input, autoSharding, DEFAULT_BATCH_SIZE, DEFAULT_MAX_BATCH_BUFFERING_DURATION);
       return iterables.apply(
           ParDo.of(
               new WriteFn<T, V>(
@@ -2071,12 +2075,16 @@ public class JdbcIO {
     }
 
     /**
-     * Provide maximum buffering time to batch elements before committing SQL statement. Default is 200
+     * Provide maximum buffering time to batch elements before committing SQL statement. Default is
+     * 200
      *
      * @param maxBatchBufferingDuration maximum time in milliseconds before batch is committed
      */
     public WriteVoid<T> withMaxBatchBufferingDuration(long maxBatchBufferingDuration) {
-      checkArgument(maxBatchBufferingDuration > 0, "maxBatchBufferingDuration must be > 0, but was %s", maxBatchBufferingDuration);
+      checkArgument(
+          maxBatchBufferingDuration > 0,
+          "maxBatchBufferingDuration must be > 0, but was %s",
+          maxBatchBufferingDuration);
       return toBuilder().setMaxBatchBufferingDuration(maxBatchBufferingDuration).build();
     }
 
@@ -2150,7 +2158,8 @@ public class JdbcIO {
       }
 
       PCollection<Iterable<T>> iterables =
-          JdbcIO.<T>batchElements(input, getAutoSharding(), getBatchSize(), getMaxBatchBufferingDuration());
+          JdbcIO.<T>batchElements(
+              input, getAutoSharding(), getBatchSize(), getMaxBatchBufferingDuration());
 
       return iterables
           .apply(
@@ -2503,7 +2512,8 @@ public class JdbcIO {
 
         abstract Builder<T, V> setBatchSize(@Nullable Long batchSize);
 
-        abstract Builder<T, V> setMaxBatchBufferingDuration(@Nullable Long maxBatchBufferingDuration);
+        abstract Builder<T, V> setMaxBatchBufferingDuration(
+            @Nullable Long maxBatchBufferingDuration);
 
         abstract Builder<T, V> setReturnResults(Boolean returnResults);
 

--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
@@ -2066,6 +2066,8 @@ public class JdbcIO {
 
     /**
      * Provide a maximum size in number of SQL statement for the batch. Default is 1000.
+     * The pipeline will either commit a batch when this maximum is reached or its
+     * maximum buffering time has been reached. See {@link #withMaxBatchBufferingDuration(long)}
      *
      * @param batchSize maximum batch size in number of statements
      */
@@ -2075,8 +2077,9 @@ public class JdbcIO {
     }
 
     /**
-     * Provide maximum buffering time to batch elements before committing SQL statement. Default is
-     * 200
+     * Provide maximum buffering time to batch elements before committing SQL statement. Default is 200
+     * The pipeline will either commit a batch when this maximum buffering time has been reached or the maximum
+     * amount of elements has been collected. See {@link #withBatchSize(long)}
      *
      * @param maxBatchBufferingDuration maximum time in milliseconds before batch is committed
      */

--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
@@ -1982,7 +1982,7 @@ public class JdbcIO {
                       .setRetryConfiguration(getRetryConfiguration())
                       .setReturnResults(true)
                       .setBatchSize(1L)
-                      .setMaxBatchBufferingDuration(200L)
+                      .setMaxBatchBufferingDuration(DEFAULT_MAX_BATCH_BUFFERING_DURATION)
                       .build())));
     }
   }

--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcIO.java
@@ -2472,6 +2472,9 @@ public class JdbcIO {
       abstract @Nullable Long getBatchSize();
 
       @Pure
+      abstract @Nullable Long getMaxBatchBufferingDuration();
+
+      @Pure
       abstract Boolean getReturnResults();
 
       @Pure


### PR DESCRIPTION
Currently the max buffering duration for batch processing during JDBC writes is not configurable and defaulted to 200ms. I'm proposing that we add an option to configure this setting to allow for a longer duration period to accumulate batched elements. We've run into an issue where batches are committed too frequently causing many small batches to be written rather than fewer larger batches, and I'm hoping to tweak this setting to allow for the latter.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
