### PR TITLE
add support for unaligned checkpoint for flink runner

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
@@ -375,6 +375,11 @@ public class FlinkExecutionEnvironments {
                     : ExternalizedCheckpointCleanup.DELETE_ON_CANCELLATION);
       }
 
+      if (options.getUnalignedCheckpointEnabled()) {
+        flinkStreamEnv.getCheckpointConfig().enableUnalignedCheckpoints();
+      }
+      flinkStreamEnv.getCheckpointConfig().setForceUnalignedCheckpoints(options.getForceUnalignedCheckpointEnabled());
+
       long minPauseBetweenCheckpoints = options.getMinPauseBetweenCheckpoints();
       if (minPauseBetweenCheckpoints != -1) {
         flinkStreamEnv

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
@@ -378,7 +378,9 @@ public class FlinkExecutionEnvironments {
       if (options.getUnalignedCheckpointEnabled()) {
         flinkStreamEnv.getCheckpointConfig().enableUnalignedCheckpoints();
       }
-      flinkStreamEnv.getCheckpointConfig().setForceUnalignedCheckpoints(options.getForceUnalignedCheckpointEnabled());
+      flinkStreamEnv
+          .getCheckpointConfig()
+          .setForceUnalignedCheckpoints(options.getForceUnalignedCheckpointEnabled());
 
       long minPauseBetweenCheckpoints = options.getMinPauseBetweenCheckpoints();
       if (minPauseBetweenCheckpoints != -1) {

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
@@ -127,10 +127,11 @@ public interface FlinkPipelineOptions
 
   void setFinishBundleBeforeCheckpointing(boolean finishBundleBeforeCheckpointing);
 
-  @Description("If set, Unaligned checkpoints contain in-flight data (i.e., data stored in buffers) as part of the " +
-      "checkpoint state, allowing checkpoint barriers to overtake these buffers. Thus, the checkpoint duration " +
-      "becomes independent of the current throughput as checkpoint barriers are effectively not embedded into the " +
-      "stream of data anymore")
+  @Description(
+      "If set, Unaligned checkpoints contain in-flight data (i.e., data stored in buffers) as part of the "
+          + "checkpoint state, allowing checkpoint barriers to overtake these buffers. Thus, the checkpoint duration "
+          + "becomes independent of the current throughput as checkpoint barriers are effectively not embedded into the "
+          + "stream of data anymore")
   @Default.Boolean(false)
   boolean getUnalignedCheckpointEnabled();
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
@@ -127,6 +127,21 @@ public interface FlinkPipelineOptions
 
   void setFinishBundleBeforeCheckpointing(boolean finishBundleBeforeCheckpointing);
 
+  @Description("If set, Unaligned checkpoints contain in-flight data (i.e., data stored in buffers) as part of the " +
+      "checkpoint state, allowing checkpoint barriers to overtake these buffers. Thus, the checkpoint duration " +
+      "becomes independent of the current throughput as checkpoint barriers are effectively not embedded into the " +
+      "stream of data anymore")
+  @Default.Boolean(false)
+  boolean getUnalignedCheckpointEnabled();
+
+  void setUnalignedCheckpointEnabled(boolean unalignedCheckpointEnabled);
+
+  @Description("Forces unaligned checkpoints, particularly allowing them for iterative jobs.")
+  @Default.Boolean(false)
+  boolean getForceUnalignedCheckpointEnabled();
+
+  void setForceUnalignedCheckpointEnabled(boolean forceUnalignedCheckpointEnabled);
+
   @Description(
       "Shuts down sources which have been idle for the configured time of milliseconds. Once a source has been "
           + "shut down, checkpointing is not possible anymore. Shutting down the sources eventually leads to pipeline "


### PR DESCRIPTION
fixes #21233

## Description

Add support for unaligned checkpoint for Flink runner. 
As I understand the python configuration and documentation will be automatically generated from the files I modified ?