### PR TITLE
[release-2.57.0] Cherrypick #31581 into the release branch.

### DIFF
--- a/sdks/python/apache_beam/runners/worker/data_plane.py
+++ b/sdks/python/apache_beam/runners/worker/data_plane.py
@@ -452,7 +452,7 @@ class InMemoryDataChannel(DataChannel):
 class _GrpcDataChannel(DataChannel):
   """Base class for implementing a BeamFnData-based DataChannel."""
 
-  _WRITES_FINISHED = object()
+  _WRITES_FINISHED = beam_fn_api_pb2.Elements.Data()
 
   def __init__(self, data_buffer_time_limit_ms=0):
     # type: (int) -> None
@@ -475,7 +475,7 @@ class _GrpcDataChannel(DataChannel):
 
   def close(self):
     # type: () -> None
-    self._to_send.put(self._WRITES_FINISHED)  # type: ignore[arg-type]
+    self._to_send.put(self._WRITES_FINISHED)
     self._closed = True
 
   def wait(self, timeout=None):


### PR DESCRIPTION
#31581 reduces intermittent errors in pipelines that have large elements.

Reasons to cherry-pick: 
1) In 2.57.0 we introduced a warning about large elements with https://github.com/apache/beam/pull/31363, however this warning might be unactionable for cases when large elements were implicitly created by Beam.  
2) At least one customer is waiting  to see this change in a stable version of Beam.  