### PR TITLE
Add callback to with_exception_handling

### DIFF
--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -1624,7 +1624,8 @@ class ParDo(PTransformWithSideInputs):
           raise a TimeoutError.  Defaults to None, meaning no time limit.
       on_failure_callback: If an element fails or times out,
           on_failure_callback will be invoked. It will receive the exception
-          and the element being processed in as args. Be careful with this
+          and the element being processed in as args. In case of a timeout,
+          the exception will be of type `TimeoutError`. Be careful with this
           callback - if you set a timeout, it will not apply to the callback,
           and if the callback fails it will not be retried.
     """

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -2336,7 +2336,7 @@ class _ExceptionHandlingWrapperDoFn(DoFn):
         try:
           self._on_failure_callback(exn, args[0])
         except Exception as e:
-          logging.warning(f'on_failure_callback failed with error: {e}')
+          logging.warning('on_failure_callback failed with error: %s', e)
       yield pvalue.TaggedOutput(
           self._dead_letter_tag,
           (

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -1574,7 +1574,7 @@ class ParDo(PTransformWithSideInputs):
       threshold_windowing=None,
       timeout=None,
       on_failure_callback: typing.Optional[typing.Callable[
-        [Exception, typing.Any], None]] = None):
+          [Exception, typing.Any], None]] = None):
     """Automatically provides a dead letter output for skipping bad records.
     This can allow a pipeline to continue successfully rather than fail or
     continuously throw errors on retry when bad elements are encountered.
@@ -2266,7 +2266,11 @@ class _ExceptionHandlingWrapper(ptransform.PTransform):
       wrapped_fn = self._fn
     result = pcoll | ParDo(
         _ExceptionHandlingWrapperDoFn(
-            wrapped_fn, self._dead_letter_tag, self._exc_class, self._partial, self._on_failure_callback),
+            wrapped_fn,
+            self._dead_letter_tag,
+            self._exc_class,
+            self._partial,
+            self._on_failure_callback),
         *self._args,
         **self._kwargs).with_outputs(
             self._dead_letter_tag, main=self._main_tag, allow_unknown_tags=True)
@@ -2305,7 +2309,8 @@ class _ExceptionHandlingWrapper(ptransform.PTransform):
 
 
 class _ExceptionHandlingWrapperDoFn(DoFn):
-  def __init__(self, fn, dead_letter_tag, exc_class, partial, on_failure_callback):
+  def __init__(
+      self, fn, dead_letter_tag, exc_class, partial, on_failure_callback):
     self._fn = fn
     self._dead_letter_tag = dead_letter_tag
     self._exc_class = exc_class

--- a/sdks/python/apache_beam/transforms/core_test.py
+++ b/sdks/python/apache_beam/transforms/core_test.py
@@ -19,6 +19,8 @@
 # pytype: skip-file
 
 import logging
+import os
+import tempfile
 import unittest
 
 import pytest
@@ -85,6 +87,13 @@ class TestDoFn8(beam.DoFn):
       yield from [1, 2, 3]
     else:
       yield element
+
+
+class TestDoFn9(beam.DoFn):
+  def process(self, element):
+    if len(element) > 3:
+      raise ValueError('Not allowed to have long elements')
+    yield element
 
 
 class CreateTest(unittest.TestCase):
@@ -168,6 +177,64 @@ class FlattenTest(unittest.TestCase):
       source3 = p | "c3" >> beam.Create([9, 10]) | "w3" >> beam.WindowInto(
           FixedWindows(100))
       _ = (source1, source2, source3) | "flatten" >> beam.Flatten()
+
+
+class ExceptionHandlingTest(unittest.TestCase):
+  def test_routes_failures(self):
+    with beam.Pipeline() as pipeline:
+      good, bad = (
+        pipeline | beam.Create(['abc', 'bcd', 'long_word', 'foo', 'bar', 'foobar'])
+        | beam.ParDo(TestDoFn9()).with_exception_handling()
+      )
+      bad_elements = bad | beam.Map(lambda x: x[0])
+      assert_that(good, equal_to(['abc', 'bcd', 'foo', 'bar']), 'good')
+      assert_that(bad_elements, equal_to(['long_word', 'foobar']), 'bad')
+
+  def test_handles_callbacks(self):
+    with tempfile.TemporaryDirectory() as tmp_dirname:
+      tmp_path = os.path.join(tmp_dirname, 'tmp_filename')
+      file_contents = 'random content'
+      def failure_callback(e, el):
+        if type(e) is not ValueError:
+          raise Exception(f'Failed to pass in correct exception, received {e}')
+        if el != 'foobar':
+          raise Exception(f'Failed to pass in correct element, received {el}')
+        f = open(tmp_path, "a")
+        logging.warning(tmp_path)
+        f.write(file_contents)
+        f.close()
+
+      with beam.Pipeline() as pipeline:
+        good, bad = (
+          pipeline | beam.Create(['abc', 'bcd', 'foo', 'bar', 'foobar'])
+          | beam.ParDo(TestDoFn9()).with_exception_handling(on_failure_callback=failure_callback)
+        )
+        bad_elements = bad | beam.Map(lambda x: x[0])
+        assert_that(good, equal_to(['abc', 'bcd', 'foo', 'bar']), 'good')
+        assert_that(bad_elements, equal_to(['foobar']), 'bad')
+      with open(tmp_path) as f:
+        s = f.read()
+        self.assertEqual(s, file_contents)
+
+  def test_handles_no_callback_triggered(self):
+    with tempfile.TemporaryDirectory() as tmp_dirname:
+      tmp_path = os.path.join(tmp_dirname, 'tmp_filename')
+      file_contents = 'random content'
+      def failure_callback(e, el):
+        f = open(tmp_path, "a")
+        logging.warning(tmp_path)
+        f.write(file_contents)
+        f.close()
+
+      with beam.Pipeline() as pipeline:
+        good, bad = (
+          pipeline | beam.Create(['abc', 'bcd', 'foo', 'bar'])
+          | beam.ParDo(TestDoFn9()).with_exception_handling(on_failure_callback=failure_callback)
+        )
+        bad_elements = bad | beam.Map(lambda x: x[0])
+        assert_that(good, equal_to(['abc', 'bcd', 'foo', 'bar']), 'good')
+        assert_that(bad_elements, equal_to([]), 'bad')
+      self.assertFalse(os.path.isfile(tmp_path))
 
 
 class FlatMapTest(unittest.TestCase):

--- a/sdks/python/apache_beam/transforms/core_test.py
+++ b/sdks/python/apache_beam/transforms/core_test.py
@@ -186,7 +186,7 @@ class ExceptionHandlingTest(unittest.TestCase):
         pipeline | beam.Create(['abc', 'long_word', 'foo', 'bar', 'foobar'])
         | beam.ParDo(TestDoFn9()).with_exception_handling()
       )
-      bad_elements = bad | beam.Map(lambda x: x[0])
+      bad_elements = bad | beam.Keys()
       assert_that(good, equal_to(['abc', 'foo', 'bar']), 'good')
       assert_that(bad_elements, equal_to(['long_word', 'foobar']), 'bad')
 
@@ -211,7 +211,7 @@ class ExceptionHandlingTest(unittest.TestCase):
           | beam.ParDo(TestDoFn9()).with_exception_handling(
             on_failure_callback=failure_callback)
         )
-        bad_elements = bad | beam.Map(lambda x: x[0])
+        bad_elements = bad | beam.Keys()
         assert_that(good, equal_to(['abc', 'bcd', 'foo', 'bar']), 'good')
         assert_that(bad_elements, equal_to(['foobar']), 'bad')
       with open(tmp_path) as f:
@@ -235,7 +235,7 @@ class ExceptionHandlingTest(unittest.TestCase):
           | beam.ParDo(TestDoFn9()).with_exception_handling(
             on_failure_callback=failure_callback)
         )
-        bad_elements = bad | beam.Map(lambda x: x[0])
+        bad_elements = bad | beam.Keys()
         assert_that(good, equal_to(['abc', 'bcd', 'foo', 'bar']), 'good')
         assert_that(bad_elements, equal_to([]), 'bad')
       self.assertFalse(os.path.isfile(tmp_path))


### PR DESCRIPTION
Allows users to define a callback to execute only on failure. Step 1 of https://github.com/apache/beam/issues/32137 though this is also a standalone feature

See full design here - https://docs.google.com/document/d/19ves6iv-m_6DFmePJZqYpLm-bCooPu6wQ-Ti6kAl2Jo/edit

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
