### PR TITLE
[#29697] Add prism artifact building workflow.

### DIFF
--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -474,9 +474,9 @@ jobs:
           mkdir -p $OUTPUT_DIR
           echo "OUTPUT_DIR=$OUTPUT_DIR"
 
-          # Remove existing prism contents from the repo.
+          # Remove existing prism contents from the svn repo.
           cd $OUTPUT_DIR
-          rm -r *
+          rm -rf *
           cd $ROOT_DIR
 
           # Navigate to the prism command directory.

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -476,7 +476,7 @@ jobs:
 
           # Remove existing prism contents from the repo.
           cd $OUTPUT_DIR
-          rm -r .* 
+          rm -r .
           cd $ROOT_DIR
 
           # Navigate to the prism command directory.

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -509,7 +509,7 @@ jobs:
            -H "X-GitHub-Api-Version: 2022-11-28" \
            /repos/apache/beam/releases | jq '.[] | select(.tag_name | contains("$RC_TAG")) .id'`
 
-          echo "release id $GH_RELEASE_ID"
+          echo "release id $GH_RELEASE_ID for tag $RC_TAG"
 
           # svn co https://dist.apache.org/repos/dist/dev/beam
           # mkdir -p "${SVN_ARTIFACTS_DIR}"

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -507,7 +507,7 @@ jobs:
                 # Time to upload to the release!
                 # TODO automatically clobber existing binaries.
                 gh api \
-                --method POST
+                --method POST \
                 -H "Accept: application/vnd.github+json" \
                 -H "X-GitHub-Api-Version: 2022-11-28" \
                 /repos/apache/beam/release/$GH_RELEASE_ID/assets?name=$ZIP_NAME \

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -453,7 +453,7 @@ jobs:
           RELEASE_DIR: "beam/${{ github.event.inputs.RELEASE }}"
           RELEASE: "${{ github.event.inputs.RELEASE }}"
           SCRIPT_DIR: release/src/main/scripts
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.event.inputs.BEAM_SITE_TOKEN  }}
           SVN_ARTIFACTS_DIR: "beam/${{ github.event.inputs.RELEASE }}/prism"
         run: |
           # Store a reference so we can get back to the start.
@@ -470,6 +470,13 @@ jobs:
           mkdir -p $OUTPUT_DIR
 
           echo "build directory made"
+
+          export GH_RELEASE_ID=`gh api \
+           -H "Accept: application/vnd.github+json" \
+           -H "X-GitHub-Api-Version: 2022-11-28" \
+           /repos/apache/beam/releases | jq '.[] | select(.tag_name | contains(env.RC_TAG)) .id'`
+
+          echo "with gh release id $GH_RELEASE_ID for tag $RC_TAG"
           
           # Loop through and build desired set from allowed types.
           for OS in linux windows darwin; do
@@ -496,6 +503,16 @@ jobs:
                 #TODO move zip to release directory? debug output for now.
                 echo `ls`
 
+
+                # Time to upload to the release!
+                # TODO automatically clobber existing binaries.
+                gh api \
+                --method POST
+                -H "Accept: application/vnd.github+json" \
+                -H "X-GitHub-Api-Version: 2022-11-28" \
+                /repos/apache/beam/release/$GH_RELEASE_ID/assets?name=$ZIP_NAME \
+                  -f "@$ZIP_NAME"
+
                 # Return to our root build dir.
                 cd $BUILD_DIR
               else
@@ -509,20 +526,6 @@ jobs:
           # Get out of the checked out repo.
           cd .. 
 
-          export GH_RELEASE_ID=`gh api \
-           -H "Accept: application/vnd.github+json" \
-           -H "X-GitHub-Api-Version: 2022-11-28" \
-           /repos/apache/beam/releases | jq '.[] | select(.tag_name | contains(env.RC_TAG)) .id'`
-
-          echo "with gh release id $GH_RELEASE_ID for tag $RC_TAG"
-
-          export GH_RELEASE_ID=`curl -L \
-           -H "Accept: application/vnd.github+json" \
-           -H "Authorization: Bearer $GH_TOKEN" \
-           -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/apache/beam/releases | jq '.[] | select(.tag_name | contains(env.RC_TAG)) .id'`
-
-          echo "with curl release id $GH_RELEASE_ID for tag $RC_TAG"
 
           # svn co https://dist.apache.org/repos/dist/dev/beam
           # mkdir -p "${SVN_ARTIFACTS_DIR}"

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -460,24 +460,6 @@ jobs:
           echo $BUILD_DIR
 
           echo `which go`
-
-          # Only build supported Go platforms
-          GO_ALL_TARGETS=$(go tool dist list)
-
-          echo "got all targets"
-          # Turn the newline separated list into an array.
-          IFS=$'\n' read -d '' -r OS_ARCH_ARRAY <<<"$GO_ALL_TARGETS"
-
-          echo "split all targets"
-          # Declare which supported pairs we want to build.
-          # Only build for a platform if both the OS and Architecture are on this list.
-          declare -A TARGET_OSES=( 
-           ["linux"]=1  ["windows"]=1  ["darwin"]=1
-          )
-
-          declare -A TARGET_ARCHS=(
-           ["arm64"]=1  ["amd64"]=1
-          )
           OUTPUT_DIR="BUILDS"
           mkdir -p $OUTPUT_DIR
 
@@ -486,7 +468,6 @@ jobs:
           # Loop through and build desired set from allowed types.
           for OS in linux windows darwin; do
             for ARCH in amd64 arm64; do
-
               TARGET_DIR="$OUTPUT_DIR/$OS/$ARCH"
               TARGET_NAME="$NAME-$VERSION-$OS-$ARCH"
 

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -512,7 +512,7 @@ jobs:
           export GH_RELEASE_ID=`gh api \
            -H "Accept: application/vnd.github+json" \
            -H "X-GitHub-Api-Version: 2022-11-28" \
-           /repos/apache/beam/releases | jq '.[] | select(.tag_name | contains("$RC_TAG")) .id'`
+           /repos/apache/beam/releases | jq '.[] | select(.tag_name | contains(env.RC_TAG)) .id'`
 
           echo "with gh release id $GH_RELEASE_ID for tag $RC_TAG"
 
@@ -520,15 +520,9 @@ jobs:
            -H "Accept: application/vnd.github+json" \
            -H "Authorization: Bearer $GH_TOKEN" \
            -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/apache/beam/releases | jq '.[] | select(.tag_name | contains("$RC_TAG")) .id'`
+            https://api.github.com/repos/apache/beam/releases | jq '.[] | select(.tag_name | contains(env.RC_TAG)) .id'`
 
           echo "with curl release id $GH_RELEASE_ID for tag $RC_TAG"
-
-          curl -L \
-           -H "Accept: application/vnd.github+json" \
-           -H "Authorization: Bearer $GH_TOKEN" \
-           -H "X-GitHub-Api-Version: 2022-11-28" \
-            https://api.github.com/repos/apache/beam/releases
 
           # svn co https://dist.apache.org/repos/dist/dev/beam
           # mkdir -p "${SVN_ARTIFACTS_DIR}"

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -447,7 +447,7 @@ jobs:
           RELEASE_DIR: "beam/${{ github.event.inputs.RELEASE }}"
           RELEASE: "${{ github.event.inputs.RELEASE }}"
           SCRIPT_DIR: release/src/main/scripts
-          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GITHUB_TOKEN: ${{ secrets.USER_TOKEN }}
           SVN_ARTIFACTS_DIR: "beam/${{ github.event.inputs.RELEASE }}/prism"
         run: |
           # Store a reference so we can get back to the start.

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -469,7 +469,7 @@ jobs:
           for OS in linux windows darwin; do
             for ARCH in amd64 arm64; do
               TARGET_DIR="$OUTPUT_DIR/$OS/$ARCH"
-              TARGET_NAME="$NAME-$VERSION-$OS-$ARCH"
+              TARGET_NAME="prism-$RELEASE-$OS-$ARCH"
 
               echo "building $TARGET_NAME"
 

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -451,6 +451,17 @@ jobs:
           GH_TOKEN: ${{ github.event.inputs.REPO_TOKEN  }}
           SVN_ARTIFACTS_DIR: "beam/${{ github.event.inputs.RELEASE }}/prism"
         run: |
+          # TODO stop the action if a non-prerelease release exists
+          # TODO create the draft release automatically if none exist.
+          # TODO update the draft release's RC tag to current.
+
+          export GH_RELEASE_ID=`gh api \
+           -H "Accept: application/vnd.github+json" \
+           -H "X-GitHub-Api-Version: 2022-11-28" \
+           /repos/apache/beam/releases | jq '.[] | select(.tag_name | contains(env.RC_TAG)) .id'`
+
+          echo "with gh release id $GH_RELEASE_ID for tag $RC_TAG"
+
           # Store a reference so we can get back to the start.
           ROOT_DIR=`pwd`
           echo "ROOT_DIR=$ROOT_DIR"
@@ -463,24 +474,16 @@ jobs:
           mkdir -p $OUTPUT_DIR
           echo "OUTPUT_DIR=$OUTPUT_DIR"
 
-          # TODO remove existing output directory contents.
+          # Remove existing prism contents from the repo.
+          cd $OUTPUT_DIR
+          rm -r .* 
+          cd $ROOT_DIR
 
           # Navigate to the prism command directory.
           cd sdks/go/cmd/prism
 
           # Store a reference to where we're building from.
           BUILD_DIR=`pwd`
-
-          # TODO stop the action if a non-prerelease release exists
-          # TODO create the draft release automatically if none exist.
-          # TODO update the draft release's RC tag to current.
-
-          export GH_RELEASE_ID=`gh api \
-           -H "Accept: application/vnd.github+json" \
-           -H "X-GitHub-Api-Version: 2022-11-28" \
-           /repos/apache/beam/releases | jq '.[] | select(.tag_name | contains(env.RC_TAG)) .id'`
-
-          echo "with gh release id $GH_RELEASE_ID for tag $RC_TAG"
 
           echo "............Build and stage prism artifacts in the Github Release $GH_RELEASE_ID for tag $RC_TAG.........."
           
@@ -511,8 +514,6 @@ jobs:
                 
                 # Remove the binary from the release directory
                 rm $ARTIFACT
-                echo `pwd`
-                echo `ls`
                 
                 # Return to our root build dir.
                 cd $BUILD_DIR
@@ -527,8 +528,8 @@ jobs:
           cd $ROOT_DIR
           cd $RELEASE_DIR
 
-          echo "...........Adding to the dev Apache SVN repo..........."
+          echo "...........Adding prism artifacts to the Dev Apache SVN repo..........."
 
           svn add --force prism
           svn status
-          # svn commit -m "Staging Prism artifacts for Apache Beam ${RELEASE} RC${RC_NUM}" --non-interactive --username "${{ github.event.inputs.APACHE_ID }}" --password "${{ github.event.inputs.APACHE_PASSWORD }}"
+          svn commit -m "Staging Prism artifacts for Apache Beam ${RELEASE} RC${RC_NUM}" --non-interactive --username "${{ github.event.inputs.APACHE_ID }}" --password "${{ github.event.inputs.APACHE_PASSWORD }}"

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -453,7 +453,7 @@ jobs:
           RELEASE_DIR: "beam/${{ github.event.inputs.RELEASE }}"
           RELEASE: "${{ github.event.inputs.RELEASE }}"
           SCRIPT_DIR: release/src/main/scripts
-          GH_TOKEN: ${{ github.event.inputs.BEAM_SITE_TOKEN  }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SVN_ARTIFACTS_DIR: "beam/${{ github.event.inputs.RELEASE }}/prism"
         run: |
           # Store a reference so we can get back to the start.

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -447,7 +447,7 @@ jobs:
           RELEASE_DIR: "beam/${{ github.event.inputs.RELEASE }}"
           RELEASE: "${{ github.event.inputs.RELEASE }}"
           SCRIPT_DIR: release/src/main/scripts
-          GITHUB_TOKEN: ${{ secrets.USER_TOKEN }}
+          GH_TOKEN: ${{ secrets.USER_TOKEN }}
           SVN_ARTIFACTS_DIR: "beam/${{ github.event.inputs.RELEASE }}/prism"
         run: |
           # Store a reference so we can get back to the start.

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -503,15 +503,8 @@ jobs:
                 #TODO move zip to release directory? debug output for now.
                 echo `ls`
 
-
                 # Time to upload to the release!
-                # TODO automatically clobber existing binaries.
-                gh api \
-                --method POST \
-                -H "Accept: application/vnd.github+json" \
-                -H "X-GitHub-Api-Version: 2022-11-28" \
-                /repos/apache/beam/release/$GH_RELEASE_ID/assets?name=$ZIP_NAME \
-                  -f "@$ZIP_NAME"
+                gh release upload $RC_TAG $ZIP_NAME --clobber
 
                 # Return to our root build dir.
                 cd $BUILD_DIR

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -37,7 +37,7 @@ on:
           --
           python_artifacts: stage the python artifacts into https://dist.apache.org/repos/dist/dev/beam/
           --
-          beam_site: create the documentation update PR against apache/beam-site.
+          beam_site_pr: create the documentation update PR against apache/beam-site.
           --
           prism: build and upload the artifacts to the release for this tag 
         required: true
@@ -46,7 +46,7 @@ on:
             java_source: "no",
             docker_artifacts: "no",
             python_artifacts: "no",
-            beam_site: "no",
+            beam_site_pr: "no",
             prism: "no"}
 
 env:

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -484,47 +484,39 @@ jobs:
           echo "build directory made"
           
           # Loop through and build desired set from allowed types.
-          for OS_ARCH in "${OS_ARCH_ARRAY[@]}"; do
-            # Extract the OS and architecture from the pair
-            OS=$(echo "$OS_ARCH" | cut -f1 -d'/')
-            ARCH=$(echo "$OS_ARCH" | cut -f2 -d'/')
+          for OS in linux windows darwin; do
+            for ARCH in amd64 arm64; do
 
-            if !  [[ -n "${TARGET_OSES[$OS]}" ]]; then
-              continue 
-            fi
-            if ! [[ -n "${TARGET_ARCHS[$ARCH]}" ]]; then
-              continue
-            fi
+              TARGET_DIR="$OUTPUT_DIR/$OS/$ARCH"
+              TARGET_NAME="$NAME-$VERSION-$OS-$ARCH"
 
-            TARGET_DIR="$OUTPUT_DIR/$OS/$ARCH"
-            TARGET_NAME="$NAME-$VERSION-$OS-$ARCH"
+              echo "building $TARGET_NAME"
 
-            echo "building $TARGET_NAME"
+              mkdir -p "$TARGET_DIR"
+              OUTPUT_FILE="$TARGET_DIR/$TARGET_NAME"
+              if GOOS=$OS GOARCH=$ARCH CGO_ENABLED=0 go build -trimpath -o "$OUTPUT_FILE" . > /dev/null 2>&1; then
+                cd $TARGET_DIR
+                # Extract real output name. Windows builds automatically have .exe added. 
+                ARTIFACT=`ls`
+                echo "target built  - $OS - $ARCH"
+                # Sign and hash
+                gpg --local-user "${{steps.import_gpg.outputs.name}}" --armor --batch --yes --detach-sig $ARTIFACT
+                sha512sum $ARTIFACT > "${ARTIFACT}.sha512"
 
-            mkdir -p "$TARGET_DIR"
-            OUTPUT_FILE="$TARGET_DIR/$TARGET_NAME"
-            if GOOS=$OS GOARCH=$ARCH CGO_ENABLED=0 go build -trimpath -o "$OUTPUT_FILE" . > /dev/null 2>&1; then
-              cd $TARGET_DIR
-              # Extract real output name. Windows builds automatically have .exe added. 
-              ARTIFACT=`ls`
-              echo "target built  - $OS - $ARCH"
-              # Sign and hash
-              gpg --local-user "${{steps.import_gpg.outputs.name}}" --armor --batch --yes --detach-sig $ARTIFACT
-              sha512sum $ARTIFACT > "${ARTIFACT}.sha512"
+                ZIP_NAME="$TARGET_NAME.zip"
+                zip -r $ZIP_NAME .
 
-              ZIP_NAME="$TARGET_NAME.zip"
-              zip -r $ZIP_NAME .
+                #TODO move zip to release directory? debug output for now.
+                echo `ls`
 
-              #TODO move zip to release directory? debug output for now.
-              echo `ls`
-
-              # Return to our root build dir.
-              cd $BUILD_DIR
-            else
-              echo "target failed - $OS - $ARCH"
-              rm -f "$OUTPUT_FILE"
-              exit 1 # Do not continue action
-            fi
+                # Return to our root build dir.
+                cd $BUILD_DIR
+              else
+                echo "target failed - $OS - $ARCH"
+                rm -f "$OUTPUT_FILE"
+                exit 1 # Do not continue action
+              fi
+            done
           done
           cd $ROOT
           # Get out of the checked out repo.

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -28,17 +28,17 @@ on:
       STAGE:
         description: |
           Configure which actions this workflow should perform, by setting the desired fields to "yes".
-          --
+          <br/>
           java_artifacts: publish java artifacts to https://repository.apache.org/#stagingRepositories
-          --
+          <br/>
           java_source: java source into https://dist.apache.org/repos/dist/dev/beam/
-          --
+          <br/>
           docker_artifacts: stage SDK docker images to docker hub Apache organization
-          --
+          <br/>
           python_artifacts: stage the python artifacts into https://dist.apache.org/repos/dist/dev/beam/
-          --
+          <br/>
           beam_site: create the documentation update PR against apache/beam-site.
-          --
+          <br/>
           prism: build and upload the artifacts to the release for this tag 
         required: true
         default: |
@@ -448,24 +448,27 @@ jobs:
           GIT_REPO_BASE_URL: https://github.com/apache/beam
           RELEASE_DIR: "beam/${{ github.event.inputs.RELEASE }}"
           RELEASE: "${{ github.event.inputs.RELEASE }}"
-          SCRIPT_DIR: release/src/main/scripts
           GH_TOKEN: ${{ github.event.inputs.REPO_TOKEN  }}
           SVN_ARTIFACTS_DIR: "beam/${{ github.event.inputs.RELEASE }}/prism"
         run: |
           # Store a reference so we can get back to the start.
           ROOT_DIR=`pwd`
-          echo $ROOT_DIR
+
+          svn co https://dist.apache.org/repos/dist/dev/beam
+          mkdir -p "${SVN_ARTIFACTS_DIR}"
+
           # Navigate to the prism command directory.
           cd sdks/go/cmd/prism
           # Store a reference to where we're building from.
           BUILD_DIR=`pwd`
-          echo $BUILD_DIR
 
-          echo `which go`
-          OUTPUT_DIR="BUILDS"
+          OUTPUT_DIR=$ROOT_DIR/$SVN_ARTIFACTS_DIR
           mkdir -p $OUTPUT_DIR
 
-          echo "build directory made"
+          # TODO stop the action if a non-prerelease release exists
+          # TODO create the draft release automatically if none exist.
+          # TODO update the draft release's RC tag to current.
+
 
           export GH_RELEASE_ID=`gh api \
            -H "Accept: application/vnd.github+json" \
@@ -473,14 +476,14 @@ jobs:
            /repos/apache/beam/releases | jq '.[] | select(.tag_name | contains(env.RC_TAG)) .id'`
 
           echo "with gh release id $GH_RELEASE_ID for tag $RC_TAG"
+
+          echo "............Build and stage prism artifacts in the Github Release $GH_RELEASE_ID for tag $RC_TAG.........."
           
           # Loop through and build desired set from allowed types.
           for OS in linux windows darwin; do
             for ARCH in amd64 arm64; do
               TARGET_DIR="$OUTPUT_DIR/$OS/$ARCH"
-              TARGET_NAME="prism-$RELEASE-$OS-$ARCH"
-
-              echo "building $TARGET_NAME"
+              TARGET_NAME="apache-beam-$RELEASE-prism-$OS-$ARCH"
 
               mkdir -p "$TARGET_DIR"
               OUTPUT_FILE="$TARGET_DIR/$TARGET_NAME"
@@ -488,37 +491,44 @@ jobs:
                 cd $TARGET_DIR
                 # Extract real output name. Windows builds automatically have .exe added. 
                 ARTIFACT=`ls`
-                echo "target built  - $OS - $ARCH"
+                echo "target built - $ARTIFACT"
+
+                ZIP_NAME="$ARTIFACT.zip"
+                zip -r $ZIP_NAME $ARTIFACT
+
                 # Sign and hash
-                gpg --local-user "${{steps.import_gpg.outputs.name}}" --armor --batch --yes --detach-sig $ARTIFACT
-                sha512sum $ARTIFACT > "${ARTIFACT}.sha512"
+                gpg --local-user "${{steps.import_gpg.outputs.name}}" --armor --batch --yes --detach-sig $ZIP_NAME
+                sha512sum $ZIP_NAME > "${ZIP_NAME}.sha512"
 
-                ZIP_NAME="$TARGET_NAME.zip"
-                zip -r $ZIP_NAME .
-
-                #TODO move zip to release directory? debug output for now.
                 echo `ls`
 
-                # Time to upload to the release!
-                gh release upload $RC_TAG $ZIP_NAME --clobber
-
+                # Upload to the release.
+                gh release upload $RC_TAG $ZIP_NAME ${ZIP_NAME}.sha512 ${ZIP_NAME}.asc --clobber
+                
+                # Remove the binary from the release directory
+                rm $ARTIFACT
+                echo `pwd`
+                echo `ls`
+                
                 # Return to our root build dir.
                 cd $BUILD_DIR
               else
-                echo "target failed - $OS - $ARCH"
+                echo "target failed for $OS - $ARCH"
                 rm -f "$OUTPUT_FILE"
                 exit 1 # Do not continue action
               fi
             done
           done
+          echo "-------Prism builds done------"
+          echo `pwd`
           cd $ROOT
-          # Get out of the checked out repo.
-          cd .. 
+          # Get into the dev repo for the release.
+          cd $RELEASE_DIR
 
+          echo "-------Adding SVN to dev repo------"
+          echo `pwd`
+          echo `ls`
 
-          # svn co https://dist.apache.org/repos/dist/dev/beam
-          # mkdir -p "${SVN_ARTIFACTS_DIR}"
-          # cd ..
-          # svn add --force prism
-          # svn status
+          svn add --force prism
+          svn status
           # svn commit -m "Staging Prism artifacts for Apache Beam ${RELEASE} RC${RC_NUM}" --non-interactive --username "${{ github.event.inputs.APACHE_ID }}" --password "${{ github.event.inputs.APACHE_PASSWORD }}"

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -513,6 +513,7 @@ jobs:
             fi
           done
           cd $ROOT
+          echo `which jq`
 
           # svn co https://dist.apache.org/repos/dist/dev/beam
           # mkdir -p "${SVN_ARTIFACTS_DIR}"

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -464,11 +464,11 @@ jobs:
           # Only build supported Go platforms
           GO_ALL_TARGETS=$(go tool dist list)
 
-          echo `got all targets`
+          echo "got all targets"
           # Turn the newline separated list into an array.
           IFS=$'\n' read -d '' -r -a OS_ARCH_ARRAY <<<"$GO_ALL_TARGETS"
 
-          echo `split all targets`
+          echo "split all targets"
           # Declare which supported pairs we want to build.
           # Only build for a platform if both the OS and Architecture are on this list.
           declare -A TARGET_OSES=( 
@@ -481,7 +481,7 @@ jobs:
           OUTPUT_DIR="BUILDS"
           mkdir -p $OUTPUT_DIR
 
-          echo `build directory made`
+          echo "build directory made"
           
           # Loop through and build desired set from allowed types.
           for OS_ARCH in "${OS_ARCH_ARRAY[@]}"; do
@@ -499,7 +499,7 @@ jobs:
             TARGET_DIR="$OUTPUT_DIR/$OS/$ARCH"
             TARGET_NAME="$NAME-$VERSION-$OS-$ARCH"
 
-            echo `building $TARGET_NAME`
+            echo "building $TARGET_NAME"
 
             mkdir -p "$TARGET_DIR"
             OUTPUT_FILE="$TARGET_DIR/$TARGET_NAME"

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -459,12 +459,16 @@ jobs:
           BUILD_DIR=`pwd`
           echo $BUILD_DIR
 
+          echo `which go`
+
           # Only build supported Go platforms
           GO_ALL_TARGETS=$(go tool dist list)
 
+          echo `got all targets`
           # Turn the newline separated list into an array.
           IFS=$'\n' read -d '' -r -a OS_ARCH_ARRAY <<<"$GO_ALL_TARGETS"
 
+          echo `split all targets`
           # Declare which supported pairs we want to build.
           # Only build for a platform if both the OS and Architecture are on this list.
           declare -A TARGET_OSES=( 
@@ -476,6 +480,8 @@ jobs:
           )
           OUTPUT_DIR="BUILDS"
           mkdir -p $OUTPUT_DIR
+
+          echo `build directory made`
           
           # Loop through and build desired set from allowed types.
           for OS_ARCH in "${OS_ARCH_ARRAY[@]}"; do
@@ -492,6 +498,9 @@ jobs:
 
             TARGET_DIR="$OUTPUT_DIR/$OS/$ARCH"
             TARGET_NAME="$NAME-$VERSION-$OS-$ARCH"
+
+            echo `building $TARGET_NAME`
+
             mkdir -p "$TARGET_DIR"
             OUTPUT_FILE="$TARGET_DIR/$TARGET_NAME"
             if GOOS=$OS GOARCH=$ARCH CGO_ENABLED=0 go build -trimpath -o "$OUTPUT_FILE" . > /dev/null 2>&1; then

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -492,7 +492,7 @@ jobs:
           for OS in linux windows darwin; do
             for ARCH in amd64 arm64; do
               TARGET_DIR="$OUTPUT_DIR/$OS/$ARCH"
-              TARGET_NAME="apache-beam-$RELEASE-prism-$OS-$ARCH"
+              TARGET_NAME="apache_beam-$RELEASE-prism-$OS-$ARCH"
 
               mkdir -p "$TARGET_DIR"
               OUTPUT_FILE="$TARGET_DIR/$TARGET_NAME"

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -46,9 +46,12 @@ on:
         description: Whether to build signed Prism artifacts and stage them in the draft release.
         required: true
         default: |
-           {python: "no",
-            prism: "no",
-            create_beam_site: "no"}'
+           {publish_java: "no",
+            stage_java_source: "no",
+            stage_docker: "no",
+            stage_python: "no",
+            create_beam_site: "no",
+            prism: "no"}'
 
 env:
   GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
@@ -450,7 +453,7 @@ jobs:
           RELEASE_DIR: "beam/${{ github.event.inputs.RELEASE }}"
           RELEASE: "${{ github.event.inputs.RELEASE }}"
           SCRIPT_DIR: release/src/main/scripts
-          GH_TOKEN: ${{ secrets.USER_TOKEN }}
+          GH_TOKEN: ${{ github.event.inputs.BEAM_SITE_TOKEN }}
           SVN_ARTIFACTS_DIR: "beam/${{ github.event.inputs.RELEASE }}/prism"
         run: |
           # Store a reference so we can get back to the start.

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -504,6 +504,13 @@ jobs:
           cd .. 
           echo `which jq`
 
+          GH_RELEASE_ID=`gh api \
+           -H "Accept: application/vnd.github+json" \
+           -H "X-GitHub-Api-Version: 2022-11-28" \
+           /repos/apache/beam/releases | jq '.[] | select(.tag_name | contains("$RC_TAG")) .id'`
+
+          echo "release id $GH_RELEASE_ID"
+
           # svn co https://dist.apache.org/repos/dist/dev/beam
           # mkdir -p "${SVN_ARTIFACTS_DIR}"
           # cd ..

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -412,6 +412,9 @@ jobs:
     steps:
       - name: Checkout
         uses: actions/checkout@v4
+        with:
+          ref: "v${{ github.event.inputs.RELEASE }}-RC${{ github.event.inputs.RC }}"
+          repository: apache/beam
       - name: Mask Apache Password
         run: |
           # Workaround for Actions bug - https://github.com/actions/runner/issues/643
@@ -449,10 +452,12 @@ jobs:
         run: |
           # Store a reference so we can get back to the start.
           ROOT_DIR=`pwd`
+          echo $ROOT_DIR
           # Navigate to the prism command directory.
           cd beam/sdks/go/cmd/prism
           # Store a reference to where we're building from.
           BUILD_DIR=`pwd`
+          echo $BUILD_DIR
 
           # Only build supported Go platforms
           GO_ALL_TARGETS=$(go tool dist list)

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -42,6 +42,10 @@ on:
         description: Whether to create the documentation update PR against apache/beam-site.
         required: true
         default: 'no'
+      BUILD_AND_STAGE_PRISM:
+        description: Whether to build signed Prism artifacts and stage them in the draft release.
+        required: true
+        default: 'no'
 
 env:
   GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
@@ -401,3 +405,118 @@ jobs:
           PR_BODY: "Content generated from https://github.com/apache/beam/tree/${{ env.RC_TAG }}."
         run: |
             gh pr create -t "$PR_TITLE" -b "$PR_BODY" --base release-docs
+
+  build_and_stage_prism:
+    if: ${{github.event.inputs.BUILD_AND_STAGE_PRISM == 'yes'}}
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@v4
+      - name: Mask Apache Password
+        run: |
+          # Workaround for Actions bug - https://github.com/actions/runner/issues/643
+          APACHE_PASS=$(jq -r '.inputs.APACHE_PASSWORD' $GITHUB_EVENT_PATH)
+          echo "::add-mask::$APACHE_PASS"
+      - name: Mask apache id/password
+        run: |
+          if [ "${{ github.event.inputs.APACHE_ID }}" == "" ]
+          then
+            echo "Must provide an apache id to stage artifacts to https://dist.apache.org/repos/dist/dev/beam/"
+          fi
+          if [ "${{ github.event.inputs.APACHE_PASSWORD }}" == "" ]
+          then
+            echo "Must provide an apache password to stage artifacts to https://dist.apache.org/repos/dist/dev/beam/"
+          fi
+      - uses: actions/setup-go@v5
+        with:
+          go-version: '1.22'
+          cache-dependency-path: |
+             sdks/go.sum
+      - name: Import GPG key
+        id: import_gpg
+        uses: crazy-max/ghaction-import-gpg@111c56156bcc6918c056dbef52164cfa583dc549
+        with:
+          gpg_private_key: ${{ secrets.GPG_PRIVATE_KEY }}
+      - name: Build prism artifacts
+        env:
+          RC_TAG: "v${{ github.event.inputs.RELEASE }}-RC${{ github.event.inputs.RC }}"
+          GIT_REPO_BASE_URL: https://github.com/apache/beam
+          RELEASE_DIR: "beam/${{ github.event.inputs.RELEASE }}"
+          RELEASE: "${{ github.event.inputs.RELEASE }}"
+          SCRIPT_DIR: release/src/main/scripts
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          SVN_ARTIFACTS_DIR: "beam/${{ github.event.inputs.RELEASE }}/prism"
+        run: |
+          # Store a reference so we can get back to the start.
+          ROOT_DIR=`pwd`
+          # Navigate to the prism command directory.
+          cd beam/sdks/go/cmd/prism
+          # Store a reference to where we're building from.
+          BUILD_DIR=`pwd`
+
+          # Only build supported Go platforms
+          GO_ALL_TARGETS=$(go tool dist list)
+
+          # Turn the newline separated list into an array.
+          IFS=$'\n' read -d '' -r -a OS_ARCH_ARRAY <<<"$GO_ALL_TARGETS"
+
+          # Declare which supported pairs we want to build.
+          # Only build for a platform if both the OS and Architecture are on this list.
+          declare -A TARGET_OSES=( 
+           ["linux"]=1  ["windows"]=1  ["darwin"]=1
+          )
+
+          declare -A TARGET_ARCHS=(
+           ["arm64"]=1  ["amd64"]=1
+          )
+          OUTPUT_DIR="BUILDS"
+          mkdir -p $OUTPUT_DIR
+          
+          # Loop through and build desired set from allowed types.
+          for OS_ARCH in "${OS_ARCH_ARRAY[@]}"; do
+            # Extract the OS and architecture from the pair
+            OS=$(echo "$OS_ARCH" | cut -f1 -d'/')
+            ARCH=$(echo "$OS_ARCH" | cut -f2 -d'/')
+
+            if !  [[ -n "${TARGET_OSES[$OS]}" ]]; then
+              continue 
+            fi
+            if ! [[ -n "${TARGET_ARCHS[$ARCH]}" ]]; then
+              continue
+            fi
+
+            TARGET_DIR="$OUTPUT_DIR/$OS/$ARCH"
+            TARGET_NAME="$NAME-$VERSION-$OS-$ARCH"
+            mkdir -p "$TARGET_DIR"
+            OUTPUT_FILE="$TARGET_DIR/$TARGET_NAME"
+            if GOOS=$OS GOARCH=$ARCH CGO_ENABLED=0 go build -trimpath -o "$OUTPUT_FILE" . > /dev/null 2>&1; then
+              cd $TARGET_DIR
+              # Extract real output name. Windows builds automatically have .exe added. 
+              ARTIFACT=`ls`
+              echo "target built  - $OS - $ARCH"
+              # Sign and hash
+              gpg --local-user "${{steps.import_gpg.outputs.name}}" --armor --batch --yes --detach-sig $ARTIFACT
+              sha512sum $ARTIFACT > "${ARTIFACT}.sha512"
+
+              ZIP_NAME="$TARGET_NAME.zip"
+              zip -r $ZIP_NAME .
+
+              #TODO move zip to release directory? debug output for now.
+              echo `ls`
+
+              # Return to our root build dir.
+              cd $BUILD_DIR
+            else
+              echo "target failed - $OS - $ARCH"
+              rm -f "$OUTPUT_FILE"
+              exit 1 # Do not continue action
+            fi
+          done
+          cd $ROOT
+
+          # svn co https://dist.apache.org/repos/dist/dev/beam
+          # mkdir -p "${SVN_ARTIFACTS_DIR}"
+          # cd ..
+          # svn add --force prism
+          # svn status
+          # svn commit -m "Staging Prism artifacts for Apache Beam ${RELEASE} RC${RC_NUM}" --non-interactive --username "${{ github.event.inputs.APACHE_ID }}" --password "${{ github.event.inputs.APACHE_PASSWORD }}"

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -463,8 +463,11 @@ jobs:
           mkdir -p $OUTPUT_DIR
           echo "OUTPUT_DIR=$OUTPUT_DIR"
 
+          # TODO remove existing output directory contents.
+
           # Navigate to the prism command directory.
           cd sdks/go/cmd/prism
+
           # Store a reference to where we're building from.
           BUILD_DIR=`pwd`
 
@@ -480,6 +483,7 @@ jobs:
           echo "with gh release id $GH_RELEASE_ID for tag $RC_TAG"
 
           echo "............Build and stage prism artifacts in the Github Release $GH_RELEASE_ID for tag $RC_TAG.........."
+          
           
           # Loop through and build desired set from allowed types.
           for OS in linux windows darwin; do

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -453,7 +453,7 @@ jobs:
           RELEASE_DIR: "beam/${{ github.event.inputs.RELEASE }}"
           RELEASE: "${{ github.event.inputs.RELEASE }}"
           SCRIPT_DIR: release/src/main/scripts
-          GH_TOKEN: ${{ github.event.inputs.BEAM_SITE_TOKEN }}
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
           SVN_ARTIFACTS_DIR: "beam/${{ github.event.inputs.RELEASE }}/prism"
         run: |
           # Store a reference so we can get back to the start.
@@ -516,6 +516,8 @@ jobs:
            /repos/apache/beam/releases | jq '.[] | select(.tag_name | contains("$RC_TAG")) .id'`
 
           echo "release id $GH_RELEASE_ID for tag $RC_TAG"
+
+          gh release list
 
           # svn co https://dist.apache.org/repos/dist/dev/beam
           # mkdir -p "${SVN_ARTIFACTS_DIR}"

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -509,14 +509,14 @@ jobs:
           # Get out of the checked out repo.
           cd .. 
 
-          GH_RELEASE_ID=`gh api \
+          export GH_RELEASE_ID=`gh api \
            -H "Accept: application/vnd.github+json" \
            -H "X-GitHub-Api-Version: 2022-11-28" \
            /repos/apache/beam/releases | jq '.[] | select(.tag_name | contains("$RC_TAG")) .id'`
 
           echo "with gh release id $GH_RELEASE_ID for tag $RC_TAG"
 
-          GH_RELEASE_ID=`curl -L \
+          export GH_RELEASE_ID=`curl -L \
            -H "Accept: application/vnd.github+json" \
            -H "Authorization: Bearer $GH_TOKEN" \
            -H "X-GitHub-Api-Version: 2022-11-28" \

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -38,10 +38,10 @@ on:
         description: Whether to stage the python artifacts into https://dist.apache.org/repos/dist/dev/beam/
         required: true
         default: 'no'
-      CREATE_BEAM_SITE_PR:
-        description: Whether to create the documentation update PR against apache/beam-site.
-        required: true
-        default: 'no'
+    #  CREATE_BEAM_SITE_PR:
+    #    description: Whether to create the documentation update PR against apache/beam-site.
+    #    required: true
+    #    default: 'no'
       BUILD_AND_STAGE_PRISM:
         description: Whether to build signed Prism artifacts and stage them in the draft release.
         required: true
@@ -287,7 +287,7 @@ jobs:
         run: ./gradlew :pushAllDockerImages -PisRelease -Pdocker-pull-licenses -Pprune-images -Pdocker-tag=${{ github.event.inputs.RELEASE }}rc${{ github.event.inputs.RC }} -Pjava11Home=${{steps.export-java11.outputs.JAVA11_HOME}} --no-daemon --no-parallel
 
   beam_site_pr:
-    if: ${{github.event.inputs.CREATE_BEAM_SITE_PR == 'yes'}}
+    if: ${{github.event.inputs.STAGE_PYTHON_ARTIFACTS == 'yes'}}
     # Note: if this ever changes to self-hosted, remove the "Remove default github maven configuration" step
     runs-on: ubuntu-latest
     env:

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -454,7 +454,7 @@ jobs:
           ROOT_DIR=`pwd`
           echo $ROOT_DIR
           # Navigate to the prism command directory.
-          cd beam/sdks/go/cmd/prism
+          cd sdks/go/cmd/prism
           # Store a reference to where we're building from.
           BUILD_DIR=`pwd`
           echo $BUILD_DIR
@@ -518,6 +518,8 @@ jobs:
             fi
           done
           cd $ROOT
+          # Get out of the checked out repo.
+          cd .. 
           echo `which jq`
 
           # svn co https://dist.apache.org/repos/dist/dev/beam

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -492,7 +492,7 @@ jobs:
           for OS in linux windows darwin; do
             for ARCH in amd64 arm64; do
               TARGET_DIR="$OUTPUT_DIR/$OS/$ARCH"
-              TARGET_NAME="apache_beam-$RELEASE-prism-$OS-$ARCH"
+              TARGET_NAME="apache_beam-v$RELEASE-prism-$OS-$ARCH"
 
               mkdir -p "$TARGET_DIR"
               OUTPUT_FILE="$TARGET_DIR/$TARGET_NAME"

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -453,7 +453,7 @@ jobs:
           RELEASE_DIR: "beam/${{ github.event.inputs.RELEASE }}"
           RELEASE: "${{ github.event.inputs.RELEASE }}"
           SCRIPT_DIR: release/src/main/scripts
-          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          GH_TOKEN: ${{ github.event.inputs.BEAM_SITE_TOKEN  }}
           SVN_ARTIFACTS_DIR: "beam/${{ github.event.inputs.RELEASE }}/prism"
         run: |
           # Store a reference so we can get back to the start.
@@ -508,16 +508,21 @@ jobs:
           cd $ROOT
           # Get out of the checked out repo.
           cd .. 
-          echo `which jq`
 
           GH_RELEASE_ID=`gh api \
            -H "Accept: application/vnd.github+json" \
            -H "X-GitHub-Api-Version: 2022-11-28" \
            /repos/apache/beam/releases | jq '.[] | select(.tag_name | contains("$RC_TAG")) .id'`
 
-          echo "release id $GH_RELEASE_ID for tag $RC_TAG"
+          echo "with gh release id $GH_RELEASE_ID for tag $RC_TAG"
 
-          gh release list -R apache/beam
+          GH_RELEASE_ID=`curl -L \
+           -H "Accept: application/vnd.github+json" \
+           -H "Authorization: Bearer $GH_TOKEN" \
+           -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/apache/beam/releases | jq '.[] | select(.tag_name | contains("$RC_TAG")) .id'`
+
+          echo "with curl release id $GH_RELEASE_ID for tag $RC_TAG"
 
           # svn co https://dist.apache.org/repos/dist/dev/beam
           # mkdir -p "${SVN_ARTIFACTS_DIR}"

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -523,23 +523,11 @@ jobs:
               fi
             done
           done
-          echo "...........Prism builds done..........."
-          echo `pwd`
-          cd $ROOT
-          echo "beam root directory?"
-          echo `pwd`
-          echo `ls`
+          echo "...........Prism builds done!..........."
+          cd $ROOT_DIR
+          cd $RELEASE_DIR
 
-          cd beam
-          echo "beam SVN directory?"
-          echo `ls`
-
-          # Get into the dev repo for the release.
-          cd $RELEASE
-
-          echo "...........Adding SVN to dev repo..........."
-          echo `pwd`
-          echo `ls`
+          echo "...........Adding to the dev Apache SVN repo..........."
 
           svn add --force prism
           svn status

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -524,6 +524,12 @@ jobs:
 
           echo "with curl release id $GH_RELEASE_ID for tag $RC_TAG"
 
+          curl -L \
+           -H "Accept: application/vnd.github+json" \
+           -H "Authorization: Bearer $GH_TOKEN" \
+           -H "X-GitHub-Api-Version: 2022-11-28" \
+            https://api.github.com/repos/apache/beam/releases
+
           # svn co https://dist.apache.org/repos/dist/dev/beam
           # mkdir -p "${SVN_ARTIFACTS_DIR}"
           # cd ..

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -466,7 +466,7 @@ jobs:
 
           echo "got all targets"
           # Turn the newline separated list into an array.
-          IFS=$'\n' read -d '' -r -a OS_ARCH_ARRAY <<<"$GO_ALL_TARGETS"
+          IFS=$'\n' read -d '' -r OS_ARCH_ARRAY <<<"$GO_ALL_TARGETS"
 
           echo "split all targets"
           # Declare which supported pairs we want to build.

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -28,17 +28,17 @@ on:
       STAGE:
         description: |
           Configure which actions this workflow should perform, by setting the desired fields to "yes".
-          <br/>
+          --
           java_artifacts: publish java artifacts to https://repository.apache.org/#stagingRepositories
-          <br/>
+          --
           java_source: java source into https://dist.apache.org/repos/dist/dev/beam/
-          <br/>
+          --
           docker_artifacts: stage SDK docker images to docker hub Apache organization
-          <br/>
+          --
           python_artifacts: stage the python artifacts into https://dist.apache.org/repos/dist/dev/beam/
-          <br/>
+          --
           beam_site: create the documentation update PR against apache/beam-site.
-          <br/>
+          --
           prism: build and upload the artifacts to the release for this tag 
         required: true
         default: |
@@ -47,7 +47,7 @@ on:
             docker_artifacts: "no",
             python_artifacts: "no",
             beam_site: "no",
-            prism: "no"}'
+            prism: "no"}
 
 env:
   GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
@@ -453,22 +453,24 @@ jobs:
         run: |
           # Store a reference so we can get back to the start.
           ROOT_DIR=`pwd`
+          echo "ROOT_DIR=$ROOT_DIR"
+          echo "............Checking out Apache Dev Repo.........."
 
           svn co https://dist.apache.org/repos/dist/dev/beam
           mkdir -p "${SVN_ARTIFACTS_DIR}"
+          
+          OUTPUT_DIR=$ROOT_DIR/$SVN_ARTIFACTS_DIR
+          mkdir -p $OUTPUT_DIR
+          echo "OUTPUT_DIR=$OUTPUT_DIR"
 
           # Navigate to the prism command directory.
           cd sdks/go/cmd/prism
           # Store a reference to where we're building from.
           BUILD_DIR=`pwd`
 
-          OUTPUT_DIR=$ROOT_DIR/$SVN_ARTIFACTS_DIR
-          mkdir -p $OUTPUT_DIR
-
           # TODO stop the action if a non-prerelease release exists
           # TODO create the draft release automatically if none exist.
           # TODO update the draft release's RC tag to current.
-
 
           export GH_RELEASE_ID=`gh api \
            -H "Accept: application/vnd.github+json" \
@@ -500,8 +502,6 @@ jobs:
                 gpg --local-user "${{steps.import_gpg.outputs.name}}" --armor --batch --yes --detach-sig $ZIP_NAME
                 sha512sum $ZIP_NAME > "${ZIP_NAME}.sha512"
 
-                echo `ls`
-
                 # Upload to the release.
                 gh release upload $RC_TAG $ZIP_NAME ${ZIP_NAME}.sha512 ${ZIP_NAME}.asc --clobber
                 
@@ -519,13 +519,21 @@ jobs:
               fi
             done
           done
-          echo "-------Prism builds done------"
+          echo "...........Prism builds done..........."
           echo `pwd`
           cd $ROOT
-          # Get into the dev repo for the release.
-          cd $RELEASE_DIR
+          echo "beam root directory?"
+          echo `pwd`
+          echo `ls`
 
-          echo "-------Adding SVN to dev repo------"
+          cd beam
+          echo "beam SVN directory?"
+          echo `ls`
+
+          # Get into the dev repo for the release.
+          cd $RELEASE
+
+          echo "...........Adding SVN to dev repo..........."
           echo `pwd`
           echo `ls`
 

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -476,7 +476,7 @@ jobs:
 
           # Remove existing prism contents from the repo.
           cd $OUTPUT_DIR
-          rm -r .
+          rm -r *
           cd $ROOT_DIR
 
           # Navigate to the prism command directory.

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -517,7 +517,7 @@ jobs:
 
           echo "release id $GH_RELEASE_ID for tag $RC_TAG"
 
-          gh release list
+          gh release list -R apache/beam
 
           # svn co https://dist.apache.org/repos/dist/dev/beam
           # mkdir -p "${SVN_ARTIFACTS_DIR}"

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -496,7 +496,7 @@ jobs:
 
               mkdir -p "$TARGET_DIR"
               OUTPUT_FILE="$TARGET_DIR/$TARGET_NAME"
-              if GOOS=$OS GOARCH=$ARCH CGO_ENABLED=0 go build -trimpath -o "$OUTPUT_FILE" . > /dev/null 2>&1; then
+              if GOOS=$OS GOARCH=$ARCH CGO_ENABLED=0 go build -trimpath -buildvcs=false -o "$OUTPUT_FILE" . > /dev/null 2>&1; then
                 cd $TARGET_DIR
                 # Extract real output name. Windows builds automatically have .exe added. 
                 ARTIFACT=`ls`

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -19,38 +19,34 @@ on:
       APACHE_PASSWORD:
         description: Your Apache password. Required if you want to stage artifacts into https://dist.apache.org/repos/dist/dev/beam/
         required: false
-      BEAM_SITE_TOKEN:
-        description:  Github Personal Access Token with apache/beam-site repo permission if you want to create the beam-site docs PR. See https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens.
+      REPO_TOKEN:
+        description: |
+          Github Personal Access Token with repo permissions if you want to create the beam-site docs PR,
+          create a draft release, or upload prism artifacts to that release.
+          See https://docs.github.com/en/authentication/keeping-your-account-and-data-secure/managing-your-personal-access-tokens.
         default: ''
-      PUBLISH_JAVA_ARTIFACTS:
-        description: Whether to publish java artifacts to https://repository.apache.org/#stagingRepositories (yes/no)
-        required: true
-        default: 'no'
-      STAGE_JAVA_SOURCE:
-        description: Whether to stage the java source into https://dist.apache.org/repos/dist/dev/beam/
-        required: true
-        default: 'no'
-      STAGE_DOCKER_ARTIFACTS:
-        description: Whether to stage SDK docker images to docker hub Apache organization
-        required: true
-        default: 'no'
-      STAGE_PYTHON_ARTIFACTS:
-        description: Whether to stage the python artifacts into https://dist.apache.org/repos/dist/dev/beam/
-        required: true
-        default: 'no'
-    #  CREATE_BEAM_SITE_PR:
-    #    description: Whether to create the documentation update PR against apache/beam-site.
-    #    required: true
-    #    default: 'no'
-      BUILD_AND_STAGE_PRISM:
-        description: Whether to build signed Prism artifacts and stage them in the draft release.
+      STAGE:
+        description: |
+          Configure which actions this workflow should perform, by setting the desired fields to "yes".
+
+          java_artifacts: publish java artifacts to https://repository.apache.org/#stagingRepositories
+
+          java_source: java source into https://dist.apache.org/repos/dist/dev/beam/
+
+          docker_artifacts: stage SDK docker images to docker hub Apache organization
+
+          python_artifacts: stage the python artifacts into https://dist.apache.org/repos/dist/dev/beam/
+
+          beam_site: create the documentation update PR against apache/beam-site.
+
+          prism: build and upload the artifacts to the 
         required: true
         default: |
-           {publish_java: "no",
-            stage_java_source: "no",
-            stage_docker: "no",
-            stage_python: "no",
-            create_beam_site: "no",
+           {java_artifacts: "no",
+            java_source: "no",
+            docker_artifacts: "no",
+            python_artifacts: "no",
+            beam_site: "no",
             prism: "no"}'
 
 env:
@@ -60,7 +56,7 @@ env:
 
 jobs:
   publish_java_artifacts:
-    if: ${{github.event.inputs.PUBLISH_JAVA_ARTIFACTS == 'yes'}}
+    if:  ${{ fromJson(github.event.inputs.STAGE).java_artifacts == 'yes'}}
     runs-on: [self-hosted, ubuntu-20.04, main]
     steps:
       - name: Checkout
@@ -102,7 +98,7 @@ jobs:
 
 
   stage_java_source:
-    if: ${{github.event.inputs.STAGE_JAVA_SOURCE == 'yes'}}
+    if:  ${{ fromJson(github.event.inputs.STAGE).java_source == 'yes'}}
     runs-on: ubuntu-latest
     steps:
       - name: Mask Apache Password
@@ -166,7 +162,7 @@ jobs:
             svn commit -m "Staging Java artifacts for Apache Beam ${{ github.event.inputs.RELEASE }} RC${{ github.event.inputs.RC }}" --non-interactive --username "${{ github.event.inputs.APACHE_ID }}" --password "${{ github.event.inputs.APACHE_PASSWORD }}"
 
   stage_python_artifacts:
-    if: ${{github.event.inputs.STAGE_PYTHON_ARTIFACTS == 'yes'}}
+    if:  ${{ fromJson(github.event.inputs.STAGE).python_artifacts == 'yes'}}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -249,7 +245,7 @@ jobs:
 
 
   stage_docker:
-    if: ${{github.event.inputs.STAGE_DOCKER_ARTIFACTS == 'yes'}}
+    if:  ${{ fromJson(github.event.inputs.STAGE).docker_artifacts == 'yes'}}
     # Note: if this ever changes to self-hosted, remove the "Remove default github maven configuration" step
     runs-on: ubuntu-latest
     steps:
@@ -293,7 +289,7 @@ jobs:
         run: ./gradlew :pushAllDockerImages -PisRelease -Pdocker-pull-licenses -Pprune-images -Pdocker-tag=${{ github.event.inputs.RELEASE }}rc${{ github.event.inputs.RC }} -Pjava11Home=${{steps.export-java11.outputs.JAVA11_HOME}} --no-daemon --no-parallel
 
   beam_site_pr:
-    if: ${{github.event.inputs.STAGE_PYTHON_ARTIFACTS == 'yes'}}
+    if:  ${{ fromJson(github.event.inputs.STAGE).beam_site_pr == 'yes'}}
     # Note: if this ever changes to self-hosted, remove the "Remove default github maven configuration" step
     runs-on: ubuntu-latest
     env:
@@ -313,7 +309,7 @@ jobs:
         with:
           repository: apache/beam-site
           path: beam-site
-          token: ${{ github.event.inputs.BEAM_SITE_TOKEN }}
+          token: ${{ github.event.inputs.REPO_TOKEN }}
           ref: release-docs
       - name: Install Python 3.8
         uses: actions/setup-python@v5
@@ -406,14 +402,14 @@ jobs:
       - name: Create beam-site PR
         working-directory: beam-site
         env:
-          GH_TOKEN: ${{ github.event.inputs.BEAM_SITE_TOKEN }}
+          GH_TOKEN: ${{ github.event.inputs.REPO_TOKEN }}
           PR_TITLE: "Publish docs for ${{ github.event.inputs.RELEASE }} release"
           PR_BODY: "Content generated from https://github.com/apache/beam/tree/${{ env.RC_TAG }}."
         run: |
             gh pr create -t "$PR_TITLE" -b "$PR_BODY" --base release-docs
 
   build_and_stage_prism:
-    if: ${{ fromJson(github.event.inputs.BUILD_AND_STAGE_PRISM).prism == 'yes'}}
+    if: ${{ fromJson(github.event.inputs.STAGE).prism == 'yes'}}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout
@@ -453,7 +449,7 @@ jobs:
           RELEASE_DIR: "beam/${{ github.event.inputs.RELEASE }}"
           RELEASE: "${{ github.event.inputs.RELEASE }}"
           SCRIPT_DIR: release/src/main/scripts
-          GH_TOKEN: ${{ github.event.inputs.BEAM_SITE_TOKEN  }}
+          GH_TOKEN: ${{ github.event.inputs.REPO_TOKEN  }}
           SVN_ARTIFACTS_DIR: "beam/${{ github.event.inputs.RELEASE }}/prism"
         run: |
           # Store a reference so we can get back to the start.

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -45,7 +45,10 @@ on:
       BUILD_AND_STAGE_PRISM:
         description: Whether to build signed Prism artifacts and stage them in the draft release.
         required: true
-        default: 'no'
+        default: |
+           {python: "no",
+            prism: "no",
+            create_beam_site: "no"}'
 
 env:
   GRADLE_ENTERPRISE_ACCESS_KEY: ${{ secrets.GE_ACCESS_TOKEN }}
@@ -407,7 +410,7 @@ jobs:
             gh pr create -t "$PR_TITLE" -b "$PR_BODY" --base release-docs
 
   build_and_stage_prism:
-    if: ${{github.event.inputs.BUILD_AND_STAGE_PRISM == 'yes'}}
+    if: ${{ fromJson(github.event.inputs.BUILD_AND_STAGE_PRISM).prism == 'yes'}}
     runs-on: ubuntu-latest
     steps:
       - name: Checkout

--- a/.github/workflows/build_release_candidate.yml
+++ b/.github/workflows/build_release_candidate.yml
@@ -28,18 +28,18 @@ on:
       STAGE:
         description: |
           Configure which actions this workflow should perform, by setting the desired fields to "yes".
-
+          --
           java_artifacts: publish java artifacts to https://repository.apache.org/#stagingRepositories
-
+          --
           java_source: java source into https://dist.apache.org/repos/dist/dev/beam/
-
+          --
           docker_artifacts: stage SDK docker images to docker hub Apache organization
-
+          --
           python_artifacts: stage the python artifacts into https://dist.apache.org/repos/dist/dev/beam/
-
+          --
           beam_site: create the documentation update PR against apache/beam-site.
-
-          prism: build and upload the artifacts to the 
+          --
+          prism: build and upload the artifacts to the release for this tag 
         required: true
         default: |
            {java_artifacts: "no",


### PR DESCRIPTION
Adds a build & stage to RC creation to release signed hashed and zipped prism binaries to a release.

Currently requires a release with the RC tag to exist, actually straightening out the logic is best handled in a separate PR, as this change is sufficiently complex as is without including the clobber protection logic if targetting an already published release.

Changes the workflow dispatch to us a JSON object instead of individual string fields. The dialog now looks like this:

![image](https://github.com/apache/beam/assets/13907733/768012b7-2a5c-40c7-9d08-e35fc00e99a5)

Not an ideal experience, but we hit the 10 input limit otherwise.

The action syncs down the Dev Apache SVN repo, builds prism binaries for ARM64, AMD64 for Linux, Darwin (osx), and Windows, zipping up the binary, creating signature and sha512 hash files.

These are uploaded to a Github prerelease for the RC tag, like so: https://github.com/apache/beam/releases/tag/untagged-819e4037252d95b05550

Finally, the same artifacts are committed to the Dev Apache repository for final publishing.

Signature and hash are not included in the Zip so the archive doesn't need to be decompressed before being able to validate it.

TODO in a subsequent PR:
* automatically create a draft prerelease release for the tag if one doesn't exist yet.
* Update existing draft GH release for the release version with the new RC tag.
* Fail early if a published release has already gone out for the version to avoid clobbering an existing non-RC GH release.

* Updating the Release Manager guide.

Part of #29697

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
