### PR TITLE
Add UnboundedReaderMaxReadTimeMs to DataflowPipelineDebugOptions, deprecate UnboundedReaderMaxReadTimeSec

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -223,7 +223,6 @@ public interface DataflowPipelineDebugOptions
    */
   @Description(
       "The max amount of time before an UnboundedReader is consumed before checkpointing, in seconds.")
-  @Default.Integer(10)
   @Deprecated
   Integer getUnboundedReaderMaxReadTimeSec();
 
@@ -232,10 +231,24 @@ public interface DataflowPipelineDebugOptions
   /** The max amount of time an UnboundedReader is consumed before checkpointing. */
   @Description(
       "The max amount of time before an UnboundedReader is consumed before checkpointing, in millis.")
-  @Default.Integer(10 * 1000)
+  @Default.InstanceFactory(UnboundedReaderMaxReadTimeFactory.class)
   Integer getUnboundedReaderMaxReadTimeMs();
 
   void setUnboundedReaderMaxReadTimeMs(Integer value);
+
+  /**
+   * Sets Integer value based on old, deprecated field ({@link
+   * DataflowPipelineDebugOptions#getUnboundedReaderMaxReadTimeSec()}) is set.
+   */
+  class UnboundedReaderMaxReadTimeFactory implements DefaultValueFactory<Integer> {
+    @Override
+    public Integer create(PipelineOptions options) {
+      DataflowPipelineDebugOptions debugOptions = options.as(DataflowPipelineDebugOptions.class);
+      if (debugOptions.getUnboundedReaderMaxReadTimeSec() != null) {
+        return debugOptions.getUnboundedReaderMaxReadTimeSec() * 1000;
+      } else return 10000;
+    }
+  }
 
   /** The max elements read from an UnboundedReader before checkpointing. */
   @Description("The max elements read from an UnboundedReader before checkpointing. ")

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -246,7 +246,9 @@ public interface DataflowPipelineDebugOptions
       DataflowPipelineDebugOptions debugOptions = options.as(DataflowPipelineDebugOptions.class);
       if (debugOptions.getUnboundedReaderMaxReadTimeSec() != null) {
         return debugOptions.getUnboundedReaderMaxReadTimeSec() * 1000;
-      } else return 10000;
+      } else {
+        return 10000;
+      }
     }
   }
 

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -224,6 +224,7 @@ public interface DataflowPipelineDebugOptions
   @Description(
       "The max amount of time before an UnboundedReader is consumed before checkpointing, in seconds.")
   @Deprecated
+  @Default.Integer(10)
   Integer getUnboundedReaderMaxReadTimeSec();
 
   void setUnboundedReaderMaxReadTimeSec(Integer value);
@@ -238,17 +239,13 @@ public interface DataflowPipelineDebugOptions
 
   /**
    * Sets Integer value based on old, deprecated field ({@link
-   * DataflowPipelineDebugOptions#getUnboundedReaderMaxReadTimeSec()}) is set.
+   * DataflowPipelineDebugOptions#getUnboundedReaderMaxReadTimeSec()}).
    */
-  class UnboundedReaderMaxReadTimeFactory implements DefaultValueFactory<Integer> {
+  static final class UnboundedReaderMaxReadTimeFactory implements DefaultValueFactory<Integer> {
     @Override
     public Integer create(PipelineOptions options) {
       DataflowPipelineDebugOptions debugOptions = options.as(DataflowPipelineDebugOptions.class);
-      if (debugOptions.getUnboundedReaderMaxReadTimeSec() != null) {
-        return debugOptions.getUnboundedReaderMaxReadTimeSec() * 1000;
-      } else {
-        return 10000;
-      }
+      return debugOptions.getUnboundedReaderMaxReadTimeSec() * 1000;
     }
   }
 

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -241,7 +241,7 @@ public interface DataflowPipelineDebugOptions
    * Sets Integer value based on old, deprecated field ({@link
    * DataflowPipelineDebugOptions#getUnboundedReaderMaxReadTimeSec()}).
    */
-  static final class UnboundedReaderMaxReadTimeFactory implements DefaultValueFactory<Integer> {
+  final class UnboundedReaderMaxReadTimeFactory implements DefaultValueFactory<Integer> {
     @Override
     public Integer create(PipelineOptions options) {
       DataflowPipelineDebugOptions debugOptions = options.as(DataflowPipelineDebugOptions.class);

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowPipelineDebugOptions.java
@@ -216,13 +216,26 @@ public interface DataflowPipelineDebugOptions
 
   void setReaderCacheTimeoutSec(Integer value);
 
-  /** The max amount of time an UnboundedReader is consumed before checkpointing. */
+  /**
+   * The max amount of time an UnboundedReader is consumed before checkpointing.
+   *
+   * @deprecated use {@link DataflowPipelineDebugOptions#getUnboundedReaderMaxReadTimeMs()} instead
+   */
   @Description(
       "The max amount of time before an UnboundedReader is consumed before checkpointing, in seconds.")
   @Default.Integer(10)
+  @Deprecated
   Integer getUnboundedReaderMaxReadTimeSec();
 
   void setUnboundedReaderMaxReadTimeSec(Integer value);
+
+  /** The max amount of time an UnboundedReader is consumed before checkpointing. */
+  @Description(
+      "The max amount of time before an UnboundedReader is consumed before checkpointing, in millis.")
+  @Default.Integer(10 * 1000)
+  Integer getUnboundedReaderMaxReadTimeMs();
+
+  void setUnboundedReaderMaxReadTimeMs(Integer value);
 
   /** The max elements read from an UnboundedReader before checkpointing. */
   @Description("The max elements read from an UnboundedReader before checkpointing. ")

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSources.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSources.java
@@ -796,9 +796,13 @@ public class WorkerCustomSources {
       this.context = context;
       this.started = started;
       DataflowPipelineDebugOptions debugOptions = options.as(DataflowPipelineDebugOptions.class);
-      this.endTime =
-          Instant.now()
-              .plus(Duration.standardSeconds(debugOptions.getUnboundedReaderMaxReadTimeSec()));
+      long MaxReadTimeMsDeprecated = debugOptions.getUnboundedReaderMaxReadTimeSec() * 1000L;
+      long maxReadTimeMs = debugOptions.getUnboundedReaderMaxReadTimeMs();
+      if (MaxReadTimeMsDeprecated != 10000L && maxReadTimeMs == 10000L) {
+        // Take old field if UnboundedReaderMaxReadTimeMs is default
+        maxReadTimeMs = MaxReadTimeMsDeprecated;
+      }
+      this.endTime = Instant.now().plus(Duration.millis(maxReadTimeMs));
       this.maxElems = debugOptions.getUnboundedReaderMaxElements();
       this.backoffFactory =
           FluentBackoff.DEFAULT

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSources.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSources.java
@@ -796,12 +796,7 @@ public class WorkerCustomSources {
       this.context = context;
       this.started = started;
       DataflowPipelineDebugOptions debugOptions = options.as(DataflowPipelineDebugOptions.class);
-      long MaxReadTimeMsDeprecated = debugOptions.getUnboundedReaderMaxReadTimeSec() * 1000L;
       long maxReadTimeMs = debugOptions.getUnboundedReaderMaxReadTimeMs();
-      if (MaxReadTimeMsDeprecated != 10000L && maxReadTimeMs == 10000L) {
-        // Take old field if UnboundedReaderMaxReadTimeMs is default
-        maxReadTimeMs = MaxReadTimeMsDeprecated;
-      }
       this.endTime = Instant.now().plus(Duration.millis(maxReadTimeMs));
       this.maxElems = debugOptions.getUnboundedReaderMaxElements();
       this.backoffFactory =

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/WorkerCustomSourcesTest.java
@@ -645,10 +645,10 @@ public class WorkerCustomSourcesTest {
         numReadOnThisIteration++;
       }
       Instant afterReading = Instant.now();
-      long maxReadSec = debugOptions.getUnboundedReaderMaxReadTimeSec();
+      long maxReadMs = debugOptions.getUnboundedReaderMaxReadTimeMs();
       assertThat(
-          new Duration(beforeReading, afterReading).getStandardSeconds(),
-          lessThanOrEqualTo(maxReadSec + 1));
+          new Duration(beforeReading, afterReading).getMillis(),
+          lessThanOrEqualTo(maxReadMs + 1000L));
       assertThat(
           numReadOnThisIteration, lessThanOrEqualTo(debugOptions.getUnboundedReaderMaxElements()));
 


### PR DESCRIPTION
UnboundedReader is controlled with UnboundedReaderMaxReadTimeSec and UnboundedReaderMaxElements.
For sub second latency user has to set UnboundedReaderMaxElements to 1 which is not flexible as there may be multiple situation where there are more elements.

In this change UnboundedReaderMaxReadTimeSec becomes deprecated. 
UnboundedReaderMaxReadTimeMs is introduced. 
Change is backward compatible - it takes into account both values - If UnboundedReaderMaxReadTimeSec is non default it will take overwrite  UnboundedReaderMaxReadTimeMs.

