### PR TITLE
Stop using KV as the Key for Histogram Metrics

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/LockFreeHistogram.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/LockFreeHistogram.java
@@ -29,7 +29,6 @@ import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.metrics.Histogram;
 import org.apache.beam.sdk.metrics.MetricName;
 import org.apache.beam.sdk.util.HistogramData;
-import org.apache.beam.sdk.values.KV;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.primitives.ImmutableLongArray;
 
 /**
@@ -54,9 +53,9 @@ public final class LockFreeHistogram implements Histogram {
   private final AtomicBoolean dirty;
 
   /** Create a histogram. */
-  public LockFreeHistogram(KV<MetricName, HistogramData.BucketType> kv) {
-    this.name = kv.getKey();
-    this.bucketType = kv.getValue();
+  public LockFreeHistogram(MetricName name, HistogramData.BucketType bucketType) {
+    this.name = name;
+    this.bucketType = bucketType;
     this.buckets = new AtomicLongArray(bucketType.getNumBuckets());
     this.underflowStatistic =
         new AtomicReference<LockFreeHistogram.OutlierStatistic>(OutlierStatistic.EMPTY);

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingStepMetricsContainer.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/StreamingStepMetricsContainer.java
@@ -42,7 +42,6 @@ import org.apache.beam.sdk.metrics.MetricKey;
 import org.apache.beam.sdk.metrics.MetricName;
 import org.apache.beam.sdk.metrics.MetricsContainer;
 import org.apache.beam.sdk.util.HistogramData;
-import org.apache.beam.sdk.values.KV;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Function;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Predicates;
@@ -71,8 +70,8 @@ public class StreamingStepMetricsContainer implements MetricsContainer {
   private MetricsMap<MetricName, DeltaDistributionCell> distributions =
       new MetricsMap<>(DeltaDistributionCell::new);
 
-  private MetricsMap<KV<MetricName, HistogramData.BucketType>, LockFreeHistogram>
-      perWorkerHistograms = new MetricsMap<>(LockFreeHistogram::new);
+  private final ConcurrentHashMap<MetricName, LockFreeHistogram> perWorkerHistograms =
+      new ConcurrentHashMap<>();
 
   private final Map<MetricName, Instant> perWorkerCountersByFirstStaleTime;
 
@@ -163,11 +162,17 @@ public class StreamingStepMetricsContainer implements MetricsContainer {
   @Override
   public Histogram getPerWorkerHistogram(
       MetricName metricName, HistogramData.BucketType bucketType) {
-    if (enablePerWorkerMetrics) {
-      return perWorkerHistograms.get(KV.of(metricName, bucketType));
-    } else {
+    if (!enablePerWorkerMetrics) {
       return MetricsContainer.super.getPerWorkerHistogram(metricName, bucketType);
     }
+
+    LockFreeHistogram val = perWorkerHistograms.get(metricName);
+    if (val != null) {
+      return val;
+    }
+
+    return perWorkerHistograms.computeIfAbsent(
+        metricName, name -> new LockFreeHistogram(metricName, bucketType));
   }
 
   public Iterable<CounterUpdate> extractUpdates() {
@@ -300,7 +305,7 @@ public class StreamingStepMetricsContainer implements MetricsContainer {
         });
     perWorkerHistograms.forEach(
         (k, v) -> {
-          v.getSnapshotAndReset().ifPresent(snapshot -> histograms.put(k.getKey(), snapshot));
+          v.getSnapshotAndReset().ifPresent(snapshot -> histograms.put(k, snapshot));
         });
 
     deleteStaleCounters(currentZeroValuedCounters, Instant.now(clock));

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/LockFreeHistogramTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/LockFreeHistogramTest.java
@@ -29,7 +29,6 @@ import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import org.apache.beam.sdk.metrics.MetricName;
 import org.apache.beam.sdk.util.HistogramData;
-import org.apache.beam.sdk.values.KV;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.primitives.ImmutableLongArray;
 import org.junit.Test;
 import org.junit.runner.RunWith;
@@ -43,7 +42,7 @@ public class LockFreeHistogramTest {
   public void testUpdate_OverflowValues() {
     HistogramData.BucketType bucketType = HistogramData.LinearBuckets.of(0, 10, 3);
     LockFreeHistogram histogram =
-        new LockFreeHistogram(KV.of(MetricName.named("name", "namespace"), bucketType));
+        new LockFreeHistogram(MetricName.named("name", "namespace"), bucketType);
     histogram.update(35, 40, 45);
     Optional<LockFreeHistogram.Snapshot> snapshot = histogram.getSnapshotAndReset();
 
@@ -65,7 +64,7 @@ public class LockFreeHistogramTest {
   public void testUpdate_UnderflowValues() {
     HistogramData.BucketType bucketType = HistogramData.LinearBuckets.of(100, 10, 3);
     LockFreeHistogram histogram =
-        new LockFreeHistogram(KV.of(MetricName.named("name", "namespace"), bucketType));
+        new LockFreeHistogram(MetricName.named("name", "namespace"), bucketType);
     histogram.update(35, 40, 45);
     Optional<LockFreeHistogram.Snapshot> snapshot = histogram.getSnapshotAndReset();
 
@@ -86,7 +85,7 @@ public class LockFreeHistogramTest {
   public void testUpdate_InBoundsValues() {
     HistogramData.BucketType bucketType = HistogramData.LinearBuckets.of(0, 10, 3);
     LockFreeHistogram histogram =
-        new LockFreeHistogram(KV.of(MetricName.named("name", "namespace"), bucketType));
+        new LockFreeHistogram(MetricName.named("name", "namespace"), bucketType);
     histogram.update(5, 15, 25);
     Optional<LockFreeHistogram.Snapshot> snapshot = histogram.getSnapshotAndReset();
 
@@ -105,7 +104,7 @@ public class LockFreeHistogramTest {
   public void testUpdate_EmptySnapshot() {
     HistogramData.BucketType bucketType = HistogramData.LinearBuckets.of(0, 10, 3);
     LockFreeHistogram histogram =
-        new LockFreeHistogram(KV.of(MetricName.named("name", "namespace"), bucketType));
+        new LockFreeHistogram(MetricName.named("name", "namespace"), bucketType);
     histogram.update(5, 15, 25);
     Optional<LockFreeHistogram.Snapshot> snapshot_1 = histogram.getSnapshotAndReset();
 
@@ -155,7 +154,7 @@ public class LockFreeHistogramTest {
 
     HistogramData.BucketType bucketType = HistogramData.ExponentialBuckets.of(1, 10);
     LockFreeHistogram histogram =
-        new LockFreeHistogram(KV.of(MetricName.named("name", "namespace"), bucketType));
+        new LockFreeHistogram(MetricName.named("name", "namespace"), bucketType);
 
     List<UpdateHistogramCallable> callables = new ArrayList<>();
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/MetricsToPerStepNamespaceMetricsConverterTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/MetricsToPerStepNamespaceMetricsConverterTest.java
@@ -35,7 +35,6 @@ import java.util.Map;
 import org.apache.beam.sdk.metrics.LabeledMetricNameUtils;
 import org.apache.beam.sdk.metrics.MetricName;
 import org.apache.beam.sdk.util.HistogramData;
-import org.apache.beam.sdk.values.KV;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.primitives.ImmutableLongArray;
 import org.hamcrest.collection.IsMapContaining;
@@ -139,8 +138,7 @@ public class MetricsToPerStepNamespaceMetricsConverterTest {
 
     Map<MetricName, LockFreeHistogram.Snapshot> histograms = new HashMap<>();
     MetricName invalidName2 = MetricName.named("BigQuerySink", "****");
-    LockFreeHistogram nonEmptyLinearHistogram =
-        new LockFreeHistogram(KV.of(invalidName2, lienarBuckets));
+    LockFreeHistogram nonEmptyLinearHistogram = new LockFreeHistogram(invalidName2, lienarBuckets);
     nonEmptyLinearHistogram.update(-5.0);
     histograms.put(invalidName2, nonEmptyLinearHistogram.getSnapshotAndReset().get());
 
@@ -162,12 +160,12 @@ public class MetricsToPerStepNamespaceMetricsConverterTest {
     MetricName bigQueryMetric3 = MetricName.named("BigQuerySink", "zeroValue");
 
     LockFreeHistogram nonEmptyLinearHistogram =
-        new LockFreeHistogram(KV.of(bigQueryMetric1, lienarBuckets));
+        new LockFreeHistogram(bigQueryMetric1, lienarBuckets);
     nonEmptyLinearHistogram.update(-5.0, 15.0, 25.0, 35.0, 105.0);
     histograms.put(bigQueryMetric1, nonEmptyLinearHistogram.getSnapshotAndReset().get());
 
     LockFreeHistogram noEmptyExponentialHistogram =
-        new LockFreeHistogram(KV.of(bigQueryMetric2, exponentialBuckets));
+        new LockFreeHistogram(bigQueryMetric2, exponentialBuckets);
     noEmptyExponentialHistogram.update(-5.0, 15.0, 25.0, 35.0, 105.0);
     histograms.put(bigQueryMetric2, noEmptyExponentialHistogram.getSnapshotAndReset().get());
 
@@ -267,8 +265,7 @@ public class MetricsToPerStepNamespaceMetricsConverterTest {
     Map<MetricName, LockFreeHistogram.Snapshot> histograms = new HashMap<>();
 
     MetricName bigQueryMetric1 = MetricName.named("BigQuerySink", "baseLabel");
-    LockFreeHistogram histogram =
-        new LockFreeHistogram(KV.of(bigQueryMetric1, new TestBucketType()));
+    LockFreeHistogram histogram = new LockFreeHistogram(bigQueryMetric1, new TestBucketType());
     histogram.update(1.0, 2.0);
     histograms.put(bigQueryMetric1, histogram.getSnapshotAndReset().get());
 
@@ -290,8 +287,7 @@ public class MetricsToPerStepNamespaceMetricsConverterTest {
     counters.put(counterMetricName, 3L);
 
     MetricName histogramMetricName = MetricName.named("BigQuerySink", "histogram*label2:val2;");
-    LockFreeHistogram linearHistogram =
-        new LockFreeHistogram(KV.of(histogramMetricName, lienarBuckets));
+    LockFreeHistogram linearHistogram = new LockFreeHistogram(histogramMetricName, lienarBuckets);
     linearHistogram.update(5.0);
     histograms.put(histogramMetricName, linearHistogram.getSnapshotAndReset().get());
 


### PR DESCRIPTION
Currenlty, PerWorkerHistograms are in a Map that's keyed by `KV<MetricName, BucketType>`. After this change the map they're stored in will be Keyed by `MetricName`.

Computing a hash/equality for the `KV` object is non-trivial and has a fair amount of overhead [src](https://github.com/apache/beam/blob/master/sdks/java/core/src/main/java/org/apache/beam/sdk/values/KV.java#L124). Since we need to do a map lookup for the histogram metric every time we record a value, we can remove a lot of the overhead by simply using a map that's only Keyed by `MetricName`.

The first time a `Histogram` is requested for a `<Metric Name, Bucket Type>` we will use the `BucketType` to create the histogram object. Future requests for a `Histogram` for that `Metric Name` will return the original histogram object, regardless of what the future `Bucket Type` is. Since `Bucket Types` are statically defined, this change does not affect BigQuery Per Worker Metrics. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
