### PR TITLE
Call `DateTime(long)` instead of `DateTime(Object)`.

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/TimeUtil.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/util/TimeUtil.java
@@ -57,7 +57,10 @@ public final class TimeUtil {
     // millisecond resolution.
 
     // Translate the ReadableInstant to a DateTime with ISOChronology.
-    DateTime time = new DateTime(instant);
+    // We avoid passing `instant` directly to the constructor because that constructor calls into
+    // the thread-unsafe ConverterManager. Instead, we pass `instant.getMillis()`, which doesn't
+    // trigger the pluggable conversion system.
+    DateTime time = new DateTime(instant.getMillis());
 
     int millis = time.getMillisOfSecond();
     if (millis == 0) {


### PR DESCRIPTION
The latter uses `ConverterManager.getInstance()`, which is not thread-safe:
https://github.com/JodaOrg/joda-time/blob/main/src/main/java/org/joda/time/convert/ConverterManager.java#L89

We learned of this inside Google because of a report by TSAN.

I don't know whether simple changes like this are exempt from the issue
process discussed in
https://github.com/apache/beam/blob/master/CONTRIBUTING.md#share-your-intent.
Let me know if I should in fact open an issue. Thanks.
