### PR TITLE
Address a data race on numMessages in DirectStreamObserver.java

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/fn/stream/DirectStreamObserver.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/fn/stream/DirectStreamObserver.java
@@ -53,7 +53,7 @@ public final class DirectStreamObserver<T> implements StreamObserver<T> {
   private final int maxMessagesBeforeCheck;
 
   private final Object lock = new Object();
-  private int numMessages = -1;
+  private int numMessages;
 
   public DirectStreamObserver(Phaser phaser, CallStreamObserver<T> outboundObserver) {
     this(phaser, outboundObserver, DEFAULT_MAX_MESSAGES_BEFORE_CHECK);
@@ -61,9 +61,12 @@ public final class DirectStreamObserver<T> implements StreamObserver<T> {
 
   DirectStreamObserver(
       Phaser phaser, CallStreamObserver<T> outboundObserver, int maxMessagesBeforeCheck) {
-    this.phaser = phaser;
-    this.outboundObserver = outboundObserver;
-    this.maxMessagesBeforeCheck = maxMessagesBeforeCheck;
+    synchronized (this.lock) {
+      this.phaser = phaser;
+      this.outboundObserver = outboundObserver;
+      this.maxMessagesBeforeCheck = maxMessagesBeforeCheck;
+      this.numMessages = -1;
+    }
   }
 
   @Override


### PR DESCRIPTION
Fixes a data race found in DirectStreamObserver.java (between `onNext()` and `<init>`):

```
WARNING: ThreadSanitizer: data race (pid=9059)
  Read of size 4 at 0x00009409f010 by thread T3381 (mutexes: write M0):
    #0 org.apache.beam.sdk.fn.stream.DirectStreamObserver.onNext(Ljava/lang/Object;)V DirectStreamObserver.java:72 
    #1 org.apache.beam.fn.harness.control.BeamFnControlClient.sendInstructionResponse(Lorg/apache/beam/model/fnexecution/v1/BeamFnApi$InstructionResponse;)V BeamFnControlClient.java:175 
    #2 org.apache.beam.fn.harness.control.BeamFnControlClient$InboundObserver.lambda$onNext$0(Lorg/apache/beam/model/fnexecution/v1/BeamFnApi$InstructionRequest;)V BeamFnControlClient.java:116 
    #3 org.apache.beam.fn.harness.control.BeamFnControlClient$InboundObserver$$Lambda$562.run()V ?? 
    #4 java.util.concurrent.Executors$RunnableAdapter.call()Ljava/lang/Object; Executors.java:515 
    #5 java.util.concurrent.FutureTask.run()V FutureTask.java:264 
    #6 org.apache.beam.sdk.util.UnboundedScheduledExecutorService$ScheduledFutureTask.run()V UnboundedScheduledExecutorService.java:163 
    #7 java.util.concurrent.ThreadPoolExecutor.runWorker(Ljava/util/concurrent/ThreadPoolExecutor$Worker;)V ThreadPoolExecutor.java:1130 
    #8 java.util.concurrent.ThreadPoolExecutor$Worker.run()V ThreadPoolExecutor.java:630 
    #9 java.lang.Thread.run()V Thread.java:830 
    #10 (Generated Stub) <null> 

  Previous write of size 4 at 0x00009409f010 by thread T3293:
    #0 org.apache.beam.sdk.fn.stream.DirectStreamObserver.<init>(Ljava/util/concurrent/Phaser;Lio/grpc/stub/CallStreamObserver;I)V DirectStreamObserver.java:56 
    #1 org.apache.beam.sdk.fn.stream.DirectStreamObserver.<init>(Ljava/util/concurrent/Phaser;Lio/grpc/stub/CallStreamObserver;)V DirectStreamObserver.java:59 
    #2 org.apache.beam.sdk.fn.stream.OutboundObserverFactory$DirectClient.outboundObserverFor(Lorg/apache/beam/sdk/fn/stream/OutboundObserverFactory$BasicFactory;Lio/grpc/stub/StreamObserver;)Lio/grpc/stub/StreamObserver; OutboundObserverFactory.java:98 
    #3 org.apache.beam.fn.harness.control.BeamFnControlClient.<init>(Lorg/apache/beam/model/fnexecution/v1/BeamFnControlGrpc$BeamFnControlStub;Lorg/apache/beam/sdk/fn/stream/OutboundObserverFactory;Ljava/util/concurrent/Executor;Ljava/util/EnumMap;)V BeamFnControlClient.java:87 
    #4 org.apache.beam.fn.harness.FnHarness.main(Ljava/lang/String;Lorg/apache/beam/sdk/options/PipelineOptions;Ljava/util/Set;Lorg/apache/beam/model/pipeline/v1/Endpoints$ApiServiceDescriptor;Lorg/apache/beam/model/pipeline/v1/Endpoints$ApiServiceDescriptor;Lor FnHarness.java:409 
```


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
