### PR TITLE
Fix permared Iceberg unit tests

### DIFF
--- a/.github/workflows/IO_Iceberg_Unit_Tests.yml
+++ b/.github/workflows/IO_Iceberg_Unit_Tests.yml
@@ -91,6 +91,12 @@ jobs:
           github_job: ${{ matrix.job_name }} (${{ matrix.job_phrase }})
       - name: Setup environment
         uses: ./.github/actions/setup-environment-action
+      - name: hello
+        id: Authenticate on GCP
+        uses: google-github-actions/auth@v1
+        with:
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
+          project_id: ${{ secrets.GCP_PROJECT_ID }}
       - name: run IcebergIO build script
         uses: ./.github/actions/gradle-command-self-hosted-action
         with:


### PR DESCRIPTION
We need to setup GCP auth before running integration tests.