### PR TITLE
Allow override beam version for PythonExternalTransform via pipeline option

### DIFF
--- a/sdks/java/extensions/python/src/main/java/org/apache/beam/sdk/extensions/python/PythonExternalTransformOptions.java
+++ b/sdks/java/extensions/python/src/main/java/org/apache/beam/sdk/extensions/python/PythonExternalTransformOptions.java
@@ -29,4 +29,14 @@ public interface PythonExternalTransformOptions extends PipelineOptions {
   boolean getUseTransformService();
 
   void setUseTransformService(boolean useTransformService);
+
+  @Description("Custom Beam version for bootstrap Beam venv.")
+  String getCustomBeamRequirement();
+
+  /**
+   * Set custom Beam version for bootstrap Beam venv.
+   *
+   * <p>For example: 2.50.0rc1, "/path/to/apache-beam.whl"
+   */
+  void setCustomBeamRequirement(String customBeamRequirement);
 }

--- a/sdks/java/extensions/python/src/main/java/org/apache/beam/sdk/extensions/python/PythonService.java
+++ b/sdks/java/extensions/python/src/main/java/org/apache/beam/sdk/extensions/python/PythonService.java
@@ -41,6 +41,7 @@ public class PythonService {
   private static final Logger LOG = LoggerFactory.getLogger(PythonService.class);
 
   private final String module;
+  private String beamRequirement;
   private final List<String> args;
   private final List<String> extraPackages;
 
@@ -48,6 +49,8 @@ public class PythonService {
     this.module = module;
     this.args = args;
     this.extraPackages = extraPackages;
+    this.beamRequirement =
+        getMatchingStablePythonSDKVersion(ReleaseInfo.getReleaseInfo().getSdkVersion());
   }
 
   public PythonService(String module, List<String> args) {
@@ -72,6 +75,18 @@ public class PythonService {
         ImmutableList.<String>builder().addAll(this.extraPackages).addAll(extraPackages).build());
   }
 
+  /**
+   * Override the Beam version to be installed in the service environment.
+   *
+   * @param customBeamRequirement the custom Beam requirement, can be a version (e.g. 2.57.0) or a
+   *     path (e.g. /path/to/apache-beam.whl).
+   * @return this instance where Beam version overriden in place.
+   */
+  public PythonService withCustomBeamRequirement(String customBeamRequirement) {
+    this.beamRequirement = customBeamRequirement;
+    return this;
+  }
+
   @SuppressWarnings("argument")
   public AutoCloseable start() throws IOException, InterruptedException {
     File bootstrapScript = File.createTempFile("bootstrap_beam_venv", ".py");
@@ -82,9 +97,7 @@ public class PythonService {
     List<String> bootstrapCommand = new ArrayList<>();
     bootstrapCommand.add(whichPython());
     bootstrapCommand.add(bootstrapScript.getAbsolutePath());
-    bootstrapCommand.add(
-        "--beam_version="
-            + getMatchingStablePythonSDKVersion(ReleaseInfo.getReleaseInfo().getSdkVersion()));
+    bootstrapCommand.add("--beam_version=" + beamRequirement);
     if (!extraPackages.isEmpty()) {
       bootstrapCommand.add("--extra_packages=" + String.join(";", extraPackages));
     }


### PR DESCRIPTION
Fix #31680

This was exposed in bootstrap_beam_venv.py, incuding the ability to send a tarball:

https://github.com/apache/beam/blob/90d3f8a177ff935a09852fd85892bb1399b85c91/sdks/java/extensions/python/src/main/resources/org/apache/beam/sdk/extensions/python/bootstrap_beam_venv.py#L70-L71

However, it is not exposed in PythonExternalTransform that uses it.

Tested by manually adding a test (after adding direct-java dependency in test runtime classpath)

```
  @Test
  public void testCustomBeamRequirement() {
    PythonExternalTransformOptions options = PipelineOptionsFactory.fromArgs("--customBeamRequirement=2.55.0").create().as(PythonExternalTransformOptions.class);
    Pipeline p = Pipeline.create(options);
    p.apply(Create.of("a")).apply(PythonExternalTransform
        .<PCollection<String>, PCollection<String>>from("DummyTransform"));
  }
```

then there is log

```
[Test worker] INFO org.apache.beam.sdk.extensions.python.PythonService - Running bootstrap command [python3, /var/folders/wg/hwmcqjwd4zz75mjs0r5z_3f400y2yj/T/bootstrap_beam_venv4367253676595224584.py, --beam_version=2.55.0]
...
[Test worker] INFO org.apache.beam.sdk.extensions.python.PythonService -   Created wheel for apache_beam: filename=apache_beam-2.55.0-cp311-cp311-macosx_12_0_arm64.whl size=5128626 sha256=c737e750a451fddb5718cbb518ea92b44d7575817fd2f94438fe2b481d0af658
[Test worker] INFO org.apache.beam.sdk.extensions.python.PythonService -   Stored in directory: /Users/yathu/Library/Caches/pip/wheels/1f/20/49/92e3d6469697bbae302bab858f6fb07a89ea897f9afc95298f
[Test worker] INFO org.apache.beam.sdk.extensions.python.PythonService - Successfully built apache_beam
[Test worker] INFO org.apache.beam.sdk.extensions.python.PythonService - Starting python service with arguments [/Users/yathu/.apache_beam/cache/venvs/py-3.11-beam-2.55.0-da39a3ee5e6b4b0d3255bfef95601890afd80709/bin/python, -m, apache_beam.runners.portability.expansion_service_main, --port=54179, --fully_qualified_name_glob=*, --pickle_library=cloudpickle]

```

however it is hard to unit testing as it either requires to communicate to the real pypi service, or have a beam sdk python tarball in place.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
