### PR TITLE
Support metrics at Source.split for Direct Runner

### DIFF
--- a/runners/flink/flink_runner.gradle
+++ b/runners/flink/flink_runner.gradle
@@ -335,6 +335,8 @@ def createValidatesRunnerTask(Map m) {
         // Extremely flaky: https://github.com/apache/beam/issues/19814
         excludeTestsMatching 'org.apache.beam.sdk.transforms.ParDoLifecycleTest.testTeardownCalledAfterExceptionInProcessElementStateful'
         excludeTestsMatching 'org.apache.beam.sdk.transforms.ParDoLifecycleTest.testTeardownCalledAfterExceptionInStartBundleStateful'
+        // TODO(https://github.com/apache/beam/issues/29972) due to runtimeContext initialized after initial split
+        excludeTestsMatching 'org.apache.beam.sdk.metrics.MetricsTest$AttemptedMetricTests.testBoundedSourceMetricsInSplit'
       }
     }
   }

--- a/runners/spark/spark_runner.gradle
+++ b/runners/spark/spark_runner.gradle
@@ -290,6 +290,8 @@ def validatesRunnerBatch = tasks.register("validatesRunnerBatch", Test) {
   // TODO(https://github.com/apache/beam/issues/31231
   it.filter {
     excludeTestsMatching 'org.apache.beam.sdk.transforms.RedistributeTest.testRedistributePreservesMetadata'
+    // TODO(https://github.com/apache/beam/issues/32021)
+    excludeTestsMatching 'org.apache.beam.sdk.metrics.MetricsTest$AttemptedMetricTests.testBoundedSourceMetricsInSplit'
   }
 }
 
@@ -329,6 +331,8 @@ def validatesRunnerStreaming = tasks.register("validatesRunnerStreaming", Test) 
       excludeTestsMatching 'org.apache.beam.sdk.transforms.ReshuffleTest.testReshufflePreservesMetadata'
       // TODO(https://github.com/apache/beam/issues/31231
       excludeTestsMatching 'org.apache.beam.sdk.transforms.RedistributeTest.testRedistributePreservesMetadata'
+      // TODO(https://github.com/apache/beam/issues/32021)
+      excludeTestsMatching 'org.apache.beam.sdk.metrics.MetricsTest$AttemptedMetricTests.testBoundedSourceMetricsInSplit'
     }
 
     // TestStream using processing time is not supported in Spark
@@ -428,6 +432,8 @@ tasks.register("validatesStructuredStreamingRunnerBatch", Test) {
     excludeTestsMatching 'org.apache.beam.sdk.transforms.SplittableDoFnTest.testLifecycleMethodsBounded'
     // https://github.com/apache/beam/issues/29972
     excludeTestsMatching 'org.apache.beam.sdk.transforms.CombineTest$CombineWithContextTests.testHotKeyCombineWithSideInputs'
+    // TODO(https://github.com/apache/beam/issues/32021)
+    excludeTestsMatching 'org.apache.beam.sdk.metrics.MetricsTest$AttemptedMetricTests.testBoundedSourceMetricsInSplit'
   }
 }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/metrics/MetricResultsMatchers.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/metrics/MetricResultsMatchers.java
@@ -18,6 +18,7 @@
 package org.apache.beam.sdk.metrics;
 
 import java.util.Objects;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hamcrest.Description;
 import org.hamcrest.Matcher;
 import org.hamcrest.TypeSafeMatcher;
@@ -211,9 +212,9 @@ public class MetricResultsMatchers {
 
     private final String namespace;
     private final String name;
-    private final String step;
+    private final @Nullable String step;
 
-    MatchNameAndKey(String namespace, String name, String step) {
+    MatchNameAndKey(String namespace, String name, @Nullable String step) {
       this.namespace = namespace;
       this.name = name;
       this.step = step;
@@ -221,7 +222,11 @@ public class MetricResultsMatchers {
 
     @Override
     protected boolean matchesSafely(MetricResult<T> item) {
-      return MetricFiltering.matches(MetricsFilter.builder().addStep(step).build(), item.getKey())
+      MetricsFilter.Builder builder = MetricsFilter.builder();
+      if (step != null) {
+        builder = builder.addStep(step);
+      }
+      return MetricFiltering.matches(builder.build(), item.getKey())
           && Objects.equals(MetricName.named(namespace, name), item.getName());
     }
 
@@ -231,9 +236,10 @@ public class MetricResultsMatchers {
           .appendText("MetricResult{inNamespace=")
           .appendValue(namespace)
           .appendText(", name=")
-          .appendValue(name)
-          .appendText(", step=")
-          .appendValue(step);
+          .appendValue(name);
+      if (step != null) {
+        description.appendText(", step=").appendValue(step);
+      }
       if (this.getClass() == MatchNameAndKey.class) {
         description.appendText("}");
       }


### PR DESCRIPTION
Address #32021 for direct runner

* Added a validate runner test for this scenario

**Please** add a meaningful description for your change here

Tested manually - BUILD SUCCESSFUL for the following commands

```
./gradlew :runners:direct-java:validatesRunner --tests *testBoundedSourceMetricsInSplit
```

confirmed the new test already passing on portable runners:

```
./gradlew :runners:flink:1.18:job-server:validatesPortableRunnerBatch --tests *testBoundedSourceMetricsInSplit

./gradlew :runners:spark:3:job-server:validatesPortableRunnerBatch --tests *testBoundedSourceMetricsInSplit

./gradlew :runners:google-cloud-dataflow-java:validatesRunnerV2Test -PgcpProject=... -PgcpRegion=us-central1 -PgcpTempRoot=gs://.../tmp --tests *testBoundedSourceMetricsInSplit -info
```

Dataflow legacy runner does not support attempted metrics (and excluded it from validateRunner test). If change to match committed metrics, tested that the test also passes.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
