### PR TITLE
Change FnApiDoFnRunner to skip trySplit checkpoint requests if not draining and nothing has yet been claimed by the tracker.

### DIFF
--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -889,7 +889,8 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
         RestrictionTrackers.observe(
             doFnInvoker.invokeNewTracker(processContext),
             new ClaimObserver<PositionT>() {
-              private final AtomicBoolean claimed = Preconditions.checkNotNull(currentTrackerClaimed);
+              private final AtomicBoolean claimed =
+                  Preconditions.checkNotNull(currentTrackerClaimed);
 
               @Override
               public void onClaimed(PositionT position) {
@@ -927,7 +928,8 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
             RestrictionTrackers.observe(
                 doFnInvoker.invokeNewTracker(processContext),
                 new ClaimObserver<PositionT>() {
-                  private final AtomicBoolean claimed = Preconditions.checkNotNull(currentTrackerClaimed);
+                  private final AtomicBoolean claimed =
+                      Preconditions.checkNotNull(currentTrackerClaimed);
 
                   @Override
                   public void onClaimed(PositionT position) {
@@ -1109,7 +1111,8 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
             RestrictionTrackers.observe(
                 doFnInvoker.invokeNewTracker(processContext),
                 new ClaimObserver<PositionT>() {
-                  private final AtomicBoolean claimed = Preconditions.checkNotNull(currentTrackerClaimed);
+                  private final AtomicBoolean claimed =
+                      Preconditions.checkNotNull(currentTrackerClaimed);
 
                   @Override
                   public void onClaimed(PositionT position) {

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/FnApiDoFnRunner.java
@@ -119,6 +119,7 @@ import org.apache.beam.sdk.values.WindowingStrategy;
 import org.apache.beam.vendor.grpc.v1p60p1.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.grpc.v1p60p1.com.google.protobuf.util.Durations;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
@@ -332,7 +333,7 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
    * If non-null, set to true after currentTracker has had a tryClaim issued on it. Used to ignore
    * checkpoint split requests if no progress was made.
    */
-  private AtomicBoolean currentTrackerClaimed;
+  private @Nullable AtomicBoolean currentTrackerClaimed;
 
   /**
    * Only valid during {@link #processTimer} and {@link #processOnWindowExpiration}, null otherwise.
@@ -888,9 +889,11 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
         RestrictionTrackers.observe(
             doFnInvoker.invokeNewTracker(processContext),
             new ClaimObserver<PositionT>() {
+              private final AtomicBoolean claimed = Preconditions.checkNotNull(currentTrackerClaimed);
+
               @Override
               public void onClaimed(PositionT position) {
-                currentTrackerClaimed.lazySet(true);
+                claimed.lazySet(true);
               }
 
               @Override
@@ -924,9 +927,11 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
             RestrictionTrackers.observe(
                 doFnInvoker.invokeNewTracker(processContext),
                 new ClaimObserver<PositionT>() {
+                  private final AtomicBoolean claimed = Preconditions.checkNotNull(currentTrackerClaimed);
+
                   @Override
                   public void onClaimed(PositionT position) {
-                    currentTrackerClaimed.lazySet(true);
+                    claimed.lazySet(true);
                   }
 
                   @Override
@@ -1104,9 +1109,11 @@ public class FnApiDoFnRunner<InputT, RestrictionT, PositionT, WatermarkEstimator
             RestrictionTrackers.observe(
                 doFnInvoker.invokeNewTracker(processContext),
                 new ClaimObserver<PositionT>() {
+                  private final AtomicBoolean claimed = Preconditions.checkNotNull(currentTrackerClaimed);
+
                   @Override
                   public void onClaimed(PositionT position) {
-                    currentTrackerClaimed.lazySet(true);
+                    claimed.lazySet(true);
                   }
 
                   @Override

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/FnApiDoFnRunnerTest.java
@@ -151,6 +151,7 @@ import org.hamcrest.collection.IsMapContaining;
 import org.joda.time.Duration;
 import org.joda.time.Instant;
 import org.joda.time.format.PeriodFormat;
+import org.junit.Assert;
 import org.junit.Before;
 import org.junit.Ignore;
 import org.junit.Rule;
@@ -1370,41 +1371,74 @@ public class FnApiDoFnRunnerTest implements Serializable {
      *   <li>splitting thread: {@link
      *       NonWindowObservingTestSplittableDoFn#waitForSplitElementToBeProcessed()}
      *   <li>process element thread: {@link
-     *       NonWindowObservingTestSplittableDoFn#enableAndWaitForTrySplitToHappen()}
+     *       NonWindowObservingTestSplittableDoFn#splitElementProcessed()}
      *   <li>splitting thread: perform try split
-     *   <li>splitting thread: {@link
-     *       NonWindowObservingTestSplittableDoFn#releaseWaitingProcessElementThread()}
+     *   <li>splitting thread: {@link NonWindowObservingTestSplittableDoFn#trySplitPerformed()} *
+     *   <li>process element thread: {@link
+     *       NonWindowObservingTestSplittableDoFn#waitForTrySplitPerformed()}
      * </ul>
      */
     static class NonWindowObservingTestSplittableDoFn extends DoFn<String, String> {
-      private static final ConcurrentMap<String, KV<CountDownLatch, CountDownLatch>>
-          DOFN_INSTANCE_TO_LOCK = new ConcurrentHashMap<>();
+      private static final ConcurrentMap<String, Latches> DOFN_INSTANCE_TO_LATCHES =
+          new ConcurrentHashMap<>();
       private static final long SPLIT_ELEMENT = 3;
       private static final long CHECKPOINT_UPPER_BOUND = 8;
 
-      private KV<CountDownLatch, CountDownLatch> getLatches() {
-        return DOFN_INSTANCE_TO_LOCK.computeIfAbsent(
-            this.uuid, (uuid) -> KV.of(new CountDownLatch(1), new CountDownLatch(1)));
+      static class Latches {
+        public Latches() {}
+
+        CountDownLatch blockProcessLatch = new CountDownLatch(0);
+        CountDownLatch processEnteredLatch = new CountDownLatch(1);
+        CountDownLatch splitElementProcessedLatch = new CountDownLatch(1);
+        CountDownLatch trySplitPerformedLatch = new CountDownLatch(1);
       }
 
-      public void enableAndWaitForTrySplitToHappen() throws Exception {
-        KV<CountDownLatch, CountDownLatch> latches = getLatches();
-        latches.getKey().countDown();
-        if (!latches.getValue().await(30, TimeUnit.SECONDS)) {
+      private Latches getLatches() {
+        return DOFN_INSTANCE_TO_LATCHES.computeIfAbsent(this.uuid, (uuid) -> new Latches());
+      }
+
+      public void splitElementProcessed() {
+        getLatches().splitElementProcessedLatch.countDown();
+      }
+
+      public void waitForSplitElementToBeProcessed() throws InterruptedException {
+        if (!getLatches().splitElementProcessedLatch.await(30, TimeUnit.SECONDS)) {
           fail("Failed to wait for trySplit to occur.");
         }
       }
 
-      public void waitForSplitElementToBeProcessed() throws Exception {
-        KV<CountDownLatch, CountDownLatch> latches = getLatches();
-        if (!latches.getKey().await(30, TimeUnit.SECONDS)) {
-          fail("Failed to wait for split element to be processed.");
+      public void trySplitPerformed() {
+        getLatches().trySplitPerformedLatch.countDown();
+      }
+
+      public void waitForTrySplitPerformed() throws InterruptedException {
+        if (!getLatches().trySplitPerformedLatch.await(30, TimeUnit.SECONDS)) {
+          fail("Failed to wait for trySplit to occur.");
         }
       }
 
-      public void releaseWaitingProcessElementThread() {
-        KV<CountDownLatch, CountDownLatch> latches = getLatches();
-        latches.getValue().countDown();
+      // Must be called before process is invoked. Will prevent process from doing anything until
+      // unblockProcess is
+      // called.
+      public void setupBlockProcess() {
+        getLatches().blockProcessLatch = new CountDownLatch(1);
+      }
+
+      public void enterProcessAndBlockIfEnabled() throws InterruptedException {
+        getLatches().processEnteredLatch.countDown();
+        if (!getLatches().blockProcessLatch.await(30, TimeUnit.SECONDS)) {
+          fail("Failed to wait for unblockProcess to occur.");
+        }
+      }
+
+      public void waitForProcessEntered() throws InterruptedException {
+        if (!getLatches().processEnteredLatch.await(5, TimeUnit.SECONDS)) {
+          fail("Failed to wait for process to begin.");
+        }
+      }
+
+      public void unblockProcess() throws InterruptedException {
+        getLatches().blockProcessLatch.countDown();
       }
 
       private final String uuid;
@@ -1427,7 +1461,8 @@ public class FnApiDoFnRunnerTest implements Serializable {
           if (!claimStatus) {
             break;
           } else if (position == SPLIT_ELEMENT) {
-            enableAndWaitForTrySplitToHappen();
+            splitElementProcessed();
+            waitForTrySplitPerformed();
           }
           context.outputWithTimestamp(
               context.element() + ":" + position,
@@ -1511,6 +1546,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
           RestrictionTracker<OffsetRange, Long> tracker,
           ManualWatermarkEstimator<Instant> watermarkEstimator)
           throws Exception {
+        enterProcessAndBlockIfEnabled();
         long checkpointUpperBound = Long.parseLong(context.sideInput(singletonSideInput));
         long position = tracker.currentRestriction().getFrom();
         boolean claimStatus;
@@ -1519,7 +1555,8 @@ public class FnApiDoFnRunnerTest implements Serializable {
           if (!claimStatus) {
             break;
           } else if (position == NonWindowObservingTestSplittableDoFn.SPLIT_ELEMENT) {
-            enableAndWaitForTrySplitToHappen();
+            splitElementProcessed();
+            waitForTrySplitPerformed();
           }
           context.outputWithTimestamp(
               context.element() + ":" + position,
@@ -1549,7 +1586,8 @@ public class FnApiDoFnRunnerTest implements Serializable {
           throws Exception {
         // Waiting for split when we are on the second window.
         if (splitAtTruncate && processedWindowCount == PROCESSED_WINDOW) {
-          enableAndWaitForTrySplitToHappen();
+          splitElementProcessed();
+          waitForTrySplitPerformed();
         }
         processedWindowCount += 1;
         return TruncateResult.of(new OffsetRange(range.getFrom(), range.getTo() / 2));
@@ -1755,7 +1793,217 @@ public class FnApiDoFnRunnerTest implements Serializable {
 
                     return ((HandlesSplits) mainInput).trySplit(0);
                   } finally {
-                    doFn.releaseWaitingProcessElementThread();
+                    doFn.trySplitPerformed();
+                  }
+                });
+
+        // Check that before processing an element we don't report progress
+        assertNoReportedProgress(context.getBundleProgressReporters());
+        mainInput.accept(
+            valueInGlobalWindow(
+                KV.of(
+                    KV.of("7", KV.of(new OffsetRange(0, 5), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                    2.0)));
+        HandlesSplits.SplitResult trySplitResult = trySplitFuture.get();
+
+        // Check that after processing an element we don't report progress
+        assertNoReportedProgress(context.getBundleProgressReporters());
+
+        // Since the SPLIT_ELEMENT is 3 we will process 0, 1, 2, 3 then be split.
+        // We expect that the watermark advances to MIN + 2 since the manual watermark estimator
+        // has yet to be invoked for the split element and that the primary represents [0, 4) with
+        // the original watermark while the residual represents [4, 5) with the new MIN + 2
+        // watermark.
+        assertThat(
+            mainOutputValues,
+            contains(
+                timestampedValueInGlobalWindow(
+                    "7:0", GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.millis(0))),
+                timestampedValueInGlobalWindow(
+                    "7:1", GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.millis(1))),
+                timestampedValueInGlobalWindow(
+                    "7:2", GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.millis(2))),
+                timestampedValueInGlobalWindow(
+                    "7:3", GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.millis(3)))));
+
+        BundleApplication primaryRoot = Iterables.getOnlyElement(trySplitResult.getPrimaryRoots());
+        DelayedBundleApplication residualRoot =
+            Iterables.getOnlyElement(trySplitResult.getResidualRoots());
+        assertEquals(ParDoTranslation.getMainInputName(pTransform), primaryRoot.getInputId());
+        assertEquals(TEST_TRANSFORM_ID, primaryRoot.getTransformId());
+        assertEquals(
+            ParDoTranslation.getMainInputName(pTransform),
+            residualRoot.getApplication().getInputId());
+        assertEquals(TEST_TRANSFORM_ID, residualRoot.getApplication().getTransformId());
+        assertEquals(
+            valueInGlobalWindow(
+                KV.of(
+                    KV.of("7", KV.of(new OffsetRange(0, 4), GlobalWindow.TIMESTAMP_MIN_VALUE)),
+                    4.0)),
+            inputCoder.decode(primaryRoot.getElement().newInput()));
+        assertEquals(
+            valueInGlobalWindow(
+                KV.of(
+                    KV.of(
+                        "7",
+                        KV.of(
+                            new OffsetRange(4, 5),
+                            GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.millis(2)))),
+                    1.0)),
+            inputCoder.decode(residualRoot.getApplication().getElement().newInput()));
+        Instant expectedOutputWatermark = GlobalWindow.TIMESTAMP_MIN_VALUE.plus(Duration.millis(2));
+        assertEquals(
+            ImmutableMap.of(
+                "output",
+                org.apache.beam.vendor.grpc.v1p60p1.com.google.protobuf.Timestamp.newBuilder()
+                    .setSeconds(expectedOutputWatermark.getMillis() / 1000)
+                    .setNanos((int) (expectedOutputWatermark.getMillis() % 1000) * 1000000)
+                    .build()),
+            residualRoot.getApplication().getOutputWatermarksMap());
+        // We expect 0 resume delay.
+        assertEquals(
+            residualRoot.getRequestedTimeDelay().getDefaultInstanceForType(),
+            residualRoot.getRequestedTimeDelay());
+        // We don't expect the outputs to goto the SDK initiated checkpointing listener.
+        assertTrue(splitListener.getPrimaryRoots().isEmpty());
+        assertTrue(splitListener.getResidualRoots().isEmpty());
+        mainOutputValues.clear();
+        executorService.shutdown();
+      }
+
+      Iterables.getOnlyElement(context.getFinishBundleFunctions()).run();
+      assertThat(mainOutputValues, empty());
+
+      Iterables.getOnlyElement(context.getTearDownFunctions()).run();
+      assertThat(mainOutputValues, empty());
+
+      // Assert that state data did not change
+      assertEquals(
+          new FakeBeamFnStateClient(StringUtf8Coder.of(), stateData).getData(),
+          fakeClient.getData());
+    }
+
+    @Test
+    public void testProcessElementForSizedElementAndRestrictionSplitBeforeTryClaim()
+        throws Exception {
+      Pipeline p = Pipeline.create();
+      addExperiment(p.getOptions().as(ExperimentalOptions.class), "beam_fn_api");
+      // TODO(BEAM-10097): Remove experiment once all portable runners support this view type
+      addExperiment(p.getOptions().as(ExperimentalOptions.class), "use_runner_v2");
+      PCollection<String> valuePCollection = p.apply(Create.of("unused"));
+      PCollectionView<String> singletonSideInputView = valuePCollection.apply(View.asSingleton());
+      WindowObservingTestSplittableDoFn doFn =
+          new WindowObservingTestSplittableDoFn(singletonSideInputView);
+      valuePCollection.apply(
+          TEST_TRANSFORM_ID, ParDo.of(doFn).withSideInputs(singletonSideInputView));
+
+      RunnerApi.Pipeline pProto =
+          ProtoOverrides.updateTransform(
+              PTransformTranslation.PAR_DO_TRANSFORM_URN,
+              PipelineTranslation.toProto(p, SdkComponents.create(p.getOptions()), true),
+              SplittableParDoExpander.createSizedReplacement());
+      String expandedTransformId =
+          Iterables.find(
+                  pProto.getComponents().getTransformsMap().entrySet(),
+                  entry ->
+                      entry
+                              .getValue()
+                              .getSpec()
+                              .getUrn()
+                              .equals(
+                                  PTransformTranslation
+                                      .SPLITTABLE_PROCESS_SIZED_ELEMENTS_AND_RESTRICTIONS_URN)
+                          && entry.getValue().getUniqueName().contains(TEST_TRANSFORM_ID))
+              .getKey();
+      RunnerApi.PTransform pTransform =
+          pProto.getComponents().getTransformsOrThrow(expandedTransformId);
+      String inputPCollectionId =
+          pTransform.getInputsOrThrow(ParDoTranslation.getMainInputName(pTransform));
+      RunnerApi.PCollection inputPCollection =
+          pProto.getComponents().getPcollectionsOrThrow(inputPCollectionId);
+      RehydratedComponents rehydratedComponents =
+          RehydratedComponents.forComponents(pProto.getComponents());
+      Coder<WindowedValue> inputCoder =
+          WindowedValue.getFullCoder(
+              CoderTranslation.fromProto(
+                  pProto.getComponents().getCodersOrThrow(inputPCollection.getCoderId()),
+                  rehydratedComponents,
+                  TranslationContext.DEFAULT),
+              (Coder)
+                  CoderTranslation.fromProto(
+                      pProto
+                          .getComponents()
+                          .getCodersOrThrow(
+                              pProto
+                                  .getComponents()
+                                  .getWindowingStrategiesOrThrow(
+                                      inputPCollection.getWindowingStrategyId())
+                                  .getWindowCoderId()),
+                      rehydratedComponents,
+                      TranslationContext.DEFAULT));
+      String outputPCollectionId = pTransform.getOutputsOrThrow("output");
+
+      ImmutableMap<StateKey, List<String>> stateData =
+          ImmutableMap.of(
+              iterableSideInputKey(
+                  singletonSideInputView.getTagInternal().getId(), ByteString.EMPTY),
+              asList("8"));
+
+      FakeBeamFnStateClient fakeClient = new FakeBeamFnStateClient(StringUtf8Coder.of(), stateData);
+
+      BundleSplitListener.InMemory splitListener = BundleSplitListener.InMemory.create();
+
+      PTransformRunnerFactoryTestContext context =
+          PTransformRunnerFactoryTestContext.builder(TEST_TRANSFORM_ID, pTransform)
+              .beamFnStateClient(fakeClient)
+              .processBundleInstructionId("57")
+              .pCollections(pProto.getComponentsOrBuilder().getPcollectionsMap())
+              .coders(pProto.getComponents().getCodersMap())
+              .windowingStrategies(pProto.getComponents().getWindowingStrategiesMap())
+              .splitListener(splitListener)
+              .build();
+      List<WindowedValue<String>> mainOutputValues = new ArrayList<>();
+      context.addPCollectionConsumer(
+          outputPCollectionId,
+          (FnDataReceiver) (FnDataReceiver<WindowedValue<String>>) mainOutputValues::add);
+
+      new FnApiDoFnRunner.Factory<>().createRunnerForPTransform(context);
+
+      Iterables.getOnlyElement(context.getStartBundleFunctions()).run();
+      mainOutputValues.clear();
+
+      assertThat(
+          context.getPCollectionConsumers().keySet(),
+          containsInAnyOrder(inputPCollectionId, outputPCollectionId));
+
+      FnDataReceiver<WindowedValue<?>> mainInput =
+          context.getPCollectionConsumer(inputPCollectionId);
+      assertThat(mainInput, instanceOf(HandlesSplits.class));
+
+      doFn.setupBlockProcess();
+      {
+        // Setup and launch the trySplit thread.
+        ExecutorService executorService = Executors.newSingleThreadExecutor();
+        Future<HandlesSplits.SplitResult> trySplitFuture =
+            executorService.submit(
+                () -> {
+                  try {
+                    // Verify that a split before anything is claimed is ignored.
+                    doFn.waitForProcessEntered();
+                    Assert.assertNull(((HandlesSplits) mainInput).trySplit(0));
+                    doFn.unblockProcess();
+
+                    doFn.waitForSplitElementToBeProcessed();
+                    // Currently processing "3" out of range [0, 5) elements.
+                    assertEquals(0.6, ((HandlesSplits) mainInput).getProgress(), 0.01);
+
+                    // Check that during progressing of an element we report progress
+                    assertReportedProgressEquals(
+                        context.getShortIdMap(), context.getBundleProgressReporters(), 3.0, 2.0);
+
+                    return ((HandlesSplits) mainInput).trySplit(0);
+                  } finally {
+                    doFn.trySplitPerformed();
                   }
                 });
 
@@ -2187,7 +2435,7 @@ public class FnApiDoFnRunnerTest implements Serializable {
 
                     return ((HandlesSplits) mainInput).trySplit(0);
                   } finally {
-                    doFn.releaseWaitingProcessElementThread();
+                    doFn.trySplitPerformed();
                   }
                 });
 
@@ -3143,10 +3391,11 @@ public class FnApiDoFnRunnerTest implements Serializable {
               () -> {
                 try {
                   doFn.waitForSplitElementToBeProcessed();
-
-                  return ((HandlesSplits) mainInput).trySplit(0);
+                  HandlesSplits.SplitResult result = ((HandlesSplits) mainInput).trySplit(0);
+                  Assert.assertNotNull(result);
+                  return result;
                 } finally {
-                  doFn.releaseWaitingProcessElementThread();
+                  doFn.trySplitPerformed();
                 }
               });
 


### PR DESCRIPTION
This ensures that an SDF makes progress if the runner repeatedly attempts to split the restriction before work has been claimed.
This affects the Dataflow Runner which attempts to split in streaming pipelines after 5 seconds by default. If the SDF takes over 5 seconds to read the first element and attempt to claim it, the split will occur first, checkpointing the same restriction and the element will be dropped. On retry, it will resume from the same restriction and this may repeat.

This matches the behavior of the core java sdf invoker [here](https://github.com/apache/beam/blob/2f93d8bc19917f83d15f531bcbbfb7f36e21ff88/runners/core-java/src/main/java/org/apache/beam/runners/core/OutputAndTimeBoundedSplittableProcessElementInvoker.java#L309) which didn't start the split thread until the tryClaim was observed.  Having the sdk ignore such split requests seems better than requiring the runner to attempt to time the split better as the sdf may be making progress just not returning any data yet to the runner.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
