### PR TITLE
Add hard delete function to multi_process_shared

### DIFF
--- a/sdks/python/apache_beam/utils/multi_process_shared_test.py
+++ b/sdks/python/apache_beam/utils/multi_process_shared_test.py
@@ -169,9 +169,9 @@ class MultiProcessSharedTest(unittest.TestCase):
 
   def test_unsafe_hard_delete(self):
     shared1 = multi_process_shared.MultiProcessShared(
-        Counter, tag='test_release', always_proxy=True)
+        Counter, tag='test_unsafe_hard_delete', always_proxy=True)
     shared2 = multi_process_shared.MultiProcessShared(
-        Counter, tag='test_release', always_proxy=True)
+        Counter, tag='test_unsafe_hard_delete', always_proxy=True)
 
     counter1 = shared1.acquire()
     counter2 = shared2.acquire()
@@ -179,7 +179,7 @@ class MultiProcessSharedTest(unittest.TestCase):
     self.assertEqual(counter2.increment(), 2)
 
     multi_process_shared.MultiProcessShared(
-        Counter, tag='test_release').unsafe_hard_delete()
+        Counter, tag='test_unsafe_hard_delete').unsafe_hard_delete()
 
     with self.assertRaises(Exception):
       counter1.get()
@@ -187,11 +187,28 @@ class MultiProcessSharedTest(unittest.TestCase):
       counter2.get()
 
     shared3 = multi_process_shared.MultiProcessShared(
-        Counter, tag='test_release', always_proxy=True)
+        Counter, tag='test_unsafe_hard_delete', always_proxy=True)
 
     counter3 = shared3.acquire()
 
     self.assertEqual(counter3.increment(), 1)
+
+  def test_unsafe_hard_delete_no_op(self):
+    shared1 = multi_process_shared.MultiProcessShared(
+        Counter, tag='test_unsafe_hard_delete_no_op', always_proxy=True)
+    shared2 = multi_process_shared.MultiProcessShared(
+        Counter, tag='test_unsafe_hard_delete_no_op', always_proxy=True)
+
+    counter1 = shared1.acquire()
+    counter2 = shared2.acquire()
+    self.assertEqual(counter1.increment(), 1)
+    self.assertEqual(counter2.increment(), 2)
+
+    multi_process_shared.MultiProcessShared(
+        Counter, tag='no_tag_to_delete').unsafe_hard_delete()
+
+    self.assertEqual(counter1.increment(), 3)
+    self.assertEqual(counter2.increment(), 4)
 
   def test_release_always_proxy(self):
     shared1 = multi_process_shared.MultiProcessShared(

--- a/sdks/python/apache_beam/utils/multi_process_shared_test.py
+++ b/sdks/python/apache_beam/utils/multi_process_shared_test.py
@@ -167,6 +167,32 @@ class MultiProcessSharedTest(unittest.TestCase):
     with self.assertRaisesRegex(Exception, 'released'):
       counter1.get()
 
+  def test_unsafe_hard_delete(self):
+    shared1 = multi_process_shared.MultiProcessShared(
+        Counter, tag='test_release', always_proxy=True)
+    shared2 = multi_process_shared.MultiProcessShared(
+        Counter, tag='test_release', always_proxy=True)
+
+    counter1 = shared1.acquire()
+    counter2 = shared2.acquire()
+    self.assertEqual(counter1.increment(), 1)
+    self.assertEqual(counter2.increment(), 2)
+
+    multi_process_shared.MultiProcessShared(
+        Counter, tag='test_release').unsafe_hard_delete()
+
+    with self.assertRaises(Exception):
+      counter1.get()
+    with self.assertRaises(Exception):
+      counter2.get()
+
+    shared3 = multi_process_shared.MultiProcessShared(
+        Counter, tag='test_release', always_proxy=True)
+
+    counter3 = shared3.acquire()
+
+    self.assertEqual(counter3.increment(), 1)
+
   def test_release_always_proxy(self):
     shared1 = multi_process_shared.MultiProcessShared(
         Counter, tag='test_release_always_proxy', always_proxy=True)


### PR DESCRIPTION
Adds an unsafe delete option to be used for garbage collection of multi_process_shared objects. This allows cleanup of multiprocess objects even if some references have been entirely lost (e.g. due to running in a subprocess mode) or if its unclear when they'll be invoked again (because Beam may not schedule work to that DoFn for a bit).

This is intentionally unsafe and should only be used when other synchronization mechanisms are in place to prevent usage of the already deleted object. For example, this will be used as part of our runinference timeout feature - for more details see  https://docs.google.com/document/d/19ves6iv-m_6DFmePJZqYpLm-bCooPu6wQ-Ti6kAl2Jo/edit#heading=h.cfdh3ijyabi3

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
