### PR TITLE
[Test only] Introduce checkpointtimeout

### DIFF
--- a/sdks/java/io/jms/build.gradle
+++ b/sdks/java/io/jms/build.gradle
@@ -48,3 +48,4 @@ dependencies {
   testRuntimeOnly library.java.slf4j_jdk14
   testRuntimeOnly project(path: ":runners:direct-java", configuration: "shadow")
 }
+test.outputs.upToDateWhen {false}

--- a/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsCheckpointMark.java
+++ b/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsCheckpointMark.java
@@ -58,7 +58,11 @@ class JmsCheckpointMark implements UnboundedSource.CheckpointMark, Serializable 
 
   /** Acknowledge all outstanding message. */
   @Override
-  public void finalizeCheckpoint() {
+  public synchronized void finalizeCheckpoint() {
+    closeSession();
+  }
+
+  synchronized void closeSession() {
     try {
       // Jms spec will implicitly acknowledge _all_ messaged already received by the same
       // session if one message in this session is being acknowledged.

--- a/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOIT.java
+++ b/sdks/java/io/jms/src/test/java/org/apache/beam/sdk/io/jms/JmsIOIT.java
@@ -116,7 +116,7 @@ public class JmsIOIT implements Serializable {
     void setLocalJmsBrokerEnabled(boolean isEnabled);
 
     @Description("JMS Read Timeout in seconds")
-    @Default.Integer(30)
+    @Default.Integer(180)
     Integer getReadTimeout();
 
     void setReadTimeout(Integer timeout);


### PR DESCRIPTION
Test only, attempt to fix https://github.com/apache/beam/pull/30218#issuecomment-2037429676

However, found that if the checkpoint can expire, the messages unacked will get redelivered, but the new checkpoint won't finalize either, causing repetitive redeliver and duplicate messages.

I now think the underlying issue is that finalizing checkpoint is not guaranteed to happen timely. This is work as expected. Expiring outstanding checkpoint won't resolve the stucked messages when throughput is low given the asynchronous ack mechanism.

Thus, another option is to expose "Auto acknowledge" client option to JmsIO to retain the previous behavior, however, data loss is possible, as in previous implementation 

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
