### PR TITLE
start/close streams in parallel on new worker metadata

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/FanOutStreamingEngineClientTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/FanOutStreamingEngineClientTest.java
@@ -74,7 +74,7 @@ import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 @RunWith(JUnit4.class)
-public class StreamingEngineClientTest {
+public class FanOutStreamingEngineClientTest {
   private static final WindmillServiceAddress DEFAULT_WINDMILL_SERVICE_ADDRESS =
       WindmillServiceAddress.create(HostAndPort.fromParts(WindmillChannelFactory.LOCALHOST, 443));
   private static final ImmutableMap<String, WorkerMetadataResponse.Endpoint> DEFAULT =
@@ -114,7 +114,7 @@ public class StreamingEngineClientTest {
   private Server fakeStreamingEngineServer;
   private CountDownLatch getWorkerMetadataReady;
   private GetWorkerMetadataTestStub fakeGetWorkerMetadataStub;
-  private StreamingEngineClient streamingEngineClient;
+  private FanOutStreamingEngineClient fanOutStreamingEngineClient;
 
   private static WorkItemProcessor noOpProcessWorkItemFn() {
     return (computation,
@@ -165,16 +165,16 @@ public class StreamingEngineClientTest {
 
   @After
   public void cleanUp() {
-    Preconditions.checkNotNull(streamingEngineClient).finish();
+    Preconditions.checkNotNull(fanOutStreamingEngineClient).finish();
     fakeStreamingEngineServer.shutdownNow();
     stubFactory.shutdown();
   }
 
-  private StreamingEngineClient newStreamingEngineClient(
+  private FanOutStreamingEngineClient newStreamingEngineClient(
       GetWorkBudget getWorkBudget,
       GetWorkBudgetDistributor getWorkBudgetDistributor,
       WorkItemProcessor workItemProcessor) {
-    return StreamingEngineClient.forTesting(
+    return FanOutStreamingEngineClient.forTesting(
         JOB_HEADER,
         getWorkBudget,
         connections,
@@ -195,7 +195,7 @@ public class StreamingEngineClientTest {
     TestGetWorkBudgetDistributor getWorkBudgetDistributor =
         spy(new TestGetWorkBudgetDistributor(numBudgetDistributionsExpected));
 
-    streamingEngineClient =
+    fanOutStreamingEngineClient =
         newStreamingEngineClient(
             GetWorkBudget.builder().setItems(items).setBytes(bytes).build(),
             getWorkBudgetDistributor,
@@ -246,7 +246,7 @@ public class StreamingEngineClientTest {
   public void testScheduledBudgetRefresh() throws InterruptedException {
     TestGetWorkBudgetDistributor getWorkBudgetDistributor =
         spy(new TestGetWorkBudgetDistributor(2));
-    streamingEngineClient =
+    fanOutStreamingEngineClient =
         newStreamingEngineClient(
             GetWorkBudget.builder().setItems(1L).setBytes(1L).build(),
             getWorkBudgetDistributor,
@@ -269,7 +269,7 @@ public class StreamingEngineClientTest {
     int metadataCount = 2;
     TestGetWorkBudgetDistributor getWorkBudgetDistributor =
         spy(new TestGetWorkBudgetDistributor(metadataCount));
-    streamingEngineClient =
+    fanOutStreamingEngineClient =
         newStreamingEngineClient(
             GetWorkBudget.builder().setItems(1).setBytes(1).build(),
             getWorkBudgetDistributor,
@@ -359,7 +359,7 @@ public class StreamingEngineClientTest {
 
     TestGetWorkBudgetDistributor getWorkBudgetDistributor =
         spy(new TestGetWorkBudgetDistributor(workerMetadataResponses.size()));
-    streamingEngineClient =
+    fanOutStreamingEngineClient =
         newStreamingEngineClient(
             GetWorkBudget.builder().setItems(1).setBytes(1).build(),
             getWorkBudgetDistributor,


### PR DESCRIPTION
Previously, `StreamingEngineClient` would start and close streams after getting new worker metadata synchronously (close 1 stream at time, open 1 stream at a time).

Make this happen in parallel and run async only blocking when needed.
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
