### PR TITLE
[Go SDK] Make it clearer that timers and data don't interact negatively in element batches.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/datasource.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/datasource.go
@@ -149,6 +149,7 @@ func (n *DataSource) process(ctx context.Context, data func(bcr *byteCountReader
 				// Returning splitSuccess means we've split, and aren't consuming the remaining buffer.
 				// We mark the PTransform done to ignore further data.
 				splitPrimaryComplete[e.PtransformID] = true
+				err = nil // Reset the error for timer handling.
 			} else if err != nil && err != io.EOF {
 				return errors.Wrapf(err, "source failed processing data")
 			}


### PR DESCRIPTION
Make it clearer that Data and Timers aren't interacting negatively, as a cursory look made it appear that if Elements ever contained Data and Timers simultaneously, that a successful execution of timers would cause an error processing data to be swallowed.

Likely a red herring though, as Data and Timers do not have the same PtransformID: Data always points to the synthetic DataSource transform, while timers are directly routed to their consuming Transform's OnTimer callback. But it's nicer to not have to remember that.

Similarly, in the name of readability, the split check is also moved into the Data handling callback in DataSource.Process, so it doesn't look like a Split in bundle processing would skip any outstanding timers. Since the check relies on the targeted PTransformID and they are never the same, it shouldn't happen.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
