### PR TITLE
[#31926] [java] call provision service when creating external workers.

### DIFF
--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/ExternalWorkerService.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/ExternalWorkerService.java
@@ -20,21 +20,30 @@ package org.apache.beam.fn.harness;
 import static org.apache.beam.sdk.util.Preconditions.checkArgumentNotNull;
 
 import java.util.Collections;
+import java.util.Set;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.StartWorkerRequest;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.StartWorkerResponse;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.StopWorkerRequest;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.StopWorkerResponse;
 import org.apache.beam.model.fnexecution.v1.BeamFnExternalWorkerPoolGrpc.BeamFnExternalWorkerPoolImplBase;
+import org.apache.beam.model.fnexecution.v1.ProvisionApi;
+import org.apache.beam.model.fnexecution.v1.ProvisionServiceGrpc;
 import org.apache.beam.model.pipeline.v1.Endpoints;
+import org.apache.beam.model.pipeline.v1.RunnerApi.StandardRunnerProtocols;
+import org.apache.beam.sdk.fn.channel.AddHarnessIdInterceptor;
+import org.apache.beam.sdk.fn.channel.ManagedChannelFactory;
 import org.apache.beam.sdk.fn.server.FnService;
 import org.apache.beam.sdk.fn.server.GrpcFnServer;
 import org.apache.beam.sdk.fn.server.ServerFactory;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.beam.sdk.options.PortablePipelineOptions;
 import org.apache.beam.sdk.util.Sleeper;
+import org.apache.beam.sdk.util.construction.BeamUrns;
 import org.apache.beam.sdk.util.construction.Environments;
 import org.apache.beam.sdk.util.construction.PipelineOptionsTranslation;
 import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.stub.StreamObserver;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Sets;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -61,6 +70,29 @@ public class ExternalWorkerService extends BeamFnExternalWorkerPoolImplBase impl
         request.getWorkerId(),
         request.getControlEndpoint().getUrl());
     LOG.debug("Worker request {}.", request);
+
+    Endpoints.ApiServiceDescriptor loggingEndpoint = request.getLoggingEndpoint();
+    Endpoints.ApiServiceDescriptor controlEndpoint = request.getControlEndpoint();
+    Set<String> runnerCapabilites = Collections.emptySet();
+    if (request.hasProvisionEndpoint()) {
+      ManagedChannelFactory channelFactory = ManagedChannelFactory.createDefault()
+          .withInterceptors(ImmutableList.of(AddHarnessIdInterceptor.create(request.getWorkerId())));
+
+      ProvisionServiceGrpc.ProvisionServiceBlockingStub provisionStub = ProvisionServiceGrpc.newBlockingStub(channelFactory.forDescriptor(request.getProvisionEndpoint()));
+      ProvisionApi.ProvisionInfo provisionInfo = provisionStub.getProvisionInfo(ProvisionApi.GetProvisionInfoRequest.newBuilder().build()).getInfo();
+
+      runnerCapabilites = Sets.newHashSet(provisionInfo.getRunnerCapabilitiesList());
+      if (provisionInfo.hasControlEndpoint()) {
+        controlEndpoint = provisionInfo.getControlEndpoint();
+      }
+      if (provisionInfo.hasLoggingEndpoint()) {
+        loggingEndpoint = provisionInfo.getLoggingEndpoint();
+      }
+    }
+    // Lambda closured variables must be final.
+    final Endpoints.ApiServiceDescriptor logEndpoint = loggingEndpoint;
+    final Endpoints.ApiServiceDescriptor ctrlEndpoint = controlEndpoint;
+    final Set<String> capabilities = runnerCapabilites;
     Thread th =
         new Thread(
             () -> {
@@ -68,9 +100,9 @@ public class ExternalWorkerService extends BeamFnExternalWorkerPoolImplBase impl
                 FnHarness.main(
                     request.getWorkerId(),
                     options,
-                    Collections.emptySet(),
-                    request.getLoggingEndpoint(),
-                    request.getControlEndpoint(),
+                    capabilities,
+                    logEndpoint,
+                    ctrlEndpoint,
                     null);
                 LOG.info("Successfully started worker {}.", request.getWorkerId());
               } catch (Exception exn) {


### PR DESCRIPTION
This fixes metrics from the Java SDK when running in Loopback mode against Prism (and probably a few other usecases too).

* The Provision API is usually called by the container bootloader to initialize the worker.
* Without calling the ProvisionAPI, the worker doesn't know a runner's capabilities.
* This lead to the Java SDK to send old style metrics in loopback mode, which prism doesn't support.
* That meant there were no metrics being propagated at in the UI.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
