### PR TITLE
[Dataflow Streaming] Move a few options from StreamingDataflowWorkerOptions to DataflowPipelineDebugOptions

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -266,6 +266,43 @@ public interface DataflowPipelineDebugOptions
 
   void setWindmillServiceCommitThreads(Integer value);
 
+
+  @Description(
+      "If positive, frequency at which windmill service streaming rpcs will have application "
+          + "level health checks.")
+  @Default.Integer(10000)
+  int getWindmillServiceStreamingRpcHealthCheckPeriodMs();
+
+  void setWindmillServiceStreamingRpcHealthCheckPeriodMs(int value);
+
+  @Description(
+      "If positive, the number of messages to send on streaming rpc before checking isReady."
+          + "Higher values reduce cost of output overhead at the cost of more memory used in grpc "
+          + "buffers.")
+  @Default.Integer(10)
+  int getWindmillMessagesBetweenIsReadyChecks();
+
+  void setWindmillMessagesBetweenIsReadyChecks(int value);
+
+  @Description("If true, a most a single active rpc will be used per channel.")
+  @Default.Boolean(false)
+  boolean getUseWindmillIsolatedChannels();
+
+  void setUseWindmillIsolatedChannels(boolean value);
+
+  @Description(
+      "If true, separate streaming rpcs will be used for heartbeats instead of sharing streams with state reads.")
+  @Default.Boolean(false)
+  boolean getUseSeparateWindmillHeartbeatStreams();
+
+  void setUseSeparateWindmillHeartbeatStreams(boolean value);
+
+  @Description("The number of streams to use for GetData requests.")
+  @Default.Integer(1)
+  int getWindmillGetDataStreamCount();
+
+  void setWindmillGetDataStreamCount(int value);
+
   /**
    * The amount of time before UnboundedReaders are considered idle and closed during streaming
    * execution.

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/options/StreamingDataflowWorkerOptions.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/options/StreamingDataflowWorkerOptions.java
@@ -113,42 +113,6 @@ public interface StreamingDataflowWorkerOptions extends DataflowWorkerHarnessOpt
 
   void setWindmillServiceRpcChannelAliveTimeoutSec(int value);
 
-  @Description(
-      "If positive, frequency at which windmill service streaming rpcs will have application "
-          + "level health checks.")
-  @Default.Integer(10000)
-  int getWindmillServiceStreamingRpcHealthCheckPeriodMs();
-
-  void setWindmillServiceStreamingRpcHealthCheckPeriodMs(int value);
-
-  @Description(
-      "If positive, the number of messages to send on streaming rpc before checking isReady."
-          + "Higher values reduce cost of output overhead at the cost of more memory used in grpc "
-          + "buffers.")
-  @Default.Integer(10)
-  int getWindmillMessagesBetweenIsReadyChecks();
-
-  void setWindmillMessagesBetweenIsReadyChecks(int value);
-
-  @Description("If true, a most a single active rpc will be used per channel.")
-  @Default.Boolean(false)
-  boolean getUseWindmillIsolatedChannels();
-
-  void setUseWindmillIsolatedChannels(boolean value);
-
-  @Description(
-      "If true, separate streaming rpcs will be used for heartbeats instead of sharing streams with state reads.")
-  @Default.Boolean(false)
-  boolean getUseSeparateWindmillHeartbeatStreams();
-
-  void setUseSeparateWindmillHeartbeatStreams(boolean value);
-
-  @Description("The number of streams to use for GetData requests.")
-  @Default.Integer(1)
-  int getWindmillGetDataStreamCount();
-
-  void setWindmillGetDataStreamCount(int value);
-
   /**
    * Factory for creating local Windmill address. Reads from system propery 'windmill.hostport' for
    * backwards compatibility.


### PR DESCRIPTION
Options in StreamingDataflowWorkerOptions are currently not registered with PipelineOptionsRegistry. Registration will be fixed in a future PR.
