### PR TITLE
Fix verifyJavaVersion in a few places

### DIFF
--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -657,6 +657,9 @@ task examplesJavaRunnerV2PreCommit(type: Test) {
 task examplesJavaRunnerV2IntegrationTest(type: Test) {
   group = "Verification"
   dependsOn buildAndPushDockerJavaContainer
+  if (project.hasProperty("testJavaVersion")) {
+    dependsOn ":sdks:java:testing:test-utils:verifyJavaVersion${project.property("testJavaVersion")}"
+  }
 
   systemProperty "beamTestPipelineOptions", JsonOutput.toJson(runnerV2PipelineOptions)
 

--- a/runners/google-cloud-dataflow-java/examples/build.gradle
+++ b/runners/google-cloud-dataflow-java/examples/build.gradle
@@ -183,6 +183,9 @@ task java21PostCommit() {
 task preCommit() {
   dependsOn preCommitLegacyWorker
   dependsOn preCommitLegacyWorkerImpersonate
+  if (project.hasProperty("testJavaVersion")) {
+    dependsOn ":sdks:java:testing:test-utils:verifyJavaVersion${project.property("testJavaVersion")}"
+  }
 }
 
 task verifyPortabilityApi() {

--- a/sdks/java/container/common.gradle
+++ b/sdks/java/container/common.gradle
@@ -103,6 +103,9 @@ task validateJavaHome {
     def requiredForVer = ["11", "17", "21"]
     if (requiredForVer.contains(imageJavaVersion)) {
         doFirst {
+            if (JavaVersion.VERSION_1_8.compareTo(JavaVersion.current()) < 0) {
+                return
+            }
             boolean propertyFound = false
             // enable to build agent with compatible java versions (11-requiredForVer)
             for (def checkVer : requiredForVer) {
@@ -115,7 +118,7 @@ task validateJavaHome {
                 }
             }
             if (!propertyFound) {
-                throw new GradleException("java${imageJavaVersion}Home or compatible properties required for imageJavaVersion=${imageJavaVersion}. Re-run with -Pjava${imageJavaVersion}Home")
+                throw new GradleException("System Java needs to have version 11+ or java${imageJavaVersion}Home required for imageJavaVersion=${imageJavaVersion}. Re-run with -Pjava${imageJavaVersion}Home")
             }
         }
     }

--- a/sdks/java/testing/test-utils/build.gradle
+++ b/sdks/java/testing/test-utils/build.gradle
@@ -43,12 +43,12 @@ dependencies {
   testRuntimeOnly project(path: ":runners:direct-java", configuration: "shadowTest")
 }
 
-['8', '11', '17', '21'].each {
-  tasks.create(name: "verifyJavaVersion${it}", type: Test) {
+['8', '11', '17', '21'].each { String ver ->
+  tasks.create(name: "verifyJavaVersion${ver}", type: Test) {
     filter {
       includeTestsMatching "org.apache.beam.sdk.testutils.jvmverification.JvmVerification.verifyCodeIsCompiledWithJava8"
-      includeTestsMatching "org.apache.beam.sdk.testutils.jvmverification.JvmVerification.verifyTestCodeIsCompiledWithJava${it}"
-      includeTestsMatching "org.apache.beam.sdk.testutils.jvmverification.JvmVerification.verifyRunningJVMVersionIs${it}"
+      includeTestsMatching "org.apache.beam.sdk.testutils.jvmverification.JvmVerification.verifyTestCodeIsCompiledWithJava${ver}"
+      includeTestsMatching "org.apache.beam.sdk.testutils.jvmverification.JvmVerification.verifyRunningJVMVersionIs${ver}"
     }
     doLast {
       println 'Java verified'

--- a/sdks/java/testing/test-utils/build.gradle
+++ b/sdks/java/testing/test-utils/build.gradle
@@ -40,7 +40,7 @@ dependencies {
   provided library.java.jmh_core
 
   testImplementation library.java.junit
-  testRuntimeOnly project(path: ":runners:direct-java", configuration: "shadowTest")
+  testRuntimeOnly project(path: ":runners:direct-java", configuration: "shadow")
 }
 
 ['8', '11', '17', '21'].each { String ver ->


### PR DESCRIPTION
Two issues

1. It is found that after #28918, the java version verification test only checks that the source code was compile with Java8, but not test code compiled/running on certain Java version

2. We had overly strict sdks:java:docker:javaX:validateJavaHome . If system java version is Java11, xlangPythonUsingJava will add a java 11 docker task, which currently requires `-Pjava11Home`, which is not necessary.

**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
