### PR TITLE
correctly close the javadoc tag in JmsIO.Write

### DIFF
--- a/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsIO.java
+++ b/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsIO.java
@@ -1011,12 +1011,13 @@ public class JmsIO {
      * Specify the JMS topic destination name where to send messages to dynamically. The {@link
      * JmsIO.Write} acts as a publisher on the topic.
      *
-     * <p>This method is exclusive with {@link JmsIO.Write#withQueue(String)} and
-     * {@link JmsIO.Write#withTopic(String)}. The user has to specify a {@link SerializableFunction}
-     * that takes {@code EventT} object as a parameter, and returns the topic name depending of the content
-     * of the event object.
+     * <p>This method is exclusive with {@link JmsIO.Write#withQueue(String)} and {@link
+     * JmsIO.Write#withTopic(String)}. The user has to specify a {@link SerializableFunction} that
+     * takes {@code EventT} object as a parameter, and returns the topic name depending of the
+     * content of the event object.
      *
      * <p>For example:
+     *
      * <pre>{@code
      * SerializableFunction<CompanyEvent, String> topicNameMapper =
      *   (event ->

--- a/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsIO.java
+++ b/sdks/java/io/jms/src/main/java/org/apache/beam/sdk/io/jms/JmsIO.java
@@ -1011,7 +1011,7 @@ public class JmsIO {
      * Specify the JMS topic destination name where to send messages to dynamically. The {@link
      * JmsIO.Write} acts as a publisher on the topic.
      *
-     * <p>This method is exclusive with {@link JmsIO.Write#withQueue(String) and
+     * <p>This method is exclusive with {@link JmsIO.Write#withQueue(String)} and
      * {@link JmsIO.Write#withTopic(String)}. The user has to specify a {@link SerializableFunction}
      * that takes {@code EventT} object as a parameter, and returns the topic name depending of the content
      * of the event object.


### PR DESCRIPTION
This should fix the incorrectly rendered javadoc for that method, see the problem [here](https://beam.apache.org/releases/javadoc/2.57.0/org/apache/beam/sdk/io/jms/JmsIO.Write.html#withTopicNameMapper-org.apache.beam.sdk.transforms.SerializableFunction-)

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
