### PR TITLE
Emit a warning when large elements are detected.

### DIFF
--- a/sdks/python/apache_beam/runners/worker/data_plane.py
+++ b/sdks/python/apache_beam/runners/worker/data_plane.py
@@ -128,7 +128,7 @@ class ClosableOutputStream(OutputStream):
 class SizeBasedBufferingClosableOutputStream(ClosableOutputStream):
   """A size-based buffering OutputStream."""
 
-  _large_flush_last_observed_timestamp = 0
+  _large_flush_last_observed_timestamp = 0.0
 
   def __init__(
       self,

--- a/sdks/python/apache_beam/runners/worker/data_plane.py
+++ b/sdks/python/apache_beam/runners/worker/data_plane.py
@@ -128,15 +128,19 @@ class ClosableOutputStream(OutputStream):
 class SizeBasedBufferingClosableOutputStream(ClosableOutputStream):
   """A size-based buffering OutputStream."""
 
+  _large_flush_last_observed_timestamp = 0
+
   def __init__(
       self,
       close_callback=None,  # type: Optional[Callable[[bytes], None]]
       flush_callback=None,  # type: Optional[Callable[[bytes], None]]
-      size_flush_threshold=_DEFAULT_SIZE_FLUSH_THRESHOLD  # type: int
+      size_flush_threshold=_DEFAULT_SIZE_FLUSH_THRESHOLD,  # type: int
+      large_buffer_warn_threshold_mib = 512  # type: int
   ):
     super().__init__(close_callback)
     self._flush_callback = flush_callback
     self._size_flush_threshold = size_flush_threshold
+    self._large_buffer_warn_threshold_mib = large_buffer_warn_threshold_mib
 
   # This must be called explicitly to avoid flushing partial elements.
   def maybe_flush(self):
@@ -148,24 +152,31 @@ class SizeBasedBufferingClosableOutputStream(ClosableOutputStream):
     # type: () -> None
     if self._flush_callback:
       size = self.size()
-      if size > _FLUSH_MAX_SIZE:
-        raise ValueError(
-            f'Buffer size {size} exceeds GRPC limit {_FLUSH_MAX_SIZE}. '
-            'This is likely due to a single element that is too large. '
-            'To resolve, prefer multiple small elements over single large '
-            'elements in PCollections. If needed, store large blobs in '
-            'external storage systems, and use PCollections to pass their '
-            'metadata, or use a custom coder that reduces the element\'s size.')
-      if size > 536870912:
-        _LOGGER.warning(
-            f'Data output stream buffer size {size} exceeds 512 MB. '
-            'This is likely due to a large element in a PCollection. '
-            'Large elements increase pipeline RAM requirements and '
-            'can cause runtime errors. '
-            'Prefer multiple small elements over single large '
-            'elements in PCollections. If needed, store large blobs in '
-            'external storage systems, and use PCollections to pass their '
-            'metadata, or use a custom coder that reduces the element\'s size.')
+      if (self._large_buffer_warn_threshold_mib and
+          size > self._large_buffer_warn_threshold_mib << 20):
+        if size > _FLUSH_MAX_SIZE:
+          raise ValueError(
+              f'Buffer size {size} exceeds GRPC limit {_FLUSH_MAX_SIZE}. '
+              'This is likely due to a single element that is too large. '
+              'To resolve, prefer multiple small elements over single large '
+              'elements in PCollections. If needed, store large blobs in '
+              'external storage systems, and use PCollections to pass their '
+              'metadata, or use a custom coder that reduces the element\'s '
+              'size.')
+
+        if self._large_flush_last_observed_timestamp + 600 < time.time():
+          self._large_flush_last_observed_timestamp = time.time()
+          _LOGGER.warning(
+              'Data output stream buffer size %s exceeds %s MB. '
+              'This is likely due to a large element in a PCollection. '
+              'Large elements increase pipeline RAM requirements and '
+              'can cause runtime errors. '
+              'Prefer multiple small elements over single large elements '
+              'in PCollections. If needed, store large blobs in external '
+              'storage systems, and use PCollections to pass their metadata, '
+              'or use a custom coder that reduces the element\'s size.',
+              size,
+              self._large_buffer_warn_threshold_mib)
 
       self._flush_callback(self.get())
       self._clear()


### PR DESCRIPTION
https://github.com/apache/beam/pull/30639 added an codepath to fail early when SDK emits a large element. 

This PR adds a warning when we detect large elements that can be problematic, but still within the GRPC limits.