### PR TITLE
Revert setuptools upperbound since buggy releases are yanked.

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -19,8 +19,7 @@
 # this is the minimum requirements for the build system to execute.
 [build-system]
 requires = [
-    # TODO: remove after setuptools bug resolved. https://github.com/apache/beam/issues/30955
-    "setuptools<69.3.0",
+    "setuptools",
     "wheel>=0.36.0",
     "grpcio-tools==1.62.1",
     "mypy-protobuf==3.5.0",


### PR DESCRIPTION
https://github.com/apache/beam/issues/30955
Reverts apache/beam#30956