### PR TITLE
Properly close Storage API batch connections

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/AppendClientInfo.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/AppendClientInfo.java
@@ -30,6 +30,8 @@ import com.google.protobuf.Message;
 import java.util.function.Consumer;
 import java.util.function.Supplier;
 import javax.annotation.Nullable;
+import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Metrics;
 
 /**
  * Container class used by {@link StorageApiWritesShardedRecords} and {@link
@@ -38,6 +40,9 @@ import javax.annotation.Nullable;
  */
 @AutoValue
 abstract class AppendClientInfo {
+  private final Counter activeConnections =
+      Metrics.counter(AppendClientInfo.class, "activeConnections");
+
   abstract @Nullable BigQueryServices.StreamAppendClient getStreamAppendClient();
 
   abstract TableSchema getTableSchema();
@@ -114,12 +119,13 @@ abstract class AppendClientInfo {
       return this;
     } else {
       String streamName = getStreamName.get();
-      return toBuilder()
-          .setStreamName(streamName)
-          .setStreamAppendClient(
-              writeStreamService.getStreamAppendClient(
-                  streamName, getDescriptor(), useConnectionPool, missingValueInterpretation))
-          .build();
+      BigQueryServices.StreamAppendClient client =
+          writeStreamService.getStreamAppendClient(
+              streamName, getDescriptor(), useConnectionPool, missingValueInterpretation);
+
+      activeConnections.inc();
+
+      return toBuilder().setStreamName(streamName).setStreamAppendClient(client).build();
     }
   }
 
@@ -127,6 +133,7 @@ abstract class AppendClientInfo {
     BigQueryServices.StreamAppendClient client = getStreamAppendClient();
     if (client != null) {
       getCloseAppendClient().accept(client);
+      activeConnections.dec();
     }
   }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/StorageApiWriteUnshardedRecords.java
@@ -519,17 +519,17 @@ public class StorageApiWriteUnshardedRecords<DestinationT, ElementT>
             }
             // The default stream is cached across multiple different DoFns. If they all try and
             // invalidate, then we can get races between threads invalidating and recreating
-            // streams.
-            // For this reason, we check to see that the cache still contains the object we
-            // created before invalidating (in case another thread has already invalidated and
-            // recreated the stream).
-            String streamEntryKey = getStreamAppendClientCacheEntryKey();
+            // streams. For this reason,
+            // we check to see that the cache still contains the object we created before
+            // invalidating (in case another
+            // thread has already invalidated and recreated the stream).
+            String cacheEntryKey = getStreamAppendClientCacheEntryKey();
             @Nullable
-            AppendClientInfo cachedAppendClient = APPEND_CLIENTS.getIfPresent(streamEntryKey);
+            AppendClientInfo cachedAppendClient = APPEND_CLIENTS.getIfPresent(cacheEntryKey);
             if (cachedAppendClient != null
                 && System.identityHashCode(cachedAppendClient)
                     == System.identityHashCode(appendClientInfo)) {
-              APPEND_CLIENTS.invalidate(streamEntryKey);
+              APPEND_CLIENTS.invalidate(cacheEntryKey);
             }
           }
           appendClientInfo = null;


### PR DESCRIPTION
Storage API connections in batch are left open and not closed properly.
This is because we pin the underlying StreamAppendClient twice: once for the bundle and once for the cache
When we are finished with the stream however, we only unpin once for the bundle (and not for the cache).

Batch mode already creates a lot of streams and connections (one stream/connection per destination per bundle) compared to streaming mode. Leaving connections unclosed leads to many concurrent connections and can quickly exhaust the [quota](https://cloud.google.com/bigquery/quotas#write-api-limits).

This change adds a line to invalidate the cached client after we finish using it in a bundle.

Also creates a counter to keep track of active connections.