### PR TITLE
fixed documentation in sdks/python/apache_beam/io/gcp/pubsub.py WriteToPubSub

### DIFF
--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -452,7 +452,7 @@ createCrossLanguageValidatesRunnerTask(
     "--timeout=4500",
     "--log-cli-level=INFO",
   ],
-  goScrptOptions: [
+  goScriptOptions: [
     "--runner dataflow",
     "--project ${dataflowProject}",
     "--dataflow_project ${dataflowProject}",

--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -452,7 +452,7 @@ createCrossLanguageValidatesRunnerTask(
     "--timeout=4500",
     "--log-cli-level=INFO",
   ],
-  goScriptOptions: [
+  goScrptOptions: [
     "--runner dataflow",
     "--project ${dataflowProject}",
     "--dataflow_project ${dataflowProject}",

--- a/sdks/python/apache_beam/io/gcp/pubsub.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub.py
@@ -337,7 +337,7 @@ class WriteToPubSub(PTransform):
     """Initializes ``WriteToPubSub``.
 
     Args:
-      topic: Cloud Pub/Sub topic in the form "/topics/<project>/<topic>".
+      topic: Cloud Pub/Sub topic in the form "/projects/<project>/topics/<topic>".
       with_attributes:
         True - input elements will be :class:`~PubsubMessage` objects.
         False - input elements will be of type ``bytes`` (message

--- a/sdks/python/apache_beam/io/gcp/pubsub.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub.py
@@ -337,7 +337,7 @@ class WriteToPubSub(PTransform):
     """Initializes ``WriteToPubSub``.
 
     Args:
-      topic: Cloud Pub/Sub topic in the form "/projects/<project>/topics/<topic>".
+      topic: Cloud Pub/Sub topic in the form "projects/<project>/topics/<topic>".
       with_attributes:
         True - input elements will be :class:`~PubsubMessage` objects.
         False - input elements will be of type ``bytes`` (message

--- a/sdks/python/apache_beam/io/gcp/pubsub.py
+++ b/sdks/python/apache_beam/io/gcp/pubsub.py
@@ -337,7 +337,9 @@ class WriteToPubSub(PTransform):
     """Initializes ``WriteToPubSub``.
 
     Args:
-      topic: Cloud Pub/Sub topic in the form "projects/<project>/topics/<topic>".
+      topic:
+          Cloud Pub/Sub topic in the form
+          "projects/<project>/topics/<topic>".
       with_attributes:
         True - input elements will be :class:`~PubsubMessage` objects.
         False - input elements will be of type ``bytes`` (message


### PR DESCRIPTION
fixed documentation in sdks/python/apache_beam/io/gcp/pubsub.py WriteToPubSub

------------------------

sdks/python/apache_beam/io/gcp/pubsub.py WriteToPubSub documentation

topic arg changed from
topic: Cloud Pub/Sub topic in the form "/topics/<project>/<topic>".

to
topic: Cloud Pub/Sub topic in the form "/projects/<project>/topics/<topic>".)

