### PR TITLE
[Flink] Speed up file write in batch mode by using larger bundle size

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkTransformOverrides.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkTransformOverrides.java
@@ -36,18 +36,19 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Immuta
 class FlinkTransformOverrides {
   static List<PTransformOverride> getDefaultOverrides(FlinkPipelineOptions options) {
     ImmutableList.Builder<PTransformOverride> builder = ImmutableList.builder();
+    if (options.isStreaming()) {
+      builder.add(
+          PTransformOverride.of(
+              FlinkStreamingPipelineTranslator.StreamingShardedWriteFactory
+                  .writeFilesNeedsOverrides(),
+              new FlinkStreamingPipelineTranslator.StreamingShardedWriteFactory(
+                  checkNotNull(options))));
+    }
     if (options.isStreaming() || options.getUseDataStreamForBatch()) {
-      builder
-          .add(
-              PTransformOverride.of(
-                  FlinkStreamingPipelineTranslator.StreamingShardedWriteFactory
-                      .writeFilesNeedsOverrides(),
-                  new FlinkStreamingPipelineTranslator.StreamingShardedWriteFactory(
-                      checkNotNull(options))))
-          .add(
-              PTransformOverride.of(
-                  PTransformMatchers.urnEqualTo(PTransformTranslation.CREATE_VIEW_TRANSFORM_URN),
-                  CreateStreamingFlinkView.Factory.INSTANCE));
+      builder.add(
+          PTransformOverride.of(
+              PTransformMatchers.urnEqualTo(PTransformTranslation.CREATE_VIEW_TRANSFORM_URN),
+              CreateStreamingFlinkView.Factory.INSTANCE));
     }
     builder
         .add(

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineOptionsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineOptionsTest.java
@@ -91,14 +91,22 @@ public class FlinkPipelineOptionsTest {
     assertThat(options.getStateBackendFactory(), is(nullValue()));
     assertThat(options.getStateBackend(), is(nullValue()));
     assertThat(options.getStateBackendStoragePath(), is(nullValue()));
-    assertThat(options.getMaxBundleSize(), is(1000L));
-    assertThat(options.getMaxBundleTimeMills(), is(1000L));
     assertThat(options.getExecutionModeForBatch(), is(ExecutionMode.PIPELINED.name()));
     assertThat(options.getUseDataStreamForBatch(), is(false));
     assertThat(options.getSavepointPath(), is(nullValue()));
     assertThat(options.getAllowNonRestoredState(), is(false));
     assertThat(options.getDisableMetrics(), is(false));
     assertThat(options.getFasterCopy(), is(false));
+
+    assertThat(options.isStreaming(), is(false));
+    assertThat(options.getMaxBundleSize(), is(1000000L));
+    assertThat(options.getMaxBundleTimeMills(), is(10000L));
+
+    // In streaming mode bundle size and bundle time are shorter
+    FlinkPipelineOptions optionsStreaming = FlinkPipelineOptions.defaults();
+    optionsStreaming.setStreaming(true);
+    assertThat(optionsStreaming.getMaxBundleSize(), is(1000L));
+    assertThat(optionsStreaming.getMaxBundleTimeMills(), is(1000L));
   }
 
   @Test(expected = Exception.class)


### PR DESCRIPTION
This PR removes the automated file sharding normally applied when the runner is passed `--useDataStreamForBatch`.

 Currently `FlinkStreamingPipelineTranslator.StreamingShardedWriteFactory` automatically forces file sharding because without it each bundle becomes an output file. Writing a very large number of small files is obviously very inefficient, but for batch jobs we can simply make bundles much much larger which makes sharding unnecessary.

Without this fix, `useDataStreamForBatch` can be much slower because of the extra shuffle step. 
It seems the dataflow runner is following a similar approach were sharding in only added in streaming mode. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
