### PR TITLE
[#32245][Go SDK] Copy bytes sent over the State API Writer.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -86,6 +86,7 @@
 * Fixed incorrect service account impersonation flow for Python pipelines using BigQuery IOs ([#32030](https://github.com/apache/beam/issues/32030)).
 * Auto-disable broken and meaningless `upload_graph` feature when using Dataflow Runner V2 ([#32159](https://github.com/apache/beam/issues/32159)).
 * (Python) Upgraded google-cloud-storage to version 2.18.2 to fix a data corruption issue ([#32135](https://github.com/apache/beam/pull/32135)).
+* (Go) Fix corruption on State API writes. ([#32245](https://github.com/apache/beam/issues/32245)).
 
 ## Security Fixes
 * Fixed (CVE-YYYY-NNNN)[https://www.cve.org/CVERecord?id=CVE-YYYY-NNNN] (Java/Python/Go) ([#X](https://github.com/apache/beam/issues/X)).

--- a/sdks/go/pkg/beam/core/runtime/harness/statemgr.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/statemgr.go
@@ -468,7 +468,7 @@ func (r *stateKeyReader) Close() error {
 	return nil
 }
 
-func (r * 	) Write(buf []byte) (int, error) {
+func (r *stateKeyWriter) Write(buf []byte) (int, error) {
 	r.mu.Lock()
 	localChannel := r.ch
 	r.mu.Unlock()

--- a/sdks/go/pkg/beam/core/runtime/harness/statemgr.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/statemgr.go
@@ -468,7 +468,7 @@ func (r *stateKeyReader) Close() error {
 	return nil
 }
 
-func (r *stateKeyWriter) Write(buf []byte) (int, error) {
+func (r * 	) Write(buf []byte) (int, error) {
 	r.mu.Lock()
 	localChannel := r.ch
 	r.mu.Unlock()
@@ -643,7 +643,7 @@ func (c *StateChannel) read(ctx context.Context) {
 
 		select {
 		case ch <- msg:
-		// ok
+			// ok
 		default:
 			panic(fmt.Sprintf("StateChannel[%v].read: failed to consume state response: %v", c.id, msg.String()))
 		}

--- a/sdks/go/pkg/beam/core/runtime/harness/statemgr.go
+++ b/sdks/go/pkg/beam/core/runtime/harness/statemgr.go
@@ -16,6 +16,7 @@
 package harness
 
 import (
+	"bytes"
 	"context"
 	"fmt"
 	"io"
@@ -452,6 +453,9 @@ func (r *stateKeyReader) Read(buf []byte) (int, error) {
 		r.buf = nil
 	default:
 		r.buf = r.buf[n:]
+		if len(r.buf) == 0 {
+			r.buf = nil
+		}
 	}
 	return n, nil
 }
@@ -469,6 +473,7 @@ func (r *stateKeyWriter) Write(buf []byte) (int, error) {
 	localChannel := r.ch
 	r.mu.Unlock()
 
+	toSend := bytes.Clone(buf)
 	var req *fnpb.StateRequest
 	switch r.writeType {
 	case writeTypeAppend:
@@ -478,7 +483,7 @@ func (r *stateKeyWriter) Write(buf []byte) (int, error) {
 			StateKey:      r.key,
 			Request: &fnpb.StateRequest_Append{
 				Append: &fnpb.StateAppendRequest{
-					Data: buf,
+					Data: toSend,
 				},
 			},
 		}
@@ -499,7 +504,7 @@ func (r *stateKeyWriter) Write(buf []byte) (int, error) {
 	if err != nil {
 		return 0, err
 	}
-	return len(buf), nil
+	return len(toSend), nil
 }
 
 // StateChannelManager manages data channels over the State API. A fixed number of channels
@@ -638,7 +643,7 @@ func (c *StateChannel) read(ctx context.Context) {
 
 		select {
 		case ch <- msg:
-			// ok
+		// ok
 		default:
 			panic(fmt.Sprintf("StateChannel[%v].read: failed to consume state response: %v", c.id, msg.String()))
 		}


### PR DESCRIPTION
Copy bytes sent over the State API Writer. Eagerly nil the buffer if it's at zero length.

* stateKeyWriter wasn't implementing the io.Writer interface correctly, as it was retaining a reference to the passed in byte slice.
* This, combined with the escape analysis subversion function (ioutilx.WriteUnsafe), and a change in Go 1.23 made a data corruption more likely, as the underlying memory for the byte slice was used for other things. 
* This largely only happened sometimes because state is written to asynchronously over 3 goroutines (user, writer, reader, with user blocking until the reader confirms the write response).

A better fix would be to avoid the WriteUnsafe hack altogether, but that leads to an egregious number of small allocations, hurting performance, and would be much wider in scope to change.

Eagerly nilling a zero length read buffer avoid an extra round trip to the state reader to first return a 0 length read, before requesting more bytes or returning io.EOF.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
