### PR TITLE
Include Python 3.12 in release validation steps.

### DIFF
--- a/release/src/main/Dockerfile
+++ b/release/src/main/Dockerfile
@@ -33,9 +33,9 @@ RUN apt-get update && \
 RUN apt-get install -y build-essential libssl-dev zlib1g-dev \
     libbz2-dev libreadline-dev libsqlite3-dev llvm \
     libncurses5-dev libncursesw5-dev xz-utils tk-dev \
-    libffi-dev liblzma-dev python3-openssl 
+    libffi-dev liblzma-dev python3-openssl
 
-# Install pyenv and install all of the Python versions 
+# Install pyenv and install all of the Python versions
 # needed to build containers
 RUN curl https://pyenv.run | bash && \
     echo 'export PYENV_ROOT="$HOME/.pyenv"' >> /root/.bashrc && \
@@ -46,7 +46,8 @@ RUN curl https://pyenv.run | bash && \
     pyenv install 3.9.4 && \
     pyenv install 3.10.7 && \
     pyenv install 3.11.3 && \
-    pyenv global 3.8.9 3.9.4 3.10.7 3.11.3
+    pyenv install 3.12.3 && \
+    pyenv global 3.8.9 3.9.4 3.10.7 3.11.3 3.12.3
 
 # Install a Go version >= 1.16 so we can bootstrap higher
 # Go versions

--- a/release/src/main/python-release/python_release_automation.sh
+++ b/release/src/main/python-release/python_release_automation.sh
@@ -19,7 +19,7 @@
 source release/src/main/python-release/run_release_candidate_python_quickstart.sh
 source release/src/main/python-release/run_release_candidate_python_mobile_gaming.sh
 
-for version in 3.8 3.9 3.10 3.11
+for version in 3.8 3.9 3.10 3.11 3.12
 do
   run_release_candidate_python_quickstart    "tar"   "python${version}"
   run_release_candidate_python_mobile_gaming "tar"   "python${version}"

--- a/release/src/main/scripts/build_release_candidate.sh
+++ b/release/src/main/scripts/build_release_candidate.sh
@@ -348,7 +348,7 @@ if [[ $confirmation = "y" ]]; then
   cd ${BEAM_ROOT_DIR}
   RELEASE_COMMIT=$(git rev-list -n 1 "tags/${RC_TAG}")
   # TODO(https://github.com/apache/beam/issues/20209): Don't hardcode py version in this file.
-  cd sdks/python && tox -e py38-docs
+  cd sdks/python && tox -e docs
   GENERATED_PYDOC=~/${LOCAL_WEBSITE_UPDATE_DIR}/${LOCAL_PYTHON_DOC}/${BEAM_ROOT_DIR}/sdks/python/target/docs/_build
   rm -rf ${GENERATED_PYDOC}/.doctrees
 


### PR DESCRIPTION
Include Python 3.12 for release validation purposes.

drive-by change: update a reference to docs tox task, it was recently changed, see: https://github.com/apache/beam/blob/e764fc9c17dbc575d4a16b5e6454f4d38ef752be/sdks/python/tox.ini#L148

#29149