### PR TITLE
[#32115] Fix timer support, support timer clears.

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
@@ -907,7 +907,6 @@ func (em *ElementManager) triageTimers(d TentativeData, inputInfo PColInfo, stag
 	}
 
 	if len(pendingEventTimers) > 0 {
-		fmt.Println("pendingEventTimers", len(pendingEventTimers), pendingEventTimers)
 		count := stage.AddPending(pendingEventTimers)
 		em.addPending(count)
 	}

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/elementmanager.go
@@ -869,14 +869,20 @@ func (em *ElementManager) triageTimers(d TentativeData, inputInfo PColInfo, stag
 	for tentativeKey, timers := range d.timers {
 		keyToTimers := map[timerKey]element{}
 		for _, t := range timers {
-			key, tag, elms := decodeTimer(inputInfo.KeyDec, true, t)
-			for _, e := range elms {
-				keyToTimers[timerKey{key: string(key), tag: tag, win: e.window}] = e
-			}
-			if len(elms) == 0 {
-				// TODO(lostluck): Determine best way to mark a timer cleared.
-				continue
-			}
+			// TODO: Call in a for:range loop when Beam's minimum Go version hits 1.23.0
+			iter := decodeTimerIter(inputInfo.KeyDec, true, t)
+			iter(func(ret timerRet) bool {
+				for _, e := range ret.elms {
+					keyToTimers[timerKey{key: string(ret.keyBytes), tag: ret.tag, win: e.window}] = e
+				}
+				if len(ret.elms) == 0 {
+					for _, w := range ret.windows {
+						delete(keyToTimers, timerKey{key: string(ret.keyBytes), tag: ret.tag, win: w})
+					}
+				}
+				// Indicate we'd like to continue iterating.
+				return true
+			})
 		}
 
 		for _, elm := range keyToTimers {
@@ -901,6 +907,7 @@ func (em *ElementManager) triageTimers(d TentativeData, inputInfo PColInfo, stag
 	}
 
 	if len(pendingEventTimers) > 0 {
+		fmt.Println("pendingEventTimers", len(pendingEventTimers), pendingEventTimers)
 		count := stage.AddPending(pendingEventTimers)
 		em.addPending(count)
 	}

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/timers.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/timers.go
@@ -38,7 +38,7 @@ type timerRet struct {
 	windows  []typex.Window
 }
 
-// decodeTimerIter extracts timers to to elements for insertion into their keyed queues,
+// decodeTimerIter extracts timers to elements for insertion into their keyed queues,
 // through a go iterator function, to be called by the caller with their processing function.
 //
 // For each timer, a key, tag, windowed elements, and the window set are returned.

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/timers.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/timers.go
@@ -46,8 +46,8 @@ type timerRet struct {
 // If the timer has been cleared, no elements will be returned. Any existing timers
 // for the tag *must* be cleared from the pending queue. The windows associated with
 // the clear are provided to be able to delete pending timers.
-func decodeTimerIter(keyDec func(io.Reader) []byte, usesGlobalWindow bool, raw []byte) func(yeild func(timerRet) bool) {
-	return func(yeild func(timerRet) bool) {
+func decodeTimerIter(keyDec func(io.Reader) []byte, usesGlobalWindow bool, raw []byte) func(func(timerRet) bool) {
+	return func(yield func(timerRet) bool) {
 		for len(raw) > 0 {
 			keyBytes := keyDec(bytes.NewBuffer(raw))
 			d := decoder{raw: raw, cursor: len(keyBytes)}
@@ -69,7 +69,7 @@ func decodeTimerIter(keyDec func(io.Reader) []byte, usesGlobalWindow bool, raw [
 			clear := d.Bool()
 			hold := mtime.MaxTimestamp
 			if clear {
-				if !yeild(timerRet{keyBytes, tag, nil, ws}) {
+				if !yield(timerRet{keyBytes, tag, nil, ws}) {
 					return // Halt iteration if yeild returns false.
 				}
 				// Otherwise continue handling the remaining bytes.
@@ -95,7 +95,7 @@ func decodeTimerIter(keyDec func(io.Reader) []byte, usesGlobalWindow bool, raw [
 				})
 			}
 
-			if !yeild(timerRet{keyBytes, tag, elms, ws}) {
+			if !yield(timerRet{keyBytes, tag, elms, ws}) {
 				return // Halt iteration if yeild returns false.
 			}
 			// Otherwise continue handling the remaining bytes.

--- a/sdks/go/pkg/beam/runners/prism/internal/engine/timers.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/engine/timers.go
@@ -31,53 +31,77 @@ import (
 	"google.golang.org/protobuf/encoding/protowire"
 )
 
-// DecodeTimer extracts timers to elements for insertion into their keyed queues.
-// Returns the key bytes, tag, window exploded elements, and the hold timestamp.
+type timerRet struct {
+	keyBytes []byte
+	tag      string
+	elms     []element
+	windows  []typex.Window
+}
+
+// decodeTimerIter extracts timers to to elements for insertion into their keyed queues,
+// through a go iterator function, to be called by the caller with their processing function.
+//
+// For each timer, a key, tag, windowed elements, and the window set are returned.
+//
 // If the timer has been cleared, no elements will be returned. Any existing timers
-// for the tag *must* be cleared from the pending queue.
-func decodeTimer(keyDec func(io.Reader) []byte, usesGlobalWindow bool, raw []byte) ([]byte, string, []element) {
-	keyBytes := keyDec(bytes.NewBuffer(raw))
+// for the tag *must* be cleared from the pending queue. The windows associated with
+// the clear are provided to be able to delete pending timers.
+func decodeTimerIter(keyDec func(io.Reader) []byte, usesGlobalWindow bool, raw []byte) func(yeild func(timerRet) bool) {
+	return func(yeild func(timerRet) bool) {
+		for len(raw) > 0 {
+			keyBytes := keyDec(bytes.NewBuffer(raw))
+			d := decoder{raw: raw, cursor: len(keyBytes)}
+			tag := string(d.Bytes())
 
-	d := decoder{raw: raw, cursor: len(keyBytes)}
-	tag := string(d.Bytes())
+			var ws []typex.Window
+			numWin := d.Fixed32()
+			if usesGlobalWindow {
+				for i := 0; i < int(numWin); i++ {
+					ws = append(ws, window.GlobalWindow{})
+				}
+			} else {
+				// Assume interval windows here, since we don't understand custom windows yet.
+				for i := 0; i < int(numWin); i++ {
+					ws = append(ws, d.IntervalWindow())
+				}
+			}
 
-	var ws []typex.Window
-	numWin := d.Fixed32()
-	if usesGlobalWindow {
-		for i := 0; i < int(numWin); i++ {
-			ws = append(ws, window.GlobalWindow{})
+			clear := d.Bool()
+			hold := mtime.MaxTimestamp
+			if clear {
+				if !yeild(timerRet{keyBytes, tag, nil, ws}) {
+					return // Halt iteration if yeild returns false.
+				}
+				// Otherwise continue handling the remaining bytes.
+				raw = d.UnusedBytes()
+				continue
+			}
+
+			firing := d.Timestamp()
+			hold = d.Timestamp()
+			pane := d.Pane()
+
+			var elms []element
+			for _, w := range ws {
+				elms = append(elms, element{
+					tag:           tag,
+					elmBytes:      nil, // indicates this is a timer.
+					keyBytes:      keyBytes,
+					window:        w,
+					timestamp:     firing,
+					holdTimestamp: hold,
+					pane:          pane,
+					sequence:      len(elms),
+				})
+			}
+
+			if !yeild(timerRet{keyBytes, tag, elms, ws}) {
+				return // Halt iteration if yeild returns false.
+			}
+			// Otherwise continue handling the remaining bytes.
+			raw = d.UnusedBytes()
 		}
-	} else {
-		// Assume interval windows here, since we don't understand custom windows yet.
-		for i := 0; i < int(numWin); i++ {
-			ws = append(ws, d.IntervalWindow())
-		}
 	}
-
-	clear := d.Bool()
-	hold := mtime.MaxTimestamp
-	if clear {
-		return keyBytes, tag, nil
-	}
-
-	firing := d.Timestamp()
-	hold = d.Timestamp()
-	pane := d.Pane()
-
-	var ret []element
-	for _, w := range ws {
-		ret = append(ret, element{
-			tag:           tag,
-			elmBytes:      nil, // indicates this is a timer.
-			keyBytes:      keyBytes,
-			window:        w,
-			timestamp:     firing,
-			holdTimestamp: hold,
-			pane:          pane,
-			sequence:      len(ret),
-		})
-	}
-	return keyBytes, tag, ret
 }
 
 type decoder struct {
@@ -138,6 +162,13 @@ func (d *decoder) Bytes() []byte {
 	b := d.raw[d.cursor:end]
 	d.cursor = end
 	return b
+}
+
+// UnusedBytes returns the remainder of bytes in the buffer that weren't yet used.
+// Multiple timers can be provided in a single timers buffer, since multiple dynamic
+// timer tags may be set.
+func (d *decoder) UnusedBytes() []byte {
+	return d.raw[d.cursor:]
 }
 
 func (d *decoder) Bool() bool {

--- a/sdks/python/apache_beam/runners/portability/prism_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner_test.py
@@ -40,6 +40,7 @@ from apache_beam.options.pipeline_options import PortableOptions
 from apache_beam.runners.portability import portable_runner_test
 from apache_beam.testing.util import assert_that
 from apache_beam.testing.util import equal_to
+from apache_beam.transforms import userstate
 from apache_beam.transforms import window
 from apache_beam.transforms.sql import SqlTransform
 from apache_beam.utils import timestamp
@@ -199,6 +200,39 @@ class PrismRunnerTest(portable_runner_test.PortableRunnerTest):
           | beam.Map(lambda k_vs1: (k_vs1[0], sorted(k_vs1[1]))))
       assert_that(
           res, equal_to([('k', [1, 2]), ('k', [100, 101, 102]), ('k', [123])]))
+
+  # The fn_runner_test.py version of this test doesn't execute the process method
+  # for some reason. Overridden here to validate that the cleared timer won't
+  # re-fire.
+  def test_pardo_timers_clear(self):
+    timer_spec = userstate.TimerSpec('timer', userstate.TimeDomain.WATERMARK)
+
+    class TimerDoFn(beam.DoFn):
+      def process(
+          self,
+          element,
+          timer=beam.DoFn.TimerParam(timer_spec)):
+        unused_key, ts = element
+        timer.set(ts)
+        timer.set(2 * ts)
+
+      @userstate.on_timer(timer_spec)
+      def process_timer(self, 
+          ts=beam.DoFn.TimestampParam,
+          timer=beam.DoFn.TimerParam(timer_spec)):
+        timer.set(timestamp.Timestamp(micros=2 * ts.micros))
+        timer.clear() # Shouldn't fire again
+        yield 'fired'
+
+    with self.create_pipeline() as p:
+      actual = (
+          p
+          | beam.Create([('k1', 10), ('k2', 100)])
+          | beam.ParDo(TimerDoFn())
+          | beam.Map(lambda x, ts=beam.DoFn.TimestampParam: (x, ts)))
+
+      expected = [('fired', ts) for ts in (20, 200)]
+      assert_that(actual, equal_to(expected))
 
   # Can't read host files from within docker, read a "local" file there.
   def test_read(self):

--- a/sdks/python/apache_beam/runners/portability/prism_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner_test.py
@@ -208,7 +208,6 @@ class PrismRunnerTest(portable_runner_test.PortableRunnerTest):
     timer_spec = userstate.TimerSpec('timer', userstate.TimeDomain.WATERMARK)
 
     class TimerDoFn(beam.DoFn):
-
       def process(self, element, timer=beam.DoFn.TimerParam(timer_spec)):
         unused_key, ts = element
         timer.set(ts)

--- a/sdks/python/apache_beam/runners/portability/prism_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner_test.py
@@ -201,9 +201,9 @@ class PrismRunnerTest(portable_runner_test.PortableRunnerTest):
       assert_that(
           res, equal_to([('k', [1, 2]), ('k', [100, 101, 102]), ('k', [123])]))
 
-  # The fn_runner_test.py version of this test doesn't execute the process method
-  # for some reason. Overridden here to validate that the cleared timer won't
-  # re-fire.
+  # The fn_runner_test.py version of this test doesn't execute the process
+  # method for some reason. Overridden here to validate that the cleared
+  # timer won't re-fire.
   def test_pardo_timers_clear(self):
     timer_spec = userstate.TimerSpec('timer', userstate.TimeDomain.WATERMARK)
 

--- a/sdks/python/apache_beam/runners/portability/prism_runner_test.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner_test.py
@@ -208,20 +208,19 @@ class PrismRunnerTest(portable_runner_test.PortableRunnerTest):
     timer_spec = userstate.TimerSpec('timer', userstate.TimeDomain.WATERMARK)
 
     class TimerDoFn(beam.DoFn):
-      def process(
-          self,
-          element,
-          timer=beam.DoFn.TimerParam(timer_spec)):
+
+      def process(self, element, timer=beam.DoFn.TimerParam(timer_spec)):
         unused_key, ts = element
         timer.set(ts)
         timer.set(2 * ts)
 
       @userstate.on_timer(timer_spec)
-      def process_timer(self, 
+      def process_timer(
+          self,
           ts=beam.DoFn.TimestampParam,
           timer=beam.DoFn.TimerParam(timer_spec)):
         timer.set(timestamp.Timestamp(micros=2 * ts.micros))
-        timer.clear() # Shouldn't fire again
+        timer.clear()  # Shouldn't fire again
         yield 'fired'
 
     with self.create_pipeline() as p:


### PR DESCRIPTION
* Prism wasn't decoding *all* timers returned in the logical timer stream, dropping later set timers.
  * Moved timer decoding to be iterator compatible for the future, instead of trying to reprocess inplace, or returning the remaining byte buffer.
* From there supporting clearing timers was simple, by additionally returning the window set, and deleting existing entries to the pending timer list. 
* Needed to re-write + override the timer clearing test, since for some reason the test DoFn would not execute when there were multiple timer parameters to the DoFn.

Allows a few of the Python timer based tests to pass.

TODO for a different test: Support interval and custom window functions for timers.

Fixes #32115

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
