### PR TITLE
Build rc wheels in parallel to main wheels

### DIFF
--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -214,7 +214,7 @@ jobs:
         run: gsutil cp -r -a public-read source/* ${{ env.GCP_PATH }}
 
   build_wheels:
-    name: Build python wheels on ${{matrix.arch}} for ${{ matrix.os_python.os }}
+    name: Build python wheels on ${{matrix.arch}} for ${{ matrix.os_python.os }}. Is RC - ${{ matrix.is_rc_build }}
     needs:
       - check_env_variables
       - build_source
@@ -232,9 +232,14 @@ jobs:
           {"os": "windows-latest", "runner": "windows-latest", "python": "${{ needs.check_env_variables.outputs.py-versions-test }}" },
         ]
         arch: [auto]
+        is_rc_build: ['true', 'false']
         include:
           - os_python: {"os": "ubuntu-20.04", "runner": [self-hosted, ubuntu-20.04, main], "python": "${{ needs.check_env_variables.outputs.py-versions-test }}" }
             arch: aarch64
+            is_rc_build: 'true'
+          - os_python: {"os": "ubuntu-20.04", "runner": [self-hosted, ubuntu-20.04, main], "python": "${{ needs.check_env_variables.outputs.py-versions-test }}" }
+            arch: aarch64
+            is_rc_build: 'false'
     steps:
     - name: Download python source distribution from artifacts
       # Pinned to v3 because of https://github.com/actions/download-artifact/issues/249
@@ -243,7 +248,7 @@ jobs:
         name: source
         path: apache-beam-source
     - name: Download Python SDK RC source distribution from artifacts
-      if: ${{ needs.build_source.outputs.is_rc == 1 }}
+      if: ${{ needs.build_source.outputs.is_rc == 1 && matrix.is_rc_build == 'true' }}
       # Pinned to v3 because of https://github.com/actions/download-artifact/issues/249
       uses: actions/download-artifact@v3
       with:
@@ -268,6 +273,7 @@ jobs:
         CIBW_BEFORE_BUILD: pip install cython==0.29.36 numpy --config-settings=setup-args="-Dallow-noblas=true" && pip install --upgrade setuptools
       run: cibuildwheel --print-build-identifiers && cibuildwheel --output-dir wheelhouse
       shell: bash
+      if: ${{ matrix.is_rc_build == 'false' }}
     - name: install sha512sum on MacOS
       if: startsWith(matrix.os_python.os, 'macos')
       run: brew install coreutils
@@ -278,14 +284,16 @@ jobs:
           sha512sum $file > ${file}.sha512
         done
       shell: bash
+      if: ${{ matrix.is_rc_build == 'false' }}
     - name: Upload wheels as artifacts
       # Pinned to v3 because of https://github.com/actions/download-artifact/issues/249
       uses: actions/upload-artifact@v3
       with:
         name: wheelhouse-${{ matrix.os_python.os }}${{ (matrix.arch == 'aarch64' && '-aarch64') || '' }}
         path: apache-beam-source/wheelhouse/
+      if: ${{ matrix.is_rc_build == 'false' }}
     - name: Build RC wheels
-      if: ${{ needs.build_source.outputs.is_rc == 1 }}
+      if: ${{ needs.build_source.outputs.is_rc == 1 && matrix.is_rc_build == 'true' }}
       working-directory: apache-beam-source-rc
       env:
         CIBW_BUILD: ${{ matrix.os_python.python }}
@@ -295,7 +303,7 @@ jobs:
       run: cibuildwheel --print-build-identifiers && cibuildwheel --output-dir wheelhouse
       shell: bash
     - name: Add RC checksums
-      if: ${{ needs.build_source.outputs.is_rc == 1 }}
+      if: ${{ needs.build_source.outputs.is_rc == 1 && matrix.is_rc_build == 'true' }}
       working-directory: apache-beam-source-rc/wheelhouse/
       run: |
         for file in *.whl; do
@@ -303,7 +311,7 @@ jobs:
         done
       shell: bash
     - name: Upload RC wheels as artifacts
-      if: ${{ needs.build_source.outputs.is_rc == 1 }}
+      if: ${{ needs.build_source.outputs.is_rc == 1 && matrix.is_rc_build == 'true' }}
       # Pinned to v3 because of https://github.com/actions/download-artifact/issues/249
       uses: actions/upload-artifact@v3
       with:

--- a/.github/workflows/build_wheels.yml
+++ b/.github/workflows/build_wheels.yml
@@ -247,6 +247,7 @@ jobs:
       with:
         name: source
         path: apache-beam-source
+      if: ${{ matrix.is_rc_build == 'false' }}
     - name: Download Python SDK RC source distribution from artifacts
       if: ${{ needs.build_source.outputs.is_rc == 1 && matrix.is_rc_build == 'true' }}
       # Pinned to v3 because of https://github.com/actions/download-artifact/issues/249


### PR DESCRIPTION
This will greatly speed up our time to release (now docker artifacts will be the bottleneck, though we could do something similar for them if needed

- Example of this running on a non-rc - https://github.com/apache/beam/actions/runs/10516450029 - technically used some extra compute, but all the (empty) RC stages took <30 seconds, **takes 3.5 hours**
Example of this running on a (fake) RC - RC faked with https://github.com/apache/beam/commit/1048b6e1b7b4dac47538af649d5dc63c857a50b6 - https://github.com/apache/beam/actions/runs/10516478683 - **takes 5 hours**. I expect this may be on the higher end since the RC wheels themselves took quite long despite being the same as the normal wheels, which took 4 hours. Still is an improvement regardless, but hopefully it will be more like <4 hours in general. It should also be driven down when we deprecate python 3.8
Example of running without this change on an RC - https://github.com/apache/beam/actions/runs/10408455748 - **takes 7 hours**

Fixes #32217

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
