### PR TITLE
Add Ms part of duration for UnboundedReaderMaxReadTime 

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -224,13 +224,13 @@ public interface DataflowPipelineDebugOptions
 
   void setUnboundedReaderMaxReadTimeSec(Integer value);
 
-    /** The max amount of time an UnboundedReader is consumed before checkpointing. */
-    @Description(
-        "The max amount of time (UnboundedReaderMaxReadTimeSec+UnboundedReaderMaxReadTimeMs) before an UnboundedReader is consumed before checkpointing, millis part.")
-    @Default.Integer(0)
-    Integer getUnboundedReaderMaxReadTimeMs();
-  
-    void setUnboundedReaderMaxReadTimeMs(Integer value);
+  /** The max amount of time an UnboundedReader is consumed before checkpointing. */
+  @Description(
+      "The max amount of time (UnboundedReaderMaxReadTimeSec+UnboundedReaderMaxReadTimeMs) before an UnboundedReader is consumed before checkpointing, millis part.")
+  @Default.Integer(0)
+  Integer getUnboundedReaderMaxReadTimeMs();
+
+  void setUnboundedReaderMaxReadTimeMs(Integer value);
 
   /** The max elements read from an UnboundedReader before checkpointing. */
   @Description("The max elements read from an UnboundedReader before checkpointing. ")

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -218,11 +218,19 @@ public interface DataflowPipelineDebugOptions
 
   /** The max amount of time an UnboundedReader is consumed before checkpointing. */
   @Description(
-      "The max amount of time before an UnboundedReader is consumed before checkpointing, in seconds.")
+      "The max amount of time (UnboundedReaderMaxReadTimeSec+UnboundedReaderMaxReadTimeMs) before an UnboundedReader is consumed before checkpointing, seconds part.")
   @Default.Integer(10)
   Integer getUnboundedReaderMaxReadTimeSec();
 
   void setUnboundedReaderMaxReadTimeSec(Integer value);
+
+    /** The max amount of time an UnboundedReader is consumed before checkpointing. */
+    @Description(
+        "The max amount of time (UnboundedReaderMaxReadTimeSec+UnboundedReaderMaxReadTimeMs) before an UnboundedReader is consumed before checkpointing, millis part.")
+    @Default.Integer(0)
+    Integer getUnboundedReaderMaxReadTimeMs();
+  
+    void setUnboundedReaderMaxReadTimeMs(Integer value);
 
   /** The max elements read from an UnboundedReader before checkpointing. */
   @Description("The max elements read from an UnboundedReader before checkpointing. ")

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSources.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSources.java
@@ -798,7 +798,8 @@ public class WorkerCustomSources {
       DataflowPipelineDebugOptions debugOptions = options.as(DataflowPipelineDebugOptions.class);
       this.endTime =
           Instant.now()
-              .plus(Duration.standardSeconds(debugOptions.getUnboundedReaderMaxReadTimeSec()));
+              .plus(Duration.standardSeconds(debugOptions.getUnboundedReaderMaxReadTimeSec()))
+              .plus(Duration.millis(debugOptions.getUnboundedReaderMaxReadTimeMs()));
       this.maxElems = debugOptions.getUnboundedReaderMaxElements();
       this.backoffFactory =
           FluentBackoff.DEFAULT

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
@@ -649,7 +649,7 @@ public class WorkerCustomSourcesTest {
           debugOptions.getUnboundedReaderMaxReadTimeSec() * 1000
               + debugOptions.getUnboundedReaderMaxReadTimeMs();
       assertThat(
-          new Duration(beforeReading, afterReading).millis(),
+          new Duration(beforeReading, afterReading).getMillis(),
           lessThanOrEqualTo(maxReadMillis + 1000));
       assertThat(
           numReadOnThisIteration, lessThanOrEqualTo(debugOptions.getUnboundedReaderMaxElements()));

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
@@ -645,10 +645,10 @@ public class WorkerCustomSourcesTest {
         numReadOnThisIteration++;
       }
       Instant afterReading = Instant.now();
-      long maxReadSec = debugOptions.getUnboundedReaderMaxReadTimeSec()*1000+debugOptions.getUnboundedReaderMaxReadTimeMs();
+      long maxReadMillis = debugOptions.getUnboundedReaderMaxReadTimeSec()*1000+debugOptions.getUnboundedReaderMaxReadTimeMs();
       assertThat(
           new Duration(beforeReading, afterReading).millis(),
-          lessThanOrEqualTo(maxReadSec + 100));
+          lessThanOrEqualTo(maxReadMillis + 1000));
       assertThat(
           numReadOnThisIteration, lessThanOrEqualTo(debugOptions.getUnboundedReaderMaxElements()));
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
@@ -646,11 +646,11 @@ public class WorkerCustomSourcesTest {
       }
       Instant afterReading = Instant.now();
       long maxReadMillis =
-          debugOptions.getUnboundedReaderMaxReadTimeSec() * 1000
+          debugOptions.getUnboundedReaderMaxReadTimeSec() * 1000L
               + debugOptions.getUnboundedReaderMaxReadTimeMs();
       assertThat(
           new Duration(beforeReading, afterReading).getMillis(),
-          lessThanOrEqualTo(maxReadMillis + 1000));
+          lessThanOrEqualTo(maxReadMillis + 1000L));
       assertThat(
           numReadOnThisIteration, lessThanOrEqualTo(debugOptions.getUnboundedReaderMaxElements()));
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
@@ -645,10 +645,10 @@ public class WorkerCustomSourcesTest {
         numReadOnThisIteration++;
       }
       Instant afterReading = Instant.now();
-      long maxReadSec = debugOptions.getUnboundedReaderMaxReadTimeSec();
+      long maxReadSec = debugOptions.getUnboundedReaderMaxReadTimeSec()*1000+debugOptions.getUnboundedReaderMaxReadTimeMs();
       assertThat(
-          new Duration(beforeReading, afterReading).getStandardSeconds(),
-          lessThanOrEqualTo(maxReadSec + 1));
+          new Duration(beforeReading, afterReading).millis(),
+          lessThanOrEqualTo(maxReadSec + 100));
       assertThat(
           numReadOnThisIteration, lessThanOrEqualTo(debugOptions.getUnboundedReaderMaxElements()));
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
@@ -645,7 +645,9 @@ public class WorkerCustomSourcesTest {
         numReadOnThisIteration++;
       }
       Instant afterReading = Instant.now();
-      long maxReadMillis = debugOptions.getUnboundedReaderMaxReadTimeSec()*1000+debugOptions.getUnboundedReaderMaxReadTimeMs();
+      long maxReadMillis =
+          debugOptions.getUnboundedReaderMaxReadTimeSec() * 1000
+              + debugOptions.getUnboundedReaderMaxReadTimeMs();
       assertThat(
           new Duration(beforeReading, afterReading).millis(),
           lessThanOrEqualTo(maxReadMillis + 1000));


### PR DESCRIPTION

UnboundedReader is controlled with UnboundedReaderMaxReadTimeSec and UnboundedReaderMaxElements.
For sub second latency user has to set UnboundedReaderMaxElements to 1 which is not flexible as there may be multiple situation where there are more elements. 

In this change UnboundedReaderMaxReadTime will be controlled by UnboundedReaderMaxReadTimeSec+UnboundedReaderMaxReadTimeMs.
For backward compatibility UnboundedReaderMaxReadTimeMs default is 0 and UnboundedReaderMaxReadTime is sum of both. 

