### PR TITLE
#19851: Proof-of-concept to implement deferred side inputs for combiners

### DIFF
--- a/sdks/python/apache_beam/runners/direct/helper_transforms.py
+++ b/sdks/python/apache_beam/runners/direct/helper_transforms.py
@@ -28,26 +28,49 @@ from apache_beam.transforms.combiners import _CurriedFn
 from apache_beam.utils.windowed_value import WindowedValue
 
 
+from apache_beam.transforms import core
 class LiftedCombinePerKey(beam.PTransform):
   """An implementation of CombinePerKey that does mapper-side pre-combining.
   """
   def __init__(self, combine_fn, args, kwargs):
     args_to_check = itertools.chain(args, kwargs.values())
     if isinstance(combine_fn, _CurriedFn):
+      raise NotImplementedError('Curried CombineFns not supported.')
       args_to_check = itertools.chain(
           args_to_check, combine_fn.args, combine_fn.kwargs.values())
-    if any(isinstance(arg, ArgumentPlaceholder) for arg in args_to_check):
+    #if any(isinstance(arg, ArgumentPlaceholder) for arg in args_to_check):
       # This isn't implemented in dataflow either...
-      raise NotImplementedError('Deferred CombineFn side inputs.')
-    self._combine_fn = beam.transforms.combiners.curry_combine_fn(
-        combine_fn, args, kwargs)
+      #raise NotImplementedError('Deferred CombineFn side inputs.')
+    side_input_args = [
+        arg for arg in args if isinstance(arg, beam.pvalue.AsSideInput)]
+    side_input_kwargs = {
+        k: v for k, v in kwargs.items()
+        if isinstance(v, beam.pvalue.AsSideInput)}
+    self.args = [arg for arg in args if not isinstance(arg, beam.pvalue.AsSideInput)]
+    self.kwargs = {
+        k: v for k, v in kwargs.items()
+        if not isinstance(v, beam.pvalue.AsSideInput)}
+    self.side_input_args = side_input_args
+    self.side_input_kwargs = side_input_kwargs
+    self._combine_fn = core.CombineFn.from_callable(combine_fn)
 
   def expand(self, pcoll):
+    if self.side_input_args:
+      PGBKCV = beam.ParDo(
+          PartialGroupByKeyCombiningValues(self._combine_fn, self.args, self.kwargs),
+          *self.side_input_args)
+    elif self.side_input_kwargs:
+      PGBKCV = beam.ParDo(
+          PartialGroupByKeyCombiningValues(self._combine_fn, self.args, self.kwargs),
+          **self.side_input_kwargs)
+    else:
+      PGBKCV = beam.ParDo(
+          PartialGroupByKeyCombiningValues(self._combine_fn, self.args, self.kwargs))
     return (
         pcoll
-        | beam.ParDo(PartialGroupByKeyCombiningValues(self._combine_fn))
+        | PGBKCV
         | beam.GroupByKey()
-        | beam.ParDo(FinishCombine(self._combine_fn)))
+        | beam.ParDo(FinishCombine(self._combine_fn, self.args, self.kwargs), **self.side_input_kwargs))
 
 
 class PartialGroupByKeyCombiningValues(beam.DoFn):
@@ -55,8 +78,12 @@ class PartialGroupByKeyCombiningValues(beam.DoFn):
 
   As bundles are in-memory-sized, we don't bother flushing until the very end.
   """
-  def __init__(self, combine_fn):
+  def __init__(self, combine_fn, args, kwargs):
     self._combine_fn = combine_fn
+    self.args = args
+    self.kwargs = kwargs
+    self.side_input_args = []
+    self.side_input_kwargs = {}
 
   def setup(self):
     self._combine_fn.setup()
@@ -64,57 +91,49 @@ class PartialGroupByKeyCombiningValues(beam.DoFn):
   def start_bundle(self):
     self._cache = collections.defaultdict(self._combine_fn.create_accumulator)
 
-  def process(self, element, window=beam.DoFn.WindowParam):
+  def process(self, element, window=beam.DoFn.WindowParam, **side_input_kwargs):
+    side_input_args = []
     k, vi = element
     self._cache[k, window] = self._combine_fn.add_input(
-        self._cache[k, window], vi)
+        self._cache[k, window], vi, *self.args, *side_input_args, **self.kwargs, **side_input_kwargs)
+    self.side_input_args = side_input_args
+    self.side_input_kwargs = side_input_kwargs
 
   def finish_bundle(self):
     for (k, w), va in self._cache.items():
       # We compact the accumulator since a GBK (which necessitates encoding)
       # will follow.
-      yield WindowedValue((k, self._combine_fn.compact(va)), w.end, (w, ))
+      yield WindowedValue((k, self._combine_fn.compact(va, *self.args, *self.side_input_args, **self.kwargs, **self.side_input_kwargs)), w.end, (w, ))
 
   def teardown(self):
     self._combine_fn.teardown()
-
-  def default_type_hints(self):
-    hints = self._combine_fn.get_type_hints()
-    K = typehints.TypeVariable('K')
-    if hints.input_types:
-      args, kwargs = hints.input_types
-      args = (typehints.Tuple[K, args[0]], ) + args[1:]
-      hints = hints.with_input_types(*args, **kwargs)
-    else:
-      hints = hints.with_input_types(typehints.Tuple[K, typing.Any])
-    hints = hints.with_output_types(typehints.Tuple[K, typing.Any])
-    return hints
 
 
 class FinishCombine(beam.DoFn):
   """Merges partially combined results.
   """
-  def __init__(self, combine_fn):
+  def __init__(self, combine_fn, args, kwargs):
     self._combine_fn = combine_fn
+    self.args = args
+    self.kwargs = kwargs
+    self.side_input_args = []
+    self.side_input_kwargs = {}
 
   def setup(self):
     self._combine_fn.setup()
 
-  def process(self, element):
+  def process(self, element, window=beam.DoFn.WindowParam,
+              **side_input_kwargs):
+
     k, vs = element
     return [(
         k,
         self._combine_fn.extract_output(
-            self._combine_fn.merge_accumulators(vs)))]
+            self._combine_fn.merge_accumulators(vs, *self.args, **self.kwargs, **side_input_kwargs), **side_input_kwargs))]
 
   def teardown(self):
-    self._combine_fn.teardown()
+    try:
+      self._combine_fn.teardown()
+    except AttributeError:
+      pass
 
-  def default_type_hints(self):
-    hints = self._combine_fn.get_type_hints()
-    K = typehints.TypeVariable('K')
-    hints = hints.with_input_types(typehints.Tuple[K, typing.Any])
-    if hints.output_types:
-      main_output_type = hints.simple_output_type('')
-      hints = hints.with_output_types(typehints.Tuple[K, main_output_type])
-    return hints

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/fn_runner.py
@@ -195,7 +195,6 @@ class FnApiRunner(runner.PipelineRunner):
           'effect. direct_num_workers: %d ; running_mode: %s',
           self._num_workers,
           running_mode)
-    pipeline.replace_all(_get_transform_overrides(options))
 
     self._profiler_factory = Profile.factory_from_options(
         options.view_as(pipeline_options.ProfilingOptions))
@@ -1611,45 +1610,3 @@ class RunnerResult(runner.PipelineResult):
   def monitoring_infos(self):
     for ms in self._monitoring_infos_by_stage.values():
       yield from ms
-
-
-from apache_beam.transforms.core import CombinePerKey
-
-def _get_transform_overrides(pipeline_options):
-  # A list of PTransformOverride objects to be applied before running a pipeline
-  # using DirectRunner.
-  # Currently this only works for overrides where the input and output types do
-  # not change.
-  # For internal use only; no backwards-compatibility guarantees.
-
-  # Importing following locally to avoid a circular dependency.
-  from apache_beam.pipeline import PTransformOverride
-  from apache_beam.runners.direct.helper_transforms import LiftedCombinePerKey
-  from apache_beam.runners.direct.sdf_direct_runner import ProcessKeyedElementsViaKeyedWorkItemsOverride
-  from apache_beam.runners.direct.sdf_direct_runner import SplittableParDoOverride
-
-  class CombinePerKeyOverride(PTransformOverride):
-    def matches(self, applied_ptransform):
-      return False
-      has_side_inputs = bool(applied_ptransform.side_inputs)
-      is_globally_windowed = False
-      if isinstance(applied_ptransform.transform, CombinePerKey):
-        is_globally_windowed = applied_ptransform.inputs[0].windowing.is_default()
-      return has_side_inputs and is_globally_windowed
-
-    def get_replacement_transform_for_applied_ptransform(
-        self, applied_ptransform):
-      # TODO: Move imports to top. Pipeline <-> Runner dependency cause problems
-      # with resolving imports when they are at top.
-      # pylint: disable=wrong-import-position
-      try:
-        transform = applied_ptransform.transform
-        return LiftedCombinePerKey(
-            transform.fn, transform.args, transform.kwargs)
-      except NotImplementedError:
-        raise
-        return transform
-
-    def get_replacement_inputs(self, applied_ptransform):  # type: (AppliedPTransform) -> Iterable[pvalue.PValue]
-      return applied_ptransform.inputs
-  return [CombinePerKeyOverride()]

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations_test.py
@@ -37,6 +37,33 @@ from apache_beam.transforms.core import Create
 
 
 class TranslationsTest(unittest.TestCase):
+
+  def test_lift_combiners(self):
+
+    def get_common_items(sets, side=0):
+      # set.intersection() takes multiple sets as separete arguments.
+      # We unpack the `sets` list into multiple arguments with the * operator.
+      # The combine transform might give us an empty list of `sets`,
+      # so we use a list with an empty set as a default value.
+      assert side == 1
+      return set.intersection(*(sets or [set()]))
+
+    with beam.Pipeline() as pipeline:
+      pc = (pipeline | beam.Create([1]))
+      common_items = (
+              pipeline
+              | 'Create produce' >> beam.Create([
+                  {'🍓', '🥕', '🍌', '🍅', '🌶️'},
+                  {'🍇', '🥕', '🥝', '🍅', '🥔'},
+                  {'🍉', '🥕', '🍆', '🍅', '🍍'},
+                  {'🥑', '🥕', '🌽', '🍅', '🥥'},
+                ])
+              | beam.WithKeys(lambda x: None)
+              | 'Get common items' >> beam.CombinePerKey(get_common_items,
+                                                           side=beam.pvalue.AsSingleton(
+                                                             pc))
+              | beam.Map(print))
+
   def test_eliminate_common_key_with_void(self):
     class MultipleKeyWithNone(beam.PTransform):
       def expand(self, pcoll):

--- a/start-build-env.sh
+++ b/start-build-env.sh
@@ -90,8 +90,6 @@ RUN useradd -g ${GROUP_ID} -G docker -u ${USER_ID} -k /root -m ${USER_NAME} -d "
 RUN echo "${USER_NAME} ALL=NOPASSWD: ALL" > "/etc/sudoers.d/beam-build-${USER_ID}"
 ENV HOME "${DOCKER_HOME_DIR}"
 ENV GOPATH ${DOCKER_HOME_DIR}/beam/sdks/go/examples/.gogradle/project_gopath
-# This next command still runs as root causing the ~/.cache/go-build to be owned by root
-RUN go get github.com/linkedin/goavro/v2
 RUN chown -R ${USER_NAME}:${GROUP_ID} ${DOCKER_HOME_DIR}/.cache
 UserSpecificDocker
 


### PR DESCRIPTION
#19851 
This is a proof-of-concept draft for fixing/implementing deferred side inputs with Combiners. I could use feedback on how to proceed and then I'll clean it up as well.

**Issue:**
Currently if you try to use a side input with a combine function, you end up with a traceback during the pipeline translation step:
```
  File "/Users/jtran/builds/2024-2/build/internal/lib/python3.11/site-packages/apache_beam/runners/portability/fn_api_runner/translations.py", line 1367, in lift_combiners
    expansion = lifted_stages if can_lift(transform) else unlifted_stages
                                 ^^^^^^^^^^^^^^^^^^^
  File "/Users/jtran/builds/2024-2/build/internal/lib/python3.11/site-packages/apache_beam/runners/portability/fn_api_runner/translations.py", line 1239, in can_lift
    context.components.pcollections[only_element(
                                    ^^^^^^^^^^^^^
  File "/Users/jtran/builds/2024-2/build/internal/lib/python3.11/site-packages/apache_beam/runners/portability/fn_api_runner/translations.py", line 2082, in only_element
    element, = iterable
    ^^^^^^^^
ValueError: too many values to unpack (expected 1)
```
**Fix?:**
The issue is because in the code where we determine whether or not to lift a combiner, we assume the combiner has a single input pcoll, which is not true when the combiner has a deferred side input.

I went through fixing this and then realized that we also don't have plumbing for deferred side inputs implemented at the `operations.py` layer either. It seemed like a lot of work to duplicate all the side input plumbing that ParDo has when the phases of the combiners can be expressed as ParDos anyways.

Inside of `direct/helper_transforms.py` we actually already define a ParDo-based version of a lifted combiner. I tried adding an override to use it only if we have a combiner with side inputs but at that point we've already substituted away the side input for a `ArgumentPlaceholder`s. I instead updated it and returned it in `CombinePerKey.__new__`. I couldn't put it in `CombinePerKey.expand` since `CombinePerKey` has the special urn that would've resulted in the subtransforms getting ignored
