### PR TITLE
Pins SnakeYAML version to 1.33 for Hadoop Format tests

### DIFF
--- a/sdks/java/io/hadoop-format/build.gradle
+++ b/sdks/java/io/hadoop-format/build.gradle
@@ -47,6 +47,8 @@ configurations.testRuntimeClasspath {
 
   // Force use the old version of JAMM that cassandra relies on
   resolutionStrategy.force 'com.github.jbellis:jamm:0.3.0'
+  // Pin snakeyaml version due to cassandra-all does not support 2.x
+  resolutionStrategy.force 'org.yaml:snakeyaml:1.33'
 }
 
 dependencies {
@@ -88,12 +90,6 @@ dependencies {
   testImplementation library.java.cassandra_driver_mapping
   // TODO(yathu) bump to cassandra-5.x which uses newer jamm when released & beam runs test on Java11
   testImplementation "org.apache.cassandra:cassandra-all:3.11.10"
-  // Pin snakeyaml version due to cassandra-all not support 2.x
-  testImplementation ("org.yaml:snakeyaml") {
-    version {
-      strictly '[1,1.34['
-    }
-  }
   testImplementation library.java.hadoop_common
   testImplementation library.java.hadoop_hdfs
   testImplementation library.java.hadoop_mapreduce_client_core


### PR DESCRIPTION
https://github.com/apache/beam/pull/31406 bumped up the SnakeYAML dependency used by Expansion Services to 2.2 which seems to have changed the dependency resolution for the hadoop-format module resulting in a failure. This tries to resolve by pinning the SnakeYAML version to 1.33.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
