### PR TITLE
Don't hardcode python version in tox.ini for lint, mypy and docs.

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -491,12 +491,11 @@ tasks.register("pythonDockerBuildPreCommit") {
 }
 
 tasks.register("pythonLintPreCommit") {
-  // TODO(https://github.com/apache/beam/issues/20209): Find a better way to specify lint and formatter tasks without hardcoding py version.
-  dependsOn(":sdks:python:test-suites:tox:py38:lint")
+  dependsOn(":sdks:python:test-suites:tox:pycommon:linter")
 }
 
 tasks.register("pythonFormatterPreCommit") {
-  dependsOn("sdks:python:test-suites:tox:py38:formatter")
+  dependsOn("sdks:python:test-suites:tox:pycommon:formatter")
 }
 
 tasks.register("python38PostCommit") {

--- a/sdks/python/test-suites/tox/py38/build.gradle
+++ b/sdks/python/test-suites/tox/py38/build.gradle
@@ -29,17 +29,7 @@ pythonVersion = '3.8'
 toxTask "formatter", "py3-yapf-check"
 check.dependsOn formatter
 
-// TODO(BEAM-12000): Move tasks that aren't specific to 3.8 to Py 3.9.
 def posargs = project.findProperty("posargs") ?: ""
-
-task lint {}
-check.dependsOn lint
-
-toxTask "lintPy38", "py38-lint", "${posargs}"
-lint.dependsOn lintPy38
-
-toxTask "mypyPy38", "py38-mypy", "${posargs}"
-lint.dependsOn mypyPy38
 
 apply from: "../common.gradle"
 

--- a/sdks/python/test-suites/tox/py38/build.gradle
+++ b/sdks/python/test-suites/tox/py38/build.gradle
@@ -26,13 +26,9 @@ applyPythonNature()
 // Required to setup a Python 3 virtualenv and task names.
 pythonVersion = '3.8'
 
-toxTask "formatter", "py3-yapf-check"
-check.dependsOn formatter
-
 def posargs = project.findProperty("posargs") ?: ""
 
 apply from: "../common.gradle"
-
 
 toxTask "testPy38CloudCoverage", "py38-cloudcoverage", "${posargs}"
 test.dependsOn "testPy38CloudCoverage"

--- a/sdks/python/test-suites/tox/pycommon/build.gradle
+++ b/sdks/python/test-suites/tox/pycommon/build.gradle
@@ -31,7 +31,7 @@ task preCommitPyCommon() {
 }
 
 task linter {}
-check.dependsOn lint
+check.dependsOn linter
 
 toxTask "lint", "lint", "${posargs}"
 linter.dependsOn lint

--- a/sdks/python/test-suites/tox/pycommon/build.gradle
+++ b/sdks/python/test-suites/tox/pycommon/build.gradle
@@ -24,6 +24,8 @@
 plugins { id 'org.apache.beam.module' }
 applyPythonNature()
 
+def posargs = project.findProperty("posargs") ?: ""
+
 toxTask "docs", "docs"
 assemble.dependsOn docs
 
@@ -32,6 +34,9 @@ task preCommitPyCommon() {
 
 task linter {}
 check.dependsOn linter
+
+toxTask "formatter", "py3-yapf-check"
+check.dependsOn formatter
 
 toxTask "lint", "lint", "${posargs}"
 linter.dependsOn lint

--- a/sdks/python/test-suites/tox/pycommon/build.gradle
+++ b/sdks/python/test-suites/tox/pycommon/build.gradle
@@ -24,8 +24,17 @@
 plugins { id 'org.apache.beam.module' }
 applyPythonNature()
 
-toxTask "docs", "py38-docs"
+toxTask "docs", "docs"
 assemble.dependsOn docs
 
 task preCommitPyCommon() {
 }
+
+task linter {}
+check.dependsOn lint
+
+toxTask "lint", "lint", "${posargs}"
+linter.dependsOn lint
+
+toxTask "mypy", "mypy", "${posargs}"
+linter.dependsOn mypy

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -17,7 +17,7 @@
 
 [tox]
 # new environments will be excluded by default unless explicitly added to envlist.
-envlist = py38,py39,py310,py311,py38-{cloud,docs,lint,mypy,cloudcoverage,dask},py39-{cloud},py310-{cloud,dask},py311-{cloud,dask},whitespacelint
+envlist = py38,py39,py310,py311,py38-{cloud,cloudcoverage,dask},py39-{cloud},py310-{cloud,dask},py311-{cloud,dask},docs,lint,mypy,whitespacelint
 toxworkdir = {toxinidir}/target/{env:ENV_NAME:.tox}
 
 [pycodestyle]
@@ -103,7 +103,7 @@ extras = test,gcp,interactive,dataframe,aws
 commands =
   bash {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}" "--cov-report=xml --cov=. --cov-append"
 
-[testenv:py38-lint]
+[testenv:lint]
 # Don't set TMPDIR to avoid "AF_UNIX path too long" errors in pylint.
 setenv =
 # keep the version of pylint in sync with the 'rev' in .pre-commit-config.yaml
@@ -124,7 +124,7 @@ deps =
 commands =
   time {toxinidir}/scripts/run_whitespacelint.sh
 
-[testenv:py38-mypy]
+[testenv:mypy]
 deps =
   mypy==0.790
   dask==2022.01.0
@@ -137,7 +137,7 @@ commands =
   python setup.py mypy
 
 
-[testenv:py38-docs]
+[testenv:docs]
 extras = test,gcp,docs,interactive,dataframe,dask
 deps =
   Sphinx==1.8.5


### PR DESCRIPTION
Delegate the choice of python version for linters, docs generation and mypy checks to GHA configs, instead of hardcoding both in tox.ini, in gradle configs, and in yml files for GHA actions.

Possible sideeffects: when running the checks locally, different users might not be using a consistent python version, which might cause issues for if mypy produces different results on different versions. GHA should still run with a consistent version for everyone. It is still possible to manually set `basepython = python3.8` setting in tox.ini if it becomes necessary.  

https://github.com/apache/beam/issues/20209

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
