### PR TITLE
[#30870]: support consumer polling timeout in KafkaIO expansion service

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -831,6 +831,17 @@ public class KafkaIO {
         // We can expose dynamic read to external build when ReadFromKafkaDoFn is the default
         // implementation.
         builder.setDynamicRead(false);
+
+        if(config.consumerPollingTimeoutSeconds != null) {
+          if(config.consumerPollingTimeoutSeconds <= 0) {
+            throw new IllegalArgumentException("consumerPollingTimeoutSeconds should be > 0.");
+          }
+          builder.setConsumerPollingTimeout(
+              Duration.standardSeconds(config.consumerPollingTimeoutSeconds));
+        } else {
+          builder.setConsumerPollingTimeout(
+              Duration.standardSeconds(2L));
+        }
       }
 
       private static <T> Coder<T> resolveCoder(Class<Deserializer<T>> deserializer) {
@@ -893,6 +904,7 @@ public class KafkaIO {
         private Long maxNumRecords;
         private Long maxReadTime;
         private Boolean commitOffsetInFinalize;
+        private Long consumerPollingTimeoutSeconds;
         private String timestampPolicy;
 
         public void setConsumerConfig(Map<String, String> consumerConfig) {
@@ -933,6 +945,10 @@ public class KafkaIO {
 
         public void setTimestampPolicy(String timestampPolicy) {
           this.timestampPolicy = timestampPolicy;
+        }
+
+        public void setConsumerPollingTimeoutSeconds(Long consumerPollingTimeoutSeconds) {
+          this.consumerPollingTimeoutSeconds = consumerPollingTimeoutSeconds;
         }
       }
     }
@@ -1342,7 +1358,7 @@ public class KafkaIO {
 
     /**
      * Sets the timeout time for Kafka consumer polling request in the {@link ReadFromKafkaDoFn}.
-     * The default is 2 second.
+     * The default is 2 seconds.
      */
     public Read<K, V> withConsumerPollingTimeout(Duration duration) {
       checkState(
@@ -2387,7 +2403,7 @@ public class KafkaIO {
 
     /**
      * Sets the timeout time for Kafka consumer polling request in the {@link ReadFromKafkaDoFn}.
-     * The default is 2 second.
+     * The default is 2 seconds.
      */
     public ReadSourceDescriptors<K, V> withConsumerPollingTimeout(@Nullable Duration duration) {
       return toBuilder().setConsumerPollingTimeout(duration).build();

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -2402,6 +2402,8 @@ public class KafkaIO {
 
     /**
      * Sets the timeout time for Kafka consumer polling request in the {@link ReadFromKafkaDoFn}.
+     * A lower timeout optimizes for latency.
+     * Increase the timeout if the consumer is not fetching enough (or any) records. 
      * The default is 2 seconds.
      */
     public ReadSourceDescriptors<K, V> withConsumerPollingTimeout(@Nullable Duration duration) {

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -832,15 +832,14 @@ public class KafkaIO {
         // implementation.
         builder.setDynamicRead(false);
 
-        if(config.consumerPollingTimeoutSeconds != null) {
-          if(config.consumerPollingTimeoutSeconds <= 0) {
+        if (config.consumerPollingTimeoutSeconds != null) {
+          if (config.consumerPollingTimeoutSeconds <= 0) {
             throw new IllegalArgumentException("consumerPollingTimeoutSeconds should be > 0.");
           }
           builder.setConsumerPollingTimeout(
               Duration.standardSeconds(config.consumerPollingTimeoutSeconds));
         } else {
-          builder.setConsumerPollingTimeout(
-              Duration.standardSeconds(2L));
+          builder.setConsumerPollingTimeout(Duration.standardSeconds(2L));
         }
       }
 

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -1357,6 +1357,8 @@ public class KafkaIO {
 
     /**
      * Sets the timeout time for Kafka consumer polling request in the {@link ReadFromKafkaDoFn}.
+     * A lower timeout optimizes for latency.
+     * Increase the timeout if the consumer is not fetching enough (or any) records. 
      * The default is 2 seconds.
      */
     public Read<K, V> withConsumerPollingTimeout(Duration duration) {

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -832,12 +832,12 @@ public class KafkaIO {
         // implementation.
         builder.setDynamicRead(false);
 
-        if (config.consumerPollingTimeoutSeconds != null) {
-          if (config.consumerPollingTimeoutSeconds <= 0) {
-            throw new IllegalArgumentException("consumerPollingTimeoutSeconds should be > 0.");
+        if (config.consumerPollingTimeout != null) {
+          if (config.consumerPollingTimeout <= 0) {
+            throw new IllegalArgumentException("consumerPollingTimeout should be > 0.");
           }
           builder.setConsumerPollingTimeout(
-              Duration.standardSeconds(config.consumerPollingTimeoutSeconds));
+              Duration.standardSeconds(config.consumerPollingTimeout));
         } else {
           builder.setConsumerPollingTimeout(Duration.standardSeconds(2L));
         }
@@ -903,7 +903,7 @@ public class KafkaIO {
         private Long maxNumRecords;
         private Long maxReadTime;
         private Boolean commitOffsetInFinalize;
-        private Long consumerPollingTimeoutSeconds;
+        private Long consumerPollingTimeout;
         private String timestampPolicy;
 
         public void setConsumerConfig(Map<String, String> consumerConfig) {
@@ -946,8 +946,8 @@ public class KafkaIO {
           this.timestampPolicy = timestampPolicy;
         }
 
-        public void setConsumerPollingTimeoutSeconds(Long consumerPollingTimeoutSeconds) {
-          this.consumerPollingTimeoutSeconds = consumerPollingTimeoutSeconds;
+        public void setConsumerPollingTimeout(Long consumerPollingTimeout) {
+          this.consumerPollingTimeout = consumerPollingTimeout;
         }
       }
     }

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -1356,10 +1356,9 @@ public class KafkaIO {
     }
 
     /**
-     * Sets the timeout time for Kafka consumer polling request in the {@link ReadFromKafkaDoFn}.
-     * A lower timeout optimizes for latency.
-     * Increase the timeout if the consumer is not fetching enough (or any) records. 
-     * The default is 2 seconds.
+     * Sets the timeout time for Kafka consumer polling request in the {@link ReadFromKafkaDoFn}. A
+     * lower timeout optimizes for latency. Increase the timeout if the consumer is not fetching
+     * enough (or any) records. The default is 2 seconds.
      */
     public Read<K, V> withConsumerPollingTimeout(Duration duration) {
       checkState(
@@ -2403,10 +2402,9 @@ public class KafkaIO {
     }
 
     /**
-     * Sets the timeout time for Kafka consumer polling request in the {@link ReadFromKafkaDoFn}.
-     * A lower timeout optimizes for latency.
-     * Increase the timeout if the consumer is not fetching enough (or any) records. 
-     * The default is 2 seconds.
+     * Sets the timeout time for Kafka consumer polling request in the {@link ReadFromKafkaDoFn}. A
+     * lower timeout optimizes for latency. Increase the timeout if the consumer is not fetching
+     * enough (or any) records. The default is 2 seconds.
      */
     public ReadSourceDescriptors<K, V> withConsumerPollingTimeout(@Nullable Duration duration) {
       return toBuilder().setConsumerPollingTimeout(duration).build();

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOExternalTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOExternalTest.java
@@ -108,7 +108,7 @@ public class KafkaIOExternalTest {
                         Field.of("start_read_time", FieldType.INT64),
                         Field.of("commit_offset_in_finalize", FieldType.BOOLEAN),
                         Field.of("timestamp_policy", FieldType.STRING),
-                        Field.of("consumer_polling_timeout_seconds", FieldType.INT64)))
+                        Field.of("consumer_polling_timeout", FieldType.INT64)))
                 .withFieldValue("topics", topics)
                 .withFieldValue("consumer_config", consumerConfig)
                 .withFieldValue("key_deserializer", keyDeserializer)
@@ -116,7 +116,7 @@ public class KafkaIOExternalTest {
                 .withFieldValue("start_read_time", startReadTime)
                 .withFieldValue("commit_offset_in_finalize", false)
                 .withFieldValue("timestamp_policy", "ProcessingTime")
-                .withFieldValue("consumer_polling_timeout_seconds", 5L)
+                .withFieldValue("consumer_polling_timeout", 5L)
                 .build());
 
     RunnerApi.Components defaultInstance = RunnerApi.Components.getDefaultInstance();

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOExternalTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOExternalTest.java
@@ -107,7 +107,8 @@ public class KafkaIOExternalTest {
                         Field.of("value_deserializer", FieldType.STRING),
                         Field.of("start_read_time", FieldType.INT64),
                         Field.of("commit_offset_in_finalize", FieldType.BOOLEAN),
-                        Field.of("timestamp_policy", FieldType.STRING)))
+                        Field.of("timestamp_policy", FieldType.STRING),
+                        Field.of("consumer_polling_timeout_seconds", FieldType.INT64)))
                 .withFieldValue("topics", topics)
                 .withFieldValue("consumer_config", consumerConfig)
                 .withFieldValue("key_deserializer", keyDeserializer)
@@ -115,6 +116,7 @@ public class KafkaIOExternalTest {
                 .withFieldValue("start_read_time", startReadTime)
                 .withFieldValue("commit_offset_in_finalize", false)
                 .withFieldValue("timestamp_policy", "ProcessingTime")
+                .withFieldValue("consumer_polling_timeout_seconds", 5L)
                 .build());
 
     RunnerApi.Components defaultInstance = RunnerApi.Components.getDefaultInstance();
@@ -265,6 +267,7 @@ public class KafkaIOExternalTest {
     expansionService.expand(request, observer);
     ExpansionApi.ExpansionResponse result = observer.result;
     RunnerApi.PTransform transform = result.getTransform();
+
     assertThat(
         transform.getSubtransformsList(),
         Matchers.hasItem(MatchesPattern.matchesPattern(".*KafkaIO-Read.*")));

--- a/sdks/java/io/kafka/upgrade/src/test/java/org/apache/beam/sdk/io/kafka/upgrade/KafkaIOTranslationTest.java
+++ b/sdks/java/io/kafka/upgrade/src/test/java/org/apache/beam/sdk/io/kafka/upgrade/KafkaIOTranslationTest.java
@@ -75,7 +75,7 @@ public class KafkaIOTranslationTest {
     READ_TRANSFORM_SCHEMA_MAPPING.put(
         "getValueDeserializerProvider", "value_deserializer_provider");
     READ_TRANSFORM_SCHEMA_MAPPING.put("getCheckStopReadingFn", "check_stop_reading_fn");
-    READ_TRANSFORM_SCHEMA_MAPPING.put("getConsumerPollingTimeout", "consumer_polling_timeout")
+    READ_TRANSFORM_SCHEMA_MAPPING.put("getConsumerPollingTimeout", "consumer_polling_timeout");
   }
 
   // A mapping from Write transform builder methods to the corresponding schema fields in

--- a/sdks/java/io/kafka/upgrade/src/test/java/org/apache/beam/sdk/io/kafka/upgrade/KafkaIOTranslationTest.java
+++ b/sdks/java/io/kafka/upgrade/src/test/java/org/apache/beam/sdk/io/kafka/upgrade/KafkaIOTranslationTest.java
@@ -75,6 +75,7 @@ public class KafkaIOTranslationTest {
     READ_TRANSFORM_SCHEMA_MAPPING.put(
         "getValueDeserializerProvider", "value_deserializer_provider");
     READ_TRANSFORM_SCHEMA_MAPPING.put("getCheckStopReadingFn", "check_stop_reading_fn");
+    READ_TRANSFORM_SCHEMA_MAPPING.put("getConsumerPollingTimeout", "consumer_polling_timeout")
   }
 
   // A mapping from Write transform builder methods to the corresponding schema fields in

--- a/sdks/python/apache_beam/io/kafka.py
+++ b/sdks/python/apache_beam/io/kafka.py
@@ -94,7 +94,7 @@ ReadFromKafkaSchema = typing.NamedTuple(
      ('max_num_records', typing.Optional[int]),
      ('max_read_time', typing.Optional[int]),
      ('commit_offset_in_finalize', bool), ('timestamp_policy', str),
-     ('consumer_polling_timeout_seconds', typing.Optional[int])])
+     ('consumer_polling_timeout', typing.Optional[int])])
 
 
 def default_io_expansion_service(append_args=None):
@@ -135,7 +135,7 @@ class ReadFromKafka(ExternalTransform):
       max_read_time=None,
       commit_offset_in_finalize=False,
       timestamp_policy=processing_time_policy,
-      consumer_polling_timeout_seconds=None,
+      consumer_polling_timeout=None,
       with_metadata=False,
       expansion_service=None,
   ):
@@ -161,7 +161,7 @@ class ReadFromKafka(ExternalTransform):
     :param commit_offset_in_finalize: Whether to commit offsets when finalizing.
     :param timestamp_policy: The built-in timestamp policy which is used for
         extracting timestamp from KafkaRecord.
-    :param consumer_polling_timeout_seconds: Kafka client polling request
+    :param consumer_polling_timeout: Kafka client polling request
         timeout time in seconds. A lower timeout optimizes for latency. Increase                                   
         the timeout if the consumer is not fetching any records. Default is 2
         seconds.
@@ -193,8 +193,7 @@ class ReadFromKafka(ExternalTransform):
                 start_read_time=start_read_time,
                 commit_offset_in_finalize=commit_offset_in_finalize,
                 timestamp_policy=timestamp_policy,
-                consumer_polling_timeout_seconds=
-                consumer_polling_timeout_seconds
+                consumer_polling_timeout=consumer_polling_timeout
             )),
         expansion_service or default_io_expansion_service())
 

--- a/sdks/python/apache_beam/io/kafka.py
+++ b/sdks/python/apache_beam/io/kafka.py
@@ -193,8 +193,7 @@ class ReadFromKafka(ExternalTransform):
                 start_read_time=start_read_time,
                 commit_offset_in_finalize=commit_offset_in_finalize,
                 timestamp_policy=timestamp_policy,
-                consumer_polling_timeout=consumer_polling_timeout
-            )),
+                consumer_polling_timeout=consumer_polling_timeout)),
         expansion_service or default_io_expansion_service())
 
 

--- a/sdks/python/apache_beam/io/kafka.py
+++ b/sdks/python/apache_beam/io/kafka.py
@@ -191,7 +191,8 @@ class ReadFromKafka(ExternalTransform):
                 start_read_time=start_read_time,
                 commit_offset_in_finalize=commit_offset_in_finalize,
                 timestamp_policy=timestamp_policy,
-                consumer_polling_timeout_seconds=consumer_polling_timeout_seconds)),
+                consumer_polling_timeout_seconds=consumer_polling_timeout_seconds
+            )),
         expansion_service or default_io_expansion_service())
 
 

--- a/sdks/python/apache_beam/io/kafka.py
+++ b/sdks/python/apache_beam/io/kafka.py
@@ -93,7 +93,8 @@ ReadFromKafkaSchema = typing.NamedTuple(
      ('value_deserializer', str), ('start_read_time', typing.Optional[int]),
      ('max_num_records', typing.Optional[int]),
      ('max_read_time', typing.Optional[int]),
-     ('commit_offset_in_finalize', bool), ('timestamp_policy', str)])
+     ('commit_offset_in_finalize', bool), ('timestamp_policy', str),
+     ('consumer_polling_timeout_seconds', typing.Optional[int])])
 
 
 def default_io_expansion_service(append_args=None):
@@ -134,6 +135,7 @@ class ReadFromKafka(ExternalTransform):
       max_read_time=None,
       commit_offset_in_finalize=False,
       timestamp_policy=processing_time_policy,
+      consumer_polling_timeout_seconds=None,
       with_metadata=False,
       expansion_service=None,
   ):
@@ -159,6 +161,8 @@ class ReadFromKafka(ExternalTransform):
     :param commit_offset_in_finalize: Whether to commit offsets when finalizing.
     :param timestamp_policy: The built-in timestamp policy which is used for
         extracting timestamp from KafkaRecord.
+    :param consumer_polling_timeout_seconds: Kafka client polling request
+        timeout time in seconds. Default is 2 seconds.
     :param with_metadata: whether the returned PCollection should contain
         Kafka related metadata or not. If False (default), elements of the
         returned PCollection will be of type 'bytes' if True, elements of the
@@ -186,7 +190,8 @@ class ReadFromKafka(ExternalTransform):
                 max_read_time=max_read_time,
                 start_read_time=start_read_time,
                 commit_offset_in_finalize=commit_offset_in_finalize,
-                timestamp_policy=timestamp_policy)),
+                timestamp_policy=timestamp_policy,
+                consumer_polling_timeout_seconds=consumer_polling_timeout_seconds)),
         expansion_service or default_io_expansion_service())
 
 

--- a/sdks/python/apache_beam/io/kafka.py
+++ b/sdks/python/apache_beam/io/kafka.py
@@ -163,8 +163,8 @@ class ReadFromKafka(ExternalTransform):
         extracting timestamp from KafkaRecord.
     :param consumer_polling_timeout_seconds: Kafka client polling request
         timeout time in seconds. A lower timeout optimizes for latency. Increase                                   
-        the timeout if the consumer is not fetching enough (or any) records.                                                         
-        Default is 2 seconds.
+        the timeout if the consumer is not fetching any records. Default is 2
+        seconds.
     :param with_metadata: whether the returned PCollection should contain
         Kafka related metadata or not. If False (default), elements of the
         returned PCollection will be of type 'bytes' if True, elements of the
@@ -193,7 +193,8 @@ class ReadFromKafka(ExternalTransform):
                 start_read_time=start_read_time,
                 commit_offset_in_finalize=commit_offset_in_finalize,
                 timestamp_policy=timestamp_policy,
-                consumer_polling_timeout_seconds=consumer_polling_timeout_seconds
+                consumer_polling_timeout_seconds=
+                consumer_polling_timeout_seconds
             )),
         expansion_service or default_io_expansion_service())
 

--- a/sdks/python/apache_beam/io/kafka.py
+++ b/sdks/python/apache_beam/io/kafka.py
@@ -162,7 +162,9 @@ class ReadFromKafka(ExternalTransform):
     :param timestamp_policy: The built-in timestamp policy which is used for
         extracting timestamp from KafkaRecord.
     :param consumer_polling_timeout_seconds: Kafka client polling request
-        timeout time in seconds. Default is 2 seconds.
+        timeout time in seconds. A lower timeout optimizes for latency. Increase                                   
+        the timeout if the consumer is not fetching enough (or any) records.                                                         
+        Default is 2 seconds.
     :param with_metadata: whether the returned PCollection should contain
         Kafka related metadata or not. If False (default), elements of the
         returned PCollection will be of type 'bytes' if True, elements of the


### PR DESCRIPTION
addresses #30870. Previous PR (https://github.com/apache/beam/pull/30877) made consumer polling timeout configurable for KafkaIO.Read in Java SDK. This PR contains changes to make the same configurable for Python SDK with the new configuration variable: consumerPollingTimeoutSeconds., which must be greater than 0. If not specified, the default will be 2 second.

