### PR TITLE
[#32085][prism] Fix session windowing.

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/handlerunner.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/handlerunner.go
@@ -244,7 +244,7 @@ func (h *runner) ExecuteTransform(stageID, tid string, t *pipepb.PTransform, com
 		kc := coders[kcID]
 		ec := coders[ecID]
 
-		data = append(data, gbkBytes(ws, wc, kc, ec, inputData, coders, watermark))
+		data = append(data, gbkBytes(ws, wc, kc, ec, inputData, coders))
 		if len(data[0]) == 0 {
 			panic("no data for GBK")
 		}
@@ -290,7 +290,7 @@ func windowingStrategy(comps *pipepb.Components, tid string) *pipepb.WindowingSt
 }
 
 // gbkBytes re-encodes gbk inputs in a gbk result.
-func gbkBytes(ws *pipepb.WindowingStrategy, wc, kc, vc *pipepb.Coder, toAggregate [][]byte, coders map[string]*pipepb.Coder, watermark mtime.Time) []byte {
+func gbkBytes(ws *pipepb.WindowingStrategy, wc, kc, vc *pipepb.Coder, toAggregate [][]byte, coders map[string]*pipepb.Coder) []byte {
 	// Pick how the timestamp of the aggregated output is computed.
 	var outputTime func(typex.Window, mtime.Time, mtime.Time) mtime.Time
 	switch ws.GetOutputTime() {
@@ -333,9 +333,8 @@ func gbkBytes(ws *pipepb.WindowingStrategy, wc, kc, vc *pipepb.Coder, toAggregat
 	kd := pullDecoder(kc, coders)
 	vd := pullDecoder(vc, coders)
 
-	// Right, need to get the key coder, and the element coder.
-	// Cus I'll need to pull out anything the runner knows how to deal with.
-	// And repeat.
+	// Aggregate by windows and keys, using the window coder and KV coders.
+	// We need to extract and split the key bytes from the element bytes.
 	for _, data := range toAggregate {
 		// Parse out each element's data, and repeat.
 		buf := bytes.NewBuffer(data)
@@ -388,34 +387,41 @@ func gbkBytes(ws *pipepb.WindowingStrategy, wc, kc, vc *pipepb.Coder, toAggregat
 		}
 		// Use a decreasing sort (latest to earliest) so we can correct
 		// the output timestamp to the new end of window immeadiately.
-		// TODO need to correct this if output time is different.
 		sort.Slice(ordered, func(i, j int) bool {
 			return ordered[i].MaxTimestamp() > ordered[j].MaxTimestamp()
 		})
 
 		cur := ordered[0]
 		sessionData := windows[cur]
+		delete(windows, cur)
 		for _, iw := range ordered[1:] {
-			// If they overlap, then we merge the data.
+			// Check if the gap between windows is less than the gapSize.
+			// If not, this window is done, and we start a next window.
 			if iw.End+gapSize < cur.Start {
-				// Start a new session.
+				// Store current data with the current window.
 				windows[cur] = sessionData
+				// Use the incoming window instead, and clear it from the map.
 				cur = iw
 				sessionData = windows[iw]
+				delete(windows, cur)
+				// There's nothing to merge, since we've just started with this windowed data.
 				continue
 			}
-			// Extend the session
+			// Extend the session with the incoming window, and merge the the incoming window's data.
 			cur.Start = iw.Start
 			toMerge := windows[iw]
 			delete(windows, iw)
 			for k, kt := range toMerge {
 				skt := sessionData[k]
+				// Ensure the output time matches the given function.
+				skt.time = outputTime(cur, kt.time, skt.time)
 				skt.key = kt.key
 				skt.w = cur
 				skt.values = append(skt.values, kt.values...)
 				sessionData[k] = skt
 			}
 		}
+		windows[cur] = sessionData
 	}
 	// Everything's aggregated!
 	// Time to turn things into a windowed KV<K, Iterable<V>>

--- a/sdks/python/apache_beam/runners/portability/prism_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner_test.py
@@ -40,7 +40,9 @@ from apache_beam.options.pipeline_options import PortableOptions
 from apache_beam.runners.portability import portable_runner_test
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
+from apache_beam.transforms import window
 from apache_beam.transforms.sql import SqlTransform
+from apache_beam.utils import timestamp
 
 # Run as
 #
@@ -177,6 +179,23 @@ class PrismRunnerTest(portable_runner_test.PortableRunnerTest):
         PortableOptions).environment_options = self.environment_options
 
     return options
+
+  # Slightly more robust session window test:
+  # Validates that an inner grouping doesn't duplicate data either.
+  # Copied also because the timestamp in fn_runner_test.py isn't being
+  # inferred correctly as seconds for some reason, but as micros.
+  # The belabored specification is validating the timestamp type works at least.
+  # See https://github.com/apache/beam/issues/32085
+  def test_windowing(self):
+    with self.create_pipeline() as p:
+      res = (
+          p
+          | beam.Create([1, 2, 100, 101, 102, 123])
+          | beam.Map(lambda t: window.TimestampedValue(('k', t), timestamp.Timestamp.of(t).micros))
+          | beam.WindowInto(beam.transforms.window.Sessions(10))
+          | beam.GroupByKey()
+          | beam.Map(lambda k_vs1: (k_vs1[0], sorted(k_vs1[1]))))
+      assert_that(res, equal_to([('k', [1, 2]), ('k', [100, 101, 102]), ('k', [123])]))
 
   # Can't read host files from within docker, read a "local" file there.
   def test_read(self):

--- a/sdks/python/apache_beam/runners/portability/prism_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner_test.py
@@ -242,8 +242,8 @@ class PrismRunnerTest(portable_runner_test.PortableRunnerTest):
                 timestamp_policy=ReadFromKafka.create_time_policy,
                 expansion_service=self.get_expansion_service()))
     self.assertTrue(
-        'No resolvable bootstrap urls given in bootstrap.servers'
-        in str(ctx.exception),
+        'No resolvable bootstrap urls given in bootstrap.servers' in str(
+            ctx.exception),
         'Expected to fail due to invalid bootstrap.servers, but '
         'failed due to:\n%s' % str(ctx.exception))
 

--- a/sdks/python/apache_beam/runners/portability/prism_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner_test.py
@@ -191,11 +191,14 @@ class PrismRunnerTest(portable_runner_test.PortableRunnerTest):
       res = (
           p
           | beam.Create([1, 2, 100, 101, 102, 123])
-          | beam.Map(lambda t: window.TimestampedValue(('k', t), timestamp.Timestamp.of(t).micros))
+          | beam.Map(
+              lambda t: window.TimestampedValue(
+                  ('k', t), timestamp.Timestamp.of(t).micros))
           | beam.WindowInto(beam.transforms.window.Sessions(10))
           | beam.GroupByKey()
           | beam.Map(lambda k_vs1: (k_vs1[0], sorted(k_vs1[1]))))
-      assert_that(res, equal_to([('k', [1, 2]), ('k', [100, 101, 102]), ('k', [123])]))
+      assert_that(
+          res, equal_to([('k', [1, 2]), ('k', [100, 101, 102]), ('k', [123])]))
 
   # Can't read host files from within docker, read a "local" file there.
   def test_read(self):
@@ -239,8 +242,8 @@ class PrismRunnerTest(portable_runner_test.PortableRunnerTest):
                 timestamp_policy=ReadFromKafka.create_time_policy,
                 expansion_service=self.get_expansion_service()))
     self.assertTrue(
-        'No resolvable bootstrap urls given in bootstrap.servers' in str(
-            ctx.exception),
+        'No resolvable bootstrap urls given in bootstrap.servers'
+        in str(ctx.exception),
         'Expected to fail due to invalid bootstrap.servers, but '
         'failed due to:\n%s' % str(ctx.exception))
 


### PR DESCRIPTION
* Updates the basic session windowing to correctly aggregate across windows and remove old data.
* Fixes session windowing to respect the correct output timestamp.
* Overrides the fn_runner_test.py test_windowing method to a slightly more robust test, having an inner session, rather than just an first and last. This better validates boundary conditions.
  * There seemed to be a weird interpretation issue WRT the int timestamp converting to microseconds properly. It appears to be done properly in the timestamp type, but I couldn't figure out where the discrepency lies. Prism was receiving the element timestamps as microseconds, but the session gap was correctly converted to microseconds from seconds. 

Fixes #32085 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
