### PR TITLE
Fix an incompatibility with hamcrest 2.2

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/CoderPropertiesTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/testing/CoderPropertiesTest.java
@@ -120,7 +120,11 @@ public class CoderPropertiesTest {
       error = e;
     }
     assertNotNull("Expected AssertionError", error);
-    assertThat(error.getMessage(), CoreMatchers.containsString("<84>, <101>, <115>, <116>, <68>"));
+    assertThat(
+        error.getMessage(),
+        CoreMatchers.anyOf(
+            CoreMatchers.containsString("<84>, <101>, <115>, <116>, <68>"),
+            CoreMatchers.containsString("<84b>, <101b>, <115b>, <116b>, <68b>")));
   }
 
   @Test


### PR DESCRIPTION
This test asserts on the message of an AssertionError thrown by a
failing hamcrest assertion. The message changes in the latest versions
of hamcrest.

```
1) testBadCoderIsNotDeterministic(org.apache.beam.sdk.testing.CoderPropertiesTest)
java.lang.AssertionError:
Expected: a string containing "<84>, <101>, <115>, <116>, <68>"
     but: was "
Expected: [<24b>, <84b>, <101b>, <115b>, <116b>, <68b>, <97b>, <116b>, <97b>, <51b>, <51b>, <50b>, <54b>, <49b>, <57b>, <57b>, <52b>, <57b>, <48b>, <57b>, <57b>, <55b>, <48b>, <53b>, <53b>]
     but: was [<24b>, <84b>, <101b>, <115b>, <116b>, <68b>, <97b>, <116b>, <97b>, <51b>, <51b>, <50b>, <54b>, <49b>, <57b>, <57b>, <52b>, <56b>, <50b>, <48b>, <52b>, <49b>, <54b>, <49b>, <53b>]"
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:20)
        at org.hamcrest.MatcherAssert.assertThat(MatcherAssert.java:6)
        at org.apache.beam.sdk.testing.CoderPropertiesTest.testBadCoderIsNotDeterministic(CoderPropertiesTest.java:123)
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
