### PR TITLE
Fix mobile gaming tests Google Cloud storage object output clash

### DIFF
--- a/release/src/main/groovy/MobileGamingCommands.groovy
+++ b/release/src/main/groovy/MobileGamingCommands.groovy
@@ -21,6 +21,7 @@
 class MobileGamingCommands {
 
   private TestScripts testScripts
+  private String testRunId
 
   private static final INPUT_GAMING_DATA = "gs://dataflow-samples/game/5000_gaming_data.csv"
 
@@ -58,11 +59,11 @@ class MobileGamingCommands {
     "BattleshipGrey"))
 
   public String getUserScoreOutputName(String runner){
-    return "java-userscore-result-${RUNNERS[runner]}.txt"
+    return "java-userscore-result-${RUNNERS[runner]}/${testRunId}/output"
   }
 
   public String getHourlyTeamScoreOutputName(String runner){
-    return "java-hourlyteamscore-result-${RUNNERS[runner]}.txt"
+    return "java-hourlyteamscore-result-${RUNNERS[runner]}/${testRunId}/output"
   }
 
   public String createPipelineCommand(String exampleName, String runner, String jobName='', String className=null){

--- a/release/src/main/groovy/mobilegaming-java-dataflow.groovy
+++ b/release/src/main/groovy/mobilegaming-java-dataflow.groovy
@@ -18,7 +18,6 @@
  */
 
 t = new TestScripts(args)
-mobileGamingCommands = new MobileGamingCommands(testScripts: t)
 
 /*
  * Run the mobile game examples on Dataflow.
@@ -36,6 +35,8 @@ String command_output_text
  *  Run the UserScore example on DataflowRunner
  * */
 
+mobileGamingCommands = new MobileGamingCommands(testScripts: t, testRunId: UUID.randomUUID().toString())
+
 t.intent("Running: UserScore example on DataflowRunner")
 t.run(mobileGamingCommands.createPipelineCommand("UserScore", runner))
 command_output_text = t.run "gsutil cat gs://${t.gcsBucket()}/${mobileGamingCommands.getUserScoreOutputName(runner)}* | grep user19_BananaWallaby"
@@ -47,6 +48,8 @@ t.run "gsutil rm gs://${t.gcsBucket()}/${mobileGamingCommands.getUserScoreOutput
 /**
  * Run the HourlyTeamScore example on DataflowRunner
  * */
+
+mobileGamingCommands = new MobileGamingCommands(testScripts: t, testRunId: UUID.randomUUID().toString())
 
 t.intent("Running: HourlyTeamScore example on DataflowRunner")
 t.run(mobileGamingCommands.createPipelineCommand("HourlyTeamScore", runner))

--- a/release/src/main/groovy/mobilegaming-java-direct.groovy
+++ b/release/src/main/groovy/mobilegaming-java-direct.groovy
@@ -18,7 +18,6 @@
  */
 
 t = new TestScripts(args)
-mobileGamingCommands = new MobileGamingCommands(testScripts: t)
 
 /*
  * Run the mobile game examples on DirectRunner.
@@ -36,6 +35,8 @@ String command_output_text
  * Run the UserScore example with DirectRunner
  * */
 
+mobileGamingCommands = new MobileGamingCommands(testScripts: t, testRunId: UUID.randomUUID().toString())
+
 t.intent("Running: UserScore example on DirectRunner")
 t.run(mobileGamingCommands.createPipelineCommand("UserScore", runner))
 command_output_text = t.run "grep user19_BananaWallaby ${mobileGamingCommands.getUserScoreOutputName(runner)}* "
@@ -46,6 +47,8 @@ t.success("UserScore successfully run on DirectRunners.")
 /**
  * Run the HourlyTeamScore example with DirectRunner
  * */
+
+mobileGamingCommands = new MobileGamingCommands(testScripts: t, testRunId: UUID.randomUUID().toString())
 
 t.intent("Running: HourlyTeamScore example on DirectRunner")
 t.run(mobileGamingCommands.createPipelineCommand("HourlyTeamScore", runner))


### PR DESCRIPTION
This PR addresses #30447 assigning a unique Google Cloud storage path to mobile gaming tests' output. Even `./gradlew :release:runJavaExamplesValidationTask` at master failed on my local machine so I'm seeing if the checks in this PR could help validate this change.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
