### PR TITLE
Don't build sdist or create a venv for tox tasks.

### DIFF
--- a/sdks/python/apache_beam/transforms/sql.py
+++ b/sdks/python/apache_beam/transforms/sql.py
@@ -68,7 +68,7 @@ class SqlTransform(ExternalTransform):
   `apache_beam.examples.wordcount_xlang_sql`, `apache_beam.examples.sql_taxi`,
   and `apache_beam.transforms.sql_test`.
 
-  For more details about Beam SQL in general see the `Java transform
+  For more details about Beam SQL in general, see the `Java transform
   <https://beam.apache.org/releases/javadoc/current/org/apache/beam/sdk/extensions/sql/SqlTransform.html>`_,
   and the `documentation
   <https://beam.apache.org/documentation/dsls/sql/overview/>`_.


### PR DESCRIPTION
It should not be nessessary to build sdist or bdists for tox tasks, which we currently use to run unit tests only.

This should fix #31289 , if not, we can go with: https://github.com/apache/beam/pull/31282 or https://github.com/apache/beam/pull/31283 