### PR TITLE
fixed the display issue for impersonateServiceAccount with Java

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -270,6 +270,10 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
       missing.add("appName");
     }
 
+    LOG.info("ImpersonateServiceAccount is {}", dataflowOptions.getImpersonateServiceAccount());
+
+    dataflowOptions.setImpersonateServiceAccount(null);
+
     if (Strings.isNullOrEmpty(dataflowOptions.getRegion())
         && isServiceEndpoint(dataflowOptions.getDataflowEndpoint())) {
       missing.add("region");

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -488,6 +488,7 @@ public class StreamingDataflowWorker {
         "%s cannot be main() class with beam_fn_api enabled",
         StreamingDataflowWorker.class.getSimpleName());
 
+    LOG.info("Creating StreamingDataflowWorker from options: {}", options);
     StreamingDataflowWorker worker = StreamingDataflowWorker.fromOptions(options);
 
     // Use the MetricsLogger container which is used by BigQueryIO to periodically log process-wide

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingDataflowWorker.java
@@ -488,7 +488,7 @@ public class StreamingDataflowWorker {
         "%s cannot be main() class with beam_fn_api enabled",
         StreamingDataflowWorker.class.getSimpleName());
 
-    LOG.info("Creating StreamingDataflowWorker from options: {}", options);
+    LOG.debug("Creating StreamingDataflowWorker from options: {}", options);
     StreamingDataflowWorker worker = StreamingDataflowWorker.fromOptions(options);
 
     // Use the MetricsLogger container which is used by BigQueryIO to periodically log process-wide

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkerPipelineOptionsFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkerPipelineOptionsFactory.java
@@ -80,6 +80,12 @@ public class WorkerPipelineOptionsFactory {
       options.setWorkerPool(System.getProperty("worker_pool"));
     }
 
+    // Remove impersonate information from workers
+    // More details: https://cloud.google.com/dataflow/docs/reference/pipeline-options#security_and_networking
+    if (options.getImpersonateServiceAccount()!=null) {
+      options.setImpersonateServiceAccount(null);
+    }
+
     return options;
   }
 }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkerPipelineOptionsFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkerPipelineOptionsFactory.java
@@ -81,8 +81,12 @@ public class WorkerPipelineOptionsFactory {
     }
 
     // Remove impersonate information from workers
-    // More details: https://cloud.google.com/dataflow/docs/reference/pipeline-options#security_and_networking
-    if (options.getImpersonateServiceAccount()!=null) {
+    // More details:
+    // https://cloud.google.com/dataflow/docs/reference/pipeline-options#security_and_networking
+    if (options.getImpersonateServiceAccount() != null) {
+      LOG.info(
+          "Remove the impersonateServiceAccount pipeline option ({}) when starting the Worker harness.",
+          options.getImpersonateServiceAccount());
       options.setImpersonateServiceAccount(null);
     }
 

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/options/GcpOptions.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/options/GcpOptions.java
@@ -220,7 +220,6 @@ public interface GcpOptions extends GoogleApiDebugOptions, PipelineOptions {
           + " either a single service account as the impersonator, or a"
           + " comma-separated list of service accounts to create an"
           + " impersonation delegation chain.")
-  @JsonIgnore
   @Nullable
   String getImpersonateServiceAccount();
 

--- a/sdks/java/harness/build.gradle
+++ b/sdks/java/harness/build.gradle
@@ -31,6 +31,7 @@ dependencies {
   provided project(path: ":sdks:java:core", configuration: "shadow")
   provided project(path: ":sdks:java:transform-service:launcher")
   provided library.java.avro
+  provided library.java.jackson_databind
   provided library.java.joda_time
   provided library.java.slf4j_api
   provided library.java.vendored_grpc_1_60_1

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnHarness.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnHarness.java
@@ -19,19 +19,18 @@ package org.apache.beam.fn.harness;
 
 import com.fasterxml.jackson.databind.JsonNode;
 import com.fasterxml.jackson.databind.ObjectMapper;
-
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
 import java.nio.file.Path;
 import java.nio.file.Paths;
 import java.util.Collections;
 import java.util.EnumMap;
+import java.util.Iterator;
+import java.util.Map;
 import java.util.Set;
 import java.util.concurrent.CompletableFuture;
 import java.util.concurrent.ExecutorService;
 import java.util.function.Function;
-import java.util.Iterator;
-import java.util.Map;
 import javax.annotation.Nullable;
 import org.apache.beam.fn.harness.control.BeamFnControlClient;
 import org.apache.beam.fn.harness.control.ExecutionStateSampler;
@@ -111,7 +110,6 @@ public class FnHarness {
     TextFormat.merge(descriptor, apiServiceDescriptorBuilder);
     return apiServiceDescriptorBuilder.build();
   }
-
 
   public static String removeNestedKey(String jsonString, String keyToRemove) throws Exception {
     ObjectMapper mapper = new ObjectMapper();

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnHarness.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnHarness.java
@@ -171,6 +171,7 @@ public class FnHarness {
     }
 
     System.out.format("Pipeline options %s%n", pipelineOptionsJson);
+    // TODO: https://github.com/apache/beam/issues/30301
     pipelineOptionsJson = removeNestedKey(pipelineOptionsJson, "impersonateServiceAccount");
 
     PipelineOptions options = PipelineOptionsTranslation.fromJson(pipelineOptionsJson);


### PR DESCRIPTION
When using `impersonateServiceAccount`, per https://cloud.google.com/dataflow/docs/reference/pipeline-options#security_and_networking, Dataflow UI should display this useful option but this option should be ignored when staring the worker harness.

This PR fixes this. Here is what the UI displays with this option is set:

<img width="474" alt="image" src="https://github.com/apache/beam/assets/7833268/7c954156-9042-4111-b2b1-fe498809bd3f">


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
