### PR TITLE
Avoid system exit during `PipelineOptions` instantiation

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -216,7 +216,7 @@ class PipelineOptions(HasDisplayData):
     # self._flags stores a list of not yet parsed arguments, typically,
     # command-line flags. This list is shared across different views.
     # See: view_as().
-    self._flags = flags
+    self._flags = [] if flags is None else flags
 
     # Build parser that will parse options recognized by the [sub]class of
     # PipelineOptions whose object is being instantiated.
@@ -229,9 +229,7 @@ class PipelineOptions(HasDisplayData):
 
     # The _visible_options attribute will contain options that were recognized
     # by the parser.
-    self._visible_options = argparse.Namespace()
-    if self.flags:
-      self._visible_options, _ = parser.parse_known_args(flags)
+    self._visible_options, _ = parser.parse_known_args(flags)
 
     # self._all_options is initialized with overrides to flag values,
     # provided in kwargs, and will store key-value pairs for options recognized

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -229,7 +229,9 @@ class PipelineOptions(HasDisplayData):
 
     # The _visible_options attribute will contain options that were recognized
     # by the parser.
-    self._visible_options, _ = parser.parse_known_args(flags)
+    self._visible_options = argparse.Namespace()
+    if self.flags:
+      self._visible_options, _ = parser.parse_known_args(flags)
 
     # self._all_options is initialized with overrides to flag values,
     # provided in kwargs, and will store key-value pairs for options recognized


### PR DESCRIPTION
## Background
Suppose you have the following script
```python
from apache_beam.options.pipeline_options import PipelineOptions
PipelineOptions()
assert False
```

Here's is the behavior when running this script
```bash
$ python3 test.py 
Traceback (most recent call last):
  File "/Users/chintala/./test.py", line 5, in <module>
    assert False
AssertionError


$ python3 test.py  -h
usage: test.py [-h]

options:
  -h, --help  show this help message and exit
```

During `__init__` of `PipelineOptions` we make a call to `parse_known_args` with the `self._flags` field. The behavior of `parse_known_args` is if it is given `None` as an argument it will use `sys.argv` for the argument list and parse those. If `-h` is within the argument list `parse_known_args` will print the help statement and then exit the python process.

The ultimately means that if you run a python script that defines a `PipelineOptions` at top level and supply `-h` in the command line arguments your program will exist upon instantiating `PipelineOptions` which is undesired behavior.

## Solution
Instead of defaults `self._flags` to `None` we set it to an empty list instead. This means when we call `parse_known_args` it will never read from `sys.argv`.
