### PR TITLE
Kafka poll interval

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java
@@ -158,6 +158,7 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
      */
     while (true) {
       if (curBatch.hasNext()) {
+        // data from the next partition?
         PartitionState<K, V> pState = curBatch.next();
 
         if (!pState.recordIter.hasNext()) { // -- (c)
@@ -228,14 +229,16 @@ class KafkaUnboundedReader<K, V> extends UnboundedReader<KafkaRecord<K, V>> {
         for (Map.Entry<String, Long> backlogSplit : perPartitionBacklogMetrics.entrySet()) {
           backlogBytesOfSplit.set(backlogSplit.getValue());
         }
-        return true;
+        return true; // record has been read and proccessed, so we return. (only read a record at a time)
 
       } else { // -- (b)
-        nextBatch();
+        nextBatch(); // void, returns nothing, can this be done in the background instead of when we call advance?
 
-        if (!curBatch.hasNext()) {
+        if (!curBatch.hasNext()) { // returns false because nothing returned in time?
           return false;
         }
+        // Gives no such element exception
+        // return true; //? returns, then will call advance again. Whats the difference between repeatedly calling advance vs iterating over constatnly? 
       }
     }
   }

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -1092,7 +1092,7 @@ public class KafkaIOTest {
 
   @Test
   public void testUnboundedSourceWithExceptionInKafkaFetch() {
-    // Similar testUnboundedSource, but with an injected exception inside Kafk Consumer poll.
+    // Similar testUnboundedSource, but with an injected exception inside Kafka Consumer poll.
 
     // The reader should throw an IOException:
     thrown.expectCause(isA(IOException.class));


### PR DESCRIPTION
Force atleast one poll to Kafka cluster to complete, before returning

addresses #21630

Context: (pulled from the bug above)

The [consumerPollLoop](https://github.com/apache/beam/blob/master/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java#L515) that polls data via a Kafka Consumer if there's no pending data already, and offers it to the availableRecordsQueue otherwise. It calls the [nextBatch function](https://github.com/apache/beam/blob/master/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java#L573) repeatedly until an attempt to [fetch an element from the avaliableRecordsQueue](https://github.com/apache/beam/blob/master/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaUnboundedReader.java#L580) times out. After the timeout, it returns the control to the worker and it may take relatively long time until the loop is scheduled again.

This is what we think is happening when the poll latency is high:

consumerPollLoop fetches data bundle from Kafka via poll() and offers it to the avaliableRecordsQueue
message processing loop fetches bundle from avaliableRecordsQueue and unblocks the consumerPollLoop
consumerPollLoop calls poll() again
message processing loop completes processing the bundle BEFORE the poll() call above completes, and tries to fetch next bundle from avaliableRecordsQueue.
fetch from avaliableRecordsQueue has a very short timeout (10ms) and if it expires before the pending poll() in the consumerPollLoop completes the message processing loop will believe there's no fresh data in Kafka and exit. All the time until the message processing loop is rescheduled is wasted.

This PR prevents the above by waiting for at least one poll to complete before we complete the message processing loop, so even if polling latency degrades, we wait for it to finish to process the new messages.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
