### PR TITLE
Fix Beam Schema to Iceberg Schema ID conversion logic

### DIFF
--- a/.github/trigger_files/IO_Iceberg_Integration_Tests.json
+++ b/.github/trigger_files/IO_Iceberg_Integration_Tests.json
@@ -1,4 +1,4 @@
 {
     "comment": "Modify this file in a trivial way to cause this test suite to run",
-    "modification": 2
+    "modification": 3
 }


### PR DESCRIPTION
Fixes #32050

Current iceberg utils does Schema conversion in a way where unique IDs are given to nested fields before top-level fields. When retrieving an Iceberg table's schema and inspecting it, we see that unique IDs are given to top-level fields first, then each nested type. This PR fixes our utils to align with it