### PR TITLE
Elasticsearch enable Point In Time based searches

### DIFF
--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-8/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOIT.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-8/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOIT.java
@@ -99,6 +99,12 @@ public class ElasticsearchIOIT {
   }
 
   @Test
+  public void testReadPITVolume() throws Exception {
+    elasticsearchIOTestCommon.setPipeline(pipeline);
+    elasticsearchIOTestCommon.testReadPIT();
+  }
+
+  @Test
   public void testWriteVolume() throws Exception {
     // cannot share elasticsearchIOTestCommon because tests run in parallel.
     ElasticsearchIOTestCommon elasticsearchIOTestCommonWrite =

--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-8/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTest.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-8/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTest.java
@@ -105,12 +105,30 @@ public class ElasticsearchIOTest implements Serializable {
   }
 
   @Test
+  public void testReadPIT() throws Exception {
+    // need to create the index using the helper method (not create it at first insertion)
+    // for the indexSettings() to be run
+    createIndex(elasticsearchIOTestCommon.restClient, getEsIndex());
+    elasticsearchIOTestCommon.setPipeline(pipeline);
+    elasticsearchIOTestCommon.testReadPIT();
+  }
+
+  @Test
   public void testReadWithQueryString() throws Exception {
     // need to create the index using the helper method (not create it at first insertion)
     // for the indexSettings() to be run
     createIndex(elasticsearchIOTestCommon.restClient, getEsIndex());
     elasticsearchIOTestCommon.setPipeline(pipeline);
-    elasticsearchIOTestCommon.testRead();
+    elasticsearchIOTestCommon.testReadWithQueryString();
+  }
+
+  @Test
+  public void testReadWithQueryStringAndPIT() throws Exception {
+    // need to create the index using the helper method (not create it at first insertion)
+    // for the indexSettings() to be run
+    createIndex(elasticsearchIOTestCommon.restClient, getEsIndex());
+    elasticsearchIOTestCommon.setPipeline(pipeline);
+    elasticsearchIOTestCommon.testReadWithQueryAndPIT();
   }
 
   @Test

--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-8/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTest.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-8/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTest.java
@@ -122,7 +122,7 @@ public class ElasticsearchIOTest implements Serializable {
     elasticsearchIOTestCommon.testReadWithQueryString();
   }
 
-  @Test
+  //@Test
   public void testReadWithQueryStringAndPIT() throws Exception {
     // need to create the index using the helper method (not create it at first insertion)
     // for the indexSettings() to be run

--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-8/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTest.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-8/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTest.java
@@ -122,7 +122,7 @@ public class ElasticsearchIOTest implements Serializable {
     elasticsearchIOTestCommon.testReadWithQueryString();
   }
 
-  //@Test
+  @Test
   public void testReadWithQueryStringAndPIT() throws Exception {
     // need to create the index using the helper method (not create it at first insertion)
     // for the indexSettings() to be run

--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestCommon.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestCommon.java
@@ -275,7 +275,7 @@ class ElasticsearchIOTestCommon implements Serializable {
             + "    \"scientist\" : {\n"
             + "      \"query\" : \"Einstein\"\n"
             + "    }\n"
-            + "  }\n"
+            + "   }\n"
             + "  }\n"
             + "}";
 

--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestCommon.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestCommon.java
@@ -235,17 +235,35 @@ class ElasticsearchIOTestCommon implements Serializable {
     pipeline.run();
   }
 
+  void testReadPIT() throws Exception {
+    if (!useAsITests) {
+      ElasticsearchIOTestUtils.insertTestDocuments(connectionConfiguration, numDocs, restClient);
+    }
+
+    PCollection<String> output =
+        pipeline.apply(
+            ElasticsearchIO.read()
+                .withConnectionConfiguration(connectionConfiguration)
+                .withPointInTimeSearch());
+    PAssert.thatSingleton(output.apply("Count", Count.globally())).isEqualTo(numDocs);
+    pipeline.run();
+  }
+
   void testReadWithQueryString() throws Exception {
-    testReadWithQueryInternal(Read::withQuery);
+    testReadWithQueryInternal(Read::withQuery, true);
+  }
+
+  void testReadWithQueryAndPIT() throws Exception {
+    testReadWithQueryInternal(Read::withQuery, false);
   }
 
   void testReadWithQueryValueProvider() throws Exception {
     testReadWithQueryInternal(
-        (read, query) -> read.withQuery(ValueProvider.StaticValueProvider.of(query)));
+        (read, query) -> read.withQuery(ValueProvider.StaticValueProvider.of(query)), true);
   }
 
-  private void testReadWithQueryInternal(BiFunction<Read, String, Read> queryConfigurer)
-      throws IOException {
+  private void testReadWithQueryInternal(
+      BiFunction<Read, String, Read> queryConfigurer, boolean useScrollAPI) throws IOException {
     if (!useAsITests) {
       ElasticsearchIOTestUtils.insertTestDocuments(connectionConfiguration, numDocs, restClient);
     }
@@ -264,6 +282,8 @@ class ElasticsearchIOTestCommon implements Serializable {
     Read read = ElasticsearchIO.read().withConnectionConfiguration(connectionConfiguration);
 
     read = queryConfigurer.apply(read, query);
+
+    read = useScrollAPI ? read : read.withPointInTimeSearch();
 
     PCollection<String> output = pipeline.apply(read);
 

--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestCommon.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestCommon.java
@@ -268,16 +268,16 @@ class ElasticsearchIOTestCommon implements Serializable {
       ElasticsearchIOTestUtils.insertTestDocuments(connectionConfiguration, numDocs, restClient);
     }
 
-    String query =
-        "{\n"
-            + "  \"query\": {\n"
+    String queryBase =
+        "  \"query\": {\n"
             + "  \"match\" : {\n"
             + "    \"scientist\" : {\n"
             + "      \"query\" : \"Einstein\"\n"
             + "    }\n"
             + "  }\n"
-            + "  }\n"
-            + "}";
+            + "  }\n";
+
+    String query = useScrollAPI ? "{\n" + queryBase + "}" : queryBase;
 
     Read read = ElasticsearchIO.read().withConnectionConfiguration(connectionConfiguration);
 

--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestCommon.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestCommon.java
@@ -228,7 +228,7 @@ class ElasticsearchIOTestCommon implements Serializable {
             ElasticsearchIO.read()
                 .withConnectionConfiguration(connectionConfiguration)
                 // set to default value, useful just to test parameter passing.
-                .withScrollKeepalive("5m")
+                .withIteratorKeepalive("5m")
                 // set to default value, useful just to test parameter passing.
                 .withBatchSize(100L));
     PAssert.thatSingleton(output.apply("Count", Count.globally())).isEqualTo(numDocs);

--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestCommon.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestCommon.java
@@ -228,13 +228,14 @@ class ElasticsearchIOTestCommon implements Serializable {
             ElasticsearchIO.read()
                 .withConnectionConfiguration(connectionConfiguration)
                 // set to default value, useful just to test parameter passing.
-                .withIteratorKeepalive("5m")
+                .withScrollKeepalive("5m")
                 // set to default value, useful just to test parameter passing.
                 .withBatchSize(100L));
     PAssert.thatSingleton(output.apply("Count", Count.globally())).isEqualTo(numDocs);
     pipeline.run();
   }
 
+  /** Point in Time search is currently available for Elasticsearch version 8+. */
   void testReadPIT() throws Exception {
     if (!useAsITests) {
       ElasticsearchIOTestUtils.insertTestDocuments(connectionConfiguration, numDocs, restClient);

--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestCommon.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestCommon.java
@@ -268,16 +268,16 @@ class ElasticsearchIOTestCommon implements Serializable {
       ElasticsearchIOTestUtils.insertTestDocuments(connectionConfiguration, numDocs, restClient);
     }
 
-    String queryBase =
-        "  \"query\": {\n"
+    String query =
+        "{\n"
+            + "  \"query\": {\n"
             + "  \"match\" : {\n"
             + "    \"scientist\" : {\n"
             + "      \"query\" : \"Einstein\"\n"
             + "    }\n"
             + "  }\n"
-            + "  }\n";
-
-    String query = useScrollAPI ? "{\n" + queryBase + "}" : queryBase;
+            + "  }\n"
+            + "}";
 
     Read read = ElasticsearchIO.read().withConnectionConfiguration(connectionConfiguration);
 

--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestUtils.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestUtils.java
@@ -335,6 +335,7 @@ class ElasticsearchIOTestUtils {
   static List<String> createDocuments(long numDocs, InjectionMode injectionMode) {
 
     ArrayList<String> data = new ArrayList<>();
+    LocalDateTime baseDateTime =  LocalDateTime.now();
     for (int i = 0; i < numDocs; i++) {
       int index = i % FAMOUS_SCIENTISTS.length;
       // insert 2 malformed documents
@@ -345,7 +346,7 @@ class ElasticsearchIOTestUtils {
         data.add(
             String.format(
                 "{\"scientist\":\"%s\", \"id\":%s, \"@timestamp\" : \"%s\"}",
-                FAMOUS_SCIENTISTS[index], i, LocalDateTime.now().toString()));
+                FAMOUS_SCIENTISTS[index], i, baseDateTime.plusSeconds(i).toString()));
       }
     }
     return data;

--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestUtils.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestUtils.java
@@ -335,7 +335,7 @@ class ElasticsearchIOTestUtils {
   static List<String> createDocuments(long numDocs, InjectionMode injectionMode) {
 
     ArrayList<String> data = new ArrayList<>();
-    LocalDateTime baseDateTime =  LocalDateTime.now();
+    LocalDateTime baseDateTime = LocalDateTime.now();
     for (int i = 0; i < numDocs; i++) {
       int index = i % FAMOUS_SCIENTISTS.length;
       // insert 2 malformed documents

--- a/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestUtils.java
+++ b/sdks/java/io/elasticsearch-tests/elasticsearch-tests-common/src/test/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIOTestUtils.java
@@ -29,6 +29,7 @@ import com.fasterxml.jackson.databind.ObjectMapper;
 import com.fasterxml.jackson.databind.node.ObjectNode;
 import java.io.IOException;
 import java.time.Duration;
+import java.time.LocalDateTime;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -341,7 +342,10 @@ class ElasticsearchIOTestUtils {
           && INVALID_DOCS_IDS.contains(i)) {
         data.add(String.format("{\"scientist\";\"%s\", \"id\":%s}", FAMOUS_SCIENTISTS[index], i));
       } else {
-        data.add(String.format("{\"scientist\":\"%s\", \"id\":%s}", FAMOUS_SCIENTISTS[index], i));
+        data.add(
+            String.format(
+                "{\"scientist\":\"%s\", \"id\":%s, \"@timestamp\" : \"%s\"}",
+                FAMOUS_SCIENTISTS[index], i, LocalDateTime.now().toString()));
       }
     }
     return data;

--- a/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
+++ b/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
@@ -857,29 +857,17 @@ public class ElasticsearchIO {
     /**
      * Provide a scroll keepalive. See <a
      * href="https://www.elastic.co/guide/en/elasticsearch/reference/7.17/search-request-scroll.html">scroll
-     * API</a> Default is "5m". Change this only if you get "No search context found" errors.
+     * API</a> Default is "5m". Change this only if you get "No search context found" errors. When
+     * configuring the read to use Point In Time (PIT) search this configuration is used to set the
+     * PIT keep alive.
      *
-     * @deprecated use {@link Read#withIteratorKeepalive} instead
      * @param scrollKeepalive keepalive duration of the scroll
      * @return a {@link PTransform} reading data from Elasticsearch.
      */
-    @Deprecated
     public Read withScrollKeepalive(String scrollKeepalive) {
-      return this.withIteratorKeepalive(scrollKeepalive);
-    }
-
-    /**
-     * Sets the iterator keepalive. This setting should work the same for Scroll or Point In Team
-     * search iteration. Default is "5m". Change this only if you get "No search context found"
-     * errors.
-     *
-     * @param iteratorKeepalive keepalive duration of the selected iterator.
-     * @return a {@link PTransform} reading data from Elasticsearch.
-     */
-    public Read withIteratorKeepalive(String iteratorKeepalive) {
-      checkArgument(iteratorKeepalive != null, "iteratorKeepalive can not be null");
-      checkArgument(!"0m".equals(iteratorKeepalive), "iteratorKeepalive can not be 0m");
-      return builder().setIteratorKeepalive(iteratorKeepalive).build();
+      checkArgument(scrollKeepalive != null, "iteratorKeepalive can not be null");
+      checkArgument(!"0m".equals(scrollKeepalive), "iteratorKeepalive can not be 0m");
+      return builder().setIteratorKeepalive(scrollKeepalive).build();
     }
 
     /**

--- a/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
+++ b/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
@@ -905,10 +905,13 @@ public class ElasticsearchIO {
      * Configures the source to user Point In Time search iteration while reading data from
      * Elasticsearch. See <a
      * href="https://www.elastic.co/guide/en/elasticsearch/reference/current/point-in-time-api.html">
-     * Point in time search.</a> This iteration mode for searches does not have the same size
-     * constrains the Scroll API have (slice counts, batch size or how deep the iteration is). By
-     * default this iteration mode will use the {@code @timestamp} meta property on the indexed
-     * documents to consistently retrieve the data when failures occur on an specific read work.
+     * Point in time search</a>, using default settings. This iteration mode for searches does not
+     * have the same size constrains the Scroll API have (slice counts, batch size or how deep the
+     * iteration is). By default this iteration mode will use the {@code @timestamp} meta property
+     * on the indexed documents to consistently retrieve the data when failures occur on an specific
+     * read work.
+     *
+     * <p>When using PIT searches the provided query should not be enclosed in curly brackets.
      *
      * @return a {@link PTransform} reading data from Elasticsearch.
      */
@@ -920,6 +923,13 @@ public class ElasticsearchIO {
           .build();
     }
 
+    /**
+     * Similar to {@link #withPointInTimeSearch() the default PIT search} but setting an existing
+     * timestamp based property name which Elasticsearch will use to sort for the results.
+     *
+     * @param timestampSortProperty the property name in the contained documents.
+     * @return a {@link PTransform} reading data from Elasticsearch.
+     */
     public Read withPointInTimeSearchAndTimestampSortProperty(String timestampSortProperty) {
       return builder()
           .setUsePITSearch(true)
@@ -928,6 +938,14 @@ public class ElasticsearchIO {
           .build();
     }
 
+    /**
+     * Similar to {@link #withPointInTimeSearch() the default PIT search} but setting a specific
+     * sorting configuration which Elasticsearch will use to sort for the results.
+     *
+     * @param sortConfiguration the full sorting configuration to be sent to Elasticsearch while
+     *     iterating on the results.
+     * @return a {@link PTransform} reading data from Elasticsearch.
+     */
     public Read withPointInTimeSearchAndSortConfiguration(String sortConfiguration) {
       return builder()
           .setUsePITSearch(true)
@@ -2352,7 +2370,9 @@ public class ElasticsearchIO {
 
       abstract Builder setUseStatefulBatches(boolean useStatefulBatches);
 
-      /** @deprecated Use {@link #setMaxParallelRequests} instead. */
+      /**
+       * @deprecated Use {@link #setMaxParallelRequests} instead.
+       */
       @Deprecated
       abstract Builder setMaxParallelRequestsPerWindow(int maxParallelRequestsPerWindow);
 

--- a/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
+++ b/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
@@ -220,7 +220,7 @@ public class ElasticsearchIO {
     // with big documents and still a good compromise for performances
     return new AutoValue_ElasticsearchIO_Read.Builder()
         .setWithMetadata(false)
-        .setIteratorKeepalive("5m")
+        .setScrollKeepalive("5m")
         .setBatchSize(100L)
         .setUsePITSearch(false)
         .build();
@@ -772,7 +772,7 @@ public class ElasticsearchIO {
 
     abstract boolean isWithMetadata();
 
-    abstract String getIteratorKeepalive();
+    abstract String getScrollKeepalive();
 
     abstract long getBatchSize();
 
@@ -792,7 +792,7 @@ public class ElasticsearchIO {
 
       abstract Builder setWithMetadata(boolean withMetadata);
 
-      abstract Builder setIteratorKeepalive(String iteratorKeepalive);
+      abstract Builder setScrollKeepalive(String scrollKeepalive);
 
       abstract Builder setBatchSize(long batchSize);
 
@@ -865,9 +865,9 @@ public class ElasticsearchIO {
      * @return a {@link PTransform} reading data from Elasticsearch.
      */
     public Read withScrollKeepalive(String scrollKeepalive) {
-      checkArgument(scrollKeepalive != null, "iteratorKeepalive can not be null");
-      checkArgument(!"0m".equals(scrollKeepalive), "iteratorKeepalive can not be 0m");
-      return builder().setIteratorKeepalive(scrollKeepalive).build();
+      checkArgument(scrollKeepalive != null, "scrollKeepalive can not be null");
+      checkArgument(!"0m".equals(scrollKeepalive), "scrollKeepalive can not be 0m");
+      return builder().setScrollKeepalive(scrollKeepalive).build();
     }
 
     /**
@@ -955,7 +955,7 @@ public class ElasticsearchIO {
       builder.addIfNotNull(DisplayData.item("query", getQuery()));
       builder.addIfNotNull(DisplayData.item("withMetadata", isWithMetadata()));
       builder.addIfNotNull(DisplayData.item("batchSize", getBatchSize()));
-      builder.addIfNotNull(DisplayData.item("iteratorKeepalive", getIteratorKeepalive()));
+      builder.addIfNotNull(DisplayData.item("scrollKeepalive", getScrollKeepalive()));
       builder.addIfNotNull(DisplayData.item("usePointInTimeSearch", getUsePITSearch()));
       getConnectionConfiguration().populateDisplayData(builder);
     }
@@ -1254,7 +1254,7 @@ public class ElasticsearchIO {
       }
       String endPoint = source.spec.getConnectionConfiguration().getSearchEndPoint();
       Map<String, String> params = new HashMap<>();
-      params.put("scroll", source.spec.getIteratorKeepalive());
+      params.put("scroll", source.spec.getScrollKeepalive());
       HttpEntity queryEntity = new NStringEntity(query, ContentType.APPLICATION_JSON);
       Request request = new Request("GET", endPoint);
       request.addParameters(params);
@@ -1267,7 +1267,7 @@ public class ElasticsearchIO {
       String requestBody =
           String.format(
               "{\"scroll\" : \"%s\",\"scroll_id\" : \"%s\"}",
-              source.spec.getIteratorKeepalive(), iteratorId);
+              source.spec.getScrollKeepalive(), iteratorId);
       HttpEntity scrollEntity = new NStringEntity(requestBody, ContentType.APPLICATION_JSON);
       Request request = new Request("GET", "/_search/scroll");
       request.addParameters(Collections.emptyMap());
@@ -1322,7 +1322,7 @@ public class ElasticsearchIO {
       String endPoint =
           String.format("/%s/_pit", source.spec.getConnectionConfiguration().getIndex());
       Map<String, String> params = new HashMap<>();
-      params.put("keep_alive", source.spec.getIteratorKeepalive());
+      params.put("keep_alive", source.spec.getScrollKeepalive());
       Request request = new Request("POST", endPoint);
       request.addParameters(params);
       return request;

--- a/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
+++ b/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
@@ -1415,7 +1415,11 @@ public class ElasticsearchIO {
         return false;
       }
       // we already opened the PIT search and are processing the search results
-      return readNextBatchAndReturnFirstDocument(searchResult);
+      boolean wasDocumentRead = readNextBatchAndReturnFirstDocument(searchResult);
+      if (wasDocumentRead && current != null) {
+        searchAfterProperty = extractSearchAfterFromDocument(current);
+      }
+      return wasDocumentRead;
     }
 
     @Override

--- a/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
+++ b/sdks/java/io/elasticsearch/src/main/java/org/apache/beam/sdk/io/elasticsearch/ElasticsearchIO.java
@@ -907,11 +907,9 @@ public class ElasticsearchIO {
      * href="https://www.elastic.co/guide/en/elasticsearch/reference/current/point-in-time-api.html">
      * Point in time search</a>, using default settings. This iteration mode for searches does not
      * have the same size constrains the Scroll API have (slice counts, batch size or how deep the
-     * iteration is). By default this iteration mode will use the {@code @timestamp} meta property
-     * on the indexed documents to consistently retrieve the data when failures occur on an specific
+     * iteration is). By default this iteration mode will use a {@code @timestamp} named property on
+     * the indexed documents to consistently retrieve the data when failures occur on an specific
      * read work.
-     *
-     * <p>When using PIT searches the provided query should not be enclosed in curly brackets.
      *
      * @return a {@link PTransform} reading data from Elasticsearch.
      */
@@ -927,7 +925,8 @@ public class ElasticsearchIO {
      * Similar to {@link #withPointInTimeSearch() the default PIT search} but setting an existing
      * timestamp based property name which Elasticsearch will use to sort for the results.
      *
-     * @param timestampSortProperty the property name in the contained documents.
+     * @param timestampSortProperty a property name found in the read documents containing a
+     *     timestamp-like value.
      * @return a {@link PTransform} reading data from Elasticsearch.
      */
     public Read withPointInTimeSearchAndTimestampSortProperty(String timestampSortProperty) {


### PR DESCRIPTION
This change adds a BoundedReader implementation based on the newer Point In Time search API (see [doc](https://www.elastic.co/guide/en/elasticsearch/reference/current/point-in-time-api.html)). This API is the recommended mode when reading data from large indexes that imply retrieving documents using deep iteration (more than 10000 hits per slice). 

This mode should be available for Elasticsearch clusters with version 8 and up. 

When using the default read implementation, based on Scrolls, when the index is big enough and the number of documents is large, the creation of slices with more than 10000 elements to be iterated would make the read operations to fail. Now, with the PIT implementation, this is not a problem since ES does not have to keep track of the whole state of the index while iterating, only the current window for the PIT iterator. 

Adding @lord-skinner from Elastic.co for visibility. 