### PR TITLE
[release-2.56.0] Cherry-picks #31070

### DIFF
--- a/sdks/python/apache_beam/runners/portability/stager.py
+++ b/sdks/python/apache_beam/runners/portability/stager.py
@@ -791,6 +791,7 @@ class Stager(object):
               Stager._get_python_executable(),
               '-m',
               'build',
+              '--no-isolation',  # Otherwise, we need internet access to PyPI.
               '--sdist',
               '--outdir',
               temp_dir,


### PR DESCRIPTION
Don't use isolated builds when building an sdist for a pipeline package supplied in --setup_file option. 