### PR TITLE
Update Dataflow containers

### DIFF
--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -52,7 +52,7 @@ evaluationDependsOn(":sdks:java:container:java11")
 ext.dataflowLegacyEnvironmentMajorVersion = '8'
 ext.dataflowFnapiEnvironmentMajorVersion = '8'
 ext.dataflowLegacyContainerVersion = 'beam-master-20240718'
-ext.dataflowFnapiContainerVersion = 'beam-master-20240716'
+ext.dataflowFnapiContainerVersion = 'beam-master-20240718'
 ext.dataflowContainerBaseRepository = 'gcr.io/cloud-dataflow/v1beta3'
 
 processResources {


### PR DESCRIPTION
Released a new runner v2 image with an identical name to the legacy image. This is a workaround for #30634