### PR TITLE
add pythonpath to cloudcoverage tox environment

### DIFF
--- a/.github/workflows/beam_PreCommit_Python_Coverage.yml
+++ b/.github/workflows/beam_PreCommit_Python_Coverage.yml
@@ -90,6 +90,10 @@ jobs:
           gradle-command: :sdks:python:test-suites:tox:py38:preCommitPyCoverage
           arguments: |
             -PuseWheelDistribution
+      - uses: codecov/codecov-action@v3
+        with:
+          flags: python
+          directory: sdks/python
       - name: Archive Python Test Results
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/beam_PreCommit_Python_Coverage.yml
+++ b/.github/workflows/beam_PreCommit_Python_Coverage.yml
@@ -90,7 +90,7 @@ jobs:
           gradle-command: :sdks:python:test-suites:tox:py38:preCommitPyCoverage
           arguments: |
             -PuseWheelDistribution
-      - uses: codecov/codecov-action@v3
+      - uses: codecov/codecov-action@v4
         with:
           flags: python
           directory: sdks/python

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -96,17 +96,13 @@ deps =
   pytest-cov==3.0.0
 # Don't set TMPDIR to avoid "AF_UNIX path too long" errors in certain tests.
 setenv =
+  PYTHONPATH = {toxinidir}
 platform = linux
-passenv = GIT_*,BUILD_*,ghprb*,CHANGE_ID,BRANCH_NAME,JENKINS_*,CODECOV_*
+passenv = GIT_*,BUILD_*,ghprb*,CHANGE_ID,BRANCH_NAME,JENKINS_*,CODECOV_*,GITHUB_*
 extras = test,gcp,interactive,dataframe,aws
 commands =
-  -rm .coverage
-  curl -Os https://uploader.codecov.io/latest/linux/codecov
-  chmod +x codecov
   bash {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}" "--cov-report=xml --cov=. --cov-append"
-  ./codecov -F python
-  -rm codecov
-
+  
 [testenv:py38-lint]
 # Don't set TMPDIR to avoid "AF_UNIX path too long" errors in pylint.
 setenv =


### PR DESCRIPTION
Adds PYTHONPATH environment variable to cloudcoverage tox environment set to toxinidir (sdks/python). 
This allows pytest to load all the modules and run the correct coverage report

Also removes codecov uploader which has issues if no codecov token is provided. Its replaced by codecov-action which can work in tokenless setup
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
