### PR TITLE
Avoid length-prefix-bytes substitutions for Flink boundaries.

### DIFF
--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/adapter/BeamAdapterUtils.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/adapter/BeamAdapterUtils.java
@@ -29,6 +29,7 @@ import org.apache.beam.sdk.options.PortablePipelineOptions;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.util.Preconditions;
 import org.apache.beam.sdk.util.construction.Environments;
+import org.apache.beam.sdk.util.construction.PTransformTranslation;
 import org.apache.beam.sdk.util.construction.PipelineTranslation;
 import org.apache.beam.sdk.util.construction.SdkComponents;
 import org.apache.beam.sdk.values.PBegin;
@@ -37,6 +38,7 @@ import org.apache.beam.sdk.values.PCollectionTuple;
 import org.apache.beam.sdk.values.PInput;
 import org.apache.beam.sdk.values.POutput;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Maps;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 
@@ -108,6 +110,26 @@ class BeamAdapterUtils {
     // Extract the pipeline definition so that we can apply or Flink translation logic.
     SdkComponents components = SdkComponents.create(pipelineOptions);
     RunnerApi.Pipeline pipelineProto = PipelineTranslation.toProto(pipeline, components);
+
+    // Avoid swapping input and output coders for BytesCoders.
+    // As we have instantiated the actual coder objects here, there is no need ot length prefix them
+    // anyway.
+    // TODO(robertwb): Even better would be to avoid coding and decoding along these edges via a
+    // direct
+    // in-memory channel for embedded mode.  As well as improving performance, there could be
+    // control-flow advantages too.
+    for (RunnerApi.PTransform transformProto :
+        pipelineProto.getComponents().getTransforms().values()) {
+      if (FlinkInput.URN.equals(PTransformTranslation.urnForTransformOrNull(transformProto))) {
+        BeamAdapterCoderUtils.registerKnownCoderFor(
+            pipelineProto, Iterables.getOnlyElement(transformProto.getOutputs().values()));
+      } else if (FlinkOutput.URN.equals(
+          PTransformTranslation.urnForTransformOrNull(transformProto))) {
+        BeamAdapterCoderUtils.registerKnownCoderFor(
+            pipelineProto, Iterables.getOnlyElement(transformProto.getInputs().values()));
+      }
+    }
+
     return translator.translate(inputs, pipelineProto, executionEnvironment);
   }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/adapter/BeamFlinkDataSetAdapter.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/adapter/BeamFlinkDataSetAdapter.java
@@ -246,7 +246,6 @@ public class BeamFlinkDataSetAdapter {
       Coder<InputT> outputCoder =
           BeamAdapterCoderUtils.lookupCoder(
               p, Iterables.getOnlyElement(t.getTransform().getInputsMap().values()));
-      // TODO(robertwb): Also handle or disable length prefix coding (for embedded mode at least).
       outputMap.put(
           outputId,
           new MapOperator<WindowedValue<InputT>, InputT>(

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/adapter/BeamFlinkDataStreamAdapter.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/adapter/BeamFlinkDataStreamAdapter.java
@@ -271,7 +271,6 @@ public class BeamFlinkDataStreamAdapter {
       Coder<InputT> outputCoder =
           BeamAdapterCoderUtils.lookupCoder(
               p, Iterables.getOnlyElement(transform.getInputsMap().values()));
-      // TODO(robertwb): Also handle or disable length prefix coding (for embedded mode at least).
       outputMap.put(
           outputId,
           inputDataStream.transform(


### PR DESCRIPTION
The runner infrastructure typically substitutes "unknown" coders for length-prefixed bytes, but for elements going into or out of the Beam pipeline fragment we want the actual objects.  Fortunately, we know these coders are known on the Runner side as well as the SDK side as we have them in hand there.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
