### PR TITLE
SolaceIO.Write: add data classes, connector interface

### DIFF
--- a/sdks/java/io/solace/src/main/java/org/apache/beam/sdk/io/solace/SolaceIO.java
+++ b/sdks/java/io/solace/src/main/java/org/apache/beam/sdk/io/solace/SolaceIO.java
@@ -22,6 +22,7 @@ import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Pr
 
 import com.google.auto.value.AutoValue;
 import com.solacesystems.jcsmp.BytesXMLMessage;
+import com.solacesystems.jcsmp.DeliveryMode;
 import com.solacesystems.jcsmp.Destination;
 import com.solacesystems.jcsmp.JCSMPFactory;
 import com.solacesystems.jcsmp.Queue;
@@ -31,18 +32,22 @@ import org.apache.beam.sdk.Pipeline;
 import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.io.solace.broker.BasicAuthJcsmpSessionServiceFactory;
+import org.apache.beam.sdk.io.solace.broker.GCPSecretSessionServiceFactory;
 import org.apache.beam.sdk.io.solace.broker.SempClientFactory;
 import org.apache.beam.sdk.io.solace.broker.SessionService;
 import org.apache.beam.sdk.io.solace.broker.SessionServiceFactory;
 import org.apache.beam.sdk.io.solace.data.Solace;
 import org.apache.beam.sdk.io.solace.data.Solace.SolaceRecordMapper;
 import org.apache.beam.sdk.io.solace.read.UnboundedSolaceSource;
+import org.apache.beam.sdk.io.solace.write.SolaceOutput;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.schemas.NoSuchSchemaException;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.PBegin;
 import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
 import org.checkerframework.checker.nullness.qual.Nullable;
@@ -181,10 +186,6 @@ import org.slf4j.LoggerFactory;
  *
  * }</pre>
  *
- * <h2>Writing</h2>
- *
- * TBD
- *
  * <h3>Authentication</h3>
  *
  * <p>When reading from Solace, the user must use {@link
@@ -198,6 +199,186 @@ import org.slf4j.LoggerFactory;
  * <p>For the authentication to the SEMP API ({@link Read#withSempClientFactory(SempClientFactory)})
  * the connector provides {@link org.apache.beam.sdk.io.solace.broker.BasicAuthSempClientFactory} to
  * authenticate using the Basic Authentication.
+ *
+ * <h2>Writing</h2>
+ *
+ * <p>To write to Solace, use {@link #write()} with a {@link PCollection<Solace.Record>}. You can
+ * also use {@link #write(SerializableFunction)} to specify a format function to convert the input
+ * type to {@link Solace.Record}.
+ *
+ * <h3>Writing to a static topic or queue</h3>
+ *
+ * <p>The connector uses the <a href=
+ * "https://docs.solace.com/API/Messaging-APIs/JCSMP-API/jcsmp-api-home.htm">Solace JCSMP API</a>.
+ * The clients will write to a <a href="https://docs.solace.com/Messaging/SMF-Topics.htm">SMF
+ * topic</a> to the port 55555 of the host. If you want to use a different port, specify it in the
+ * host property with the format "X.X.X.X:PORT".
+ *
+ * <p>Once you have a {@link PCollection} of {@link Solace.Record}, you can write to Solace using:
+ *
+ * <pre>{@code
+ * PCollection<Solace.Record> solaceRecs = ...;
+ *
+ * PCollection<Solace.PublishResult> results =
+ *         solaceRecs.apply(
+ *                 "Write to Solace",
+ *                 SolaceIO.write()
+ *                         .to(SolaceIO.topicFromName("some-topic"))
+ *                         .withSessionServiceFactory(
+ *                            BasicAuthJcsmpSessionServiceFactory.builder()
+ *                              .username("username")
+ *                              .password("password")
+ *                              .host("host:port")
+ *                              .build()));
+ * }</pre>
+ *
+ * <p>The above code snippet will write to the VPN named "default", using 4 clients per worker (VM
+ * in Dataflow), and a maximum of 20 workers/VMs for writing (default values). You can change the
+ * default VPN name by setting the required JCSMP property in the session factory (in this case,
+ * with {@link BasicAuthJcsmpSessionServiceFactory#vpnName()}), the number of clients per worker
+ * with {@link Write#withNumberOfClientsPerWorker(int)} and the number of parallel write clients
+ * using {@link Write#withMaxNumOfUsedWorkers(int)}.
+ *
+ * <h3>Writing to dynamic destinations</h3>
+ *
+ * To write to dynamic destinations, don't set the {@link Write#to(Solace.Queue)} or {@link
+ * Write#to(Solace.Topic)} property and make sure that all the {@link Solace.Record}s have their
+ * destination field set to either a topic or a queue. You can do this prior to calling the write
+ * connector, or by using a format function and {@link #write(SerializableFunction)}.
+ *
+ * <p>For instance, you can create a function like the following:
+ *
+ * <pre>{@code
+ * // Generate Record with different destinations
+ * SerializableFunction<MyType, Solace.Record> formatFn =
+ *    (MyType msg) -> {
+ *       int queue = ... // some random number
+ *       return Solace.Record.builder()
+ *         .setDestination(Solace.Destination.builder()
+ *                        .setName(String.format("q%d", queue))
+ *                        .setType(Solace.DestinationType.QUEUE)
+ *                        .build())
+ *         .setMessageId(msg.getMessageId())
+ *         .build();
+ * };
+ * }</pre>
+ *
+ * And then use the connector as follows:
+ *
+ * <pre>{@code
+ * // Ignore "to" method to use dynamic destinations
+ * SolaceOutput solaceResponses = msgs.apply("Write to Solace",
+ *   SolaceIO.<MyType>write(formatFn)
+ *        .withDeliveryMode(DeliveryMode.PERSISTENT)
+ *        .withWriterType(SolaceIO.WriterType.STREAMING)
+ * ...
+ * }</pre>
+ *
+ * <h3>Direct and persistent messages, and latency metrics</h3>
+ *
+ * <p>The connector can write either direct or persistent messages. The default mode is DIRECT.
+ *
+ * <p>The connector returns a {@link PCollection} of {@link Solace.PublishResult}, that you can use
+ * to get a confirmation of messages that have been published, or rejected, but only if it is
+ * publishing persistent messages.
+ *
+ * <p>If you are publishing persistent messages, then you can have some feedback about whether the
+ * messages have been published, and some publishing latency metrics. If the message has been
+ * published, {@link Solace.PublishResult#getPublished()} will be true. If it is false, it means
+ * that the message could not be published, and {@link Solace.PublishResult#getError()} will contain
+ * more details about why the message could not be published. To get latency metrics as well as the
+ * results, set the property {@link Write#publishLatencyMetrics()}.
+ *
+ * <h3>Throughput and latency</h3>
+ *
+ * <p>This connector can work in two main modes: high latency or high throughput. The default mode
+ * favors high throughput over high latency. You can control this behavior with the methods {@link
+ * Write#withSubmissionMode(SubmissionMode)} and {@link Write#withWriterType(WriterType)}.
+ *
+ * <p>The default mode works like the following options:
+ *
+ * <pre>{@code
+ * PCollection<Solace.Record> solaceRecs = ...;
+ *
+ * PCollection<Solace.PublishResult> results =
+ *         solaceRecs.apply(
+ *                 "Write to Solace",
+ *                 SolaceIO.write()
+ *                         .to(SolaceIO.topicFromName("some-topic"))
+ *                         .withSessionServiceFactory(
+ *                            BasicAuthJcsmpSessionServiceFactory.builder()
+ *                              .username("username")
+ *                              .password("password")
+ *                              .host("host:port")
+ *                              .build())
+ *                         .withSubmissionMode(SubmissionMode.HIGHER_THROUGHPUT)
+ *                         .withWriterType(WriterType.BATCHED));
+ * }</pre>
+ *
+ * <p>{@link SubmissionMode#HIGHER_THROUGHPUT} and {@link WriterType#BATCHED} are the default
+ * values, and offer the higher possible throughput, and the lowest usage of resources in the runner
+ * side (due to the lower backpressure).
+ *
+ * <p>This connector writes bundles of 50 messages, using a bulk publish JCSMP method. This will
+ * increase the latency, since a message needs to "wait" until 50 messages are accumulated, before
+ * they are submitted to Solace.
+ *
+ * <p>For the lowest latency possible, use {@link SubmissionMode#LOWER_LATENCY} and {@link
+ * WriterType#STREAMING}.
+ *
+ * <pre>{@code
+ * PCollection<Solace.PublishResult> results =
+ *         solaceRecs.apply(
+ *                 "Write to Solace",
+ *                 SolaceIO.write()
+ *                         .to(SolaceIO.topicFromName("some-topic"))
+ *                         .withSessionServiceFactory(
+ *                            BasicAuthJcsmpSessionServiceFactory.builder()
+ *                              .username("username")
+ *                              .password("password")
+ *                              .host("host:port")
+ *                              .build())
+ *                         .withSubmissionMode(SubmissionMode.LOWER_LATENCY)
+ *                         .withWriterType(WriterType.STREAMING));
+ * }</pre>
+ *
+ * <p>The streaming connector publishes each message individually, without holding up or batching
+ * before the message is sent to Solace. This will ensure the lowest possible latency, but it will
+ * offer a much lower throughput. The streaming connector does not use state & timers.
+ *
+ * <p>Both connectors uses state & timers to control the level of parallelism. If you are using
+ * Cloud Dataflow, it is recommended that you enable <a
+ * href="https://cloud.google.com/dataflow/docs/streaming-engine">Streaming Engine</a> to use this
+ * connector.
+ *
+ * <h3>Authentication</h3>
+ *
+ * <p>When writing to Solace, the user must use {@link
+ * Write#withSessionServiceFactory(SessionServiceFactory)} to create a JCSMP session.
+ *
+ * <p>See {@link Write#withSessionServiceFactory(SessionServiceFactory)} for session authentication.
+ * The connector provides implementation of the {@link SessionServiceFactory} using basic
+ * authentication ({@link BasicAuthJcsmpSessionServiceFactory}), and another implementation using
+ * basic authentication but with a password stored as a secret in Google Cloud Secret Manager
+ * ({@link GCPSecretSessionServiceFactory})
+ *
+ * <h2>Connector retries</h2>
+ *
+ * <p>When the worker using the connector is created, the connector will attempt to connect to
+ * Solace.
+ *
+ * <p>If the client cannot connect to Solace for whatever reason, the connector will retry the
+ * connections using the following strategy. There will be a maximum of 4 retries. The first retry
+ * will be attempted 1 second after the first connection attempt. Every subsequent retry will
+ * multiply that time by a factor of two, with a maximum of 10 seconds.
+ *
+ * <p>If after those retries the client is still unable to connect to Solace, the connector will
+ * attempt to reconnect using the same strategy repeated for every single incoming message. If for
+ * some reason, there is a persistent issue that prevents the connection (e.g. client quota
+ * exhausted), you will need to stop your job manually, or the connector will keep retrying.
+ *
+ * <p>This strategy is applied to all the remote calls sent to Solace, either to connect, pull
+ * messages, push messages, etc.
  */
 @Internal
 public class SolaceIO {
@@ -213,11 +394,13 @@ public class SolaceIO {
       };
   private static final boolean DEFAULT_DEDUPLICATE_RECORDS = false;
 
-  // Part of the new write connector, documentation to be updated in upcoming pull requests
-  public enum SubmissionMode {
-    HIGHER_THROUGHPUT,
-    LOWER_LATENCY
-  }
+  public static final int DEFAULT_WRITER_MAX_NUMBER_OF_WORKERS = 20;
+  public static final int DEFAULT_WRITER_CLIENTS_PER_WORKER = 4;
+  public static final Boolean DEFAULT_WRITER_PUBLISH_LATENCY_METRICS = false;
+  public static final SubmissionMode DEFAULT_WRITER_SUBMISSION_MODE =
+      SubmissionMode.HIGHER_THROUGHPUT;
+  public static final DeliveryMode DEFAULT_WRITER_DELIVERY_MODE = DeliveryMode.DIRECT;
+  public static final WriterType DEFAULT_WRITER_TYPE = WriterType.BATCHED;
 
   /** Get a {@link Topic} object from the topic name. */
   static Topic topicFromName(String topicName) {
@@ -285,6 +468,24 @@ public class SolaceIO {
             .setParseFn(parseFn)
             .setTimestampFn(timestampFn)
             .setDeduplicateRecords(DEFAULT_DEDUPLICATE_RECORDS));
+  }
+
+  /**
+   * Create a {@link Write} transform, to write to Solace with a custom type.
+   *
+   * <p>If you are using a custom data class, the format function should return a {@link
+   * Solace.Record} corresponding to your custom data class instance.
+   *
+   * <p>If you are using this formatting function with dynamic destinations, you must ensure that
+   * you set the right value in the destination value of the {@link Solace.Record} messages.
+   */
+  public static <T> Write<T> write(SerializableFunction<T, Solace.Record> formatFunction) {
+    return Write.<T>builder().setFormatFunction(formatFunction).build();
+  }
+
+  /** Create a {@link Write} transform, to write to Solace using {@link Solace.Record} objects. */
+  public static Write<Solace.Record> write() {
+    return Write.<Solace.Record>builder().build();
   }
 
   public static class Read<T> extends PTransform<PBegin, PCollection<T>> {
@@ -577,6 +778,234 @@ public class SolaceIO {
           throw new RuntimeException(e);
         }
       }
+    }
+  }
+
+  public enum SubmissionMode {
+    HIGHER_THROUGHPUT,
+    LOWER_LATENCY
+  }
+
+  public enum WriterType {
+    STREAMING,
+    BATCHED
+  }
+
+  @AutoValue
+  public abstract static class Write<T> extends PTransform<PCollection<T>, SolaceOutput> {
+
+    public static final TupleTag<Solace.PublishResult> FAILED_PUBLISH_TAG =
+        new TupleTag<Solace.PublishResult>() {};
+    public static final TupleTag<Solace.PublishResult> SUCCESSFUL_PUBLISH_TAG =
+        new TupleTag<Solace.PublishResult>() {};
+
+    /**
+     * Write to a Solace topic.
+     *
+     * <p>The topic does not need to exist before launching the pipeline.
+     *
+     * <p>This will write all records to the same topic, ignoring their destination field.
+     *
+     * <p>Optional. If not specified, the connector will use dynamic destinations based on the
+     * destination field of {@link Solace.Record}.
+     */
+    public Write<T> to(Solace.Topic topic) {
+      return toBuilder().setDestination(topicFromName(topic.getName())).build();
+    }
+
+    /**
+     * Write to a Solace queue.
+     *
+     * <p>The queue must exist prior to launching the pipeline.
+     *
+     * <p>This will write all records to the same queue, ignoring their destination field.
+     *
+     * <p>Optional. If not specified, the connector will use dynamic destinations based on the
+     * destination field of {@link Solace.Record}.
+     */
+    public Write<T> to(Solace.Queue queue) {
+      return toBuilder().setDestination(queueFromName(queue.getName())).build();
+    }
+
+    /**
+     * The number of workers used by the job to write to Solace.
+     *
+     * <p>This is optional, the default value is 20.
+     *
+     * <p>This is the maximum value that the job would use, but depending on the amount of data, the
+     * actual number of writers may be lower than this value. With the Dataflow runner, the
+     * connector will as maximum this number of VMs in the job (but the job itself may use more
+     * VMs).
+     *
+     * <p>Set this number taking into account the limits in the number of clients in your Solace
+     * cluster, and the need for performance when writing to Solace (more workers will achieve
+     * higher throughput).
+     */
+    public Write<T> withMaxNumOfUsedWorkers(int maxNumOfUsedWorkers) {
+      return toBuilder().setMaxNumOfUsedWorkers(maxNumOfUsedWorkers).build();
+    }
+
+    /**
+     * The number of clients that each worker will create.
+     *
+     * <p>This is optional, the default number is 4.
+     *
+     * <p>The number of clients is per worker. If there are more than one worker, the number of
+     * clients will be multiplied by the number of workers. With the Dataflow runner, this will be
+     * the number of clients created per VM. The clients will be re-used across different threads in
+     * the same worker.
+     *
+     * <p>Set this number in combination with {@link #withMaxNumOfUsedWorkers}, to ensure that the
+     * limit for number of clients in your Solace cluster is not exceeded.
+     *
+     * <p>Normally, using a higher number of clients with fewer workers will achieve better
+     * throughput at a lower cost, since the workers are better utilized. A good rule of thumb to
+     * use is setting as many clients per worker as vCPUs the worker has.
+     */
+    public Write<T> withNumberOfClientsPerWorker(int numberOfClientsPerWorker) {
+      return toBuilder().setNumberOfClientsPerWorker(numberOfClientsPerWorker).build();
+    }
+
+    /**
+     * Set the delivery mode. This is optional, the default value is DIRECT.
+     *
+     * <p>For more details, see <a
+     * href="https://docs.solace.com/API/API-Developer-Guide/Message-Delivery-Modes.htm">https://docs.solace.com/API/API-Developer-Guide/Message-Delivery-Modes.htm</a>
+     */
+    public Write<T> withDeliveryMode(DeliveryMode deliveryMode) {
+      return toBuilder().setDeliveryMode(deliveryMode).build();
+    }
+
+    /**
+     * Publish latency metrics using Beam metrics.
+     *
+     * <p>Latency metrics are only available if {@link #withDeliveryMode(DeliveryMode)} is set to
+     * PERSISTENT. In that mode, latency is measured for each single message, as the time difference
+     * between the message creation and the reception of the publishing confirmation.
+     *
+     * <p>For the batched writer, the creation time is set for every message in a batch shortly
+     * before the batch is submitted. So the latency is very close to the actual publishing latency,
+     * and it does not take into account the time spent waiting for the batch to be submitted.
+     *
+     * <p>This is optional, the default value is false (don't publish latency metrics).
+     */
+    public Write<T> publishLatencyMetrics() {
+      return toBuilder().setPublishLatencyMetrics(true).build();
+    }
+
+    /**
+     * This setting controls the JCSMP property MESSAGE_CALLBACK_ON_REACTOR. Optional.
+     *
+     * <p>For full details, please check <a
+     * href="https://docs.solace.com/API/API-Developer-Guide/Java-API-Best-Practices.htm">https://docs.solace.com/API/API-Developer-Guide/Java-API-Best-Practices.htm</a>.
+     *
+     * <p>The Solace JCSMP client libraries can dispatch messages using two different modes:
+     *
+     * <p>One of the modes dispatches messages directly from the same thread that is doing the rest
+     * of I/O work. This mode favors lower latency but lower throughput. Set this to LOWER_LATENCY
+     * to use that mode (MESSAGE_CALLBACK_ON_REACTOR set to True).
+     *
+     * <p>The other mode uses a parallel thread to accumulate and dispatch messages. This mode
+     * favors higher throughput but also has higher latency. Set this to HIGHER_THROUGHPUT to use
+     * that mode. This is the default mode (MESSAGE_CALLBACK_ON_REACTOR set to False).
+     *
+     * <p>This is optional, the default value is HIGHER_THROUGHPUT.
+     */
+    public Write<T> withSubmissionMode(SubmissionMode submissionMode) {
+      return toBuilder().setDispatchMode(submissionMode).build();
+    }
+
+    /**
+     * Set the type of writer used by the connector. Optional.
+     *
+     * <p>The Solace writer can either use the JCSMP modes in streaming or batched.
+     *
+     * <p>In streaming mode, the publishing latency will be lower, but the throughput will also be
+     * lower.
+     *
+     * <p>With the batched mode, messages are accumulated until a batch size of 50 is reached, or 5
+     * seconds have elapsed since the first message in the batch was received. The 50 messages are
+     * sent to Solace in a single batch. This writer offers higher throughput but higher publishing
+     * latency, as messages can be held up for up to 5 seconds until they are published.
+     *
+     * <p>Notice that this is the message publishing latency, not the end-to-end latency. For very
+     * large scale pipelines, you will probably prefer to use the HIGHER_THROUGHPUT mode, as with
+     * lower throughput messages will accumulate in the pipeline, and the end-to-end latency may
+     * actually be higher.
+     *
+     * <p>This is optional, the default is the BATCHED writer.
+     */
+    public Write<T> withWriterType(WriterType writerType) {
+      return toBuilder().setWriterType(writerType).build();
+    }
+
+    /**
+     * Set the provider used to obtain the properties to initialize a new session in the broker.
+     *
+     * <p>This provider should define the destination host where the broker is listening, and all
+     * the properties related to authentication (base auth, client certificate, etc.).
+     */
+    public Write<T> withSessionServiceFactory(SessionServiceFactory factory) {
+      return toBuilder().setSessionServiceFactory(factory).build();
+    }
+
+    abstract int getMaxNumOfUsedWorkers();
+
+    abstract int getNumberOfClientsPerWorker();
+
+    abstract @Nullable Destination getDestination();
+
+    abstract DeliveryMode getDeliveryMode();
+
+    abstract boolean getPublishLatencyMetrics();
+
+    abstract SubmissionMode getDispatchMode();
+
+    abstract WriterType getWriterType();
+
+    abstract @Nullable SerializableFunction<T, Solace.Record> getFormatFunction();
+
+    abstract @Nullable SessionServiceFactory getSessionServiceFactory();
+
+    static <T> Builder<T> builder() {
+      return new AutoValue_SolaceIO_Write.Builder<T>()
+          .setDeliveryMode(DEFAULT_WRITER_DELIVERY_MODE)
+          .setMaxNumOfUsedWorkers(DEFAULT_WRITER_MAX_NUMBER_OF_WORKERS)
+          .setNumberOfClientsPerWorker(DEFAULT_WRITER_CLIENTS_PER_WORKER)
+          .setPublishLatencyMetrics(DEFAULT_WRITER_PUBLISH_LATENCY_METRICS)
+          .setDispatchMode(DEFAULT_WRITER_SUBMISSION_MODE)
+          .setWriterType(DEFAULT_WRITER_TYPE);
+    }
+
+    abstract Builder<T> toBuilder();
+
+    @AutoValue.Builder
+    abstract static class Builder<T> {
+      abstract Builder<T> setMaxNumOfUsedWorkers(int maxNumOfUsedWorkers);
+
+      abstract Builder<T> setNumberOfClientsPerWorker(int numberOfClientsPerWorker);
+
+      abstract Builder<T> setDestination(Destination topicOrQueue);
+
+      abstract Builder<T> setDeliveryMode(DeliveryMode deliveryMode);
+
+      abstract Builder<T> setPublishLatencyMetrics(Boolean publishLatencyMetrics);
+
+      abstract Builder<T> setDispatchMode(SubmissionMode submissionMode);
+
+      abstract Builder<T> setWriterType(WriterType writerType);
+
+      abstract Builder<T> setFormatFunction(SerializableFunction<T, Solace.Record> formatFunction);
+
+      abstract Builder<T> setSessionServiceFactory(SessionServiceFactory factory);
+
+      abstract Write<T> build();
+    }
+
+    @Override
+    public SolaceOutput expand(PCollection<T> input) {
+      // TODO: will be sent in upcoming PR
+      return SolaceOutput.in(input.getPipeline(), null, null);
     }
   }
 }

--- a/sdks/java/io/solace/src/main/java/org/apache/beam/sdk/io/solace/write/SolaceOutput.java
+++ b/sdks/java/io/solace/src/main/java/org/apache/beam/sdk/io/solace/write/SolaceOutput.java
@@ -1,0 +1,104 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.solace.write;
+
+import java.util.Map;
+import org.apache.beam.sdk.Pipeline;
+import org.apache.beam.sdk.io.solace.SolaceIO;
+import org.apache.beam.sdk.io.solace.data.Solace;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PInput;
+import org.apache.beam.sdk.values.POutput;
+import org.apache.beam.sdk.values.PValue;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * The {@link SolaceIO.Write} transform's output return this type, containing both the successful
+ * publishes ({@link #getSuccessfulPublish()}) and the failed publishes ({@link
+ * #getFailedPublish()}).
+ *
+ * <p>The streaming writer with DIRECT messages does not return anything, and the output {@link
+ * PCollection}s will be equal to null.
+ */
+public final class SolaceOutput implements POutput {
+  private final Pipeline pipeline;
+  private final TupleTag<Solace.PublishResult> failedPublishTag;
+  private final TupleTag<Solace.PublishResult> successfulPublishTag;
+  private final @Nullable PCollection<Solace.PublishResult> failedPublish;
+  private final @Nullable PCollection<Solace.PublishResult> successfulPublish;
+
+  public @Nullable PCollection<Solace.PublishResult> getFailedPublish() {
+    return failedPublish;
+  }
+
+  public @Nullable PCollection<Solace.PublishResult> getSuccessfulPublish() {
+    return successfulPublish;
+  }
+
+  public static SolaceOutput in(
+      Pipeline pipeline,
+      @Nullable PCollection<Solace.PublishResult> failedPublish,
+      @Nullable PCollection<Solace.PublishResult> successfulPublish) {
+    return new SolaceOutput(
+        pipeline,
+        SolaceIO.Write.FAILED_PUBLISH_TAG,
+        SolaceIO.Write.SUCCESSFUL_PUBLISH_TAG,
+        failedPublish,
+        successfulPublish);
+  }
+
+  private SolaceOutput(
+      Pipeline pipeline,
+      TupleTag<Solace.PublishResult> failedPublishTag,
+      TupleTag<Solace.PublishResult> successfulPublishTag,
+      @Nullable PCollection<Solace.PublishResult> failedPublish,
+      @Nullable PCollection<Solace.PublishResult> successfulPublish) {
+    this.pipeline = pipeline;
+    this.failedPublishTag = failedPublishTag;
+    this.successfulPublishTag = successfulPublishTag;
+    this.failedPublish = failedPublish;
+    this.successfulPublish = successfulPublish;
+  }
+
+  @Override
+  public Pipeline getPipeline() {
+    return pipeline;
+  }
+
+  @Override
+  public Map<TupleTag<?>, PValue> expand() {
+    ImmutableMap.Builder<TupleTag<?>, PValue> builder = ImmutableMap.<TupleTag<?>, PValue>builder();
+
+    if (failedPublish != null) {
+      builder.put(failedPublishTag, failedPublish);
+    }
+
+    if (successfulPublish != null) {
+      builder.put(successfulPublishTag, successfulPublish);
+    }
+
+    return builder.build();
+  }
+
+  @Override
+  public void finishSpecifyingOutput(
+      String transformName, PInput input, PTransform<?, ?> transform) {}
+}

--- a/sdks/java/io/solace/src/main/java/org/apache/beam/sdk/io/solace/write/package-info.java
+++ b/sdks/java/io/solace/src/main/java/org/apache/beam/sdk/io/solace/write/package-info.java
@@ -1,0 +1,20 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+/** SolaceIO Write connector. */
+package org.apache.beam.sdk.io.solace.write;


### PR DESCRIPTION
This is a followup PR to #31906, and part of the issue #31905

This adds the interface of the Write connector and a few classes (data classes, POutput) that are used by the connector.

More changes are coming in a subsequent PR.

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
