### PR TITLE
Fix DebeziumIO testWrongHost trying to connect real external address

### DIFF
--- a/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumReadSchemaTransformTest.java
+++ b/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumReadSchemaTransformTest.java
@@ -188,26 +188,19 @@ public class DebeziumReadSchemaTransformTest {
   }
 
   @Test
-  public void testWrongHost() throws Exception {
+  public void testWrongHost() {
     Pipeline readPipeline = Pipeline.create();
-    Exception ex =
-        assertThrows(
-            Exception.class,
-            () -> {
-              PCollectionRowTuple.empty(readPipeline)
-                  .apply(
-                      makePtransform(
-                          userName,
-                          password,
-                          database,
-                          databaseContainer.getMappedPort(port),
-                          "23.128.129.130"))
-                  .get("output");
-            });
-    Throwable lowestCause = ex.getCause();
-    while (lowestCause.getCause() != null) {
-      lowestCause = lowestCause.getCause();
-    }
-    assertThat(lowestCause.getMessage(), Matchers.containsString("Connection refused"));
+    assertThrows(
+        Exception.class,
+        () ->
+            PCollectionRowTuple.empty(readPipeline)
+                .apply(
+                    makePtransform(
+                        userName,
+                        password,
+                        database,
+                        databaseContainer.getMappedPort(port),
+                        "169.254.254.254"))
+                .get("output"));
   }
 }


### PR DESCRIPTION
`Fix` #31346

The "wrong host" used for the test is a real IP. It is resolvable. It either changed recently or added firewall rule causing test failure

solution is to use a true wrong host (169.254.x.x), and remove the check of error content, as it is platform dependent

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
