### PR TITLE
Remove expensive shuffle of read data in KafkaIO when using sdf and commit offsets

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaCommitOffset.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaCommitOffset.java
@@ -33,6 +33,7 @@ import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.Window;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
@@ -41,6 +42,7 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.joda.time.Duration;
+import org.joda.time.Instant;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -49,9 +51,12 @@ public class KafkaCommitOffset<K, V>
     extends PTransform<
         PCollection<KV<KafkaSourceDescriptor, KafkaRecord<K, V>>>, PCollection<Void>> {
   private final KafkaIO.ReadSourceDescriptors<K, V> readSourceDescriptors;
+  private final boolean useLegacyImplementation;
 
-  KafkaCommitOffset(KafkaIO.ReadSourceDescriptors<K, V> readSourceDescriptors) {
+  KafkaCommitOffset(
+      KafkaIO.ReadSourceDescriptors<K, V> readSourceDescriptors, boolean useLegacyImplementation) {
     this.readSourceDescriptors = readSourceDescriptors;
+    this.useLegacyImplementation = useLegacyImplementation;
   }
 
   static class CommitOffsetDoFn extends DoFn<KV<KafkaSourceDescriptor, Long>, Void> {
@@ -90,7 +95,7 @@ public class KafkaCommitOffset<K, V>
               || description.getBootStrapServers() != null);
       Map<String, Object> config = new HashMap<>(currentConfig);
       if (description.getBootStrapServers() != null
-          && description.getBootStrapServers().size() > 0) {
+          && !description.getBootStrapServers().isEmpty()) {
         config.put(
             ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
             String.join(",", description.getBootStrapServers()));
@@ -99,13 +104,69 @@ public class KafkaCommitOffset<K, V>
     }
   }
 
+  static class MaxOffsetFn<K, V>
+      extends DoFn<KV<KafkaSourceDescriptor, KafkaRecord<K, V>>, KV<KafkaSourceDescriptor, Long>> {
+    static class OffsetAndTimestamp {
+      OffsetAndTimestamp(long offset, Instant timestamp) {
+        this.offset = offset;
+        this.timestamp = timestamp;
+      }
+
+      void merge(long offset, Instant timestamp) {
+        if (this.offset < offset) {
+          this.offset = offset;
+          this.timestamp = timestamp;
+        }
+      }
+
+      long offset;
+      Instant timestamp;
+    }
+
+    private final Map<KafkaSourceDescriptor, OffsetAndTimestamp> maxObserved = new HashMap<>();
+
+    @StartBundle
+    public void startBundle() {
+      maxObserved.clear();
+    }
+
+    @RequiresStableInput
+    @ProcessElement
+    public void processElement(
+        @Element KV<KafkaSourceDescriptor, KafkaRecord<K, V>> element,
+        @Timestamp Instant timestamp) {
+      maxObserved.compute(
+          element.getKey(),
+          (k, v) -> {
+            long offset = element.getValue().getOffset();
+            if (v == null) {
+              return new OffsetAndTimestamp(offset, timestamp);
+            }
+            v.merge(offset, timestamp);
+            return v;
+          });
+    }
+
+    @FinishBundle
+    public void finishBundle(FinishBundleContext context) {
+      maxObserved.forEach(
+          (k, v) -> context.output(KV.of(k, v.offset), v.timestamp, GlobalWindow.INSTANCE));
+    }
+  }
+
   @Override
   public PCollection<Void> expand(PCollection<KV<KafkaSourceDescriptor, KafkaRecord<K, V>>> input) {
     try {
-      return input
-          .apply(
-              MapElements.into(new TypeDescriptor<KV<KafkaSourceDescriptor, Long>>() {})
-                  .via(element -> KV.of(element.getKey(), element.getValue().getOffset())))
+      PCollection<KV<KafkaSourceDescriptor, Long>> offsets;
+      if (useLegacyImplementation) {
+        offsets =
+            input.apply(
+                MapElements.into(new TypeDescriptor<KV<KafkaSourceDescriptor, Long>>() {})
+                    .via(element -> KV.of(element.getKey(), element.getValue().getOffset())));
+      } else {
+        offsets = input.apply(ParDo.of(new MaxOffsetFn<>()));
+      }
+      return offsets
           .setCoder(
               KvCoder.of(
                   input

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -2706,8 +2706,9 @@ public class KafkaIO {
               useLegacyImplementation = true;
             }
           }
+          // Use expensive reshuffle of payloads for update compatibility and tweak how offsets are
+          // committed.
           if (useLegacyImplementation) {
-            // Use expensive reshuffle of payloads for update compatibility.
             outputWithDescriptor =
                 outputWithDescriptor
                     .apply(Reshuffle.viaRandomKey())

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaCommitOffsetTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaCommitOffsetTest.java
@@ -55,13 +55,13 @@ public class KafkaCommitOffsetTest {
   @Rule public final transient TestPipeline pipeline = TestPipeline.create();
   @Rule public ExpectedLogs expectedLogs = ExpectedLogs.none(CommitOffsetDoFn.class);
 
-  private static final KafkaCommitOffsetMockConsumer consumer =
+  private final KafkaCommitOffsetMockConsumer consumer =
       new KafkaCommitOffsetMockConsumer(null, false);
-  private static final KafkaCommitOffsetMockConsumer errorConsumer =
+  private final KafkaCommitOffsetMockConsumer errorConsumer =
       new KafkaCommitOffsetMockConsumer(null, true);
-  private static final KafkaCommitOffsetMockConsumer compositeConsumerDefaultBootstrap =
+  private final KafkaCommitOffsetMockConsumer compositeConsumerDefaultBootstrap =
       new KafkaCommitOffsetMockConsumer(null, false);
-  private static final KafkaCommitOffsetMockConsumer compositeConsumerBootstrapOverridden =
+  private final KafkaCommitOffsetMockConsumer compositeConsumerBootstrapOverridden =
       new KafkaCommitOffsetMockConsumer(null, false);
   private static final Map<String, Object> configMap =
       ImmutableMap.of(ConsumerConfig.GROUP_ID_CONFIG, "group1");

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaCommitOffsetTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaCommitOffsetTest.java
@@ -17,13 +17,25 @@
  */
 package org.apache.beam.sdk.io.kafka;
 
+import java.util.ArrayList;
 import java.util.HashMap;
+import java.util.List;
 import java.util.Map;
+import java.util.concurrent.TimeUnit;
+import org.apache.beam.sdk.coders.CannotProvideCoderException;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.io.kafka.KafkaCommitOffset.CommitOffsetDoFn;
 import org.apache.beam.sdk.io.kafka.KafkaIO.ReadSourceDescriptors;
 import org.apache.beam.sdk.testing.ExpectedLogs;
+import org.apache.beam.sdk.testing.NeedsRunner;
+import org.apache.beam.sdk.testing.TestPipeline;
+import org.apache.beam.sdk.transforms.Create;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.MockConsumer;
@@ -33,44 +45,140 @@ import org.apache.kafka.common.TopicPartition;
 import org.junit.Assert;
 import org.junit.Rule;
 import org.junit.Test;
+import org.junit.experimental.categories.Category;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 
 /** Unit tests for {@link KafkaCommitOffset}. */
 @RunWith(JUnit4.class)
 public class KafkaCommitOffsetTest {
-
-  private final TopicPartition partition = new TopicPartition("topic", 0);
+  @Rule public final transient TestPipeline pipeline = TestPipeline.create();
   @Rule public ExpectedLogs expectedLogs = ExpectedLogs.none(CommitOffsetDoFn.class);
 
-  private final KafkaCommitOffsetMockConsumer consumer =
+  private static final KafkaCommitOffsetMockConsumer consumer =
       new KafkaCommitOffsetMockConsumer(null, false);
-  private final KafkaCommitOffsetMockConsumer errorConsumer =
+  private static final KafkaCommitOffsetMockConsumer errorConsumer =
       new KafkaCommitOffsetMockConsumer(null, true);
+  private static final KafkaCommitOffsetMockConsumer compositeConsumerDefaultBootstrap =
+      new KafkaCommitOffsetMockConsumer(null, false);
+  private static final KafkaCommitOffsetMockConsumer compositeConsumerBootstrapOverridden =
+      new KafkaCommitOffsetMockConsumer(null, false);
+  private static final Map<String, Object> configMap =
+      ImmutableMap.of(ConsumerConfig.GROUP_ID_CONFIG, "group1");
 
   @Test
   public void testCommitOffsetDoFn() {
-    Map<String, Object> configMap = new HashMap<>();
-    configMap.put(ConsumerConfig.GROUP_ID_CONFIG, "group1");
-
     ReadSourceDescriptors<Object, Object> descriptors =
         ReadSourceDescriptors.read()
             .withBootstrapServers("bootstrap_server")
             .withConsumerConfigUpdates(configMap)
             .withConsumerFactoryFn(
-                new SerializableFunction<Map<String, Object>, Consumer<byte[], byte[]>>() {
-                  @Override
-                  public Consumer<byte[], byte[]> apply(Map<String, Object> input) {
-                    Assert.assertEquals("group1", input.get(ConsumerConfig.GROUP_ID_CONFIG));
-                    return consumer;
-                  }
-                });
+                (SerializableFunction<Map<String, Object>, Consumer<byte[], byte[]>>)
+                    input -> {
+                      Assert.assertEquals("group1", input.get(ConsumerConfig.GROUP_ID_CONFIG));
+                      return consumer;
+                    });
     CommitOffsetDoFn doFn = new CommitOffsetDoFn(descriptors);
 
+    final TopicPartition topicPartition1 = new TopicPartition("topic", 0);
+    final TopicPartition topicPartition2 = new TopicPartition("other_topic", 1);
     doFn.processElement(
-        KV.of(KafkaSourceDescriptor.of(partition, null, null, null, null, null), 1L));
+        KV.of(KafkaSourceDescriptor.of(topicPartition1, null, null, null, null, null), 2L));
+    doFn.processElement(
+        KV.of(KafkaSourceDescriptor.of(topicPartition2, null, null, null, null, null), 200L));
 
-    Assert.assertEquals(2L, consumer.commit.get(partition).offset());
+    Assert.assertEquals(3L, (long) consumer.commitOffsets.get(topicPartition1));
+    Assert.assertEquals(201L, (long) consumer.commitOffsets.get(topicPartition2));
+
+    doFn.processElement(
+        KV.of(KafkaSourceDescriptor.of(topicPartition1, null, null, null, null, null), 3L));
+    Assert.assertEquals(4L, (long) consumer.commitOffsets.get(topicPartition1));
+  }
+
+  KafkaRecord<String, String> makeTestRecord(int i) {
+    return new KafkaRecord<>(
+        "", 0, i, 0, KafkaTimestampType.NO_TIMESTAMP_TYPE, null, KV.of("key" + i, "value" + i));
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testKafkaOffsetComposite() throws CannotProvideCoderException {
+    testKafkaOffsetHelper(false);
+  }
+
+  @Test
+  @Category(NeedsRunner.class)
+  public void testKafkaOffsetCompositeLegacy() throws CannotProvideCoderException {
+    testKafkaOffsetHelper(true);
+  }
+
+  private void testKafkaOffsetHelper(boolean useLegacyImplementation)
+      throws CannotProvideCoderException {
+    ReadSourceDescriptors<String, String> descriptors =
+        ReadSourceDescriptors.<String, String>read()
+            .withBootstrapServers("bootstrap_server")
+            .withConsumerConfigUpdates(configMap)
+            .withConsumerFactoryFn(
+                (SerializableFunction<Map<String, Object>, Consumer<byte[], byte[]>>)
+                    input -> {
+                      Assert.assertEquals("group1", input.get(ConsumerConfig.GROUP_ID_CONFIG));
+                      if (input
+                          .get(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG)
+                          .equals("bootstrap_server")) {
+                        return compositeConsumerDefaultBootstrap;
+                      }
+                      Assert.assertEquals(
+                          "bootstrap_overridden",
+                          input.get(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG));
+                      return compositeConsumerBootstrapOverridden;
+                    });
+
+    KafkaSourceDescriptor d1 =
+        KafkaSourceDescriptor.of(new TopicPartition("topic", 0), null, null, null, null, null);
+    KafkaSourceDescriptor d2 =
+        KafkaSourceDescriptor.of(new TopicPartition("topic", 1), null, null, null, null, null);
+    KafkaSourceDescriptor d3 =
+        KafkaSourceDescriptor.of(
+            new TopicPartition("topic", 0),
+            null,
+            null,
+            null,
+            null,
+            ImmutableList.of("bootstrap_overridden"));
+    KafkaSourceDescriptor d4 =
+        KafkaSourceDescriptor.of(
+            new TopicPartition("topic1", 0),
+            null,
+            null,
+            null,
+            null,
+            ImmutableList.of("bootstrap_overridden"));
+    List<KV<KafkaSourceDescriptor, KafkaRecord<String, String>>> elements = new ArrayList<>();
+    elements.add(KV.of(d1, makeTestRecord(10)));
+
+    elements.add(KV.of(d2, makeTestRecord(20)));
+    elements.add(KV.of(d3, makeTestRecord(30)));
+    elements.add(KV.of(d4, makeTestRecord(40)));
+    elements.add(KV.of(d2, makeTestRecord(10)));
+    elements.add(KV.of(d1, makeTestRecord(100)));
+    PCollection<KV<KafkaSourceDescriptor, KafkaRecord<String, String>>> input =
+        pipeline.apply(
+            Create.of(elements)
+                .withCoder(
+                    KvCoder.of(
+                        pipeline.getCoderRegistry().getCoder(KafkaSourceDescriptor.class),
+                        KafkaRecordCoder.of(StringUtf8Coder.of(), StringUtf8Coder.of()))));
+    input.apply(new KafkaCommitOffset<>(descriptors, useLegacyImplementation));
+    pipeline.run();
+
+    HashMap<TopicPartition, Long> expectedOffsets = new HashMap<>();
+    expectedOffsets.put(d1.getTopicPartition(), 101L);
+    expectedOffsets.put(d2.getTopicPartition(), 21L);
+    Assert.assertEquals(expectedOffsets, compositeConsumerDefaultBootstrap.commitOffsets);
+    expectedOffsets.clear();
+    expectedOffsets.put(d3.getTopicPartition(), 31L);
+    expectedOffsets.put(d4.getTopicPartition(), 41L);
+    Assert.assertEquals(expectedOffsets, compositeConsumerBootstrapOverridden.commitOffsets);
   }
 
   @Test
@@ -83,25 +191,25 @@ public class KafkaCommitOffsetTest {
             .withBootstrapServers("bootstrap_server")
             .withConsumerConfigUpdates(configMap)
             .withConsumerFactoryFn(
-                new SerializableFunction<Map<String, Object>, Consumer<byte[], byte[]>>() {
-                  @Override
-                  public Consumer<byte[], byte[]> apply(Map<String, Object> input) {
-                    Assert.assertEquals("group1", input.get(ConsumerConfig.GROUP_ID_CONFIG));
-                    return errorConsumer;
-                  }
-                });
+                (SerializableFunction<Map<String, Object>, Consumer<byte[], byte[]>>)
+                    input -> {
+                      Assert.assertEquals("group1", input.get(ConsumerConfig.GROUP_ID_CONFIG));
+                      return errorConsumer;
+                    });
     CommitOffsetDoFn doFn = new CommitOffsetDoFn(descriptors);
 
+    final TopicPartition partition = new TopicPartition("topic", 0);
     doFn.processElement(
         KV.of(KafkaSourceDescriptor.of(partition, null, null, null, null, null), 1L));
 
     expectedLogs.verifyWarn("Getting exception when committing offset: Test Exception");
+    Assert.assertTrue(errorConsumer.commitOffsets.isEmpty());
   }
 
   private static class KafkaCommitOffsetMockConsumer extends MockConsumer<byte[], byte[]> {
 
-    public Map<TopicPartition, OffsetAndMetadata> commit;
-    private boolean throwException;
+    public final HashMap<TopicPartition, Long> commitOffsets = new HashMap<>();
+    private final boolean throwException;
 
     public KafkaCommitOffsetMockConsumer(
         OffsetResetStrategy offsetResetStrategy, boolean throwException) {
@@ -115,8 +223,14 @@ public class KafkaCommitOffsetTest {
         throw new RuntimeException("Test Exception");
       } else {
         commitAsync(offsets, null);
-        commit = offsets;
+        offsets.forEach(
+            (topic, offsetMetadata) -> commitOffsets.put(topic, offsetMetadata.offset()));
       }
+    }
+
+    @Override
+    public synchronized void close(long timeout, TimeUnit unit) {
+      // Ignore closing since we're using a single consumer.
     }
   }
 }


### PR DESCRIPTION
The reshuffle adds a barrier so that the read records were committed before possibly committing offsets. However this is unnecessary as the DoFn is annotated with RequiresStableInput and the fusion barrier can be introduced with just shuffling the offsets.

In both cases it is possible for a commit offset to be committed back to kafka before the data has been entirely processed by the pipeline. However with support to drain data from the pipeline (such as in Cloud Dataflow) this allows for exactly-once semantics for KafkaIO via the committed offsets to the topics across pipeline drain and restart.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
