### PR TITLE
Fix nullable array issue 31674 in AvroGenericRecordToStorageApiProto

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/AvroGenericRecordToStorageApiProto.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/AvroGenericRecordToStorageApiProto.java
@@ -312,7 +312,9 @@ public class AvroGenericRecordToStorageApiProto {
       FieldDescriptor fieldDescriptor, Schema.Field avroField, String name, GenericRecord record) {
     @Nullable Object value = record.get(name);
     if (value == null) {
-      if (fieldDescriptor.isOptional()) {
+      if (fieldDescriptor.isOptional()
+          || avroField.schema().getTypes().stream()
+              .anyMatch(t -> t.getType() == Schema.Type.NULL)) {
         return null;
       } else {
         throw new IllegalArgumentException(

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/AvroGenericRecordToStorageApiProto.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/AvroGenericRecordToStorageApiProto.java
@@ -277,6 +277,7 @@ public class AvroGenericRecordToStorageApiProto {
         builder =
             builder
                 .setType(unionFieldSchema.getType())
+                .setMode(unionFieldSchema.getMode())
                 .addAllFields(unionFieldSchema.getFieldsList());
         break;
       default:

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/AvroGenericRecordToStorageApiProtoTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/AvroGenericRecordToStorageApiProtoTest.java
@@ -581,7 +581,7 @@ public class AvroGenericRecordToStorageApiProtoTest {
   }
 
   @Test
-  public void testMessageFromGenericRecordWithArray() throws Exception {
+  public void testMessageFromGenericRecordWithNullableArray() throws Exception {
     ImmutableList<String> aList = ImmutableList.of("one", "two", "red", "blue");
     GenericRecord recordWithMap =
         new GenericRecordBuilder(SCHEMA_WITH_NULLABLE_ARRAY)

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/AvroGenericRecordToStorageApiProtoTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/AvroGenericRecordToStorageApiProtoTest.java
@@ -584,13 +584,12 @@ public class AvroGenericRecordToStorageApiProtoTest {
   public void testMessageFromGenericRecordWithNullableArray() throws Exception {
     ImmutableList<String> aList = ImmutableList.of("one", "two", "red", "blue");
     GenericRecord recordWithMap =
-        new GenericRecordBuilder(SCHEMA_WITH_NULLABLE_ARRAY)
-            .set("aNullableArray", aList)
-            .build();
+        new GenericRecordBuilder(SCHEMA_WITH_NULLABLE_ARRAY).set("aNullableArray", aList).build();
 
     Descriptors.Descriptor descriptor =
         TableRowToStorageApiProto.getDescriptorFromTableSchema(
-            AvroGenericRecordToStorageApiProto.protoTableSchemaFromAvroSchema(SCHEMA_WITH_NULLABLE_ARRAY),
+            AvroGenericRecordToStorageApiProto.protoTableSchemaFromAvroSchema(
+                SCHEMA_WITH_NULLABLE_ARRAY),
             true,
             false);
     DynamicMessage msg =


### PR DESCRIPTION
fixes #31674 

There is an issue with the `AvroGenericRecordToStorageApiProto.java` class in Apache Beam, which is responsible for converting an Avro generic record into a proto object for writing to BigQuery using the Storage API.

The funtion `private TableFieldSchema fieldDescriptorFromAvroField(Schema.Field field)` handles the array types effectively when the array in the Avro schema is defined as follows:

```json
{
  "name": "anullablearray",
  "type": "array",
  "items": "string",
  "default": []
}
```

it produces such a proto field as expected:

```proto
name: "De0c5bb51_aded_475d_946d_6ece875416a8"
field {
  name: "anullablearray"
  number: 1
  label: LABEL_REPEATED
  type: TYPE_STRING
}
```

However, it doesn't preserve the type `array` and uses the element type of the array when a nullable array is used, such as:

```json
{
  "name": "anullablearray",
  "type": [
    "null",
    {
      "type": "array",
      "items": "string"
    }
  ],
  "default": null
}
```

in this case, it produces such a proto field which is not expected and wrong:

```proto
name: "D94a1b8de_41fa_4d59_b308_999b9fc12f0a"
field {
  name: "anullablearray"
  number: 1
  label: LABEL_OPTIONAL
  type: TYPE_STRING
}
```

While handling the union, the function overwrites the array element type with nullability and results in this behaviour. I believe, it can be easily fixed by setting the `mode` with the union field schema in the `TableSchemaBuilder` while constructing the schema.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
