### PR TITLE
merging non-canonical environments fails

### DIFF
--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -1998,10 +1998,18 @@ def merge_common_environments(pipeline_proto, inplace=False):
     pipeline_proto = copy.copy(pipeline_proto)
 
   for t in pipeline_proto.components.transforms.values():
-    if t.environment_id in environment_remappings:
+    if t.environment_id not in pipeline_proto.components.environments:
+      # TODO(https://github.com/apache/beam/issues/30876): Remove this
+      #  workaround.
+      continue
+    if t.environment_id:
       t.environment_id = environment_remappings[t.environment_id]
   for w in pipeline_proto.components.windowing_strategies.values():
-    if w.environment_id in environment_remappings:
+    if w.environment_id not in pipeline_proto.components.environments:
+      # TODO(https://github.com/apache/beam/issues/30876): Remove this
+      #  workaround.
+      continue
+    if w.environment_id:
       w.environment_id = environment_remappings[w.environment_id]
   for e in set(pipeline_proto.components.environments.keys()) - set(
       environment_remappings.values()):

--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -1981,28 +1981,27 @@ def merge_common_environments(pipeline_proto, inplace=False):
             base_env_key(e)
             for e in environments.expand_anyof_environments(env)))
 
-  cannonical_enviornments = collections.defaultdict(list)
+  canonical_environments = collections.defaultdict(list)
   for env_id, env in pipeline_proto.components.environments.items():
-    cannonical_enviornments[env_key(env)].append(env_id)
+    canonical_environments[env_key(env)].append(env_id)
 
-  if len(cannonical_enviornments) == len(
-      pipeline_proto.components.environments):
+  if len(canonical_environments) == len(pipeline_proto.components.environments):
     # All environments are already sufficiently distinct.
     return pipeline_proto
 
   environment_remappings = {
       e: es[0]
-      for es in cannonical_enviornments.values() for e in es
+      for es in canonical_environments.values() for e in es
   }
 
   if not inplace:
     pipeline_proto = copy.copy(pipeline_proto)
 
   for t in pipeline_proto.components.transforms.values():
-    if t.environment_id:
+    if t.environment_id in environment_remappings:
       t.environment_id = environment_remappings[t.environment_id]
   for w in pipeline_proto.components.windowing_strategies.values():
-    if w.environment_id:
+    if w.environment_id in environment_remappings:
       w.environment_id = environment_remappings[w.environment_id]
   for e in set(pipeline_proto.components.environments.keys()) - set(
       environment_remappings.values()):


### PR DESCRIPTION
There are cases where environments are specified at the transform/windowing level that are not included in the top-level components' environments.

This is particularly present when running sql-backed provider on multiple inputs (i.e. when joining 2 pcollections) in Beam YAML which creates 2 default environments, but only declares one in the proto.components.environments section.

Perhaps the real issue lies in how Beam YAML providers create transforms, but this is a nice safeguard regardless.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
