### PR TITLE
Lower various logging statement levels to clean up example printing

### DIFF
--- a/sdks/python/apache_beam/internal/gcp/auth.py
+++ b/sdks/python/apache_beam/internal/gcp/auth.py
@@ -131,9 +131,9 @@ class _Credentials(object):
       # apitools use urllib with the global timeout. Set it to 60 seconds
       # to prevent network related stuckness issues.
       if not socket.getdefaulttimeout():
-        _LOGGER.info("Setting socket default timeout to 60 seconds.")
+        _LOGGER.debug("Setting socket default timeout to 60 seconds.")
         socket.setdefaulttimeout(60)
-      _LOGGER.info(
+      _LOGGER.debug(
           "socket default timeout is %s seconds.", socket.getdefaulttimeout())
 
       cls._credentials = cls._get_service_credentials(pipeline_options)

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/translations.py
@@ -709,10 +709,7 @@ def create_and_optimize_stages(
 
   # Apply each phase in order.
   for phase in phases:
-    _LOGGER.info('%s %s %s', '=' * 20, phase, '=' * 20)
     stages = list(phase(stages, pipeline_context))
-    _LOGGER.debug('%s %s' % (len(stages), [len(s.transforms) for s in stages]))
-    _LOGGER.debug('Stages: %s', [str(s) for s in stages])
 
   # Return the (possibly mutated) context and ordered set of stages.
   return pipeline_context, stages

--- a/sdks/python/apache_beam/runners/portability/fn_api_runner/worker_handlers.py
+++ b/sdks/python/apache_beam/runners/portability/fn_api_runner/worker_handlers.py
@@ -919,7 +919,7 @@ class WorkerHandlerManager(object):
             self.state_servicer,
             self._job_provision_info.for_environment(environment),
             grpc_server)
-        _LOGGER.info(
+        _LOGGER.debug(
             "Created Worker handler %s for environment %s (%s, %r)",
             worker_handler,
             environment_id,

--- a/sdks/python/apache_beam/runners/worker/statecache.py
+++ b/sdks/python/apache_beam/runners/worker/statecache.py
@@ -231,7 +231,7 @@ class StateCache(object):
   """
   def __init__(self, max_weight):
     # type: (int) -> None
-    _LOGGER.debug('Creating state cache with size %s', max_weight)
+    _LOGGER.info('Creating state cache with size %s', max_weight)
     self._max_weight = max_weight
     self._current_weight = 0
     self._cache = collections.OrderedDict(

--- a/sdks/python/apache_beam/runners/worker/statecache.py
+++ b/sdks/python/apache_beam/runners/worker/statecache.py
@@ -231,7 +231,7 @@ class StateCache(object):
   """
   def __init__(self, max_weight):
     # type: (int) -> None
-    _LOGGER.info('Creating state cache with size %s', max_weight)
+    _LOGGER.debug('Creating state cache with size %s', max_weight)
     self._max_weight = max_weight
     self._current_weight = 0
     self._cache = collections.OrderedDict(


### PR DESCRIPTION
The playground examples have tons of info logging that drown out any actual logging that the example might've caused. This is somewhat of a big hit to the playground experience (not just noted by me, but by others that I've been introducing to Beam)

I attempted a fix to change the playground's [log level](https://github.com/apache/beam/pull/29948) but that didn't seem to take. Vlado Djerek also tried to figure out where the logging level is set but was also unsuccessful.

In lieu of a real fix, I just changed or deleted various logging statements that I suspect are probably not all that useful. I suspect especially that the translation prints which really clog up the examples don't offer much useful information.

Here's an example of what running the example looks like right now:
<img width="1077" alt="image" src="https://github.com/apache/beam/assets/10524948/12cb97a0-9558-4c38-9d9a-bc0f0eb5ec95">