### PR TITLE
Fix Kafka with Redistribute

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -1698,7 +1698,7 @@ public class KafkaIO {
         if (kafkaRead.isRedistributed()) {
           if (kafkaRead.isCommitOffsetsInFinalizeEnabled() && kafkaRead.isAllowDuplicates()) {
             LOG.warn(
-                "Offsets committed due to usage of commitOffsetsInFinalize() may not capture all work processed due to use of withRedistribute()");
+                "Offsets committed due to usage of commitOffsetsInFinalize() and may not capture all work processed due to use of withRedistribute() with duplicates enabled");
           }
           PCollection<KafkaRecord<K, V>> output = input.getPipeline().apply(transform);
 

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -1696,7 +1696,7 @@ public class KafkaIO {
         }
 
         if (kafkaRead.isRedistributed()) {
-          if (kafkaRead.isCommitOffsetsInFinalizeEnabled()) {
+          if (kafkaRead.isCommitOffsetsInFinalizeEnabled() && kafkaRead.isAllowDuplicates()) {
             LOG.warn(
                 "Offsets committed due to usage of commitOffsetsInFinalize() may not capture all work processed due to use of withRedistribute()");
           }
@@ -1797,7 +1797,7 @@ public class KafkaIO {
             return pcol.apply(
                 "Insert Redistribute with Shards",
                 Redistribute.<KafkaRecord<K, V>>arbitrarily()
-                    .withAllowDuplicates(true)
+                    .withAllowDuplicates(kafkaRead.isAllowDuplicates())
                     .withNumBuckets((int) kafkaRead.getRedistributeNumKeys()));
           }
         }
@@ -2654,10 +2654,10 @@ public class KafkaIO {
         if (getRedistributeNumKeys() == 0) {
           LOG.warn("This will create a key per record, which is sub-optimal for most use cases.");
         }
-        if (isCommitOffsetEnabled() || configuredKafkaCommit()) {
+        if ((isCommitOffsetEnabled() || configuredKafkaCommit()) && isAllowDuplicates()) {
           LOG.warn(
               "Either auto_commit is set, or commitOffsetEnabled is enabled (or both), but since "
-                  + "withRestribute() is enabled, the runner may have additional work processed that "
+                  + "withRestribute() is enabled with allow duplicates, the runner may have additional work processed that "
                   + "is ahead of the current checkpoint");
         }
       }
@@ -2717,7 +2717,7 @@ public class KafkaIO {
               < 0) {
             // Redistribute is not allowed with commits prior to 2.59.0, since there is a Reshuffle
             // prior to the redistribute. The reshuffle will occur before commits are offsetted and
-            // before outputting KafkaRecords. Adding a redistrube then afterwards doesn't provide
+            // before outputting KafkaRecords. Adding a redistribute then afterwards doesn't provide
             // additional performance benefit.
             checkArgument(
                 !isRedistribute(),

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -1699,8 +1699,14 @@ public class KafkaIO {
         if (kafkaRead.isRedistributed()) {
           // fail here instead.
           checkArgument(
-              kafkaRead.isCommitOffsetsInFinalizeEnabled(),
-              "commitOffsetsInFinalize() can't be enabled with isRedistributed");
+              !kafkaRead.isCommitOffsetsInFinalizeEnabled(),
+              "commitOffsetsInFinalize() can't be enabled with withRedistribute()");
+
+          if (Boolean.TRUE.equals(
+              kafkaRead.getConsumerConfig().get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG))) {
+            LOG.warn(
+                "config.ENABLE_AUTO_COMMIT_CONFIG doesn't need to be set with withRedistribute()");
+          }
           PCollection<KafkaRecord<K, V>> output = input.getPipeline().apply(transform);
           if (kafkaRead.getRedistributeNumKeys() == 0) {
             return output.apply(

--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/KafkaIO.java
@@ -1698,12 +1698,7 @@ public class KafkaIO {
         if (kafkaRead.isRedistributed()) {
           if (kafkaRead.isCommitOffsetsInFinalizeEnabled()) {
             LOG.warn(
-                "commitOffsetsInFinalize() will not capture all work processed if set with withRedistribute()");
-          }
-          if (Boolean.TRUE.equals(
-              kafkaRead.getConsumerConfig().get(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG))) {
-            LOG.warn(
-                "config.ENABLE_AUTO_COMMIT_CONFIG doesn't need to be set with withRedistribute()");
+                "Offsets committed due to usage of commitOffsetsInFinalize() may not capture all work processed due to use of withRedistribute()");
           }
           PCollection<KafkaRecord<K, V>> output = input.getPipeline().apply(transform);
 
@@ -2659,7 +2654,6 @@ public class KafkaIO {
         if (getRedistributeNumKeys() == 0) {
           LOG.warn("This will create a key per record, which is sub-optimal for most use cases.");
         }
-        // is another check here needed for with commit offsets
         if (isCommitOffsetEnabled() || configuredKafkaCommit()) {
           LOG.warn(
               "Either auto_commit is set, or commitOffsetEnabled is enabled (or both), but since "

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOReadImplementationCompatibilityTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOReadImplementationCompatibilityTest.java
@@ -108,7 +108,13 @@ public class KafkaIOReadImplementationCompatibilityTest {
       Function<KafkaIO.Read<Integer, Long>, KafkaIO.Read<Integer, Long>> kafkaReadDecorator) {
     p.apply(
         kafkaReadDecorator.apply(
-            mkKafkaReadTransform(1000, null, new ValueAsTimestampFn(), false, 0)));
+            mkKafkaReadTransform(
+                1000,
+                null,
+                new ValueAsTimestampFn(),
+                false, /*redistribute*/
+                false, /*allowDuplicates*/
+                0)));
     return p.run();
   }
 

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -644,7 +644,7 @@ public class KafkaIOTest {
   }
 
   @Test
-  public void testCommitOffsetsInFinalizeAndRedistributeWarningsWithAllowDuplicates() {
+  public void warningsWithAllowDuplicatesEnabledAndCommitOffsets() {
     int numElements = 1000;
 
     PCollection<Long> input =
@@ -666,11 +666,11 @@ public class KafkaIOTest {
     p.run();
 
     kafkaIOExpectedLogs.verifyWarn(
-        "Offsets committed due to usage of commitOffsetsInFinalize() may not capture all work processed due to use of withRedistribute()");
+        "Offsets committed due to usage of commitOffsetsInFinalize() and may not capture all work processed due to use of withRedistribute() with duplicates enabled");
   }
 
   @Test
-  public void testCommitOffsetsInFinalizeAndRedistributeNoWarningsWithAllowDuplicates() {
+  public void noWarningsWithNoAllowDuplicatesAndCommitOffsets() {
     int numElements = 1000;
 
     PCollection<Long> input =

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/KafkaIOTest.java
@@ -645,7 +645,7 @@ public class KafkaIOTest {
     p.run();
 
     kafkaIOExpectedLogs.verifyWarn(
-        "commitOffsetsInFinalize() will not capture all work processed if set with withRedistribute()");
+        "Offsets committed due to usage of commitOffsetsInFinalize() may not capture all work processed due to use of withRedistribute()");
   }
 
   @Test
@@ -695,29 +695,6 @@ public class KafkaIOTest {
                 .withProcessingTime()
                 .commitOffsets());
     p.run();
-  }
-
-  @Test
-  public void testEnableAutoCommitWithRedistribute() throws Exception {
-
-    int numElements = 1000;
-
-    PCollection<Long> input =
-        p.apply(
-                mkKafkaReadTransform(numElements, numElements, new ValueAsTimestampFn(), true, 0)
-                    .withRedistribute()
-                    .withRedistributeNumKeys(100)
-                    .withConsumerConfigUpdates(
-                        ImmutableMap.of(ConsumerConfig.ENABLE_AUTO_COMMIT_CONFIG, true))
-                    .withoutMetadata())
-            .apply(Values.create());
-
-    addCountingAsserts(input, numElements);
-
-    p.run();
-
-    kafkaIOExpectedLogs.verifyWarn(
-        "config.ENABLE_AUTO_COMMIT_CONFIG doesn't need to be set with withRedistribute()");
   }
 
   @Test


### PR DESCRIPTION
Change KafkaIO read withDuplicates to warn but still commit offsets if configured

Two ways to enable commits, 
1) explicitly via commitOffsetsInFinalize()
2) Via consumer config  ENABLE_AUTO_COMMIT_CONFIG=true

If the first is true, redistribute can't be enabled
If the second is true, the pipeline can still be passed, but isn't the most optimal, since if the runner wants to enable duplicates, there is no point of introducing the additional overhead of checkpointing messages within Kafka itself., though it is not semantically incorrect.  The first option uses internal beam state to track which messages have been processed for preventing duplicates, which doesn't make sense if we also have a runner hint that duplicates can be allowed. 

Before this fix, it just meant customers weren't able to set withRedistribute on the transform, even if commits weren't configured. 

Updated tests to catch this. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
