### PR TITLE
[Prism] Connect Web UI cancel requests with backend

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/execute.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/execute.go
@@ -69,7 +69,7 @@ func RunPipeline(j *jobservices.Job) {
 	j.SendMsg("running " + j.String())
 	j.Running()
 
-	if err := executePipeline(j.RootCtx, wks, j); err != nil {
+	if err := executePipeline(j.RootCtx, wks, j); err != nil && !errors.Is(err, jobservices.ErrCancel) {
 		j.Failed(err)
 		return
 	}

--- a/sdks/go/pkg/beam/runners/prism/internal/jobservices/management.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/jobservices/management.go
@@ -243,8 +243,8 @@ func (s *Server) Run(ctx context.Context, req *jobpb.RunJobRequest) (*jobpb.RunJ
 // Otherwise, returns nil if Job does not exist or the Job's existing state as part of the CancelJobResponse.
 func (s *Server) Cancel(_ context.Context, req *jobpb.CancelJobRequest) (*jobpb.CancelJobResponse, error) {
 	s.mu.Lock()
-	defer s.mu.Unlock()
 	job, ok := s.jobs[req.GetJobId()]
+	s.mu.Unlock()
 	if !ok {
 		return nil, nil
 	}

--- a/sdks/go/pkg/beam/runners/prism/internal/jobservices/management.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/jobservices/management.go
@@ -250,14 +250,14 @@ func (s *Server) Cancel(_ context.Context, req *jobpb.CancelJobRequest) (*jobpb.
 	}
 	state := job.state.Load().(jobpb.JobState_Enum)
 	switch state {
-	case jobpb.JobState_CANCELLED, jobpb.JobState_DONE, jobpb.JobState_DRAINED, jobpb.JobState_UPDATED, jobpb.JobState_FAILED, jobpb.JobState_STOPPED:
+	case jobpb.JobState_CANCELLED, jobpb.JobState_DONE, jobpb.JobState_DRAINED, jobpb.JobState_UPDATED, jobpb.JobState_FAILED:
 		// Already at terminal state.
 		return &jobpb.CancelJobResponse{
 			State: state,
 		}, nil
 	}
 	job.SendMsg("canceling " + job.String())
-	job.Canceled()
+	job.Canceling()
 	job.CancelFn(ErrCancel)
 	return &jobpb.CancelJobResponse{
 		State: jobpb.JobState_CANCELLING,

--- a/sdks/go/pkg/beam/runners/prism/internal/jobservices/management_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/jobservices/management_test.go
@@ -46,9 +46,13 @@ func TestServer(t *testing.T) {
 
 	cmpOpts := []cmp.Option{protocmp.Transform(), cmpopts.EquateEmpty()}
 	tests := []struct {
-		name                       string
+		name         string
+		postRunState jobpb.JobState_Enum
+		// noJobsCheck tests in the setting that the Job doesn't exist
+		// postPrepCheck tests after Server Prepare invoked
 		noJobsCheck, postPrepCheck func(context.Context, *testing.T, *Server)
-		postRunCheck               func(context.Context, *testing.T, *Server, string)
+		// postRunCheck tests after Server Run invoked
+		postRunCheck func(context.Context, *testing.T, *Server, string)
 	}{
 		{
 			name: "GetJobs",
@@ -170,34 +174,38 @@ func TestServer(t *testing.T) {
 			},
 		},
 		{
-			name:        "Canceling",
-			noJobsCheck: func(ctx context.Context, t *testing.T, undertest *Server) {},
+			name:         "Canceling",
+			postRunState: jobpb.JobState_RUNNING,
+			noJobsCheck: func(ctx context.Context, t *testing.T, undertest *Server) {
+				id := "job-001"
+				_, err := undertest.Cancel(ctx, &jobpb.CancelJobRequest{JobId: id})
+				// Cancel currently returns nil, nil when Job not found
+				if err != nil {
+					t.Errorf("Cancel(%q) = %v, want not found error", id, err)
+				}
+			},
 			postPrepCheck: func(ctx context.Context, t *testing.T, undertest *Server) {
 				id := "job-001"
-				job, ok := undertest.jobs[id]
-				if !ok {
-					t.Fatalf("job not found in undertest.jobs: %s", id)
-				}
-				job.state.Store(jobpb.JobState_RUNNING)
 				resp, err := undertest.Cancel(ctx, &jobpb.CancelJobRequest{JobId: id})
 				if err != nil {
-					t.Errorf("Canceling(\"%s\") = %v, want nil", id, err)
+					t.Errorf("Cancel(%q) = %v, want not found error", id, err)
 				}
 				if diff := cmp.Diff(&jobpb.CancelJobResponse{
 					State: jobpb.JobState_CANCELLING,
 				}, resp, cmpOpts...); diff != "" {
-					t.Errorf("Canceling(\"%s\") (-want, +got):\n%v", id, diff)
+					t.Errorf("Cancel(%q) (-want, +got):\n%s", id, diff)
 				}
 			},
 			postRunCheck: func(ctx context.Context, t *testing.T, undertest *Server, jobID string) {
-				resp, err := undertest.GetState(ctx, &jobpb.GetJobStateRequest{JobId: jobID})
+				id := "job-001"
+				resp, err := undertest.Cancel(ctx, &jobpb.CancelJobRequest{JobId: id})
 				if err != nil {
-					t.Errorf("GetState(\"%s\") = %v, want nil", jobID, err)
+					t.Errorf("Cancel(%q) = %v, want not found error", id, err)
 				}
-				want := jobpb.JobState_CANCELLED
-				got := resp.State
-				if got != want {
-					t.Errorf("Canceling(\"%s\") = %s, want %s", jobID, got, want)
+				if diff := cmp.Diff(&jobpb.CancelJobResponse{
+					State: jobpb.JobState_CANCELLING,
+				}, resp, cmpOpts...); diff != "" {
+					t.Errorf("Cancel(%q) (-want, +got):\n%s", id, diff)
 				}
 			},
 		},
@@ -229,8 +237,8 @@ func TestServer(t *testing.T) {
 				},
 			})
 			state := jobpb.JobState_DONE
-			if j.state.Load() == jobpb.JobState_CANCELLED {
-				state = jobpb.JobState_CANCELLED
+			if test.postRunState != jobpb.JobState_UNSPECIFIED {
+				state = test.postRunState
 			}
 			j.state.Store(state)
 			called.Done()

--- a/sdks/go/pkg/beam/runners/prism/internal/web/assets/job-action.js
+++ b/sdks/go/pkg/beam/runners/prism/internal/web/assets/job-action.js
@@ -12,6 +12,12 @@
  limitations under the License.
  */
 
+/**
+ * job-action.js provides UI functionality for taking actions on Prism Jobs via:
+ * - jobManager:        Client for Job Management.
+ * - uiStateProvider:   Encapsulates UI state of user interactive elements on the page.
+ */
+
 /** Element class for job action container. */
 const JOB_ACTION = '.job-action'
 
@@ -20,6 +26,24 @@ const CANCEL = '.cancel'
 
 /** Element class assigned to RUNNING Job state. */
 const RUNNING = 'RUNNING'
+
+/** Element class for elements reporting Job state details. */
+const JOB_STATE = '.job-state'
+
+/** PATH holds consts that map to backend endpoints. */
+const PATH = {
+
+    /** ROOT_ is the Job management path prefix for mapped backend endpoints. */
+    ROOT_: '/job',
+
+    /** CANCEL maps to the backend endpoint to cancel a Job. Terminates with '/' to prevent ServeMux 301 redirect. */
+    get CANCEL() {
+        return `${this.ROOT_}/cancel/`
+    }
+}
+
+/** HTTP related consts. */
+const HTTP_POST = 'POST'
 
 /**
  * Client for Job Management.
@@ -34,9 +58,28 @@ const jobManager = {
      * @param jobId
      * TODO(https://github.com/apache/beam/issues/29669) Send request to backend service.
      */
-    cancel: function(jobId) {
+    cancel: function (jobId) {
         console.debug(`cancel button for Job: ${jobId} clicked`)
-    }
+        const path = PATH.CANCEL
+        const request = {
+            method: HTTP_POST,
+            body: JSON.stringify(new CancelJobRequest(jobId))
+        }
+        fetch(path, request)
+            .then(response => {
+                const requestJson = JSON.stringify(request)
+                const responseJson = JSON.stringify(response)
+                if (response.ok) {
+                    console.debug(`Job cancellation request to ${path} of ${requestJson} for Job: ${jobId} sent successfully, response: ${responseJson}`)
+                    uiStateProvider.onJobCancel(response)
+                } else {
+                    console.error(`Failed to send job cancellation request to ${path} of ${requestJson} for Job: ${jobId}, response: ${responseJson}`)
+                }
+            })
+            .catch(error => {
+                console.error(`Error occurred while sending job cancellation request for Job: ${jobId}`, error)
+            })
+    },
 }
 
 /**
@@ -84,14 +127,85 @@ const uiStateProvider = {
      */
     get isStateRunning() {
         return this.jobAction.classList.contains(RUNNING)
+    },
+
+    /**
+     * Queries the element containing the {@link JOB_STATE} class.
+     * @return {Element}
+     */
+    get jobStateElement() {
+        let element = document.querySelector(JOB_STATE)
+        if (element === null) {
+            console.error(`no element found at ${JOB_STATE}`)
+        }
+        return element
+    },
+
+    /**
+     * Callback for successful Job Cancel requests.
+     * @param response {Response}
+     */
+    onJobCancel(response) {
+        response.json().then(json => {
+            console.debug(`job cancel response json: ${JSON.stringify(json)}`)
+            uiStateProvider.jobStateElement.textContent = JobState_Enum[json.state]
+        })
+            .catch(error => {
+                console.error(`error Response.json() ${error}`)
+            })
     }
 }
 
 /**
  * Attaches an event listener to the window for 'load' events.
  */
-window.addEventListener("load", function(){
+window.addEventListener("load", function () {
     console.debug(JOB_ACTION, uiStateProvider.jobAction)
     console.debug(CANCEL, uiStateProvider.cancelButton)
     uiStateProvider.init()
 })
+
+/**
+ * CancelJobRequest models a request to cancel a Job.
+ *
+ * Models after its proto namesake in:
+ * https://github.com/apache/beam/blob/master/model/job-management/src/main/proto/org/apache/beam/model/job_management/v1/beam_job_api.proto
+ */
+class CancelJobRequest {
+    job_id_;
+
+    constructor(jobId) {
+        this.job_id_ = jobId
+    }
+
+    /**
+     * The ID of the Job to cancel.
+     * @return {string}
+     */
+    get job_id() {
+        return this.job_id_
+    }
+
+    /** toJSON overrides JSON.stringify serialization behavior. */
+    toJSON() {
+        return {job_id: this.job_id}
+    }
+}
+
+/** Maps JobState_Enum from Job Management server response to the Job State name. See proto for more details:
+ * https://github.com/apache/beam/blob/master/model/job-management/src/main/proto/org/apache/beam/model/job_management/v1/beam_job_api.proto
+ */
+const JobState_Enum = {
+    0: "UNSPECIFIED",
+    1: "STOPPED",
+    2: "RUNNING",
+    3: "DONE",
+    4: "FAILED",
+    5: "CANCELLED",
+    6: "UPDATED",
+    7: "DRAINING",
+    8: "DRAINED",
+    9: "STARTING",
+    10: "CANCELLING",
+    11: "UPDATING",
+}

--- a/sdks/go/pkg/beam/runners/prism/internal/web/jobdetails.html
+++ b/sdks/go/pkg/beam/runners/prism/internal/web/jobdetails.html
@@ -33,7 +33,7 @@ limitations under the License. See accompanying LICENSE file.
                         onclick="if (jobManager !== null) { jobManager.cancel('{{.JobID}}') }"
                 >Cancel</button>
             </div>
-            <div>{{.State}}</div>
+            <div class="job-state">{{.State}}</div>
         </header>
         <section class="container">
             {{ if .Error}}<div class="child">{{.Error}}</div>{{end}}


### PR DESCRIPTION
# About

This PR addresses #29669 connecting Web UI cancel requests with the backend Job Management server.

# Changes

- Fixes loading of CANCELED state for previously canceled Jobs
- Triggers Web request from UI to backend on cancel clicks
- Adds to /job/cancel http handler more detailed error reporting

# Testing

In addition to `go test ...`, manual testing of this PR was as follows:

1. Run prism via `go run ./go/cmd/prism`
2. Execute example via `go run ./go/examples/large_wordcount --output=/tmp/large_wordcount/out --runner=universal --endpoint=localhost:8073 --environment_type=LOOPBACK`
3. Validate job display in web console at http://localhost:8074/job/job-001 with state `RUNNING`
4. Click Cancel button
5. Validate cancel-related log messages populate in console after [filtering for debug level logs](https://developer.chrome.com/docs/devtools/console/log#level)
6. Validate Cancel button disabled with Job state change from `RUNNING` to `CANCELLING`
7. On reload of http://localhost:8074/job/job-001, validate state is `CANCELED`
8. Navigating to http://localhost:8074 shows job-001 in Jobs list as `CANCELED`

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - ~Update `CHANGES.md` with noteworthy changes.~
 - ~If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).~

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
