### PR TITLE
[WIP] Add background thread and caching of consumers to Kafka SDF

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaConsumerPollThread.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaConsumerPollThread.java
@@ -1,0 +1,209 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.kafka;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.concurrent.*;
+import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.concurrent.atomic.AtomicReference;
+import java.util.stream.Collectors;
+import org.apache.beam.sdk.io.UnboundedSource;
+import org.apache.beam.sdk.util.Preconditions;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.io.Closeables;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetAndMetadata;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.WakeupException;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KafkaConsumerPollThread {
+
+  KafkaConsumerPollThread() {
+    recordsDequeuePollTimeout = Duration.ofMillis(10);
+    consumer = null;
+    pollFuture = null;
+  }
+
+  private @Nullable Consumer<byte[], byte[]> consumer;
+
+  /**
+   * The poll timeout while reading records from Kafka. If option to commit reader offsets in to
+   * Kafka in {@link KafkaCheckpointMark#finalizeCheckpoint()} is enabled, it would be delayed until
+   * this poll returns. It should be reasonably low as a result. At the same time it probably can't
+   * be very low like 10 millis, I am not sure how it affects when the latency is high. Probably
+   * good to experiment. Often multiple marks would be finalized in a batch, it reduce finalization
+   * overhead to wait a short while and finalize only the last checkpoint mark.
+   */
+  private static final Duration KAFKA_POLL_TIMEOUT = Duration.ofSeconds(1);
+
+  private Duration recordsDequeuePollTimeout;
+  private static final Duration RECORDS_DEQUEUE_POLL_TIMEOUT_MIN = Duration.ofMillis(1);
+  private static final Duration RECORDS_DEQUEUE_POLL_TIMEOUT_MAX = Duration.ofMillis(20);
+  private static final Duration RECORDS_ENQUEUE_POLL_TIMEOUT = Duration.ofMillis(100);
+
+  private static final long UNINITIALIZED_OFFSET = -1;
+
+  private final AtomicReference<Exception> consumerPollException = new AtomicReference<>();
+  private final SynchronousQueue<ConsumerRecords<byte[], byte[]>> availableRecordsQueue =
+      new SynchronousQueue<>();
+  private final AtomicReference<@Nullable KafkaCheckpointMark> finalizedCheckpointMark =
+      new AtomicReference<>();
+  private final AtomicBoolean closed = new AtomicBoolean(false);
+
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaConsumerPollThread.class);
+
+  private @Nullable Future<?> pollFuture;
+
+  void startOnExecutor(ExecutorService executorService, Consumer<byte[], byte[]> consumer) {
+    this.consumer = consumer;
+    // Use a separate thread to read Kafka messages. Kafka Consumer does all its work including
+    // network I/O inside poll(). Polling only inside #advance(), especially with a small timeout
+    // like 100 milliseconds does not work well. This along with large receive buffer for
+    // consumer achieved best throughput in tests (see `defaultConsumerProperties`).
+    pollFuture = executorService.submit(this::consumerPollLoop);
+  }
+
+  void close() throws IOException {
+    if (consumer == null) {
+      LOG.debug("Closing consumer poll thread that was never started.");
+      return;
+    }
+    Preconditions.checkStateNotNull(pollFuture);
+    closed.set(true);
+    try {
+      // Wait for threads to shutdown. Trying this as a loop to handle a tiny race where poll thread
+      // might block to enqueue right after availableRecordsQueue.poll() below.
+      while (true) {
+        if (consumer != null) {
+          consumer.wakeup();
+        }
+        availableRecordsQueue.poll(); // drain unread batch, this unblocks consumer thread.
+        try {
+          Preconditions.checkStateNotNull(pollFuture);
+          pollFuture.get(10, TimeUnit.SECONDS);
+          break;
+        } catch (InterruptedException e) {
+          Thread.currentThread().interrupt();
+          throw new RuntimeException(e); // not expected
+        } catch (ExecutionException e) {
+          throw new IOException(e.getCause());
+        } catch (TimeoutException ignored) {
+        }
+        LOG.warn("An internal thread is taking a long time to shutdown. will retry.");
+      }
+    } finally {
+      Closeables.close(consumer, true);
+    }
+  }
+
+  private void consumerPollLoop() {
+    // Read in a loop and enqueue the batch of records, if any, to availableRecordsQueue.
+    Consumer<byte[], byte[]> consumer = Preconditions.checkStateNotNull(this.consumer);
+
+    try {
+      ConsumerRecords<byte[], byte[]> records = ConsumerRecords.empty();
+      while (!closed.get()) {
+        try {
+          if (records.isEmpty()) {
+            records = consumer.poll(KAFKA_POLL_TIMEOUT);
+          } else if (availableRecordsQueue.offer(
+              records, RECORDS_ENQUEUE_POLL_TIMEOUT.toMillis(), TimeUnit.MILLISECONDS)) {
+            records = ConsumerRecords.empty();
+          }
+
+          commitCheckpointMark();
+        } catch (InterruptedException e) {
+          LOG.warn("{}: consumer thread is interrupted", this, e); // not expected
+          break;
+        } catch (WakeupException e) {
+          break;
+        }
+      }
+    } catch (Exception e) { // mostly an unrecoverable KafkaException.
+      LOG.error("{}: Exception while reading from Kafka", this, e);
+      consumerPollException.set(e);
+      throw e;
+    }
+    LOG.info("{}: Returning from consumer pool loop", this);
+    // Commit any pending finalized checkpoint before shutdown.
+    commitCheckpointMark();
+  }
+
+  ConsumerRecords<byte[], byte[]> readRecords() throws IOException {
+    @Nullable ConsumerRecords<byte[], byte[]> records = null;
+    try {
+      // poll available records, wait (if necessary) up to the specified timeout.
+      records =
+          availableRecordsQueue.poll(recordsDequeuePollTimeout.toMillis(), TimeUnit.MILLISECONDS);
+    } catch (InterruptedException e) {
+      Thread.currentThread().interrupt();
+      LOG.warn("{}: Unexpected", this, e);
+    }
+
+    if (records == null) {
+      // Check if the poll thread failed with an exception.
+      if (consumerPollException.get() != null) {
+        throw new IOException("Exception while reading from Kafka", consumerPollException.get());
+      }
+      if (recordsDequeuePollTimeout.compareTo(RECORDS_DEQUEUE_POLL_TIMEOUT_MIN) > 0) {
+        recordsDequeuePollTimeout = recordsDequeuePollTimeout.minus(Duration.ofMillis(1));
+        LOG.debug("Reducing poll timeout for reader to " + recordsDequeuePollTimeout.toMillis());
+      }
+    } else if (recordsDequeuePollTimeout.compareTo(RECORDS_DEQUEUE_POLL_TIMEOUT_MAX) < 0) {
+      recordsDequeuePollTimeout = recordsDequeuePollTimeout.plus(Duration.ofMillis(1));
+      LOG.debug("Increasing poll timeout for reader to " + recordsDequeuePollTimeout.toMillis());
+      LOG.debug("Record count: " + records.count());
+    }
+
+    return records == null ? ConsumerRecords.empty() : records;
+  }
+
+  /**
+   * Enqueue checkpoint mark to be committed to Kafka. This does not block until it is committed.
+   * There could be a delay of up to KAFKA_POLL_TIMEOUT (1 second). Any checkpoint mark enqueued
+   * earlier is dropped in favor of this checkpoint mark. Documentation for {@link
+   * UnboundedSource.CheckpointMark#finalizeCheckpoint()} says these are finalized in order. Only
+   * the latest offsets need to be committed.
+   *
+   * <p>Returns if a existing checkpoint mark was skipped.
+   */
+  boolean finalizeCheckpointMarkAsync(KafkaCheckpointMark checkpointMark) {
+    return finalizedCheckpointMark.getAndSet(checkpointMark) != null;
+  }
+
+  private void commitCheckpointMark() {
+    KafkaCheckpointMark checkpointMark = finalizedCheckpointMark.getAndSet(null);
+
+    if (checkpointMark != null) {
+      LOG.debug("{}: Committing finalized checkpoint {}", this, checkpointMark);
+      Consumer<byte[], byte[]> consumer = Preconditions.checkStateNotNull(this.consumer);
+
+      consumer.commitSync(
+          checkpointMark.getPartitions().stream()
+              .filter(p -> p.getNextOffset() != UNINITIALIZED_OFFSET)
+              .collect(
+                  Collectors.toMap(
+                      p -> new TopicPartition(p.getTopic(), p.getPartition()),
+                      p -> new OffsetAndMetadata(p.getNextOffset()))));
+    }
+  }
+}

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaConsumerPollThreadCache.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaConsumerPollThreadCache.java
@@ -1,0 +1,207 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.kafka;
+
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkNotNull;
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState;
+
+import java.io.IOException;
+import java.time.Duration;
+import java.util.HashMap;
+import java.util.Map;
+import java.util.Objects;
+import java.util.concurrent.ExecutorService;
+import java.util.concurrent.Executors;
+import java.util.concurrent.TimeUnit;
+import javax.annotation.Nullable;
+import org.apache.beam.sdk.transforms.SerializableFunction;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.cache.Cache;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.cache.CacheBuilder;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.cache.RemovalCause;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.cache.RemovalNotification;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.ThreadFactoryBuilder;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerConfig;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+public class KafkaConsumerPollThreadCache {
+
+  private static final Logger LOG = LoggerFactory.getLogger(KafkaConsumerPollThreadCache.class);
+  private final ExecutorService invalidationExecutor =
+      Executors.newCachedThreadPool(
+          new ThreadFactoryBuilder()
+              .setDaemon(true)
+              .setNameFormat("KafkaConsumerPollCache-invalidation-%d")
+              .build());
+  private final ExecutorService backgroundThreads =
+      Executors.newCachedThreadPool(
+          new ThreadFactoryBuilder()
+              .setDaemon(true)
+              .setNameFormat("KafkaConsumerPollCache-poll-%d")
+              .build());
+
+  // Note on thread safety. This class is thread safe because:
+  //   - Guava Cache is thread safe.
+  //   - There is no state other than Cache.
+  //   - API is strictly a 1:1 wrapper over Cache API (not counting cache.cleanUp() calls).
+  //       - i.e. it does not invoke more than one call, which could make it inconsistent.
+  // If any of these conditions changes, please test ensure and test thread safety.
+
+  private static class CacheKey {
+    final Map<String, Object> consumerConfig;
+    final SerializableFunction<Map<String, Object>, Consumer<byte[], byte[]>> consumerFactoryFn;
+    final KafkaSourceDescriptor descriptor;
+
+    CacheKey(
+        Map<String, Object> consumerConfig,
+        SerializableFunction<Map<String, Object>, Consumer<byte[], byte[]>> consumerFactoryFn,
+        KafkaSourceDescriptor descriptor) {
+      this.consumerConfig = consumerConfig;
+      this.consumerFactoryFn = consumerFactoryFn;
+      this.descriptor = descriptor;
+    }
+
+    @Override
+    public boolean equals(@Nullable Object other) {
+      if (other == null) {
+        return false;
+      }
+      if (!(other instanceof CacheKey)) {
+        return false;
+      }
+      CacheKey otherKey = (CacheKey) other;
+      return descriptor.equals(otherKey.descriptor)
+          && consumerFactoryFn.equals(otherKey.consumerFactoryFn)
+          && consumerConfig.equals(otherKey.consumerConfig);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(descriptor, consumerFactoryFn, consumerConfig);
+    }
+  }
+
+  private static class CacheEntry {
+
+    final KafkaConsumerPollThread pollThread;
+    final long offset;
+
+    CacheEntry(KafkaConsumerPollThread pollThread, long offset) {
+      this.pollThread = pollThread;
+      this.offset = offset;
+    }
+  }
+
+  private final Duration cacheDuration = Duration.ofMinutes(1);
+  private final Cache<CacheKey, CacheEntry> cache;
+
+  @SuppressWarnings("method.invocation")
+  KafkaConsumerPollThreadCache() {
+    this.cache =
+        CacheBuilder.newBuilder()
+            .expireAfterWrite(cacheDuration.toMillis(), TimeUnit.MILLISECONDS)
+            .removalListener(
+                (RemovalNotification<CacheKey, CacheEntry> notification) -> {
+                  if (notification.getCause() != RemovalCause.EXPLICIT) {
+                    LOG.info(
+                        "Asynchronously closing reader for {} as it has been idle for over {}",
+                        notification.getKey(),
+                        cacheDuration);
+                    asyncCloseConsumer(
+                        checkNotNull(notification.getKey()), checkNotNull(notification.getValue()));
+                  }
+                })
+            .build();
+  }
+
+  KafkaConsumerPollThread acquireConsumer(
+      Map<String, Object> consumerConfig,
+      SerializableFunction<Map<String, Object>, Consumer<byte[], byte[]>> consumerFactoryFn,
+      KafkaSourceDescriptor kafkaSourceDescriptor,
+      long offset) {
+    CacheKey key = new CacheKey(consumerConfig, consumerFactoryFn, kafkaSourceDescriptor);
+    CacheEntry entry = cache.asMap().remove(key);
+    cache.cleanUp();
+    if (entry != null) {
+      if (entry.offset == offset) {
+        return entry.pollThread;
+      } else {
+        // Offset doesn't match, close.
+        LOG.info("Closing consumer as it is no longer valid {}", kafkaSourceDescriptor);
+        asyncCloseConsumer(key, entry);
+      }
+    }
+
+    Map<String, Object> updatedConsumerConfig =
+        overrideBootstrapServersConfig(consumerConfig, kafkaSourceDescriptor);
+    LOG.info(
+        "Creating Kafka consumer for process continuation for {}",
+        kafkaSourceDescriptor.getTopicPartition());
+    Consumer<byte[], byte[]> consumer = consumerFactoryFn.apply(updatedConsumerConfig);
+    ConsumerSpEL.evaluateAssign(
+        consumer, ImmutableList.of(kafkaSourceDescriptor.getTopicPartition()));
+    consumer.seek(kafkaSourceDescriptor.getTopicPartition(), offset);
+    KafkaConsumerPollThread pollThread = new KafkaConsumerPollThread();
+    pollThread.startOnExecutor(backgroundThreads, consumer);
+    return pollThread;
+  }
+
+  /** Close the reader and log a warning if close fails. */
+  private void asyncCloseConsumer(CacheKey key, CacheEntry entry) {
+    invalidationExecutor.execute(
+        () -> {
+          try {
+            entry.pollThread.close();
+            LOG.info("Finished closing consumer for {}", key);
+          } catch (IOException e) {
+            LOG.warn("Failed to close consumer for {}", key, e);
+          }
+        });
+  }
+
+  void releaseConsumer(
+      Map<String, Object> consumerConfig,
+      SerializableFunction<Map<String, Object>, Consumer<byte[], byte[]>> consumerFactoryFn,
+      KafkaSourceDescriptor kafkaSourceDescriptor,
+      KafkaConsumerPollThread pollThread,
+      long offset) {
+    CacheKey key = new CacheKey(consumerConfig, consumerFactoryFn, kafkaSourceDescriptor);
+    CacheEntry existing = cache.asMap().putIfAbsent(key, new CacheEntry(pollThread, offset));
+    if (existing != null) {
+      LOG.warn("Unexpected collision of topic and partition");
+      asyncCloseConsumer(key, existing);
+    }
+    cache.cleanUp();
+  }
+
+  private Map<String, Object> overrideBootstrapServersConfig(
+      Map<String, Object> currentConfig, KafkaSourceDescriptor description) {
+    checkState(
+        currentConfig.containsKey(ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG)
+            || description.getBootStrapServers() != null);
+    Map<String, Object> config = new HashMap<>(currentConfig);
+    if (description.getBootStrapServers() != null && !description.getBootStrapServers().isEmpty()) {
+      config.put(
+          ConsumerConfig.BOOTSTRAP_SERVERS_CONFIG,
+          String.join(",", description.getBootStrapServers()));
+    }
+    return config;
+  }
+}

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java
@@ -33,11 +33,9 @@ import java.util.concurrent.ExecutorService;
 import java.util.concurrent.Executors;
 import java.util.concurrent.Future;
 import java.util.concurrent.ScheduledExecutorService;
-import java.util.concurrent.SynchronousQueue;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.TimeoutException;
 import java.util.concurrent.atomic.AtomicBoolean;
-import java.util.concurrent.atomic.AtomicReference;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.io.UnboundedSource;
 import org.apache.beam.sdk.io.UnboundedSource.CheckpointMark;
@@ -61,9 +59,7 @@ import org.apache.kafka.clients.consumer.Consumer;
 import org.apache.kafka.clients.consumer.ConsumerConfig;
 import org.apache.kafka.clients.consumer.ConsumerRecord;
 import org.apache.kafka.clients.consumer.ConsumerRecords;
-import org.apache.kafka.clients.consumer.OffsetAndMetadata;
 import org.apache.kafka.common.TopicPartition;
-import org.apache.kafka.common.errors.WakeupException;
 import org.apache.kafka.common.serialization.Deserializer;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.Duration;
@@ -102,7 +98,7 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
     // This problem of blocking API calls to kafka is solved in higher versions of kafka
     // client by `KIP-266`
     for (final PartitionState<K, V> pState : partitionStates) {
-      Future<?> future = consumerPollThread.submit(() -> setupInitialOffset(pState));
+      Future<?> future = backgroundThread.submit(() -> setupInitialOffset(pState));
       try {
         Duration timeout = resolveDefaultApiTimeout(spec);
         future.get(timeout.getMillis(), TimeUnit.MILLISECONDS);
@@ -129,7 +125,7 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
 
     // Start consumer read loop.
     // Note that consumer is not thread safe, should not be accessed out side consumerPollLoop().
-    consumerPollThread.submit(this::consumerPollLoop);
+    pollThread.startOnExecutor(backgroundThread, consumer);
 
     // offsetConsumer setup :
     Map<String, Object> offsetConsumerConfig =
@@ -345,44 +341,26 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
   private final Counter bytesReadBySplit;
   private final Gauge backlogBytesOfSplit;
   private final Gauge backlogElementsOfSplit;
-  private HashMap<String, Long> perPartitionBacklogMetrics = new HashMap<String, Long>();;
+  private final HashMap<String, Long> perPartitionBacklogMetrics = new HashMap<>();
   private final Counter checkpointMarkCommitsEnqueued =
       Metrics.counter(METRIC_NAMESPACE, CHECKPOINT_MARK_COMMITS_ENQUEUED_METRIC);
   // Checkpoint marks skipped in favor of newer mark (only the latest needs to be committed).
   private final Counter checkpointMarkCommitsSkipped =
       Metrics.counter(METRIC_NAMESPACE, CHECKPOINT_MARK_COMMITS_SKIPPED_METRIC);
 
-  /**
-   * The poll timeout while reading records from Kafka. If option to commit reader offsets in to
-   * Kafka in {@link KafkaCheckpointMark#finalizeCheckpoint()} is enabled, it would be delayed until
-   * this poll returns. It should be reasonably low as a result. At the same time it probably can't
-   * be very low like 10 millis, I am not sure how it affects when the latency is high. Probably
-   * good to experiment. Often multiple marks would be finalized in a batch, it reduce finalization
-   * overhead to wait a short while and finalize only the last checkpoint mark.
-   */
-  private static final Duration KAFKA_POLL_TIMEOUT = Duration.millis(1000);
-
-  private Duration recordsDequeuePollTimeout;
-  private static final Duration RECORDS_DEQUEUE_POLL_TIMEOUT_MIN = Duration.millis(1);
-  private static final Duration RECORDS_DEQUEUE_POLL_TIMEOUT_MAX = Duration.millis(20);
-  private static final Duration RECORDS_ENQUEUE_POLL_TIMEOUT = Duration.millis(100);
+  private final KafkaConsumerPollThread pollThread;
 
   // Use a separate thread to read Kafka messages. Kafka Consumer does all its work including
   // network I/O inside poll(). Polling only inside #advance(), especially with a small timeout
   // like 100 milliseconds does not work well. This along with large receive buffer for
   // consumer achieved best throughput in tests (see `defaultConsumerProperties`).
-  private final ExecutorService consumerPollThread =
+  private final ExecutorService backgroundThread =
       Executors.newSingleThreadExecutor(
           new ThreadFactoryBuilder()
               .setDaemon(true)
               .setNameFormat("KafkaConsumerPoll-thread")
               .build());
-  private AtomicReference<Exception> consumerPollException = new AtomicReference<>();
-  private final SynchronousQueue<ConsumerRecords<byte[], byte[]>> availableRecordsQueue =
-      new SynchronousQueue<>();
-  private AtomicReference<@Nullable KafkaCheckpointMark> finalizedCheckpointMark =
-      new AtomicReference<>();
-  private AtomicBoolean closed = new AtomicBoolean(false);
+  private final AtomicBoolean closed = new AtomicBoolean(false);
 
   // Backlog support :
   // Kafka consumer does not have an API to fetch latest offset for topic. We need to seekToEnd()
@@ -397,7 +375,7 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
   private static final long UNINITIALIZED_OFFSET = -1;
 
   /** watermark before any records have been read. */
-  private static Instant initialWatermark = BoundedWindow.TIMESTAMP_MIN_VALUE;
+  private static final Instant initialWatermark = BoundedWindow.TIMESTAMP_MIN_VALUE;
 
   @Override
   public String toString() {
@@ -436,8 +414,8 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
 
     private Iterator<ConsumerRecord<byte[], byte[]>> recordIter = Collections.emptyIterator();
 
-    private KafkaIOUtils.MovingAvg avgRecordSize = new KafkaIOUtils.MovingAvg();
-    private KafkaIOUtils.MovingAvg avgOffsetGap =
+    private final KafkaIOUtils.MovingAvg avgRecordSize = new KafkaIOUtils.MovingAvg();
+    private final KafkaIOUtils.MovingAvg avgOffsetGap =
         new KafkaIOUtils.MovingAvg(); // > 0 only when log compaction is enabled.
 
     PartitionState(
@@ -538,7 +516,7 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
       }
 
       PartitionState<K, V> state =
-          new PartitionState<K, V>(
+          new PartitionState<>(
               tp,
               nextOffset,
               source
@@ -556,55 +534,7 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
     bytesReadBySplit = SourceMetrics.bytesReadBySplit(splitId);
     backlogBytesOfSplit = SourceMetrics.backlogBytesOfSplit(splitId);
     backlogElementsOfSplit = SourceMetrics.backlogElementsOfSplit(splitId);
-    recordsDequeuePollTimeout = Duration.millis(10);
-  }
-
-  private void consumerPollLoop() {
-    // Read in a loop and enqueue the batch of records, if any, to availableRecordsQueue.
-    Consumer<byte[], byte[]> consumer = Preconditions.checkStateNotNull(this.consumer);
-
-    try {
-      ConsumerRecords<byte[], byte[]> records = ConsumerRecords.empty();
-      while (!closed.get()) {
-        try {
-          if (records.isEmpty()) {
-            records = consumer.poll(KAFKA_POLL_TIMEOUT.getMillis());
-          } else if (availableRecordsQueue.offer(
-              records, RECORDS_ENQUEUE_POLL_TIMEOUT.getMillis(), TimeUnit.MILLISECONDS)) {
-            records = ConsumerRecords.empty();
-          }
-
-          commitCheckpointMark();
-        } catch (InterruptedException e) {
-          LOG.warn("{}: consumer thread is interrupted", this, e); // not expected
-          break;
-        } catch (WakeupException e) {
-          break;
-        }
-      }
-      LOG.info("{}: Returning from consumer pool loop", this);
-    } catch (Exception e) { // mostly an unrecoverable KafkaException.
-      LOG.error("{}: Exception while reading from Kafka", this, e);
-      consumerPollException.set(e);
-      throw e;
-    }
-  }
-
-  private void commitCheckpointMark() {
-    KafkaCheckpointMark checkpointMark = finalizedCheckpointMark.getAndSet(null);
-
-    if (checkpointMark != null) {
-      LOG.debug("{}: Committing finalized checkpoint {}", this, checkpointMark);
-      Consumer<byte[], byte[]> consumer = Preconditions.checkStateNotNull(this.consumer);
-
-      consumer.commitSync(
-          checkpointMark.getPartitions().stream()
-              .filter(p -> p.getNextOffset() != UNINITIALIZED_OFFSET)
-              .collect(
-                  Collectors.toMap(
-                      p -> new TopicPartition(p.getTopic(), p.getPartition()),
-                      p -> new OffsetAndMetadata(p.getNextOffset()))));
-    }
+    pollThread = new KafkaConsumerPollThread();
   }
 
   /**
@@ -615,7 +545,7 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
    * need to be committed.
    */
   void finalizeCheckpointMarkAsync(KafkaCheckpointMark checkpointMark) {
-    if (finalizedCheckpointMark.getAndSet(checkpointMark) != null) {
+    if (pollThread.finalizeCheckpointMarkAsync(checkpointMark)) {
       checkpointMarkCommitsSkipped.inc();
     }
     checkpointMarkCommitsEnqueued.inc();
@@ -624,39 +554,12 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
   private void nextBatch() throws IOException {
     curBatch = Collections.emptyIterator();
 
-    ConsumerRecords<byte[], byte[]> records;
-    try {
-      // poll available records, wait (if necessary) up to the specified timeout.
-      records =
-          availableRecordsQueue.poll(recordsDequeuePollTimeout.getMillis(), TimeUnit.MILLISECONDS);
-    } catch (InterruptedException e) {
-      Thread.currentThread().interrupt();
-      LOG.warn("{}: Unexpected", this, e);
-      return;
+    ConsumerRecords<byte[], byte[]> records = pollThread.readRecords();
+    if (records != null) {
+      partitionStates.forEach(p -> p.recordIter = records.records(p.topicPartition).iterator());
+      // cycle through the partitions in order to interleave records from each.
+      curBatch = Iterators.cycle(new ArrayList<>(partitionStates));
     }
-
-    if (records == null) {
-      // Check if the poll thread failed with an exception.
-      if (consumerPollException.get() != null) {
-        throw new IOException("Exception while reading from Kafka", consumerPollException.get());
-      }
-      if (recordsDequeuePollTimeout.isLongerThan(RECORDS_DEQUEUE_POLL_TIMEOUT_MIN)) {
-        recordsDequeuePollTimeout = recordsDequeuePollTimeout.minus(Duration.millis(1));
-        LOG.debug("Reducing poll timeout for reader to " + recordsDequeuePollTimeout.getMillis());
-      }
-      return;
-    }
-
-    if (recordsDequeuePollTimeout.isShorterThan(RECORDS_DEQUEUE_POLL_TIMEOUT_MAX)) {
-      recordsDequeuePollTimeout = recordsDequeuePollTimeout.plus(Duration.millis(1));
-      LOG.debug("Increasing poll timeout for reader to " + recordsDequeuePollTimeout.getMillis());
-      LOG.debug("Record count: " + records.count());
-    }
-
-    partitionStates.forEach(p -> p.recordIter = records.records(p.topicPartition).iterator());
-
-    // cycle through the partitions in order to interleave records from each.
-    curBatch = Iterators.cycle(new ArrayList<>(partitionStates));
   }
 
   private void setupInitialOffset(PartitionState<K, V> pState) {
@@ -738,7 +641,7 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
   @Override
   public void close() throws IOException {
     closed.set(true);
-    consumerPollThread.shutdown();
+    pollThread.close();
     offsetFetcherThread.shutdown();
 
     boolean isShutdown = false;
@@ -746,18 +649,11 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
     // Wait for threads to shutdown. Trying this as a loop to handle a tiny race where poll thread
     // might block to enqueue right after availableRecordsQueue.poll() below.
     while (!isShutdown) {
-
-      if (consumer != null) {
-        consumer.wakeup();
-      }
       if (offsetConsumer != null) {
         offsetConsumer.wakeup();
       }
-      availableRecordsQueue.poll(); // drain unread batch, this unblocks consumer thread.
       try {
-        isShutdown =
-            consumerPollThread.awaitTermination(10, TimeUnit.SECONDS)
-                && offsetFetcherThread.awaitTermination(10, TimeUnit.SECONDS);
+        isShutdown = offsetFetcherThread.awaitTermination(10, TimeUnit.SECONDS);
       } catch (InterruptedException e) {
         Thread.currentThread().interrupt();
         throw new RuntimeException(e); // not expected
@@ -768,14 +664,10 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
       }
     }
 
-    // Commit any pending finalized checkpoint before shutdown.
-    commitCheckpointMark();
-
     Closeables.close(keyDeserializerInstance, true);
     Closeables.close(valueDeserializerInstance, true);
 
     Closeables.close(offsetConsumer, true);
-    Closeables.close(consumer, true);
   }
 
   @VisibleForTesting

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -114,12 +114,7 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Immuta
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.Uninterruptibles;
-import org.apache.kafka.clients.consumer.Consumer;
-import org.apache.kafka.clients.consumer.ConsumerConfig;
-import org.apache.kafka.clients.consumer.ConsumerRecord;
-import org.apache.kafka.clients.consumer.MockConsumer;
-import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
-import org.apache.kafka.clients.consumer.OffsetResetStrategy;
+import org.apache.kafka.clients.consumer.*;
 import org.apache.kafka.clients.producer.MockProducer;
 import org.apache.kafka.clients.producer.Producer;
 import org.apache.kafka.clients.producer.ProducerConfig;
@@ -151,6 +146,7 @@ import org.junit.Ignore;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.Timeout;
 import org.junit.runner.RunWith;
 import org.junit.runners.JUnit4;
 import org.slf4j.Logger;
@@ -162,7 +158,7 @@ import org.slf4j.LoggerFactory;
  */
 @RunWith(JUnit4.class)
 public class KafkaIOTest {
-
+  @Rule public transient Timeout globalTimeout = Timeout.seconds(600);
   private static final Logger LOG = LoggerFactory.getLogger(KafkaIOTest.class);
 
   /*
@@ -178,7 +174,7 @@ public class KafkaIOTest {
   @Rule public ExpectedException thrown = ExpectedException.none();
 
   @Rule
-  public ExpectedLogs unboundedReaderExpectedLogs = ExpectedLogs.none(KafkaUnboundedReader.class);
+  public ExpectedLogs pollThreadExpectedLogs = ExpectedLogs.none(KafkaConsumerPollThread.class);
 
   @Rule public ExpectedLogs kafkaIOExpectedLogs = ExpectedLogs.none(KafkaIO.class);
 
@@ -1398,7 +1394,7 @@ public class KafkaIOTest {
   }
 
   @Test
-  public void testUnboundedReaderLogsCommitFailure() throws Exception {
+  public void testUnboundedReaderLogsFetchFailure() throws Exception {
 
     List<String> topics = ImmutableList.of("topic_a");
 
@@ -1415,9 +1411,12 @@ public class KafkaIOTest {
 
     UnboundedReader<KafkaRecord<Integer, Long>> reader = source.createReader(null, null);
 
-    reader.start();
-
-    unboundedReaderExpectedLogs.verifyWarn("exception while fetching latest offset for partition");
+    try {
+      reader.start();
+    } catch (Exception e) {
+      // Racy if we observe the exception on initial advance.
+    }
+    pollThreadExpectedLogs.verifyError("Exception while reading from Kafka");
 
     reader.close();
   }

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/ReadFromKafkaDoFnTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/ReadFromKafkaDoFnTest.java
@@ -83,8 +83,10 @@ import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
 import org.junit.rules.ExpectedException;
+import org.junit.rules.Timeout;
 
 public class ReadFromKafkaDoFnTest {
+  @Rule public transient Timeout globalTimeout = Timeout.seconds(600);
 
   private final TopicPartition topicPartition = new TopicPartition("topic", 0);
 


### PR DESCRIPTION
Attempt to improve SDF throughput to UnboundedReader impl by similarly performing blocking kafka polls in background thread and is cached.
This allows main partition consuming thread to be blocked less, prefetches, and caching reduces consuemr connections.

Remaining work:
- figure out how to address when a read is stopped due to splitting.  Currently records that were pulled off of background queue are lost.  Could perhaps be added back to the background queue in some way or we could change the interface to internally vend a record at a time and keep track of if it is consumed or not.
- unit testing and performance testing
- some of the timeout configuration plumbing needs to be fixed

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
