### PR TITLE
[YAML] Increase re-use of providers with implicitly overlapping transforms.

### DIFF
--- a/sdks/python/apache_beam/yaml/yaml_provider.py
+++ b/sdks/python/apache_beam/yaml/yaml_provider.py
@@ -78,6 +78,13 @@ class Provider:
   def description(self, type):
     return None
 
+  def __repr__(self):
+    ts = ','.join(sorted(self.provided_transforms()))
+    return f'{self.__class__.__name__}[{ts}]'
+
+  def to_json(self):
+    return {'type': self.__class__.__name__}
+
   def requires_inputs(self, typ: str, args: Mapping[str, Any]) -> bool:
     """Returns whether this transform requires inputs.
 
@@ -104,6 +111,19 @@ class Provider:
     provider that should actually be used for affinity checking.
     """
     return self
+
+  def with_underlying_provider(self, provider):
+    """Returns a provider that vends as many transforms of this provider as
+    possible but uses the given underlying provider.
+
+    This is used to try to minimize the number of distinct environments that
+    are used as many providers implicitly or explicitly link in many common
+    transforms.
+    """
+    return None
+
+  def extra_urns():
+    return ()
 
   def affinity(self, other: "Provider"):
     """Returns a value approximating how good it would be for this provider
@@ -151,6 +171,17 @@ class ExternalProvider(Provider):
 
   def provided_transforms(self):
     return self._urns.keys()
+
+  def with_underlying_provider(self, other_provider):
+    if not isinstance(other_provider, ExternalProvider):
+      return
+
+    all_urns = set(other_provider.schema_transforms().keys()).union(
+        set(other_provider._urns.values()))
+    for name, urn in self._urns.items():
+      if urn in all_urns and name not in other_provider._urns:
+        other_provider._urns[name] = urn
+    return other_provider
 
   def schema_transforms(self):
     if callable(self._service):
@@ -517,6 +548,15 @@ class SqlBackedProvider(Provider):
 
   def underlying_provider(self):
     return self.sql_provider()
+
+  def with_underlying_provider(self, other_provider):
+    new_sql_provider = self.sql_provider().with_underlying_provider(
+        other_provider)
+    if new_sql_provider is None:
+      new_sql_provider = other_provider
+    if new_sql_provider and 'Sql' in set(
+        new_sql_provider.provided_transforms()):
+      return SqlBackedProvider(self._transforms, new_sql_provider)
 
   def to_json(self):
     return {'type': "SqlBackedProvider"}
@@ -995,7 +1035,12 @@ class PypiExpansionService:
 
 @ExternalProvider.register_provider_type('renaming')
 class RenamingProvider(Provider):
-  def __init__(self, transforms, mappings, underlying_provider, defaults=None):
+  def __init__(
+      self,
+      transforms: Mapping[str, str],
+      mappings: Mapping[str, Mapping[str, str]],
+      underlying_provider: Provider,
+      defaults: Optional[Mapping[str, Mapping[str, Any]]] = None):
     if isinstance(underlying_provider, dict):
       underlying_provider = ExternalProvider.provider_from_spec(
           underlying_provider)
@@ -1096,6 +1141,23 @@ class RenamingProvider(Provider):
 
   def underlying_provider(self):
     return self._underlying_provider.underlying_provider()
+
+  def with_underlying_provider(self, other_provider):
+    new_underlying_provider = (
+        self._underlying_provider.with_underlying_provider(other_provider))
+    if new_underlying_provider:
+      provided = set(new_underlying_provider.provided_transforms())
+      new_transforms = {
+          alias: actual
+          for alias,
+          actual in self._transforms.items() if actual in provided
+      }
+      if new_transforms:
+        return RenamingProvider(
+            new_transforms,
+            self._mappings,
+            new_underlying_provider,
+            self._defaults)
 
   def cache_artifacts(self):
     self._underlying_provider.cache_artifacts()

--- a/sdks/python/apache_beam/yaml/yaml_provider_test.py
+++ b/sdks/python/apache_beam/yaml/yaml_provider_test.py
@@ -1,0 +1,76 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import contextlib
+import logging
+import unittest
+
+import apache_beam as beam
+from apache_beam.yaml import yaml_provider
+
+
+class FakeTransform(beam.PTransform):
+  def __init__(self, creator, urn):
+    self.creator = creator
+    self.urn = urn
+
+
+class FakeExternalProvider(yaml_provider.ExternalProvider):
+  def __init__(self, id, known_transforms, extra_transform_urns):
+    super().__init__(known_transforms, None)
+    self._id = id
+    self._schema_transforms = {urn: None for urn in extra_transform_urns}
+
+  def create_transform(self, type, *unused_args, **unused_kwargs):
+    return FakeTransform(self._id, self._urns[type])
+
+
+class YamlProvidersTest(unittest.TestCase):
+  def test_external_with_underlying_provider(self):
+    providerA = FakeExternalProvider("A", {'A': 'a:urn'}, ['b:urn'])
+    providerB = FakeExternalProvider("B", {'B': 'b:urn', 'alias': 'a:urn'}, [])
+    newA = providerB.with_underlying_provider(providerA)
+
+    self.assertIn('B', list(newA.provided_transforms()))
+    t = newA.create_transform('B')
+    self.assertEqual('A', t.creator)
+    self.assertEqual('b:urn', t.urn)
+
+    self.assertIn('alias', list(newA.provided_transforms()))
+    t = newA.create_transform('alias')
+    self.assertEqual('A', t.creator)
+    self.assertEqual('a:urn', t.urn)
+
+  def test_renaming_with_underlying_provider(self):
+    providerA = FakeExternalProvider("A", {'A': 'a:urn'}, ['b:urn'])
+    providerB = FakeExternalProvider("B", {'B': 'b:urn', 'C': 'c:urn'}, [])
+    providerR = yaml_provider.RenamingProvider(  # keep wrapping
+        {'RenamedB': 'B', 'RenamedC': 'C' },
+        {'RenamedB': {},  'RenamedC': {}},
+        providerB)
+
+    newR = providerR.with_underlying_provider(providerA)
+    self.assertIn('RenamedB', list(newR.provided_transforms()))
+    self.assertNotIn('RenamedC', list(newR.provided_transforms()))
+    t = newR.create_transform('RenamedB', {}, None)
+    self.assertEqual('A', t.creator)
+    self.assertEqual('b:urn', t.urn)
+
+
+if __name__ == '__main__':
+  logging.getLogger().setLevel(logging.INFO)
+  unittest.main()


### PR DESCRIPTION
We use the schema transform discovery service to determine all the transforms that a given provider vends which may be larger than those that were explicitly declared (e.g. the basic mapping transforms are part of java core) and use this to expand the possible set of transforms this provider can be used to instanciate (attaching the appropreate renaming, etc. as needed). This can greatly increase the chances that we can use the same provider, and hence same SDK and environment, for adjacent steps.

This is done lazily as transforms are used to avoid instanciating all possible providers for all pipelines.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
