### PR TITLE
Implement BigQuery Stress Test

### DIFF
--- a/it/google-cloud-platform/build.gradle
+++ b/it/google-cloud-platform/build.gradle
@@ -81,4 +81,7 @@ dependencies {
 
 tasks.register("GCSPerformanceTest", IoPerformanceTestUtilities.IoPerformanceTest, project, 'google-cloud-platform', 'FileBasedIOLT', ['configuration':'large','project':'apache-beam-testing', 'artifactBucket':'io-performance-temp'])
 tasks.register("BigTablePerformanceTest", IoPerformanceTestUtilities.IoPerformanceTest, project, 'google-cloud-platform', 'BigTableIOLT', ['configuration':'large','project':'apache-beam-testing', 'artifactBucket':'io-performance-temp'])
+tasks.register("BigQueryPerformanceTest", IoPerformanceTestUtilities.IoPerformanceTest, project, 'google-cloud-platform', 'BigQueryIOLT', ['configuration':'medium','project':'apache-beam-testing', 'artifactBucket':'io-performance-temp'])
+tasks.register("BigQueryStressTest", IoPerformanceTestUtilities.IoPerformanceTest, project, 'google-cloud-platform', 'BigQueryIOST', ['configuration':'medium','project':'apache-beam-testing', 'artifactBucket':'io-performance-temp'])
 tasks.register("BigQueryStorageApiStreamingPerformanceTest", IoPerformanceTestUtilities.IoPerformanceTest, project, 'google-cloud-platform', 'BigQueryStreamingLT', ['configuration':'large', 'project':'apache-beam-testing', 'artifactBucket':'io-performance-temp'])
+tasks.register("WordCountIntegrationTest", IoPerformanceTestUtilities.IoPerformanceTest, project, 'google-cloud-platform', 'WordCountIT', ['project':'apache-beam-testing', 'artifactBucket':'io-performance-temp'])

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/bigquery/BigQueryIOST.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/bigquery/BigQueryIOST.java
@@ -1,0 +1,559 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.it.gcp.bigquery;
+
+import static org.apache.beam.it.truthmatchers.PipelineAsserts.assertThatResult;
+import static org.junit.Assert.assertEquals;
+
+import com.fasterxml.jackson.annotation.JsonProperty;
+import com.google.api.services.bigquery.model.TableFieldSchema;
+import com.google.api.services.bigquery.model.TableRow;
+import com.google.api.services.bigquery.model.TableSchema;
+import java.io.IOException;
+import java.nio.ByteBuffer;
+import java.text.ParseException;
+import java.time.Duration;
+import java.time.ZoneId;
+import java.time.format.DateTimeFormatter;
+import java.util.ArrayList;
+import java.util.Arrays;
+import java.util.Base64;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
+import java.util.UUID;
+import org.apache.avro.generic.GenericData;
+import org.apache.avro.generic.GenericRecord;
+import org.apache.beam.it.common.PipelineLauncher;
+import org.apache.beam.it.common.PipelineOperator;
+import org.apache.beam.it.common.TestProperties;
+import org.apache.beam.it.common.utils.ResourceManagerUtils;
+import org.apache.beam.it.gcp.IOLoadTestBase;
+import org.apache.beam.runners.dataflow.options.DataflowPipelineWorkerPoolOptions;
+import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
+import org.apache.beam.sdk.io.gcp.bigquery.AvroWriteRequest;
+import org.apache.beam.sdk.io.gcp.bigquery.BigQueryIO;
+import org.apache.beam.sdk.io.synthetic.SyntheticSourceOptions;
+import org.apache.beam.sdk.options.StreamingOptions;
+import org.apache.beam.sdk.options.ValueProvider;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.testing.TestPipelineOptions;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.MapElements;
+import org.apache.beam.sdk.transforms.ParDo;
+import org.apache.beam.sdk.transforms.PeriodicImpulse;
+import org.apache.beam.sdk.transforms.Reshuffle;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Strings;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.primitives.Longs;
+import org.joda.time.Instant;
+import org.junit.AfterClass;
+import org.junit.Before;
+import org.junit.BeforeClass;
+import org.junit.Ignore;
+import org.junit.Rule;
+import org.junit.Test;
+
+/**
+ * BigQueryIO stress tests. The test is designed to assess the performance of BigQueryIO under
+ * various conditions.
+ */
+public final class BigQueryIOST extends IOLoadTestBase {
+
+  private static final String READ_ELEMENT_METRIC_NAME = "read_count";
+  private static final String RUNNER_V2_FLAG = "use_runner_v2";
+  private static final int DEFAULT_ROWS_PER_SECOND = 1000;
+  private static final int[] DEFAULT_LOAD_INCREASE_ARRAY = {1, 2, 2, 4, 2, 1};
+
+  private static BigQueryResourceManager resourceManager;
+  private static String sourceTableQualifier;
+  private static String outputTableQualifier;
+
+  private Configuration configuration;
+  private String tempLocation;
+  private TableSchema schema;
+
+  @Rule public TestPipeline generateDataPipeline = TestPipeline.create();
+  @Rule public TestPipeline readAndWritePipeline = TestPipeline.create();
+
+  @BeforeClass
+  public static void beforeClass() {
+    resourceManager =
+        BigQueryResourceManager.builder("io-bigquery-lt", project, CREDENTIALS).build();
+    resourceManager.createDataset(region);
+  }
+
+  @Before
+  public void setup() {
+    // generate a random table names
+    String sourceTableName =
+        "io-bq-source-table-"
+            + DateTimeFormatter.ofPattern("MMddHHmmssSSS")
+                .withZone(ZoneId.of("UTC"))
+                .format(java.time.Instant.now())
+            + UUID.randomUUID().toString().substring(0, 10);
+    sourceTableQualifier =
+        String.format("%s:%s.%s", project, resourceManager.getDatasetId(), sourceTableName);
+    String outputTableName =
+        "io-bq-output-table-"
+            + DateTimeFormatter.ofPattern("MMddHHmmssSSS")
+                .withZone(ZoneId.of("UTC"))
+                .format(java.time.Instant.now())
+            + UUID.randomUUID().toString().substring(0, 10);
+    outputTableQualifier =
+        String.format("%s:%s.%s", project, resourceManager.getDatasetId(), outputTableName);
+
+    // parse configuration
+    String testConfig =
+        TestProperties.getProperty("configuration", "local", TestProperties.Type.PROPERTY);
+    configuration = TEST_CONFIGS_PRESET.get(testConfig);
+    if (configuration == null) {
+      try {
+        configuration = Configuration.fromJsonString(testConfig, Configuration.class);
+      } catch (IOException e) {
+        throw new IllegalArgumentException(
+            String.format(
+                "Unknown test configuration: [%s]. Pass to a valid configuration json, or use"
+                    + " config presets: %s",
+                testConfig, TEST_CONFIGS_PRESET.keySet()));
+      }
+    }
+
+    // prepare schema
+    List<TableFieldSchema> fields = new ArrayList<>(configuration.numColumns);
+    for (int idx = 0; idx < configuration.numColumns; ++idx) {
+      fields.add(new TableFieldSchema().setName("data_" + idx).setType("BYTES"));
+    }
+    schema = new TableSchema().setFields(fields);
+
+    // tempLocation needs to be set for bigquery IO writes
+    if (!Strings.isNullOrEmpty(tempBucketName)) {
+      tempLocation = String.format("gs://%s/temp/", tempBucketName);
+      generateDataPipeline.getOptions().as(TestPipelineOptions.class).setTempRoot(tempLocation);
+      generateDataPipeline.getOptions().setTempLocation(tempLocation);
+      readAndWritePipeline.getOptions().as(TestPipelineOptions.class).setTempRoot(tempLocation);
+      readAndWritePipeline.getOptions().setTempLocation(tempLocation);
+    }
+  }
+
+  @AfterClass
+  public static void tearDownClass() {
+    ResourceManagerUtils.cleanResources(resourceManager);
+  }
+
+  private static final Map<String, Configuration> TEST_CONFIGS_PRESET;
+
+  static {
+    try {
+      TEST_CONFIGS_PRESET =
+          ImmutableMap.of(
+              "medium",
+              Configuration.fromJsonString(
+                  "{\"rowsPerSecond\":50000,\"minutes\":180,\"numRecords\":1080000000,\"valueSizeBytes\":1000,\"pipelineTimeout\":300,\"runner\":\"DataflowRunner\"}",
+                  Configuration.class));
+    } catch (IOException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Test
+  public void testJsonStreamingWriteThenRead() throws IOException {
+    configuration.writeFormat = "JSON";
+    configuration.writeMethod = "STREAMING_INSERTS";
+    runTest();
+  }
+
+  @Test
+  @Ignore
+  public void testStorageAPIWriteThenRead() throws IOException {
+    configuration.readMethod = "DIRECT_READ";
+    configuration.writeFormat = "AVRO";
+    configuration.writeMethod = "STORAGE_WRITE_API";
+    runTest();
+  }
+
+  /**
+   * Runs a stress test for BigQueryIO based on the specified configuration parameters. The method
+   * initializes the stress test by determining the WriteFormat, configuring the BigQueryIO. Write
+   * instance accordingly, and then executing data generation and read/write operations on BigQuery.
+   */
+  private void runTest() throws IOException {
+    WriteFormat writeFormat = WriteFormat.valueOf(configuration.writeFormat);
+    BigQueryIO.Write<byte[]> generateDataWriteIO = null;
+    switch (writeFormat) {
+      case AVRO:
+        generateDataWriteIO =
+            BigQueryIO.<byte[]>write()
+                .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_TRUNCATE)
+                .withAvroFormatFunction(
+                    new AvroFormatFn(
+                        configuration.numColumns,
+                        !("STORAGE_WRITE_API".equalsIgnoreCase(configuration.writeMethod))));
+        break;
+      case JSON:
+        generateDataWriteIO =
+            BigQueryIO.<byte[]>write()
+                .withSuccessfulInsertsPropagation(false)
+                .withFormatFunction(new JsonFormatFn(configuration.numColumns));
+        break;
+    }
+    generateData(generateDataWriteIO);
+    readAndWrite();
+  }
+
+  /**
+   * The method creates a pipeline to simulate data generation and write operations to BigQuery
+   * source table, based on the specified configuration parameters. The stress test involves varying
+   * the load dynamically over time, with options to use configurable parameters.
+   */
+  private void generateData(BigQueryIO.Write<byte[]> writeIO) throws IOException {
+    BigQueryIO.Write.Method method = BigQueryIO.Write.Method.valueOf(configuration.writeMethod);
+    generateDataPipeline.getOptions().as(StreamingOptions.class).setStreaming(true);
+
+    // The PeriodicImpulse source will generate an element every this many millis:
+    int fireInterval = 1;
+    // Each element from PeriodicImpulse will fan out to this many elements:
+    int startMultiplier =
+        Math.max(configuration.rowsPerSecond, DEFAULT_ROWS_PER_SECOND) / DEFAULT_ROWS_PER_SECOND;
+    long stopAfterMillis =
+        org.joda.time.Duration.standardMinutes(configuration.minutes).getMillis();
+    long totalRows = startMultiplier * stopAfterMillis / fireInterval;
+    List<LoadPeriod> loadPeriods =
+        getLoadPeriods(configuration.minutes, DEFAULT_LOAD_INCREASE_ARRAY);
+
+    PCollection<byte[]> source =
+        generateDataPipeline
+            .apply(
+                PeriodicImpulse.create()
+                    .stopAfter(org.joda.time.Duration.millis(stopAfterMillis - 1))
+                    // .stopAt(Instant.now().plus(org.joda.time.Duration.millis(millis - 1)))
+                    .withInterval(org.joda.time.Duration.millis(fireInterval)))
+            .apply(
+                "Extract row IDs",
+                MapElements.into(TypeDescriptor.of(byte[].class))
+                    .via(instant -> Longs.toByteArray(instant.getMillis() % totalRows)));
+    if (startMultiplier > 1) {
+      source =
+          source
+              .apply(
+                  "One input to multiple outputs",
+                  ParDo.of(new MultiplierDoFn(startMultiplier, loadPeriods)))
+              .apply("Reshuffle fanout", Reshuffle.viaRandomKey());
+    }
+    source.apply(
+        "Write to BQ",
+        writeIO
+            .to(sourceTableQualifier)
+            .withMethod(method)
+            .withSchema(schema)
+            .withCustomGcsTempLocation(ValueProvider.StaticValueProvider.of(tempLocation)));
+
+    PipelineLauncher.LaunchConfig options =
+        PipelineLauncher.LaunchConfig.builder("write-bigquery")
+            .setSdk(PipelineLauncher.Sdk.JAVA)
+            .setPipeline(generateDataPipeline)
+            .addParameter("runner", configuration.runner)
+            .addParameter(
+                "autoscalingAlgorithm",
+                DataflowPipelineWorkerPoolOptions.AutoscalingAlgorithmType.THROUGHPUT_BASED
+                    .toString())
+            .addParameter("numWorkers", "20")
+            .addParameter("maxNumWorkers", "100")
+            .addParameter(
+                "experiments", GcpOptions.STREAMING_ENGINE_EXPERIMENT + "," + RUNNER_V2_FLAG)
+            .build();
+
+    // We don't wait on this job, because the read/write job will run in parallel,
+    // and it will take longer anyway; this job will finish by then.
+    pipelineLauncher.launch(project, region, options);
+  }
+
+  private void readAndWrite() throws IOException {
+    BigQueryIO.Write<TableRow> writeIO =
+        BigQueryIO.<TableRow>write()
+            .withWriteDisposition(BigQueryIO.Write.WriteDisposition.WRITE_TRUNCATE);
+    BigQueryIO.TypedRead.Method method =
+        BigQueryIO.TypedRead.Method.valueOf(configuration.readMethod);
+
+    readAndWritePipeline
+        .apply(
+            "Read from BQ",
+            BigQueryIO.readTableRows().from(sourceTableQualifier).withMethod(method))
+        .apply("Counting element", ParDo.of(new CountingFn<>(READ_ELEMENT_METRIC_NAME)))
+        .apply(
+            "Write to BQ",
+            writeIO
+                .to(outputTableQualifier)
+                .withMethod(BigQueryIO.Write.Method.valueOf(configuration.writeMethod))
+                .withSchema(schema)
+                .withCustomGcsTempLocation(ValueProvider.StaticValueProvider.of(tempLocation)));
+
+    PipelineLauncher.LaunchConfig options =
+        PipelineLauncher.LaunchConfig.builder("read-bigquery")
+            .setSdk(PipelineLauncher.Sdk.JAVA)
+            .setPipeline(readAndWritePipeline)
+            .addParameter("runner", configuration.runner)
+            .build();
+
+    PipelineLauncher.LaunchInfo launchInfo = pipelineLauncher.launch(project, region, options);
+    PipelineOperator.Result result =
+        pipelineOperator.waitUntilDone(
+            createConfig(launchInfo, Duration.ofMinutes(configuration.pipelineTimeout)));
+
+    // Fail the test if pipeline failed or timeout.
+    assertThatResult(result).isLaunchFinished();
+
+    // check metrics
+    double numRecords =
+        pipelineLauncher.getMetric(
+            project,
+            region,
+            launchInfo.jobId(),
+            getBeamMetricsName(PipelineMetricsType.COUNTER, READ_ELEMENT_METRIC_NAME));
+    assertEquals(configuration.numRecords, numRecords, 0.5);
+
+    // export metrics
+    MetricsConfiguration metricsConfig =
+        MetricsConfiguration.builder()
+            .setInputPCollection("")
+            .setInputPCollectionV2("")
+            .setOutputPCollection("Counting element.out0")
+            .setOutputPCollectionV2("Counting element/ParMultiDo(Counting).out0")
+            .build();
+    try {
+      exportMetricsToBigQuery(launchInfo, getMetrics(launchInfo, metricsConfig));
+    } catch (ParseException | InterruptedException e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  /**
+   * Custom Apache Beam DoFn designed for use in stress testing scenarios. It introduces a dynamic
+   * load increase over time, multiplying the input elements based on the elapsed time since the
+   * start of processing. This class aims to simulate various load levels during stress testing.
+   */
+  private static class MultiplierDoFn extends DoFn<byte[], byte[]> {
+    private final int startMultiplier;
+    private final long startTimesMillis;
+    private final List<LoadPeriod> loadPeriods;
+
+    MultiplierDoFn(int startMultiplier, List<LoadPeriod> loadPeriods) {
+      this.startMultiplier = startMultiplier;
+      this.startTimesMillis = Instant.now().getMillis();
+      this.loadPeriods = loadPeriods;
+    }
+
+    @ProcessElement
+    public void processElement(
+        @Element byte[] element,
+        OutputReceiver<byte[]> outputReceiver,
+        @Timestamp Instant timestamp) {
+
+      int multiplier = this.startMultiplier;
+      long elapsedTimeMillis = timestamp.getMillis() - startTimesMillis;
+
+      for (LoadPeriod loadPeriod : loadPeriods) {
+        if (elapsedTimeMillis >= loadPeriod.getPeriodStartMillis()
+            && elapsedTimeMillis < loadPeriod.getPeriodEndMillis()) {
+          multiplier *= loadPeriod.getLoadIncreaseMultiplier();
+          break;
+        }
+      }
+      for (int i = 0; i < multiplier; i++) {
+        outputReceiver.output(element);
+      }
+    }
+  }
+
+  abstract static class FormatFn<InputT, OutputT> implements SerializableFunction<InputT, OutputT> {
+    protected final int numColumns;
+
+    public FormatFn(int numColumns) {
+      this.numColumns = numColumns;
+    }
+  }
+
+  /** Avro format function that transforms AvroWriteRequest<byte[]> into a GenericRecord. */
+  private static class AvroFormatFn extends FormatFn<AvroWriteRequest<byte[]>, GenericRecord> {
+
+    protected final boolean isWrapBytes;
+
+    public AvroFormatFn(int numColumns, boolean isWrapBytes) {
+      super(numColumns);
+      this.isWrapBytes = isWrapBytes;
+    }
+
+    // TODO(https://github.com/apache/beam/issues/26408) eliminate this method once the Beam issue
+    // resolved
+    private Object maybeWrapBytes(byte[] input) {
+      if (isWrapBytes) {
+        return ByteBuffer.wrap(input);
+      } else {
+        return input;
+      }
+    }
+
+    @Override
+    public GenericRecord apply(AvroWriteRequest<byte[]> writeRequest) {
+      byte[] data = Objects.requireNonNull(writeRequest.getElement());
+      GenericRecord record = new GenericData.Record(writeRequest.getSchema());
+      if (numColumns == 1) {
+        // only one column, just wrap incoming bytes
+        record.put("data_0", maybeWrapBytes(data));
+      } else {
+        // otherwise, distribute bytes
+        int bytePerCol = data.length / numColumns;
+        int curIdx = 0;
+        for (int idx = 0; idx < numColumns - 1; ++idx) {
+          record.put(
+              "data_" + idx, maybeWrapBytes(Arrays.copyOfRange(data, curIdx, curIdx + bytePerCol)));
+          curIdx += bytePerCol;
+        }
+        record.put(
+            "data_" + (numColumns - 1),
+            maybeWrapBytes(Arrays.copyOfRange(data, curIdx, data.length)));
+      }
+      return record;
+    }
+  }
+
+  /** JSON format function that transforms byte[] into a TableRow. */
+  private static class JsonFormatFn extends FormatFn<byte[], TableRow> {
+
+    public JsonFormatFn(int numColumns) {
+      super(numColumns);
+    }
+
+    @Override
+    public TableRow apply(byte[] input) {
+      TableRow tableRow = new TableRow();
+      Base64.Encoder encoder = Base64.getEncoder();
+      if (numColumns == 1) {
+        // only one column, just wrap incoming bytes
+        tableRow.set("data_0", encoder.encodeToString(input));
+      } else {
+        // otherwise, distribute bytes
+        int bytePerCol = input.length / numColumns;
+        int curIdx = 0;
+        for (int idx = 0; idx < numColumns - 1; ++idx) {
+          tableRow.set(
+              "data_" + idx,
+              encoder.encodeToString(Arrays.copyOfRange(input, curIdx, curIdx + bytePerCol)));
+          curIdx += bytePerCol;
+        }
+        tableRow.set(
+            "data_" + (numColumns - 1),
+            encoder.encodeToString(Arrays.copyOfRange(input, curIdx, input.length)));
+      }
+      return tableRow;
+    }
+  }
+
+  /**
+   * Generates and returns a list of LoadPeriod instances representing periods of load increase
+   * based on the specified load increase array and total duration in minutes.
+   *
+   * @param minutesTotal The total duration in minutes for which the load periods are generated.
+   * @return A list of LoadPeriod instances defining periods of load increase.
+   */
+  private List<LoadPeriod> getLoadPeriods(int minutesTotal, int[] loadIncreaseArray) {
+
+    List<LoadPeriod> loadPeriods = new ArrayList<>();
+    long periodDurationMillis =
+        Duration.ofMinutes(minutesTotal / loadIncreaseArray.length).toMillis();
+    long startTimeMillis = 0;
+
+    for (int loadIncreaseMultiplier : loadIncreaseArray) {
+      long endTimeMillis = startTimeMillis + periodDurationMillis;
+      loadPeriods.add(new LoadPeriod(loadIncreaseMultiplier, startTimeMillis, endTimeMillis));
+
+      startTimeMillis = endTimeMillis;
+    }
+    return loadPeriods;
+  }
+
+  private enum WriteFormat {
+    AVRO,
+    JSON
+  }
+
+  /** Options for Bigquery IO stress test. */
+  static class Configuration extends SyntheticSourceOptions {
+
+    /**
+     * Number of columns of each record. The column size is equally distributed as
+     * valueSizeBytes/numColumns.
+     */
+    @JsonProperty public int numColumns = 10;
+
+    /** Pipeline timeout in minutes. Must be a positive value. */
+    @JsonProperty public int pipelineTimeout = 20;
+
+    /** Runner specified to run the pipeline. */
+    @JsonProperty public String runner = "DirectRunner";
+
+    /** BigQuery read method: DEFAULT/DIRECT_READ/EXPORT. */
+    @JsonProperty public String readMethod = "DEFAULT";
+
+    /** BigQuery write method: DEFAULT/FILE_LOADS/STREAMING_INSERTS/STORAGE_WRITE_API. */
+    @JsonProperty public String writeMethod = "DEFAULT";
+
+    /** BigQuery write format: AVRO/JSON. */
+    @JsonProperty public String writeFormat = "AVRO";
+
+    /**
+     * Rate of generated elements sent to the source table. Will run with a minimum of 1k rows per
+     * second.
+     */
+    @JsonProperty public int rowsPerSecond = DEFAULT_ROWS_PER_SECOND;
+
+    /** Rows will be generated for this many minutes. */
+    @JsonProperty public int minutes = 15;
+  }
+
+  /**
+   * Represents a period of time with associated load increase properties for stress testing
+   * scenarios.
+   */
+  private static class LoadPeriod {
+    private final int loadIncreaseMultiplier;
+    private final long periodStartMillis;
+    private final long periodEndMillis;
+
+    public LoadPeriod(int loadIncreaseMultiplier, long periodStartMillis, long periodEndMin) {
+      this.loadIncreaseMultiplier = loadIncreaseMultiplier;
+      this.periodStartMillis = periodStartMillis;
+      this.periodEndMillis = periodEndMin;
+    }
+
+    public int getLoadIncreaseMultiplier() {
+      return loadIncreaseMultiplier;
+    }
+
+    public long getPeriodStartMillis() {
+      return periodStartMillis;
+    }
+
+    public long getPeriodEndMillis() {
+      return periodEndMillis;
+    }
+  }
+}

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/bigquery/BigQueryIOST.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/bigquery/BigQueryIOST.java
@@ -382,7 +382,7 @@ public final class BigQueryIOST extends IOLoadTestBase {
     public void processElement(
         @Element byte[] element,
         OutputReceiver<byte[]> outputReceiver,
-        @Timestamp Instant timestamp) {
+        @DoFn.Timestamp Instant timestamp) {
 
       int multiplier = this.startMultiplier;
       long elapsedTimeMillis = timestamp.getMillis() - startTimesMillis;

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/bigquery/BigQueryIOST.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/bigquery/BigQueryIOST.java
@@ -106,6 +106,7 @@ public final class BigQueryIOST extends IOLoadTestBase {
 
   private Configuration configuration;
   private String tempLocation;
+  private String testConfigName;
   private TableSchema schema;
 
   @Rule public TestPipeline writePipeline = TestPipeline.create();
@@ -130,18 +131,18 @@ public final class BigQueryIOST extends IOLoadTestBase {
         String.format("%s:%s.%s", project, resourceManager.getDatasetId(), sourceTableName);
 
     // parse configuration
-    String testConfig =
-        TestProperties.getProperty("configuration", "local", TestProperties.Type.PROPERTY);
-    configuration = TEST_CONFIGS_PRESET.get(testConfig);
+    testConfigName =
+        TestProperties.getProperty("configuration", "medium", TestProperties.Type.PROPERTY);
+    configuration = TEST_CONFIGS_PRESET.get(testConfigName);
     if (configuration == null) {
       try {
-        configuration = Configuration.fromJsonString(testConfig, Configuration.class);
+        configuration = Configuration.fromJsonString(testConfigName, Configuration.class);
       } catch (IOException e) {
         throw new IllegalArgumentException(
             String.format(
                 "Unknown test configuration: [%s]. Pass to a valid configuration json, or use"
                     + " config presets: %s",
-                testConfig, TEST_CONFIGS_PRESET.keySet()));
+                testConfigName, TEST_CONFIGS_PRESET.keySet()));
       }
     }
 
@@ -233,7 +234,10 @@ public final class BigQueryIOST extends IOLoadTestBase {
               .withMeasurement(
                   configuration.influxMeasurement
                       + "_"
+                      + testConfigName
+                      + "_"
                       + configuration.writeFormat
+                      + "_"
                       + configuration.writeMethod)
               .get();
     }

--- a/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/bigquery/BigQueryIOST.java
+++ b/it/google-cloud-platform/src/test/java/org/apache/beam/it/gcp/bigquery/BigQueryIOST.java
@@ -313,8 +313,8 @@ public final class BigQueryIOST extends IOLoadTestBase {
                 "autoscalingAlgorithm",
                 DataflowPipelineWorkerPoolOptions.AutoscalingAlgorithmType.THROUGHPUT_BASED
                     .toString())
-            .addParameter("numWorkers", "20")
-            .addParameter("maxNumWorkers", "100")
+            .addParameter("numWorkers", String.valueOf(configuration.numWorkers))
+            .addParameter("maxNumWorkers", String.valueOf(configuration.maxNumWorkers))
             .addParameter("experiments", GcpOptions.STREAMING_ENGINE_EXPERIMENT)
             .build();
 
@@ -526,6 +526,12 @@ public final class BigQueryIOST extends IOLoadTestBase {
 
     /** Runner specified to run the pipeline. */
     @JsonProperty public String runner = "DirectRunner";
+
+    /** Number of workers for the pipeline. */
+    @JsonProperty public int numWorkers = 20;
+
+    /** Maximum number of workers for the pipeline. */
+    @JsonProperty public int maxNumWorkers = 100;
 
     /** BigQuery write method: DEFAULT/FILE_LOADS/STREAMING_INSERTS/STORAGE_WRITE_API. */
     @JsonProperty public String writeMethod = "DEFAULT";


### PR DESCRIPTION
This pull request introduces stress tests for BigQueryIO, designed to assess the performance under various conditions. The stress tests simulate dynamic load increases and evaluate the behavior of BigQueryIO for different write formats and methods.

**Changes:**

- Added stress tests for BigQueryIO.
- Implemented dynamic load increases over time to simulate varying workloads.
- Introduced configurations for controlling the stress test parameters, such as the number of columns, write method, write format, etc.
- Added support for exporting metrics to _InfluxDB_ or _BigQuery_ based on the configuration parameter.

**Dynamic load increases over time example:**
![image (2)](https://github.com/apache/beam/assets/17278361/35bad92b-5a85-40b1-bfdb-dca998c81e60)

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
