### PR TITLE
Changed the retry order for test_big_query_write_temp_table_append_schema_update

### DIFF
--- a/sdks/python/apache_beam/io/gcp/bigquery_write_it_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_write_it_test.py
@@ -511,9 +511,9 @@ class BigQueryWriteIntegrationTests(unittest.TestCase):
       param(file_format=FileFormat.JSON),
       param(file_format=None),
   ])
-  @retry(reraise=True, stop=stop_after_attempt(3))
   @mock.patch(
       "apache_beam.io.gcp.bigquery_file_loads._MAXIMUM_SOURCE_URIS", new=1)
+  @retry(reraise=True, stop=stop_after_attempt(3))
   def test_big_query_write_temp_table_append_schema_update(self, file_format):
     """
     Test that nested schema update options and schema relaxation

--- a/sdks/python/apache_beam/io/gcp/bigquery_write_it_test.py
+++ b/sdks/python/apache_beam/io/gcp/bigquery_write_it_test.py
@@ -506,12 +506,12 @@ class BigQueryWriteIntegrationTests(unittest.TestCase):
           equal_to(bq_result_errors))
 
   @pytest.mark.it_postcommit
-  @retry(reraise=True, stop=stop_after_attempt(3))
   @parameterized.expand([
       param(file_format=FileFormat.AVRO),
       param(file_format=FileFormat.JSON),
       param(file_format=None),
   ])
+  @retry(reraise=True, stop=stop_after_attempt(3))
   @mock.patch(
       "apache_beam.io.gcp.bigquery_file_loads._MAXIMUM_SOURCE_URIS", new=1)
   def test_big_query_write_temp_table_append_schema_update(self, file_format):

--- a/sdks/python/apache_beam/ml/inference/tensorflow_inference_test.py
+++ b/sdks/python/apache_beam/ml/inference/tensorflow_inference_test.py
@@ -146,6 +146,7 @@ class TFRunInferenceTest(unittest.TestCase):
       model_handler = TFModelHandlerTensor(
           model_uri=model_path,
           inference_fn=fake_batching_inference_fn,
+          load_model_args={'safe_mode': False},
           min_batch_size=2,
           max_batch_size=2)
       examples = [
@@ -193,6 +194,7 @@ class TFRunInferenceTest(unittest.TestCase):
       model_handler = TFModelHandlerTensor(
           model_uri=model_path,
           inference_fn=fake_batching_inference_fn,
+          load_model_args={'safe_mode': False},
           large_model=True)
       examples = [
           tf.convert_to_tensor(numpy.array([1.1, 2.2, 3.3], dtype='float32')),
@@ -237,6 +239,7 @@ class TFRunInferenceTest(unittest.TestCase):
       model_handler = TFModelHandlerNumpy(
           model_uri=model_path,
           inference_fn=fake_batching_inference_fn,
+          load_model_args={'safe_mode': False},
           min_batch_size=2,
           max_batch_size=2)
       examples = [
@@ -280,6 +283,7 @@ class TFRunInferenceTest(unittest.TestCase):
 
       model_handler = TFModelHandlerNumpy(
           model_uri=model_path,
+          load_model_args={'safe_mode': False},
           inference_fn=fake_inference_fn,
           large_model=True)
       examples = [

--- a/sdks/python/apache_beam/ml/inference/tensorflow_inference_test.py
+++ b/sdks/python/apache_beam/ml/inference/tensorflow_inference_test.py
@@ -127,7 +127,7 @@ class TFRunInferenceTest(unittest.TestCase):
 
   def test_predict_tensor_with_batch_size(self):
     model = _create_mult2_model()
-    model_path = os.path.join(self.tmpdir, 'mult2')
+    model_path = os.path.join(self.tmpdir, 'mult2.keras')
     tf.keras.models.save_model(model, model_path)
     with TestPipeline() as pipeline:
 
@@ -172,7 +172,7 @@ class TFRunInferenceTest(unittest.TestCase):
 
   def test_predict_tensor_with_large_model(self):
     model = _create_mult2_model()
-    model_path = os.path.join(self.tmpdir, 'mult2')
+    model_path = os.path.join(self.tmpdir, 'mult2.keras')
     tf.keras.models.save_model(model, model_path)
     with TestPipeline() as pipeline:
 
@@ -218,7 +218,7 @@ class TFRunInferenceTest(unittest.TestCase):
 
   def test_predict_numpy_with_batch_size(self):
     model = _create_mult2_model()
-    model_path = os.path.join(self.tmpdir, 'mult2_numpy')
+    model_path = os.path.join(self.tmpdir, 'mult2_numpy.keras')
     tf.keras.models.save_model(model, model_path)
     with TestPipeline() as pipeline:
 
@@ -260,7 +260,7 @@ class TFRunInferenceTest(unittest.TestCase):
 
   def test_predict_numpy_with_large_model(self):
     model = _create_mult2_model()
-    model_path = os.path.join(self.tmpdir, 'mult2_numpy')
+    model_path = os.path.join(self.tmpdir, 'mult2_numpy.keras')
     tf.keras.models.save_model(model, model_path)
     with TestPipeline() as pipeline:
 

--- a/sdks/python/apache_beam/ml/inference/tensorflow_inference_test.py
+++ b/sdks/python/apache_beam/ml/inference/tensorflow_inference_test.py
@@ -65,7 +65,7 @@ class FakeTFTensorModel:
 
 
 def _create_mult2_model():
-  inputs = tf.keras.Input(shape=(3))
+  inputs = tf.keras.Input(shape=(3, ))
   outputs = tf.keras.layers.Lambda(lambda x: x * 2, dtype='float32')(inputs)
   return tf.keras.Model(inputs=inputs, outputs=outputs)
 


### PR DESCRIPTION
After https://github.com/apache/beam/pull/31364 is merged, we started seeing this:

```

=================================== FAILURES =================================== |  
-- | --
  | [31m[1m_ BigQueryWriteIntegrationTests.test_big_query_write_temp_table_append_schema_update _[0m |  
  | [gw5] linux -- Python 3.10.14 /runner/_work/beam/beam/build/gradleenv/417525523/bin/python3.10 |  
  |   |  
  | args = (<apache_beam.io.gcp.bigquery_write_it_test.BigQueryWriteIntegrationTests testMethod=test_big_query_write_temp_table_append_schema_update>,) |  
  | kw = {} |  
  |   |  
  | @functools.wraps( |  
  | f, functools.WRAPPER_ASSIGNMENTS + ("__defaults__", "__kwdefaults__") |  
  | ) |  
  | def wrapped_f(*args: t.Any, **kw: t.Any) -> t.Any: |  
  | >       return self(f, *args, **kw) |  
  |   |  
  | [1m[31m../../build/gradleenv/417525523/lib/python3.10/site-packages/tenacity/__init__.py[0m:330: |  
  | _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ |  
  | [1m[31m../../build/gradleenv/417525523/lib/python3.10/site-packages/tenacity/__init__.py[0m:467: in __call__ |  
  | do = self.iter(retry_state=retry_state) |  
  | [1m[31m../../build/gradleenv/417525523/lib/python3.10/site-packages/tenacity/__init__.py[0m:368: in iter |  
  | result = action(retry_state) |  
  | [1m[31m../../build/gradleenv/417525523/lib/python3.10/site-packages/tenacity/__init__.py[0m:410: in exc_check |  
  | raise retry_exc.reraise() |  
  | [1m[31m../../build/gradleenv/417525523/lib/python3.10/site-packages/tenacity/__init__.py[0m:183: in reraise |  
  | raise self.last_attempt.result() |  
  | [1m[31m/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/concurrent/futures/_base.py[0m:451: in result |  
  | return self.__get_result() |  
  | [1m[31m/opt/hostedtoolcache/Python/3.10.14/x64/lib/python3.10/concurrent/futures/_base.py[0m:403: in __get_result |  
  | raise self._exception

_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ |  
-- | --
  |   |  
  | self = <Retrying object at 0x7e82b58ae410 (stop=<tenacity.stop.stop_after_attempt object at 0x7e82b58ae350>, wait=<tenacity.w...0x7e82b58ad690>, before=<function before_nothing at 0x7e82b5896170>, after=<function after_nothing at 0x7e82b5896dd0>)> |  
  | fn = None |  
  | args = (<apache_beam.io.gcp.bigquery_write_it_test.BigQueryWriteIntegrationTests testMethod=test_big_query_write_temp_table_append_schema_update>,) |  
  | kwargs = {} |  
  | retry_state = <RetryCallState 139099832550016: attempt #3; slept for 0.0; last result: failed (TypeError 'NoneType' object is not callable)> |  
  | do = <tenacity.DoAttempt object at 0x7e82b41bb940> |  
  |   |  
  | def __call__( |  
  | self, |  
  | fn: t.Callable[..., WrappedFnReturnT], |  
  | *args: t.Any, |  
  | **kwargs: t.Any, |  
  | ) -> WrappedFnReturnT: |  
  | self.begin() |  
  |   |  
  | retry_state = RetryCallState(retry_object=self, fn=fn, args=args, kwargs=kwargs) |  
  | while True: |  
  | do = self.iter(retry_state=retry_state) |  
  | if isinstance(do, DoAttempt): |  
  | try: |  
  | >                   result = fn(*args, **kwargs) |  
  | [1m[31mE                   TypeError: 'NoneType' object is not callable[0m |  
  |   |  
  | [1m[31m../../build/gradleenv/417525523/lib/python3.10/site-packages/tenacity/__init__.py[0m:470: TypeError



```

https://ge.apache.org/s/t3t76xr2mbgdo/console-log/task/:sdks:python:test-suites:direct:py310:postCommitIT?anchor=203&page=1

I suspect the retry order might cause this issue.

I also fixed the ML test issues.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
