### PR TITLE
[Java] Add job name to GCS custom audit info

### DIFF
--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/RetryHttpRequestInitializer.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/RetryHttpRequestInitializer.java
@@ -32,6 +32,7 @@ import java.util.Arrays;
 import java.util.Collection;
 import java.util.Collections;
 import java.util.HashSet;
+import java.util.Map;
 import java.util.Set;
 import org.apache.beam.sdk.metrics.Counter;
 import org.apache.beam.sdk.metrics.Metrics;
@@ -208,6 +209,8 @@ public class RetryHttpRequestInitializer implements HttpRequestInitializer {
 
   private Set<Integer> ignoredResponseCodes = new HashSet<>(DEFAULT_IGNORED_RESPONSE_CODES);
 
+  private Map<String, String> httpHeaders = null;
+
   public RetryHttpRequestInitializer() {
     this(Collections.emptyList());
   }
@@ -270,6 +273,9 @@ public class RetryHttpRequestInitializer implements HttpRequestInitializer {
     request.setUnsuccessfulResponseHandler(loggingHttpBackOffHandler);
     request.setIOExceptionHandler(loggingHttpBackOffHandler);
 
+    if (this.httpHeaders != null)
+      request.getHeaders().putAll(this.httpHeaders);
+
     // Set response initializer
     if (responseInterceptor != null) {
       request.setResponseInterceptor(responseInterceptor);
@@ -283,5 +289,9 @@ public class RetryHttpRequestInitializer implements HttpRequestInitializer {
   /** @param writeTimeout in milliseconds. */
   public void setWriteTimeout(int writeTimeout) {
     this.writeTimeout = writeTimeout;
+  }
+
+  public void setHttpHeaders(Map<String, String> httpHeaders) {
+    this.httpHeaders = httpHeaders;
   }
 }

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/RetryHttpRequestInitializer.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/RetryHttpRequestInitializer.java
@@ -273,8 +273,9 @@ public class RetryHttpRequestInitializer implements HttpRequestInitializer {
     request.setUnsuccessfulResponseHandler(loggingHttpBackOffHandler);
     request.setIOExceptionHandler(loggingHttpBackOffHandler);
 
-    if (this.httpHeaders != null)
+    if (this.httpHeaders != null) {
       request.getHeaders().putAll(this.httpHeaders);
+    }
 
     // Set response initializer
     if (responseInterceptor != null) {

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/Transport.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/Transport.java
@@ -17,6 +17,8 @@
  */
 package org.apache.beam.sdk.extensions.gcp.util;
 
+import static com.google.common.base.Strings.isNullOrEmpty;
+
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpRequestInitializer;
 import com.google.api.client.http.HttpTransport;
@@ -31,9 +33,12 @@ import java.net.MalformedURLException;
 import java.net.URL;
 import java.nio.file.Paths;
 import java.security.GeneralSecurityException;
+import java.util.Optional;
 import org.apache.beam.sdk.extensions.gcp.auth.NullCredentialInitializer;
 import org.apache.beam.sdk.extensions.gcp.options.GcsOptions;
+import org.apache.beam.sdk.util.ReleaseInfo;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 
 /** Helpers for cloud communication. */
 public class Transport {
@@ -89,20 +94,32 @@ public class Transport {
 
   /** Returns a Cloud Storage client builder using the specified {@link GcsOptions}. */
   public static Storage.Builder newStorageClient(GcsOptions options) {
-    String applicationNameSuffix = " (GPN:Beam)";
+    String jobName = Optional.ofNullable(options.getJobName()).orElse("UNKNOWN");
+
+    String applicationName = String.format(
+        "%sapache-beam/%s (GPN:Beam)",
+        isNullOrEmpty(options.getAppName()) ? "" : options.getAppName() + " ",
+        ReleaseInfo.getReleaseInfo().getSdkVersion()
+    );
+
     String servicePath = options.getGcsEndpoint();
+
+    // Do not log the code 404. Code up the stack will deal with 404's if needed,
+    // and logging it by default clutters the output during file staging.
+    RetryHttpRequestInitializer retryHttpRequestInitializer = new RetryHttpRequestInitializer(
+        ImmutableList.of(404), new UploadIdResponseInterceptor());
+
+    // Set custom audit info in request headers
+    retryHttpRequestInitializer.setHttpHeaders(ImmutableMap.of("x-goog-custom-audit-job", jobName));
+
     Storage.Builder storageBuilder =
         new Storage.Builder(
                 getTransport(),
                 getJsonFactory(),
                 chainHttpRequestInitializer(
                     options.getGcpCredential(),
-                    // Do not log the code 404. Code up the stack will deal with 404's if needed,
-                    // and
-                    // logging it by default clutters the output during file staging.
-                    new RetryHttpRequestInitializer(
-                        ImmutableList.of(404), new UploadIdResponseInterceptor())))
-            .setApplicationName(options.getAppName() + applicationNameSuffix)
+                    retryHttpRequestInitializer))
+            .setApplicationName(applicationName)
             .setGoogleClientRequestInitializer(options.getGoogleApiTrace());
     if (servicePath != null) {
       ApiComponents components = apiComponentsFromUrl(servicePath);

--- a/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/Transport.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/Transport.java
@@ -17,7 +17,7 @@
  */
 package org.apache.beam.sdk.extensions.gcp.util;
 
-import static com.google.common.base.Strings.isNullOrEmpty;
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Strings.isNullOrEmpty;
 
 import com.google.api.client.googleapis.javanet.GoogleNetHttpTransport;
 import com.google.api.client.http.HttpRequestInitializer;
@@ -96,18 +96,18 @@ public class Transport {
   public static Storage.Builder newStorageClient(GcsOptions options) {
     String jobName = Optional.ofNullable(options.getJobName()).orElse("UNKNOWN");
 
-    String applicationName = String.format(
-        "%sapache-beam/%s (GPN:Beam)",
-        isNullOrEmpty(options.getAppName()) ? "" : options.getAppName() + " ",
-        ReleaseInfo.getReleaseInfo().getSdkVersion()
-    );
+    String applicationName =
+        String.format(
+            "%sapache-beam/%s (GPN:Beam)",
+            isNullOrEmpty(options.getAppName()) ? "" : options.getAppName() + " ",
+            ReleaseInfo.getReleaseInfo().getSdkVersion());
 
     String servicePath = options.getGcsEndpoint();
 
     // Do not log the code 404. Code up the stack will deal with 404's if needed,
     // and logging it by default clutters the output during file staging.
-    RetryHttpRequestInitializer retryHttpRequestInitializer = new RetryHttpRequestInitializer(
-        ImmutableList.of(404), new UploadIdResponseInterceptor());
+    RetryHttpRequestInitializer retryHttpRequestInitializer =
+        new RetryHttpRequestInitializer(ImmutableList.of(404), new UploadIdResponseInterceptor());
 
     // Set custom audit info in request headers
     retryHttpRequestInitializer.setHttpHeaders(ImmutableMap.of("x-goog-custom-audit-job", jobName));
@@ -117,8 +117,7 @@ public class Transport {
                 getTransport(),
                 getJsonFactory(),
                 chainHttpRequestInitializer(
-                    options.getGcpCredential(),
-                    retryHttpRequestInitializer))
+                    options.getGcpCredential(), retryHttpRequestInitializer))
             .setApplicationName(applicationName)
             .setGoogleClientRequestInitializer(options.getGoogleApiTrace());
     if (servicePath != null) {

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/util/TransportTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/util/TransportTest.java
@@ -53,23 +53,22 @@ public class TransportTest {
     // "test-app apache-beam/2.57.0.dev (GPN:Beam) Google-API-Java-Client/2.0.0"
     // For a valid user-agent string, a comment like "(GPN:Beam)" cannot be the first token.
     // https://www.rfc-editor.org/rfc/rfc7231#section-5.5.3
-    assertThat(Arrays.asList(request.getHeaders().getUserAgent().split(" "))
-            .indexOf("test-app"),
+    assertThat(
+        Arrays.asList(request.getHeaders().getUserAgent().split(" ")).indexOf("test-app"),
         greaterThanOrEqualTo(0));
 
     assertThat(
         Arrays.asList(request.getHeaders().getUserAgent().split(" "))
-            .indexOf(String.format("apache-beam/%s",
-                ReleaseInfo.getReleaseInfo().getSdkVersion())),
+            .indexOf(String.format("apache-beam/%s", ReleaseInfo.getReleaseInfo().getSdkVersion())),
         greaterThan(0));
 
     assertThat(
-        Arrays.asList(request.getHeaders().getUserAgent().split(" "))
-            .indexOf("(GPN:Beam)"),
+        Arrays.asList(request.getHeaders().getUserAgent().split(" ")).indexOf("(GPN:Beam)"),
         greaterThan(0));
 
     // there should be one and only one custom audit entry for job name
-    assertEquals(request.getHeaders().getHeaderStringValues("x-goog-custom-audit-job"),
+    assertEquals(
+        request.getHeaders().getHeaderStringValues("x-goog-custom-audit-job"),
         Collections.singletonList("test-job"));
   }
 }

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/util/TransportTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/util/TransportTest.java
@@ -19,12 +19,18 @@ package org.apache.beam.sdk.extensions.gcp.util;
 
 import static org.hamcrest.MatcherAssert.assertThat;
 import static org.hamcrest.Matchers.greaterThan;
+import static org.hamcrest.Matchers.greaterThanOrEqualTo;
+import static org.junit.Assert.assertEquals;
 
+import com.google.api.client.http.HttpRequest;
 import com.google.api.services.storage.Storage;
 import java.io.IOException;
 import java.util.Arrays;
+import java.util.Collections;
+import org.apache.beam.sdk.extensions.gcp.auth.TestCredential;
 import org.apache.beam.sdk.extensions.gcp.options.GcsOptions;
 import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.apache.beam.sdk.util.ReleaseInfo;
 import org.junit.Test;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
@@ -33,17 +39,37 @@ import org.junit.runners.JUnit4;
 public class TransportTest {
 
   @Test
-  public void testUserAgentInGcsRequestHeaders() throws IOException {
+  public void testUserAgentAndCustomAuditInGcsRequestHeaders() throws IOException {
     GcsOptions gcsOptions = PipelineOptionsFactory.as(GcsOptions.class);
+    gcsOptions.setGcpCredential(new TestCredential());
+    gcsOptions.setJobName("test-job");
+    gcsOptions.setAppName("test-app");
+
     Storage storageClient = Transport.newStorageClient(gcsOptions).build();
-    Storage.Objects.Get getObject = storageClient.objects().get("testbucket", "testobject");
+    Storage.Objects.Get getObject = storageClient.objects().get("test-bucket", "test-object");
+    HttpRequest request = getObject.buildHttpRequest();
+
     // An example of user agent string will be like
-    // "TransportTest (GPN:Beam) Google-API-Java-Client/2.0.0"
+    // "test-app apache-beam/2.57.0.dev (GPN:Beam) Google-API-Java-Client/2.0.0"
     // For a valid user-agent string, a comment like "(GPN:Beam)" cannot be the first token.
     // https://www.rfc-editor.org/rfc/rfc7231#section-5.5.3
+    assertThat(Arrays.asList(request.getHeaders().getUserAgent().split(" "))
+            .indexOf("test-app"),
+        greaterThanOrEqualTo(0));
+
     assertThat(
-        Arrays.asList(getObject.getRequestHeaders().getUserAgent().split(" "))
+        Arrays.asList(request.getHeaders().getUserAgent().split(" "))
+            .indexOf(String.format("apache-beam/%s",
+                ReleaseInfo.getReleaseInfo().getSdkVersion())),
+        greaterThan(0));
+
+    assertThat(
+        Arrays.asList(request.getHeaders().getUserAgent().split(" "))
             .indexOf("(GPN:Beam)"),
         greaterThan(0));
+
+    // there should be one and only one custom audit entry for job name
+    assertEquals(request.getHeaders().getHeaderStringValues("x-goog-custom-audit-job"),
+        Collections.singletonList("test-job"));
   }
 }


### PR DESCRIPTION
This PR implements feature request #31299 for Java SDK.

We also try to make the Java user-agent consistent with the Python one (see #31300) 
by inserting "apache-beam/VERSION".

---
Some more notes:

In Java SDK, GCSIO (from `com.google.cloud.hadoop.gcsio`) is used as an accessing layer to communicate with GCS. Internally, it depends on the storage client (from `com.google.api.services.storage`) to assemble and handle HTTP requests.  

GCSIO can either create a new Google Cloud Storage client during initialization or utilize an existing one, which is the approach adopted by Beam. Ideally, it will be better if Beam can use the first code path so that we can leave all the GCS connection detail to GCSIO. 

Follow-up tasks

- [ ] To investigate the gaps between the two code paths and find a better way for Beam so that it doesn't need to initialize its own storage client. The starting point will be [RetryHttpInitializer.java](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/f39c78fafe8fae243eab3b3c1d113912514fe73a/util/src/main/java/com/google/cloud/hadoop/util/RetryHttpInitializer.java#L43), [GoogleCloudStorageImpl.java](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/f39c78fafe8fae243eab3b3c1d113912514fe73a/gcsio/src/main/java/com/google/cloud/hadoop/gcsio/GoogleCloudStorageImpl.java#L333) from gcsio and [RetryHttpRequestInitializer.java](https://github.com/apache/beam/blob/2babd0aee5b65f75e06702b30192c2aa8a24fdf9/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/RetryHttpRequestInitializer.java#L50), [Transport.java](https://github.com/apache/beam/blob/999f7deb94e9875be85679ac0d17b331d9e36fd0/sdks/java/extensions/google-cloud-platform-core/src/main/java/org/apache/beam/sdk/extensions/gcp/util/Transport.java#L94) in Beam
- [ ] To implement #31299 for Go SDK. Previously, user-agent was added to Go SDK in PR #26702.