### PR TITLE
Use proper coders in interactive cache.

### DIFF
--- a/sdks/python/apache_beam/runners/interactive/cache_manager.py
+++ b/sdks/python/apache_beam/runners/interactive/cache_manager.py
@@ -17,6 +17,7 @@
 
 # pytype: skip-file
 
+import base64
 import collections
 import os
 import tempfile
@@ -28,6 +29,7 @@ from apache_beam import coders
 from apache_beam.io import filesystems
 from apache_beam.io import textio
 from apache_beam.io import tfrecordio
+from apache_beam.testing import test_stream
 from apache_beam.transforms import combiners
 
 
@@ -154,7 +156,15 @@ class FileBasedCacheManager(CacheManager):
   """Maps PCollections to local temp files for materialization."""
 
   _available_formats = {
-      'text': (textio.ReadFromText, textio.WriteToText),
+      'text': (
+          lambda path: textio.ReadFromText(
+              path,
+              coder=Base64Coder(),
+              compression_type=filesystems.CompressionTypes.BZIP2),
+          lambda path: textio.WriteToText(
+              path,
+              coder=Base64Coder(),
+              compression_type=filesystems.CompressionTypes.BZIP2)),
       'tfrecord': (tfrecordio.ReadFromTFRecord, tfrecordio.WriteToTFRecord)
   }
 
@@ -226,12 +236,13 @@ class FileBasedCacheManager(CacheManager):
       return iter([]), -1
 
     # Otherwise, return a generator to the cached PCollection.
-    source = self.source(*labels)._source
+    coder = self.load_pcoder('reify', *labels[1:])
+    source = self.raw_source(*labels)._source
     range_tracker = source.get_range_tracker(None, None)
     reader = source.read(range_tracker)
     version = self._latest_version(*labels)
 
-    return reader, version
+    return (coder.decode(b) for b in reader), version
 
   def write(self, values, *labels):
     """Imitates how a WriteCache transform works without running a pipeline.
@@ -242,16 +253,17 @@ class FileBasedCacheManager(CacheManager):
     pcoder = coders.registry.get_coder(type(values[0]))
     # Save the pcoder for the actual labels.
     self.save_pcoder(pcoder, *labels)
+    self.save_pcoder(pcoder, 'reify', *labels[-1:])
     single_shard_labels = [*labels[:-1], '-00000-of-00001']
     # Save the pcoder for the labels that imitates the sharded cache file name
     # suffix.
     self.save_pcoder(pcoder, *single_shard_labels)
     # Put a '-%05d-of-%05d' suffix to the cache file.
-    sink = self.sink(single_shard_labels)._sink
+    sink = self.raw_sink(single_shard_labels)._sink
     path = self._path(*labels[:-1])
     writer = sink.open_writer(path, labels[-1])
     for v in values:
-      writer.write(v)
+      writer.write(pcoder.encode(v))
     writer.close()
 
   def clear(self, *labels):
@@ -261,12 +273,20 @@ class FileBasedCacheManager(CacheManager):
     return False
 
   def source(self, *labels):
-    return self._reader_class(
-        self._glob_path(*labels), coder=self.load_pcoder(*labels))
+    coder = self.load_pcoder('reify', *labels[1:])
+    return self.raw_source(*labels) | beam.Map(
+        lambda b: test_stream.WindowedValueHolder(coder.decode(b)))
 
   def sink(self, labels, is_capture=False):
-    return self._writer_class(
-        self._path(*labels), coder=self.load_pcoder(*labels))
+    coder = self.load_pcoder('reify', *labels[1:])
+    return beam.Map(lambda wvh: coder.encode(wvh.windowed_value)
+                    ) | self.raw_sink(labels, is_capture)
+
+  def raw_sink(self, labels, is_capture=False):
+    return self._writer_class(self._path(*labels))
+
+  def raw_source(self, *labels):
+    return self._reader_class(self._glob_path(*labels))
 
   def cleanup(self):
     if self._cache_dir.startswith('gs://'):
@@ -343,6 +363,12 @@ class WriteCache(beam.PTransform):
     # cached PCollection. _cache_manager.sink(...) call below
     # should be using this saved pcoder.
     self._cache_manager.save_pcoder(
+        beam.coders.WindowedValueCoder(
+            beam.coders.registry.get_coder(pcoll.element_type),
+            pcoll.windowing.windowfn.get_window_coder()),
+        'reify',
+        self._label)
+    self._cache_manager.save_pcoder(
         coders.registry.get_coder(pcoll.element_type), prefix, self._label)
 
     if self._sample:
@@ -365,3 +391,9 @@ class SafeFastPrimitivesCoder(coders.Coder):
 
   def decode(self, value):
     return coders.coders.FastPrimitivesCoder().decode(unquote_to_bytes(value))
+
+
+class Base64Coder(coders.Coder):
+  """Used to safely encode arbitrary bytes to textio."""
+  encode = staticmethod(base64.b64encode)
+  decode = staticmethod(base64.b64decode)

--- a/sdks/python/apache_beam/runners/interactive/cache_manager_test.py
+++ b/sdks/python/apache_beam/runners/interactive/cache_manager_test.py
@@ -102,10 +102,9 @@ class FileBasedCacheManagerTest(object):
     coder = self.cache_manager.load_pcoder(prefix, cache_label)
     encoded = coder.encode(value)
 
-    # Add one to the size on disk because of the extra new-line character when
-    # writing to file.
-    self.assertEqual(
-        self.cache_manager.size(prefix, cache_label), len(encoded) + 1)
+    # We encode in a format that escapes newlines.
+    self.assertGreater(
+        self.cache_manager.size(prefix, cache_label), len(encoded))
 
   def test_clear(self):
     """Test that CacheManager can correctly tell if the cache exists or not."""

--- a/sdks/python/apache_beam/runners/interactive/recording_manager_test.py
+++ b/sdks/python/apache_beam/runners/interactive/recording_manager_test.py
@@ -308,7 +308,7 @@ class RecordingManagerTest(unittest.TestCase):
     # that all elements were written to cache.
     elems = list(numbers_stream.read())
     expected_elems = [
-        WindowedValue(i, MIN_TIMESTAMP, [GlobalWindow()]) for i in range(3)
+        WindowedValue(i, MIN_TIMESTAMP, (GlobalWindow(), )) for i in range(3)
     ]
     self.assertListEqual(elems, expected_elems)
 

--- a/sdks/python/apache_beam/runners/interactive/utils.py
+++ b/sdks/python/apache_beam/runners/interactive/utils.py
@@ -40,6 +40,7 @@ from apache_beam.runners.interactive.caching.cacheable import CacheKey
 from apache_beam.runners.interactive.caching.expression_cache import ExpressionCache
 from apache_beam.testing.test_stream import WindowedValueHolder
 from apache_beam.typehints.schemas import named_fields_from_element_type
+from apache_beam.utils.windowed_value import WindowedValue
 
 _LOGGER = logging.getLogger(__name__)
 
@@ -83,6 +84,8 @@ def to_element_list(
       elif isinstance(e, WindowedValueHolder):
         yield (
             e.windowed_value if include_window_info else e.windowed_value.value)
+      elif isinstance(e, WindowedValue):
+        yield (e if include_window_info else e.value)
       else:
         yield e
 


### PR DESCRIPTION
Formerly the coder used was always a url-excaped pickling[1] of windowed values. This is quite inefficient in time and space.

The default (text) sink is modified to use base64 encoding to avoid embedded newlines, and also has compression by defuault (which helps enormously in the case of common windowing and timestamp metadata).

[1] The FastPrimitivesCoder is targeted at efficiently coding elements, not windows or windowedvalues.

Also add compression to account for base64 expansion and (often) highly repetative windowing metadata.


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
