### PR TITLE
[YAML] Fix simple YAML mappings type hinting

### DIFF
--- a/sdks/python/apache_beam/yaml/yaml_combine.py
+++ b/sdks/python/apache_beam/yaml/yaml_combine.py
@@ -144,7 +144,7 @@ class PyJsYamlCombine(beam.PTransform):
 
     for output, agg in self._combine.items():
       expr = yaml_mapping._as_callable(
-          all_fields, agg['value'], 'Combine', self._language)
+          all_fields, agg['value'], 'Combine', self._language, input_types)
       fn = create_combine_fn(agg['fn'])
       transform = transform.aggregate_field(expr, fn, output)
 

--- a/sdks/python/apache_beam/yaml/yaml_mapping.py
+++ b/sdks/python/apache_beam/yaml/yaml_mapping.py
@@ -285,6 +285,8 @@ def _as_callable(original_fields, expr, transform_name, language, input_schema):
 
   # Extract original type from upstream pcoll when doing simple mappings
   original_type = input_schema.get(str(expr), None)
+  if expr in original_fields:
+    language = "python"
 
   # TODO(yaml): support an imports parameter
   # TODO(yaml): support a requirements parameter (possibly at a higher level)

--- a/sdks/python/apache_beam/yaml/yaml_mapping.py
+++ b/sdks/python/apache_beam/yaml/yaml_mapping.py
@@ -281,15 +281,10 @@ def _as_callable_for_pcoll(
         list(input_schema.keys()), fn_spec, msg, language, input_schema)
 
 
-def _as_callable(
-    original_fields, expr, transform_name, language, input_schema=None):
+def _as_callable(original_fields, expr, transform_name, language, input_schema):
 
   # Extract original type from upstream pcoll when doing simple mappings
-  if input_schema is None:
-    input_schema = {}
-  original_type = input_schema.get(transform_name, None)
-  if expr in original_fields:
-    original_type = input_schema.get(expr, None)
+  original_type = input_schema.get(str(expr), None)
 
   # TODO(yaml): support an imports parameter
   # TODO(yaml): support a requirements parameter (possibly at a higher level)


### PR DESCRIPTION
There have been type inferencing issues with Beam YAML `MapToFields` where the type(s) from the upstream pcollection are dropped when the `beam.Select` is used on unmapped fields in the `MapToFields` expansion (i.e. when using `append: true`, the unmapped fields are mapped to AnyType). 

The fix is to register type hints for the implicitly appended fields.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
