### PR TITLE
Allow JSON type in TableSchema for WriteToBigQuery with FILE_LOAD method in Python SDK

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -2181,7 +2181,7 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
               logging.warn(
                 "Found JSON type in TableSchema for 'File_LOADS' write method. "
                 "Make sure the TableSchema field is a parsed JSON to ensure "
-                "the read as a JSON type."
+                "the read as a JSON type. Otherwise it will read as a raw (escaped) string."
               )
             elif field['type'] == 'STRUCT':
               find_in_nested_dict(field)

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -2179,9 +2179,10 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
           for field in schema['fields']:
             if field['type'] == 'JSON':
               logging.warn(
-                "Found JSON type in TableSchema for 'File_LOADS' write method. "
-                "Make sure the TableSchema field is a parsed JSON to ensure "
-                "the read as a JSON type. Otherwise it will read as a raw (escaped) string."
+                'Found JSON type in TableSchema for "File_LOADS" write method.'
+                'Make sure the TableSchema field is a parsed JSON to ensure '
+                'the read as a JSON type. Otherwise it will read as a raw '
+                '(escaped) string.'
               )
             elif field['type'] == 'STRUCT':
               find_in_nested_dict(field)

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -2178,12 +2178,11 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
         def find_in_nested_dict(schema):
           for field in schema['fields']:
             if field['type'] == 'JSON':
-              logging.warn(
-                'Found JSON type in TableSchema for "File_LOADS" write method.'
-                'Make sure the TableSchema field is a parsed JSON to ensure '
-                'the read as a JSON type. Otherwise it will read as a raw '
-                '(escaped) string.'
-              )
+              logging.warning(
+                  'Found JSON type in TableSchema for "File_LOADS" write '
+                  'method. Make sure the TableSchema field is a parsed '
+                  'JSON to ensure the read as a JSON type. Otherwise it '
+                  'will read as a raw (escaped) string.')
             elif field['type'] == 'STRUCT':
               find_in_nested_dict(field)
 

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -2173,23 +2173,6 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
               'A schema must be provided when writing to BigQuery using '
               'Avro based file loads')
 
-      if self.schema and type(self.schema) is dict:
-
-        def find_in_nested_dict(schema):
-          for field in schema['fields']:
-            if field['type'] == 'JSON':
-              raise ValueError(
-                  'Found JSON type in table schema. JSON data '
-                  'insertion is currently not supported with '
-                  'FILE_LOADS write method. This is supported with '
-                  'STREAMING_INSERTS. For more information: '
-                  'https://cloud.google.com/bigquery/docs/reference/'
-                  'standard-sql/json-data#ingest_json_data')
-            elif field['type'] == 'STRUCT':
-              find_in_nested_dict(field)
-
-        find_in_nested_dict(self.schema)
-
       from apache_beam.io.gcp.bigquery_file_loads import BigQueryBatchFileLoads
       # Only cast to int when a value is given.
       # We only use an int for BigQueryBatchFileLoads

--- a/sdks/python/apache_beam/io/gcp/bigquery.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery.py
@@ -2173,6 +2173,21 @@ bigquery_v2_messages.TableSchema`. or a `ValueProvider` that has a JSON string,
               'A schema must be provided when writing to BigQuery using '
               'Avro based file loads')
 
+      if self.schema and type(self.schema) is dict:
+
+        def find_in_nested_dict(schema):
+          for field in schema['fields']:
+            if field['type'] == 'JSON':
+              logging.warn(
+                "Found JSON type in TableSchema for 'File_LOADS' write method. "
+                "Make sure the TableSchema field is a parsed JSON to ensure "
+                "the read as a JSON type."
+              )
+            elif field['type'] == 'STRUCT':
+              find_in_nested_dict(field)
+
+        find_in_nested_dict(self.schema)
+
       from apache_beam.io.gcp.bigquery_file_loads import BigQueryBatchFileLoads
       # Only cast to int when a value is given.
       # We only use an int for BigQueryBatchFileLoads


### PR DESCRIPTION
Removing the JSON type check when using WriteToBigQuery with FILE_LOAD method in Python SDK. Throwing a warning instead.

* Related to the change in Java SDK: https://github.com/apache/beam/pull/29923. Consistent with this PR for Java SDK, I have changed the `raise ValueError` to a logging.warn`.
* Relevant lines of code
https://github.com/apache/beam/blob/8a74a1c279c86a262def9b99418e7eb03366e2d9/sdks/python/apache_beam/io/gcp/bigquery.py#L2178-L2191

I did some hackish testing against a table of my own and it was able to insert the json fields correctly without a problem.

NOT RECOMMENDED but it solves the problem for those who need this tomorrow:

In my docker file that has Apache Beam installed, I used `sed` to replace the check:

```bash
RUN sed -i 's/if field\['\''type'\''\] == '\''JSON'\'':/if field\['\''type'\''\] == '\''JSON_IS_OKAY'\'':/g' /usr/local/lib/python3.11/site-packages/apache_beam/io/gcp/bigquery.py

```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
