### PR TITLE
Suppress BigQuery read stream splitAtFraction when API  busy call or timeout

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
@@ -35,6 +35,12 @@ import java.io.IOException;
 import java.util.Iterator;
 import java.util.List;
 import java.util.NoSuchElementException;
+import java.util.concurrent.ExecutionException;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.Future;
+import java.util.concurrent.TimeUnit;
+import java.util.concurrent.TimeoutException;
 import org.apache.beam.runners.core.metrics.ServiceCallMetric;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.io.BoundedSource;
@@ -192,6 +198,7 @@ class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
             "split-at-fraction-calls-failed-due-to-other-reasons");
     private final Counter successfulSplitCalls =
         Metrics.counter(BigQueryStorageStreamReader.class, "split-at-fraction-calls-successful");
+    private static final ExecutorService executor = Executors.newCachedThreadPool();
 
     private BigQueryStorageStreamReader(
         BigQueryStorageStreamSource<T> source, BigQueryOptions options) throws IOException {
@@ -238,9 +245,12 @@ class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
     private synchronized boolean readNextRecord() throws IOException {
       Iterator<ReadRowsResponse> responseIterator = this.responseIterator;
       while (reader.readyForNextReadResponse()) {
+        boolean previous = splitAllowed;
+        splitAllowed = false;
         // hasNext call has internal retry. Record throttling metrics after called
         boolean hasNext = responseIterator.hasNext();
         storageClient.reportPendingMetrics();
+        splitAllowed = previous;
 
         if (!hasNext) {
           fractionConsumed = 1d;
@@ -388,8 +398,22 @@ class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
           // The following line is required to trigger the `FailedPreconditionException` on which
           // the SplitReadStream validation logic depends. Removing it will cause incorrect
           // split operations to succeed.
-          newResponseIterator.hasNext();
-          storageClient.reportPendingMetrics();
+          Future<Boolean> future = executor.submit(newResponseIterator::hasNext);
+          try {
+            // The intended wait time is in sync with splitReadStreamSettings.setRetrySettings in
+            // StorageClientImpl.
+            future.get(30, TimeUnit.SECONDS);
+          } catch (TimeoutException | InterruptedException | ExecutionException e) {
+            badSplitPointCalls.inc();
+            LOG.info(
+                "Split of stream {} abandoned because current position check failed with {}.",
+                source.readStream.getName(),
+                e.getClass().getName());
+
+            return null;
+          } finally {
+            future.cancel(true); // may or may not desire this
+          }
         } catch (FailedPreconditionException e) {
           // The current source has already moved past the split point, so this split attempt
           // is unsuccessful.

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
@@ -249,8 +249,8 @@ class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
         splitAllowed = false;
         // hasNext call has internal retry. Record throttling metrics after called
         boolean hasNext = responseIterator.hasNext();
-        storageClient.reportPendingMetrics();
         splitAllowed = previous;
+        storageClient.reportPendingMetrics();
 
         if (!hasNext) {
           fractionConsumed = 1d;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
@@ -412,7 +412,7 @@ class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
 
             return null;
           } finally {
-            future.cancel(true); // may or may not desire this
+            future.cancel(true);
           }
         } catch (FailedPreconditionException e) {
           // The current source has already moved past the split point, so this split attempt

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
@@ -246,10 +246,11 @@ class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
       Iterator<ReadRowsResponse> responseIterator = this.responseIterator;
       while (reader.readyForNextReadResponse()) {
         boolean previous = splitAllowed;
+        // disallow splitAtFraction (where it also calls hasNext) when iterator busy
         splitAllowed = false;
-        // hasNext call has internal retry. Record throttling metrics after called
         boolean hasNext = responseIterator.hasNext();
         splitAllowed = previous;
+        // hasNext call has internal retry. Record throttling metrics after called
         storageClient.reportPendingMetrics();
 
         if (!hasNext) {

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageReadTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageReadTest.java
@@ -1464,7 +1464,7 @@ public class BigQueryIOStorageReadTest {
     // wait until thread proceed
     latch.await();
 
-    // Beam does not split storage read api v2 stream
+    // SplitAfFraction rejected while response iterator busy
     assertNull(reader.splitAtFraction(0.5));
     t.interrupt();
   }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageReadTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageReadTest.java
@@ -1394,10 +1394,6 @@ public class BigQueryIOStorageReadTest {
       this.latch = latch;
     }
 
-    static final Object lock = new Object();
-
-    static boolean hasNextCalled = false;
-
     @Override
     public Iterator<ReadRowsResponse> iterator() {
       return new StuckIterator();

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageReadTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageReadTest.java
@@ -66,7 +66,9 @@ import java.nio.channels.Channels;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collection;
+import java.util.Iterator;
 import java.util.List;
+import java.util.concurrent.CountDownLatch;
 import org.apache.arrow.memory.BufferAllocator;
 import org.apache.arrow.memory.RootAllocator;
 import org.apache.arrow.vector.BigIntVector;
@@ -1382,6 +1384,91 @@ public class BigQueryIOStorageReadTest {
       return KV.of(
           input.getRecord().get("name").toString(), (Long) input.getRecord().get("number"));
     }
+  }
+
+  static class StuckResponse extends ArrayList<ReadRowsResponse> {
+
+    private CountDownLatch latch;
+
+    public StuckResponse(CountDownLatch latch) {
+      this.latch = latch;
+    }
+
+    static final Object lock = new Object();
+
+    static boolean hasNextCalled = false;
+
+    @Override
+    public Iterator<ReadRowsResponse> iterator() {
+      return new StuckIterator();
+    }
+
+    private class StuckIterator implements Iterator<ReadRowsResponse> {
+
+      @Override
+      public boolean hasNext() {
+        latch.countDown();
+        try {
+          Thread.sleep(Long.MAX_VALUE);
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+        }
+        return false;
+      }
+
+      @Override
+      public ReadRowsResponse next() {
+        return null;
+      }
+    }
+  }
+
+  @Test
+  public void testStreamSourceSplitAtFractionFailsWhenReaderRunning() throws Exception {
+    ReadSession readSession =
+        ReadSession.newBuilder()
+            .setName("readSession")
+            .setAvroSchema(AvroSchema.newBuilder().setSchema(AVRO_SCHEMA_STRING))
+            .build();
+
+    ReadRowsRequest expectedRequest =
+        ReadRowsRequest.newBuilder().setReadStream("readStream").build();
+
+    CountDownLatch latch = new CountDownLatch(1);
+    StorageClient fakeStorageClient = mock(StorageClient.class);
+    when(fakeStorageClient.readRows(expectedRequest, ""))
+        .thenReturn(new FakeBigQueryServerStream<>(new StuckResponse(latch)));
+
+    // new StuckIteratorList<Void>()
+
+    BigQueryStorageStreamSource<TableRow> streamSource =
+        BigQueryStorageStreamSource.create(
+            readSession,
+            ReadStream.newBuilder().setName("readStream").build(),
+            TABLE_SCHEMA,
+            new TableRowParser(),
+            TableRowJsonCoder.of(),
+            new FakeBigQueryServices().withStorageClient(fakeStorageClient));
+
+    BigQueryStorageStreamReader<TableRow> reader = streamSource.createReader(options);
+
+    Thread t =
+        new Thread(
+            () -> {
+              try {
+                reader.start();
+              } catch (IOException e) {
+                throw new RuntimeException(e);
+              }
+            });
+    t.start();
+
+    // wait until thread proceed
+    latch.await();
+
+    // Beam does not split storage read api v2 stream
+    assertNull(reader.splitAtFraction(0.5));
+    t.interrupt();
   }
 
   @Test

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageReadTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOStorageReadTest.java
@@ -1386,6 +1386,10 @@ public class BigQueryIOStorageReadTest {
     }
   }
 
+  /**
+   * A mock response that stuck indefinitely when the returned iterator's hasNext get called,
+   * intended to simulate server side issue.
+   */
   static class StuckResponse extends ArrayList<ReadRowsResponse> {
 
     private CountDownLatch latch;
@@ -1434,8 +1438,6 @@ public class BigQueryIOStorageReadTest {
     StorageClient fakeStorageClient = mock(StorageClient.class);
     when(fakeStorageClient.readRows(expectedRequest, ""))
         .thenReturn(new FakeBigQueryServerStream<>(new StuckResponse(latch)));
-
-    // new StuckIteratorList<Void>()
 
     BigQueryStorageStreamSource<TableRow> streamSource =
         BigQueryStorageStreamSource.create(


### PR DESCRIPTION
`Resolve` https://github.com/apache/beam/issues/30646#issuecomment-2080102737

* Reject split attempt early when there is an ongoing hasNext call in work item thread

* TImeout hasNext call in splitAtFraction in alignment with client splitReadStreamSettings

The issue exist on both released Beam and after #31096

Tested on read stream API v1 (default) and Dataflow legacy runner in a quota restricted project:

<img width="987" alt="image" src="https://github.com/apache/beam/assets/8010435/156dc67a-468a-4016-8f09-d32eed5652ad">


Without the change, the pipeline appears to stuck indefinitely. the [onRetryAttempt](https://github.com/apache/beam/blob/673da546c1465c931fdbbc5769e7d566ff55b4d8/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryServicesImpl.java#L1683) callback get called periodically.


**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
