### PR TITLE
Support custom JdbcReadWithPartitionsHelper for Jdbc.ReadWithPartitions

### DIFF
--- a/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcReadWithPartitionsHelper.java
+++ b/sdks/java/io/jdbc/src/main/java/org/apache/beam/sdk/io/jdbc/JdbcReadWithPartitionsHelper.java
@@ -1,0 +1,49 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.jdbc;
+
+import java.sql.PreparedStatement;
+import java.sql.ResultSet;
+import org.apache.beam.sdk.io.jdbc.JdbcIO.PreparedStatementSetter;
+import org.apache.beam.sdk.io.jdbc.JdbcIO.ReadWithPartitions;
+import org.apache.beam.sdk.io.jdbc.JdbcIO.RowMapper;
+import org.apache.beam.sdk.values.KV;
+
+/**
+ * A helper for {@link ReadWithPartitions} that handles range calculations.
+ *
+ * @param <PartitionT> Element type of the column used for partition.
+ */
+public interface JdbcReadWithPartitionsHelper<PartitionT>
+    extends PreparedStatementSetter<KV<PartitionT, PartitionT>>,
+        RowMapper<KV<Long, KV<PartitionT, PartitionT>>> {
+
+  /**
+   * Calculate the range of each partition from the lower and upper bound, and number of partitions.
+   *
+   * <p>Return a list of pairs for each lower and upper bound within each partition.
+   */
+  Iterable<KV<PartitionT, PartitionT>> calculateRanges(
+      PartitionT lowerBound, PartitionT upperBound, Long partitions);
+
+  @Override
+  void setParameters(KV<PartitionT, PartitionT> element, PreparedStatement preparedStatement);
+
+  @Override
+  KV<Long, KV<PartitionT, PartitionT>> mapRow(ResultSet resultSet) throws Exception;
+}

--- a/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcIOTest.java
+++ b/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcIOTest.java
@@ -45,6 +45,7 @@ import java.sql.Connection;
 import java.sql.Date;
 import java.sql.JDBCType;
 import java.sql.PreparedStatement;
+import java.sql.ResultSet;
 import java.sql.SQLException;
 import java.sql.Statement;
 import java.sql.Time;
@@ -91,6 +92,7 @@ import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.sdk.values.TypeDescriptors;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.commons.dbcp2.PoolingDataSource;
+import org.apache.commons.lang3.StringUtils;
 import org.hamcrest.Description;
 import org.hamcrest.TypeSafeMatcher;
 import org.joda.time.DateTime;
@@ -104,11 +106,13 @@ import org.junit.Test;
 import org.junit.rules.ExpectedException;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
 
 /** Test on the JdbcIO. */
 @RunWith(JUnit4.class)
 public class JdbcIOTest implements Serializable {
-
+  private static final Logger LOG = LoggerFactory.getLogger(JdbcIOTest.class);
   private static final DataSourceConfiguration DATA_SOURCE_CONFIGURATION =
       DataSourceConfiguration.create(
           "org.apache.derby.jdbc.EmbeddedDriver", "jdbc:derby:memory:testDB;create=true");
@@ -481,6 +485,74 @@ public class JdbcIOTest implements Serializable {
                 .withPartitionColumn("id")
                 .withLowerBound(0L)
                 .withUpperBound(1000L));
+    PAssert.thatSingleton(rows.apply("Count All", Count.globally())).isEqualTo(1000L);
+    pipeline.run();
+  }
+
+  @Test
+  public void testReadWithPartitionCustom() {
+    JdbcReadWithPartitionsHelper<String> helper =
+        new JdbcReadWithPartitionsHelper<String>() {
+          @Override
+          public Iterable<KV<String, String>> calculateRanges(
+              String lowerBound, String upperBound, Long partitions) {
+            // we expect the elements in the test case follow the format <common prefix>idx
+            String prefix = StringUtils.getCommonPrefix(lowerBound, upperBound);
+            int minChar = lowerBound.charAt(prefix.length());
+            int maxChar = upperBound.charAt(prefix.length());
+            int numPartition;
+            if (maxChar - minChar < partitions) {
+              LOG.warn(
+                  "Partition large than possible! Adjust to {} partition instead",
+                  maxChar - minChar);
+              numPartition = maxChar - minChar;
+            } else {
+              numPartition = Math.toIntExact(partitions);
+            }
+            List<KV<String, String>> ranges = new ArrayList<>();
+            int stride = (maxChar - minChar) / numPartition + 1;
+            int highest = minChar;
+            for (int i = minChar; i < maxChar - stride; i += stride) {
+              ranges.add(KV.of(prefix + (char) i, prefix + (char) (i + stride)));
+              highest = i + stride;
+            }
+            if (highest <= maxChar) {
+              ranges.add(KV.of(prefix + (char) highest, prefix + (char) (highest + stride)));
+            }
+            return ranges;
+          }
+
+          @Override
+          public void setParameters(
+              KV<String, String> element, PreparedStatement preparedStatement) {
+            try {
+              preparedStatement.setString(1, element.getKey());
+              preparedStatement.setString(2, element.getValue());
+            } catch (SQLException e) {
+              throw new RuntimeException(e);
+            }
+          }
+
+          @Override
+          public KV<Long, KV<String, String>> mapRow(ResultSet resultSet) throws Exception {
+            if (resultSet.getMetaData().getColumnCount() == 3) {
+              return KV.of(
+                  resultSet.getLong(3), KV.of(resultSet.getString(1), resultSet.getString(2)));
+            } else {
+              return KV.of(0L, KV.of(resultSet.getString(1), resultSet.getString(2)));
+            }
+          }
+        };
+
+    PCollection<TestRow> rows =
+        pipeline.apply(
+            JdbcIO.<TestRow, String>readWithPartitions(TypeDescriptors.strings())
+                .withPartitionHelper(helper)
+                .withDataSourceConfiguration(DATA_SOURCE_CONFIGURATION)
+                .withRowMapper(new JdbcTestHelper.CreateTestRowOfNameAndId())
+                .withTable(READ_TABLE_NAME)
+                .withNumPartitions(5)
+                .withPartitionColumn("name"));
     PAssert.thatSingleton(rows.apply("Count All", Count.globally())).isEqualTo(1000L);
     pipeline.run();
   }
@@ -1326,7 +1398,10 @@ public class JdbcIOTest implements Serializable {
     PCollection<KV<DateTime, DateTime>> ranges =
         pipeline
             .apply(Create.of(KV.of(10L, KV.of(new DateTime(0), DateTime.now()))))
-            .apply(ParDo.of(new PartitioningFn<>(TypeDescriptor.of(DateTime.class))));
+            .apply(
+                ParDo.of(
+                    new PartitioningFn<>(
+                        JdbcUtil.getDefaultPartitionsHelper(TypeDescriptor.of(DateTime.class)))));
 
     PAssert.that(ranges.apply(Count.globally()))
         .satisfies(
@@ -1407,7 +1482,10 @@ public class JdbcIOTest implements Serializable {
     PCollection<KV<Long, Long>> ranges =
         pipeline
             .apply(Create.of(KV.of(10L, KV.of(0L, 12346789L))))
-            .apply(ParDo.of(new PartitioningFn<>(TypeDescriptors.longs())));
+            .apply(
+                ParDo.of(
+                    new PartitioningFn<>(
+                        JdbcUtil.getDefaultPartitionsHelper(TypeDescriptors.longs()))));
 
     PAssert.that(ranges.apply(Count.globally())).containsInAnyOrder(10L);
     pipeline.run().waitUntilFinish();

--- a/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcUtilTest.java
+++ b/sdks/java/io/jdbc/src/test/java/org/apache/beam/sdk/io/jdbc/JdbcUtilTest.java
@@ -35,7 +35,6 @@ import java.sql.SQLException;
 import java.util.ArrayList;
 import java.util.List;
 import java.util.Random;
-import org.apache.beam.sdk.io.jdbc.JdbcUtil.JdbcReadWithPartitionsHelper;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.TypeDescriptor;
@@ -189,8 +188,7 @@ public class JdbcUtilTest {
   @Test
   public void testDatetimePartitioningWithSingleKey() {
     JdbcReadWithPartitionsHelper<DateTime> helper =
-        JdbcUtil.JdbcReadWithPartitionsHelper.getPartitionsHelper(
-            TypeDescriptor.of(DateTime.class));
+        JdbcUtil.getDefaultPartitionsHelper(TypeDescriptor.of(DateTime.class));
     DateTime onlyPoint = DateTime.now();
     List<KV<DateTime, DateTime>> expectedRanges =
         Lists.newArrayList(KV.of(onlyPoint, onlyPoint.plusMillis(1)));
@@ -207,8 +205,7 @@ public class JdbcUtilTest {
   @Test
   public void testDatetimePartitioningWithMultiKey() {
     JdbcReadWithPartitionsHelper<DateTime> helper =
-        JdbcUtil.JdbcReadWithPartitionsHelper.getPartitionsHelper(
-            TypeDescriptor.of(DateTime.class));
+        JdbcUtil.getDefaultPartitionsHelper(TypeDescriptor.of(DateTime.class));
     DateTime lastPoint = DateTime.now();
     // At least 10ms in the past, or more.
     DateTime firstPoint = lastPoint.minusMillis(10 + new Random().nextInt(Integer.MAX_VALUE));
@@ -222,7 +219,7 @@ public class JdbcUtilTest {
   @Test
   public void testLongPartitioningWithSingleKey() {
     JdbcReadWithPartitionsHelper<Long> helper =
-        JdbcUtil.JdbcReadWithPartitionsHelper.getPartitionsHelper(TypeDescriptors.longs());
+        JdbcUtil.getDefaultPartitionsHelper(TypeDescriptors.longs());
     List<KV<Long, Long>> expectedRanges = Lists.newArrayList(KV.of(12L, 13L));
     List<KV<Long, Long>> ranges = Lists.newArrayList(helper.calculateRanges(12L, 12L, 10L));
     // It is not possible to generate any more than one range, because the lower and upper range are
@@ -236,7 +233,7 @@ public class JdbcUtilTest {
   @Test
   public void testLongPartitioningNotEnoughRanges() {
     JdbcReadWithPartitionsHelper<Long> helper =
-        JdbcUtil.JdbcReadWithPartitionsHelper.getPartitionsHelper(TypeDescriptors.longs());
+        JdbcUtil.getDefaultPartitionsHelper(TypeDescriptors.longs());
     // The minimum stride is one, which is what causes this sort of partitioning.
     List<KV<Long, Long>> expectedRanges =
         Lists.newArrayList(KV.of(12L, 14L), KV.of(14L, 16L), KV.of(16L, 18L), KV.of(18L, 21L));


### PR DESCRIPTION
Fix #31419

String sorting is more complex than integers / datetimes (the field can be alpha-numeric; base64; alphabetic; etc, and other scenarios). The solution here is to support custom JdbcReadWithPartitionsHelper.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
