### PR TITLE
Don't set SETUPTOOLS_USE_DISTUTILS=stdlib 

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -274,7 +274,6 @@ jobs:
         CIBW_BUILD: ${{ matrix.os_python.python }}
         # TODO: https://github.com/apache/beam/issues/23048
         CIBW_SKIP: "*-musllinux_*"
-        CIBW_ENVIRONMENT: "SETUPTOOLS_USE_DISTUTILS=stdlib"
         CIBW_BEFORE_BUILD: pip install cython==0.29.36 numpy --config-settings=setup-args="-Dallow-noblas=true" && pip install --upgrade setuptools
       run: cibuildwheel --print-build-identifiers && cibuildwheel --output-dir wheelhouse
       shell: bash
@@ -301,7 +300,6 @@ jobs:
         CIBW_BUILD: ${{ matrix.os_python.python }}
         # TODO: https://github.com/apache/beam/issues/23048
         CIBW_SKIP: "*-musllinux_*"
-        CIBW_ENVIRONMENT: "SETUPTOOLS_USE_DISTUTILS=stdlib"
         CIBW_BEFORE_BUILD: pip install cython==0.29.36 numpy --config-settings=setup-args="-Dallow-noblas=true" && pip install --upgrade setuptools
       run: cibuildwheel --print-build-identifiers && cibuildwheel --output-dir wheelhouse
       shell: bash

--- a/.test-infra/jenkins/CommonJobProperties.groovy
+++ b/.test-infra/jenkins/CommonJobProperties.groovy
@@ -101,9 +101,6 @@ class CommonJobProperties {
       environmentVariables {
         // Set SPARK_LOCAL_IP for spark tests.
         env('SPARK_LOCAL_IP', '127.0.0.1')
-        // Set SETUPTOOLS_USE_DISTUTILS to workaround issue with setuptools
-        // 50.0 and Ubuntu executors (BEAM-10841)
-        env('SETUPTOOLS_USE_DISTUTILS', 'stdlib')
       }
       credentialsBinding {
         string("CODECOV_TOKEN", "beam-codecov-token")

--- a/sdks/python/build.gradle
+++ b/sdks/python/build.gradle
@@ -161,7 +161,6 @@ platform_identifiers_map.each { platform, idsuffix ->
           try {
             exec {
              environment CIBW_BUILD: "cp${pyversion}-${idsuffix}"
-             environment CIBW_ENVIRONMENT: "SETUPTOOLS_USE_DISTUTILS=stdlib"
              executable 'sh'
              args '-c', ". ${envdir}/bin/activate && " +
                  // note: sync cibuildwheel version with GitHub Action

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -383,7 +383,9 @@ if __name__ == '__main__':
           'pytz>=2018.3',
           'redis>=5.0.0,<6',
           'regex>=2020.6.8',
-          'requests>=2.24.0,<3.0.0,!=2.32.0,!=2.32.1',
+          # unblock tests until new version of `docker` is released.
+          # https://github.com/docker/docker-py/pull/3257
+          'requests>=2.24.0,<3.0.0,!=2.32.*',
           'typing-extensions>=3.7.0',
           'zstandard>=0.18.0,<1',
           # Dynamic dependencies must be specified in a separate list, otherwise


### PR DESCRIPTION
Setting this variable breaks wheel building workflow on Python 3.12 and doesn't seem to be necessary anymore on new releases of setuptools.

Required for #29149