### PR TITLE
Skip tests using TFT in Beam ML unit test suite on Python 3.11+

### DIFF
--- a/sdks/python/apache_beam/ml/transforms/embeddings/huggingface_test.py
+++ b/sdks/python/apache_beam/ml/transforms/embeddings/huggingface_test.py
@@ -21,6 +21,7 @@ import unittest
 import uuid
 
 import numpy as np
+import pytest
 from parameterized import parameterized
 
 import apache_beam as beam
@@ -80,6 +81,7 @@ _parameterized_inputs = [
 ]
 
 
+@pytest.mark.no_xdist
 @unittest.skipIf(
     SentenceTransformerEmbeddings is None,
     'sentence-transformers is not installed.')

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -490,14 +490,15 @@ if __name__ == '__main__':
           # We don't expect users to install this extra. Users should install
           # necessary dependencies individually, or we should create targeted
           # extras. Keeping the bounds open as much as possible so that we
-          # can find out early when using Beam with new versions doesn't work.
+          # can find out early when Beam doesn't work with new versions.
           'ml_test': [
               'datatable',
               'embeddings',
               'onnxruntime',
               'sentence-transformers',
               'skl2onnx',
-              'tensorflow',
+              # https://github.com/apache/beam/issues/31294
+              'tensorflow<2.16.0',
               'tensorflow-hub',
               # https://github.com/tensorflow/transform/issues/313
               'tensorflow-transform;python_version<"3.11"',

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -499,7 +499,8 @@ if __name__ == '__main__':
               'skl2onnx',
               'tensorflow',
               'tensorflow-hub',
-              'tensorflow_transform',
+              # https://github.com/tensorflow/transform/issues/313
+              'tensorflow-transform;python_version<"3.11"',
               'tf2onnx',
               'torch',
               'transformers',


### PR DESCRIPTION
- Skip TFT tests on 3.11+ due to https://github.com/tensorflow/transform/issues/313
- Add an upper bound to TF due to https://github.com/apache/beam/issues/31294
- Run Huggingface tests serially

Fixes: #31287 

