### PR TITLE
Support FLOAT32 type in Spanner

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/MutationSizeEstimator.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/MutationSizeEstimator.java
@@ -106,6 +106,8 @@ class MutationSizeEstimator {
     switch (v.getType().getCode()) {
       case BOOL:
         return 1;
+      case FLOAT32:
+        return 4;
       case INT64:
       case FLOAT64:
       case ENUM:
@@ -142,6 +144,8 @@ class MutationSizeEstimator {
     switch (v.getType().getArrayElementType().getCode()) {
       case BOOL:
         return v.getBoolArray().size();
+      case FLOAT32:
+        return 4L * v.getFloat32Array().size();
       case INT64:
       case ENUM:
         return 8L * v.getInt64Array().size();

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/MutationUtils.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/MutationUtils.java
@@ -207,12 +207,7 @@ final class MutationUtils {
         mutationBuilder.set(columnName).to(row.getInt64(columnName));
         break;
       case FLOAT:
-        @Nullable Float floatValue = row.getFloat(columnName);
-        if (floatValue == null) {
-          mutationBuilder.set(columnName).to(((Double) null));
-        } else {
-          mutationBuilder.set(columnName).to(floatValue);
-        }
+        mutationBuilder.set(columnName).to(row.getFloat(columnName));
         break;
       case DOUBLE:
         mutationBuilder.set(columnName).to(row.getDouble(columnName));
@@ -311,6 +306,8 @@ final class MutationUtils {
         mutationBuilder.set(column).toInt64Array((Iterable<Long>) ((Object) iterable));
         break;
       case FLOAT:
+        mutationBuilder.set(column).toFloat32Array((Iterable<Float>) ((Object) iterable));
+        break;
       case DOUBLE:
         mutationBuilder.set(column).toFloat64Array((Iterable<Double>) ((Object) iterable));
         break;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerSchema.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerSchema.java
@@ -172,6 +172,9 @@ public abstract class SpannerSchema implements Serializable {
           if ("INT64".equals(spannerType)) {
             return Type.int64();
           }
+          if ("FLOAT32".equals(spannerType)) {
+            return Type.float32();
+          }
           if ("FLOAT64".equals(spannerType)) {
             return Type.float64();
           }
@@ -226,6 +229,9 @@ public abstract class SpannerSchema implements Serializable {
           }
           if ("BIGINT".equals(spannerType)) {
             return Type.int64();
+          }
+          if ("REAL".equals(spannerType)) {
+            return Type.float32();
           }
           if ("DOUBLE PRECISION".equals(spannerType)) {
             return Type.float64();

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/StructUtils.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/StructUtils.java
@@ -76,12 +76,7 @@ final class StructUtils {
               addIterableToStructBuilder(structBuilder, row.getIterable(column), field);
               break;
             case FLOAT:
-              @Nullable Float floatValue = row.getFloat(column);
-              if (floatValue == null) {
-                structBuilder.set(column).to((Double) null);
-              } else {
-                structBuilder.set(column).to(floatValue);
-              }
+              structBuilder.set(column).to(row.getFloat(column));
               break;
             case DOUBLE:
               structBuilder.set(column).to(row.getDouble(column));
@@ -187,8 +182,9 @@ final class StructUtils {
       case INT16:
         return Type.int64();
       case DOUBLE:
-      case FLOAT:
         return Type.float64();
+      case FLOAT:
+        return Type.float32();
       case DECIMAL:
         return Type.numeric();
       case STRING:
@@ -242,6 +238,8 @@ final class StructUtils {
         structBuilder.set(column).toInt64Array((Iterable<Long>) ((Object) iterable));
         break;
       case FLOAT:
+        structBuilder.set(column).toFloat32Array((Iterable<Float>) ((Object) iterable));
+        break;
       case DOUBLE:
         structBuilder.set(column).toFloat64Array((Iterable<Double>) ((Object) iterable));
         break;
@@ -306,6 +304,8 @@ final class StructUtils {
         return DateTime.parse(struct.getDate(column).toString());
       case INT64:
         return struct.getLong(column);
+      case FLOAT32:
+        return struct.getFloat(column);
       case FLOAT64:
         return struct.getDouble(column);
       case NUMERIC:
@@ -352,6 +352,8 @@ final class StructUtils {
             .collect(toList());
       case INT64:
         return struct.getLongList(column);
+      case FLOAT32:
+        return struct.getFloatList(column);
       case FLOAT64:
         return struct.getDoubleList(column);
       case STRING:

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/MutationSizeEstimatorTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/MutationSizeEstimatorTest.java
@@ -45,6 +45,7 @@ public class MutationSizeEstimatorTest {
   @Test
   public void primitives() throws Exception {
     Mutation int64 = Mutation.newInsertOrUpdateBuilder("test").set("one").to(1).build();
+    Mutation float32 = Mutation.newInsertOrUpdateBuilder("test").set("one").to(1.3f).build();
     Mutation float64 = Mutation.newInsertOrUpdateBuilder("test").set("one").to(2.9).build();
     Mutation bool = Mutation.newInsertOrUpdateBuilder("test").set("one").to(false).build();
     Mutation numeric =
@@ -72,6 +73,7 @@ public class MutationSizeEstimatorTest {
             .build();
 
     assertThat(MutationSizeEstimator.sizeOf(int64), is(8L));
+    assertThat(MutationSizeEstimator.sizeOf(float32), is(4L));
     assertThat(MutationSizeEstimator.sizeOf(float64), is(8L));
     assertThat(MutationSizeEstimator.sizeOf(bool), is(1L));
     assertThat(MutationSizeEstimator.sizeOf(numeric), is(30L));
@@ -88,6 +90,11 @@ public class MutationSizeEstimatorTest {
         Mutation.newInsertOrUpdateBuilder("test")
             .set("one")
             .toInt64Array(new long[] {1L, 2L, 3L})
+            .build();
+    Mutation float32 =
+        Mutation.newInsertOrUpdateBuilder("test")
+            .set("one")
+            .toFloat32Array(new float[] {1.0f, 2.0f})
             .build();
     Mutation float64 =
         Mutation.newInsertOrUpdateBuilder("test")
@@ -160,6 +167,7 @@ public class MutationSizeEstimatorTest {
                 "customer.app.TestMessage")
             .build();
     assertThat(MutationSizeEstimator.sizeOf(int64), is(24L));
+    assertThat(MutationSizeEstimator.sizeOf(float32), is(8L));
     assertThat(MutationSizeEstimator.sizeOf(float64), is(16L));
     assertThat(MutationSizeEstimator.sizeOf(bool), is(4L));
     assertThat(MutationSizeEstimator.sizeOf(numeric), is(153L));
@@ -180,6 +188,8 @@ public class MutationSizeEstimatorTest {
             .set("one")
             .toProtoEnumArray(null, "customer.app.TestEnum")
             .build();
+    Mutation float32 =
+        Mutation.newInsertOrUpdateBuilder("test").set("one").toFloat32Array((float[]) null).build();
     Mutation float64 =
         Mutation.newInsertOrUpdateBuilder("test")
             .set("one")
@@ -202,6 +212,7 @@ public class MutationSizeEstimatorTest {
         Mutation.newInsertOrUpdateBuilder("test").set("one").toPgJsonbArray(null).build();
 
     assertThat(MutationSizeEstimator.sizeOf(int64), is(0L));
+    assertThat(MutationSizeEstimator.sizeOf(float32), is(0L));
     assertThat(MutationSizeEstimator.sizeOf(float64), is(0L));
     assertThat(MutationSizeEstimator.sizeOf(bool), is(0L));
     assertThat(MutationSizeEstimator.sizeOf(numeric), is(0L));
@@ -384,12 +395,13 @@ public class MutationSizeEstimatorTest {
   @Test
   public void group() throws Exception {
     Mutation int64 = Mutation.newInsertOrUpdateBuilder("test").set("one").to(1).build();
+    Mutation float32 = Mutation.newInsertOrUpdateBuilder("test").set("one").to(1.3f).build();
     Mutation float64 = Mutation.newInsertOrUpdateBuilder("test").set("one").to(2.9).build();
     Mutation bool = Mutation.newInsertOrUpdateBuilder("test").set("one").to(false).build();
 
-    MutationGroup group = MutationGroup.create(int64, float64, bool);
+    MutationGroup group = MutationGroup.create(int64, float32, float64, bool);
 
-    assertThat(MutationSizeEstimator.sizeOf(group), is(17L));
+    assertThat(MutationSizeEstimator.sizeOf(group), is(21L));
   }
 
   @Test

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/MutationUtilsTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/MutationUtilsTest.java
@@ -48,6 +48,7 @@ public class MutationUtilsTest {
   private static final Schema WRITE_ROW_SCHEMA =
       Schema.builder()
           .addNullableField("f_int64", Schema.FieldType.INT64)
+          .addNullableField("f_float32", Schema.FieldType.FLOAT)
           .addNullableField("f_float64", Schema.FieldType.DOUBLE)
           .addNullableField("f_string", Schema.FieldType.STRING)
           .addNullableField("f_bytes", Schema.FieldType.BYTES)
@@ -56,6 +57,7 @@ public class MutationUtilsTest {
           .addNullableField("f_struct", Schema.FieldType.row(EMPTY_SCHEMA))
           .addNullableField("f_struct_int64", Schema.FieldType.row(INT64_SCHEMA))
           .addNullableField("f_array", Schema.FieldType.array(Schema.FieldType.INT64))
+          .addNullableField("f_float_array", Schema.FieldType.array(Schema.FieldType.FLOAT))
           .addNullableField("f_double_array", Schema.FieldType.array(Schema.FieldType.DOUBLE))
           .addNullableField("f_decimal_array", Schema.FieldType.array(Schema.FieldType.DECIMAL))
           .addNullableField("f_boolean_array", Schema.FieldType.array(Schema.FieldType.BOOLEAN))
@@ -66,7 +68,6 @@ public class MutationUtilsTest {
               "f_struct_array", Schema.FieldType.array(Schema.FieldType.row(INT64_SCHEMA)))
           .addNullableField("f_int16", Schema.FieldType.INT16)
           .addNullableField("f_int32", Schema.FieldType.INT32)
-          .addNullableField("f_float", Schema.FieldType.FLOAT)
           .addNullableField("f_decimal", Schema.FieldType.DECIMAL)
           .addNullableField("f_byte", Schema.FieldType.BYTE)
           .addNullableField("f_iterable", Schema.FieldType.iterable(Schema.FieldType.INT64))
@@ -75,6 +76,7 @@ public class MutationUtilsTest {
   private static final Row WRITE_ROW =
       Row.withSchema(WRITE_ROW_SCHEMA)
           .withFieldValue("f_int64", 1L)
+          .withFieldValue("f_float32", 2.1f)
           .withFieldValue("f_float64", 1.1)
           .withFieldValue("f_string", "donald_duck")
           .withFieldValue("f_bytes", "some_bytes".getBytes(UTF_8))
@@ -83,6 +85,7 @@ public class MutationUtilsTest {
           .withFieldValue("f_struct", EMPTY_ROW)
           .withFieldValue("f_struct_int64", INT64_ROW)
           .withFieldValue("f_array", ImmutableList.of(2L, 3L))
+          .withFieldValue("f_float_array", ImmutableList.of(3.0f, 4.0f))
           .withFieldValue("f_double_array", ImmutableList.of(1., 2.))
           .withFieldValue(
               "f_decimal_array",
@@ -101,7 +104,6 @@ public class MutationUtilsTest {
           .withFieldValue("f_struct_array", ImmutableList.of(INT64_ROW, INT64_ROW))
           .withFieldValue("f_int16", (short) 2)
           .withFieldValue("f_int32", 0x7fffffff)
-          .withFieldValue("f_float", 0.0f)
           .withFieldValue("f_decimal", BigDecimal.valueOf(Long.MIN_VALUE))
           .withFieldValue("f_byte", Byte.parseByte("127"))
           .withFieldValue("f_iterable", ImmutableList.of(2L, 3L))
@@ -110,6 +112,7 @@ public class MutationUtilsTest {
   private static final Schema WRITE_ROW_SCHEMA_NULLS =
       Schema.builder()
           .addNullableField("f_int64", Schema.FieldType.INT64)
+          .addNullableField("f_float32", Schema.FieldType.FLOAT)
           .addNullableField("f_float64", Schema.FieldType.DOUBLE)
           .addNullableField("f_string", Schema.FieldType.STRING)
           .addNullableField("f_bytes", Schema.FieldType.BYTES)
@@ -134,11 +137,13 @@ public class MutationUtilsTest {
           .addValue(null)
           .addValue(null)
           .addValue(null)
+          .addValue(null)
           .build();
 
   private static final Schema KEY_SCHEMA =
       Schema.builder()
           .addNullableField("f_int64", Schema.FieldType.INT64)
+          .addNullableField("f_float32", Schema.FieldType.FLOAT)
           .addNullableField("f_float64", Schema.FieldType.DOUBLE)
           .addNullableField("f_string", Schema.FieldType.STRING)
           .addNullableField("f_bytes", Schema.FieldType.BYTES)
@@ -146,7 +151,6 @@ public class MutationUtilsTest {
           .addNullableField("f_bool", Schema.FieldType.BOOLEAN)
           .addNullableField("f_int16", Schema.FieldType.INT16)
           .addNullableField("f_int32", Schema.FieldType.INT32)
-          .addNullableField("f_float", Schema.FieldType.FLOAT)
           .addNullableField("f_decimal", Schema.FieldType.DECIMAL)
           .addNullableField("f_byte", Schema.FieldType.BYTE)
           .build();
@@ -154,6 +158,7 @@ public class MutationUtilsTest {
   private static final Row KEY_ROW =
       Row.withSchema(KEY_SCHEMA)
           .withFieldValue("f_int64", 1L)
+          .withFieldValue("f_float32", 2.1f)
           .withFieldValue("f_float64", 1.1)
           .withFieldValue("f_string", "donald_duck")
           .withFieldValue("f_bytes", "some_bytes".getBytes(UTF_8))
@@ -161,7 +166,6 @@ public class MutationUtilsTest {
           .withFieldValue("f_bool", false)
           .withFieldValue("f_int16", (short) 2)
           .withFieldValue("f_int32", 0x7fffffff)
-          .withFieldValue("f_float", 0.0f)
           .withFieldValue("f_decimal", BigDecimal.valueOf(Long.MIN_VALUE))
           .withFieldValue("f_byte", Byte.parseByte("127"))
           .build();
@@ -263,6 +267,7 @@ public class MutationUtilsTest {
     Key key =
         Key.newBuilder()
             .append(1L)
+            .append(2.1f)
             .append(1.1)
             .append("donald_duck")
             .append(ByteArray.copyFrom("some_bytes".getBytes(UTF_8)))
@@ -270,7 +275,6 @@ public class MutationUtilsTest {
             .append(false)
             .append((short) 2)
             .append(0x7fffffff)
-            .append(0.0f)
             .append(BigDecimal.valueOf(Long.MIN_VALUE))
             .append(Byte.parseByte("127"))
             .build();
@@ -295,6 +299,8 @@ public class MutationUtilsTest {
     return builder
         .set("f_int64")
         .to(1L)
+        .set("f_float32")
+        .to(2.1f)
         .set("f_float64")
         .to(1.1)
         .set("f_string")
@@ -311,6 +317,8 @@ public class MutationUtilsTest {
         .to(Struct.newBuilder().set("int64").to(3L).build())
         .set("f_array")
         .toInt64Array(ImmutableList.of(2L, 3L))
+        .set("f_float_array")
+        .toFloat32Array(ImmutableList.of(3.0f, 4.0f))
         .set("f_double_array")
         .toFloat64Array(ImmutableList.of(1., 2.))
         .set("f_decimal_array")
@@ -339,8 +347,6 @@ public class MutationUtilsTest {
         .to((short) 2)
         .set("f_int32")
         .to(0x7fffffff)
-        .set("f_float")
-        .to(0.0f)
         .set("f_decimal")
         .to(BigDecimal.valueOf(Long.MIN_VALUE))
         .set("f_byte")
@@ -355,6 +361,8 @@ public class MutationUtilsTest {
     return builder
         .set("f_int64")
         .to((Long) null)
+        .set("f_float32")
+        .to((Float) null)
         .set("f_float64")
         .to((Double) null)
         .set("f_string")

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/StructUtilsTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/StructUtilsTest.java
@@ -52,6 +52,7 @@ public class StructUtilsTest {
             .addDecimalField("f_decimal")
             .addArrayField("f_boolean_array", Schema.FieldType.BOOLEAN)
             .addArrayField("f_string_array", Schema.FieldType.STRING)
+            .addArrayField("f_float_array", Schema.FieldType.FLOAT)
             .addArrayField("f_double_array", Schema.FieldType.DOUBLE)
             .addArrayField("f_decimal_array", Schema.FieldType.DECIMAL)
             .addArrayField("f_date_array", Schema.FieldType.DATETIME)
@@ -64,6 +65,7 @@ public class StructUtilsTest {
             .withFieldValue("f_decimal", BigDecimal.valueOf(Long.MIN_VALUE))
             .withFieldValue("f_boolean_array", ImmutableList.of(false, true))
             .withFieldValue("f_string_array", ImmutableList.of("donald_duck", "micky_mouse"))
+            .withFieldValue("f_float_array", ImmutableList.of(3.0f, 4.0f))
             .withFieldValue("f_double_array", ImmutableList.of(1., 2.))
             .withFieldValue(
                 "f_decimal_array",
@@ -86,6 +88,8 @@ public class StructUtilsTest {
             .toBoolArray(ImmutableList.of(false, true))
             .set("f_string_array")
             .toStringArray(ImmutableList.of("donald_duck", "micky_mouse"))
+            .set("f_float_array")
+            .toFloat32Array(ImmutableList.of(3.0f, 4.0f))
             .set("f_double_array")
             .toFloat64Array(ImmutableList.of(1., 2.))
             .set("f_decimal_array")
@@ -133,10 +137,10 @@ public class StructUtilsTest {
         getSchemaTemplate()
             .addIterableField("f_iterable", Schema.FieldType.INT64)
             .addDecimalField("f_decimal")
-            .addFloatField("f_float")
             .addInt16Field("f_int16")
             .addInt32Field("f_int32")
             .addByteField("f_byte")
+            .addArrayField("f_float_array", Schema.FieldType.FLOAT)
             .addArrayField("f_double_array", Schema.FieldType.DOUBLE)
             .addArrayField("f_decimal_array", Schema.FieldType.DECIMAL)
             .addArrayField("f_boolean_array", Schema.FieldType.BOOLEAN)
@@ -148,10 +152,10 @@ public class StructUtilsTest {
         getRowTemplate(schema)
             .withFieldValue("f_iterable", ImmutableList.of(20L))
             .withFieldValue("f_decimal", BigDecimal.ONE)
-            .withFieldValue("f_float", 0.0f)
             .withFieldValue("f_int16", (short) 2)
             .withFieldValue("f_int32", 0x7fffffff)
             .withFieldValue("f_byte", Byte.parseByte("127"))
+            .withFieldValue("f_float_array", ImmutableList.of(3.0f, 4.0f))
             .withFieldValue("f_double_array", ImmutableList.of(1., 2.))
             .withFieldValue(
                 "f_decimal_array",
@@ -174,14 +178,14 @@ public class StructUtilsTest {
             .toInt64Array(ImmutableList.of(20L))
             .set("f_decimal")
             .to(BigDecimal.ONE)
-            .set("f_float")
-            .to(0.0f)
             .set("f_int16")
             .to((short) 2)
             .set("f_int32")
             .to(0x7fffffff)
             .set("f_byte")
             .to(Byte.parseByte("127"))
+            .set("f_float_array")
+            .toFloat32Array(ImmutableList.of(3.0f, 4.0f))
             .set("f_double_array")
             .toFloat64Array(ImmutableList.of(1., 2.))
             .set("f_decimal_array")
@@ -246,7 +250,7 @@ public class StructUtilsTest {
     assertEquals(Type.int64(), beamTypeToSpannerType(Schema.FieldType.BYTE));
     assertEquals(Type.bytes(), beamTypeToSpannerType(Schema.FieldType.BYTES));
     assertEquals(Type.string(), beamTypeToSpannerType(Schema.FieldType.STRING));
-    assertEquals(Type.float64(), beamTypeToSpannerType(Schema.FieldType.FLOAT));
+    assertEquals(Type.float32(), beamTypeToSpannerType(Schema.FieldType.FLOAT));
     assertEquals(Type.float64(), beamTypeToSpannerType(Schema.FieldType.DOUBLE));
     assertEquals(Type.bool(), beamTypeToSpannerType(Schema.FieldType.BOOLEAN));
     assertEquals(Type.numeric(), beamTypeToSpannerType(Schema.FieldType.DECIMAL));
@@ -261,6 +265,7 @@ public class StructUtilsTest {
   private Schema.Builder getSchemaTemplate() {
     return Schema.builder()
         .addNullableField("f_int64", Schema.FieldType.INT64)
+        .addNullableField("f_float32", Schema.FieldType.FLOAT)
         .addNullableField("f_float64", Schema.FieldType.DOUBLE)
         .addNullableField("f_string", Schema.FieldType.STRING)
         .addNullableField("f_bytes", Schema.FieldType.BYTES)
@@ -276,6 +281,7 @@ public class StructUtilsTest {
   private Row.FieldValueBuilder getRowTemplate(Schema schema) {
     return Row.withSchema(schema)
         .withFieldValue("f_int64", 1L)
+        .withFieldValue("f_float32", 2.1f)
         .withFieldValue("f_float64", 5.5)
         .withFieldValue("f_string", "ducky_doo")
         .withFieldValue("f_bytes", ByteArray.copyFrom("random_bytes".getBytes(UTF_8)).toByteArray())
@@ -303,6 +309,7 @@ public class StructUtilsTest {
         .addValue(null)
         .addValue(null)
         .addValue(null)
+        .addValue(null)
         .addValue(null);
   }
 
@@ -310,6 +317,8 @@ public class StructUtilsTest {
     return Struct.newBuilder()
         .set("f_int64")
         .to(1L)
+        .set("f_float32")
+        .to(2.1f)
         .set("f_float64")
         .to(5.5)
         .set("f_string")
@@ -340,6 +349,8 @@ public class StructUtilsTest {
     return Struct.newBuilder()
         .set("f_int64")
         .to((Long) null)
+        .set("f_float32")
+        .to((Float) null)
         .set("f_float64")
         .to((Double) null)
         .set("f_string")


### PR DESCRIPTION
Adds support for the newly added FLOAT32 type in Google Cloud Spanner.

Since FLOAT was already mapped to FLOAT64, this change modifies the existing mapping to FLOAT -> FLOAT32 instead.

Addresses #30700.

Please ignore the commit bumping the BOM version to 26.36.0. This is already being done as part of #30868 

------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

