### PR TITLE
python sdk: fix several bugs regarding avto <-> beam schema conversion

### DIFF
--- a/sdks/python/apache_beam/io/avroio.py
+++ b/sdks/python/apache_beam/io/avroio.py
@@ -65,6 +65,8 @@ from apache_beam.io.iobase import Read
 from apache_beam.portability.api import schema_pb2
 from apache_beam.transforms import PTransform
 from apache_beam.typehints import schemas
+from apache_beam import coders
+import ctypes
 
 __all__ = [
     'ReadFromAvro',
@@ -544,12 +546,26 @@ BEAM_PRIMITIVES_TO_AVRO_PRIMITIVES = {
 _AvroSchemaType = Union[str, List, Dict]
 
 
+# if the union type is a nullable and it is a nullable union of an avro primitive with a corresponding beam primitive
+# then create a nullable beam field of the corresponding beam type, otherwise return an Any type
+def avro_union_type_to_beam_type(union_type: List) -> schema_pb2.FieldType:
+  if len(union_type) == 2 and "null" in union_type:
+    for avro_type in union_type:
+      if avro_type in AVRO_PRIMITIVES_TO_BEAM_PRIMITIVES:
+        return schema_pb2.FieldType(
+            atomic_type=AVRO_PRIMITIVES_TO_BEAM_PRIMITIVES[avro_type],
+            nullable=True)
+    else:
+      schemas.typing_to_runner_api(Any)
+  return schemas.typing_to_runner_api(Any)
+
+
 def avro_type_to_beam_type(avro_type: _AvroSchemaType) -> schema_pb2.FieldType:
   if isinstance(avro_type, str):
     return avro_type_to_beam_type({'type': avro_type})
   elif isinstance(avro_type, list):
     # Union type
-    return schemas.typing_to_runner_api(Any)
+    return avro_union_type_to_beam_type(avro_type)
   type_name = avro_type['type']
   if type_name in AVRO_PRIMITIVES_TO_BEAM_PRIMITIVES:
     return schema_pb2.FieldType(
@@ -605,11 +621,25 @@ def avro_dict_to_beam_row(
           to_row)
 
 
+# convert an avro atomic value to a beam atomic value
+# if the avro type is an int or long, convert the value into from signed to unsigned
+# because VarInt.java expects the number to be unsigned when decoding the number
+def avro_atomic_value_to_beam_atomic_value(avro_type: str, value):
+  if avro_type == "int":
+    return ctypes.c_uint32(value).value
+  elif avro_type == "long":
+    return ctypes.c_uint64(value).value
+  else:
+    return value
+
+
 def avro_value_to_beam_value(
     beam_type: schema_pb2.FieldType) -> Callable[[Any], Any]:
   type_info = beam_type.WhichOneof("type_info")
   if type_info == "atomic_type":
-    return lambda value: value
+    avro_type = BEAM_PRIMITIVES_TO_AVRO_PRIMITIVES[beam_type.atomic_type]
+    return lambda value: avro_atomic_value_to_beam_atomic_value(
+        avro_type, value)
   elif type_info == "array_type":
     element_converter = avro_value_to_beam_value(
         beam_type.array_type.element_type)
@@ -649,7 +679,11 @@ def beam_schema_to_avro_schema(
 def beam_type_to_avro_type(beam_type: schema_pb2.FieldType) -> _AvroSchemaType:
   type_info = beam_type.WhichOneof("type_info")
   if type_info == "atomic_type":
-    return {'type': BEAM_PRIMITIVES_TO_AVRO_PRIMITIVES[beam_type.atomic_type]}
+    avro_primitive = BEAM_PRIMITIVES_TO_AVRO_PRIMITIVES[beam_type.atomic_type]
+    if beam_type.nullable:
+      return ['null', avro_primitive]
+    else:
+      return {'type': avro_primitive}
   elif type_info == "array_type":
     return {
         'type': 'array',
@@ -693,29 +727,43 @@ def beam_row_to_avro_dict(
     return lambda row: convert(row[0])
 
 
+# convert a beam atomic value to an avro atomic value
+# since numeric values are converted to unsigned in avro_atomic_value_to_beam_atomic_value
+# we need to convert back to a signed number
+def beam_atomic_value_to_avro_atomic_value(avro_type: str, value):
+  if avro_type == "int":
+    return ctypes.c_int32(value).value
+  elif avro_type == "long":
+    return ctypes.c_int64(value).value
+  else:
+    return value
+
+
 def beam_value_to_avro_value(
     beam_type: schema_pb2.FieldType) -> Callable[[Any], Any]:
   type_info = beam_type.WhichOneof("type_info")
   if type_info == "atomic_type":
-    return lambda value: value
+    avro_type = BEAM_PRIMITIVES_TO_AVRO_PRIMITIVES[beam_type.atomic_type]
+    return lambda value: beam_atomic_value_to_avro_atomic_value(
+        avro_type, value)
   elif type_info == "array_type":
-    element_converter = avro_value_to_beam_value(
+    element_converter = beam_value_to_avro_value(
         beam_type.array_type.element_type)
     return lambda value: [element_converter(e) for e in value]
   elif type_info == "iterable_type":
-    element_converter = avro_value_to_beam_value(
+    element_converter = beam_value_to_avro_value(
         beam_type.iterable_type.element_type)
     return lambda value: [element_converter(e) for e in value]
   elif type_info == "map_type":
     if beam_type.map_type.key_type.atomic_type != schema_pb2.STRING:
       raise TypeError(
-          f'Only strings allowd as map keys when converting from AVRO, '
+          f'Only strings allowed as map keys when converting from AVRO, '
           f'found {beam_type}')
-    value_converter = avro_value_to_beam_value(beam_type.map_type.value_type)
+    value_converter = beam_value_to_avro_value(beam_type.map_type.value_type)
     return lambda value: {k: value_converter(v) for (k, v) in value.items()}
   elif type_info == "row_type":
     converters = {
-        field.name: avro_value_to_beam_value(field.type)
+        field.name: beam_value_to_avro_value(field.type)
         for field in beam_type.row_type.schema.fields
     }
     return lambda value: {


### PR DESCRIPTION
attempts to fix several issues regarding avro <-> beam schema conversion in the python sdk

1) https://github.com/apache/beam/issues/30750
2) [VarInt.java](https://github.com/apache/beam/blob/master/sdks/java/core/src/main/java/org/apache/beam/sdk/util/VarInt.java#L103) expects ints and longs to be unsigned, however the current [implementation](https://github.com/apache/beam/blob/7097443e27c90857258e9478ddb83c9d7e32afce/sdks/python/apache_beam/io/avroio.py#L612) just returns the signed number, which causes an `IOException("varint overflow " + r)` exception to get thrown when using the converted beam schema with a `SqlTransform`

NOTE: I'm not entirely sure about my logic here, since the resulting `beam.Rows` have the converted 2's complement number will get returned if the user doesn't apply a `SqlTransform` to their pipeline, but the previous implementation was also causing errors, so I'll need some help here
3) in `avroio.py`'s [beam_value_to_avro_value](https://github.com/apache/beam/blob/7097443e27c90857258e9478ddb83c9d7e32afce/sdks/python/apache_beam/io/avroio.py#L702) function, it recurses on `avro_value_to_beam_value`, rather than the `beam_value_to_avro_value` function. I'm 99% sure this should be the other way around, however since the two functions are so similar this previously wasn't causing issues. I only noticed it when I added the custom logic to convert to/from signed and unsigned numbers.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
