### PR TITLE
Downgrade google-api-core to mitigate #30927

### DIFF
--- a/sdks/python/container/py310/base_image_requirements.txt
+++ b/sdks/python/container/py310/base_image_requirements.txt
@@ -50,8 +50,8 @@ fastavro==1.9.4
 fasteners==0.19
 freezegun==1.4.0
 future==1.0.0
-google-api-core==2.18.0
-google-api-python-client==2.125.0
+google-api-core==2.16.2
+google-api-python-client==2.126.0
 google-apitools==0.5.31
 google-auth==2.29.0
 google-auth-httplib2==0.2.0
@@ -98,7 +98,7 @@ nose==1.3.7
 numpy==1.26.4
 oauth2client==4.1.3
 objsize==0.7.0
-orjson==3.10.0
+orjson==3.10.1
 overrides==7.7.0
 packaging==24.0
 pandas==2.0.3
@@ -130,7 +130,7 @@ pytz==2024.1
 PyYAML==6.0.1
 redis==5.0.3
 referencing==0.34.0
-regex==2023.12.25
+regex==2024.4.16
 requests==2.31.0
 requests-mock==1.12.1
 rpds-py==0.18.0

--- a/sdks/python/container/py311/base_image_requirements.txt
+++ b/sdks/python/container/py311/base_image_requirements.txt
@@ -48,8 +48,8 @@ fastavro==1.9.4
 fasteners==0.19
 freezegun==1.4.0
 future==1.0.0
-google-api-core==2.18.0
-google-api-python-client==2.125.0
+google-api-core==2.16.2
+google-api-python-client==2.126.0
 google-apitools==0.5.31
 google-auth==2.29.0
 google-auth-httplib2==0.2.0
@@ -96,7 +96,7 @@ nose==1.3.7
 numpy==1.26.4
 oauth2client==4.1.3
 objsize==0.7.0
-orjson==3.10.0
+orjson==3.10.1
 overrides==7.7.0
 packaging==24.0
 pandas==2.0.3
@@ -128,7 +128,7 @@ pytz==2024.1
 PyYAML==6.0.1
 redis==5.0.3
 referencing==0.34.0
-regex==2023.12.25
+regex==2024.4.16
 requests==2.31.0
 requests-mock==1.12.1
 rpds-py==0.18.0

--- a/sdks/python/container/py38/base_image_requirements.txt
+++ b/sdks/python/container/py38/base_image_requirements.txt
@@ -51,8 +51,8 @@ fastavro==1.9.4
 fasteners==0.19
 freezegun==1.4.0
 future==1.0.0
-google-api-core==2.18.0
-google-api-python-client==2.125.0
+google-api-core==2.16.2
+google-api-python-client==2.126.0
 google-apitools==0.5.31
 google-auth==2.29.0
 google-auth-httplib2==0.2.0
@@ -101,7 +101,7 @@ nose==1.3.7
 numpy==1.24.4
 oauth2client==4.1.3
 objsize==0.7.0
-orjson==3.10.0
+orjson==3.10.1
 overrides==7.7.0
 packaging==24.0
 pandas==2.0.3
@@ -134,7 +134,7 @@ pytz==2024.1
 PyYAML==6.0.1
 redis==5.0.3
 referencing==0.34.0
-regex==2023.12.25
+regex==2024.4.16
 requests==2.31.0
 requests-mock==1.12.1
 rpds-py==0.18.0

--- a/sdks/python/container/py39/base_image_requirements.txt
+++ b/sdks/python/container/py39/base_image_requirements.txt
@@ -50,8 +50,8 @@ fastavro==1.9.4
 fasteners==0.19
 freezegun==1.4.0
 future==1.0.0
-google-api-core==2.18.0
-google-api-python-client==2.125.0
+google-api-core==2.16.2
+google-api-python-client==2.126.0
 google-apitools==0.5.31
 google-auth==2.29.0
 google-auth-httplib2==0.2.0
@@ -99,7 +99,7 @@ nose==1.3.7
 numpy==1.26.4
 oauth2client==4.1.3
 objsize==0.7.0
-orjson==3.10.0
+orjson==3.10.1
 overrides==7.7.0
 packaging==24.0
 pandas==2.0.3
@@ -131,7 +131,7 @@ pytz==2024.1
 PyYAML==6.0.1
 redis==5.0.3
 referencing==0.34.0
-regex==2023.12.25
+regex==2024.4.16
 requests==2.31.0
 requests-mock==1.12.1
 rpds-py==0.18.0

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -436,7 +436,9 @@ if __name__ == '__main__':
           ],
           'gcp': [
               'cachetools>=3.1.0,<6',
-              'google-api-core>=2.0.0,<3',
+              # Temporary workaround until grpcio releases a fix for
+              # https://github.com/grpc/grpc/issues/36265
+              'google-api-core>=2.0.0,!=2.17.*,!=2.18.*,<3',
               'google-apitools>=0.5.31,<0.5.32',
               # NOTE: Maintainers, please do not require google-auth>=2.x.x
               # Until this issue is closed


### PR DESCRIPTION
A change in google-api-core 2.17.0 triggered a regression introduced in grpcio==1.58.0, which will be fixed in grpcio==1.63.0 and possibly in grpcio==1.62.2.  The regression affects Beam 2.55.0 (#30927 #30867).

This temporary change will help avoid the dependency version combination that might trigger the failure until the grpc fix is available.