### PR TITLE
Don't re-encode byte[] values in SortValues transform

### DIFF
--- a/sdks/java/extensions/sorter/src/main/java/org/apache/beam/sdk/extensions/sorter/SortValues.java
+++ b/sdks/java/extensions/sorter/src/main/java/org/apache/beam/sdk/extensions/sorter/SortValues.java
@@ -171,8 +171,8 @@ public class SortValues<PrimaryKeyT, SecondaryKeyT, ValueT>
     }
 
     @FunctionalInterface
-    private interface ThrowingFunction<T, U> {
-      U apply(T t) throws IOException, CoderException;
+    private interface ThrowingFunction<FromT, ToT> {
+      ToT apply(FromT t) throws IOException, CoderException;
     }
 
     private class KvByteTranslator {

--- a/sdks/java/extensions/sorter/src/test/java/org/apache/beam/sdk/extensions/sorter/SortValuesTest.java
+++ b/sdks/java/extensions/sorter/src/test/java/org/apache/beam/sdk/extensions/sorter/SortValuesTest.java
@@ -22,7 +22,10 @@ import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.hamcrest.Matchers.is;
 
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
+import java.util.List;
+import java.util.stream.Collectors;
 import org.apache.beam.sdk.testing.PAssert;
 import org.apache.beam.sdk.testing.TestPipeline;
 import org.apache.beam.sdk.transforms.Create;
@@ -67,30 +70,141 @@ public class SortValuesTest {
         grouped.apply(SortValues.create(BufferedExternalSorter.options()));
 
     PAssert.that(groupedAndSorted)
-        .satisfies(new AssertThatHasExpectedContentsForTestSecondaryKeySorting());
+        .satisfies(
+            new AssertThatHasExpectedContentsForTestSecondaryKeySorting<>(
+                Arrays.asList(
+                    KV.of(
+                        "key1",
+                        Arrays.asList(
+                            KV.of("secondaryKey1", 10),
+                            KV.of("secondaryKey2", 20),
+                            KV.of("secondaryKey3", 30))),
+                    KV.of(
+                        "key2",
+                        Arrays.asList(KV.of("secondaryKey1", 100), KV.of("secondaryKey2", 200))))));
 
     p.run();
   }
 
-  static class AssertThatHasExpectedContentsForTestSecondaryKeySorting
-      implements SerializableFunction<Iterable<KV<String, Iterable<KV<String, Integer>>>>, Void> {
+  @Test
+  public void testSecondaryKeyByteOptimization() {
+    PCollection<KV<String, KV<byte[], Integer>>> input =
+        p.apply(
+            Create.of(
+                Arrays.asList(
+                    KV.of("key1", KV.of("secondaryKey2".getBytes(StandardCharsets.UTF_8), 20)),
+                    KV.of("key2", KV.of("secondaryKey2".getBytes(StandardCharsets.UTF_8), 200)),
+                    KV.of("key1", KV.of("secondaryKey3".getBytes(StandardCharsets.UTF_8), 30)),
+                    KV.of("key1", KV.of("secondaryKey1".getBytes(StandardCharsets.UTF_8), 10)),
+                    KV.of("key2", KV.of("secondaryKey1".getBytes(StandardCharsets.UTF_8), 100)))));
+
+    // Group by Key, bringing <SecondaryKey, Value> pairs for the same Key together.
+    PCollection<KV<String, Iterable<KV<byte[], Integer>>>> grouped =
+        input.apply(GroupByKey.create());
+
+    // For every Key, sort the iterable of <SecondaryKey, Value> pairs by SecondaryKey.
+    PCollection<KV<String, Iterable<KV<byte[], Integer>>>> groupedAndSorted =
+        grouped.apply(SortValues.create(BufferedExternalSorter.options()));
+
+    PAssert.that(groupedAndSorted)
+        .satisfies(
+            new AssertThatHasExpectedContentsForTestSecondaryKeySorting<>(
+                Arrays.asList(
+                    KV.of(
+                        "key1",
+                        Arrays.asList(
+                            KV.of("secondaryKey1".getBytes(StandardCharsets.UTF_8), 10),
+                            KV.of("secondaryKey2".getBytes(StandardCharsets.UTF_8), 20),
+                            KV.of("secondaryKey3".getBytes(StandardCharsets.UTF_8), 30))),
+                    KV.of(
+                        "key2",
+                        Arrays.asList(
+                            KV.of("secondaryKey1".getBytes(StandardCharsets.UTF_8), 100),
+                            KV.of("secondaryKey2".getBytes(StandardCharsets.UTF_8), 200))))));
+
+    p.run();
+  }
+
+  @Test
+  public void testSecondaryKeyAndValueByteOptimization() {
+    PCollection<KV<String, KV<byte[], byte[]>>> input =
+        p.apply(
+            Create.of(
+                Arrays.asList(
+                    KV.of(
+                        "key1",
+                        KV.of("secondaryKey2".getBytes(StandardCharsets.UTF_8), new byte[] {1})),
+                    KV.of(
+                        "key2",
+                        KV.of("secondaryKey2".getBytes(StandardCharsets.UTF_8), new byte[] {2})),
+                    KV.of(
+                        "key1",
+                        KV.of("secondaryKey3".getBytes(StandardCharsets.UTF_8), new byte[] {3})),
+                    KV.of(
+                        "key1",
+                        KV.of("secondaryKey1".getBytes(StandardCharsets.UTF_8), new byte[] {4})),
+                    KV.of(
+                        "key2",
+                        KV.of("secondaryKey1".getBytes(StandardCharsets.UTF_8), new byte[] {5})))));
+
+    // Group by Key, bringing <SecondaryKey, Value> pairs for the same Key together.
+    PCollection<KV<String, Iterable<KV<byte[], byte[]>>>> grouped =
+        input.apply(GroupByKey.create());
+
+    // For every Key, sort the iterable of <SecondaryKey, Value> pairs by SecondaryKey.
+    PCollection<KV<String, Iterable<KV<byte[], byte[]>>>> groupedAndSorted =
+        grouped.apply(SortValues.create(BufferedExternalSorter.options()));
+
+    PAssert.that(groupedAndSorted)
+        .satisfies(
+            new AssertThatHasExpectedContentsForTestSecondaryKeySorting<>(
+                Arrays.asList(
+                    KV.of(
+                        "key1",
+                        Arrays.asList(
+                            KV.of("secondaryKey1".getBytes(StandardCharsets.UTF_8), new byte[] {4}),
+                            KV.of("secondaryKey2".getBytes(StandardCharsets.UTF_8), new byte[] {1}),
+                            KV.of(
+                                "secondaryKey3".getBytes(StandardCharsets.UTF_8), new byte[] {3}))),
+                    KV.of(
+                        "key2",
+                        Arrays.asList(
+                            KV.of("secondaryKey1".getBytes(StandardCharsets.UTF_8), new byte[] {5}),
+                            KV.of(
+                                "secondaryKey2".getBytes(StandardCharsets.UTF_8),
+                                new byte[] {2}))))));
+
+    p.run();
+  }
+
+  static class AssertThatHasExpectedContentsForTestSecondaryKeySorting<SecondaryKeyT, ValueT>
+      implements SerializableFunction<
+          Iterable<KV<String, Iterable<KV<SecondaryKeyT, ValueT>>>>, Void> {
+    final List<KV<String, List<KV<SecondaryKeyT, ValueT>>>> expected;
+
+    AssertThatHasExpectedContentsForTestSecondaryKeySorting(
+        List<KV<String, List<KV<SecondaryKeyT, ValueT>>>> expected) {
+      this.expected = expected;
+    }
+
     @SuppressWarnings("unchecked")
     @Override
-    public Void apply(Iterable<KV<String, Iterable<KV<String, Integer>>>> actual) {
+    public Void apply(Iterable<KV<String, Iterable<KV<SecondaryKeyT, ValueT>>>> actual) {
       assertThat(
           actual,
           containsInAnyOrder(
-              KvMatcher.isKv(
-                  is("key1"),
-                  contains(
-                      KvMatcher.isKv(is("secondaryKey1"), is(10)),
-                      KvMatcher.isKv(is("secondaryKey2"), is(20)),
-                      KvMatcher.isKv(is("secondaryKey3"), is(30)))),
-              KvMatcher.isKv(
-                  is("key2"),
-                  contains(
-                      KvMatcher.isKv(is("secondaryKey1"), is(100)),
-                      KvMatcher.isKv(is("secondaryKey2"), is(200))))));
+              expected.stream()
+                  .map(
+                      kv1 ->
+                          KvMatcher.isKv(
+                              is(kv1.getKey()),
+                              contains(
+                                  kv1.getValue().stream()
+                                      .map(
+                                          kv2 ->
+                                              KvMatcher.isKv(is(kv2.getKey()), is(kv2.getValue())))
+                                      .collect(Collectors.toList()))))
+                  .collect(Collectors.toList())));
       return null;
     }
   }


### PR DESCRIPTION
A small optimization for `SortValues` transform to avoid doubly roundtrip encoding values that are already `byte[]`s -- they can be passed directly to the Sorter.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
