### PR TITLE
Change ManagedSchemaTransformProvider to take a Row config

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/YamlUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/YamlUtilsTest.java
@@ -18,14 +18,17 @@
 package org.apache.beam.sdk.util;
 
 import static org.junit.Assert.assertEquals;
+import static org.junit.Assert.assertNull;
 
 import java.math.BigDecimal;
 import java.util.Arrays;
+import java.util.Map;
 import java.util.stream.Collectors;
 import java.util.stream.IntStream;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.utils.YamlUtils;
 import org.apache.beam.sdk.values.Row;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.CaseFormat;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.io.BaseEncoding;
 import org.junit.Rule;
 import org.junit.Test;
@@ -47,7 +50,7 @@ public class YamlUtilsTest {
   public void testEmptyYamlString() {
     Schema schema = Schema.builder().build();
 
-    assertEquals(Row.nullRow(schema), YamlUtils.toBeamRow("", schema));
+    assertNull(YamlUtils.toBeamRow("", schema));
   }
 
   @Test
@@ -224,5 +227,36 @@ public class YamlUtilsTest {
             .build();
 
     assertEquals(expectedRow, YamlUtils.toBeamRow(yamlString, schema));
+  }
+
+  private static final Schema FLAT_SCHEMA_CAMEL_CASE =
+      Schema.builder()
+          .addFields(
+              FLAT_SCHEMA.getFields().stream()
+                  .map(
+                      field ->
+                          field.withName(
+                              CaseFormat.LOWER_UNDERSCORE.to(
+                                  CaseFormat.LOWER_CAMEL, field.getName())))
+                  .collect(Collectors.toList()))
+          .build();
+
+  private static final Map<String, Object> FLAT_MAP =
+      FLAT_SCHEMA.getFields().stream()
+          .collect(
+              Collectors.toMap(
+                  Schema.Field::getName,
+                  field -> Preconditions.checkArgumentNotNull(FLAT_ROW.getValue(field.getName()))));
+
+  @Test
+  public void testSnakeCaseMapToCamelCaseRow() {
+    Row expectedRow =
+        FLAT_SCHEMA.getFields().stream()
+            .map(field -> Preconditions.checkStateNotNull(FLAT_ROW.getValue(field.getName())))
+            .collect(Row.toRow(FLAT_SCHEMA_CAMEL_CASE));
+
+    Row convertedRow = YamlUtils.toBeamRow(FLAT_MAP, FLAT_SCHEMA_CAMEL_CASE, true);
+
+    assertEquals(expectedRow, convertedRow);
   }
 }

--- a/sdks/java/managed/src/test/java/org/apache/beam/sdk/managed/ManagedSchemaTransformProviderTest.java
+++ b/sdks/java/managed/src/test/java/org/apache/beam/sdk/managed/ManagedSchemaTransformProviderTest.java
@@ -49,28 +49,27 @@ public class ManagedSchemaTransformProviderTest {
   }
 
   @Test
-  public void testGetRowFromYamlConfig() {
-    String yamlString = "extra_string: abc\n" + "extra_integer: 123";
-    ManagedConfig config =
-        ManagedConfig.builder()
-            .setTransformIdentifier(TestSchemaTransformProvider.IDENTIFIER)
-            .setConfig(yamlString)
-            .build();
-    Schema configSchema = new TestSchemaTransformProvider().configurationSchema();
-    Row expectedRow =
-        Row.withSchema(configSchema)
+  public void testGetConfigRow() {
+    Schema underlyingTransformSchema = new TestSchemaTransformProvider().configurationSchema();
+    Row configRow =
+        Row.withSchema(underlyingTransformSchema)
             .withFieldValue("extraString", "abc")
             .withFieldValue("extraInteger", 123)
             .build();
-    Row configRow =
-        ManagedSchemaTransformProvider.getRowConfig(
-            config, new TestSchemaTransformProvider().configurationSchema());
+    ManagedConfig config =
+        ManagedConfig.builder()
+            .setTransformIdentifier(TestSchemaTransformProvider.IDENTIFIER)
+            .setConfig(configRow)
+            .build();
 
-    assertEquals(expectedRow, configRow);
+    Row returnedRow =
+        ManagedSchemaTransformProvider.getRowConfig(config, underlyingTransformSchema);
+
+    assertEquals(configRow, returnedRow);
   }
 
   @Test
-  public void testGetRowFromConfigUrl() throws URISyntaxException {
+  public void testGetConfigRowFromYamlFile() throws URISyntaxException {
     String yamlConfigPath =
         Paths.get(getClass().getClassLoader().getResource("test_config.yaml").toURI())
             .toFile()


### PR DESCRIPTION
This is a small implementation detail change to make `ManagedSchemaTransformProvider` take a config represented as a Row instead of a YAML string. It makes more sense for xlang use-cases to send a Beam Row to configure the underlying transform rather than an inline Yaml string.

This PR makes no changes to the surface-level Managed Java API