### PR TITLE
Change assertion and pipeline timeout for kafka stress test

### DIFF
--- a/it/kafka/src/test/java/org/apache/beam/it/kafka/KafkaIOST.java
+++ b/it/kafka/src/test/java/org/apache/beam/it/kafka/KafkaIOST.java
@@ -155,7 +155,7 @@ public final class KafkaIOST extends IOStressTestBase {
                   Configuration.class),
               "large",
               Configuration.fromJsonString(
-                  "{\"rowsPerSecond\":50000,\"numRecords\":5000000,\"valueSizeBytes\":1000,\"minutes\":60,\"pipelineTimeout\":120,\"runner\":\"DataflowRunner\"}",
+                  "{\"rowsPerSecond\":50000,\"numRecords\":5000000,\"valueSizeBytes\":1000,\"minutes\":60,\"pipelineTimeout\":240,\"runner\":\"DataflowRunner\"}",
                   Configuration.class));
     } catch (IOException e) {
       throw new RuntimeException(e);
@@ -199,9 +199,9 @@ public final class KafkaIOST extends IOStressTestBase {
               readInfo.jobId(),
               getBeamMetricsName(PipelineMetricsType.COUNTER, READ_ELEMENT_METRIC_NAME));
 
-      // Assert that writeNumRecords equals or greater than readNumRecords since there might be
+      // Assert that readNumRecords equals or greater than writeNumRecords since there might be
       // duplicates when testing big amount of data
-      assertTrue(writeNumRecords >= readNumRecords);
+      assertTrue(readNumRecords >= writeNumRecords);
     } finally {
       // clean up pipelines
       if (pipelineLauncher.getJobStatus(project, region, writeInfo.jobId())


### PR DESCRIPTION
Previously, the assertion was that writeNumRecords was greater than readNumRecords because the read pipeline couldn't finish reading all records before the pipeline timeout. Now, thanks to the increased timeout, all records are successfully read, so readNumRecords is greater than writeNumRecords.

Example of tests:
[Write to kafka job](https://console.cloud.google.com/dataflow/jobs/us-central1/2024-04-23_13_13_52-10599600595588945166;step=Write%20to%20Kafka;mainTab=JOB_GRAPH;graphView=0?project=apache-beam-testing&pageState=(%22dfTime%22:(%22l%22:%22dfJobMaxTime%22)))
[Read from kafka job](https://console.cloud.google.com/dataflow/jobs/us-central1/2024-04-23_13_14_29-10921604080829783601;step=Read%20from%20Kafka;mainTab=JOB_GRAPH;graphView=0?project=apache-beam-testing&pageState=(%22dfTime%22:(%22l%22:%22dfJobMaxTime%22)))