### PR TITLE
Added support for the TOKENLIST type in Spanner

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerSchema.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/spanner/SpannerSchema.java
@@ -184,6 +184,9 @@ public abstract class SpannerSchema implements Serializable {
           if (spannerType.startsWith("BYTES")) {
             return Type.bytes();
           }
+          if ("TOKENLIST".equals(spannerType)) {
+            return Type.bytes();
+          }
           if ("TIMESTAMP".equals(spannerType)) {
             return Type.timestamp();
           }

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/SpannerSchemaTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/spanner/SpannerSchemaTest.java
@@ -40,16 +40,18 @@ public class SpannerSchemaTest {
             .addColumn("test", "jsonVal", "JSON")
             .addColumn("test", "protoVal", "PROTO<customer.app.TestMessage>")
             .addColumn("test", "enumVal", "ENUM<customer.app.TestEnum>")
+            .addColumn("test", "tokens", "TOKENLIST")
             .build();
 
     assertEquals(1, schema.getTables().size());
-    assertEquals(6, schema.getColumns("test").size());
+    assertEquals(7, schema.getColumns("test").size());
     assertEquals(1, schema.getKeyParts("test").size());
     assertEquals(Type.json(), schema.getColumns("test").get(3).getType());
     assertEquals(
         Type.proto("customer.app.TestMessage"), schema.getColumns("test").get(4).getType());
     assertEquals(
         Type.protoEnum("customer.app.TestEnum"), schema.getColumns("test").get(5).getType());
+    assertEquals(Type.bytes(), schema.getColumns("test").get(6).getType());
   }
 
   @Test


### PR DESCRIPTION
Extended the SpannerSchema.Column class to be able to parse a Spanner TOKENLIST typed column. This is needed to support search indexes in Teleport.
R: @darshan-sj 