### PR TITLE
Minor updates to StreamingInsertsMetrics

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingInsertsMetricsTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/StreamingInsertsMetricsTest.java
@@ -44,7 +44,7 @@ public class StreamingInsertsMetricsTest {
     results.updateSuccessfulRpcMetrics(t1, t1.plus(Duration.ofMillis(10)));
     TableReference ref = new TableReference().setTableId("t").setDatasetId("d");
 
-    results.updateStreamingInsertsMetrics(ref);
+    results.updateStreamingInsertsMetrics(ref, 5, 0);
 
     assertThat(testContainer.perWorkerCounters.size(), equalTo(0));
     assertThat(testContainer.perWorkerHistograms.size(), equalTo(0));
@@ -62,7 +62,7 @@ public class StreamingInsertsMetricsTest {
     Instant t1 = Instant.now();
     results.updateSuccessfulRpcMetrics(t1, t1.plus(Duration.ofMillis(10)));
 
-    results.updateStreamingInsertsMetrics(null);
+    results.updateStreamingInsertsMetrics(null, 0, 0);
 
     assertThat(testContainer.perWorkerCounters.size(), equalTo(0));
     assertThat(testContainer.perWorkerHistograms.size(), equalTo(0));
@@ -88,12 +88,11 @@ public class StreamingInsertsMetricsTest {
 
     StreamingInsertsMetrics results = StreamingInsertsMetrics.StreamingInsertsMetricsImpl.create();
     results.updateRetriedRowsWithStatus("INTERNAL", 10);
-    results.updateSuccessfulAndFailedRows(50, 30);
     results.updateRetriedRowsWithStatus("QuotaLimits", 10);
     results.updateRetriedRowsWithStatus("QuotaLimits", 5);
     results.updateRetriedRowsWithStatus("ServiceUnavailable", 5);
 
-    results.updateStreamingInsertsMetrics(ref);
+    results.updateStreamingInsertsMetrics(ref, 50, 30);
 
     String tableId = "datasets/d/tables/t";
     MetricName internalErrorRetriedMetricName =
@@ -129,7 +128,7 @@ public class StreamingInsertsMetricsTest {
     results.updateFailedRpcMetrics(t1, t1.plus(Duration.ofMillis(30)), "PermissionDenied");
     results.updateFailedRpcMetrics(t1, t1.plus(Duration.ofMillis(40)), "Unavailable");
 
-    results.updateStreamingInsertsMetrics(ref);
+    results.updateStreamingInsertsMetrics(ref, 5, 0);
 
     // Validate RPC latency metric.
     MetricName histogramName =
@@ -162,7 +161,7 @@ public class StreamingInsertsMetricsTest {
     StreamingInsertsMetrics results = StreamingInsertsMetrics.StreamingInsertsMetricsImpl.create();
     results.updateRetriedRowsWithStatus("INTERNAL", 10);
 
-    results.updateStreamingInsertsMetrics(ref);
+    results.updateStreamingInsertsMetrics(ref, 5, 0);
 
     String tableId = "datasets/d/tables/t";
     MetricName internalErrorRetriedMetricName =
@@ -172,7 +171,7 @@ public class StreamingInsertsMetricsTest {
 
     // Subsequent updates to this object should update the underyling metrics.
     results.updateRetriedRowsWithStatus("INTERNAL", 10);
-    results.updateStreamingInsertsMetrics(ref);
+    results.updateStreamingInsertsMetrics(ref, 5, 0);
 
     testContainer.assertPerWorkerCounterValue(internalErrorRetriedMetricName, 10L);
   }


### PR DESCRIPTION
Some minor updates to StreamingInsertsMetrics:
  - Remove some AtomicIntegers from StreamingInsertsMetricsImpl. `SuccessfulRowsCount` and `FailedRowsCount` can be derived from the main thread executing the bundle. 
  - Cache Histogram metric as a `static final` in `StreamingInsertsMetricsImpl` instead of recreating it once per bundle. 
  - Record latency metrics one at a time instead of through a double stream, while the DoubleStream helps large bundles that result in multiple BigQuery RPCs, it hurts small bundles that only send a single RPC. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
