### PR TITLE
Turn off abandoned node enforcement in some Reshuffle unit tests where it is not needed

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ReshuffleTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/transforms/ReshuffleTest.java
@@ -404,6 +404,7 @@ public class ReshuffleTest implements Serializable {
 
   @Test
   public void testNoOldTransformByDefault() {
+    pipeline.enableAbandonedNodeEnforcement(false);
     pipeline.apply(Create.of(KV.of("arbitrary", "kv"))).apply(Reshuffle.of());
 
     OldTransformSeeker seeker = new OldTransformSeeker();
@@ -413,6 +414,7 @@ public class ReshuffleTest implements Serializable {
 
   @Test
   public void testRequestOldUpdateCompatibility() {
+    pipeline.enableAbandonedNodeEnforcement(false);
     pipeline.getOptions().as(StreamingOptions.class).setUpdateCompatibilityVersion("2.53.0");
     pipeline.apply(Create.of(KV.of("arbitrary", "kv"))).apply(Reshuffle.of());
 
@@ -423,6 +425,7 @@ public class ReshuffleTest implements Serializable {
 
   @Test
   public void testRequestVeryOldUpdateCompatibility() {
+    pipeline.enableAbandonedNodeEnforcement(false);
     pipeline.getOptions().as(StreamingOptions.class).setUpdateCompatibilityVersion("2.46.0");
     pipeline.apply(Create.of(KV.of("arbitrary", "kv"))).apply(Reshuffle.of());
 
@@ -433,6 +436,7 @@ public class ReshuffleTest implements Serializable {
 
   @Test
   public void testNoOldTransformInRecentVersion() {
+    pipeline.enableAbandonedNodeEnforcement(false);
     pipeline.getOptions().as(StreamingOptions.class).setUpdateCompatibilityVersion("2.54.0");
     pipeline.apply(Create.of(KV.of("arbitrary", "kv"))).apply(Reshuffle.of());
 


### PR DESCRIPTION
These tests should have always failed. But they seem to only fail in particular contexts inside Google when we re-run them with internal tools. Perhaps worth a follow-up to check that this enforcement actually works...

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
