### PR TITLE
Implement the hash_words TFT operation

### DIFF
--- a/sdks/python/apache_beam/ml/transforms/tft.py
+++ b/sdks/python/apache_beam/ml/transforms/tft.py
@@ -637,3 +637,48 @@ class BagOfWords(TFTOperation):
 def count_unique_words(
     data: tf.SparseTensor, output_vocab_name: Optional[str]) -> None:
   tft.count_per_key(data, key_vocabulary_filename=output_vocab_name)
+
+
+@register_input_dtype(str)
+class HashStrings(TFTOperation):
+  def __init__(
+      self,
+      columns: List[str],
+      hash_buckets: int,
+      key: Optional[Iterable[int]] = None,
+      name: Optional[str] = None):
+    '''Hashes strings into the provided number of buckets.
+    
+    Args:
+      columns: A list of the column names to apply the transformation on.
+      hash_buckets: the number of buckets to hash the strings into.
+      key: optional. An array of two Python `uint64`. If passed, output will be a
+        deterministic function of `strings` and `key`. Note that hashing will be
+        slower if this value is specified.
+      name: optional. A name for this operation.
+
+    Raises:
+      ValueError if `hash_buckets` is not a positive and non-zero integer.
+    '''
+    self.hash_buckets = hash_buckets
+    self.key = key
+    self.name = name
+
+    if hash_buckets < 1:
+      raise ValueError(
+          'number of hash buckets must be positive and non-zero, got ',
+          hash_buckets)
+
+    super().__init__(columns)
+
+  def apply_transform(
+      self, data: common_types.TensorType,
+      output_col_name: str) -> Dict[str, common_types.TensorType]:
+    output_dict = {
+        output_col_name: tft.hash_strings(
+            strings=data,
+            hash_buckets=self.hash_buckets,
+            key=self.key,
+            name=self.name)
+    }
+    return output_dict

--- a/sdks/python/apache_beam/ml/transforms/tft_test.py
+++ b/sdks/python/apache_beam/ml/transforms/tft_test.py
@@ -932,5 +932,82 @@ class BagOfWordsTest(unittest.TestCase):
     self.assertEqual(expected_data, actual_data)
 
 
+class HashWordsTest(unittest.TestCase):
+  def setUp(self) -> None:
+    self.artifact_location = tempfile.mkdtemp()
+
+  def tearDown(self):
+    shutil.rmtree(self.artifact_location)
+
+  def test_single_bucket(self):
+    list_data = [{'x': 'this is a test string'}]
+    expected_values = [np.array([0])]
+    with beam.Pipeline() as p:
+      list_result = (
+          p
+          | "listCreate" >> beam.Create(list_data)
+          | "listMLTransform" >> base.MLTransform(
+              write_artifact_location=self.artifact_location).with_transform(
+                  tft.HashStrings(columns=['x'], hash_buckets=1)))
+      result = (list_result | beam.Map(lambda x: x.x))
+      assert_that(result, equal_to(expected_values, equals_fn=np.array_equal))
+
+  def test_multi_bucket_one_string(self):
+    list_data = [{'x': 'this is a test string'}]
+    expected_values = [np.array([1])]
+    with beam.Pipeline() as p:
+      list_result = (
+          p
+          | "listCreate" >> beam.Create(list_data)
+          | "listMLTransform" >> base.MLTransform(
+              write_artifact_location=self.artifact_location).with_transform(
+                  tft.HashStrings(columns=['x'], hash_buckets=2)))
+      result = (list_result | beam.Map(lambda x: x.x))
+      assert_that(result, equal_to(expected_values, equals_fn=np.array_equal))
+
+  def test_one_bucket_multi_string(self):
+    list_data = [{'x': ['these', 'are', 'test', 'strings']}]
+    expected_values = [np.array([0, 0, 0, 0])]
+    with beam.Pipeline() as p:
+      list_result = (
+          p
+          | "listCreate" >> beam.Create(list_data)
+          | "listMLTransform" >> base.MLTransform(
+              write_artifact_location=self.artifact_location).with_transform(
+                  tft.HashStrings(columns=['x'], hash_buckets=1)))
+      result = (list_result | beam.Map(lambda x: x.x))
+      assert_that(result, equal_to(expected_values, equals_fn=np.array_equal))
+
+  def test_two_bucket_multi_string(self):
+    list_data = [{'x': ['these', 'are', 'test', 'strings']}]
+    expected_values = [np.array([1, 0, 1, 0])]
+    with beam.Pipeline() as p:
+      list_result = (
+          p
+          | "listCreate" >> beam.Create(list_data)
+          | "listMLTransform" >> base.MLTransform(
+              write_artifact_location=self.artifact_location).with_transform(
+                  tft.HashStrings(
+                      columns=['x'], hash_buckets=2, key=[123, 456])))
+      result = (list_result | beam.Map(lambda x: x.x))
+      assert_that(result, equal_to(expected_values, equals_fn=np.array_equal))
+
+  def test_multi_buckets_multi_string(self):
+    # This is a recreation of one of the TFT test cases from
+    # https://github.com/tensorflow/transform/blob/master/tensorflow_transform/mappers_test.py
+    list_data = [{'x': ['Cake', 'Pie', 'Sundae']}]
+    expected_values = [np.array([6, 5, 6])]
+    with beam.Pipeline() as p:
+      list_result = (
+          p
+          | "listCreate" >> beam.Create(list_data)
+          | "listMLTransform" >> base.MLTransform(
+              write_artifact_location=self.artifact_location).with_transform(
+                  tft.HashStrings(
+                      columns=['x'], hash_buckets=11, key=[123, 456])))
+      result = (list_result | beam.Map(lambda x: x.x))
+      assert_that(result, equal_to(expected_values, equals_fn=np.array_equal))
+
+
 if __name__ == '__main__':
   unittest.main()


### PR DESCRIPTION
Adds the TFT [hash_words operation](https://github.com/tensorflow/transform/blob/126081204f6095ea9ebbffd470b5ed961bf79b29/tensorflow_transform/mappers.py#L1704) to MLTransform. Also adds some sanity unit tests plus a recreation of a TFT hash_words unit test. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
