### PR TITLE
Remove pipeline options override from SpannerIO readChangeStream connector

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerIO.java
@@ -1725,11 +1725,6 @@ public class SpannerIO {
           new PostProcessingMetricsDoFn(metrics);
 
       LOG.info("Partition metadata table that will be used is " + partitionMetadataTableName);
-      input
-          .getPipeline()
-          .getOptions()
-          .as(SpannerChangeStreamOptions.class)
-          .setMetadataTable(partitionMetadataTableName);
 
       final PCollection<byte[]> impulseOut = input.apply(Impulse.create());
       final PCollection<PartitionMetadata> partitionsOut =


### PR DESCRIPTION
`SpannerIO` is setting pipeline options under the hood, causing potential clashes with user defined options, or when the connector is used more than once in the same pipeline (and using conflicting values).

This PR just removes the code setting the pipeline options. All tests are passing. Running this version in a job using the `readChangeStream()` connector is working fine. The only noticeable effect is that the `metadata_table` option is not set in the pipeline options.

This fixes #31411 

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
