### PR TITLE
Make state cache optional due to a potential performance regression for some users. 

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -131,7 +131,7 @@
 
 ## Known Issues
 
-* N/A
+* Some Python pipelines that run with 2.52.0-2.54.0 SDKs and use large materialized side inputs might be affected by a performance regression. To restore the prior behavior on these SDK versions, supply the `--max_cache_memory_usage_mb=0` pipeline option. ([#30360](https://github.com/apache/beam/issues/30360)).
 
 # [2.53.0] - 2024-01-04
 
@@ -172,7 +172,8 @@
 
 ## Known Issues
 
-* ([#29987](https://github.com/apache/beam/issues/29987)).
+* Potential race condition causing NPE in DataflowExecutionStateSampler in Dataflow Java Streaming pipelines ([#29987](https://github.com/apache/beam/issues/29987)).
+* Some Python pipelines that run with 2.52.0-2.54.0 SDKs and use large materialized side inputs might be affected by a performance regression. To restore the prior behavior on these SDK versions, supply the `--max_cache_memory_usage_mb=0` pipeline option. ([#30360](https://github.com/apache/beam/issues/30360)).
 
 # [2.52.0] - 2023-11-17
 
@@ -191,7 +192,7 @@ should handle this. ([#25252](https://github.com/apache/beam/issues/25252)).
   jobs using the DataStream API. By default the option is set to false, so the batch jobs are still executed
   using the DataSet API.
 * `upload_graph` as one of the Experiments options for DataflowRunner is no longer required when the graph is larger than 10MB for Java SDK ([PR#28621](https://github.com/apache/beam/pull/28621)).
-* state amd side input cache has been enabled to a default of 100 MB. Use `--max_cache_memory_usage_mb=X` to provide cache size for the user state API and side inputs. (Python) ([#28770](https://github.com/apache/beam/issues/28770)).
+* Introduced a pipeline option `--max_cache_memory_usage_mb` to configure state and side input cache size. The cache has been enabled to a default of 100 MB. Use `--max_cache_memory_usage_mb=X` to provide cache size for the user state API and side inputs. ([#28770](https://github.com/apache/beam/issues/28770)).
 * Beam YAML stable release. Beam pipelines can now be written using YAML and leverage the Beam YAML framework which includes a preliminary set of IO's and turnkey transforms. More information can be found in the YAML root folder and in the [README](https://github.com/apache/beam/blob/master/sdks/python/apache_beam/yaml/README.md).
 
 
@@ -217,6 +218,7 @@ as a workaround, a copy of "old" `CountingSource` class should be placed into a 
 ## Known issues
 
 * MLTransform drops the identical elements in the output PCollection. For any duplicate elements, a single element will be emitted downstream. ([#29600](https://github.com/apache/beam/issues/29600)).
+* Some Python pipelines that run with 2.52.0-2.54.0 SDKs and use large materialized side inputs might be affected by a performance regression. To restore the prior behavior on these SDK versions, supply the `--max_cache_memory_usage_mb=0` pipeline option. (Python) ([#30360](https://github.com/apache/beam/issues/30360)).
 
 # [2.51.0] - 2023-10-03
 

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -77,6 +77,7 @@
 * Go SDK users who build custom worker containers may run into issues with the move to distroless containers as a base (see Security Fixes).
   * The issue stems from distroless containers lacking additional tools, which current custom container processes may rely on.
   * See https://beam.apache.org/documentation/runtime/environments/#from-scratch-go for instructions on building and using a custom container.
+* Python SDK has changed the default value for the `--max_cache_memory_usage_mb` pipeline option from 100 to 0. This option was first introduced in 2.52.0 SDK. This change restores the behavior of 2.51.0 SDK, which does not use the state cache. If your pipeline uses iterable side inputs views, consider increasing the cache size by setting the option manually. ([#30360](https://github.com/apache/beam/issues/30360)).
 
 ## Deprecations
 

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -1194,18 +1194,22 @@ class WorkerOptions(PipelineOptions):
         '--max_cache_memory_usage_mb',
         dest='max_cache_memory_usage_mb',
         type=int,
-        default=100,
+        default=0,
         help=(
             'Size of the SDK Harness cache to store user state and side '
-            'inputs in MB. Default is 100MB. If the cache is full, least '
+            'inputs in MB. The cache is disabled by default. Increasing '
+            'cache size might improve performance of some pipelines, such as '
+            'pipelines that use iterable side input views, but can '
+            'lead to an increase in memory consumption and OOM errors if '
+            'workers are not appropriately provisioned. '
+            'Using the cache might decrease performance pipelines using '
+            'materialized side inputs. '
+            'If the cache is full, least '
             'recently used elements will be evicted. This cache is per '
             'each SDK Harness instance. SDK Harness is a component '
             'responsible for executing the user code and communicating with '
             'the runner. Depending on the runner, there may be more than one '
-            'SDK Harness process running on the same worker node. Increasing '
-            'cache size might improve performance of some pipelines, but can '
-            'lead to an increase in memory consumption and OOM errors if '
-            'workers are not appropriately provisioned.'))
+            'SDK Harness process running on the same worker node.'))
 
   def validate(self, validator):
     errors = []


### PR DESCRIPTION
Make state cache optional due to a potential performance regression that might affect some users: https://github.com/apache/beam/issues/30360. 

