### PR TITLE
[Test only] clickhouse tests failures

### DIFF
--- a/.github/workflows/beam_PreCommit_Java_IOs_Direct.yml
+++ b/.github/workflows/beam_PreCommit_Java_IOs_Direct.yml
@@ -22,6 +22,7 @@ on:
     paths:
       - "sdks/java/io/common/**"
       - "sdks/java/core/src/main/**"
+      - "buildSrc/**"
       - ".github/workflows/beam_PreCommit_Java_IOs_Direct.yml"
   pull_request_target:
     branches: ['master', 'release-*']

--- a/sdks/java/io/clickhouse/build.gradle
+++ b/sdks/java/io/clickhouse/build.gradle
@@ -66,7 +66,6 @@ dependencies {
   testImplementation library.java.testcontainers_clickhouse
   testRuntimeOnly library.java.slf4j_jdk14
   testRuntimeOnly project(path: ":runners:direct-java", configuration: "shadow")
-  testImplementation project(path: ":sdks:java:extensions:avro", configuration: "testRuntimeMigration")
 }
 
 processTestResources {

--- a/sdks/java/io/clickhouse/src/test/java/org/apache/beam/sdk/io/clickhouse/BaseClickHouseTest.java
+++ b/sdks/java/io/clickhouse/src/test/java/org/apache/beam/sdk/io/clickhouse/BaseClickHouseTest.java
@@ -48,7 +48,7 @@ public class BaseClickHouseTest {
     network = Network.newNetwork();
 
     zookeeper =
-        new GenericContainer<>("zookeeper:3.4.13")
+        new GenericContainer<>("zookeeper:3.9")
             .withStartupAttempts(10)
             .withExposedPorts(2181)
             .withNetwork(network)
@@ -58,7 +58,7 @@ public class BaseClickHouseTest {
     zookeeper.start();
 
     clickHouse =
-        new ClickHouseContainer("clickhouse/clickhouse-server:22.9")
+        new ClickHouseContainer("clickhouse/clickhouse-server:24.4")
             .withStartupAttempts(10)
             .withNetwork(network)
             .withClasspathResourceMapping(
@@ -84,10 +84,9 @@ public class BaseClickHouseTest {
   }
 
   ResultSet executeQuery(String sql) throws SQLException {
-    try (Connection connection = clickHouse.createConnection("");
-        Statement statement = connection.createStatement()) {
-      return statement.executeQuery(sql);
-    }
+    Connection connection = clickHouse.createConnection("");
+    Statement statement = connection.createStatement();
+    return statement.executeQuery(sql);
   }
 
   long executeQueryAsLong(String sql) throws SQLException {


### PR DESCRIPTION
Demonstrate errors seen on newer clickhouse testcontainer

There was an issue

```
java.sql.SQLException: Cannot operate on a closed ResultSet
	at com.clickhouse.jdbc.SqlExceptionUtils.clientError(SqlExceptionUtils.java:43)
	at com.clickhouse.jdbc.AbstractResultSet.ensureOpen(AbstractResultSet.java:24)
	at com.clickhouse.jdbc.ClickHouseResultSet.next(ClickHouseResultSet.java:708)
```

affecting many clickhouse tests due to #31531 . After fixing connection issue, there are failing tests indicating breaking changes on clickhouse server side

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
