### PR TITLE
Don't install TF on Python 3.12, since there is no compatible version atm.

### DIFF
--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -490,7 +490,7 @@ if __name__ == '__main__':
               'skl2onnx',
               # Support TF 2.16.0: https://github.com/apache/beam/issues/31294
               # Once TF version is unpinned, also don't restrict Python version.
-              'tensorflow<2.16.0;python_version<"3.11"',
+              'tensorflow<2.16.0;python_version<"3.12"',
               'tensorflow-hub',
               # https://github.com/tensorflow/transform/issues/313
               'tensorflow-transform;python_version<"3.11"',

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -488,8 +488,9 @@ if __name__ == '__main__':
               'onnxruntime',
               'sentence-transformers',
               'skl2onnx',
-              # https://github.com/apache/beam/issues/31294
-              'tensorflow<2.16.0',
+              # Support TF 2.16.0: https://github.com/apache/beam/issues/31294
+              # Once TF version is unpinned, also don't restrict Python version.
+              'tensorflow<2.16.0;python_version<"3.11"',
               'tensorflow-hub',
               # https://github.com/tensorflow/transform/issues/313
               'tensorflow-transform;python_version<"3.11"',


### PR DESCRIPTION
fixes: #31385 