### PR TITLE
Fix using `GcsIO` from a `DoFn`in Python

### DIFF
--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -147,8 +147,10 @@ class GcsIO(object):
       storage_client = create_storage_client(pipeline_options)
 
     google_cloud_options = pipeline_options.view_as(GoogleCloudOptions)
-    self.enable_read_bucket_metric =  getattr(google_cloud_options, 'enable_bucket_read_metric_counter', False)
-    self.enable_write_bucket_metric = getattr(google_cloud_options, 'enable_bucket_write_metric_counter', False)
+    self.enable_read_bucket_metric = getattr(
+      google_cloud_options, 'enable_bucket_read_metric_counter', False)
+    self.enable_write_bucket_metric = getattr(
+      google_cloud_options, 'enable_bucket_write_metric_counter', False)
 
     self.client = storage_client
     self._rewrite_cb = None

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -145,8 +145,11 @@ class GcsIO(object):
       pipeline_options = PipelineOptions.from_dictionary(pipeline_options)
     if storage_client is None:
       storage_client = create_storage_client(pipeline_options)
-    self.enable_read_bucket_metric = getattr(pipeline_options, 'enable_bucket_read_metric_counter', False)
-    self.enable_write_bucket_metric = getattr(pipeline_options, 'enable_bucket_write_metric_counter', False)
+
+    google_cloud_options = pipeline_options.view_as(GoogleCloudOptions)
+    self.enable_read_bucket_metric =  getattr(google_cloud_options, 'enable_bucket_read_metric_counter', False)
+    self.enable_write_bucket_metric = getattr(google_cloud_options, 'enable_bucket_write_metric_counter', False)
+
     self.client = storage_client
     self._rewrite_cb = None
     self.bucket_to_project_number = {}

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -145,10 +145,8 @@ class GcsIO(object):
       pipeline_options = PipelineOptions.from_dictionary(pipeline_options)
     if storage_client is None:
       storage_client = create_storage_client(pipeline_options)
-    self.enable_read_bucket_metric = pipeline_options.get_all_options(
-    )['enable_bucket_read_metric_counter']
-    self.enable_write_bucket_metric = pipeline_options.get_all_options(
-    )['enable_bucket_write_metric_counter']
+    self.enable_read_bucket_metric = getattr(pipeline_options, 'enable_bucket_read_metric_counter', False)
+    self.enable_write_bucket_metric = getattr(pipeline_options, 'enable_bucket_write_metric_counter', False)
     self.client = storage_client
     self._rewrite_cb = None
     self.bucket_to_project_number = {}

--- a/sdks/python/apache_beam/io/gcp/gcsio.py
+++ b/sdks/python/apache_beam/io/gcp/gcsio.py
@@ -148,9 +148,9 @@ class GcsIO(object):
 
     google_cloud_options = pipeline_options.view_as(GoogleCloudOptions)
     self.enable_read_bucket_metric = getattr(
-      google_cloud_options, 'enable_bucket_read_metric_counter', False)
+        google_cloud_options, 'enable_bucket_read_metric_counter', False)
     self.enable_write_bucket_metric = getattr(
-      google_cloud_options, 'enable_bucket_write_metric_counter', False)
+        google_cloud_options, 'enable_bucket_write_metric_counter', False)
 
     self.client = storage_client
     self._rewrite_cb = None


### PR DESCRIPTION
`GcsIO` is failing when trying to use from a `DoFn` in Dataflow, due to repeated parsing of the pipeline options. This change avoids parsing the options just to retrieve an already-parsed option.

This change fixes #32361.