### PR TITLE
Filter out old actions runs from dashboard

### DIFF
--- a/.test-infra/metrics/sync/github/github_runs_prefetcher/code/main.py
+++ b/.test-infra/metrics/sync/github/github_runs_prefetcher/code/main.py
@@ -307,6 +307,8 @@ async def fetch_workflow_runs():
     number_of_entries_per_page = 100  # The number of results per page (max 100)
     params = {"branch": "master", "page": page, "per_page": number_of_entries_per_page}
     concurrent_requests = 30  # Number of requests to send simultaneously
+    start = datetime.now() - timedelta(days=90)
+    earliest_run_creation_date = start.strftime('%Y-%m-%d')
     semaphore = asyncio.Semaphore(concurrent_requests)
 
     print("Start fetching recent workflow runs")
@@ -338,6 +340,7 @@ async def fetch_workflow_runs():
                     "page": page,
                     "per_page": number_of_entries_per_page,
                     "exclude_pull_requests": "true",
+                    "created": f'>={earliest_run_creation_date}',
                 }
                 workflow_run_tasks.append(fetch(runs_url, semaphore, params, headers))
                 page += 1


### PR DESCRIPTION
We don't need to be paying attention to these old runs.

I deployed this to test and it works - https://pantheon.corp.google.com/functions/details/us-central1/github_workflow_prefetcher?q=search&referrer=search&project=apache-beam-testing&e=13802955&mods=-ai_platform_fake_service,ai_platform_staging_service&tab=metrics

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
