### PR TITLE
PubsubMessageWithTopicCoder.of() is returning wrong coder

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIO.java
@@ -1488,7 +1488,7 @@ public class PubsubIO {
                   .get(BAD_RECORD_TAG)
                   .setCoder(BadRecord.getCoder(input.getPipeline())));
       PCollection<PubsubMessage> pubsubMessages =
-          pubsubMessageTuple.get(pubsubMessageTupleTag).setCoder(new PubsubMessageWithTopicCoder());
+          pubsubMessageTuple.get(pubsubMessageTupleTag).setCoder(PubsubMessageWithTopicCoder.of());
       switch (input.isBounded()) {
         case BOUNDED:
           pubsubMessages.apply(

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubMessageWithTopicCoder.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubMessageWithTopicCoder.java
@@ -45,8 +45,8 @@ public class PubsubMessageWithTopicCoder extends CustomCoder<PubsubMessage> {
     return of();
   }
 
-  public static PubsubMessageWithAttributesAndMessageIdCoder of() {
-    return new PubsubMessageWithAttributesAndMessageIdCoder();
+  public static PubsubMessageWithTopicCoder of() {
+    return new PubsubMessageWithTopicCoder();
   }
 
   @Override

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubIOTest.java
@@ -732,7 +732,7 @@ public class PubsubIOTest {
       PCollection<PubsubMessage> messages =
           pipeline.apply(
               Create.timestamped(ImmutableList.of(pubsubMsg, failingPubsubMsg))
-                  .withCoder(new PubsubMessageWithTopicCoder()));
+                  .withCoder(PubsubMessageWithTopicCoder.of()));
       messages.setIsBoundedInternal(PCollection.IsBounded.BOUNDED);
       ErrorHandler<BadRecord, PCollection<Long>> badRecordErrorHandler =
           pipeline.registerBadRecordErrorHandler(new ErrorSinkTransform());
@@ -882,7 +882,7 @@ public class PubsubIOTest {
 
       PCollection<PubsubMessage> messages =
           pipeline.apply(
-              Create.timestamped(pubsubMessages).withCoder(new PubsubMessageWithTopicCoder()));
+              Create.timestamped(pubsubMessages).withCoder(PubsubMessageWithTopicCoder.of()));
       if (!isBounded) {
         messages = messages.setIsBoundedInternal(PCollection.IsBounded.UNBOUNDED);
       }
@@ -919,7 +919,7 @@ public class PubsubIOTest {
       PCollection<PubsubMessage> messages =
           pipeline.apply(
               Create.timestamped(ImmutableList.of(pubsubMsg))
-                  .withCoder(new PubsubMessageWithTopicCoder()));
+                  .withCoder(PubsubMessageWithTopicCoder.of()));
       messages.setIsBoundedInternal(PCollection.IsBounded.BOUNDED);
       messages.apply(PubsubIO.writeMessagesDynamic().withClientFactory(factory));
       pipeline.run();

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSinkTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/pubsub/PubsubUnboundedSinkTest.java
@@ -223,7 +223,7 @@ public class PubsubUnboundedSinkTest implements Serializable {
                           Instant.ofEpochMilli(o.getTimestampMsSinceEpoch())))
               .collect(Collectors.toList());
 
-      p.apply(Create.timestamped(pubsubMessages).withCoder(new PubsubMessageWithTopicCoder()))
+      p.apply(Create.timestamped(pubsubMessages).withCoder(PubsubMessageWithTopicCoder.of()))
           .apply(sink);
       p.run();
     }


### PR DESCRIPTION
PubsubMessageWithTopicCoder should return PubsubMessageWithTopicCoder PubsubMessageWithAttributesAndMessageIdCoder. 

While investigating Dynamic Destinations on Direct runner I found out that PubsubMessageWithTopicCoder is never used and topic is lost and pipeline fails. 

fixes #31679

