### PR TITLE
[Java11 Migration] Migrate Go testing to use Java11 container image for xlang

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -544,7 +544,7 @@ class BeamModulePlugin implements Plugin<Project> {
     project.taskTree { noRepeat = true }
 
     project.ext.currentJavaVersion = getSupportedJavaVersion()
-  
+
     project.ext.allFlinkVersions = project.flink_versions.split(',')
     project.ext.latestFlinkVersion = project.ext.allFlinkVersions.last()
 

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -543,6 +543,8 @@ class BeamModulePlugin implements Plugin<Project> {
     project.apply plugin: "com.dorongold.task-tree"
     project.taskTree { noRepeat = true }
 
+    project.ext.currentJavaVersion = getSupportedJavaVersion()
+  
     project.ext.allFlinkVersions = project.flink_versions.split(',')
     project.ext.latestFlinkVersion = project.ext.allFlinkVersions.last()
 

--- a/sdks/go/examples/kafka/taxi.go
+++ b/sdks/go/examples/kafka/taxi.go
@@ -91,8 +91,8 @@
 // Docker Hub.
 //
 //	export DOCKER_ROOT="Your Docker Repository Root"
-//	./gradlew :sdks:java:container:java8:docker -Pdocker-repository-root=$DOCKER_ROOT -Pdocker-tag=latest
-//	docker push $DOCKER_ROOT/beam_java8_sdk:latest
+//	./gradlew :sdks:java:container:java11:docker -Pdocker-repository-root=$DOCKER_ROOT -Pdocker-tag=latest
+//	docker push $DOCKER_ROOT/beam_java11_sdk:latest
 //
 // For runners in local mode, simply building the container using the default
 // values for docker-repository-root and docker-tag will work to have it
@@ -102,7 +102,7 @@
 // pipeline with the --sdk_harness_container_image_override flag for Java, or
 // --environment_config flag for Go. For example:
 //
-//	--sdk_harness_container_image_override=".*java.*,${DOCKER_ROOT}/beam_java8_sdk:latest" \
+//	--sdk_harness_container_image_override=".*java.*,${DOCKER_ROOT}/beam_java11_sdk:latest" \
 //	--environment_config=${DOCKER_ROOT}/beam_go_sdk:latest
 package main
 

--- a/sdks/go/examples/xlang/bigquery/wordcount.go
+++ b/sdks/go/examples/xlang/bigquery/wordcount.go
@@ -76,8 +76,8 @@
 // container repository, such as Docker Hub.
 //
 //	export DOCKER_ROOT="Your Docker Repository Root"
-//	./gradlew :sdks:java:container:java8:docker -Pdocker-repository-root=$DOCKER_ROOT -Pdocker-tag=latest
-//	docker push $DOCKER_ROOT/beam_java8_sdk:latest
+//	./gradlew :sdks:java:container:java11:docker -Pdocker-repository-root=$DOCKER_ROOT -Pdocker-tag=latest
+//	docker push $DOCKER_ROOT/beam_java11_sdk:latest
 //
 // For runners in local mode, simply building the container using the default values for
 // docker-repository-root and docker-tag will work to have it accessible locally.
@@ -86,7 +86,7 @@
 // --sdk_harness_container_image_override flag for Java, or --environment_config flag for Go. For
 // example:
 //
-//	--sdk_harness_container_image_override=".*java.*,${DOCKER_ROOT}/beam_java8_sdk:latest" \
+//	--sdk_harness_container_image_override=".*java.*,${DOCKER_ROOT}/beam_java11_sdk:latest" \
 //	--environment_config=${DOCKER_ROOT}/beam_go_sdk:latest
 package main
 

--- a/sdks/go/test/build.gradle
+++ b/sdks/go/test/build.gradle
@@ -69,7 +69,7 @@ task flinkValidatesRunner {
 
   dependsOn ":sdks:go:test:goBuild"
   dependsOn ":sdks:go:container:docker"
-  dependsOn ":sdks:java:container:java8:docker"
+  dependsOn ":sdks:java:container:java11:docker"
   dependsOn ":runners:flink:${project.ext.latestFlinkVersion}:job-server:shadowJar"
   dependsOn ":sdks:java:testing:expansion-service:buildTestExpansionServiceJar"
   doLast {
@@ -93,7 +93,7 @@ task flinkValidatesRunner {
 task samzaValidatesRunner {
   dependsOn ":sdks:go:test:goBuild"
   dependsOn ":sdks:go:container:docker"
-  dependsOn ":sdks:java:container:java8:docker"
+  dependsOn ":sdks:java:container:java11:docker"
   dependsOn ":runners:samza:job-server:shadowJar"
   dependsOn ":sdks:java:testing:expansion-service:buildTestExpansionServiceJar"
   doLast {
@@ -118,7 +118,7 @@ task sparkValidatesRunner {
   group = "Verification"
 
   dependsOn ":sdks:go:test:goBuild"
-  dependsOn ":sdks:java:container:java8:docker"
+  dependsOn ":sdks:java:container:java11:docker"
   dependsOn ":runners:spark:3:job-server:shadowJar"
   dependsOn ":sdks:java:testing:expansion-service:buildTestExpansionServiceJar"
   doLast {
@@ -149,7 +149,7 @@ tasks.register("ulrValidatesRunner") {
 
   dependsOn ":sdks:go:test:goBuild"
   dependsOn ":sdks:go:container:docker"
-  dependsOn ":sdks:java:container:java8:docker"
+  dependsOn ":sdks:java:container:java11:docker"
   dependsOn "setupVirtualenv"
   dependsOn ":sdks:python:buildPython"
   dependsOn ":sdks:java:testing:expansion-service:buildTestExpansionServiceJar"
@@ -180,7 +180,7 @@ task prismValidatesRunner {
 
   dependsOn ":sdks:go:test:goBuild"
   dependsOn ":sdks:go:container:docker"
-  dependsOn ":sdks:java:container:java8:docker"
+  dependsOn ":sdks:java:container:java11:docker"
   dependsOn ":sdks:java:testing:expansion-service:buildTestExpansionServiceJar"
   doLast {
     def pipelineOptions = [  // Pipeline options piped directly to Go SDK flags.

--- a/sdks/go/test/build.gradle
+++ b/sdks/go/test/build.gradle
@@ -69,7 +69,7 @@ task flinkValidatesRunner {
 
   dependsOn ":sdks:go:test:goBuild"
   dependsOn ":sdks:go:container:docker"
-  dependsOn ":sdks:java:container:java11:docker"
+  dependsOn ":sdks:java:container:${project.ext.currentJavaVersion}:docker"
   dependsOn ":runners:flink:${project.ext.latestFlinkVersion}:job-server:shadowJar"
   dependsOn ":sdks:java:testing:expansion-service:buildTestExpansionServiceJar"
   doLast {
@@ -93,7 +93,7 @@ task flinkValidatesRunner {
 task samzaValidatesRunner {
   dependsOn ":sdks:go:test:goBuild"
   dependsOn ":sdks:go:container:docker"
-  dependsOn ":sdks:java:container:java11:docker"
+  dependsOn ":sdks:java:container:${project.ext.currentJavaVersion}:docker"
   dependsOn ":runners:samza:job-server:shadowJar"
   dependsOn ":sdks:java:testing:expansion-service:buildTestExpansionServiceJar"
   doLast {
@@ -118,7 +118,7 @@ task sparkValidatesRunner {
   group = "Verification"
 
   dependsOn ":sdks:go:test:goBuild"
-  dependsOn ":sdks:java:container:java11:docker"
+  dependsOn ":sdks:java:container:${project.ext.currentJavaVersion}:docker"
   dependsOn ":runners:spark:3:job-server:shadowJar"
   dependsOn ":sdks:java:testing:expansion-service:buildTestExpansionServiceJar"
   doLast {
@@ -149,7 +149,7 @@ tasks.register("ulrValidatesRunner") {
 
   dependsOn ":sdks:go:test:goBuild"
   dependsOn ":sdks:go:container:docker"
-  dependsOn ":sdks:java:container:java11:docker"
+  dependsOn ":sdks:java:container:${project.ext.currentJavaVersion}:docker"
   dependsOn "setupVirtualenv"
   dependsOn ":sdks:python:buildPython"
   dependsOn ":sdks:java:testing:expansion-service:buildTestExpansionServiceJar"
@@ -180,7 +180,7 @@ task prismValidatesRunner {
 
   dependsOn ":sdks:go:test:goBuild"
   dependsOn ":sdks:go:container:docker"
-  dependsOn ":sdks:java:container:java11:docker"
+  dependsOn ":sdks:java:container:${project.ext.currentJavaVersion}:docker"
   dependsOn ":sdks:java:testing:expansion-service:buildTestExpansionServiceJar"
   doLast {
     def pipelineOptions = [  // Pipeline options piped directly to Go SDK flags.


### PR DESCRIPTION
The default Xlang transforms got moved to Java 11, but we were only building the Java8 ones, so 11 wasn't available.

Move to use Java 11 to unbreak the existing tests.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
