### PR TITLE
Revert "Bump Jackson databind to 2.15"

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -617,7 +617,7 @@ class BeamModulePlugin implements Plugin<Project> {
     def influxdb_version = "2.19"
     def httpclient_version = "4.5.13"
     def httpcore_version = "4.4.14"
-    def jackson_version = "2.15.4"
+    def jackson_version = "2.14.1"
     def jaxb_api_version = "2.3.3"
     def jsr305_version = "3.0.2"
     def everit_json_version = "1.14.2"

--- a/sdks/java/container/license_scripts/dep_urls_java.yaml
+++ b/sdks/java/container/license_scripts/dep_urls_java.yaml
@@ -58,7 +58,7 @@ xz:
   '1.5': # The original repo is down. This license is taken from https://tukaani.org/xz/java.html.
     license: "file://{}/xz/COPYING"
 jackson-bom:
-  '2.15.4':
+  '2.14.1':
     license: "https://raw.githubusercontent.com/FasterXML/jackson-bom/master/LICENSE"
     type: "Apache License 2.0"
 junit-dep:

--- a/sdks/java/io/cdap/build.gradle
+++ b/sdks/java/io/cdap/build.gradle
@@ -70,6 +70,8 @@ dependencies {
     testImplementation library.java.mockito_core
     testImplementation library.java.testcontainers_postgresql
     testImplementation project(path: ":sdks:java:extensions:avro", configuration: "testRuntimeMigration")
+    testImplementation project(path: ":sdks:java:io:hadoop-common", configuration: "testRuntimeMigration")
+    testImplementation project(path: ":sdks:java:io:hadoop-format", configuration: "testRuntimeMigration")
     testImplementation project(path: ":sdks:java:testing:test-utils", configuration: "testRuntimeMigration")
     testImplementation project(path: ":runners:direct-java", configuration: "shadow")
     testImplementation project(path: ":sdks:java:io:common", configuration: "testRuntimeMigration")


### PR DESCRIPTION
Reverts apache/beam#31473

Trying to track down a performance regression, flagging this commit (among others) as a potential source. If that proves incorrect I'll just close the PR.