### PR TITLE
[yaml] add --providers and --providers_file flags

### DIFF
--- a/sdks/python/apache_beam/yaml/main.py
+++ b/sdks/python/apache_beam/yaml/main.py
@@ -23,6 +23,7 @@ import apache_beam as beam
 from apache_beam.io.filesystems import FileSystems
 from apache_beam.typehints.schemas import LogicalType
 from apache_beam.typehints.schemas import MillisInstant
+from apache_beam.yaml import yaml_provider
 from apache_beam.yaml import yaml_transform
 
 # Workaround for https://github.com/apache/beam/issues/28151.
@@ -45,6 +46,11 @@ def _configure_parser(argv):
       help='none: do no pipeline validation against the schema; '
       'generic: validate the pipeline shape, but not individual transforms; '
       'per_transform: also validate the config of known transforms')
+  parser.add_argument(
+      '--providers', help='A yaml description of the providers to attach.')
+  parser.add_argument(
+      '--providers_file',
+      help='A file containing a yaml description of the providers to attach.')
   return parser.parse_known_args(argv)
 
 
@@ -64,10 +70,25 @@ def _pipeline_spec_from_args(known_args):
   return pipeline_yaml
 
 
+def _provider_spec_from_args(known_args):
+  if known_args.providers_file and known_args.providers:
+    raise ValueError("Only one of providers or providers_file can be set.")
+  elif known_args.providers_file:
+    with FileSystems.open(known_args.providers_file) as fin:
+      provider_spec = yaml.load(
+          fin.read().decode(), Loader=yaml_transform.SafeLineLoader)
+      return yaml_provider.parse_providers(provider_spec)
+  elif known_args.providers:
+    return known_args.providers
+
+  return None
+
+
 def run(argv=None):
   known_args, pipeline_args = _configure_parser(argv)
   pipeline_yaml = _pipeline_spec_from_args(known_args)
   pipeline_spec = yaml.load(pipeline_yaml, Loader=yaml_transform.SafeLineLoader)
+  provider_spec = _provider_spec_from_args(known_args)
 
   with beam.Pipeline(  # linebreak for better yapf formatting
       options=beam.options.pipeline_options.PipelineOptions(
@@ -78,7 +99,10 @@ def run(argv=None):
       display_data={'yaml': pipeline_yaml}) as p:
     print("Building pipeline...")
     yaml_transform.expand_pipeline(
-        p, pipeline_spec, validate_schema=known_args.json_schema_validation)
+        p,
+        pipeline_spec,
+        providers=provider_spec,
+        validate_schema=known_args.json_schema_validation)
     print("Running pipeline...")
 
 


### PR DESCRIPTION
Allows a user to separate the pipeline spec from the providers spec.

This is particularly useful when creating a catalog of transforms that is defined in a shared file that can be passed as an argument for multiple pipelines that utilize the transforms without the need to redefine and version control the providers.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
