### PR TITLE
Cleanup TableRow of unknowns for good structs 

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TableRowToStorageApiProto.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/TableRowToStorageApiProto.java
@@ -524,6 +524,15 @@ public class TableRowToStorageApiProto {
         if (value != null) {
           builder.setField(fieldDescriptor, value);
         }
+        // For STRUCT fields, we add a placeholder to unknownFields using the getNestedUnknown
+        // supplier (in case we encounter unknown nested fields). If the placeholder comes out
+        // to be empty, we should clean it up
+        if (fieldSchemaInformation.getType().equals(TableFieldSchema.Type.STRUCT)
+            && unknownFields != null
+            && unknownFields.get(entry.getKey().toLowerCase()) instanceof Map
+            && ((Map<?, ?>) unknownFields.get(entry.getKey().toLowerCase())).isEmpty()) {
+          unknownFields.remove(entry.getKey().toLowerCase());
+        }
       } catch (Exception e) {
         throw new SchemaDoesntMatchException(
             "Problem converting field "

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/TableRowToStorageApiProtoTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/TableRowToStorageApiProtoTest.java
@@ -1577,17 +1577,21 @@ public class TableRowToStorageApiProtoTest {
 
   @Test
   public void testIgnoreUnknownNestedField() throws Exception {
+    TableRow rowNoFWithUnknowns = new TableRow();
+    rowNoFWithUnknowns.putAll(BASE_TABLE_ROW_NO_F);
+    rowNoFWithUnknowns.set("unknown", "foobar");
+    TableRow rowWithFWithUnknowns = new TableRow();
+    List<TableCell> cellsWithUnknowns = Lists.newArrayList(BASE_TABLE_ROW.getF());
+    cellsWithUnknowns.add(new TableCell().setV("foobar"));
+    rowWithFWithUnknowns.setF(cellsWithUnknowns);
+    // Nested records with no unknowns should not show up
     TableRow rowNoF = new TableRow();
     rowNoF.putAll(BASE_TABLE_ROW_NO_F);
-    rowNoF.set("unknown", "foobar");
-    TableRow rowWithF = new TableRow();
-    List<TableCell> cells = Lists.newArrayList(BASE_TABLE_ROW.getF());
-    cells.add(new TableCell().setV("foobar"));
-    rowWithF.setF(cells);
     TableRow topRow =
         new TableRow()
-            .set("nestedValueNoF1", rowNoF)
-            .set("nestedValue1", rowWithF)
+            .set("nestedValueNoF1", rowNoFWithUnknowns)
+            .set("nestedValue1", rowWithFWithUnknowns)
+            .set("nestedValueNoF2", rowNoF)
             .set("unknowntop", "foobar");
 
     Descriptor descriptor =


### PR DESCRIPTION
When converting TableRows to dynamic messages with auto-schema update enabled, we gather any unknown fields that we encounter and store them in a TableRow. When we encounter a STRUCT field, we create a placeholder in our "unknown TableRow" in case we need to populate it with unknown nested fields.

If we don't cleanup this placeholder properly, we end up wrongfully marking the STRUCT field as unknown. 

Fixes #30850