### PR TITLE
[#32004] Ensure all pcollection coders are length prefixed if necessary.

### DIFF
--- a/sdks/go/pkg/beam/core/runtime/exec/hash.go
+++ b/sdks/go/pkg/beam/core/runtime/exec/hash.go
@@ -37,6 +37,13 @@ type elementHasher interface {
 func makeElementHasher(c *coder.Coder, wc *coder.WindowCoder) elementHasher {
 	hasher := &maphash.Hash{}
 	we := MakeWindowEncoder(wc)
+
+	// Unwrap length prefix coders.
+	// A length prefix changes the hash itself, but shouldn't affect
+	// that identical elements have the same hash, so skip them here.
+	if c.Kind == coder.LP {
+		c = c.Components[0]
+	}
 	switch c.Kind {
 	case coder.Bytes:
 		return &bytesHasher{hash: hasher, we: we}

--- a/sdks/go/pkg/beam/runners/prism/internal/stage.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/stage.go
@@ -478,6 +478,8 @@ func buildDescriptor(stg *stage, comps *pipepb.Components, wk *worker.W, em *eng
 	col := clonePColToBundle(stg.primaryInput)
 	if newCID, err := lpUnknownCoders(col.GetCoderId(), coders, comps.GetCoders()); err == nil && col.GetCoderId() != newCID {
 		col.CoderId = newCID
+	} else if err != nil {
+		return fmt.Errorf("buildDescriptor: couldn't rewrite coder %q for primary input pcollection %q: %w", col.GetCoderId(), stg.primaryInput, err)
 	}
 
 	wInCid, err := makeWindowedValueCoder(stg.primaryInput, comps, coders)
@@ -508,6 +510,8 @@ func buildDescriptor(stg *stage, comps *pipepb.Components, wk *worker.W, em *eng
 		col := clonePColToBundle(pid)
 		if newCID, err := lpUnknownCoders(col.GetCoderId(), coders, comps.GetCoders()); err == nil && col.GetCoderId() != newCID {
 			col.CoderId = newCID
+		} else if err != nil {
+			return fmt.Errorf("buildDescriptor: coder  couldn't rewrite coder %q for internal pcollection %q: %w", col.GetCoderId(), pid, err)
 		}
 	}
 	// Add coders for all windowing strategies.


### PR DESCRIPTION
Prism wasn't length prefix wrapping unknown coders for bundle internal PCollections, or for the parallel input pcollection. This prevented Java and Python SplittableDoFns from correctly encoding their sub element split results, since they pull their coder from the input PCollection.

Go is arguably incorrectly pulling it's coder from the DataSource transform itself, but explains why prism developed this bug.

This change ensures all the internal PCollections are wrapped, and updated with the correct coder. Further prism now only sends precisely the PCollections needed or used in the bundle, instead of the entire set of pipeline PCollections.

Fixes #32004.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
