### PR TITLE
Solace Read connector: Use ByteBuffer instead of BytesString in the Record class

### DIFF
--- a/sdks/java/io/solace/build.gradle
+++ b/sdks/java/io/solace/build.gradle
@@ -38,7 +38,6 @@ dependencies {
     implementation library.java.google_cloud_core
     implementation library.java.vendored_guava_32_1_2_jre
     implementation project(":sdks:java:extensions:avro")
-    implementation library.java.vendored_grpc_1_60_1
     implementation library.java.avro
     permitUnusedDeclared library.java.avro
     implementation library.java.google_api_common

--- a/sdks/java/io/solace/src/main/java/org/apache/beam/sdk/io/solace/data/Solace.java
+++ b/sdks/java/io/solace/src/main/java/org/apache/beam/sdk/io/solace/data/Solace.java
@@ -21,9 +21,9 @@ import com.google.auto.value.AutoValue;
 import com.solacesystems.jcsmp.BytesXMLMessage;
 import java.io.ByteArrayOutputStream;
 import java.io.IOException;
+import java.nio.ByteBuffer;
 import org.apache.beam.sdk.schemas.AutoValueSchema;
 import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
-import org.apache.beam.vendor.grpc.v1p60p1.com.google.protobuf.ByteString;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -127,7 +127,7 @@ public class Solace {
      *
      * @return The message payload.
      */
-    public abstract ByteString getPayload();
+    public abstract ByteBuffer getPayload();
     /**
      * Gets the destination (topic or queue) to which the message was sent.
      *
@@ -234,7 +234,7 @@ public class Solace {
      *
      * @return The attachment data, or an empty ByteString if no attachment is present.
      */
-    public abstract ByteString getAttachmentBytes();
+    public abstract ByteBuffer getAttachmentBytes();
 
     static Builder builder() {
       return new AutoValue_Solace_Record.Builder();
@@ -244,7 +244,7 @@ public class Solace {
     abstract static class Builder {
       abstract Builder setMessageId(@Nullable String messageId);
 
-      abstract Builder setPayload(ByteString payload);
+      abstract Builder setPayload(ByteBuffer payload);
 
       abstract Builder setDestination(@Nullable Destination destination);
 
@@ -266,7 +266,7 @@ public class Solace {
 
       abstract Builder setReplicationGroupMessageId(@Nullable String replicationGroupMessageId);
 
-      abstract Builder setAttachmentBytes(ByteString attachmentBytes);
+      abstract Builder setAttachmentBytes(ByteBuffer attachmentBytes);
 
       abstract Record build();
     }
@@ -313,10 +313,9 @@ public class Solace {
 
       Destination replyTo = getDestination(msg.getCorrelationId(), msg.getReplyTo());
       Destination destination = getDestination(msg.getCorrelationId(), msg.getDestination());
-
       return Record.builder()
           .setMessageId(msg.getApplicationMessageId())
-          .setPayload(ByteString.copyFrom(payloadBytesStream.toByteArray()))
+          .setPayload(ByteBuffer.wrap(payloadBytesStream.toByteArray()))
           .setDestination(destination)
           .setExpiration(msg.getExpiration())
           .setPriority(msg.getPriority())
@@ -330,7 +329,7 @@ public class Solace {
               msg.getReplicationGroupMessageId() != null
                   ? msg.getReplicationGroupMessageId().toString()
                   : null)
-          .setAttachmentBytes(ByteString.copyFrom(attachmentBytesStream.toByteArray()))
+          .setAttachmentBytes(ByteBuffer.wrap(attachmentBytesStream.toByteArray()))
           .build();
     }
 

--- a/sdks/java/io/solace/src/test/java/org/apache/beam/sdk/io/solace/data/SolaceDataUtils.java
+++ b/sdks/java/io/solace/src/test/java/org/apache/beam/sdk/io/solace/data/SolaceDataUtils.java
@@ -38,7 +38,6 @@ import java.util.Objects;
 import org.apache.beam.sdk.schemas.JavaBeanSchema;
 import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
 import org.apache.beam.sdk.transforms.SerializableFunction;
-import org.apache.beam.vendor.grpc.v1p60p1.com.google.protobuf.ByteString;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 public class SolaceDataUtils {
@@ -101,7 +100,7 @@ public class SolaceDataUtils {
             : DEFAULT_REPLICATION_GROUP_ID.toString();
 
     return Solace.Record.builder()
-        .setPayload(ByteString.copyFrom(payload, StandardCharsets.UTF_8))
+        .setPayload(ByteBuffer.wrap(payload.getBytes(StandardCharsets.UTF_8)))
         .setMessageId(messageId)
         .setDestination(
             Solace.Destination.builder()
@@ -117,7 +116,7 @@ public class SolaceDataUtils {
         .setTimeToLive(1000L)
         .setSenderTimestamp(null)
         .setReplicationGroupMessageId(replicationGroupMessageIdString)
-        .setAttachmentBytes(ByteString.EMPTY)
+        .setAttachmentBytes(ByteBuffer.wrap(new byte[0]))
         .build();
   }
 


### PR DESCRIPTION
Beam Schemas don't support `ByteString` types. The pipeline was throwing the following exception in runtime:

```
    SEVERE: Error occurred within org.apache.beam.runners.direct.DirectTransformExecutor@3df140ba
    java.lang.VerifyError: Bad type on operand stack
    Exception Details:
      Location:
        org/apache/beam/sdk/io/solace/data/SchemaUserTypeCreator$SchemaCodeGen$uTIIUHuv.create([Ljava/lang/Object;)Ljava/lang/Object; @90: invokevirtual
      Reason:
        Type 'java/lang/Iterable' (current frame, stack[2]) is not assignable to 'org/apache/beam/vendor/grpc/v1p60p1/com/google/protobuf/ByteString'
      Current Frame:
        bci: @90
        flags: { }
        locals: { 'org/apache/beam/sdk/io/solace/data/SchemaUserTypeCreator$SchemaCodeGen$uTIIUHuv', '[Ljava/lang/Object;' }
        stack: { 'org/apache/beam/sdk/io/solace/data/AutoValue_Solace_Record$Builder', 'org/apache/beam/sdk/io/solace/data/AutoValue_Solace_Record$Builder', 'java/lang/Iterable' }
```

I changed the field type to BufferString, which is supported by the Schemas.
(addresses #31440).

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
