### PR TITLE
[release-2.56.0] Exclude broken versions of GRPCIO and upgrade the base image requirements 

### DIFF
--- a/sdks/python/container/py310/base_image_requirements.txt
+++ b/sdks/python/container/py310/base_image_requirements.txt
@@ -50,7 +50,7 @@ fastavro==1.9.4
 fasteners==0.19
 freezegun==1.4.0
 future==1.0.0
-google-api-core==2.16.2
+google-api-core==2.18.0
 google-api-python-client==2.126.0
 google-apitools==0.5.31
 google-auth==2.29.0
@@ -78,8 +78,8 @@ googleapis-common-protos==1.63.0
 greenlet==3.0.3
 grpc-google-iam-v1==0.13.0
 grpc-interceptor==0.15.4
-grpcio==1.62.1
-grpcio-status==1.62.1
+grpcio==1.62.2
+grpcio-status==1.62.2
 guppy3==3.1.4.post1
 hdfs==2.7.3
 httplib2==0.22.0
@@ -137,7 +137,7 @@ rpds-py==0.18.0
 rsa==4.9
 scikit-learn==1.4.2
 scipy==1.13.0
-shapely==2.0.3
+shapely==2.0.4
 six==1.16.0
 sortedcontainers==2.4.0
 soupsieve==2.5

--- a/sdks/python/container/py311/base_image_requirements.txt
+++ b/sdks/python/container/py311/base_image_requirements.txt
@@ -48,7 +48,7 @@ fastavro==1.9.4
 fasteners==0.19
 freezegun==1.4.0
 future==1.0.0
-google-api-core==2.16.2
+google-api-core==2.18.0
 google-api-python-client==2.126.0
 google-apitools==0.5.31
 google-auth==2.29.0
@@ -76,8 +76,8 @@ googleapis-common-protos==1.63.0
 greenlet==3.0.3
 grpc-google-iam-v1==0.13.0
 grpc-interceptor==0.15.4
-grpcio==1.62.1
-grpcio-status==1.62.1
+grpcio==1.62.2
+grpcio-status==1.62.2
 guppy3==3.1.4.post1
 hdfs==2.7.3
 httplib2==0.22.0
@@ -135,7 +135,7 @@ rpds-py==0.18.0
 rsa==4.9
 scikit-learn==1.4.2
 scipy==1.13.0
-shapely==2.0.3
+shapely==2.0.4
 six==1.16.0
 sortedcontainers==2.4.0
 soupsieve==2.5

--- a/sdks/python/container/py38/base_image_requirements.txt
+++ b/sdks/python/container/py38/base_image_requirements.txt
@@ -51,7 +51,7 @@ fastavro==1.9.4
 fasteners==0.19
 freezegun==1.4.0
 future==1.0.0
-google-api-core==2.16.2
+google-api-core==2.18.0
 google-api-python-client==2.126.0
 google-apitools==0.5.31
 google-auth==2.29.0
@@ -79,8 +79,8 @@ googleapis-common-protos==1.63.0
 greenlet==3.0.3
 grpc-google-iam-v1==0.13.0
 grpc-interceptor==0.15.4
-grpcio==1.62.1
-grpcio-status==1.62.1
+grpcio==1.62.2
+grpcio-status==1.62.2
 guppy3==3.1.4.post1
 hdfs==2.7.3
 httplib2==0.22.0
@@ -141,7 +141,7 @@ rpds-py==0.18.0
 rsa==4.9
 scikit-learn==1.3.2
 scipy==1.10.1
-shapely==2.0.3
+shapely==2.0.4
 six==1.16.0
 sortedcontainers==2.4.0
 soupsieve==2.5

--- a/sdks/python/container/py39/base_image_requirements.txt
+++ b/sdks/python/container/py39/base_image_requirements.txt
@@ -50,7 +50,7 @@ fastavro==1.9.4
 fasteners==0.19
 freezegun==1.4.0
 future==1.0.0
-google-api-core==2.16.2
+google-api-core==2.18.0
 google-api-python-client==2.126.0
 google-apitools==0.5.31
 google-auth==2.29.0
@@ -78,8 +78,8 @@ googleapis-common-protos==1.63.0
 greenlet==3.0.3
 grpc-google-iam-v1==0.13.0
 grpc-interceptor==0.15.4
-grpcio==1.62.1
-grpcio-status==1.62.1
+grpcio==1.62.2
+grpcio-status==1.62.2
 guppy3==3.1.4.post1
 hdfs==2.7.3
 httplib2==0.22.0
@@ -138,7 +138,7 @@ rpds-py==0.18.0
 rsa==4.9
 scikit-learn==1.4.2
 scipy==1.13.0
-shapely==2.0.3
+shapely==2.0.4
 six==1.16.0
 sortedcontainers==2.4.0
 soupsieve==2.5

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -365,7 +365,7 @@ if __name__ == '__main__':
           'cloudpickle~=2.2.1',
           'fastavro>=0.23.6,<2',
           'fasteners>=0.3,<1.0',
-          'grpcio>=1.33.1,!=1.48.0,<2',
+          'grpcio>=1.33.1,<2,!=1.48.0,!=1.59.*,!=1.60.*,!=1.61.*,!=1.62.0,!=1.62.1',  # pylint: disable=line-too-long
           'hdfs>=2.1.0,<3.0.0',
           'httplib2>=0.8,<0.23.0',
           # https://github.com/PiotrDabkowski/Js2Py/issues/317
@@ -436,9 +436,7 @@ if __name__ == '__main__':
           ],
           'gcp': [
               'cachetools>=3.1.0,<6',
-              # Temporary workaround until grpcio releases a fix for
-              # https://github.com/grpc/grpc/issues/36265
-              'google-api-core>=2.0.0,!=2.17.*,!=2.18.*,<3',
+              'google-api-core>=2.0.0,<3',
               'google-apitools>=0.5.31,<0.5.32',
               # NOTE: Maintainers, please do not require google-auth>=2.x.x
               # Until this issue is closed


### PR DESCRIPTION
cherry-pick: #31044 to the release branch. 

fixes: #30867