### PR TITLE
Implement LengthPrefixCoder.to_type_hint

### DIFF
--- a/sdks/python/apache_beam/coders/coders.py
+++ b/sdks/python/apache_beam/coders/coders.py
@@ -242,9 +242,10 @@ class Coder(object):
     return self.__dict__
 
   def to_type_hint(self):
-    raise NotImplementedError(
-        'https://github.com/apache/beam/issues/18490: %s' %
-        self.__class__.__name__)
+    # TODO: After https://github.com/apache/beam/issues/18490 we should be
+    # able to infer the type hint rather than require every subclass define
+    # it
+    raise NotImplementedError
 
   @classmethod
   def from_type_hint(cls, unused_typehint, unused_registry):
@@ -1481,6 +1482,9 @@ class LengthPrefixCoder(FastCoder):
 
   def __hash__(self):
     return hash((type(self), self._value_coder))
+
+  def to_type_hint(length_prefix_coder):
+    return length_prefix_coder.value_coder().to_type_hint()
 
 
 Coder.register_structured_urn(

--- a/sdks/python/apache_beam/coders/coders_test.py
+++ b/sdks/python/apache_beam/coders/coders_test.py
@@ -236,6 +236,12 @@ class NullableCoderTest(unittest.TestCase):
       nondeterministic.as_deterministic_coder('label')
 
 
+class LengthPrefixCoderTest(unittest.TestCase):
+  def test_to_type_hint(self):
+    coder = coders.LengthPrefixCoder(coders.BytesCoder())
+    assert coder.to_type_hint() is bytes
+
+
 if __name__ == '__main__':
   logging.getLogger().setLevel(logging.INFO)
   unittest.main()


### PR DESCRIPTION
(Duplicate of another [PR](https://github.com/apache/beam/pull/30559) but without rebase issues)
LengthPrefixCoder doesn't define to_type_hint even though it seems pretty well defined. I've implemented it by just inferring it from its value coder.

Motivating use case - we have some debug tools that infer the types of pcollections based on to_type_hint. The LPCoder is used in a lot of places.

Bonus/unrelated change - I've pulled out the GitHub issue referenced in the NotImplementedError raised by to_type_hint. Every time I run into this error, I check the github issue and get more confused. It doesn't seem useful to refer to it in the error message, but does still seem relevant, so I pulled it out into a comment.

Testing Done
I haven't actually run the new unit test I wrote since I'm struggling to get my python sdk dev environment up (I've posted on the dev@ mailing list). Hoping the GH Action can just do it for me :)