### PR TITLE
[#30083][prism] Stabilize additional teststream cases.

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/engine/engine_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/engine_test.go
@@ -186,6 +186,11 @@ func TestTestStream(t *testing.T) {
 		{pipeline: primitives.TestStreamTwoFloat64Sequences},
 		{pipeline: primitives.TestStreamTwoInt64Sequences},
 		{pipeline: primitives.TestStreamTwoUserTypeSequences},
+
+		{pipeline: primitives.TestStreamSimple},
+		{pipeline: primitives.TestStreamSimple_InfinityDefault},
+		{pipeline: primitives.TestStreamToGBK},
+		{pipeline: primitives.TestStreamTimersEventTime},
 	}
 
 	configs := []struct {

--- a/sdks/go/pkg/beam/runners/prism/internal/worker/bundle.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/bundle.go
@@ -73,9 +73,10 @@ type B struct {
 func (b *B) Init() {
 	// We need to see final data and timer signals that match the number of
 	// outputs the stage this bundle executes posesses
-	b.dataSema.Store(int32(b.OutputCount + len(b.HasTimers)))
+	outCap := int32(b.OutputCount + len(b.HasTimers))
+	b.dataSema.Store(outCap)
 	b.DataWait = make(chan struct{})
-	if b.OutputCount == 0 {
+	if outCap == 0 {
 		close(b.DataWait) // Can happen if there are no outputs for the bundle.
 	}
 	b.Resp = make(chan *fnpb.ProcessBundleResponse, 1)

--- a/sdks/go/test/integration/primitives/teststream.go
+++ b/sdks/go/test/integration/primitives/teststream.go
@@ -16,7 +16,10 @@
 package primitives
 
 import (
+	"fmt"
+
 	"github.com/apache/beam/sdks/v2/go/pkg/beam"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/register"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/testing/passert"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/testing/teststream"
 )
@@ -171,4 +174,75 @@ func TestStreamInt16Sequence(s beam.Scope) {
 
 	passert.Count(s, col, "teststream int15", 3)
 	passert.EqualsList(s, col, ele)
+}
+
+// panicIfNot42 panics if the value is not 42.
+func panicIfNot42(v int) {
+	if v != 42 {
+		panic(fmt.Sprintf("got %v, want 42", v))
+	}
+}
+
+// dropKeyEmitValues panics if the value is not 42.
+func dropKeyEmitValues(_ int, vs func(*int) bool, emit func(int)) {
+	var v int
+	for vs(&v) {
+		emit(v)
+	}
+}
+
+func init() {
+	register.Function1x0(panicIfNot42)
+	register.Function3x0(dropKeyEmitValues)
+}
+
+// TestStreamSimple is a trivial pipeline where teststream sends
+// a single element to a DoFn that checks that it's received the value.
+// Intended for runner validation.
+func TestStreamSimple(s beam.Scope) {
+	con := teststream.NewConfig()
+	ele := []int{42}
+	con.AddElementList(100, ele)
+	con.AdvanceWatermarkToInfinity()
+
+	col := teststream.Create(s, con)
+	beam.ParDo0(s, panicIfNot42, col)
+}
+
+// TestStreamSimple_InfinityDefault is the same trivial pipeline that
+// validates that the watermark is automatically advanced to infinity
+// even when the user doesn't set it.
+// Intended for runner validation.
+func TestStreamSimple_InfinityDefault(s beam.Scope) {
+	con := teststream.NewConfig()
+	ele := []int{42}
+	con.AddElementList(100, ele)
+
+	col := teststream.Create(s, con)
+	beam.ParDo0(s, panicIfNot42, col)
+}
+
+// TestStreamToGBK is a trivial pipeline where teststream sends
+// a single element to a GBK.
+func TestStreamToGBK(s beam.Scope) {
+	con := teststream.NewConfig()
+	ele := []int{42}
+	con.AddElementList(100, ele)
+	con.AdvanceWatermarkToInfinity()
+
+	col := teststream.Create(s, con)
+	keyed := beam.AddFixedKey(s, col)
+	gbk := beam.GroupByKey(s, keyed)
+	dropped := beam.ParDo(s, dropKeyEmitValues, gbk)
+	beam.ParDo0(s, panicIfNot42, dropped)
+}
+
+// TestStreamTimersEventTime validates event time timers in a test stream "driven" pipeline.
+func TestStreamTimersEventTime(s beam.Scope) {
+	timersEventTimePipelineBuilder(func(s beam.Scope) beam.PCollection {
+		c := teststream.NewConfig()
+		c.AddElements(123456, []byte{42})
+		c.AdvanceWatermarkToInfinity()
+		return teststream.Create(s, c)
+	})(s)
 }

--- a/sdks/go/test/integration/primitives/teststream.go
+++ b/sdks/go/test/integration/primitives/teststream.go
@@ -183,7 +183,7 @@ func panicIfNot42(v int) {
 	}
 }
 
-// dropKeyEmitValues panics if the value is not 42.
+// dropKeyEmitValues drops the key and emits the value.
 func dropKeyEmitValues(_ int, vs func(*int) bool, emit func(int)) {
 	var v int
 	for vs(&v) {

--- a/sdks/go/test/integration/primitives/teststream_test.go
+++ b/sdks/go/test/integration/primitives/teststream_test.go
@@ -87,7 +87,7 @@ func TestTestStreamToGBK(t *testing.T) {
 	ptest.BuildAndRun(t, TestStreamToGBK)
 }
 
-func TestTestStreamTimersEventTimeTestStream(t *testing.T) {
+func TestTestStreamTimersEventTime(t *testing.T) {
 	integration.CheckFilters(t)
 	ptest.BuildAndRun(t, TestStreamTimersEventTime)
 }

--- a/sdks/go/test/integration/primitives/teststream_test.go
+++ b/sdks/go/test/integration/primitives/teststream_test.go
@@ -71,3 +71,23 @@ func TestTestStreamTwoUserTypeSequences(t *testing.T) {
 	integration.CheckFilters(t)
 	ptest.BuildAndRun(t, TestStreamTwoUserTypeSequences)
 }
+
+func TestTestStreamSimple(t *testing.T) {
+	integration.CheckFilters(t)
+	ptest.BuildAndRun(t, TestStreamSimple)
+}
+
+func TestTestStreamTestStreamSimple_InfinityDefault(t *testing.T) {
+	integration.CheckFilters(t)
+	ptest.BuildAndRun(t, TestStreamSimple_InfinityDefault)
+}
+
+func TestTestStreamToGBK(t *testing.T) {
+	integration.CheckFilters(t)
+	ptest.BuildAndRun(t, TestStreamToGBK)
+}
+
+func TestTestStreamTimersEventTimeTestStream(t *testing.T) {
+	integration.CheckFilters(t)
+	ptest.BuildAndRun(t, TestStreamTimersEventTime)
+}

--- a/sdks/go/test/integration/primitives/teststream_test.go
+++ b/sdks/go/test/integration/primitives/teststream_test.go
@@ -77,7 +77,7 @@ func TestTestStreamSimple(t *testing.T) {
 	ptest.BuildAndRun(t, TestStreamSimple)
 }
 
-func TestTestStreamTestStreamSimple_InfinityDefault(t *testing.T) {
+func TestTestStreamSimple_InfinityDefault(t *testing.T) {
 	integration.CheckFilters(t)
 	ptest.BuildAndRun(t, TestStreamSimple_InfinityDefault)
 }

--- a/sdks/go/test/integration/primitives/timers.go
+++ b/sdks/go/test/integration/primitives/timers.go
@@ -93,7 +93,7 @@ func (fn *eventTimeFn) OnTimer(ctx context.Context, ts beam.EventTime, sp state.
 	}
 }
 
-// TimersEventTime takes in an impulse transform and produces a pipeline construction
+// timersEventTimePipelineBuilder takes in an impulse transform and produces a pipeline construction
 // function that validates EventTime timers.
 //
 // The impulse is provided outside to swap between a bounded impulse, and


### PR DESCRIPTION
While working on adding Processing Time handling, it came to light that there were some inconsistent cases WRT handling TestStream based pipelines, in particular when there were no impulses included.

This fix uses the existing watermark hold system to restrain execution until the test stream is ready, and reflect holds based on test stream watermark events properly before their execution.

This discovered flaky fail behavior due to how timers and data outputs were handled in bundle processing, also fixed in this PR. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
