### PR TITLE
fix failing ProtoSchemaTranslator on proto3 optional fields

### DIFF
--- a/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslator.java
+++ b/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslator.java
@@ -204,7 +204,8 @@ class ProtoSchemaTranslator {
 
     for (Descriptors.FieldDescriptor fieldDescriptor : descriptor.getFields()) {
       int fieldDescriptorNumber = fieldDescriptor.getNumber();
-      if (!(oneOfComponentFields.contains(fieldDescriptorNumber) && fieldDescriptor.getRealContainingOneof() != null)) {
+      if (!(oneOfComponentFields.contains(fieldDescriptorNumber)
+          && fieldDescriptor.getRealContainingOneof() != null)) {
         // Store proto field number in metadata.
         FieldType fieldType = beamFieldTypeFromProtoField(fieldDescriptor);
         fields.add(

--- a/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslator.java
+++ b/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslator.java
@@ -204,7 +204,7 @@ class ProtoSchemaTranslator {
 
     for (Descriptors.FieldDescriptor fieldDescriptor : descriptor.getFields()) {
       int fieldDescriptorNumber = fieldDescriptor.getNumber();
-      if (!oneOfComponentFields.contains(fieldDescriptorNumber)) {
+      if (!(oneOfComponentFields.contains(fieldDescriptorNumber) && fieldDescriptor.getRealContainingOneof() != null)) {
         // Store proto field number in metadata.
         FieldType fieldType = beamFieldTypeFromProtoField(fieldDescriptor);
         fields.add(

--- a/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslatorTest.java
+++ b/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslatorTest.java
@@ -55,8 +55,8 @@ public class ProtoSchemaTranslatorTest {
   @Test
   public void testProto3OptionalPrimitiveSchema() {
     assertEquals(
-            TestProtoSchemas.PROTO3_OPTIONAL_PRIMITIVE_SCHEMA,
-            ProtoSchemaTranslator.getSchema(Proto3SchemaMessages.OptionalPrimitive.class));
+        TestProtoSchemas.PROTO3_OPTIONAL_PRIMITIVE_SCHEMA,
+        ProtoSchemaTranslator.getSchema(Proto3SchemaMessages.OptionalPrimitive.class));
   }
 
   @Test
@@ -179,8 +179,8 @@ public class ProtoSchemaTranslatorTest {
   @Test
   public void testProto3OptionalNestedSchema() {
     assertEquals(
-            TestProtoSchemas.PROTO3_OPTIONAL_NESTED_SCHEMA,
-            ProtoSchemaTranslator.getSchema(Proto3SchemaMessages.OptionalNested.class));
+        TestProtoSchemas.PROTO3_OPTIONAL_NESTED_SCHEMA,
+        ProtoSchemaTranslator.getSchema(Proto3SchemaMessages.OptionalNested.class));
   }
 
   @Test

--- a/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslatorTest.java
+++ b/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/ProtoSchemaTranslatorTest.java
@@ -53,6 +53,13 @@ public class ProtoSchemaTranslatorTest {
   }
 
   @Test
+  public void testProto3OptionalPrimitiveSchema() {
+    assertEquals(
+            TestProtoSchemas.PROTO3_OPTIONAL_PRIMITIVE_SCHEMA,
+            ProtoSchemaTranslator.getSchema(Proto3SchemaMessages.OptionalPrimitive.class));
+  }
+
+  @Test
   public void testRequiredPrimitiveSchema() {
     assertEquals(
         TestProtoSchemas.REQUIRED_PRIMITIVE_SCHEMA,
@@ -170,6 +177,13 @@ public class ProtoSchemaTranslatorTest {
   }
 
   @Test
+  public void testProto3OptionalNestedSchema() {
+    assertEquals(
+            TestProtoSchemas.PROTO3_OPTIONAL_NESTED_SCHEMA,
+            ProtoSchemaTranslator.getSchema(Proto3SchemaMessages.OptionalNested.class));
+  }
+
+  @Test
   public void testRequiredNestedSchema() {
     assertEquals(
         TestProtoSchemas.REQUIRED_NESTED_SCHEMA,
@@ -266,6 +280,7 @@ public class ProtoSchemaTranslatorTest {
     assertEquals("foobar in field", optionMessage.getString("single_string"));
     assertEquals(Integer.valueOf(56), optionMessage.getInt32("single_int32"));
     assertEquals(Long.valueOf(78L), optionMessage.getInt64("single_int64"));
+    assertEquals("this is optional", optionMessage.getString("optional_string"));
   }
 
   @Test

--- a/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/TestProtoSchemas.java
+++ b/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/TestProtoSchemas.java
@@ -126,18 +126,18 @@ class TestProtoSchemas {
           .build();
 
   static final Schema PROTO3_OPTIONAL_PRIMITIVE_SCHEMA =
-          Schema.builder()
-                  .addField(withFieldNumber("primitive_int32", FieldType.INT32, 1))
-                  .addField(withFieldNumber("primitive_bool", FieldType.BOOLEAN, 2))
-                  .addField(withFieldNumber("primitive_string", FieldType.STRING, 3))
-                  .addField(withFieldNumber("primitive_bytes", FieldType.BYTES, 4))
-                  .setOptions(
-                          Schema.Options.builder()
-                                  .setOption(
-                                          SCHEMA_OPTION_META_TYPE_NAME,
-                                          FieldType.STRING,
-                                          "proto3_schema_messages.OptionalPrimitive"))
-                  .build();
+      Schema.builder()
+          .addField(withFieldNumber("primitive_int32", FieldType.INT32, 1))
+          .addField(withFieldNumber("primitive_bool", FieldType.BOOLEAN, 2))
+          .addField(withFieldNumber("primitive_string", FieldType.STRING, 3))
+          .addField(withFieldNumber("primitive_bytes", FieldType.BYTES, 4))
+          .setOptions(
+              Schema.Options.builder()
+                  .setOption(
+                      SCHEMA_OPTION_META_TYPE_NAME,
+                      FieldType.STRING,
+                      "proto3_schema_messages.OptionalPrimitive"))
+          .build();
 
   static final Schema REQUIRED_PRIMITIVE_SCHEMA =
       Schema.builder()
@@ -667,12 +667,12 @@ class TestProtoSchemas {
           .build();
 
   static final Schema PROTO3_OPTIONAL_NESTED_SCHEMA =
-          Schema.builder()
-                  .addField(
-                          withFieldNumber("nested", FieldType.row(PROTO3_OPTIONAL_PRIMITIVE_SCHEMA), 1)
-                                  .withNullable(true))
-                  .setOptions(withTypeName("proto3_schema_messages.OptionalNested"))
-                  .build();
+      Schema.builder()
+          .addField(
+              withFieldNumber("nested", FieldType.row(PROTO3_OPTIONAL_PRIMITIVE_SCHEMA), 1)
+                  .withNullable(true))
+          .setOptions(withTypeName("proto3_schema_messages.OptionalNested"))
+          .build();
 
   // A sample instance of the proto.
   static final OptionalNested OPTIONAL_NESTED =

--- a/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/TestProtoSchemas.java
+++ b/sdks/java/extensions/protobuf/src/test/java/org/apache/beam/sdk/extensions/protobuf/TestProtoSchemas.java
@@ -125,6 +125,20 @@ class TestProtoSchemas {
                       "proto2_schema_messages.OptionalPrimitive"))
           .build();
 
+  static final Schema PROTO3_OPTIONAL_PRIMITIVE_SCHEMA =
+          Schema.builder()
+                  .addField(withFieldNumber("primitive_int32", FieldType.INT32, 1))
+                  .addField(withFieldNumber("primitive_bool", FieldType.BOOLEAN, 2))
+                  .addField(withFieldNumber("primitive_string", FieldType.STRING, 3))
+                  .addField(withFieldNumber("primitive_bytes", FieldType.BYTES, 4))
+                  .setOptions(
+                          Schema.Options.builder()
+                                  .setOption(
+                                          SCHEMA_OPTION_META_TYPE_NAME,
+                                          FieldType.STRING,
+                                          "proto3_schema_messages.OptionalPrimitive"))
+                  .build();
+
   static final Schema REQUIRED_PRIMITIVE_SCHEMA =
       Schema.builder()
           .addField(withFieldNumber("primitive_int32", FieldType.INT32, 1))
@@ -651,6 +665,14 @@ class TestProtoSchemas {
                   .withNullable(true))
           .setOptions(withTypeName("proto2_schema_messages.OptionalNested"))
           .build();
+
+  static final Schema PROTO3_OPTIONAL_NESTED_SCHEMA =
+          Schema.builder()
+                  .addField(
+                          withFieldNumber("nested", FieldType.row(PROTO3_OPTIONAL_PRIMITIVE_SCHEMA), 1)
+                                  .withNullable(true))
+                  .setOptions(withTypeName("proto3_schema_messages.OptionalNested"))
+                  .build();
 
   // A sample instance of the proto.
   static final OptionalNested OPTIONAL_NESTED =

--- a/sdks/java/extensions/protobuf/src/test/proto/proto3_schema_messages.proto
+++ b/sdks/java/extensions/protobuf/src/test/proto/proto3_schema_messages.proto
@@ -180,6 +180,7 @@ message OptionMessage {
             single_string: "foobar in field"
             single_int32: 56
             single_int64: 78
+            optional_string: "this is optional"
         },
         (proto3_schema_options.field_option_repeated) = "field_string_1",
         (proto3_schema_options.field_option_repeated) = "field_string_2",
@@ -209,4 +210,15 @@ message SecondCircularNested {
 }
 
 message Empty {
+}
+
+message OptionalPrimitive {
+    optional int32 primitive_int32 = 1;
+    optional bool primitive_bool = 2;
+    optional string primitive_string = 3;
+    optional bytes primitive_bytes = 4;
+}
+
+message OptionalNested {
+    optional OptionalPrimitive nested = 1;
 }

--- a/sdks/java/extensions/protobuf/src/test/proto/proto3_schema_options.proto
+++ b/sdks/java/extensions/protobuf/src/test/proto/proto3_schema_options.proto
@@ -90,4 +90,6 @@ message OptionTestMessage {
     }
     OptionEnum single_enum = 8;
     OptionTestSubMessage single_message = 9;
+
+    optional string optional_string = 10;
 }


### PR DESCRIPTION
I found that ProtoSchemaTranslator fails to translate the schema when proto3 definitions have optional fields. 

These optional fields creates synthetic oneOfs internally and ProtoSchemaTranslator runs into errors treating them are real oneOfs. This excludes that from happening.

I had to use `getRealContainingOneof()` since they have [deprecated isSynthetic()](https://github.com/protocolbuffers/protobuf/commit/b6b86e21fb67e22b762b7230427bce00ee8c9fec)


Fixes #32199

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
