### PR TITLE
make FieldValueTypeInformation creators take a TypeDescriptor parameter

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/AutoValueSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/AutoValueSchema.java
@@ -62,7 +62,7 @@ public class AutoValueSchema extends GetterBasedSchemaProviderV2 {
               .collect(Collectors.toList());
       List<FieldValueTypeInformation> types = Lists.newArrayListWithCapacity(methods.size());
       for (int i = 0; i < methods.size(); ++i) {
-        types.add(FieldValueTypeInformation.forGetter(methods.get(i), i));
+        types.add(FieldValueTypeInformation.forGetter(typeDescriptor, methods.get(i), i));
       }
       types.sort(Comparator.comparing(FieldValueTypeInformation::getNumber));
       validateFieldNumbers(types);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/CachingFactory.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/CachingFactory.java
@@ -20,6 +20,8 @@ package org.apache.beam.sdk.schemas;
 import java.util.Objects;
 import java.util.concurrent.ConcurrentHashMap;
 import org.apache.beam.sdk.values.TypeDescriptor;
+import org.checkerframework.checker.initialization.qual.NotOnlyInitialized;
+import org.checkerframework.checker.initialization.qual.UnknownInitialization;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -39,9 +41,9 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class CachingFactory<CreatedT> implements Factory<CreatedT> {
   private transient @Nullable ConcurrentHashMap<TypeDescriptor<?>, CreatedT> cache = null;
 
-  private final Factory<CreatedT> innerFactory;
+  private final @NotOnlyInitialized Factory<CreatedT> innerFactory;
 
-  public CachingFactory(Factory<CreatedT> innerFactory) {
+  public CachingFactory(@UnknownInitialization Factory<CreatedT> innerFactory) {
     this.innerFactory = innerFactory;
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FieldValueGetter.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FieldValueGetter.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.schemas;
 
 import java.io.Serializable;
 import org.apache.beam.sdk.annotations.Internal;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -29,7 +30,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * <p>Implementations of this interface are generated at runtime to map object fields to Row fields.
  */
 @Internal
-public interface FieldValueGetter<ObjectT, ValueT> extends Serializable {
+public interface FieldValueGetter<ObjectT extends @NonNull Object, ValueT> extends Serializable {
   @Nullable
   ValueT get(ObjectT object);
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FieldValueTypeInformation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FieldValueTypeInformation.java
@@ -41,10 +41,6 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** Represents type information for a Java type that will be used to infer a Schema type. */
 @AutoValue
-@SuppressWarnings({
-  "nullness", // TODO(https://github.com/apache/beam/issues/20497)
-  "rawtypes"
-})
 public abstract class FieldValueTypeInformation implements Serializable {
   /** Optionally returns the field index. */
   public abstract @Nullable Integer getNumber();
@@ -350,10 +346,9 @@ public abstract class FieldValueTypeInformation implements Serializable {
 
   // If the Field is a map type, returns the key or value type (0 is key type, 1 is value).
   // Otherwise returns a null reference.
-  @SuppressWarnings("unchecked")
   private static @Nullable FieldValueTypeInformation getMapType(
       TypeDescriptor<?> valueType, int index) {
-    TypeDescriptor mapType = ReflectUtils.getMapType(valueType, index);
+    TypeDescriptor<?> mapType = ReflectUtils.getMapType(valueType, index);
     if (mapType == null) {
       return null;
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FieldValueTypeInformation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FieldValueTypeInformation.java
@@ -29,6 +29,7 @@ import java.util.Collections;
 import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Stream;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.schemas.annotations.SchemaCaseFormat;
 import org.apache.beam.sdk.schemas.annotations.SchemaFieldDescription;
 import org.apache.beam.sdk.schemas.annotations.SchemaFieldName;
@@ -41,6 +42,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** Represents type information for a Java type that will be used to infer a Schema type. */
 @AutoValue
+@Internal
 public abstract class FieldValueTypeInformation implements Serializable {
   /** Optionally returns the field index. */
   public abstract @Nullable Integer getNumber();
@@ -120,10 +122,6 @@ public abstract class FieldValueTypeInformation implements Serializable {
         .setMapValueType(null)
         .setOneOfTypes(oneOfTypes)
         .build();
-  }
-
-  public static FieldValueTypeInformation forField(Field field, int index) {
-    return forField(null, field, index);
   }
 
   public static FieldValueTypeInformation forField(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/GetterBasedSchemaProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/GetterBasedSchemaProvider.java
@@ -17,13 +17,12 @@
  */
 package org.apache.beam.sdk.schemas;
 
-import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState;
-
 import java.util.ArrayList;
 import java.util.Collection;
 import java.util.List;
 import java.util.Map;
 import java.util.Objects;
+import java.util.Optional;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.Schema.LogicalType;
 import org.apache.beam.sdk.schemas.Schema.TypeName;
@@ -32,10 +31,13 @@ import org.apache.beam.sdk.schemas.logicaltypes.OneOfType;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Verify;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Collections2;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Maps;
+import org.checkerframework.checker.initialization.qual.NotOnlyInitialized;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -46,10 +48,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  *     methods which receive {@link TypeDescriptor}s instead of ordinary {@link Class}es as
  *     arguments, which permits to support generic type signatures during schema inference
  */
-@SuppressWarnings({
-  "nullness", // TODO(https://github.com/apache/beam/issues/20497)
-  "rawtypes"
-})
+@SuppressWarnings({"rawtypes"})
 @Deprecated
 public abstract class GetterBasedSchemaProvider implements SchemaProvider {
 
@@ -67,9 +66,9 @@ public abstract class GetterBasedSchemaProvider implements SchemaProvider {
    * override it if you want to use the richer type signature contained in the {@link
    * TypeDescriptor} not subject to the type erasure.
    */
-  public List<FieldValueGetter> fieldValueGetters(
-      TypeDescriptor<?> targetTypeDescriptor, Schema schema) {
-    return fieldValueGetters(targetTypeDescriptor.getRawType(), schema);
+  public <T> List<FieldValueGetter<@NonNull T, Object>> fieldValueGetters(
+      TypeDescriptor<T> targetTypeDescriptor, Schema schema) {
+    return (List) fieldValueGetters(targetTypeDescriptor.getRawType(), schema);
   }
 
   /**
@@ -112,9 +111,10 @@ public abstract class GetterBasedSchemaProvider implements SchemaProvider {
     return schemaTypeCreator(targetTypeDescriptor.getRawType(), schema);
   }
 
-  private class ToRowWithValueGetters<T> implements SerializableFunction<T, Row> {
+  private class ToRowWithValueGetters<T extends @NonNull Object>
+      implements SerializableFunction<T, Row> {
     private final Schema schema;
-    private final Factory<List<FieldValueGetter>> getterFactory;
+    private final Factory<List<FieldValueGetter<?, ?>>> getterFactory;
 
     public ToRowWithValueGetters(Schema schema) {
       this.schema = schema;
@@ -122,12 +122,17 @@ public abstract class GetterBasedSchemaProvider implements SchemaProvider {
       // schema, return a caching factory that caches the first value seen for each class. This
       // prevents having to lookup the getter list each time createGetters is called.
       this.getterFactory =
-          RowValueGettersFactory.of(GetterBasedSchemaProvider.this::fieldValueGetters);
+          RowValueGettersFactory.of(
+              (Factory<List<FieldValueGetter<?, ?>>>)
+                  (typeDescriptor, schema1) ->
+                      (List)
+                          GetterBasedSchemaProvider.this.fieldValueGetters(
+                              typeDescriptor, schema1));
     }
 
     @Override
     public Row apply(T input) {
-      return Row.withSchema(schema).withFieldValueGetters(getterFactory, input);
+      return Row.withSchema(schema).withFieldValueGetters((Factory) getterFactory, input);
     }
 
     private GetterBasedSchemaProvider getOuter() {
@@ -160,13 +165,15 @@ public abstract class GetterBasedSchemaProvider implements SchemaProvider {
     // important to capture the schema once here, so all invocations of the toRowFunction see the
     // same version of the schema. If schemaFor were to be called inside the lambda below, different
     // workers would see different versions of the schema.
-    Schema schema = schemaFor(typeDescriptor);
+    @NonNull
+    Schema schema =
+        Verify.verifyNotNull(
+            schemaFor(typeDescriptor), "can't create a ToRowFunction with null schema");
 
     return new ToRowWithValueGetters<>(schema);
   }
 
   @Override
-  @SuppressWarnings("unchecked")
   public <T> SerializableFunction<Row, T> fromRowFunction(TypeDescriptor<T> typeDescriptor) {
     return new FromRowUsingCreator<>(typeDescriptor, this);
   }
@@ -181,23 +188,24 @@ public abstract class GetterBasedSchemaProvider implements SchemaProvider {
     return obj != null && this.getClass() == obj.getClass();
   }
 
-  private static class RowValueGettersFactory implements Factory<List<FieldValueGetter>> {
-    private final Factory<List<FieldValueGetter>> gettersFactory;
-    private final Factory<List<FieldValueGetter>> cachingGettersFactory;
+  private static class RowValueGettersFactory implements Factory<List<FieldValueGetter<?, ?>>> {
+    private final Factory<List<FieldValueGetter<?, ?>>> gettersFactory;
+    private final @NotOnlyInitialized Factory<List<FieldValueGetter<?, ?>>> cachingGettersFactory;
 
-    static Factory<List<FieldValueGetter>> of(Factory<List<FieldValueGetter>> gettersFactory) {
+    static Factory<List<FieldValueGetter<?, ?>>> of(
+        Factory<List<FieldValueGetter<?, ?>>> gettersFactory) {
       return new RowValueGettersFactory(gettersFactory).cachingGettersFactory;
     }
 
-    RowValueGettersFactory(Factory<List<FieldValueGetter>> gettersFactory) {
+    RowValueGettersFactory(Factory<List<FieldValueGetter<?, ?>>> gettersFactory) {
       this.gettersFactory = gettersFactory;
       this.cachingGettersFactory = new CachingFactory<>(this);
     }
 
     @Override
-    public List<FieldValueGetter> create(TypeDescriptor<?> typeDescriptor, Schema schema) {
-      List<FieldValueGetter> getters = gettersFactory.create(typeDescriptor, schema);
-      List<FieldValueGetter> rowGetters = new ArrayList<>(getters.size());
+    public List<FieldValueGetter<?, ?>> create(TypeDescriptor<?> typeDescriptor, Schema schema) {
+      List<FieldValueGetter<?, ?>> getters = gettersFactory.create(typeDescriptor, schema);
+      List<FieldValueGetter<?, ?>> rowGetters = new ArrayList<>(getters.size());
       for (int i = 0; i < getters.size(); i++) {
         rowGetters.add(rowValueGetter(getters.get(i), schema.getField(i).getType()));
       }
@@ -209,71 +217,80 @@ public abstract class GetterBasedSchemaProvider implements SchemaProvider {
       return typeName.equals(TypeName.ROW)
           || typeName.isLogicalType()
           || ((typeName.equals(TypeName.ARRAY) || typeName.equals(TypeName.ITERABLE))
-              && needsConversion(type.getCollectionElementType()))
+              && needsConversion(Verify.verifyNotNull(type.getCollectionElementType())))
           || (typeName.equals(TypeName.MAP)
-              && (needsConversion(type.getMapKeyType())
-                  || needsConversion(type.getMapValueType())));
+              && (needsConversion(Verify.verifyNotNull(type.getMapKeyType()))
+                  || needsConversion(Verify.verifyNotNull(type.getMapValueType()))));
     }
 
-    FieldValueGetter rowValueGetter(FieldValueGetter base, FieldType type) {
+    FieldValueGetter<?, ?> rowValueGetter(FieldValueGetter base, FieldType type) {
       TypeName typeName = type.getTypeName();
       if (!needsConversion(type)) {
         return base;
       }
       if (typeName.equals(TypeName.ROW)) {
-        return new GetRow(base, type.getRowSchema(), cachingGettersFactory);
+        return new GetRow(base, Verify.verifyNotNull(type.getRowSchema()), cachingGettersFactory);
       } else if (typeName.equals(TypeName.ARRAY)) {
-        FieldType elementType = type.getCollectionElementType();
+        FieldType elementType = Verify.verifyNotNull(type.getCollectionElementType());
         return elementType.getTypeName().equals(TypeName.ROW)
             ? new GetEagerCollection(base, converter(elementType))
             : new GetCollection(base, converter(elementType));
       } else if (typeName.equals(TypeName.ITERABLE)) {
-        return new GetIterable(base, converter(type.getCollectionElementType()));
+        return new GetIterable(
+            base, converter(Verify.verifyNotNull(type.getCollectionElementType())));
       } else if (typeName.equals(TypeName.MAP)) {
-        return new GetMap(base, converter(type.getMapKeyType()), converter(type.getMapValueType()));
+        return new GetMap(
+            base,
+            converter(Verify.verifyNotNull(type.getMapKeyType())),
+            converter(Verify.verifyNotNull(type.getMapValueType())));
       } else if (type.isLogicalType(OneOfType.IDENTIFIER)) {
         OneOfType oneOfType = type.getLogicalType(OneOfType.class);
         Schema oneOfSchema = oneOfType.getOneOfSchema();
         Map<String, Integer> values = oneOfType.getCaseEnumType().getValuesMap();
 
-        Map<Integer, FieldValueGetter> converters = Maps.newHashMapWithExpectedSize(values.size());
+        Map<Integer, FieldValueGetter<?, ?>> converters =
+            Maps.newHashMapWithExpectedSize(values.size());
         for (Map.Entry<String, Integer> kv : values.entrySet()) {
           FieldType fieldType = oneOfSchema.getField(kv.getKey()).getType();
-          FieldValueGetter converter = converter(fieldType);
+          FieldValueGetter<?, ?> converter = converter(fieldType);
           converters.put(kv.getValue(), converter);
         }
 
         return new GetOneOf(base, converters, oneOfType);
       } else if (typeName.isLogicalType()) {
-        return new GetLogicalInputType(base, type.getLogicalType());
+        return new GetLogicalInputType(base, Verify.verifyNotNull(type.getLogicalType()));
       }
       return base;
     }
 
-    FieldValueGetter converter(FieldType type) {
+    FieldValueGetter<?, ?> converter(FieldType type) {
       return rowValueGetter(IDENTITY, type);
     }
 
-    static class GetRow extends Converter<Object> {
+    static class GetRow<T extends @NonNull Object, V extends @NonNull Object>
+        extends Converter<T, V> {
       final Schema schema;
-      final Factory<List<FieldValueGetter>> factory;
+      final Factory<List<FieldValueGetter<V, ?>>> factory;
 
-      GetRow(FieldValueGetter getter, Schema schema, Factory<List<FieldValueGetter>> factory) {
+      GetRow(
+          FieldValueGetter<T, V> getter,
+          Schema schema,
+          Factory<List<FieldValueGetter<V, ?>>> factory) {
         super(getter);
         this.schema = schema;
         this.factory = factory;
       }
 
       @Override
-      Object convert(Object value) {
+      Object convert(V value) {
         return Row.withSchema(schema).withFieldValueGetters(factory, value);
       }
     }
 
-    static class GetEagerCollection extends Converter<Collection> {
+    static class GetEagerCollection<T extends @NonNull Object> extends Converter<T, Collection> {
       final FieldValueGetter converter;
 
-      GetEagerCollection(FieldValueGetter getter, FieldValueGetter converter) {
+      GetEagerCollection(FieldValueGetter<T, Collection> getter, FieldValueGetter converter) {
         super(getter);
         this.converter = converter;
       }
@@ -288,15 +305,16 @@ public abstract class GetterBasedSchemaProvider implements SchemaProvider {
       }
     }
 
-    static class GetCollection extends Converter<Collection> {
+    static class GetCollection<T extends @NonNull Object> extends Converter<T, Collection> {
       final FieldValueGetter converter;
 
-      GetCollection(FieldValueGetter getter, FieldValueGetter converter) {
+      GetCollection(FieldValueGetter<T, Collection> getter, FieldValueGetter converter) {
         super(getter);
         this.converter = converter;
       }
 
       @Override
+      @SuppressWarnings({"nullness"})
       Object convert(Collection collection) {
         if (collection instanceof List) {
           // For performance reasons if the input is a list, make sure that we produce a list.
@@ -309,45 +327,51 @@ public abstract class GetterBasedSchemaProvider implements SchemaProvider {
       }
     }
 
-    static class GetIterable extends Converter<Iterable> {
+    static class GetIterable<T extends @NonNull Object> extends Converter<T, Iterable> {
       final FieldValueGetter converter;
 
-      GetIterable(FieldValueGetter getter, FieldValueGetter converter) {
+      GetIterable(FieldValueGetter<T, Iterable> getter, FieldValueGetter converter) {
         super(getter);
         this.converter = converter;
       }
 
       @Override
+      @SuppressWarnings({"nullness"})
       Object convert(Iterable value) {
         return Iterables.transform(value, converter::get);
       }
     }
 
-    static class GetMap extends Converter<Map<?, ?>> {
-      final FieldValueGetter keyConverter;
-      final FieldValueGetter valueConverter;
+    static class GetMap<T extends @NonNull Object, K1, K2, V1, V2>
+        extends Converter<T, Map<@Nullable K1, @Nullable V1>> {
+      final FieldValueGetter<@NonNull K1, K2> keyConverter;
+      final FieldValueGetter<@NonNull V1, V2> valueConverter;
 
       GetMap(
-          FieldValueGetter getter, FieldValueGetter keyConverter, FieldValueGetter valueConverter) {
+          FieldValueGetter<T, Map<@Nullable K1, @Nullable V1>> getter,
+          FieldValueGetter<@NonNull K1, K2> keyConverter,
+          FieldValueGetter<@NonNull V1, V2> valueConverter) {
         super(getter);
         this.keyConverter = keyConverter;
         this.valueConverter = valueConverter;
       }
 
       @Override
-      Object convert(Map<?, ?> value) {
-        Map returnMap = Maps.newHashMapWithExpectedSize(value.size());
-        for (Map.Entry<?, ?> entry : value.entrySet()) {
-          returnMap.put(keyConverter.get(entry.getKey()), valueConverter.get(entry.getValue()));
+      Map<@Nullable K2, @Nullable V2> convert(Map<@Nullable K1, @Nullable V1> value) {
+        Map<@Nullable K2, @Nullable V2> returnMap = Maps.newHashMapWithExpectedSize(value.size());
+        for (Map.Entry<@Nullable K1, @Nullable V1> entry : value.entrySet()) {
+          returnMap.put(
+              Optional.ofNullable(entry.getKey()).map(keyConverter::get).orElse(null),
+              Optional.ofNullable(entry.getValue()).map(valueConverter::get).orElse(null));
         }
         return returnMap;
       }
     }
 
-    static class GetLogicalInputType extends Converter<Object> {
+    static class GetLogicalInputType<T extends @NonNull Object> extends Converter<T, Object> {
       final LogicalType logicalType;
 
-      GetLogicalInputType(FieldValueGetter getter, LogicalType logicalType) {
+      GetLogicalInputType(FieldValueGetter<T, Object> getter, LogicalType logicalType) {
         super(getter);
         this.logicalType = logicalType;
       }
@@ -359,12 +383,14 @@ public abstract class GetterBasedSchemaProvider implements SchemaProvider {
       }
     }
 
-    static class GetOneOf extends Converter<OneOfType.Value> {
+    static class GetOneOf<T extends @NonNull Object> extends Converter<T, OneOfType.Value> {
       final OneOfType oneOfType;
-      final Map<Integer, FieldValueGetter> converters;
+      final Map<Integer, FieldValueGetter<@NonNull Object, Object>> converters;
 
       GetOneOf(
-          FieldValueGetter getter, Map<Integer, FieldValueGetter> converters, OneOfType oneOfType) {
+          FieldValueGetter<T, OneOfType.Value> getter,
+          Map<Integer, FieldValueGetter<@NonNull Object, Object>> converters,
+          OneOfType oneOfType) {
         super(getter);
         this.converters = converters;
         this.oneOfType = oneOfType;
@@ -373,24 +399,31 @@ public abstract class GetterBasedSchemaProvider implements SchemaProvider {
       @Override
       Object convert(OneOfType.Value value) {
         EnumerationType.Value caseType = value.getCaseType();
-        FieldValueGetter converter = converters.get(caseType.getValue());
-        checkState(converter != null, "Missing OneOf converter for case %s.", caseType);
+
+        @NonNull
+        FieldValueGetter<@NonNull Object, Object> converter =
+            Verify.verifyNotNull(
+                converters.get(caseType.getValue()),
+                "Missing OneOf converter for case %s.",
+                caseType);
+
         return oneOfType.createValue(caseType, converter.get(value.getValue()));
       }
     }
 
-    abstract static class Converter<T> implements FieldValueGetter {
-      final FieldValueGetter getter;
+    abstract static class Converter<ObjectT extends @NonNull Object, ValueT>
+        implements FieldValueGetter<ObjectT, Object> {
+      final FieldValueGetter<ObjectT, ValueT> getter;
 
-      public Converter(FieldValueGetter getter) {
+      public Converter(FieldValueGetter<ObjectT, ValueT> getter) {
         this.getter = getter;
       }
 
-      abstract Object convert(T value);
+      abstract Object convert(ValueT value);
 
       @Override
-      public @Nullable Object get(Object object) {
-        T value = (T) getter.get(object);
+      public @Nullable Object get(ObjectT object) {
+        ValueT value = getter.get(object);
         if (value == null) {
           return null;
         }
@@ -398,7 +431,7 @@ public abstract class GetterBasedSchemaProvider implements SchemaProvider {
       }
 
       @Override
-      public @Nullable Object getRaw(Object object) {
+      public @Nullable Object getRaw(ObjectT object) {
         return getter.getRaw(object);
       }
 
@@ -408,16 +441,16 @@ public abstract class GetterBasedSchemaProvider implements SchemaProvider {
       }
     }
 
-    private static final FieldValueGetter IDENTITY =
-        new FieldValueGetter() {
+    private static final FieldValueGetter<@NonNull Object, Object> IDENTITY =
+        new FieldValueGetter<@NonNull Object, Object>() {
           @Override
-          public @Nullable Object get(Object object) {
+          public Object get(@NonNull Object object) {
             return object;
           }
 
           @Override
           public String name() {
-            return null;
+            return "IDENTITY";
           }
         };
   }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/GetterBasedSchemaProviderV2.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/GetterBasedSchemaProviderV2.java
@@ -19,6 +19,7 @@ package org.apache.beam.sdk.schemas;
 
 import java.util.List;
 import org.apache.beam.sdk.values.TypeDescriptor;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * A newer version of {@link GetterBasedSchemaProvider}, which works with {@link TypeDescriptor}s,
@@ -28,12 +29,12 @@ import org.apache.beam.sdk.values.TypeDescriptor;
 public abstract class GetterBasedSchemaProviderV2 extends GetterBasedSchemaProvider {
   @Override
   public List<FieldValueGetter> fieldValueGetters(Class<?> targetClass, Schema schema) {
-    return fieldValueGetters(TypeDescriptor.of(targetClass), schema);
+    return (List) fieldValueGetters(TypeDescriptor.of(targetClass), schema);
   }
 
   @Override
-  public abstract List<FieldValueGetter> fieldValueGetters(
-      TypeDescriptor<?> targetTypeDescriptor, Schema schema);
+  public abstract <T> List<FieldValueGetter<@NonNull T, Object>> fieldValueGetters(
+      TypeDescriptor<T> targetTypeDescriptor, Schema schema);
 
   @Override
   public List<FieldValueTypeInformation> fieldValueTypeInformations(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaBeanSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaBeanSchema.java
@@ -19,7 +19,6 @@ package org.apache.beam.sdk.schemas;
 
 import java.lang.reflect.Constructor;
 import java.lang.reflect.Method;
-import java.util.Comparator;
 import java.util.List;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.schemas.annotations.SchemaCaseFormat;
@@ -34,6 +33,7 @@ import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /**
@@ -49,10 +49,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * <p>TODO: Validate equals() method is provided, and if not generate a "slow" equals method based
  * on the schema.
  */
-@SuppressWarnings({
-  "nullness", // TODO(https://github.com/apache/beam/issues/20497)
-  "rawtypes"
-})
+@SuppressWarnings({"rawtypes"})
 public class JavaBeanSchema extends GetterBasedSchemaProviderV2 {
   /** {@link FieldValueTypeSupplier} that's based on getter methods. */
   @VisibleForTesting
@@ -70,7 +67,7 @@ public class JavaBeanSchema extends GetterBasedSchemaProviderV2 {
       for (int i = 0; i < methods.size(); ++i) {
         types.add(FieldValueTypeInformation.forGetter(typeDescriptor, methods.get(i), i));
       }
-      types.sort(Comparator.comparing(FieldValueTypeInformation::getNumber));
+      types.sort(JavaBeanUtils.comparingNullFirst(FieldValueTypeInformation::getNumber));
       validateFieldNumbers(types);
       return types;
     }
@@ -117,26 +114,29 @@ public class JavaBeanSchema extends GetterBasedSchemaProviderV2 {
           .map(m -> FieldValueTypeInformation.forSetter(typeDescriptor, m))
           .map(
               t -> {
-                if (t.getMethod().getAnnotation(SchemaFieldNumber.class) != null) {
+                Method m =
+                    Preconditions.checkNotNull(
+                        t.getMethod(), JavaBeanUtils.SETTER_WITH_NULL_METHOD_ERROR);
+                if (m.getAnnotation(SchemaFieldNumber.class) != null) {
                   throw new RuntimeException(
                       String.format(
                           "@SchemaFieldNumber can only be used on getters in Java Beans. Found on"
                               + " setter '%s'",
-                          t.getMethod().getName()));
+                          m.getName()));
                 }
-                if (t.getMethod().getAnnotation(SchemaFieldName.class) != null) {
+                if (m.getAnnotation(SchemaFieldName.class) != null) {
                   throw new RuntimeException(
                       String.format(
                           "@SchemaFieldName can only be used on getters in Java Beans. Found on"
                               + " setter '%s'",
-                          t.getMethod().getName()));
+                          m.getName()));
                 }
-                if (t.getMethod().getAnnotation(SchemaCaseFormat.class) != null) {
+                if (m.getAnnotation(SchemaCaseFormat.class) != null) {
                   throw new RuntimeException(
                       String.format(
                           "@SchemaCaseFormat can only be used on getters in Java Beans. Found on"
                               + " setter '%s'",
-                          t.getMethod().getName()));
+                          m.getName()));
                 }
                 return t;
               })
@@ -172,8 +172,8 @@ public class JavaBeanSchema extends GetterBasedSchemaProviderV2 {
   }
 
   @Override
-  public List<FieldValueGetter> fieldValueGetters(
-      TypeDescriptor<?> targetTypeDescriptor, Schema schema) {
+  public <T> List<FieldValueGetter<@NonNull T, Object>> fieldValueGetters(
+      TypeDescriptor<T> targetTypeDescriptor, Schema schema) {
     return JavaBeanUtils.getGetters(
         targetTypeDescriptor,
         schema,

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaBeanSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaBeanSchema.java
@@ -68,7 +68,7 @@ public class JavaBeanSchema extends GetterBasedSchemaProviderV2 {
               .collect(Collectors.toList());
       List<FieldValueTypeInformation> types = Lists.newArrayListWithCapacity(methods.size());
       for (int i = 0; i < methods.size(); ++i) {
-        types.add(FieldValueTypeInformation.forGetter(methods.get(i), i));
+        types.add(FieldValueTypeInformation.forGetter(typeDescriptor, methods.get(i), i));
       }
       types.sort(Comparator.comparing(FieldValueTypeInformation::getNumber));
       validateFieldNumbers(types);
@@ -114,7 +114,7 @@ public class JavaBeanSchema extends GetterBasedSchemaProviderV2 {
       return ReflectUtils.getMethods(typeDescriptor.getRawType()).stream()
           .filter(ReflectUtils::isSetter)
           .filter(m -> !m.isAnnotationPresent(SchemaIgnore.class))
-          .map(FieldValueTypeInformation::forSetter)
+          .map(m -> FieldValueTypeInformation.forSetter(typeDescriptor, m))
           .map(
               t -> {
                 if (t.getMethod().getAnnotation(SchemaFieldNumber.class) != null) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaFieldSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaFieldSchema.java
@@ -21,20 +21,22 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
-import java.util.Comparator;
 import java.util.List;
 import java.util.Optional;
 import java.util.stream.Collectors;
+import java.util.stream.Stream;
 import javax.annotation.Nullable;
 import org.apache.beam.sdk.schemas.annotations.SchemaIgnore;
 import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.DefaultTypeConversionsFactory;
 import org.apache.beam.sdk.schemas.utils.FieldValueTypeSupplier;
+import org.apache.beam.sdk.schemas.utils.JavaBeanUtils;
 import org.apache.beam.sdk.schemas.utils.POJOUtils;
 import org.apache.beam.sdk.schemas.utils.ReflectUtils;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * A {@link SchemaProvider} for Java POJO objects.
@@ -49,7 +51,6 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
  * <p>TODO: Validate equals() method is provided, and if not generate a "slow" equals method based
  * on the schema.
  */
-@SuppressWarnings({"nullness", "rawtypes"})
 public class JavaFieldSchema extends GetterBasedSchemaProviderV2 {
   /** {@link FieldValueTypeSupplier} that's based on public fields. */
   @VisibleForTesting
@@ -66,7 +67,7 @@ public class JavaFieldSchema extends GetterBasedSchemaProviderV2 {
       for (int i = 0; i < fields.size(); ++i) {
         types.add(FieldValueTypeInformation.forField(typeDescriptor, fields.get(i), i));
       }
-      types.sort(Comparator.comparing(FieldValueTypeInformation::getNumber));
+      types.sort(JavaBeanUtils.comparingNullFirst(FieldValueTypeInformation::getNumber));
       validateFieldNumbers(types);
 
       // If there are no creators registered, then make sure none of the schema fields are final,
@@ -75,7 +76,9 @@ public class JavaFieldSchema extends GetterBasedSchemaProviderV2 {
           && ReflectUtils.getAnnotatedConstructor(typeDescriptor.getRawType()) == null) {
         Optional<Field> finalField =
             types.stream()
-                .map(FieldValueTypeInformation::getField)
+                .flatMap(
+                    fvti ->
+                        Optional.ofNullable(fvti.getField()).map(Stream::of).orElse(Stream.empty()))
                 .filter(f -> Modifier.isFinal(f.getModifiers()))
                 .findAny();
         if (finalField.isPresent()) {
@@ -115,8 +118,8 @@ public class JavaFieldSchema extends GetterBasedSchemaProviderV2 {
   }
 
   @Override
-  public List<FieldValueGetter> fieldValueGetters(
-      TypeDescriptor<?> targetTypeDescriptor, Schema schema) {
+  public <T> List<FieldValueGetter<@NonNull T, Object>> fieldValueGetters(
+      TypeDescriptor<T> targetTypeDescriptor, Schema schema) {
     return POJOUtils.getGetters(
         targetTypeDescriptor,
         schema,
@@ -149,7 +152,7 @@ public class JavaFieldSchema extends GetterBasedSchemaProviderV2 {
         ReflectUtils.getAnnotatedConstructor(targetTypeDescriptor.getRawType());
     if (constructor != null) {
       return POJOUtils.getConstructorCreator(
-          targetTypeDescriptor,
+          (TypeDescriptor) targetTypeDescriptor,
           constructor,
           schema,
           JavaFieldTypeSupplier.INSTANCE,

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaFieldSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaFieldSchema.java
@@ -64,7 +64,7 @@ public class JavaFieldSchema extends GetterBasedSchemaProviderV2 {
               .collect(Collectors.toList());
       List<FieldValueTypeInformation> types = Lists.newArrayListWithCapacity(fields.size());
       for (int i = 0; i < fields.size(); ++i) {
-        types.add(FieldValueTypeInformation.forField(fields.get(i), i));
+        types.add(FieldValueTypeInformation.forField(typeDescriptor, fields.get(i), i));
       }
       types.sort(Comparator.comparing(FieldValueTypeInformation::getNumber));
       validateFieldNumbers(types);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/Schema.java
@@ -89,6 +89,7 @@ public class Schema implements Serializable {
       return Arrays.toString(array);
     }
   }
+
   // A mapping between field names an indices.
   private final BiMap<String, Integer> fieldIndices = HashBiMap.create();
   private Map<String, Integer> encodingPositions = Maps.newHashMap();
@@ -823,10 +824,11 @@ public class Schema implements Serializable {
     public static FieldType map(FieldType keyType, FieldType valueType) {
       if (FieldType.BYTES.equals(keyType)) {
         LOG.warn(
-            "Using byte arrays as keys in a Map may lead to unexpected behavior and may not work as intended. "
-                + "Since arrays do not override equals() or hashCode, comparisons will be done on reference equality only. "
-                + "ByteBuffers, when used as keys, present similar challenges because Row stores ByteBuffer as a byte array. "
-                + "Consider using a different type of key for more consistent and predictable behavior.");
+            "Using byte arrays as keys in a Map may lead to unexpected behavior and may not work as"
+                + " intended. Since arrays do not override equals() or hashCode, comparisons will"
+                + " be done on reference equality only. ByteBuffers, when used as keys, present"
+                + " similar challenges because Row stores ByteBuffer as a byte array. Consider"
+                + " using a different type of key for more consistent and predictable behavior.");
       }
       return FieldType.forTypeName(TypeName.MAP)
           .setMapKeyType(keyType)
@@ -1436,7 +1438,7 @@ public class Schema implements Serializable {
   }
 
   /** Return the list of all field names. */
-  public List<String> getFieldNames() {
+  public List<@NonNull String> getFieldNames() {
     return getFields().stream().map(Schema.Field::getName).collect(Collectors.toList());
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AutoValueUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AutoValueUtils.java
@@ -27,6 +27,7 @@ import java.lang.reflect.Modifier;
 import java.lang.reflect.Parameter;
 import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
 import java.util.Optional;
@@ -204,11 +205,12 @@ public class AutoValueUtils {
       return null;
     }
 
-    Map<String, FieldValueTypeInformation> setterTypes =
-        ReflectUtils.getMethods(builderClass).stream()
-            .filter(ReflectUtils::isSetter)
-            .map(m -> FieldValueTypeInformation.forSetter(TypeDescriptor.of(builderClass), m))
-            .collect(Collectors.toMap(FieldValueTypeInformation::getName, Function.identity()));
+    Map<String, FieldValueTypeInformation> setterTypes = new HashMap<>();
+
+    ReflectUtils.getMethods(builderClass).stream()
+        .filter(ReflectUtils::isSetter)
+        .map(m -> FieldValueTypeInformation.forSetter(TypeDescriptor.of(builderClass), m))
+        .forEach(fv -> setterTypes.putIfAbsent(fv.getName(), fv));
 
     List<FieldValueTypeInformation> setterMethods =
         Lists.newArrayList(); // The builder methods to call in order.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AutoValueUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AutoValueUtils.java
@@ -199,7 +199,7 @@ public class AutoValueUtils {
     Map<String, FieldValueTypeInformation> setterTypes =
         ReflectUtils.getMethods(builderClass).stream()
             .filter(ReflectUtils::isSetter)
-            .map(FieldValueTypeInformation::forSetter)
+            .map(m -> FieldValueTypeInformation.forSetter(TypeDescriptor.of(builderClass), m))
             .collect(Collectors.toMap(FieldValueTypeInformation::getName, Function.identity()));
 
     List<FieldValueTypeInformation> setterMethods =

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/POJOUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/POJOUtils.java
@@ -62,8 +62,9 @@ import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils.TypeConversionsFactory;
 import org.apache.beam.sdk.schemas.utils.ReflectUtils.TypeDescriptorWithSchema;
 import org.apache.beam.sdk.util.common.ReflectHelpers;
 import org.apache.beam.sdk.values.TypeDescriptor;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Maps;
-import org.checkerframework.checker.nullness.qual.Nullable;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 /** A set of utilities to generate getter and setter classes for POJOs. */
 @SuppressWarnings({
@@ -94,38 +95,40 @@ public class POJOUtils {
 
   // The list of getters for a class is cached, so we only create the classes the first time
   // getSetters is called.
-  private static final Map<TypeDescriptorWithSchema, List<FieldValueGetter>> CACHED_GETTERS =
-      Maps.newConcurrentMap();
+  private static final Map<TypeDescriptorWithSchema<?>, List<FieldValueGetter<?, ?>>>
+      CACHED_GETTERS = Maps.newConcurrentMap();
 
-  public static List<FieldValueGetter> getGetters(
-      TypeDescriptor<?> typeDescriptor,
+  public static <T> List<FieldValueGetter<@NonNull T, Object>> getGetters(
+      TypeDescriptor<T> typeDescriptor,
       Schema schema,
       FieldValueTypeSupplier fieldValueTypeSupplier,
       TypeConversionsFactory typeConversionsFactory) {
     // Return the getters ordered by their position in the schema.
-    return CACHED_GETTERS.computeIfAbsent(
-        TypeDescriptorWithSchema.create(typeDescriptor, schema),
-        c -> {
-          List<FieldValueTypeInformation> types =
-              fieldValueTypeSupplier.get(typeDescriptor, schema);
-          List<FieldValueGetter> getters =
-              types.stream()
-                  .map(t -> createGetter(t, typeConversionsFactory))
-                  .collect(Collectors.toList());
-          if (getters.size() != schema.getFieldCount()) {
-            throw new RuntimeException(
-                "Was not able to generate getters for schema: "
-                    + schema
-                    + " class: "
-                    + typeDescriptor);
-          }
-          return getters;
-        });
+    return (List)
+        CACHED_GETTERS.computeIfAbsent(
+            TypeDescriptorWithSchema.create(typeDescriptor, schema),
+            c -> {
+              List<FieldValueTypeInformation> types =
+                  fieldValueTypeSupplier.get(typeDescriptor, schema);
+              List<FieldValueGetter<@NonNull T, Object>> getters =
+                  types.stream()
+                      .<FieldValueGetter<@NonNull T, Object>>map(
+                          t -> POJOUtils.createGetter(t, typeConversionsFactory))
+                      .collect(Collectors.toList());
+              if (getters.size() != schema.getFieldCount()) {
+                throw new RuntimeException(
+                    "Was not able to generate getters for schema: "
+                        + schema
+                        + " class: "
+                        + typeDescriptor);
+              }
+              return (List) getters;
+            });
   }
 
   // The list of constructors for a class is cached, so we only create the classes the first time
   // getConstructor is called.
-  public static final Map<TypeDescriptorWithSchema, SchemaUserTypeCreator> CACHED_CREATORS =
+  public static final Map<TypeDescriptorWithSchema<?>, SchemaUserTypeCreator> CACHED_CREATORS =
       Maps.newConcurrentMap();
 
   public static <T> SchemaUserTypeCreator getSetFieldCreator(
@@ -150,7 +153,9 @@ public class POJOUtils {
       TypeConversionsFactory typeConversionsFactory) {
     // Get the list of class fields ordered by schema.
     List<Field> fields =
-        types.stream().map(FieldValueTypeInformation::getField).collect(Collectors.toList());
+        types.stream()
+            .map(type -> Preconditions.checkNotNull(type.getField()))
+            .collect(Collectors.toList());
     try {
       DynamicType.Builder<SchemaUserTypeCreator> builder =
           BYTE_BUDDY
@@ -175,14 +180,16 @@ public class POJOUtils {
         | InvocationTargetException e) {
       throw new RuntimeException(
           String.format(
-              "Unable to generate a creator for POJO '%s' with inferred schema: %s%nNote POJOs must have a zero-argument constructor, or a constructor annotated with @SchemaCreate.",
+              "Unable to generate a creator for POJO '%s' with inferred schema: %s%nNote POJOs must"
+                  + " have a zero-argument constructor, or a constructor annotated with"
+                  + " @SchemaCreate.",
               clazz, schema));
     }
   }
 
-  public static SchemaUserTypeCreator getConstructorCreator(
-      TypeDescriptor<?> typeDescriptor,
-      Constructor constructor,
+  public static <T> SchemaUserTypeCreator getConstructorCreator(
+      TypeDescriptor<T> typeDescriptor,
+      Constructor<T> constructor,
       Schema schema,
       FieldValueTypeSupplier fieldValueTypeSupplier,
       TypeConversionsFactory typeConversionsFactory) {
@@ -191,13 +198,13 @@ public class POJOUtils {
         c -> {
           List<FieldValueTypeInformation> types =
               fieldValueTypeSupplier.get(typeDescriptor, schema);
-          return createConstructorCreator(
+          return POJOUtils.createConstructorCreator(
               typeDescriptor.getRawType(), constructor, schema, types, typeConversionsFactory);
         });
   }
 
   public static <T> SchemaUserTypeCreator createConstructorCreator(
-      Class<T> clazz,
+      Class<? super T> clazz,
       Constructor<T> constructor,
       Schema schema,
       List<FieldValueTypeInformation> types,
@@ -291,11 +298,10 @@ public class POJOUtils {
    *   }
    * </code></pre>
    */
-  @SuppressWarnings("unchecked")
-  static @Nullable <ObjectT, ValueT> FieldValueGetter<ObjectT, ValueT> createGetter(
+  static <ObjectT, ValueT> FieldValueGetter<@NonNull ObjectT, ValueT> createGetter(
       FieldValueTypeInformation typeInformation, TypeConversionsFactory typeConversionsFactory) {
-    Field field = typeInformation.getField();
-    DynamicType.Builder<FieldValueGetter> builder =
+    Field field = Preconditions.checkNotNull(typeInformation.getField());
+    DynamicType.Builder<FieldValueGetter<@NonNull ObjectT, ValueT>> builder =
         ByteBuddyUtils.subclassGetterInterface(
             BYTE_BUDDY,
             field.getDeclaringClass(),
@@ -322,11 +328,12 @@ public class POJOUtils {
     }
   }
 
-  private static DynamicType.Builder<FieldValueGetter> implementGetterMethods(
-      DynamicType.Builder<FieldValueGetter> builder,
-      Field field,
-      String name,
-      TypeConversionsFactory typeConversionsFactory) {
+  private static <ObjectT, ValueT>
+      DynamicType.Builder<FieldValueGetter<@NonNull ObjectT, ValueT>> implementGetterMethods(
+          DynamicType.Builder<FieldValueGetter<@NonNull ObjectT, ValueT>> builder,
+          Field field,
+          String name,
+          TypeConversionsFactory typeConversionsFactory) {
     return builder
         .visit(new AsmVisitorWrapper.ForDeclaredMethods().writerFlags(ClassWriter.COMPUTE_FRAMES))
         .method(ElementMatchers.named("name"))
@@ -337,24 +344,25 @@ public class POJOUtils {
 
   // The list of setters for a class is cached, so we only create the classes the first time
   // getSetters is called.
-  private static final Map<TypeDescriptorWithSchema, List<FieldValueSetter>> CACHED_SETTERS =
-      Maps.newConcurrentMap();
+  private static final Map<TypeDescriptorWithSchema<?>, List<FieldValueSetter<?, ?>>>
+      CACHED_SETTERS = Maps.newConcurrentMap();
 
-  public static List<FieldValueSetter> getSetters(
-      TypeDescriptor<?> typeDescriptor,
+  public static <T> List<FieldValueSetter<@NonNull T, Object>> getSetters(
+      TypeDescriptor<T> typeDescriptor,
       Schema schema,
       FieldValueTypeSupplier fieldValueTypeSupplier,
       TypeConversionsFactory typeConversionsFactory) {
     // Return the setters, ordered by their position in the schema.
-    return CACHED_SETTERS.computeIfAbsent(
-        TypeDescriptorWithSchema.create(typeDescriptor, schema),
-        c -> {
-          List<FieldValueTypeInformation> types =
-              fieldValueTypeSupplier.get(typeDescriptor, schema);
-          return types.stream()
-              .map(t -> createSetter(t, typeConversionsFactory))
-              .collect(Collectors.toList());
-        });
+    return (List)
+        CACHED_SETTERS.computeIfAbsent(
+            TypeDescriptorWithSchema.create(typeDescriptor, schema),
+            c -> {
+              List<FieldValueTypeInformation> types =
+                  fieldValueTypeSupplier.get(typeDescriptor, schema);
+              return types.stream()
+                  .map(t -> createSetter(t, typeConversionsFactory))
+                  .collect(Collectors.toList());
+            });
   }
 
   /**
@@ -376,8 +384,8 @@ public class POJOUtils {
   @SuppressWarnings("unchecked")
   private static <ObjectT, ValueT> FieldValueSetter<ObjectT, ValueT> createSetter(
       FieldValueTypeInformation typeInformation, TypeConversionsFactory typeConversionsFactory) {
-    Field field = typeInformation.getField();
-    DynamicType.Builder<FieldValueSetter> builder =
+    Field field = Preconditions.checkNotNull(typeInformation.getField());
+    DynamicType.Builder<FieldValueSetter<ObjectT, ValueT>> builder =
         ByteBuddyUtils.subclassSetterInterface(
             BYTE_BUDDY,
             field.getDeclaringClass(),
@@ -403,10 +411,11 @@ public class POJOUtils {
     }
   }
 
-  private static DynamicType.Builder<FieldValueSetter> implementSetterMethods(
-      DynamicType.Builder<FieldValueSetter> builder,
-      Field field,
-      TypeConversionsFactory typeConversionsFactory) {
+  private static <ObjectT, ValueT>
+      DynamicType.Builder<FieldValueSetter<ObjectT, ValueT>> implementSetterMethods(
+          DynamicType.Builder<FieldValueSetter<ObjectT, ValueT>> builder,
+          Field field,
+          TypeConversionsFactory typeConversionsFactory) {
     return builder
         .visit(new AsmVisitorWrapper.ForDeclaredMethods().writerFlags(ClassWriter.COMPUTE_FRAMES))
         .method(ElementMatchers.named("name"))
@@ -505,11 +514,11 @@ public class POJOUtils {
   // Implements a method to construct an object.
   static class SetFieldCreateInstruction implements Implementation {
     private final List<Field> fields;
-    private final Class pojoClass;
+    private final Class<?> pojoClass;
     private final TypeConversionsFactory typeConversionsFactory;
 
     SetFieldCreateInstruction(
-        List<Field> fields, Class pojoClass, TypeConversionsFactory typeConversionsFactory) {
+        List<Field> fields, Class<?> pojoClass, TypeConversionsFactory typeConversionsFactory) {
       this.fields = fields;
       this.pojoClass = pojoClass;
       this.typeConversionsFactory = typeConversionsFactory;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/common/ReflectHelpers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/common/ReflectHelpers.java
@@ -44,6 +44,7 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Fluent
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableSet;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableSortedSet;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Queues;
+import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** Utilities for working with with {@link Class Classes} and {@link Method Methods}. */
 @SuppressWarnings({"nullness", "keyfor"}) // TODO(https://github.com/apache/beam/issues/20497)
@@ -216,7 +217,7 @@ public class ReflectHelpers {
    * which by default would use the proposed {@code ClassLoader}, which can be null. The fallback is
    * as follows: context ClassLoader, class ClassLoader and finally the system ClassLoader.
    */
-  public static ClassLoader findClassLoader(final ClassLoader proposed) {
+  public static ClassLoader findClassLoader(@Nullable final ClassLoader proposed) {
     ClassLoader classLoader = proposed;
     if (classLoader == null) {
       classLoader = ReflectHelpers.class.getClassLoader();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
@@ -48,6 +48,7 @@ import org.apache.beam.sdk.values.RowUtils.FieldOverrides;
 import org.apache.beam.sdk.values.RowUtils.RowFieldMatcher;
 import org.apache.beam.sdk.values.RowUtils.RowPosition;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import org.joda.time.DateTime;
 import org.joda.time.ReadableDateTime;
@@ -771,6 +772,7 @@ public abstract class Row implements Serializable {
       checkState(values.isEmpty());
       return new FieldValueBuilder(schema, null).withFieldValue(fieldAccessDescriptor, value);
     }
+
     /**
      * Sets field values using the field names. Nested values can be set using the field selection
      * syntax.
@@ -836,10 +838,10 @@ public abstract class Row implements Serializable {
     }
 
     @Internal
-    public Row withFieldValueGetters(
-        Factory<List<FieldValueGetter>> fieldValueGetterFactory, Object getterTarget) {
+    public <T extends @NonNull Object> Row withFieldValueGetters(
+        Factory<List<FieldValueGetter<T, ?>>> fieldValueGetterFactory, T getterTarget) {
       checkState(getterTarget != null, "getters require withGetterTarget.");
-      return new RowWithGetters(schema, fieldValueGetterFactory, getterTarget);
+      return new RowWithGetters<>(schema, fieldValueGetterFactory, getterTarget);
     }
 
     public Row build() {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/Row.java
@@ -838,8 +838,8 @@ public abstract class Row implements Serializable {
     }
 
     @Internal
-    public <T extends @NonNull Object> Row withFieldValueGetters(
-        Factory<List<FieldValueGetter<T, ?>>> fieldValueGetterFactory, T getterTarget) {
+    public <@NonNull T> Row withFieldValueGetters(
+        Factory<List<FieldValueGetter<T, Object>>> fieldValueGetterFactory, T getterTarget) {
       checkState(getterTarget != null, "getters require withGetterTarget.");
       return new RowWithGetters<>(schema, fieldValueGetterFactory, getterTarget);
     }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/values/RowWithGetters.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/values/RowWithGetters.java
@@ -44,11 +44,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 @SuppressWarnings("rawtypes")
 public class RowWithGetters<T extends @NonNull Object> extends Row {
   private final T getterTarget;
-  private final List<FieldValueGetter<T, ?>> getters;
+  private final List<FieldValueGetter<T, Object>> getters;
   private @Nullable Map<Integer, @Nullable Object> cache = null;
 
   RowWithGetters(
-      Schema schema, Factory<List<FieldValueGetter<T, ?>>> getterFactory, T getterTarget) {
+      Schema schema, Factory<List<FieldValueGetter<T, Object>>> getterFactory, T getterTarget) {
     super(schema);
     this.getterTarget = getterTarget;
     this.getters = getterFactory.create(TypeDescriptor.of(getterTarget.getClass()), schema);
@@ -56,7 +56,7 @@ public class RowWithGetters<T extends @NonNull Object> extends Row {
 
   @Override
   @SuppressWarnings({"TypeParameterUnusedInFormals", "unchecked"})
-  public @Nullable Object getValue(int fieldIdx) {
+  public <W> W getValue(int fieldIdx) {
     Field field = getSchema().getField(fieldIdx);
     boolean cacheField = cacheFieldType(field);
 
@@ -75,8 +75,7 @@ public class RowWithGetters<T extends @NonNull Object> extends Row {
               new Function<Integer, @Nullable Object>() {
                 @Override
                 public @Nullable Object apply(Integer idx) {
-                  FieldValueGetter<T, Object> getter =
-                      (FieldValueGetter<T, Object>) getters.get(idx);
+                  FieldValueGetter<T, Object> getter = getters.get(idx);
                   checkStateNotNull(getter);
                   return getter.get(getterTarget);
                 }
@@ -88,7 +87,7 @@ public class RowWithGetters<T extends @NonNull Object> extends Row {
     if (fieldValue == null && !field.getType().getNullable()) {
       throw new RuntimeException("Null value set on non-nullable field " + field);
     }
-    return fieldValue;
+    return (W) fieldValue;
   }
 
   private boolean cacheFieldType(Field field) {
@@ -114,7 +113,7 @@ public class RowWithGetters<T extends @NonNull Object> extends Row {
     return rawValues;
   }
 
-  public List<FieldValueGetter<T, ?>> getGetters() {
+  public List<FieldValueGetter<T, Object>> getGetters() {
     return getters;
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/FieldValueTypeInformationTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/FieldValueTypeInformationTest.java
@@ -1,0 +1,70 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.schemas;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Map;
+import org.apache.beam.sdk.values.TypeDescriptor;
+import org.junit.Test;
+
+public class FieldValueTypeInformationTest {
+  public static class GenericClass<T> {
+    public T t;
+
+    public GenericClass(T t) {
+      this.t = t;
+    }
+
+    public T getT() {
+      return t;
+    }
+
+    public void setT(T t) {
+      this.t = t;
+    }
+  }
+
+  private final TypeDescriptor<GenericClass<Map<String, Integer>>> typeDescriptor =
+      new TypeDescriptor<GenericClass<Map<String, Integer>>>() {};
+  private final TypeDescriptor<Map<String, Integer>> expectedFieldTypeDescriptor =
+      new TypeDescriptor<Map<String, Integer>>() {};
+
+  @Test
+  public void testForGetter() throws Exception {
+    FieldValueTypeInformation actual =
+        FieldValueTypeInformation.forGetter(
+            typeDescriptor, GenericClass.class.getMethod("getT"), 0);
+    assertEquals(expectedFieldTypeDescriptor, actual.getType());
+  }
+
+  @Test
+  public void testForField() throws Exception {
+    FieldValueTypeInformation actual =
+        FieldValueTypeInformation.forField(typeDescriptor, GenericClass.class.getField("t"), 0);
+    assertEquals(expectedFieldTypeDescriptor, actual.getType());
+  }
+
+  @Test
+  public void testForSetter() throws Exception {
+    FieldValueTypeInformation actual =
+        FieldValueTypeInformation.forSetter(
+            typeDescriptor, GenericClass.class.getMethod("setT", Object.class));
+    assertEquals(expectedFieldTypeDescriptor, actual.getType());
+  }
+}

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtilsTest.java
@@ -53,6 +53,7 @@ import org.apache.beam.sdk.schemas.utils.TestJavaBeans.PrimitiveArrayBean;
 import org.apache.beam.sdk.schemas.utils.TestJavaBeans.PrimitiveMapBean;
 import org.apache.beam.sdk.schemas.utils.TestJavaBeans.SimpleBean;
 import org.apache.beam.sdk.values.TypeDescriptor;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.joda.time.DateTime;
 import org.junit.Test;
 
@@ -142,11 +143,11 @@ public class JavaBeanUtilsTest {
     simpleBean.setBigDecimal(new BigDecimal(42));
     simpleBean.setStringBuilder(new StringBuilder("stringBuilder"));
 
-    List<FieldValueGetter> getters =
+    List<FieldValueGetter<@NonNull SimpleBean, Object>> getters =
         JavaBeanUtils.getGetters(
             new TypeDescriptor<SimpleBean>() {},
             SIMPLE_BEAN_SCHEMA,
-            new JavaBeanSchema.GetterTypeSupplier(),
+            new GetterTypeSupplier(),
             new DefaultTypeConversionsFactory());
     assertEquals(12, getters.size());
     assertEquals("str", getters.get(0).name());
@@ -220,7 +221,7 @@ public class JavaBeanUtilsTest {
     bean.setaLong(44L);
     bean.setaBoolean(true);
 
-    List<FieldValueGetter> getters =
+    List<FieldValueGetter<@NonNull BeanWithBoxedFields, Object>> getters =
         JavaBeanUtils.getGetters(
             new TypeDescriptor<BeanWithBoxedFields>() {},
             BEAN_WITH_BOXED_FIELDS_SCHEMA,

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/POJOUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/POJOUtilsTest.java
@@ -52,6 +52,7 @@ import org.apache.beam.sdk.schemas.utils.TestPOJOs.PrimitiveArrayPOJO;
 import org.apache.beam.sdk.schemas.utils.TestPOJOs.PrimitiveMapPOJO;
 import org.apache.beam.sdk.schemas.utils.TestPOJOs.SimplePOJO;
 import org.apache.beam.sdk.values.TypeDescriptor;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.joda.time.DateTime;
 import org.joda.time.Instant;
 import org.junit.Test;
@@ -158,7 +159,7 @@ public class POJOUtilsTest {
             new BigDecimal(42),
             new StringBuilder("stringBuilder"));
 
-    List<FieldValueGetter> getters =
+    List<FieldValueGetter<SimplePOJO, Object>> getters =
         POJOUtils.getGetters(
             new TypeDescriptor<SimplePOJO>() {},
             SIMPLE_POJO_SCHEMA,
@@ -184,7 +185,7 @@ public class POJOUtilsTest {
   @Test
   public void testGeneratedSimpleSetters() {
     SimplePOJO simplePojo = new SimplePOJO();
-    List<FieldValueSetter> setters =
+    List<FieldValueSetter<SimplePOJO, Object>> setters =
         POJOUtils.getSetters(
             new TypeDescriptor<SimplePOJO>() {},
             SIMPLE_POJO_SCHEMA,
@@ -223,7 +224,7 @@ public class POJOUtilsTest {
   public void testGeneratedSimpleBoxedGetters() {
     POJOWithBoxedFields pojo = new POJOWithBoxedFields((byte) 41, (short) 42, 43, 44L, true);
 
-    List<FieldValueGetter> getters =
+    List<FieldValueGetter<@NonNull POJOWithBoxedFields, Object>> getters =
         POJOUtils.getGetters(
             new TypeDescriptor<POJOWithBoxedFields>() {},
             POJO_WITH_BOXED_FIELDS_SCHEMA,
@@ -239,7 +240,7 @@ public class POJOUtilsTest {
   @Test
   public void testGeneratedSimpleBoxedSetters() {
     POJOWithBoxedFields pojo = new POJOWithBoxedFields();
-    List<FieldValueSetter> setters =
+    List<FieldValueSetter<POJOWithBoxedFields, Object>> setters =
         POJOUtils.getSetters(
             new TypeDescriptor<POJOWithBoxedFields>() {},
             POJO_WITH_BOXED_FIELDS_SCHEMA,
@@ -262,7 +263,7 @@ public class POJOUtilsTest {
   @Test
   public void testGeneratedByteBufferSetters() {
     POJOWithByteArray pojo = new POJOWithByteArray();
-    List<FieldValueSetter> setters =
+    List<FieldValueSetter<POJOWithByteArray, Object>> setters =
         POJOUtils.getSetters(
             new TypeDescriptor<POJOWithByteArray>() {},
             POJO_WITH_BYTE_ARRAY_SCHEMA,

--- a/sdks/java/extensions/arrow/src/main/java/org/apache/beam/sdk/extensions/arrow/ArrowConversion.java
+++ b/sdks/java/extensions/arrow/src/main/java/org/apache/beam/sdk/extensions/arrow/ArrowConversion.java
@@ -276,11 +276,11 @@ public class ArrowConversion {
         new ArrowValueConverterVisitor();
     private final Schema schema;
     private final VectorSchemaRoot vectorSchemaRoot;
-    private final Factory<List<FieldValueGetter>> fieldValueGetters;
+    private final Factory<List<FieldValueGetter<Integer, ?>>> fieldValueGetters;
     private Integer currRowIndex;
 
     private static class FieldVectorListValueGetterFactory
-        implements Factory<List<FieldValueGetter>> {
+        implements Factory<List<FieldValueGetter<Integer, ?>>> {
       private final List<FieldVector> fieldVectors;
 
       static FieldVectorListValueGetterFactory of(List<FieldVector> fieldVectors) {
@@ -292,7 +292,8 @@ public class ArrowConversion {
       }
 
       @Override
-      public List<FieldValueGetter> create(TypeDescriptor<?> typeDescriptor, Schema schema) {
+      public List<FieldValueGetter<Integer, ?>> create(
+          TypeDescriptor<?> typeDescriptor, Schema schema) {
         return this.fieldVectors.stream()
             .map(
                 (fieldVector) -> {

--- a/sdks/java/extensions/arrow/src/main/java/org/apache/beam/sdk/extensions/arrow/ArrowConversion.java
+++ b/sdks/java/extensions/arrow/src/main/java/org/apache/beam/sdk/extensions/arrow/ArrowConversion.java
@@ -276,11 +276,11 @@ public class ArrowConversion {
         new ArrowValueConverterVisitor();
     private final Schema schema;
     private final VectorSchemaRoot vectorSchemaRoot;
-    private final Factory<List<FieldValueGetter<Integer, ?>>> fieldValueGetters;
+    private final Factory<List<FieldValueGetter<Integer, Object>>> fieldValueGetters;
     private Integer currRowIndex;
 
     private static class FieldVectorListValueGetterFactory
-        implements Factory<List<FieldValueGetter<Integer, ?>>> {
+        implements Factory<List<FieldValueGetter<Integer, Object>>> {
       private final List<FieldVector> fieldVectors;
 
       static FieldVectorListValueGetterFactory of(List<FieldVector> fieldVectors) {
@@ -292,7 +292,7 @@ public class ArrowConversion {
       }
 
       @Override
-      public List<FieldValueGetter<Integer, ?>> create(
+      public List<FieldValueGetter<Integer, Object>> create(
           TypeDescriptor<?> typeDescriptor, Schema schema) {
         return this.fieldVectors.stream()
             .map(

--- a/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/schemas/AvroRecordSchema.java
+++ b/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/schemas/AvroRecordSchema.java
@@ -26,6 +26,7 @@ import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.SchemaProvider;
 import org.apache.beam.sdk.schemas.SchemaUserTypeCreator;
 import org.apache.beam.sdk.values.TypeDescriptor;
+import org.checkerframework.checker.nullness.qual.NonNull;
 
 /**
  * A {@link SchemaProvider} for AVRO generated SpecificRecords and POJOs.
@@ -44,8 +45,8 @@ public class AvroRecordSchema extends GetterBasedSchemaProviderV2 {
   }
 
   @Override
-  public List<FieldValueGetter> fieldValueGetters(
-      TypeDescriptor<?> targetTypeDescriptor, Schema schema) {
+  public <T> List<FieldValueGetter<@NonNull T, Object>> fieldValueGetters(
+      TypeDescriptor<T> targetTypeDescriptor, Schema schema) {
     return AvroUtils.getGetters(targetTypeDescriptor, schema);
   }
 

--- a/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/schemas/utils/AvroUtils.java
+++ b/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/schemas/utils/AvroUtils.java
@@ -821,7 +821,7 @@ public class AvroUtils {
         Method method = methods.get(i);
         if (ReflectUtils.isGetter(method)) {
           FieldValueTypeInformation fieldValueTypeInformation =
-              FieldValueTypeInformation.forGetter(method, i);
+              FieldValueTypeInformation.forGetter(typeDescriptor, method, i);
           String name = mapping.get(fieldValueTypeInformation.getName());
           if (name != null) {
             types.add(fieldValueTypeInformation.withName(name));
@@ -871,7 +871,8 @@ public class AvroUtils {
       for (int i = 0; i < classFields.size(); ++i) {
         java.lang.reflect.Field f = classFields.get(i);
         if (!f.isAnnotationPresent(AvroIgnore.class)) {
-          FieldValueTypeInformation typeInformation = FieldValueTypeInformation.forField(f, i);
+          FieldValueTypeInformation typeInformation =
+              FieldValueTypeInformation.forField(typeDescriptor, f, i);
           AvroName avroname = f.getAnnotation(AvroName.class);
           if (avroname != null) {
             typeInformation = typeInformation.withName(avroname.value());

--- a/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoByteBuddyUtils.java
+++ b/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoByteBuddyUtils.java
@@ -104,16 +104,14 @@ import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Strings;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Verify;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Maps;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Multimap;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-@SuppressWarnings({
-  "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
-  "nullness" // TODO(https://github.com/apache/beam/issues/20497)
-})
 class ProtoByteBuddyUtils {
   private static final ByteBuddy BYTE_BUDDY = new ByteBuddy();
   private static final TypeDescriptor<ByteString> BYTE_STRING_TYPE_DESCRIPTOR =
@@ -270,7 +268,7 @@ class ProtoByteBuddyUtils {
             .build();
 
     @Override
-    public Type convert(TypeDescriptor typeDescriptor) {
+    public Type convert(TypeDescriptor<?> typeDescriptor) {
       if (typeDescriptor.equals(BYTE_STRING_TYPE_DESCRIPTOR)
           || typeDescriptor.isSubtypeOf(BYTE_STRING_TYPE_DESCRIPTOR)) {
         return byte[].class;
@@ -297,7 +295,7 @@ class ProtoByteBuddyUtils {
     }
 
     @Override
-    public StackManipulation convert(TypeDescriptor type) {
+    public StackManipulation convert(TypeDescriptor<?> type) {
       if (type.equals(BYTE_STRING_TYPE_DESCRIPTOR)
           || type.isSubtypeOf(BYTE_STRING_TYPE_DESCRIPTOR)) {
         return new Compound(
@@ -372,7 +370,7 @@ class ProtoByteBuddyUtils {
     }
 
     @Override
-    public StackManipulation convert(TypeDescriptor type) {
+    public StackManipulation convert(TypeDescriptor<?> type) {
       if (type.isSubtypeOf(TypeDescriptor.of(ByteString.class))) {
         return new Compound(
             readValue,
@@ -459,7 +457,7 @@ class ProtoByteBuddyUtils {
 
   // The list of getters for a class is cached, so we only create the classes the first time
   // getSetters is called.
-  private static final Map<ClassWithSchema, List<FieldValueGetter>> CACHED_GETTERS =
+  private static final Map<ClassWithSchema, List<FieldValueGetter<?, ?>>> CACHED_GETTERS =
       Maps.newConcurrentMap();
 
   /**
@@ -467,35 +465,36 @@ class ProtoByteBuddyUtils {
    *
    * <p>The returned list is ordered by the order of fields in the schema.
    */
-  public static List<FieldValueGetter> getGetters(
-      Class<?> clazz,
+  public static <T> List<FieldValueGetter<@NonNull T, Object>> getGetters(
+      Class<? super T> clazz,
       Schema schema,
       FieldValueTypeSupplier fieldValueTypeSupplier,
       TypeConversionsFactory typeConversionsFactory) {
     Multimap<String, Method> methods = ReflectUtils.getMethodsMap(clazz);
-    return CACHED_GETTERS.computeIfAbsent(
-        ClassWithSchema.create(clazz, schema),
-        c -> {
-          List<FieldValueTypeInformation> types =
-              fieldValueTypeSupplier.get(TypeDescriptor.of(clazz), schema);
-          return types.stream()
-              .map(
-                  t ->
-                      createGetter(
-                          t,
-                          typeConversionsFactory,
-                          clazz,
-                          methods,
-                          schema.getField(t.getName()),
-                          fieldValueTypeSupplier))
-              .collect(Collectors.toList());
-        });
+    return (List)
+        CACHED_GETTERS.computeIfAbsent(
+            ClassWithSchema.create(clazz, schema),
+            c -> {
+              List<FieldValueTypeInformation> types =
+                  fieldValueTypeSupplier.get(TypeDescriptor.of(clazz), schema);
+              return types.stream()
+                  .map(
+                      t ->
+                          createGetter(
+                              t,
+                              typeConversionsFactory,
+                              clazz,
+                              methods,
+                              schema.getField(t.getName()),
+                              fieldValueTypeSupplier))
+                  .collect(Collectors.toList());
+            });
   }
 
-  static <ProtoT> FieldValueGetter<ProtoT, OneOfType.Value> createOneOfGetter(
+  static <ProtoT> FieldValueGetter<@NonNull ProtoT, OneOfType.Value> createOneOfGetter(
       FieldValueTypeInformation typeInformation,
-      TreeMap<Integer, FieldValueGetter<ProtoT, OneOfType.Value>> getterMethodMap,
-      Class protoClass,
+      TreeMap<Integer, FieldValueGetter<@NonNull ProtoT, OneOfType.Value>> getterMethodMap,
+      Class<ProtoT> protoClass,
       OneOfType oneOfType,
       Method getCaseMethod) {
     Set<Integer> indices = getterMethodMap.keySet();
@@ -505,7 +504,7 @@ class ProtoByteBuddyUtils {
 
     int[] keys = getterMethodMap.keySet().stream().mapToInt(Integer::intValue).toArray();
 
-    DynamicType.Builder<FieldValueGetter> builder =
+    DynamicType.Builder<FieldValueGetter<@NonNull ProtoT, OneOfType.Value>> builder =
         ByteBuddyUtils.subclassGetterInterface(BYTE_BUDDY, protoClass, OneOfType.Value.class);
     builder =
         builder
@@ -514,7 +513,8 @@ class ProtoByteBuddyUtils {
             .method(ElementMatchers.named("get"))
             .intercept(new OneOfGetterInstruction(contiguous, keys, getCaseMethod));
 
-    List<FieldValueGetter> getters = Lists.newArrayList(getterMethodMap.values());
+    List<FieldValueGetter<@NonNull ProtoT, OneOfType.Value>> getters =
+        Lists.newArrayList(getterMethodMap.values());
     builder =
         builder
             // Store a field with the list of individual getters. The get() instruction will pick
@@ -556,12 +556,12 @@ class ProtoByteBuddyUtils {
       FieldValueSetter<ProtoBuilderT, Object> createOneOfSetter(
           String name,
           TreeMap<Integer, FieldValueSetter<ProtoBuilderT, Object>> setterMethodMap,
-          Class protoBuilderClass) {
+          Class<ProtoBuilderT> protoBuilderClass) {
     Set<Integer> indices = setterMethodMap.keySet();
     boolean contiguous = isContiguous(indices);
     int[] keys = setterMethodMap.keySet().stream().mapToInt(Integer::intValue).toArray();
 
-    DynamicType.Builder<FieldValueSetter> builder =
+    DynamicType.Builder<FieldValueSetter<ProtoBuilderT, Object>> builder =
         ByteBuddyUtils.subclassSetterInterface(
             BYTE_BUDDY, protoBuilderClass, OneOfType.Value.class);
     builder =
@@ -585,7 +585,8 @@ class ProtoByteBuddyUtils {
             .withParameters(List.class)
             .intercept(new OneOfSetterConstructor());
 
-    List<FieldValueSetter> setters = Lists.newArrayList(setterMethodMap.values());
+    List<FieldValueSetter<ProtoBuilderT, Object>> setters =
+        Lists.newArrayList(setterMethodMap.values());
     try {
       return builder
           .visit(new AsmVisitorWrapper.ForDeclaredMethods().writerFlags(ClassWriter.COMPUTE_FRAMES))
@@ -947,10 +948,10 @@ class ProtoByteBuddyUtils {
     }
   }
 
-  private static <ProtoT> FieldValueGetter createGetter(
+  private static <ProtoT> FieldValueGetter<@NonNull ProtoT, ?> createGetter(
       FieldValueTypeInformation fieldValueTypeInformation,
       TypeConversionsFactory typeConversionsFactory,
-      Class clazz,
+      Class<ProtoT> clazz,
       Multimap<String, Method> methods,
       Field field,
       FieldValueTypeSupplier fieldValueTypeSupplier) {
@@ -964,21 +965,23 @@ class ProtoByteBuddyUtils {
               field.getName() + "_case",
               FieldType.logicalType(oneOfType.getCaseEnumType()));
       // Create a map of case enum value to getter. This must be sorted, so store in a TreeMap.
-      TreeMap<Integer, FieldValueGetter<ProtoT, OneOfType.Value>> oneOfGetters = Maps.newTreeMap();
+      TreeMap<Integer, FieldValueGetter<@NonNull ProtoT, OneOfType.Value>> oneOfGetters =
+          Maps.newTreeMap();
       Map<String, FieldValueTypeInformation> oneOfFieldTypes =
           fieldValueTypeSupplier.get(TypeDescriptor.of(clazz), oneOfType.getOneOfSchema()).stream()
               .collect(Collectors.toMap(FieldValueTypeInformation::getName, f -> f));
       for (Field oneOfField : oneOfType.getOneOfSchema().getFields()) {
         int protoFieldIndex = getFieldNumber(oneOfField);
-        FieldValueGetter oneOfFieldGetter =
+        FieldValueGetter<@NonNull ProtoT, ?> oneOfFieldGetter =
             createGetter(
-                oneOfFieldTypes.get(oneOfField.getName()),
+                Verify.verifyNotNull(oneOfFieldTypes.get(oneOfField.getName())),
                 typeConversionsFactory,
                 clazz,
                 methods,
                 oneOfField,
                 fieldValueTypeSupplier);
-        oneOfGetters.put(protoFieldIndex, oneOfFieldGetter);
+        oneOfGetters.put(
+            protoFieldIndex, (FieldValueGetter<@NonNull ProtoT, OneOfType.Value>) oneOfFieldGetter);
       }
       return createOneOfGetter(
           fieldValueTypeInformation, oneOfGetters, clazz, oneOfType, caseMethod);
@@ -987,10 +990,11 @@ class ProtoByteBuddyUtils {
     }
   }
 
-  private static Class getProtoGeneratedBuilder(Class<?> clazz) {
+  private static <ProtoBuilderT> @Nullable Class<ProtoBuilderT> getProtoGeneratedBuilder(
+      Class<?> clazz) {
     String builderClassName = clazz.getName() + "$Builder";
     try {
-      return Class.forName(builderClassName);
+      return (Class<ProtoBuilderT>) Class.forName(builderClassName);
     } catch (ClassNotFoundException e) {
       return null;
     }
@@ -1043,7 +1047,7 @@ class ProtoByteBuddyUtils {
       OneOfType oneOfType = field.getType().getLogicalType(OneOfType.class);
       TreeMap<Integer, FieldValueSetter<ProtoBuilderT, Object>> oneOfSetters = Maps.newTreeMap();
       for (Field oneOfField : oneOfType.getOneOfSchema().getFields()) {
-        FieldValueSetter setter =
+        FieldValueSetter<ProtoBuilderT, Object> setter =
             getProtoFieldValueSetter(typeDescriptor, oneOfField, methods, builderClass);
         oneOfSetters.put(getFieldNumber(oneOfField), setter);
       }
@@ -1059,17 +1063,18 @@ class ProtoByteBuddyUtils {
 
   static <ProtoBuilderT extends MessageLite.Builder> SchemaUserTypeCreator createBuilderCreator(
       Class<?> protoClass,
-      Class<?> builderClass,
+      Class<ProtoBuilderT> builderClass,
       List<FieldValueSetter<ProtoBuilderT, Object>> setters,
       Schema schema) {
     try {
-      DynamicType.Builder<Supplier> builder =
-          BYTE_BUDDY
-              .with(new InjectPackageStrategy(builderClass))
-              .subclass(Supplier.class)
-              .method(ElementMatchers.named("get"))
-              .intercept(new BuilderSupplier(protoClass));
-      Supplier supplier =
+      DynamicType.Builder<Supplier<ProtoBuilderT>> builder =
+          (DynamicType.Builder)
+              BYTE_BUDDY
+                  .with(new InjectPackageStrategy(builderClass))
+                  .subclass(Supplier.class)
+                  .method(ElementMatchers.named("get"))
+                  .intercept(new BuilderSupplier(protoClass));
+      Supplier<ProtoBuilderT> supplier =
           builder
               .visit(
                   new AsmVisitorWrapper.ForDeclaredMethods()

--- a/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoMessageSchema.java
+++ b/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoMessageSchema.java
@@ -43,12 +43,9 @@ import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Maps;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Multimap;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
-@SuppressWarnings({
-  "nullness", // TODO(https://github.com/apache/beam/issues/20497)
-  "rawtypes" // TODO(https://github.com/apache/beam/issues/20447)
-})
 public class ProtoMessageSchema extends GetterBasedSchemaProviderV2 {
 
   private static final class ProtoClassFieldValueTypeSupplier implements FieldValueTypeSupplier {
@@ -99,8 +96,8 @@ public class ProtoMessageSchema extends GetterBasedSchemaProviderV2 {
   }
 
   @Override
-  public List<FieldValueGetter> fieldValueGetters(
-      TypeDescriptor<?> targetTypeDescriptor, Schema schema) {
+  public <T> List<FieldValueGetter<@NonNull T, Object>> fieldValueGetters(
+      TypeDescriptor<T> targetTypeDescriptor, Schema schema) {
     return ProtoByteBuddyUtils.getGetters(
         targetTypeDescriptor.getRawType(),
         schema,
@@ -155,7 +152,8 @@ public class ProtoMessageSchema extends GetterBasedSchemaProviderV2 {
   private <T> void checkForDynamicType(TypeDescriptor<T> typeDescriptor) {
     if (typeDescriptor.getRawType().equals(DynamicMessage.class)) {
       throw new RuntimeException(
-          "DynamicMessage is not allowed for the standard ProtoSchemaProvider, use ProtoDynamicMessageSchema  instead.");
+          "DynamicMessage is not allowed for the standard ProtoSchemaProvider, use"
+              + " ProtoDynamicMessageSchema  instead.");
     }
   }
 

--- a/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoMessageSchema.java
+++ b/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoMessageSchema.java
@@ -72,7 +72,8 @@ public class ProtoMessageSchema extends GetterBasedSchemaProviderV2 {
             Method method = getProtoGetter(methods, oneOfField.getName(), oneOfField.getType());
             oneOfTypes.put(
                 oneOfField.getName(),
-                FieldValueTypeInformation.forGetter(method, i).withName(field.getName()));
+                FieldValueTypeInformation.forGetter(typeDescriptor, method, i)
+                    .withName(field.getName()));
           }
           // Add an entry that encapsulates information about all possible getters.
           types.add(
@@ -82,7 +83,9 @@ public class ProtoMessageSchema extends GetterBasedSchemaProviderV2 {
         } else {
           // This is a simple field. Add the getter.
           Method method = getProtoGetter(methods, field.getName(), field.getType());
-          types.add(FieldValueTypeInformation.forGetter(method, i).withName(field.getName()));
+          types.add(
+              FieldValueTypeInformation.forGetter(typeDescriptor, method, i)
+                  .withName(field.getName()));
         }
       }
       return types;
@@ -117,7 +120,7 @@ public class ProtoMessageSchema extends GetterBasedSchemaProviderV2 {
       TypeDescriptor<?> targetTypeDescriptor, Schema schema) {
     SchemaUserTypeCreator creator =
         ProtoByteBuddyUtils.getBuilderCreator(
-            targetTypeDescriptor.getRawType(), schema, new ProtoClassFieldValueTypeSupplier());
+            targetTypeDescriptor, schema, new ProtoClassFieldValueTypeSupplier());
     if (creator == null) {
       throw new RuntimeException("Cannot create creator for " + targetTypeDescriptor);
     }

--- a/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/schemas/AwsSchemaUtils.java
+++ b/sdks/java/io/amazon-web-services2/src/main/java/org/apache/beam/sdk/io/aws2/schemas/AwsSchemaUtils.java
@@ -33,6 +33,7 @@ import org.apache.beam.sdk.schemas.FieldValueSetter;
 import org.apache.beam.sdk.schemas.utils.ByteBuddyUtils;
 import org.apache.beam.sdk.transforms.SerializableFunction;
 import org.apache.beam.sdk.util.common.ReflectHelpers;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.checkerframework.checker.nullness.qual.Nullable;
 import software.amazon.awssdk.core.SdkPojo;
 import software.amazon.awssdk.utils.builder.SdkBuilder;
@@ -78,7 +79,7 @@ class AwsSchemaUtils {
     return new ValueSetter(name, setter);
   }
 
-  static <ObjT, ValT> FieldValueGetter<ObjT, ValT> getter(
+  static <ObjT extends @NonNull Object, ValT> FieldValueGetter<ObjT, ValT> getter(
       String name, SerializableFunction<ObjT, ValT> getter) {
     return new ValueGetter<>(name, getter);
   }
@@ -107,7 +108,8 @@ class AwsSchemaUtils {
     }
   }
 
-  private static class ValueGetter<ObjT, ValT> implements FieldValueGetter<ObjT, ValT> {
+  private static class ValueGetter<ObjT extends @NonNull Object, ValT>
+      implements FieldValueGetter<ObjT, ValT> {
     private final SerializableFunction<ObjT, ValT> getter;
     private final String name;
 

--- a/sdks/java/io/thrift/src/main/java/org/apache/beam/sdk/io/thrift/ThriftSchema.java
+++ b/sdks/java/io/thrift/src/main/java/org/apache/beam/sdk/io/thrift/ThriftSchema.java
@@ -242,10 +242,12 @@ public final class ThriftSchema extends GetterBasedSchemaProviderV2 {
       if (factoryMethods.size() > 1) {
         throw new IllegalStateException("Overloaded factory methods: " + factoryMethods);
       }
-      return FieldValueTypeInformation.forSetter(factoryMethods.get(0), "");
+      return FieldValueTypeInformation.forSetter(
+          TypeDescriptor.of(type), factoryMethods.get(0), "");
     } else {
       try {
-        return FieldValueTypeInformation.forField(type.getDeclaredField(fieldName), 0);
+        return FieldValueTypeInformation.forField(
+            TypeDescriptor.of(type), type.getDeclaredField(fieldName), 0);
       } catch (NoSuchFieldException e) {
         throw new IllegalArgumentException(e);
       }


### PR DESCRIPTION
This is a 2nd PR in the series of PRs (based on the now closed #31648, with the first PR being #31785) whose ultimate goal is to add support for generic classes to schema providers. 

`FieldValueTypeInformation` creators will now accept a `TypeDescriptor` parameter describing the field's containing class, that will let them infer more accurate type information about that field. For example - consider a `MyClass<T>` class - now with a `TypeDescriptor` of `MyClass<String>` and the getter of type `T` the type resolver can infer the type of field to be `String` , see the added test class that shows the new functionality


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
