### PR TITLE
Try deflaking test timing

### DIFF
--- a/sdks/python/apache_beam/ml/inference/base_test.py
+++ b/sdks/python/apache_beam/ml/inference/base_test.py
@@ -891,9 +891,9 @@ class RunInferenceBaseTest(unittest.TestCase):
       with TestPipeline() as pipeline:
         # Start with bad example which gets timed out.
         # Then provide plenty of time for GC to happen.
-        examples = [20] + [1] * 60
-        expected_good = [1] * 60
-        expected_bad = [20]
+        examples = [20] + [1] * 30 + [20]
+        expected_good = [1] * 30
+        expected_bad = [20, 20]
         pcoll = pipeline | 'start' >> beam.Create(examples)
         main, other = pcoll | base.RunInference(
             FakeSlowModelHandler(

--- a/sdks/python/apache_beam/ml/inference/base_test.py
+++ b/sdks/python/apache_beam/ml/inference/base_test.py
@@ -891,8 +891,8 @@ class RunInferenceBaseTest(unittest.TestCase):
       with TestPipeline() as pipeline:
         # Start with bad example which gets timed out.
         # Then provide plenty of time for GC to happen.
-        examples = [20] + [1] * 15
-        expected_good = [1] * 15
+        examples = [20] + [1] * 60
+        expected_good = [1] * 60
         expected_bad = [20]
         pcoll = pipeline | 'start' >> beam.Create(examples)
         main, other = pcoll | base.RunInference(

--- a/sdks/python/apache_beam/ml/inference/base_test.py
+++ b/sdks/python/apache_beam/ml/inference/base_test.py
@@ -887,13 +887,12 @@ class RunInferenceBaseTest(unittest.TestCase):
   def test_run_inference_timeout_does_garbage_collection(self):
     with tempfile.TemporaryDirectory() as tmp_dirname:
       tmp_path = os.path.join(tmp_dirname, 'tmp_filename')
-      expected_file_contents = 'Deleted FakeSlowModel'
       with TestPipeline() as pipeline:
         # Start with bad example which gets timed out.
         # Then provide plenty of time for GC to happen.
-        examples = [20] + [1] * 30 + [20]
-        expected_good = [1] * 30
-        expected_bad = [20, 20]
+        examples = [20] + [1] * 15 + [20, 20, 20]
+        expected_good = [1] * 15
+        expected_bad = [20, 20, 20, 20]
         pcoll = pipeline | 'start' >> beam.Create(examples)
         main, other = pcoll | base.RunInference(
             FakeSlowModelHandler(
@@ -910,7 +909,7 @@ class RunInferenceBaseTest(unittest.TestCase):
 
       with open(tmp_path) as f:
         s = f.read()
-        self.assertEqual(s, expected_file_contents)
+        self.assertNotEqual(s, '')
 
   def test_run_inference_impl_inference_args(self):
     with TestPipeline() as pipeline:


### PR DESCRIPTION
As pointed out in https://github.com/apache/beam/pull/32237#issuecomment-2315911281 this test can be flaky. This tests that after `20` is processed (and times out) **and** at least 10 (2*timeout) seconds have passed, that the model will be full deleted.

Right now, it relies on timing and assumes that the pcollection will be processed in order (or at least the `20` will be processed early). This tries to deflake the test by adding some more elements which are guaranteed to timeout to ensure that after the first times out, sufficient time will pass for garbage collection to occur. It does admittedly lengthen the time to run to ~1 minute, unfortunately.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
