### PR TITLE
fix playground backend container builds

### DIFF
--- a/playground/backend/containers/java/Dockerfile
+++ b/playground/backend/containers/java/Dockerfile
@@ -49,7 +49,7 @@ RUN mvn archetype:generate \
     -DartifactId=pipeline-dependencies \
     -DgroupId=org.apache.beam.samples
 WORKDIR /pipeline-dependencies/
-RUN mvn dependency:resolve && mvn -o dependency:list
+RUN mvn dependency:resolve && mvn dependency:go-offline &&  mvn -o dependency:list
 RUN mvn dependency:copy-dependencies
 
 FROM apache/beam_java11_sdk:$BEAM_VERSION

--- a/playground/backend/containers/python/Dockerfile
+++ b/playground/backend/containers/python/Dockerfile
@@ -64,7 +64,9 @@ COPY kafka-emulator/kafka-emulator.tar /opt/playground/backend/kafka-emulator/
 RUN cd /opt/playground/backend/kafka-emulator/ && tar -xvf kafka-emulator.tar && rm kafka-emulator.tar &&\
     mv kafka-emulator/*.jar . && rmdir kafka-emulator/ &&\
     mv beam-playground-kafka-emulator-*.jar beam-playground-kafka-emulator.jar
-RUN apt-get update && apt-get install -y openjdk-11-jre-headless
+RUN apt-get update && \
+    wget http://http.us.debian.org/debian/pool/main/o/openjdk-11/openjdk-11-jre-headless_11.0.22+7-1~deb11u1_amd64.deb && \
+    apt install -y ./openjdk-11-jre-headless_11.0.22+7-1~deb11u1_amd64.deb
 
 # Create a user group `appgroup` and a user `appuser`
 RUN groupadd --gid 20000 appgroup \


### PR DESCRIPTION
1) Fixes python backend container build issue. After update to debian bookworm openjdk-11-jre-headless package is no longer availabile in stable. Fix downloads the package from bullseye repo and uses apt to install. This was chosen instead of adding bullseye as oldstable to avoid package conflicts. There was an option to update to openjdk-17 but was not sure if playground code would be affected. 

2) Fixes java container build where for some reason maven uses offline  mode when doing `dependency:list`. Instead of removing offline (it was there for some reason) we just add `mvn dependency:go-offline` to preload the needed dependencies
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
