### PR TITLE
Introduce support for emitting lineage in BQ Source

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/Lineage.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/Lineage.java
@@ -22,9 +22,9 @@ package org.apache.beam.sdk.metrics;
  */
 public class Lineage {
 
-  private static final String LINEAGE_NAMESPACE = "lineage";
-  private static final String SOURCE_METRIC_NAME = "sources";
-  private static final String SINK_METRIC_NAME = "sinks";
+  public static final String LINEAGE_NAMESPACE = "lineage";
+  public static final String SOURCE_METRIC_NAME = "sources";
+  public static final String SINK_METRIC_NAME = "sinks";
 
   private static final StringSet SOURCES = Metrics.stringSet(LINEAGE_NAMESPACE, SOURCE_METRIC_NAME);
   private static final StringSet SINKS = Metrics.stringSet(LINEAGE_NAMESPACE, SINK_METRIC_NAME);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/Lineage.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/Lineage.java
@@ -1,0 +1,42 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.metrics;
+
+/** Standard collection of metrics used to record source and sinks information for
+ * lineage tracking.*/
+public class Lineage {
+
+  private static final String LINEAGE_NAMESPACE = "lineage";
+  private static final String SOURCE_METRIC_NAME = "sources";
+  private static final String SINK_METRIC_NAME = "sinks";
+
+  private static final StringSet SOURCES =
+      Metrics.stringSet(LINEAGE_NAMESPACE, SOURCE_METRIC_NAME);
+  private static final StringSet SINKS =
+      Metrics.stringSet(LINEAGE_NAMESPACE, SINK_METRIC_NAME);
+
+  /** {@link StringSet} representing sources and optionally side inputs. */
+  public static StringSet getSources() {
+    return SOURCES;
+  }
+
+  /** {@link StringSet} representing sinks. */
+  public static StringSet getSinks() {
+    return SINKS;
+  }
+}

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/Lineage.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/metrics/Lineage.java
@@ -17,18 +17,17 @@
  */
 package org.apache.beam.sdk.metrics;
 
-/** Standard collection of metrics used to record source and sinks information for
- * lineage tracking.*/
+/**
+ * Standard collection of metrics used to record source and sinks information for lineage tracking.
+ */
 public class Lineage {
 
   private static final String LINEAGE_NAMESPACE = "lineage";
   private static final String SOURCE_METRIC_NAME = "sources";
   private static final String SINK_METRIC_NAME = "sinks";
 
-  private static final StringSet SOURCES =
-      Metrics.stringSet(LINEAGE_NAMESPACE, SOURCE_METRIC_NAME);
-  private static final StringSet SINKS =
-      Metrics.stringSet(LINEAGE_NAMESPACE, SINK_METRIC_NAME);
+  private static final StringSet SOURCES = Metrics.stringSet(LINEAGE_NAMESPACE, SOURCE_METRIC_NAME);
+  private static final StringSet SINKS = Metrics.stringSet(LINEAGE_NAMESPACE, SINK_METRIC_NAME);
 
   /** {@link StringSet} representing sources and optionally side inputs. */
   public static StringSet getSources() {

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpers.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryHelpers.java
@@ -412,6 +412,11 @@ public class BigQueryHelpers {
     return sb.toString();
   }
 
+  public static String dataCatalogName(TableReference ref) {
+    return String.format(
+        "bigquery:%s.%s.%s", ref.getProjectId(), ref.getDatasetId(), ref.getTableId());
+  }
+
   static <K, V> List<V> getOrCreateMapListValue(Map<K, List<V>> map, K key) {
     return map.computeIfAbsent(key, k -> new ArrayList<>());
   }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySourceBase.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySourceBase.java
@@ -41,6 +41,8 @@ import org.apache.beam.sdk.io.fs.ResourceId;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.Status;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryResourceNaming.JobType;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices.JobService;
+import org.apache.beam.sdk.metrics.Lineage;
+import org.apache.beam.sdk.metrics.StringSet;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
@@ -152,9 +154,10 @@ abstract class BigQuerySourceBase<T> extends BoundedSource<T> {
     if (cachedSplitResult == null) {
       ExtractResult res = extractFiles(options);
       LOG.info("Extract job produced {} files", res.extractedFiles.size());
-
       if (res.extractedFiles.size() > 0) {
         BigQueryOptions bqOptions = options.as(BigQueryOptions.class);
+        // emit this table ID as a lineage source
+        Lineage.getSources().add(BigQueryHelpers.toTableSpec(getTableToExtract(bqOptions)));
         final String extractDestinationDir =
             resolveTempLocation(bqOptions.getTempLocation(), "BigQueryExtractTemp", stepUuid);
         // Match all files in the destination directory to stat them in bulk.

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySourceBase.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySourceBase.java
@@ -120,6 +120,8 @@ abstract class BigQuerySourceBase<T> extends BoundedSource<T> {
                 "Cannot start an export job since table %s does not exist",
                 BigQueryHelpers.toTableSpec(tableToExtract)));
       }
+      // emit this table ID as a lineage source
+      Lineage.getSources().add(BigQueryHelpers.dataCatalogName(tableToExtract));
 
       TableSchema schema = table.getSchema();
       JobService jobService = bqServices.getJobService(bqOptions);
@@ -156,7 +158,7 @@ abstract class BigQuerySourceBase<T> extends BoundedSource<T> {
       if (res.extractedFiles.size() > 0) {
         BigQueryOptions bqOptions = options.as(BigQueryOptions.class);
         // emit this table ID as a lineage source
-        Lineage.getSources().add(BigQueryHelpers.toTableSpec(getTableToExtract(bqOptions)));
+        Lineage.getSources().add(BigQueryHelpers.dataCatalogName(getTableToExtract(bqOptions)));
         final String extractDestinationDir =
             resolveTempLocation(bqOptions.getTempLocation(), "BigQueryExtractTemp", stepUuid);
         // Match all files in the destination directory to stat them in bulk.

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySourceBase.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQuerySourceBase.java
@@ -42,7 +42,6 @@ import org.apache.beam.sdk.io.gcp.bigquery.BigQueryHelpers.Status;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryResourceNaming.JobType;
 import org.apache.beam.sdk.io.gcp.bigquery.BigQueryServices.JobService;
 import org.apache.beam.sdk.metrics.Lineage;
-import org.apache.beam.sdk.metrics.StringSet;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageSourceBase.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageSourceBase.java
@@ -114,7 +114,7 @@ abstract class BigQueryStorageSourceBase<T> extends BoundedSource<T> {
       TableReference tableReference = targetTable.getTableReference();
       readSessionBuilder.setTable(BigQueryHelpers.toTableResourceName(tableReference));
       // register the table as lineage source
-      lineageSources.add(BigQueryHelpers.toTableSpec(tableReference));
+      lineageSources.add(BigQueryHelpers.dataCatalogName(tableReference));
     } else {
       // If the table does not exist targetTable will be null.
       // Construct the table id if we can generate it. For error recording/logging.
@@ -123,7 +123,7 @@ abstract class BigQueryStorageSourceBase<T> extends BoundedSource<T> {
         readSessionBuilder.setTable(tableReferenceId);
         // register the table as lineage source
         TableReference tableReference = BigQueryHelpers.parseTableUrn(tableReferenceId);
-        lineageSources.add(BigQueryHelpers.toTableSpec(tableReference));
+        lineageSources.add(BigQueryHelpers.dataCatalogName(tableReference));
       }
     }
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageSourceBase.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageSourceBase.java
@@ -112,8 +112,7 @@ abstract class BigQueryStorageSourceBase<T> extends BoundedSource<T> {
     StringSet lineageSources = Lineage.getSources();
     if (targetTable != null) {
       TableReference tableReference = targetTable.getTableReference();
-      readSessionBuilder.setTable(
-          BigQueryHelpers.toTableResourceName(tableReference));
+      readSessionBuilder.setTable(BigQueryHelpers.toTableResourceName(tableReference));
       // register the table as lineage source
       lineageSources.add(BigQueryHelpers.toTableSpec(tableReference));
     } else {

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOReadTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIOReadTest.java
@@ -17,10 +17,10 @@
  */
 package org.apache.beam.sdk.io.gcp.bigquery;
 
-import static com.google.common.collect.testing.Helpers.assertContains;
 import static org.apache.beam.sdk.io.gcp.bigquery.BigQueryResourceNaming.createTempTableReference;
 import static org.apache.beam.sdk.transforms.display.DisplayDataMatchers.hasDisplayItem;
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.contains;
 import static org.hamcrest.Matchers.containsInAnyOrder;
 import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertNull;
@@ -360,9 +360,9 @@ public class BigQueryIOReadTest implements Serializable {
                         MetricNameFilter.named(
                             Lineage.LINEAGE_NAMESPACE, Lineage.SOURCE_METRIC_NAME))
                     .build());
-    assertContains(
+    assertThat(
         lineageMetrics.getStringSets().iterator().next().getCommitted().getStringSet(),
-        "bigquery:" + tableName.replace(':', '.'));
+        contains("bigquery:" + tableName.replace(':', '.')));
   }
 
   @Before


### PR DESCRIPTION
- Adds a Helper class which wraps around StringSet metrics to define sources/sinks metrics for lineage.
- Add support in BQ IO Java SDK sources to emit the dataset they are accessing as lineage via stringset metrics.

addresses https://github.com/apache/beam/issues/31804


GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
