### PR TITLE
Revert "Document yaml pipeline options"

### DIFF
--- a/website/www/site/content/en/documentation/sdks/yaml.md
+++ b/website/www/site/content/en/documentation/sdks/yaml.md
@@ -366,8 +366,6 @@ pipeline:
       config:
         topic: anotherPubSubTopic
         format: json
-options:
-  streaming: true
 ```
 
 Rather than using an explicit `WindowInto` operation, one may instead tag a
@@ -394,8 +392,6 @@ pipeline:
       config:
         topic: anotherPubSubTopic
         format: json
-options:
-  streaming: true
 ```
 
 Note that the `Sql` operation itself is often a from of aggregation, and
@@ -421,8 +417,6 @@ pipeline:
       config:
         topic: anotherPubSubTopic
         format: json
-options:
-  streaming: true
 ```
 
 The specified windowing is applied to all inputs, in this case resulting in
@@ -454,8 +448,6 @@ pipeline:
       windowing:
         type: fixed
         size: 60s
-options:
-  streaming: true
 ```
 
 For a transform with no inputs, the specified windowing is instead applied to
@@ -481,8 +473,6 @@ pipeline:
       config:
         topic: anotherPubSubTopic
         format: json
-options:
-  streaming: true
 ```
 
 One can also specify windowing at the top level of a pipeline (or composite),
@@ -509,8 +499,6 @@ pipeline:
   windowing:
     type: fixed
     size: 60
-options:
-  streaming: true
 ```
 
 Note that all these windowing specifications are compatible with the `source`
@@ -542,9 +530,6 @@ pipeline:
     windowing:
       type: fixed
       size: 5m
-
-options:
-  streaming: true
 ```
 
 
@@ -597,31 +582,6 @@ providers:
            - /path/to/local/package.zip
     transforms:
        MyCustomTransform: "pkg.subpkg.PTransformClassOrCallable"
-```
-
-## Pipeline Options
-
-[Pipeline options](https://beam.apache.org/documentation/programming-guide/#configuring-pipeline-options)
-are used to configure different aspects of your pipeline, such as the pipeline runner that will execute
-your pipeline and any runner-specific configuration required by the chosen runner. To set pipeline options,
-append an options block at the end of your yaml file. For example:
-
-```
-pipeline:
-  type: chain
-  transforms:
-    - type: ReadFromPubSub
-      config:
-        topic: myPubSubTopic
-        format: ...
-        schema: ...
-    ...
-    - type: WriteToPubSub
-      config:
-        topic: anotherPubSubTopic
-        format: json
-options:
-  streaming: true
 ```
 
 ## Other Resources


### PR DESCRIPTION
Reverts apache/beam#30490

Breaking Python PreCommit.

Python SDK relying on website md has introduced unintended behavior, and the change on website alone would not trigger Python tests. We should fix this issue but until then let's revert it in master to unblock release