### PR TITLE
Change type for UnboundedReaderMaxReadTimeSec

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -224,13 +224,13 @@ public interface DataflowPipelineDebugOptions
 
   void setUnboundedReaderMaxReadTimeSec(Integer value);
 
-    /** The max amount of time an UnboundedReader is consumed before checkpointing. */
-    @Description(
-        "The max amount of time (UnboundedReaderMaxReadTimeSec+UnboundedReaderMaxReadTimeMs) before an UnboundedReader is consumed before checkpointing, millis part.")
-    @Default.Integer(0)
-    Integer getUnboundedReaderMaxReadTimeMs();
-  
-    void setUnboundedReaderMaxReadTimeMs(Integer value);
+  /** The max amount of time an UnboundedReader is consumed before checkpointing. */
+  @Description(
+      "The max amount of time (UnboundedReaderMaxReadTimeSec+UnboundedReaderMaxReadTimeMs) before an UnboundedReader is consumed before checkpointing, millis part.")
+  @Default.Integer(0)
+  Integer getUnboundedReaderMaxReadTimeMs();
+
+  void setUnboundedReaderMaxReadTimeMs(Integer value);
 
   /** The max elements read from an UnboundedReader before checkpointing. */
   @Description("The max elements read from an UnboundedReader before checkpointing. ")

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -218,11 +218,19 @@ public interface DataflowPipelineDebugOptions
 
   /** The max amount of time an UnboundedReader is consumed before checkpointing. */
   @Description(
-      "The max amount of time before an UnboundedReader is consumed before checkpointing, in seconds.")
+      "The max amount of time (UnboundedReaderMaxReadTimeSec+UnboundedReaderMaxReadTimeMs) before an UnboundedReader is consumed before checkpointing, seconds part.")
   @Default.Integer(10)
   Integer getUnboundedReaderMaxReadTimeSec();
 
   void setUnboundedReaderMaxReadTimeSec(Integer value);
+
+    /** The max amount of time an UnboundedReader is consumed before checkpointing. */
+    @Description(
+        "The max amount of time (UnboundedReaderMaxReadTimeSec+UnboundedReaderMaxReadTimeMs) before an UnboundedReader is consumed before checkpointing, millis part.")
+    @Default.Integer(0)
+    Integer getUnboundedReaderMaxReadTimeMs();
+  
+    void setUnboundedReaderMaxReadTimeMs(Integer value);
 
   /** The max elements read from an UnboundedReader before checkpointing. */
   @Description("The max elements read from an UnboundedReader before checkpointing. ")

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -218,7 +218,8 @@ public interface DataflowPipelineDebugOptions
 
   /** The max amount of time an UnboundedReader is consumed before checkpointing. */
   @Description(
-      "The max amount of time before an UnboundedReader is consumed before checkpointing, in seconds.")
+      "The max amount of time before an UnboundedReader is consumed before checkpointing, "
+      + "in seconds. Duration can be set to fractions of seconds. ")
   @Default.Double(10.0)
   double getUnboundedReaderMaxReadTimeSec();
 

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -218,19 +218,11 @@ public interface DataflowPipelineDebugOptions
 
   /** The max amount of time an UnboundedReader is consumed before checkpointing. */
   @Description(
-      "The max amount of time (UnboundedReaderMaxReadTimeSec+UnboundedReaderMaxReadTimeMs) before an UnboundedReader is consumed before checkpointing, seconds part.")
-  @Default.Integer(10)
-  Integer getUnboundedReaderMaxReadTimeSec();
+      "The max amount of time before an UnboundedReader is consumed before checkpointing, in seconds.")
+  @Default.Double(10.0)
+  Double getUnboundedReaderMaxReadTimeSec();
 
-  void setUnboundedReaderMaxReadTimeSec(Integer value);
-
-  /** The max amount of time an UnboundedReader is consumed before checkpointing. */
-  @Description(
-      "The max amount of time (UnboundedReaderMaxReadTimeSec+UnboundedReaderMaxReadTimeMs) before an UnboundedReader is consumed before checkpointing, millis part.")
-  @Default.Integer(0)
-  Integer getUnboundedReaderMaxReadTimeMs();
-
-  void setUnboundedReaderMaxReadTimeMs(Integer value);
+  void setUnboundedReaderMaxReadTimeSec(Double value);
 
   /** The max elements read from an UnboundedReader before checkpointing. */
   @Description("The max elements read from an UnboundedReader before checkpointing. ")

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -220,7 +220,7 @@ public interface DataflowPipelineDebugOptions
   @Description(
       "The max amount of time before an UnboundedReader is consumed before checkpointing, in seconds.")
   @Default.Double(10.0)
-  Double getUnboundedReaderMaxReadTimeSec();
+  double getUnboundedReaderMaxReadTimeSec();
 
   void setUnboundedReaderMaxReadTimeSec(double value);
 

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -222,7 +222,7 @@ public interface DataflowPipelineDebugOptions
   @Default.Double(10.0)
   Double getUnboundedReaderMaxReadTimeSec();
 
-  void setUnboundedReaderMaxReadTimeSec(Double value);
+  void setUnboundedReaderMaxReadTimeSec(double value);
 
   /** The max elements read from an UnboundedReader before checkpointing. */
   @Description("The max elements read from an UnboundedReader before checkpointing. ")

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -219,7 +219,7 @@ public interface DataflowPipelineDebugOptions
   /** The max amount of time an UnboundedReader is consumed before checkpointing. */
   @Description(
       "The max amount of time before an UnboundedReader is consumed before checkpointing, "
-      + "in seconds. Duration can be set to fractions of seconds. ")
+          + "in seconds. Duration can be set to fractions of seconds. ")
   @Default.Double(10.0)
   double getUnboundedReaderMaxReadTimeSec();
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSources.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSources.java
@@ -798,7 +798,8 @@ public class WorkerCustomSources {
       DataflowPipelineDebugOptions debugOptions = options.as(DataflowPipelineDebugOptions.class);
       this.endTime =
           Instant.now()
-              .plus(Duration.standardSeconds(debugOptions.getUnboundedReaderMaxReadTimeSec()));
+              .plus(Duration.standardSeconds(debugOptions.getUnboundedReaderMaxReadTimeSec()))
+              .plus(Duration.millis(debugOptions.getUnboundedReaderMaxReadTimeMs()));
       this.maxElems = debugOptions.getUnboundedReaderMaxElements();
       this.backoffFactory =
           FluentBackoff.DEFAULT

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSources.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSources.java
@@ -798,8 +798,9 @@ public class WorkerCustomSources {
       DataflowPipelineDebugOptions debugOptions = options.as(DataflowPipelineDebugOptions.class);
       this.endTime =
           Instant.now()
-              .plus(Duration.standardSeconds(debugOptions.getUnboundedReaderMaxReadTimeSec()))
-              .plus(Duration.millis(debugOptions.getUnboundedReaderMaxReadTimeMs()));
+              .plus(
+                  Duration.millis(
+                      (long) (debugOptions.getUnboundedReaderMaxReadTimeSec() * 1000L)));
       this.maxElems = debugOptions.getUnboundedReaderMaxElements();
       this.backoffFactory =
           FluentBackoff.DEFAULT

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
@@ -649,7 +649,7 @@ public class WorkerCustomSourcesTest {
           debugOptions.getUnboundedReaderMaxReadTimeSec() * 1000
               + debugOptions.getUnboundedReaderMaxReadTimeMs();
       assertThat(
-          new Duration(beforeReading, afterReading).millis(),
+          new Duration(beforeReading, afterReading).getMillis(),
           lessThanOrEqualTo(maxReadMillis + 1000));
       assertThat(
           numReadOnThisIteration, lessThanOrEqualTo(debugOptions.getUnboundedReaderMaxElements()));

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
@@ -645,10 +645,10 @@ public class WorkerCustomSourcesTest {
         numReadOnThisIteration++;
       }
       Instant afterReading = Instant.now();
-      long maxReadSec = debugOptions.getUnboundedReaderMaxReadTimeSec()*1000+debugOptions.getUnboundedReaderMaxReadTimeMs();
+      long maxReadMillis = debugOptions.getUnboundedReaderMaxReadTimeSec()*1000+debugOptions.getUnboundedReaderMaxReadTimeMs();
       assertThat(
           new Duration(beforeReading, afterReading).millis(),
-          lessThanOrEqualTo(maxReadSec + 100));
+          lessThanOrEqualTo(maxReadMillis + 1000));
       assertThat(
           numReadOnThisIteration, lessThanOrEqualTo(debugOptions.getUnboundedReaderMaxElements()));
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
@@ -646,11 +646,11 @@ public class WorkerCustomSourcesTest {
       }
       Instant afterReading = Instant.now();
       long maxReadMillis =
-          debugOptions.getUnboundedReaderMaxReadTimeSec() * 1000
+          debugOptions.getUnboundedReaderMaxReadTimeSec() * 1000L
               + debugOptions.getUnboundedReaderMaxReadTimeMs();
       assertThat(
           new Duration(beforeReading, afterReading).getMillis(),
-          lessThanOrEqualTo(maxReadMillis + 1000));
+          lessThanOrEqualTo(maxReadMillis + 1000L));
       assertThat(
           numReadOnThisIteration, lessThanOrEqualTo(debugOptions.getUnboundedReaderMaxElements()));
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
@@ -645,12 +645,10 @@ public class WorkerCustomSourcesTest {
         numReadOnThisIteration++;
       }
       Instant afterReading = Instant.now();
-      long maxReadMillis =
-          debugOptions.getUnboundedReaderMaxReadTimeSec() * 1000L
-              + debugOptions.getUnboundedReaderMaxReadTimeMs();
+      double maxReadSec = debugOptions.getUnboundedReaderMaxReadTimeSec();
       assertThat(
           new Duration(beforeReading, afterReading).getMillis(),
-          lessThanOrEqualTo(maxReadMillis + 1000L));
+          lessThanOrEqualTo((long) (maxReadSec * 1000L)));
       assertThat(
           numReadOnThisIteration, lessThanOrEqualTo(debugOptions.getUnboundedReaderMaxElements()));
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
@@ -649,7 +649,7 @@ public class WorkerCustomSourcesTest {
       double maxReadSec = debugOptions.getUnboundedReaderMaxReadTimeSec();
       assertThat(
           new Duration(beforeReading, afterReading).getMillis(),
-          lessThanOrEqualTo((long) (maxReadSec * 1000L)));
+          lessThanOrEqualTo((long) ((maxReadSec + 1) * 1000L)));
       assertThat(
           numReadOnThisIteration, lessThanOrEqualTo(debugOptions.getUnboundedReaderMaxElements()));
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
@@ -598,6 +598,7 @@ public class WorkerCustomSourcesTest {
     int maxElements = 10;
     DataflowPipelineDebugOptions debugOptions = options.as(DataflowPipelineDebugOptions.class);
     debugOptions.setUnboundedReaderMaxElements(maxElements);
+    debugOptions.setUnboundedReaderMaxReadTimeSec(10);
 
     ByteString state = ByteString.EMPTY;
     for (int i = 0; i < 10 * maxElements;

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
@@ -645,10 +645,10 @@ public class WorkerCustomSourcesTest {
         numReadOnThisIteration++;
       }
       Instant afterReading = Instant.now();
-      long maxReadSec = debugOptions.getUnboundedReaderMaxReadTimeSec();
+      long maxReadSec = debugOptions.getUnboundedReaderMaxReadTimeSec()*1000+debugOptions.getUnboundedReaderMaxReadTimeMs();
       assertThat(
-          new Duration(beforeReading, afterReading).getStandardSeconds(),
-          lessThanOrEqualTo(maxReadSec + 1));
+          new Duration(beforeReading, afterReading).millis(),
+          lessThanOrEqualTo(maxReadSec + 100));
       assertThat(
           numReadOnThisIteration, lessThanOrEqualTo(debugOptions.getUnboundedReaderMaxElements()));
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
@@ -645,7 +645,9 @@ public class WorkerCustomSourcesTest {
         numReadOnThisIteration++;
       }
       Instant afterReading = Instant.now();
-      long maxReadMillis = debugOptions.getUnboundedReaderMaxReadTimeSec()*1000+debugOptions.getUnboundedReaderMaxReadTimeMs();
+      long maxReadMillis =
+          debugOptions.getUnboundedReaderMaxReadTimeSec() * 1000
+              + debugOptions.getUnboundedReaderMaxReadTimeMs();
       assertThat(
           new Duration(beforeReading, afterReading).millis(),
           lessThanOrEqualTo(maxReadMillis + 1000));


### PR DESCRIPTION
UnboundedReader is controlled with UnboundedReaderMaxReadTimeSec and UnboundedReaderMaxElements.
For sub second latency user has to set UnboundedReaderMaxElements to 1 which is not flexible as there may be multiple situation where there are more elements.

In this change UnboundedReaderMaxReadTimeSec becomes double. Change is backward compatible. 
Unlike #31036, this doesn't introduce additional flag. 