### PR TITLE
Handle MultimapKeysSideInput in State GetRequests

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/worker/worker_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/worker_test.go
@@ -323,7 +323,7 @@ func TestWorker_State_MultimapKeysSideInput(t *testing.T) {
 			w:    window.GlobalWindow{},
 		},
 		{
-			name: "global window",
+			name: "interval window",
 			w: window.IntervalWindow{
 				Start: 1000,
 				End:   2000,

--- a/sdks/go/pkg/beam/runners/prism/internal/worker/worker_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/worker_test.go
@@ -18,7 +18,11 @@ package worker
 import (
 	"bytes"
 	"context"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/coder"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime/exec"
+	"github.com/google/go-cmp/cmp"
 	"net"
+	"sort"
 	"sync"
 	"testing"
 	"time"
@@ -95,6 +99,23 @@ func serveTestWorker(t *testing.T) (context.Context, *W, *grpc.ClientConn) {
 		t.Fatal("couldn't create bufconn grpc connection:", err)
 	}
 	return ctx, w, clientConn
+}
+
+type closeSend func()
+
+func serveTestWorkerStateStream(t *testing.T) (*W, fnpb.BeamFnState_StateClient, closeSend) {
+	ctx, wk, clientConn := serveTestWorker(t)
+
+	stateCli := fnpb.NewBeamFnStateClient(clientConn)
+	stateStream, err := stateCli.State(ctx)
+	if err != nil {
+		t.Fatal("couldn't create state client:", err)
+	}
+	return wk, stateStream, func() {
+		if err := stateStream.CloseSend(); err != nil {
+			t.Errorf("stateStream.CloseSend() = %v", err)
+		}
+	}
 }
 
 func TestWorker_Logging(t *testing.T) {
@@ -289,5 +310,79 @@ func TestWorker_State_Iterable(t *testing.T) {
 
 	if err := stateStream.CloseSend(); err != nil {
 		t.Errorf("stateStream.CloseSend() = %v", err)
+	}
+}
+
+func TestWorker_State_MultimapKeysSideInput(t *testing.T) {
+	for _, tt := range []struct {
+		name string
+		w    typex.Window
+	}{
+		{
+			name: "global window",
+			w:    window.GlobalWindow{},
+		},
+		{
+			name: "global window",
+			w: window.IntervalWindow{
+				Start: 1000,
+				End:   2000,
+			},
+		},
+	} {
+		t.Run(tt.name, func(t *testing.T) {
+			var encW []byte
+			if !tt.w.Equals(window.GlobalWindow{}) {
+				buf := bytes.Buffer{}
+				if err := exec.MakeWindowEncoder(coder.NewIntervalWindow()).EncodeSingle(tt.w, &buf); err != nil {
+					t.Fatalf("error encoding window: %v, err: %v", tt.w, err)
+				}
+				encW = buf.Bytes()
+			}
+			wk, stateStream, done := serveTestWorkerStateStream(t)
+			defer done()
+			instID := wk.NextInst()
+			wk.activeInstructions[instID] = &B{
+				MultiMapSideInputData: map[SideInputKey]map[typex.Window]map[string][][]byte{
+					SideInputKey{
+						TransformID: "transformID",
+						Local:       "i1",
+					}: {
+						tt.w: map[string][][]byte{"a": {{1}}, "b": {{2}}},
+					},
+				},
+			}
+
+			stateStream.Send(&fnpb.StateRequest{
+				Id:            "first",
+				InstructionId: instID,
+				Request: &fnpb.StateRequest_Get{
+					Get: &fnpb.StateGetRequest{},
+				},
+				StateKey: &fnpb.StateKey{Type: &fnpb.StateKey_MultimapKeysSideInput_{
+					MultimapKeysSideInput: &fnpb.StateKey_MultimapKeysSideInput{
+						TransformId: "transformID",
+						SideInputId: "i1",
+						Window:      encW,
+					},
+				}},
+			})
+
+			resp, err := stateStream.Recv()
+			if err != nil {
+				t.Fatal("couldn't receive state response:", err)
+			}
+
+			want := []int{97, 98}
+			var got []int
+			for _, b := range resp.GetGet().GetData() {
+				got = append(got, int(b))
+			}
+			sort.Ints(got)
+
+			if !cmp.Equal(got, want) {
+				t.Errorf("didn't receive expected state response data: got %v, want %v", got, want)
+			}
+		})
 	}
 }

--- a/sdks/go/pkg/beam/runners/prism/internal/worker/worker_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/worker/worker_test.go
@@ -18,8 +18,6 @@ package worker
 import (
 	"bytes"
 	"context"
-	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/coder"
-	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime/exec"
 	"github.com/google/go-cmp/cmp"
 	"net"
 	"sort"
@@ -27,7 +25,9 @@ import (
 	"testing"
 	"time"
 
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/coder"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/graph/window"
+	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/runtime/exec"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/core/typex"
 	fnpb "github.com/apache/beam/sdks/v2/go/pkg/beam/model/fnexecution_v1"
 	"github.com/apache/beam/sdks/v2/go/pkg/beam/runners/prism/internal/engine"


### PR DESCRIPTION
This PR closes #31628 adding handling for MultimapKeysSideInput in State GetRequests. Since this surfaced in Java validation tests of `org.apache.beam.sdk.transforms.ViewTest`, validated on Prism via:

```
TEST=org.apache.beam.sdk.transforms.ViewTest
./gradlew :runners:portability:java:ulrLoopbackValidatesRunnerTests -PjobEndpoint=localhost:8073 --tests="$TEST"
```

This PR fixes the following ViewTest tests:
- testMapAsEntrySetSideInput
- testWindowedMultimapAsEntrySetSideInput
- testWindowedMapAsEntrySetSideInput
- testMultimapAsEntrySetSideInput

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
