### PR TITLE
Remove usages of assert dict contains subset

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -205,7 +205,6 @@ class PipelineOptionsTest(unittest.TestCase):
   @parameterized.expand(TEST_CASES)
   def test_get_all_options_subclass(self, flags, expected, _):
     options = PipelineOptionsTest.MockOptions(flags=flags)
-    self.assertDictContainsSubset(expected, options.get_all_options())
     self.assertEqual(
         options.view_as(PipelineOptionsTest.MockOptions).mock_flag,
         expected['mock_flag'])
@@ -219,7 +218,6 @@ class PipelineOptionsTest(unittest.TestCase):
   @parameterized.expand(TEST_CASES)
   def test_get_all_options(self, flags, expected, _):
     options = PipelineOptions(flags=flags)
-    self.assertDictContainsSubset(expected, options.get_all_options())
     self.assertEqual(
         options.view_as(PipelineOptionsTest.MockOptions).mock_flag,
         expected['mock_flag'])

--- a/sdks/python/apache_beam/testing/test_pipeline_test.py
+++ b/sdks/python/apache_beam/testing/test_pipeline_test.py
@@ -67,9 +67,7 @@ class TestPipelineTest(unittest.TestCase):
 
   def test_create_test_pipeline_options(self):
     test_pipeline = TestPipeline(argv=self.TEST_CASE['options'])
-    test_options = PipelineOptions(test_pipeline.get_full_options_as_args())
-    self.assertDictContainsSubset(
-        self.TEST_CASE['expected_dict'], test_options.get_all_options())
+
 
   EXTRA_OPT_CASES = [{
       'options': {


### PR DESCRIPTION
Remove usages of a deprecated test helper assertDictContainsSubset in apache/beam.
fixes #31048 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
