### PR TITLE
Add ReadChangeStream IO param to adjust backlog estimates for replication delay

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dofn/ReadChangeStreamPartitionDoFn.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dofn/ReadChangeStreamPartitionDoFn.java
@@ -43,6 +43,7 @@ import org.apache.beam.sdk.transforms.splittabledofn.ManualWatermarkEstimator;
 import org.apache.beam.sdk.transforms.splittabledofn.RestrictionTracker;
 import org.apache.beam.sdk.transforms.splittabledofn.WatermarkEstimators.Manual;
 import org.apache.beam.sdk.values.KV;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
@@ -63,15 +64,32 @@ public class ReadChangeStreamPartitionDoFn
   private final DaoFactory daoFactory;
   private final ChangeStreamMetrics metrics;
   private final ActionFactory actionFactory;
+  private final Duration backlogReplicationAdjustment;
   private SizeEstimator<KV<ByteString, ChangeStreamRecord>> sizeEstimator;
   private ReadChangeStreamPartitionAction readChangeStreamPartitionAction;
+  private final SerializableSupplier<Instant> clock;
 
   public ReadChangeStreamPartitionDoFn(
-      DaoFactory daoFactory, ActionFactory actionFactory, ChangeStreamMetrics metrics) {
+      DaoFactory daoFactory,
+      ActionFactory actionFactory,
+      ChangeStreamMetrics metrics,
+      Duration backlogReplicationAdjustment) {
+    this(daoFactory, actionFactory, metrics, backlogReplicationAdjustment, Instant::now);
+  }
+
+  @VisibleForTesting
+  ReadChangeStreamPartitionDoFn(
+      DaoFactory daoFactory,
+      ActionFactory actionFactory,
+      ChangeStreamMetrics metrics,
+      Duration backlogReplicationAdjustment,
+      SerializableSupplier<Instant> clock) {
     this.daoFactory = daoFactory;
     this.metrics = metrics;
     this.actionFactory = actionFactory;
+    this.backlogReplicationAdjustment = backlogReplicationAdjustment;
     this.sizeEstimator = new NullSizeEstimator<>();
+    this.clock = clock;
   }
 
   @GetInitialWatermarkEstimatorState
@@ -126,12 +144,15 @@ public class ReadChangeStreamPartitionDoFn
     // this to count against the backlog and prevent scaling down, so we estimate heartbeat backlog
     // using the time we most recently processed a heartbeat. Otherwise, (for mutations) we use the
     // watermark.
-    Duration processingTimeLag =
-        Duration.millis(
-            Instant.now().getMillis() - streamProgress.getLastRunTimestamp().getMillis());
-    Duration watermarkLag = Duration.millis(Instant.now().getMillis() - lowWatermark.getMillis());
+    long processingTimeLagMillis =
+        clock.get().getMillis() - streamProgress.getLastRunTimestamp().getMillis();
+    Duration watermarkLag = Duration.millis(clock.get().getMillis() - lowWatermark.getMillis());
+    // Remove the backlogReplicationAdjustment from watermarkLag to allow replicated instances to
+    // downscale more easily.
+    long adjustedWatermarkLagMillis =
+        Math.max(0, watermarkLag.minus(backlogReplicationAdjustment).getMillis());
     long lagInMillis =
-        (streamProgress.isHeartbeat() ? processingTimeLag : watermarkLag).getMillis();
+        streamProgress.isHeartbeat() ? processingTimeLagMillis : adjustedWatermarkLagMillis;
     // Return the estimated bytes per second throughput multiplied by the amount of known work
     // outstanding (watermark lag). Cap at max double to avoid overflow.
     double estimatedSize =

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dofn/SerializableSupplier.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dofn/SerializableSupplier.java
@@ -1,0 +1,25 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.gcp.bigtable.changestreams.dofn;
+
+import java.io.Serializable;
+import java.util.function.Supplier;
+
+/** Union of Supplier and Serializable interfaces to allow serialized supplier for testing. */
+@FunctionalInterface
+interface SerializableSupplier<T> extends Supplier<T>, Serializable {}

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dofn/ReadChangeStreamPartitionDoFnTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dofn/ReadChangeStreamPartitionDoFnTest.java
@@ -58,20 +58,23 @@ public class ReadChangeStreamPartitionDoFnTest {
   private ChangeStreamDao changeStreamDao;
   private MetadataTableDao metadataTableDao;
   private CoderSizeEstimator<KV<ByteString, ChangeStreamRecord>> sizeEstimator;
+  private DaoFactory daoFactory;
+  private ActionFactory actionFactory;
+  private ChangeStreamMetrics metrics;
   private ReadChangeStreamPartitionDoFn doFn;
 
   @Before
   public void setup() throws IOException {
     Duration heartbeatDuration = Duration.standardSeconds(1);
-    DaoFactory daoFactory = mock(DaoFactory.class);
+    daoFactory = mock(DaoFactory.class);
     changeStreamDao = mock(ChangeStreamDao.class);
     metadataTableDao = mock(MetadataTableDao.class);
     when(daoFactory.getChangeStreamDao()).thenReturn(changeStreamDao);
     when(daoFactory.getMetadataTableDao()).thenReturn(metadataTableDao);
     when(daoFactory.getChangeStreamName()).thenReturn("test-id");
 
-    ActionFactory actionFactory = mock(ActionFactory.class);
-    ChangeStreamMetrics metrics = mock(ChangeStreamMetrics.class);
+    actionFactory = mock(ActionFactory.class);
+    metrics = mock(ChangeStreamMetrics.class);
 
     sizeEstimator = mock(CoderSizeEstimator.class);
     ChangeStreamAction changeStreamAction = new ChangeStreamAction(metrics);
@@ -93,7 +96,7 @@ public class ReadChangeStreamPartitionDoFnTest {
             sizeEstimator))
         .thenReturn(readChangeStreamPartitionAction);
 
-    doFn = new ReadChangeStreamPartitionDoFn(daoFactory, actionFactory, metrics);
+    doFn = new ReadChangeStreamPartitionDoFn(daoFactory, actionFactory, metrics, Duration.ZERO);
     doFn.setSizeEstimator(sizeEstimator);
   }
 
@@ -181,5 +184,43 @@ public class ReadChangeStreamPartitionDoFnTest {
                 Instant.now().plus(Duration.standardMinutes(10)),
                 true));
     assertEquals(0, heartbeatEstimate, 0);
+  }
+
+  @Test
+  public void backlogReplicationAdjustment() throws IOException {
+    SerializableSupplier<Instant> mockClock = () -> Instant.ofEpochSecond(1000);
+    doFn =
+        new ReadChangeStreamPartitionDoFn(
+            daoFactory, actionFactory, metrics, Duration.standardSeconds(30), mockClock);
+    long mutationSize = 100L;
+    when(sizeEstimator.sizeOf(any())).thenReturn(mutationSize);
+    doFn.setSizeEstimator(sizeEstimator);
+
+    Range.ByteStringRange partitionRange = Range.ByteStringRange.create("", "");
+    ChangeStreamContinuationToken testToken =
+        ChangeStreamContinuationToken.create(partitionRange, "test");
+    doFn.setup();
+
+    double mutationEstimate10Second =
+        doFn.getSize(
+            new StreamProgress(
+                testToken,
+                mockClock.get().minus(Duration.standardSeconds(10)),
+                BigDecimal.valueOf(1000),
+                mockClock.get().minus(Duration.standardSeconds(10)),
+                false));
+    // With 30s backlogReplicationAdjustment we should have no backlog when watermarkLag is < 30s
+    assertEquals(0, mutationEstimate10Second, 0);
+
+    double mutationEstimateOneMinute =
+        doFn.getSize(
+            new StreamProgress(
+                testToken,
+                mockClock.get().minus(Duration.standardSeconds(60)),
+                BigDecimal.valueOf(1000),
+                mockClock.get().minus(Duration.standardSeconds(60)),
+                false));
+    // We ignore the first 30s of backlog so this should be throughput * (60 - 30)
+    assertEquals(1000 * 30, mutationEstimateOneMinute, 0);
   }
 }


### PR DESCRIPTION
ReadChangeStreamIO estimates the backlog (via `getSize`) for each partition using `partitionLowWatermark * partitionThroughtput`. The low watermark is held back by replication delay for replicated bigtable instances, which can cause the backlog to stay above the downscaling threshold even when the pipeline is 'caught up'

This adds a parameter to adjust the backlog downwards based on an estimate of the replication delay. We default it to 30 seconds which testing has shown works well for replicated instances. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
