### PR TITLE
Replace getElementType with getValueType for MAP in AvroGenericRecord…

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/AvroGenericRecordToStorageApiProto.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/AvroGenericRecordToStorageApiProto.java
@@ -247,17 +247,17 @@ public class AvroGenericRecordToStorageApiProto {
         break;
       case MAP:
         Schema keyType = Schema.create(Schema.Type.STRING);
-        Schema valueType = TypeWithNullability.create(schema.getElementType()).getType();
+        Schema valueType = Schema.create(schema.getValueType().getType());
         if (valueType == null) {
           throw new RuntimeException("Unexpected null element type!");
         }
         TableFieldSchema keyFieldSchema =
             fieldDescriptorFromAvroField(
-                new Schema.Field("key", keyType, "key of the map entry", Schema.Field.NULL_VALUE));
+                new Schema.Field("key", keyType, "key of the map entry"));
         TableFieldSchema valueFieldSchema =
             fieldDescriptorFromAvroField(
                 new Schema.Field(
-                    "value", valueType, "value of the map entry", Schema.Field.NULL_VALUE));
+                    "value", valueType, "value of the map entry"));
         builder =
             builder
                 .setType(TableFieldSchema.Type.STRUCT)
@@ -346,7 +346,7 @@ public class AvroGenericRecordToStorageApiProto {
         return toProtoValue(fieldDescriptor, type.getType(), value);
       case MAP:
         Map<CharSequence, Object> map = (Map<CharSequence, Object>) value;
-        Schema valueType = TypeWithNullability.create(avroSchema.getElementType()).getType();
+        Schema valueType = Schema.create(avroSchema.getValueType().getType());
         if (valueType == null) {
           throw new RuntimeException("Unexpected null element type!");
         }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/AvroGenericRecordToStorageApiProto.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/AvroGenericRecordToStorageApiProto.java
@@ -252,12 +252,10 @@ public class AvroGenericRecordToStorageApiProto {
           throw new RuntimeException("Unexpected null element type!");
         }
         TableFieldSchema keyFieldSchema =
-            fieldDescriptorFromAvroField(
-                new Schema.Field("key", keyType, "key of the map entry"));
+            fieldDescriptorFromAvroField(new Schema.Field("key", keyType, "key of the map entry"));
         TableFieldSchema valueFieldSchema =
             fieldDescriptorFromAvroField(
-                new Schema.Field(
-                    "value", valueType, "value of the map entry"));
+                new Schema.Field("value", valueType, "value of the map entry"));
         builder =
             builder
                 .setType(TableFieldSchema.Type.STRUCT)

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/AvroGenericRecordToStorageApiProtoTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/AvroGenericRecordToStorageApiProtoTest.java
@@ -271,9 +271,6 @@ public class AvroGenericRecordToStorageApiProtoTest {
   private static final Schema SCHEMA_WITH_MAP;
 
   static {
-    ImmutableMap<String, Object> defaultVal =
-        ImmutableMap.<String, Object>builder().put("key1", "value1").build();
-
     SCHEMA_WITH_MAP =
         SchemaBuilder.record("TestMap")
             .fields()
@@ -286,7 +283,7 @@ public class AvroGenericRecordToStorageApiProtoTest {
             .map()
             .values()
             .stringType()
-            .mapDefault(defaultVal)
+            .mapDefault(ImmutableMap.<String, Object>builder().put("key1", "value1").build())
             .endRecord();
   }
 

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/AvroGenericRecordToStorageApiProtoTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/AvroGenericRecordToStorageApiProtoTest.java
@@ -32,6 +32,8 @@ import java.nio.charset.StandardCharsets;
 import java.security.MessageDigest;
 import java.security.NoSuchAlgorithmException;
 import java.util.EnumSet;
+import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
 import java.util.UUID;
 import java.util.stream.Collectors;
@@ -265,6 +267,28 @@ public class AvroGenericRecordToStorageApiProtoTest {
           .items(BASE_SCHEMA)
           .noDefault()
           .endRecord();
+
+  private static final Schema SCHEMA_WITH_MAP;
+
+    static {
+        ImmutableMap<String, Object> defaultVal = ImmutableMap.<String, Object>builder()
+              .put("key1", "value1")
+              .build();
+
+        SCHEMA_WITH_MAP = SchemaBuilder.record("TestMap")
+            .fields()
+            .name("nested")
+            .type()
+            .optional()
+            .type(BASE_SCHEMA)
+            .name("aMap")
+            .type()
+            .map()
+            .values()
+            .stringType()
+            .mapDefault(defaultVal)
+            .endRecord();
+    }
 
   private static GenericRecord baseRecord;
   private static GenericRecord logicalTypesRecord;
@@ -504,5 +528,45 @@ public class AvroGenericRecordToStorageApiProtoTest {
             descriptor, logicalTypesRecord, null, -1);
     assertEquals(7, msg.getAllFields().size());
     assertBaseRecord(msg, logicalTypesProtoExpectedFields);
+  }
+
+  @Test
+  public void testMessageFromGenericRecordWithMap() throws Exception {
+    // Create a GenericRecord with a map field
+    Map<String, String> mapData = new HashMap<>();
+    mapData.put("key1", "value1");
+    mapData.put("key2", "value2");
+    GenericRecord recordWithMap = new GenericRecordBuilder(SCHEMA_WITH_MAP)
+        .set("nested", baseRecord)
+        .set("aMap", mapData)
+        .build();
+
+    Descriptors.Descriptor descriptor =
+        TableRowToStorageApiProto.getDescriptorFromTableSchema(
+            AvroGenericRecordToStorageApiProto.protoTableSchemaFromAvroSchema(SCHEMA_WITH_MAP),
+            true,
+            false);
+    DynamicMessage msg =
+        AvroGenericRecordToStorageApiProto.messageFromGenericRecord(
+            descriptor, recordWithMap, null, -1);
+
+    assertEquals(2, msg.getAllFields().size());
+
+    Map<String, Descriptors.FieldDescriptor> fieldDescriptors =
+        descriptor.getFields().stream()
+            .collect(Collectors.toMap(Descriptors.FieldDescriptor::getName, Functions.identity()));
+    DynamicMessage nestedMsg = (DynamicMessage) msg.getField(fieldDescriptors.get("nested"));
+    assertBaseRecord(nestedMsg, baseProtoExpectedFields);
+
+    // Assert the map field
+    List<DynamicMessage> list = (List<DynamicMessage>) msg.getField(fieldDescriptors.get("amap"));
+    // Convert the list of DynamicMessages back to a map
+    Map<String, String> actualMap = new HashMap<>();
+    for (DynamicMessage entry : list) {
+      String key = (String) entry.getField(entry.getDescriptorForType().findFieldByName("key"));
+      String value = (String) entry.getField(entry.getDescriptorForType().findFieldByName("value"));
+      actualMap.put(key, value);
+    }
+    assertEquals(mapData, actualMap);
   }
 }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/AvroGenericRecordToStorageApiProtoTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/AvroGenericRecordToStorageApiProtoTest.java
@@ -270,12 +270,12 @@ public class AvroGenericRecordToStorageApiProtoTest {
 
   private static final Schema SCHEMA_WITH_MAP;
 
-    static {
-        ImmutableMap<String, Object> defaultVal = ImmutableMap.<String, Object>builder()
-              .put("key1", "value1")
-              .build();
+  static {
+    ImmutableMap<String, Object> defaultVal =
+        ImmutableMap.<String, Object>builder().put("key1", "value1").build();
 
-        SCHEMA_WITH_MAP = SchemaBuilder.record("TestMap")
+    SCHEMA_WITH_MAP =
+        SchemaBuilder.record("TestMap")
             .fields()
             .name("nested")
             .type()
@@ -288,7 +288,7 @@ public class AvroGenericRecordToStorageApiProtoTest {
             .stringType()
             .mapDefault(defaultVal)
             .endRecord();
-    }
+  }
 
   private static GenericRecord baseRecord;
   private static GenericRecord logicalTypesRecord;
@@ -536,10 +536,11 @@ public class AvroGenericRecordToStorageApiProtoTest {
     Map<String, String> mapData = new HashMap<>();
     mapData.put("key1", "value1");
     mapData.put("key2", "value2");
-    GenericRecord recordWithMap = new GenericRecordBuilder(SCHEMA_WITH_MAP)
-        .set("nested", baseRecord)
-        .set("aMap", mapData)
-        .build();
+    GenericRecord recordWithMap =
+        new GenericRecordBuilder(SCHEMA_WITH_MAP)
+            .set("nested", baseRecord)
+            .set("aMap", mapData)
+            .build();
 
     Descriptors.Descriptor descriptor =
         TableRowToStorageApiProto.getDescriptorFromTableSchema(


### PR DESCRIPTION
Fixes #31652 
Fixes #29516 

While trying the BigQuery Storage Write Api, I've come across an issue in the `AvroGenericRecordToStorageApiProto.java` file in the Apache Beam repository. Specifically, the issue lies in the following lines of code:

- [Line 250](https://github.com/apache/beam/blame/561bf2f07e15719e9d698d2d57455e050246105e/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/AvroGenericRecordToStorageApiProto.java#L250)
- [Line 349](https://github.com/apache/beam/blame/561bf2f07e15719e9d698d2d57455e050246105e/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/AvroGenericRecordToStorageApiProto.java#L349)

In these lines, the `getElementType` method is being called on a `schema` object:

```java
Schema valueType = TypeWithNullability.create(schema.getElementType()).getType();
```

However, the `schema` object is of type `MapSchema`, which does not implement the `getElementType` method. This method is only implemented for `ArraySchema`. For all other types, it defaults to the `Schema` class and throws an `AvroRuntimeException`:

```java
/** If this is an array, returns its element type. */
public Schema getElementType() {
  throw new AvroRuntimeException("Not an array: " + this);
}
```

Instead of calling `getElementType`,  `getValueType` could be called as follows:

```java
Schema valueType = TypeWithNullability.create(schema.getValueType()).getType();
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
