### PR TITLE
Correct the version spec

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -431,7 +431,7 @@ if __name__ == '__main__':
               'psycopg2-binary>=2.8.5,<3.0.0',
               'testcontainers[mysql]>=3.0.3,<4.0.0',
               'cryptography>=41.0.2',
-              'hypothesis>5.0.0,<=7.0.0',
+              'hypothesis>5.0.0,<7.0.0',
           ],
           'gcp': [
               'cachetools>=3.1.0,<6',


### PR DESCRIPTION
It is incorrect to use `<=` in this case, see: https://cwiki.apache.org/confluence/display/BEAM/Dependency+management+guidelines+for+Beam+Python+SDK+maintainers