### PR TITLE
Fix reporting metrics not supported warning for BigQueryIO Direct read when throttled

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServices.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServices.java
@@ -302,6 +302,14 @@ public interface BigQueryServices extends Serializable {
     SplitReadStreamResponse splitReadStream(SplitReadStreamRequest request, String fullTableId);
 
     /**
+     * Call this method on Work Item thread to report outstanding metrics.
+     *
+     * <p>Because incrementing metrics is only supported on the execution thread, callback thread
+     * that has pending metrics cannot report it directly.
+     */
+    default void reportPendingMetrics() {}
+
+    /**
      * Close the client object.
      *
      * <p>The override is required since {@link AutoCloseable} allows the close method to raise an


### PR DESCRIPTION
Fixes #30646. Actually the feature is there but there is a bug prevented it from working properly.

The pipeline, when throttled, can see warning

```
Reporting metrics are not supported in the current execution environment.
```

raised from here: https://github.com/apache/beam/blob/8454cc9503008e28f5d3e90d39659352d46af9c2/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java#L1676

This is because the method is called on a callback thread that does not have thread level metrics container. Change it to increment the metrics back to StorageClientImpl temporarily then add it to Beam metrics in work item thread resolved the issue.

Tested with reading TPCDS_1T

## Before (pipeline throttled, slowdown, scheduler aggressively upscale worker):

![image](https://github.com/apache/beam/assets/8010435/293b4e90-9b5d-4bf9-b382-3fbe08a8da88)

- max worker 106

## After (pipeline actively scale down, throttling metrics shown)

![image](https://github.com/apache/beam/assets/8010435/2cef6639-12a5-40ed-bf45-9f1d3d93edfc)
- throttling-msecs	15,060,000
- max worker: 57

## Sufficient quota:

![image](https://github.com/apache/beam/assets/8010435/dc27e742-d9aa-4744-a549-71988aac5847)

- max worker: 43

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
