### PR TITLE
Fix Python postcommits 

### DIFF
--- a/sdks/java/extensions/python/build.gradle
+++ b/sdks/java/extensions/python/build.gradle
@@ -21,6 +21,8 @@ applyJavaNature( automaticModuleName: 'org.apache.beam.sdk.extensions.python')
 
 description = "Apache Beam :: SDKs :: Java :: Extensions :: Python"
 
+evaluationDependsOn(":sdks:java:core")
+
 dependencies {
     implementation library.java.vendored_guava_32_1_2_jre
     implementation library.java.vendored_grpc_1_60_1


### PR DESCRIPTION
Many changes were made in #29924 to merge `runners:core-construction-java` into `sdks:java:core`. One missing line is causing build failures for postcommits

Error for failing postcommits ([example](https://github.com/apache/beam/actions/runs/7919598056/job/21620744814)) looks like:
```
What went wrong:
A problem occurred evaluating project ':sdks:java:extensions:python'.
> Could not get unknown property 'sourceSets' for project ':sdks:java:core' of type org.gradle.api.Project.
```