### PR TITLE
Fix row ranges issue in Bigtable Read.

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
@@ -436,14 +436,19 @@ class BigtableServiceImpl implements BigtableService {
         int startCmp = StartPoint.extract(rowRange).compareTo(new StartPoint(lastKey, true));
         int endCmp = EndPoint.extract(rowRange).compareTo(new EndPoint(lastKey, true));
 
-        if (startCmp > 0) {
-          // If the startKey is passed the split point than add the whole range
-          segment.addRowRanges(rowRange);
-        } else if (endCmp > 0) {
-          // Row is split, remove all read rowKeys and split RowSet at last buffered Row
-          RowRange subRange = rowRange.toBuilder().setStartKeyOpen(lastKey).build();
-          segment.addRowRanges(subRange);
+        if (endCmp <= 0){
+          // range end is on or left of the split: skip
+          continue;
         }
+
+        RowRange.Builder newRange = rowRange.toBuilder();
+        if (startCmp > 0){
+          // If the startKey is passed the split point than add the whole range
+          segment.addRowRanges(newRange.build());
+        } else {
+          // Row is split, remove all read rowKeys and split RowSet at last buffered Row          
+          segment.addRowRanges(newRange.setStartKeyOpen(lastKey).build());
+        } 
       }
       if (segment.getRowRangesCount() == 0) {
         return null;

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImpl.java
@@ -436,19 +436,19 @@ class BigtableServiceImpl implements BigtableService {
         int startCmp = StartPoint.extract(rowRange).compareTo(new StartPoint(lastKey, true));
         int endCmp = EndPoint.extract(rowRange).compareTo(new EndPoint(lastKey, true));
 
-        if (endCmp <= 0){
+        if (endCmp <= 0) {
           // range end is on or left of the split: skip
           continue;
         }
 
         RowRange.Builder newRange = rowRange.toBuilder();
-        if (startCmp > 0){
+        if (startCmp > 0) {
           // If the startKey is passed the split point than add the whole range
           segment.addRowRanges(newRange.build());
         } else {
-          // Row is split, remove all read rowKeys and split RowSet at last buffered Row          
+          // Row is split, remove all read rowKeys and split RowSet at last buffered Row
           segment.addRowRanges(newRange.setStartKeyOpen(lastKey).build());
-        } 
+        }
       }
       if (segment.getRowRangesCount() == 0) {
         return null;

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImplTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImplTest.java
@@ -183,7 +183,7 @@ public class BigtableServiceImplTest {
     Assert.assertEquals(expectedRow, underTest.getCurrentRow());
     Assert.assertFalse(underTest.advance());
 
-    verifyMetricWasSet("google.bigtable.v2.ReadRows", "ok", 1);
+    verifyMetricWasSet("google.bigtable.v2.ReadRowsLol", "ok", 1);
   }
 
   /**

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImplTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImplTest.java
@@ -245,6 +245,67 @@ public class BigtableServiceImplTest {
   }
 
   /**
+   * This test ensures that protobuf creation and interactions with {@link BigtableDataClient} work
+   * as expected. This test checks that a single row is returned from the future.
+   *
+   * @throws IOException
+   */
+  @Test
+  public void testReadSingleRangeAtSegmentLimit() throws Exception {
+    RowSet.Builder ranges = RowSet.newBuilder();
+    ranges.addRowRanges(
+            generateRowRange(
+                    generateByteString(DEFAULT_PREFIX, SEGMENT_SIZE), generateByteString(DEFAULT_PREFIX, SEGMENT_SIZE-1)));
+
+
+    // Set up Callable to be returned by stub.createReadRowsCallable()
+    ServerStreamingCallable<Query, Row> mockCallable = Mockito.mock(ServerStreamingCallable.class);
+    List<List<Row>> expectedResults =
+            ImmutableList.of(
+                    generateSegmentResult(DEFAULT_PREFIX, 0, SEGMENT_SIZE),
+                    ImmutableList.of());
+
+    // Return multiple answers when mockCallable is called
+    doAnswer(new MultipleAnswer<Row>(ImmutableList.of(
+            generateSegmentResult(DEFAULT_PREFIX, 0, SEGMENT_SIZE),
+            generateSegmentResult(DEFAULT_PREFIX, SEGMENT_SIZE, SEGMENT_SIZE*2),
+            ImmutableList.of())))
+            .when(mockCallable)
+            .call(any(Query.class), any(ResponseObserver.class), any(ApiCallContext.class));
+
+    when(mockStub.createReadRowsCallable(any(RowAdapter.class))).thenReturn(mockCallable);
+    ServerStreamingCallable<Query, Row> callable =
+            mockStub.createReadRowsCallable(new BigtableServiceImpl.BigtableRowProtoAdapter());
+    // Set up client to return callable
+    when(mockBigtableDataClient.readRowsCallable(any(RowAdapter.class))).thenReturn(callable);
+    when(mockBigtableSource.getTableId()).thenReturn(StaticValueProvider.of(TABLE_ID));
+
+    BigtableService.Reader underTest =
+            new BigtableServiceImpl.BigtableSegmentReaderImpl(
+                    mockBigtableDataClient,
+                    bigtableDataSettings.getProjectId(),
+                    bigtableDataSettings.getInstanceId(),
+                    mockBigtableSource.getTableId().get(),
+                    ranges.build(),
+                    RowFilter.getDefaultInstance(),
+                    SEGMENT_SIZE,
+                    DEFAULT_BYTE_SEGMENT_SIZE,
+                    mockCallMetric);
+
+    List<Row> actualResults = new ArrayList<>();
+    Assert.assertTrue(underTest.start());
+    do {
+      actualResults.add(underTest.getCurrentRow());
+    } while (underTest.advance());
+
+    Assert.assertEquals(
+            expectedResults.stream().flatMap(Collection::stream).collect(Collectors.toList()),
+            actualResults);
+
+    Mockito.verify(mockCallMetric, Mockito.times(2)).call("ok");
+  }
+
+  /**
    * This test ensures that all the rows are properly added to the buffer and read. This example
    * uses a single range with SEGMENT_SIZE*2+1 rows. Range: [b00000, b00001, ... b00199, b00200)
    *

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImplTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceImplTest.java
@@ -183,7 +183,7 @@ public class BigtableServiceImplTest {
     Assert.assertEquals(expectedRow, underTest.getCurrentRow());
     Assert.assertFalse(underTest.advance());
 
-    verifyMetricWasSet("google.bigtable.v2.ReadRowsLol", "ok", 1);
+    verifyMetricWasSet("google.bigtable.v2.ReadRows", "ok", 1);
   }
 
   /**


### PR DESCRIPTION
**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.

Issue was on end of range, where we would send a request to the server asking for rows in range X->X. Both Xs being identical resulted in a "invalid range, start needs to be smaller than end" error from server.
