### PR TITLE
Attach file extension to Iceberg writes

### DIFF
--- a/.github/trigger_files/IO_Iceberg_Integration_Tests.json
+++ b/.github/trigger_files/IO_Iceberg_Integration_Tests.json
@@ -1,4 +1,4 @@
 {
     "comment": "Modify this file in a trivial way to cause this test suite to run",
-    "modification": 4
+    "modification": 5
 }

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/RecordWriter.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/RecordWriter.java
@@ -57,10 +57,12 @@ class RecordWriter {
     this.table = table;
     this.fileFormat = fileFormat;
     if (table.spec().isUnpartitioned()) {
-      absoluteFilename = table.locationProvider().newDataLocation(filename);
+      absoluteFilename =
+          fileFormat.addExtension(table.locationProvider().newDataLocation(filename));
     } else {
       absoluteFilename =
-          table.locationProvider().newDataLocation(table.spec(), partitionKey, filename);
+          fileFormat.addExtension(
+              table.locationProvider().newDataLocation(table.spec(), partitionKey, filename));
     }
     OutputFile outputFile = table.io().newOutputFile(absoluteFilename);
 


### PR DESCRIPTION
For example, write to `data/my-file-name.parquet` instead of `data/my-file-name`