### PR TITLE
(beam-31896) Upgrade gcs-connector to 3.0.1, Hadoop to 3.3.6

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -604,7 +604,7 @@ class BeamModulePlugin implements Plugin<Project> {
     def gax_version = "2.48.0"
     def google_ads_version = "26.0.0"
     def google_clients_version = "2.0.0"
-    def google_cloud_bigdataoss_version = "2.2.16"
+    def google_cloud_bigdataoss_version = "3.0.1"
     // [bomupgrader] determined by: com.google.cloud:google-cloud-spanner, consistent with: google_cloud_platform_libraries_bom
     def google_cloud_spanner_version = "6.66.0"
     def google_code_gson_version = "2.10.1"
@@ -612,7 +612,7 @@ class BeamModulePlugin implements Plugin<Project> {
     // [bomupgrader] determined by: io.grpc:grpc-netty, consistent with: google_cloud_platform_libraries_bom
     def grpc_version = "1.62.2"
     def guava_version = "33.1.0-jre"
-    def hadoop_version = "2.10.2"
+    def hadoop_version = "3.3.6"
     def hamcrest_version = "2.1"
     def influxdb_version = "2.19"
     def httpclient_version = "4.5.13"
@@ -694,9 +694,9 @@ class BeamModulePlugin implements Plugin<Project> {
         aws_java_sdk2_profiles                      : "software.amazon.awssdk:profiles:$aws_java_sdk2_version",
         azure_sdk_bom                               : "com.azure:azure-sdk-bom:1.2.14",
         bigdataoss_gcsio                            : "com.google.cloud.bigdataoss:gcsio:$google_cloud_bigdataoss_version",
-        bigdataoss_gcs_connector                    : "com.google.cloud.bigdataoss:gcs-connector:hadoop2-$google_cloud_bigdataoss_version",
+        bigdataoss_gcs_connector                    : "com.google.cloud.bigdataoss:gcs-connector:$google_cloud_bigdataoss_version",
         bigdataoss_util                             : "com.google.cloud.bigdataoss:util:$google_cloud_bigdataoss_version",
-        bigdataoss_util_hadoop                      : "com.google.cloud.bigdataoss:util-hadoop:hadoop2-$google_cloud_bigdataoss_version",
+        bigdataoss_util_hadoop                      : "com.google.cloud.bigdataoss:util-hadoop:$google_cloud_bigdataoss_version",
         byte_buddy                                  : "net.bytebuddy:byte-buddy:1.14.12",
         cassandra_driver_core                       : "com.datastax.cassandra:cassandra-driver-core:$cassandra_driver_version",
         cassandra_driver_mapping                    : "com.datastax.cassandra:cassandra-driver-mapping:$cassandra_driver_version",

--- a/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/util/GcsUtilTest.java
+++ b/sdks/java/extensions/google-cloud-platform-core/src/test/java/org/apache/beam/sdk/extensions/gcp/util/GcsUtilTest.java
@@ -973,7 +973,7 @@ public class GcsUtilTest {
     GcsOptions pipelineOptions = gcsOptionsWithTestCredential();
     GcsUtil gcsUtil = pipelineOptions.getGcsUtil();
     GoogleCloudStorageReadOptions readOptions =
-        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFound(false).build();
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(false).build();
     SeekableByteChannel channel =
         gcsUtil.open(GcsPath.fromComponents("testbucket", "testobject"), readOptions);
     channel.close();
@@ -991,7 +991,7 @@ public class GcsUtilTest {
             .setProjectId("my_project")
             .build());
     GoogleCloudStorageReadOptions readOptions =
-        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFound(true).build();
+        GoogleCloudStorageReadOptions.builder().setFastFailOnNotFoundEnabled(true).build();
     assertThrows(
         IOException.class,
         () -> gcsUtil.open(GcsPath.fromComponents("testbucket", "testbucket"), readOptions));
@@ -1606,8 +1606,10 @@ public class GcsUtilTest {
             .thenReturn(Channels.newChannel(new ByteArrayOutputStream()));
       } else {
         SeekableByteChannel seekableByteChannel = new SeekableInMemoryByteChannel(readPayload);
-        Mockito.when(googleCloudStorageMock.open(Mockito.any())).thenReturn(seekableByteChannel);
-        Mockito.when(googleCloudStorageMock.open(Mockito.any(), Mockito.any()))
+        Mockito.when(googleCloudStorageMock.open(Mockito.any(StorageResourceId.class)))
+            .thenReturn(seekableByteChannel);
+        Mockito.when(
+                googleCloudStorageMock.open(Mockito.any(StorageResourceId.class), Mockito.any()))
             .thenReturn(seekableByteChannel);
       }
       return gcsUtilMock;
@@ -1655,7 +1657,10 @@ public class GcsUtilTest {
 
     @Override
     GoogleCloudStorage createGoogleCloudStorage(
-        GoogleCloudStorageOptions options, Storage storage, Credentials credentials) {
+        GoogleCloudStorageOptions options,
+        Credentials credentials,
+        @Nullable HttpTransport httpTransport,
+        @Nullable HttpRequestInitializer httpRequestInitializern) {
       return googleCloudStorage;
     }
   }

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BatchLoads.java
@@ -24,7 +24,6 @@ import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Pr
 
 import com.google.api.services.bigquery.model.TableReference;
 import com.google.api.services.bigquery.model.TableRow;
-import com.google.cloud.hadoop.util.AsyncWriteChannelOptions;
 import java.util.Collections;
 import java.util.List;
 import java.util.Set;
@@ -122,8 +121,11 @@ class BatchLoads<DestinationT, ElementT>
   static final int FILE_TRIGGERING_RECORD_COUNT = 500000;
   // If user triggering is supplied, we will trigger the file write after this many bytes are
   // written.
+  private static final int UPLOAD_CHUNK_SIZE_GRANULARITY = 8 * 1024 * 1024;
   static final int DEFAULT_FILE_TRIGGERING_BYTE_COUNT =
-      AsyncWriteChannelOptions.UPLOAD_CHUNK_SIZE_DEFAULT; // 64MiB as of now
+      Runtime.getRuntime().maxMemory() < 512 * 1024 * 1024
+          ? UPLOAD_CHUNK_SIZE_GRANULARITY
+          : 8 * UPLOAD_CHUNK_SIZE_GRANULARITY; // 64MiB as of now
 
   // If using auto-sharding for unbounded data, we batch the records before triggering file write
   // to avoid generating too many small files.


### PR DESCRIPTION
fixes #31896 

- Updates gcs-connector library from 2.x to 3.x. The [3.x release](https://github.com/GoogleCloudDataproc/hadoop-connectors/releases/tag/v3.0.1) adds support for the new Hadoop vectoredIO APIs, which have also been recently integrated with Parquet.
- gcs-connector 3.x drops Hadoop2 support, so hadoop is also upgraded to 3.3.6 (this is the version specified in [gcs-connector pom](https://github.com/GoogleCloudDataproc/hadoop-connectors/blob/v3.0.1/pom.xml#L103). An additional motivation to make this change is that all the existing Hadoop2 versions have known CVEs. I have done some ad-hoc testing with Hadoop3 vs Hadoop2 and not noticed any performance degradation or unexpected behavior

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
