### PR TITLE
Fix BQMS jar download error

### DIFF
--- a/.github/trigger_files/IO_Iceberg_Integration_Tests.json
+++ b/.github/trigger_files/IO_Iceberg_Integration_Tests.json
@@ -1,4 +1,4 @@
 {
     "comment": "Modify this file in a trivial way to cause this test suite to run",
-    "modification": 7
+    "modification": 8
 }

--- a/sdks/java/io/iceberg/bigquerymetastore/build.gradle
+++ b/sdks/java/io/iceberg/bigquerymetastore/build.gradle
@@ -36,7 +36,7 @@ description = "Apache Beam :: SDKs :: Java :: IO :: Iceberg :: BigQuery Metastor
 ext.summary = "A copy of the BQMS catalog with some popular libraries relocated."
 
 task downloadBqmsJar(type: Copy) {
-    def jarUrl = 'https://storage.googleapis.com/spark-lib/bigquery/iceberg-bigquery-catalog-1.5.2-0.1.0.jar'
+    def jarUrl = 'http://storage.googleapis.com/spark-lib/bigquery/iceberg-bigquery-catalog-1.5.2-0.1.0.jar'
     def outputDir = file("$bqmsLocation")
     outputDir.mkdirs()
 


### PR DESCRIPTION
In some environments (internal import), the jar download operation throws an `java.net.UnknownHostException` due to using `https` in the URL