### PR TITLE
Improve Datastream for batch performances

### DIFF
--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/GroupAlsoByWindowViaWindowSetNewDoFn.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/GroupAlsoByWindowViaWindowSetNewDoFn.java
@@ -18,6 +18,8 @@
 package org.apache.beam.runners.core;
 
 import java.util.Collection;
+
+import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.runners.core.triggers.ExecutableTriggerStateMachine;
 import org.apache.beam.runners.core.triggers.TriggerStateMachines;
 import org.apache.beam.sdk.transforms.DoFn;
@@ -41,6 +43,7 @@ public class GroupAlsoByWindowViaWindowSetNewDoFn<
     extends DoFn<RinT, KV<K, OutputT>> {
 
   private static final long serialVersionUID = 1L;
+  private final RunnerApi.Trigger triggerProto;
 
   public static <K, InputT, OutputT, W extends BoundedWindow>
       DoFn<KeyedWorkItem<K, InputT>, KV<K, OutputT>> create(
@@ -86,6 +89,7 @@ public class GroupAlsoByWindowViaWindowSetNewDoFn<
     this.windowingStrategy = noWildcard;
     this.reduceFn = reduceFn;
     this.stateInternalsFactory = stateInternalsFactory;
+    this.triggerProto = TriggerTranslation.toProto(windowingStrategy.getTrigger());
   }
 
   private OutputWindowedValue<KV<K, OutputT>> outputWindowedValue() {
@@ -123,9 +127,7 @@ public class GroupAlsoByWindowViaWindowSetNewDoFn<
         new ReduceFnRunner<>(
             key,
             windowingStrategy,
-            ExecutableTriggerStateMachine.create(
-                TriggerStateMachines.stateMachineForTrigger(
-                    TriggerTranslation.toProto(windowingStrategy.getTrigger()))),
+            ExecutableTriggerStateMachine.create(TriggerStateMachines.stateMachineForTrigger(triggerProto)),
             stateInternals,
             timerInternals,
             outputWindowedValue(),

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/GroupAlsoByWindowViaWindowSetNewDoFn.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/GroupAlsoByWindowViaWindowSetNewDoFn.java
@@ -126,7 +126,8 @@ public class GroupAlsoByWindowViaWindowSetNewDoFn<
         new ReduceFnRunner<>(
             key,
             windowingStrategy,
-            ExecutableTriggerStateMachine.create(TriggerStateMachines.stateMachineForTrigger(triggerProto)),
+            ExecutableTriggerStateMachine.create(
+                TriggerStateMachines.stateMachineForTrigger(triggerProto)),
             stateInternals,
             timerInternals,
             outputWindowedValue(),

--- a/runners/core-java/src/main/java/org/apache/beam/runners/core/GroupAlsoByWindowViaWindowSetNewDoFn.java
+++ b/runners/core-java/src/main/java/org/apache/beam/runners/core/GroupAlsoByWindowViaWindowSetNewDoFn.java
@@ -18,7 +18,6 @@
 package org.apache.beam.runners.core;
 
 import java.util.Collection;
-
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.runners.core.triggers.ExecutableTriggerStateMachine;
 import org.apache.beam.runners.core.triggers.TriggerStateMachines;

--- a/runners/flink/1.14/src/main/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializer.java
+++ b/runners/flink/1.14/src/main/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializer.java
@@ -53,7 +53,12 @@ public class CoderTypeSerializer<T> extends TypeSerializer<T> {
   private final boolean fasterCopy;
 
   public CoderTypeSerializer(Coder<T> coder, SerializablePipelineOptions pipelineOptions) {
-    this(coder, Preconditions.checkNotNull(pipelineOptions).get().as(FlinkPipelineOptions.class).getFasterCopy());
+    this(
+        coder,
+        Preconditions.checkNotNull(pipelineOptions)
+            .get()
+            .as(FlinkPipelineOptions.class)
+            .getFasterCopy());
   }
 
   public CoderTypeSerializer(Coder<T> coder, boolean fasterCopy) {

--- a/runners/flink/1.14/src/main/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializer.java
+++ b/runners/flink/1.14/src/main/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializer.java
@@ -50,23 +50,16 @@ public class CoderTypeSerializer<T> extends TypeSerializer<T> {
 
   private final Coder<T> coder;
 
-  /**
-   * {@link SerializablePipelineOptions} deserialization will cause {@link
-   * org.apache.beam.sdk.io.FileSystems} registration needed for {@link
-   * org.apache.beam.sdk.transforms.Reshuffle} translation.
-   */
-  private final SerializablePipelineOptions pipelineOptions;
-
   private final boolean fasterCopy;
 
   public CoderTypeSerializer(Coder<T> coder, SerializablePipelineOptions pipelineOptions) {
-    Preconditions.checkNotNull(coder);
-    Preconditions.checkNotNull(pipelineOptions);
-    this.coder = coder;
-    this.pipelineOptions = pipelineOptions;
+    this(coder, Preconditions.checkNotNull(pipelineOptions).get().as(FlinkPipelineOptions.class).getFasterCopy());
+  }
 
-    FlinkPipelineOptions options = pipelineOptions.get().as(FlinkPipelineOptions.class);
-    this.fasterCopy = options.getFasterCopy();
+  public CoderTypeSerializer(Coder<T> coder, boolean fasterCopy) {
+    Preconditions.checkNotNull(coder);
+    this.coder = coder;
+    this.fasterCopy = fasterCopy;
   }
 
   @Override
@@ -76,7 +69,7 @@ public class CoderTypeSerializer<T> extends TypeSerializer<T> {
 
   @Override
   public CoderTypeSerializer<T> duplicate() {
-    return new CoderTypeSerializer<>(coder, pipelineOptions);
+    return new CoderTypeSerializer<>(coder, fasterCopy);
   }
 
   @Override

--- a/runners/flink/1.17/src/main/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializer.java
+++ b/runners/flink/1.17/src/main/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializer.java
@@ -47,23 +47,16 @@ public class CoderTypeSerializer<T> extends TypeSerializer<T> {
 
   private final Coder<T> coder;
 
-  /**
-   * {@link SerializablePipelineOptions} deserialization will cause {@link
-   * org.apache.beam.sdk.io.FileSystems} registration needed for {@link
-   * org.apache.beam.sdk.transforms.Reshuffle} translation.
-   */
-  private final SerializablePipelineOptions pipelineOptions;
-
   private final boolean fasterCopy;
 
   public CoderTypeSerializer(Coder<T> coder, SerializablePipelineOptions pipelineOptions) {
-    Preconditions.checkNotNull(coder);
-    Preconditions.checkNotNull(pipelineOptions);
-    this.coder = coder;
-    this.pipelineOptions = pipelineOptions;
+    this(coder, Preconditions.checkNotNull(pipelineOptions).get().as(FlinkPipelineOptions.class).getFasterCopy());
+  }
 
-    FlinkPipelineOptions options = pipelineOptions.get().as(FlinkPipelineOptions.class);
-    this.fasterCopy = options.getFasterCopy();
+  public CoderTypeSerializer(Coder<T> coder, boolean fasterCopy) {
+    Preconditions.checkNotNull(coder);
+    this.coder = coder;
+    this.fasterCopy = fasterCopy;
   }
 
   @Override
@@ -73,7 +66,7 @@ public class CoderTypeSerializer<T> extends TypeSerializer<T> {
 
   @Override
   public CoderTypeSerializer<T> duplicate() {
-    return new CoderTypeSerializer<>(coder, pipelineOptions);
+    return new CoderTypeSerializer<>(coder, fasterCopy);
   }
 
   @Override

--- a/runners/flink/1.17/src/main/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializer.java
+++ b/runners/flink/1.17/src/main/java/org/apache/beam/runners/flink/translation/types/CoderTypeSerializer.java
@@ -50,7 +50,12 @@ public class CoderTypeSerializer<T> extends TypeSerializer<T> {
   private final boolean fasterCopy;
 
   public CoderTypeSerializer(Coder<T> coder, SerializablePipelineOptions pipelineOptions) {
-    this(coder, Preconditions.checkNotNull(pipelineOptions).get().as(FlinkPipelineOptions.class).getFasterCopy());
+    this(
+        coder,
+        Preconditions.checkNotNull(pipelineOptions)
+            .get()
+            .as(FlinkPipelineOptions.class)
+            .getFasterCopy());
   }
 
   public CoderTypeSerializer(Coder<T> coder, boolean fasterCopy) {

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
@@ -237,12 +237,15 @@ public class FlinkExecutionEnvironments {
     flinkStreamEnv.setParallelism(parallelism);
     if (options.getMaxParallelism() > 0) {
       flinkStreamEnv.setMaxParallelism(options.getMaxParallelism());
-    } else if(!options.isStreaming()) {
+    } else if (!options.isStreaming()) {
       // In Flink maxParallelism defines the number of keyGroups.
-      // (see https://github.com/apache/flink/blob/e9dd4683f758b463d0b5ee18e49cecef6a70c5cf/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupRangeAssignment.java#L76)
+      // (see
+      // https://github.com/apache/flink/blob/e9dd4683f758b463d0b5ee18e49cecef6a70c5cf/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupRangeAssignment.java#L76)
       // The default value (parallelism * 1.5)
-      // (see https://github.com/apache/flink/blob/e9dd4683f758b463d0b5ee18e49cecef6a70c5cf/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupRangeAssignment.java#L137-L147)
+      // (see
+      // https://github.com/apache/flink/blob/e9dd4683f758b463d0b5ee18e49cecef6a70c5cf/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupRangeAssignment.java#L137-L147)
       // create a lot of skew so we force maxParallelism = parallelism in Batch mode.
+      LOG.info("Setting maxParallelism to {}", parallelism);
       flinkStreamEnv.setMaxParallelism(parallelism);
     }
     // set parallelism in the options (required by some execution code)

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkExecutionEnvironments.java
@@ -237,6 +237,13 @@ public class FlinkExecutionEnvironments {
     flinkStreamEnv.setParallelism(parallelism);
     if (options.getMaxParallelism() > 0) {
       flinkStreamEnv.setMaxParallelism(options.getMaxParallelism());
+    } else if(!options.isStreaming()) {
+      // In Flink maxParallelism defines the number of keyGroups.
+      // (see https://github.com/apache/flink/blob/e9dd4683f758b463d0b5ee18e49cecef6a70c5cf/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupRangeAssignment.java#L76)
+      // The default value (parallelism * 1.5)
+      // (see https://github.com/apache/flink/blob/e9dd4683f758b463d0b5ee18e49cecef6a70c5cf/flink-runtime/src/main/java/org/apache/flink/runtime/state/KeyGroupRangeAssignment.java#L137-L147)
+      // create a lot of skew so we force maxParallelism = parallelism in Batch mode.
+      flinkStreamEnv.setMaxParallelism(parallelism);
     }
     // set parallelism in the options (required by some execution code)
     options.setParallelism(parallelism);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
@@ -246,7 +246,7 @@ public interface FlinkPipelineOptions
       if (options.as(StreamingOptions.class).isStreaming()) {
         return 1000L;
       } else {
-        return 1000000L;
+        return 5000L;
       }
     }
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkPipelineOptions.java
@@ -366,6 +366,13 @@ public interface FlinkPipelineOptions
 
   void setEnableStableInputDrain(Boolean enableStableInputDrain);
 
+  @Description(
+      "Set a slot sharing group for all bounded sources. This is required when using Datastream to have the same scheduling behaviour as the Dataset API.")
+  @Default.Boolean(true)
+  Boolean getForceSlotSharingGroup();
+
+  void setForceSlotSharingGroup(Boolean enableStableInputDrain);
+
   static FlinkPipelineOptions defaults() {
     return PipelineOptionsFactory.as(FlinkPipelineOptions.class);
   }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingAggregationsTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingAggregationsTranslators.java
@@ -1,11 +1,44 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
 package org.apache.beam.runners.flink;
 
+import java.nio.ByteBuffer;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
 import org.apache.beam.runners.core.KeyedWorkItem;
 import org.apache.beam.runners.core.SystemReduceFn;
 import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
 import org.apache.beam.runners.flink.translation.types.CoderTypeInformation;
-import org.apache.beam.runners.flink.translation.wrappers.streaming.*;
-import org.apache.beam.sdk.coders.*;
+import org.apache.beam.runners.flink.translation.wrappers.streaming.DoFnOperator;
+import org.apache.beam.runners.flink.translation.wrappers.streaming.KvToByteBufferKeySelector;
+import org.apache.beam.runners.flink.translation.wrappers.streaming.PartialReduceBundleOperator;
+import org.apache.beam.runners.flink.translation.wrappers.streaming.SingletonKeyedWorkItemCoder;
+import org.apache.beam.runners.flink.translation.wrappers.streaming.WindowDoFnOperator;
+import org.apache.beam.runners.flink.translation.wrappers.streaming.WorkItemKeySelector;
+import org.apache.beam.sdk.coders.CannotProvideCoderException;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderRegistry;
+import org.apache.beam.sdk.coders.IterableCoder;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.ListCoder;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.CombineFnBase;
 import org.apache.beam.sdk.transforms.CombineWithContext;
@@ -14,7 +47,11 @@ import org.apache.beam.sdk.transforms.join.RawUnionValue;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.util.AppliedCombineFn;
 import org.apache.beam.sdk.util.WindowedValue;
-import org.apache.beam.sdk.values.*;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollection;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.WindowingStrategy;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.flink.api.common.typeinfo.TypeInformation;
 import org.apache.flink.api.java.tuple.Tuple2;
@@ -22,9 +59,6 @@ import org.apache.flink.streaming.api.datastream.DataStream;
 import org.apache.flink.streaming.api.datastream.KeyedStream;
 import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
 import org.apache.flink.streaming.api.transformations.TwoInputTransformation;
-
-import java.nio.ByteBuffer;
-import java.util.*;
 
 public class FlinkStreamingAggregationsTranslators {
   public static class ConcatenateAsIterable<T> extends Combine.CombineFn<T, List<T>, Iterable<T>> {
@@ -64,8 +98,10 @@ public class FlinkStreamingAggregationsTranslators {
     }
   }
 
-  private static <InputT, OutputT> CombineFnBase.GlobalCombineFn<Object, Object, OutputT> toFinalFlinkCombineFn(
-      CombineFnBase.GlobalCombineFn<? super InputT, ?, OutputT> combineFn, Coder<InputT> inputTCoder) {
+  private static <InputT, OutputT>
+      CombineFnBase.GlobalCombineFn<Object, Object, OutputT> toFinalFlinkCombineFn(
+          CombineFnBase.GlobalCombineFn<? super InputT, ?, OutputT> combineFn,
+          Coder<InputT> inputTCoder) {
 
     if (combineFn instanceof Combine.CombineFn) {
       return new Combine.CombineFn<Object, Object, OutputT>() {
@@ -140,20 +176,22 @@ public class FlinkStreamingAggregationsTranslators {
   }
 
   /**
-   * Create a DoFnOperator instance that group elements per window and apply a combine function on them.
+   * Create a DoFnOperator instance that group elements per window and apply a combine function on
+   * them.
    */
-  public static <K, InputC, OutputC, InputT, OutputT> WindowDoFnOperator<K, InputC, OutputC> getWindowedAggregateDoFnOperator(
-      FlinkStreamingTranslationContext context,
-      PTransform<PCollection<KV<K, InputT>>, PCollection<KV<K, OutputT>>> transform,
-      KvCoder<K, InputC> inputKvCoder,
-      Coder<WindowedValue<KV<K, OutputC>>> outputCoder,
-      SystemReduceFn<K, InputC, ?, OutputC, BoundedWindow> reduceFn,
-      Map<Integer, PCollectionView<?>> sideInputTagMapping,
-      List<PCollectionView<?>> sideInputs) {
+  public static <K, InputAccumT, OutputAccumT, InputT, OutputT>
+      WindowDoFnOperator<K, InputAccumT, OutputAccumT> getWindowedAggregateDoFnOperator(
+          FlinkStreamingTranslationContext context,
+          PTransform<PCollection<KV<K, InputT>>, PCollection<KV<K, OutputT>>> transform,
+          KvCoder<K, InputAccumT> inputKvCoder,
+          Coder<WindowedValue<KV<K, OutputAccumT>>> outputCoder,
+          SystemReduceFn<K, InputAccumT, ?, OutputAccumT, BoundedWindow> reduceFn,
+          Map<Integer, PCollectionView<?>> sideInputTagMapping,
+          List<PCollectionView<?>> sideInputs) {
 
     // Naming
     String fullName = FlinkStreamingTransformTranslators.getCurrentTransformName(context);
-    TupleTag<KV<K, OutputC>> mainTag = new TupleTag<>("main output");
+    TupleTag<KV<K, OutputAccumT>> mainTag = new TupleTag<>("main output");
 
     // input infos
     PCollection<KV<K, InputT>> input = context.getInput(transform);
@@ -167,17 +205,15 @@ public class FlinkStreamingAggregationsTranslators {
     // Coders
     Coder<K> keyCoder = inputKvCoder.getKeyCoder();
 
-    SingletonKeyedWorkItemCoder<K, InputC> workItemCoder =
+    SingletonKeyedWorkItemCoder<K, InputAccumT> workItemCoder =
         SingletonKeyedWorkItemCoder.of(
-            keyCoder,
-            inputKvCoder.getValueCoder(),
-            windowingStrategy.getWindowFn().windowCoder());
+            keyCoder, inputKvCoder.getValueCoder(), windowingStrategy.getWindowFn().windowCoder());
 
-    WindowedValue.FullWindowedValueCoder<KeyedWorkItem<K, InputC>> windowedWorkItemCoder =
+    WindowedValue.FullWindowedValueCoder<KeyedWorkItem<K, InputAccumT>> windowedWorkItemCoder =
         WindowedValue.getFullCoder(workItemCoder, windowingStrategy.getWindowFn().windowCoder());
 
     // Key selector
-    WorkItemKeySelector<K, InputC> workItemKeySelector =
+    WorkItemKeySelector<K, InputAccumT> workItemKeySelector =
         new WorkItemKeySelector<>(keyCoder, serializablePipelineOptions);
 
     return new WindowDoFnOperator<>(
@@ -196,31 +232,36 @@ public class FlinkStreamingAggregationsTranslators {
         workItemKeySelector);
   }
 
-  public static <K, InputC, OutputC, InputT, OutputT> WindowDoFnOperator<K, InputC, OutputC> getWindowedAggregateDoFnOperator(
-      FlinkStreamingTranslationContext context,
-      PTransform<PCollection<KV<K, InputT>>, PCollection<KV<K, OutputT>>> transform,
-      KvCoder<K, InputC> inputKvCoder,
-      Coder<WindowedValue<KV<K, OutputC>>> outputCoder,
-      CombineFnBase.GlobalCombineFn<? super InputC, ?, OutputC> combineFn,
-      Map<Integer, PCollectionView<?>> sideInputTagMapping,
-      List<PCollectionView<?>> sideInputs) {
+  public static <K, InputAccumT, OutputAccumT, InputT, OutputT>
+      WindowDoFnOperator<K, InputAccumT, OutputAccumT> getWindowedAggregateDoFnOperator(
+          FlinkStreamingTranslationContext context,
+          PTransform<PCollection<KV<K, InputT>>, PCollection<KV<K, OutputT>>> transform,
+          KvCoder<K, InputAccumT> inputKvCoder,
+          Coder<WindowedValue<KV<K, OutputAccumT>>> outputCoder,
+          CombineFnBase.GlobalCombineFn<? super InputAccumT, ?, OutputAccumT> combineFn,
+          Map<Integer, PCollectionView<?>> sideInputTagMapping,
+          List<PCollectionView<?>> sideInputs) {
 
     // Combining fn
-    SystemReduceFn<K, InputC, ?, OutputC, BoundedWindow> reduceFn =
+    SystemReduceFn<K, InputAccumT, ?, OutputAccumT, BoundedWindow> reduceFn =
         SystemReduceFn.combining(
             inputKvCoder.getKeyCoder(),
             AppliedCombineFn.withInputCoder(
-                combineFn, context.getInput(transform).getPipeline().getCoderRegistry(), inputKvCoder));
+                combineFn,
+                context.getInput(transform).getPipeline().getCoderRegistry(),
+                inputKvCoder));
 
-    return getWindowedAggregateDoFnOperator(context, transform, inputKvCoder, outputCoder, reduceFn, sideInputTagMapping, sideInputs);
+    return getWindowedAggregateDoFnOperator(
+        context, transform, inputKvCoder, outputCoder, reduceFn, sideInputTagMapping, sideInputs);
   }
 
-  public static <K, InputT, AccumT, OutputT> SingleOutputStreamOperator<WindowedValue<KV<K, OutputT>>> batchCombinePerKey(
-      FlinkStreamingTranslationContext context,
-      PTransform<PCollection<KV<K, InputT>>, PCollection<KV<K, OutputT>>> transform,
-      CombineFnBase.GlobalCombineFn<InputT, AccumT, OutputT> combineFn,
-      Map<Integer, PCollectionView<?>> sideInputTagMapping,
-      List<PCollectionView<?>> sideInputs) {
+  public static <K, InputT, AccumT, OutputT>
+      SingleOutputStreamOperator<WindowedValue<KV<K, OutputT>>> batchCombinePerKey(
+          FlinkStreamingTranslationContext context,
+          PTransform<PCollection<KV<K, InputT>>, PCollection<KV<K, OutputT>>> transform,
+          CombineFnBase.GlobalCombineFn<InputT, AccumT, OutputT> combineFn,
+          Map<Integer, PCollectionView<?>> sideInputTagMapping,
+          List<PCollectionView<?>> sideInputs) {
 
     Coder<WindowedValue<KV<K, AccumT>>> windowedAccumCoder;
     KvCoder<K, AccumT> accumKvCoder;
@@ -228,8 +269,7 @@ public class FlinkStreamingAggregationsTranslators {
     PCollection<KV<K, InputT>> input = context.getInput(transform);
     String fullName = FlinkStreamingTransformTranslators.getCurrentTransformName(context);
     DataStream<WindowedValue<KV<K, InputT>>> inputDataStream = context.getInputDataStream(input);
-    KvCoder<K, InputT> inputKvCoder =
-        (KvCoder<K, InputT>) input.getCoder();
+    KvCoder<K, InputT> inputKvCoder = (KvCoder<K, InputT>) input.getCoder();
     Coder<WindowedValue<KV<K, OutputT>>> outputCoder =
         context.getWindowedInputCoder(context.getOutput(transform));
     SerializablePipelineOptions serializablePipelineOptions =
@@ -285,50 +325,54 @@ public class FlinkStreamingAggregationsTranslators {
             sideInputTagMapping,
             sideInputs);
 
-    if(sideInputs.isEmpty()) {
-      return
-          inputDataStream
-              .transform(partialName, partialTypeInfo, partialDoFnOperator)
-              .uid(partialName)
-              .keyBy(accumKeySelector)
-              .transform(fullName, outputTypeInfo, finalDoFnOperator)
-              .uid(fullName);
+    if (sideInputs.isEmpty()) {
+      return inputDataStream
+          .transform(partialName, partialTypeInfo, partialDoFnOperator)
+          .uid(partialName)
+          .keyBy(accumKeySelector)
+          .transform(fullName, outputTypeInfo, finalDoFnOperator)
+          .uid(fullName);
     } else {
       Tuple2<Map<Integer, PCollectionView<?>>, DataStream<RawUnionValue>> transformSideInputs =
           FlinkStreamingTransformTranslators.transformSideInputs(sideInputs, context);
 
       KeyedStream<WindowedValue<KV<K, AccumT>>, ByteBuffer> keyedStream =
           inputDataStream
-            .transform(partialName, partialTypeInfo, partialDoFnOperator)
-            .uid(partialName)
-            .keyBy(accumKeySelector);
+              .transform(partialName, partialTypeInfo, partialDoFnOperator)
+              .uid(partialName)
+              .keyBy(accumKeySelector);
 
-      return buildTwoInputStream(keyedStream, transformSideInputs.f1, transform.getName(), finalDoFnOperator, outputTypeInfo);
+      return buildTwoInputStream(
+          keyedStream,
+          transformSideInputs.f1,
+          transform.getName(),
+          finalDoFnOperator,
+          outputTypeInfo);
     }
   }
 
   @SuppressWarnings({
-      "nullness" // TODO(https://github.com/apache/beam/issues/20497)
+    "nullness" // TODO(https://github.com/apache/beam/issues/20497)
   })
-  public static <K, InputT, OutputT> SingleOutputStreamOperator<WindowedValue<KV<K, OutputT>>> buildTwoInputStream(
-      KeyedStream<WindowedValue<KV<K, InputT>>, ByteBuffer> keyedStream,
-      DataStream<RawUnionValue> sideInputStream,
-      String name,
-      WindowDoFnOperator<K, InputT, OutputT> operator,
-      TypeInformation<WindowedValue<KV<K, OutputT>>> outputTypeInfo
-  ) {
+  public static <K, InputT, OutputT>
+      SingleOutputStreamOperator<WindowedValue<KV<K, OutputT>>> buildTwoInputStream(
+          KeyedStream<WindowedValue<KV<K, InputT>>, ByteBuffer> keyedStream,
+          DataStream<RawUnionValue> sideInputStream,
+          String name,
+          WindowDoFnOperator<K, InputT, OutputT> operator,
+          TypeInformation<WindowedValue<KV<K, OutputT>>> outputTypeInfo) {
     // we have to manually construct the two-input transform because we're not
     // allowed to have only one input keyed, normally.
     TwoInputTransformation<
-        WindowedValue<KV<K, InputT>>, RawUnionValue, WindowedValue<KV<K, OutputT>>>
+            WindowedValue<KV<K, InputT>>, RawUnionValue, WindowedValue<KV<K, OutputT>>>
         rawFlinkTransform =
-        new TwoInputTransformation<>(
-            keyedStream.getTransformation(),
-            sideInputStream.broadcast().getTransformation(),
-            name,
-            operator,
-            outputTypeInfo,
-            keyedStream.getParallelism());
+            new TwoInputTransformation<>(
+                keyedStream.getTransformation(),
+                sideInputStream.broadcast().getTransformation(),
+                name,
+                operator,
+                outputTypeInfo,
+                keyedStream.getParallelism());
 
     rawFlinkTransform.setStateKeyType(keyedStream.getKeyType());
     rawFlinkTransform.setStateKeySelectors(keyedStream.getKeySelector(), null);
@@ -337,18 +381,19 @@ public class FlinkStreamingAggregationsTranslators {
     SingleOutputStreamOperator<WindowedValue<KV<K, OutputT>>> outDataStream =
         new SingleOutputStreamOperator(
             keyedStream.getExecutionEnvironment(),
-            rawFlinkTransform) {
-        }; // we have to cheat around the ctor being protected
+            rawFlinkTransform) {}; // we have to cheat around the ctor being protected
 
     keyedStream.getExecutionEnvironment().addOperator(rawFlinkTransform);
 
     return outDataStream;
   }
 
-  public static <K, InputT, AccumT, OutputT> SingleOutputStreamOperator<WindowedValue<KV<K, OutputT>>> batchCombinePerKeyNoSideInputs(
-      FlinkStreamingTranslationContext context,
-      PTransform<PCollection<KV<K, InputT>>, PCollection<KV<K, OutputT>>> transform,
-      CombineFnBase.GlobalCombineFn<InputT, AccumT, OutputT> combineFn) {
-    return batchCombinePerKey(context, transform, combineFn, new HashMap<>(), Collections.emptyList());
+  public static <K, InputT, AccumT, OutputT>
+      SingleOutputStreamOperator<WindowedValue<KV<K, OutputT>>> batchCombinePerKeyNoSideInputs(
+          FlinkStreamingTranslationContext context,
+          PTransform<PCollection<KV<K, InputT>>, PCollection<KV<K, OutputT>>> transform,
+          CombineFnBase.GlobalCombineFn<InputT, AccumT, OutputT> combineFn) {
+    return batchCombinePerKey(
+        context, transform, combineFn, new HashMap<>(), Collections.emptyList());
   }
 }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingAggregationsTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingAggregationsTranslators.java
@@ -1,0 +1,286 @@
+package org.apache.beam.runners.flink;
+
+import org.apache.beam.runners.core.KeyedWorkItem;
+import org.apache.beam.runners.core.SystemReduceFn;
+import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
+import org.apache.beam.runners.flink.translation.types.CoderTypeInformation;
+import org.apache.beam.runners.flink.translation.wrappers.streaming.*;
+import org.apache.beam.sdk.coders.*;
+import org.apache.beam.sdk.transforms.Combine;
+import org.apache.beam.sdk.transforms.CombineFnBase;
+import org.apache.beam.sdk.transforms.CombineWithContext;
+import org.apache.beam.sdk.transforms.PTransform;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.util.AppliedCombineFn;
+import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.beam.sdk.values.*;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
+import org.apache.flink.api.common.typeinfo.TypeInformation;
+import org.apache.flink.streaming.api.datastream.DataStream;
+import org.apache.flink.streaming.api.datastream.SingleOutputStreamOperator;
+
+import java.util.*;
+
+public class FlinkStreamingAggregationsTranslators {
+  public static class ConcatenateAsIterable<T> extends Combine.CombineFn<T, List<T>, Iterable<T>> {
+    @Override
+    public List<T> createAccumulator() {
+      return new ArrayList<>();
+    }
+
+    @Override
+    public List<T> addInput(List<T> accumulator, T input) {
+      accumulator.add(input);
+      return accumulator;
+    }
+
+    @Override
+    public List<T> mergeAccumulators(Iterable<List<T>> accumulators) {
+      List<T> result = createAccumulator();
+      for (List<T> accumulator : accumulators) {
+        result.addAll(accumulator);
+      }
+      return result;
+    }
+
+    @Override
+    public List<T> extractOutput(List<T> accumulator) {
+      return accumulator;
+    }
+
+    @Override
+    public Coder<List<T>> getAccumulatorCoder(CoderRegistry registry, Coder<T> inputCoder) {
+      return ListCoder.of(inputCoder);
+    }
+
+    @Override
+    public Coder<Iterable<T>> getDefaultOutputCoder(CoderRegistry registry, Coder<T> inputCoder) {
+      return IterableCoder.of(inputCoder);
+    }
+  }
+
+  private static <InputT, OutputT> CombineFnBase.GlobalCombineFn<Object, Object, OutputT> toFinalFlinkCombineFn(
+      CombineFnBase.GlobalCombineFn<? super InputT, ?, OutputT> combineFn, Coder<InputT> inputTCoder) {
+
+    if (combineFn instanceof Combine.CombineFn) {
+      return new Combine.CombineFn<Object, Object, OutputT>() {
+
+        @SuppressWarnings("unchecked")
+        final Combine.CombineFn<InputT, Object, OutputT> fn =
+            (Combine.CombineFn<InputT, Object, OutputT>) combineFn;
+
+        @Override
+        public Object createAccumulator() {
+          return fn.createAccumulator();
+        }
+
+        @Override
+        public Coder<Object> getAccumulatorCoder(CoderRegistry registry, Coder<Object> inputCoder)
+            throws CannotProvideCoderException {
+          return fn.getAccumulatorCoder(registry, inputTCoder);
+        }
+
+        @Override
+        public Object addInput(Object mutableAccumulator, Object input) {
+          return fn.mergeAccumulators(ImmutableList.of(mutableAccumulator, input));
+        }
+
+        @Override
+        public Object mergeAccumulators(Iterable<Object> accumulators) {
+          return fn.mergeAccumulators(accumulators);
+        }
+
+        @Override
+        public OutputT extractOutput(Object accumulator) {
+          return fn.extractOutput(accumulator);
+        }
+      };
+    } else if (combineFn instanceof CombineWithContext.CombineFnWithContext) {
+      return new CombineWithContext.CombineFnWithContext<Object, Object, OutputT>() {
+
+        @SuppressWarnings("unchecked")
+        final CombineWithContext.CombineFnWithContext<InputT, Object, OutputT> fn =
+            (CombineWithContext.CombineFnWithContext<InputT, Object, OutputT>) combineFn;
+
+        @Override
+        public Object createAccumulator(CombineWithContext.Context c) {
+          return fn.createAccumulator(c);
+        }
+
+        @Override
+        public Coder<Object> getAccumulatorCoder(CoderRegistry registry, Coder<Object> inputCoder)
+            throws CannotProvideCoderException {
+          return fn.getAccumulatorCoder(registry, inputTCoder);
+        }
+
+        @Override
+        public Object addInput(Object accumulator, Object input, CombineWithContext.Context c) {
+          return fn.mergeAccumulators(ImmutableList.of(accumulator, input), c);
+        }
+
+        @Override
+        public Object mergeAccumulators(
+            Iterable<Object> accumulators, CombineWithContext.Context c) {
+          return fn.mergeAccumulators(accumulators, c);
+        }
+
+        @Override
+        public OutputT extractOutput(Object accumulator, CombineWithContext.Context c) {
+          return fn.extractOutput(accumulator, c);
+        }
+      };
+    }
+    throw new IllegalArgumentException(
+        "Unsupported CombineFn implementation: " + combineFn.getClass());
+  }
+
+  /**
+   * Create a DoFnOperator instance that group elements per window and apply a combine function on them.
+   */
+  public static <K, InputC, OutputC, InputT, OutputT> WindowDoFnOperator<K, InputC, OutputC> getWindowedAggregateDoFnOperator(
+      FlinkStreamingTranslationContext context,
+      PTransform<PCollection<KV<K, InputT>>, PCollection<KV<K, OutputT>>> transform,
+      KvCoder<K, InputC> inputKvCoder,
+      Coder<WindowedValue<KV<K, OutputC>>> outputCoder,
+      SystemReduceFn<K, InputC, ?, OutputC, BoundedWindow> reduceFn,
+      Map<Integer, PCollectionView<?>> sideInputTagMapping,
+      List<PCollectionView<?>> sideInputs) {
+
+    // Naming
+    String fullName = FlinkStreamingTransformTranslators.getCurrentTransformName(context);
+    TupleTag<KV<K, OutputC>> mainTag = new TupleTag<>("main output");
+
+    // input infos
+    PCollection<KV<K, InputT>> input = context.getInput(transform);
+
+    @SuppressWarnings("unchecked")
+    WindowingStrategy<?, BoundedWindow> windowingStrategy =
+        (WindowingStrategy<?, BoundedWindow>) input.getWindowingStrategy();
+    SerializablePipelineOptions serializablePipelineOptions =
+        new SerializablePipelineOptions(context.getPipelineOptions());
+
+    // Coders
+    Coder<K> keyCoder = inputKvCoder.getKeyCoder();
+
+    SingletonKeyedWorkItemCoder<K, InputC> workItemCoder =
+        SingletonKeyedWorkItemCoder.of(
+            keyCoder,
+            inputKvCoder.getValueCoder(),
+            windowingStrategy.getWindowFn().windowCoder());
+
+    WindowedValue.FullWindowedValueCoder<KeyedWorkItem<K, InputC>> windowedWorkItemCoder =
+        WindowedValue.getFullCoder(workItemCoder, windowingStrategy.getWindowFn().windowCoder());
+
+    // Key selector
+    WorkItemKeySelector<K, InputC> workItemKeySelector =
+        new WorkItemKeySelector<>(keyCoder, serializablePipelineOptions);
+
+    return new WindowDoFnOperator<>(
+        reduceFn,
+        fullName,
+        (Coder) windowedWorkItemCoder,
+        mainTag,
+        Collections.emptyList(),
+        new DoFnOperator.MultiOutputOutputManagerFactory<>(
+            mainTag, outputCoder, serializablePipelineOptions),
+        windowingStrategy,
+        sideInputTagMapping,
+        sideInputs,
+        context.getPipelineOptions(),
+        keyCoder,
+        workItemKeySelector);
+  }
+
+  public static <K, InputC, OutputC, InputT, OutputT> WindowDoFnOperator<K, InputC, OutputC> getWindowedAggregateDoFnOperator(
+      FlinkStreamingTranslationContext context,
+      PTransform<PCollection<KV<K, InputT>>, PCollection<KV<K, OutputT>>> transform,
+      KvCoder<K, InputC> inputKvCoder,
+      Coder<WindowedValue<KV<K, OutputC>>> outputCoder,
+      CombineFnBase.GlobalCombineFn<? super InputC, ?, OutputC> combineFn,
+      Map<Integer, PCollectionView<?>> sideInputTagMapping,
+      List<PCollectionView<?>> sideInputs) {
+
+    // Combining fn
+    SystemReduceFn<K, InputC, ?, OutputC, BoundedWindow> reduceFn =
+        SystemReduceFn.combining(
+            inputKvCoder.getKeyCoder(),
+            AppliedCombineFn.withInputCoder(
+                combineFn, context.getInput(transform).getPipeline().getCoderRegistry(), inputKvCoder));
+
+    return getWindowedAggregateDoFnOperator(context, transform, inputKvCoder, outputCoder, reduceFn, sideInputTagMapping, sideInputs);
+  }
+
+  public static <K, InputT, AccumT, OutputT> SingleOutputStreamOperator<WindowedValue<KV<K, OutputT>>> batchCombinePerKeyNoSideInputs(
+      FlinkStreamingTranslationContext context,
+      PTransform<PCollection<KV<K, InputT>>, PCollection<KV<K, OutputT>>> transform,
+      CombineFnBase.GlobalCombineFn<InputT, AccumT, OutputT> combineFn) {
+
+    Coder<WindowedValue<KV<K, AccumT>>> windowedAccumCoder;
+    KvCoder<K, AccumT> accumKvCoder;
+
+    PCollection<KV<K, InputT>> input = context.getInput(transform);
+    String fullName = FlinkStreamingTransformTranslators.getCurrentTransformName(context);
+    DataStream<WindowedValue<KV<K, InputT>>> inputDataStream = context.getInputDataStream(input);
+    KvCoder<K, InputT> inputKvCoder =
+        (KvCoder<K, InputT>) input.getCoder();
+    Coder<WindowedValue<KV<K, OutputT>>> outputCoder =
+        context.getWindowedInputCoder(context.getOutput(transform));
+    SerializablePipelineOptions serializablePipelineOptions =
+        new SerializablePipelineOptions(context.getPipelineOptions());
+    TypeInformation<WindowedValue<KV<K, OutputT>>> outputTypeInfo =
+        context.getTypeInfo(context.getOutput(transform));
+
+    try {
+      Coder<AccumT> accumulatorCoder =
+          combineFn.getAccumulatorCoder(
+              input.getPipeline().getCoderRegistry(), inputKvCoder.getValueCoder());
+
+      accumKvCoder = KvCoder.of(inputKvCoder.getKeyCoder(), accumulatorCoder);
+
+      windowedAccumCoder =
+          WindowedValue.getFullCoder(
+              accumKvCoder, input.getWindowingStrategy().getWindowFn().windowCoder());
+    } catch (CannotProvideCoderException e) {
+      throw new RuntimeException(e);
+    }
+
+    TupleTag<KV<K, AccumT>> mainTag = new TupleTag<>("main output");
+
+    PartialReduceBundleOperator<K, InputT, OutputT, AccumT> partialDoFnOperator =
+        new PartialReduceBundleOperator<>(
+            combineFn,
+            FlinkStreamingTransformTranslators.getCurrentTransformName(context),
+            context.getWindowedInputCoder(input),
+            mainTag,
+            Collections.emptyList(),
+            new DoFnOperator.MultiOutputOutputManagerFactory<>(
+                mainTag, windowedAccumCoder, serializablePipelineOptions),
+            input.getWindowingStrategy(),
+            new HashMap<>(),
+            Collections.emptyList(),
+            context.getPipelineOptions());
+
+    // final aggregation from AccumT to OutputT
+    WindowDoFnOperator<K, AccumT, OutputT> finalDoFnOperator =
+        getWindowedAggregateDoFnOperator(
+            context,
+            transform,
+            accumKvCoder,
+            outputCoder,
+            toFinalFlinkCombineFn(combineFn, inputKvCoder.getValueCoder()),
+            new HashMap<>(),
+            Collections.emptyList());
+
+    String partialName = "Combine: " + fullName;
+    CoderTypeInformation<WindowedValue<KV<K, AccumT>>> partialTypeInfo =
+        new CoderTypeInformation<>(windowedAccumCoder, context.getPipelineOptions());
+
+    return
+        inputDataStream
+            .transform(partialName, partialTypeInfo, partialDoFnOperator)
+            .uid(partialName)
+            .keyBy(new KvToByteBufferKeySelector<>(inputKvCoder.getKeyCoder(), serializablePipelineOptions))
+            .transform(fullName, outputTypeInfo, finalDoFnOperator)
+            .uid(fullName);
+  }
+}

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
@@ -389,6 +389,9 @@ class FlinkStreamingTransformTranslators {
               new SerializablePipelineOptions(context.getPipelineOptions()),
               parallelism);
 
+      TypeInformation<WindowedValue<T>> typeInfo =
+          context.getTypeInfo(output);
+
       DataStream<WindowedValue<T>> source;
       try {
         source =
@@ -396,7 +399,8 @@ class FlinkStreamingTransformTranslators {
                 .getExecutionEnvironment()
                 .fromSource(
                     flinkBoundedSource, WatermarkStrategy.noWatermarks(), fullName, outputTypeInfo)
-                .uid(fullName);
+                .uid(fullName)
+                .returns(typeInfo);
       } catch (Exception e) {
         throw new RuntimeException("Error while translating BoundedSource: " + rawSource, e);
       }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
@@ -39,6 +39,7 @@ import org.apache.beam.runners.flink.translation.functions.ImpulseSourceFunction
 import org.apache.beam.runners.flink.translation.types.CoderTypeInformation;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.DoFnOperator;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.KvToByteBufferKeySelector;
+import org.apache.beam.runners.flink.translation.wrappers.streaming.PartialReduceBundleOperator;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.ProcessingTimeCallbackCompat;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.SingletonKeyedWorkItem;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.SingletonKeyedWorkItemCoder;
@@ -53,8 +54,10 @@ import org.apache.beam.runners.flink.translation.wrappers.streaming.io.source.Fl
 import org.apache.beam.runners.flink.translation.wrappers.streaming.io.source.bounded.FlinkBoundedSource;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.io.source.unbounded.FlinkUnboundedSource;
 import org.apache.beam.sdk.coders.ByteArrayCoder;
+import org.apache.beam.sdk.coders.CannotProvideCoderException;
 import org.apache.beam.sdk.coders.Coder;
 import org.apache.beam.sdk.coders.CoderException;
+import org.apache.beam.sdk.coders.CoderRegistry;
 import org.apache.beam.sdk.coders.IterableCoder;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.VoidCoder;
@@ -66,6 +69,7 @@ import org.apache.beam.sdk.runners.AppliedPTransform;
 import org.apache.beam.sdk.testing.TestStream;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.CombineFnBase.GlobalCombineFn;
+import org.apache.beam.sdk.transforms.CombineWithContext;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.DoFnSchemaInformation;
 import org.apache.beam.sdk.transforms.Impulse;
@@ -97,6 +101,7 @@ import org.apache.beam.sdk.values.TupleTagList;
 import org.apache.beam.sdk.values.ValueWithRecordId;
 import org.apache.beam.sdk.values.WindowingStrategy;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Maps;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
@@ -946,11 +951,6 @@ class FlinkStreamingTransformTranslators {
 
       DataStream<WindowedValue<KV<K, InputT>>> inputDataStream = context.getInputDataStream(input);
 
-//      WindowedValue.FullWindowedValueCoder<KV<K, byte[]>> windowedBinaryKVCoder =
-//          WindowedValue.getFullCoder(
-//              KvCoder.of(inputKvCoder.getKeyCoder(), ByteArrayCoder.of()),
-//              input.getWindowingStrategy().getWindowFn().windowCoder());
-
       WindowedValue.FullWindowedValueCoder<KeyedWorkItem<K, InputT>> windowedKeyedWorkItemCoder =
           WindowedValue.getFullCoder(
               KeyedWorkItemCoder.of(
@@ -959,29 +959,21 @@ class FlinkStreamingTransformTranslators {
                   input.getWindowingStrategy().getWindowFn().windowCoder()),
               input.getWindowingStrategy().getWindowFn().windowCoder());
 
-//      CoderTypeInformation<WindowedValue<KV<K, byte[]>>> binaryKVTypeInfo =
-//          new CoderTypeInformation<>(windowedBinaryKVCoder, context.getPipelineOptions());
-
-//      DataStream<WindowedValue<KV<K, byte[]>>> inputBinaryDataStream =
-//          inputDataStream
-//              .flatMap(new ToBinaryKV<>(context.getPipelineOptions(), inputKvCoder.getValueCoder()))
-//              .returns(binaryKVTypeInfo)
-//              .name("ToBinaryKV");
-
       KvToByteBufferKeySelector<K, InputT> keySelector =
           new KvToByteBufferKeySelector<>(
               inputKvCoder.getKeyCoder(),
               new SerializablePipelineOptions(context.getPipelineOptions()));
 
       KeyedStream<WindowedValue<KV<K, InputT>>, ByteBuffer> keyedWorkItemStream =
-              inputDataStream.keyBy(keySelector);
+          inputDataStream.keyBy(keySelector);
 
       SystemReduceFn<K, InputT, Iterable<InputT>, Iterable<InputT>, BoundedWindow> reduceFn =
           SystemReduceFn.buffering(inputKvCoder.getValueCoder());
 
       Coder<WindowedValue<KV<K, Iterable<InputT>>>> outputCoder =
           WindowedValue.getFullCoder(
-              KvCoder.of(inputKvCoder.getKeyCoder(), IterableCoder.of(inputKvCoder.getValueCoder())),
+              KvCoder.of(
+                  inputKvCoder.getKeyCoder(), IterableCoder.of(inputKvCoder.getValueCoder())),
               windowingStrategy.getWindowFn().windowCoder());
 
       TypeInformation<WindowedValue<KV<K, Iterable<InputT>>>> outputTypeInfo =
@@ -1014,14 +1006,7 @@ class FlinkStreamingTransformTranslators {
               workItemKeySelector);
 
       final SingleOutputStreamOperator<WindowedValue<KV<K, Iterable<InputT>>>> outDataStream =
-          keyedWorkItemStream
-              .transform(fullName, outputTypeInfo, doFnOperator)
-              .uid(fullName);
-//              .flatMap(
-//                  new ToGroupByKeyResult<>(
-//                      context.getPipelineOptions(), inputKvCoder.getValueCoder()))
-//              .returns(context.getTypeInfo(context.getOutput(transform)))
-//              .name("ToGBKResult");
+          keyedWorkItemStream.transform(fullName, outputTypeInfo, doFnOperator).uid(fullName);
 
       context.setOutputDataStream(context.getOutput(transform), outDataStream);
     }
@@ -1048,129 +1033,94 @@ class FlinkStreamingTransformTranslators {
           || ((Combine.PerKey) transform).getSideInputs().isEmpty();
     }
 
-    /*
-        private GlobalCombineFn<? super InputT, ?, ?> toPartialFlinkCombineFn(GlobalCombineFn<? super InputT, ?, OutputT> combineFn) {
+    private static <InputT, OutputT> GlobalCombineFn<Object, Object, OutputT> toFinalFlinkCombineFn(
+        GlobalCombineFn<? super InputT, ?, OutputT> combineFn, Coder<InputT> inputTCoder) {
 
-          if(combineFn instanceof Combine.CombineFn) {
-            return new Combine.CombineFn<InputT, Object, Object>() {
+      if (combineFn instanceof Combine.CombineFn) {
+        return new Combine.CombineFn<Object, Object, OutputT>() {
 
-              Combine.CombineFn<? super InputT, Object, OutputT> fn =
-                  (Combine.CombineFn<? super InputT, Object, OutputT>) combineFn;
+          @SuppressWarnings("unchecked")
+          final Combine.CombineFn<InputT, Object, OutputT> fn =
+              (Combine.CombineFn<InputT, Object, OutputT>) combineFn;
 
-              @Override
-              public Object createAccumulator() {
-                return fn.createAccumulator();
-              }
-
-              @Override
-              public Object addInput(Object mutableAccumulator, InputT input) {
-                return fn.addInput(mutableAccumulator, input);
-              }
-
-              @Override
-              public Object mergeAccumulators(Iterable<Object> accumulators) {
-                return fn.mergeAccumulators(accumulators);
-              }
-
-              @Override
-              public Object extractOutput(Object accumulator) {
-                return accumulator;
-              }
-            };
-          } else if (combineFn instanceof CombineWithContext.CombineFnWithContext){
-            return new CombineWithContext.CombineFnWithContext<InputT, Object, Object>() {
-              CombineWithContext.CombineFnWithContext<? super InputT, Object, OutputT> fn =
-                  (CombineWithContext.CombineFnWithContext<? super InputT, Object, OutputT>) combineFn;
-              @Override
-              public Object createAccumulator(CombineWithContext.Context c) {
-                return fn.createAccumulator(c);
-              }
-
-              @Override
-              public Object addInput(Object accumulator, InputT input, CombineWithContext.Context c) {
-                return fn.addInput(accumulator, input, c);
-              }
-
-              @Override
-              public Object mergeAccumulators(Iterable<Object> accumulators, CombineWithContext.Context c) {
-                return fn.mergeAccumulators(accumulators, c);
-              }
-
-              @Override
-              public Object extractOutput(Object accumulator, CombineWithContext.Context c) {
-                return accumulator;
-              }
-            };
+          @Override
+          public Object createAccumulator() {
+            return fn.createAccumulator();
           }
 
-          throw new IllegalArgumentException("Unsupported CombineFn implementation: " + combineFn.getClass());
-        }
-
-        private GlobalCombineFn<?, ?, OutputT> toFinalFlinkCombineFn(GlobalCombineFn<? super InputT, ?, OutputT> combineFn) {
-
-          if(combineFn instanceof Combine.CombineFn) {
-            return new Combine.CombineFn<Object, Object, OutputT>() {
-              Combine.CombineFn<? super InputT, Object, OutputT> fn =
-                  (Combine.CombineFn<? super InputT, Object, OutputT>) combineFn;
-              @Override
-              public Object createAccumulator() {
-                return fn.createAccumulator();
-              }
-
-              @Override
-              public Object addInput(Object mutableAccumulator, Object input) {
-                return fn.mergeAccumulators(ImmutableList.of(mutableAccumulator, input));
-              }
-
-              @Override
-              public Object mergeAccumulators(Iterable<Object> accumulators) {
-                return fn.mergeAccumulators(accumulators);
-              }
-
-              @Override
-              public OutputT extractOutput(Object accumulator) {
-                return fn.extractOutput(accumulator);
-              }
-            };
-          } else if (combineFn instanceof CombineWithContext.CombineFnWithContext){
-            return new CombineWithContext.CombineFnWithContext<Object, Object, OutputT>() {
-              CombineWithContext.CombineFnWithContext<? super InputT, Object, OutputT> fn =
-                  (CombineWithContext.CombineFnWithContext<? super InputT, Object, OutputT>) combineFn;
-              @Override
-              public Object createAccumulator(CombineWithContext.Context c) {
-                return fn.createAccumulator(c);
-              }
-
-              @Override
-              public Object addInput(Object accumulator, Object input, CombineWithContext.Context c) {
-                return fn.mergeAccumulators(ImmutableList.of(accumulator, input), c);
-              }
-
-              @Override
-              public Object mergeAccumulators(Iterable<Object> accumulators, CombineWithContext.Context c) {
-                return fn.mergeAccumulators(accumulators, c);
-              }
-
-              @Override
-              public OutputT extractOutput(Object accumulator, CombineWithContext.Context c) {
-                return fn.extractOutput(accumulator, c);
-              }
-            };
+          @Override
+          public Coder<Object> getAccumulatorCoder(CoderRegistry registry, Coder<Object> inputCoder)
+              throws CannotProvideCoderException {
+            return fn.getAccumulatorCoder(registry, inputTCoder);
           }
-          throw new IllegalArgumentException("Unsupported CombineFn implementation: " + combineFn.getClass());
-        }
-    */
 
-    private WindowDoFnOperator<K, InputT, OutputT> getDoFnOperator(
-        FlinkStreamingTranslationContext context,
-        PTransform<PCollection<KV<K, InputT>>, PCollection<KV<K, OutputT>>> transform,
-        GlobalCombineFn<? super InputT, ?, OutputT> combineFn,
-        Map<Integer, PCollectionView<?>> sideInputTagMapping,
-        List<PCollectionView<?>> sideInputs) {
+          @Override
+          public Object addInput(Object mutableAccumulator, Object input) {
+            return fn.mergeAccumulators(ImmutableList.of(mutableAccumulator, input));
+          }
+
+          @Override
+          public Object mergeAccumulators(Iterable<Object> accumulators) {
+            return fn.mergeAccumulators(accumulators);
+          }
+
+          @Override
+          public OutputT extractOutput(Object accumulator) {
+            return fn.extractOutput(accumulator);
+          }
+        };
+      } else if (combineFn instanceof CombineWithContext.CombineFnWithContext) {
+        return new CombineWithContext.CombineFnWithContext<Object, Object, OutputT>() {
+
+          @SuppressWarnings("unchecked")
+          final CombineWithContext.CombineFnWithContext<InputT, Object, OutputT> fn =
+              (CombineWithContext.CombineFnWithContext<InputT, Object, OutputT>) combineFn;
+
+          @Override
+          public Object createAccumulator(CombineWithContext.Context c) {
+            return fn.createAccumulator(c);
+          }
+
+          @Override
+          public Coder<Object> getAccumulatorCoder(CoderRegistry registry, Coder<Object> inputCoder)
+              throws CannotProvideCoderException {
+            return fn.getAccumulatorCoder(registry, inputTCoder);
+          }
+
+          @Override
+          public Object addInput(Object accumulator, Object input, CombineWithContext.Context c) {
+            return fn.mergeAccumulators(ImmutableList.of(accumulator, input), c);
+          }
+
+          @Override
+          public Object mergeAccumulators(
+              Iterable<Object> accumulators, CombineWithContext.Context c) {
+            return fn.mergeAccumulators(accumulators, c);
+          }
+
+          @Override
+          public OutputT extractOutput(Object accumulator, CombineWithContext.Context c) {
+            return fn.extractOutput(accumulator, c);
+          }
+        };
+      }
+      throw new IllegalArgumentException(
+          "Unsupported CombineFn implementation: " + combineFn.getClass());
+    }
+
+    private static <K, InputC, OutputC, InputT, OutputT>
+        WindowDoFnOperator<K, InputC, OutputC> getDoFnOperator(
+            FlinkStreamingTranslationContext context,
+            PTransform<PCollection<KV<K, InputT>>, PCollection<KV<K, OutputT>>> transform,
+            KvCoder<K, InputC> inputKvCoder,
+            Coder<WindowedValue<KV<K, OutputC>>> outputCoder,
+            GlobalCombineFn<? super InputC, ?, OutputC> combineFn,
+            Map<Integer, PCollectionView<?>> sideInputTagMapping,
+            List<PCollectionView<?>> sideInputs) {
 
       // Naming
       String fullName = getCurrentTransformName(context);
-      TupleTag<KV<K, OutputT>> mainTag = new TupleTag<>("main output");
+      TupleTag<KV<K, OutputC>> mainTag = new TupleTag<>("main output");
 
       // input infos
       PCollection<KV<K, InputT>> input = context.getInput(transform);
@@ -1181,31 +1131,26 @@ class FlinkStreamingTransformTranslators {
           new SerializablePipelineOptions(context.getPipelineOptions());
 
       // Coders
-      KvCoder<K, InputT> inputKvCoder = (KvCoder<K, InputT>) input.getCoder();
       Coder<K> keyCoder = inputKvCoder.getKeyCoder();
 
-      SingletonKeyedWorkItemCoder<K, InputT> workItemCoder =
+      SingletonKeyedWorkItemCoder<K, InputC> workItemCoder =
           SingletonKeyedWorkItemCoder.of(
               keyCoder,
               inputKvCoder.getValueCoder(),
-              input.getWindowingStrategy().getWindowFn().windowCoder());
+              windowingStrategy.getWindowFn().windowCoder());
 
-      WindowedValue.FullWindowedValueCoder<KeyedWorkItem<K, InputT>> windowedWorkItemCoder =
-          WindowedValue.getFullCoder(
-              workItemCoder, input.getWindowingStrategy().getWindowFn().windowCoder());
-
-      Coder<WindowedValue<KV<K, OutputT>>> outputCoder =
-          context.getWindowedInputCoder(context.getOutput(transform));
+      WindowedValue.FullWindowedValueCoder<KeyedWorkItem<K, InputC>> windowedWorkItemCoder =
+          WindowedValue.getFullCoder(workItemCoder, windowingStrategy.getWindowFn().windowCoder());
 
       // Combining fn
-      SystemReduceFn<K, InputT, ?, OutputT, BoundedWindow> reduceFn =
+      SystemReduceFn<K, InputC, ?, OutputC, BoundedWindow> reduceFn =
           SystemReduceFn.combining(
               keyCoder,
               AppliedCombineFn.withInputCoder(
                   combineFn, input.getPipeline().getCoderRegistry(), inputKvCoder));
 
       // Key selector
-      WorkItemKeySelector<K, InputT> workItemKeySelector =
+      WorkItemKeySelector<K, InputC> workItemKeySelector =
           new WorkItemKeySelector<>(keyCoder, serializablePipelineOptions);
 
       return new WindowDoFnOperator<>(
@@ -1234,17 +1179,21 @@ class FlinkStreamingTransformTranslators {
 
       KvCoder<K, InputT> inputKvCoder = (KvCoder<K, InputT>) input.getCoder();
       Coder<K> keyCoder = inputKvCoder.getKeyCoder();
+      Coder<WindowedValue<KV<K, OutputT>>> outputCoder =
+          context.getWindowedInputCoder(context.getOutput(transform));
 
       DataStream<WindowedValue<KV<K, InputT>>> inputDataStream = context.getInputDataStream(input);
 
       SerializablePipelineOptions serializablePipelineOptions =
           new SerializablePipelineOptions(context.getPipelineOptions());
 
-      GlobalCombineFn<? super InputT, ?, OutputT> combineFn = ((Combine.PerKey) transform).getFn();
+      @SuppressWarnings("unchecked")
+      GlobalCombineFn<InputT, ?, OutputT> combineFn = ((Combine.PerKey) transform).getFn();
 
       TypeInformation<WindowedValue<KV<K, OutputT>>> outputTypeInfo =
           context.getTypeInfo(context.getOutput(transform));
 
+      @SuppressWarnings("unchecked")
       List<PCollectionView<?>> sideInputs = ((Combine.PerKey) transform).getSideInputs();
 
       KeyedStream<WindowedValue<KV<K, InputT>>, ByteBuffer> keyedStream =
@@ -1252,12 +1201,79 @@ class FlinkStreamingTransformTranslators {
               new KvToByteBufferKeySelector<>(keyCoder, serializablePipelineOptions));
 
       if (sideInputs.isEmpty()) {
-        WindowDoFnOperator<K, InputT, OutputT> doFnOperator =
-            getDoFnOperator(
-                context, transform, combineFn, new HashMap<>(), Collections.emptyList());
+        SingleOutputStreamOperator<WindowedValue<KV<K, OutputT>>> outDataStream;
 
-        SingleOutputStreamOperator<WindowedValue<KV<K, OutputT>>> outDataStream =
-            keyedStream.transform(fullName, outputTypeInfo, doFnOperator).uid(fullName);
+        if (!context.isStreaming()) {
+          Coder<WindowedValue<KV<K, Object>>> windowedAccumCoder;
+          KvCoder<K, Object> accumKvCoder;
+          try {
+            @SuppressWarnings("unchecked")
+            Coder<Object> accumulatorCoder =
+                (Coder<Object>)
+                    combineFn.getAccumulatorCoder(
+                        input.getPipeline().getCoderRegistry(), inputKvCoder.getValueCoder());
+
+            accumKvCoder = KvCoder.of(inputKvCoder.getKeyCoder(), accumulatorCoder);
+
+            windowedAccumCoder =
+                WindowedValue.getFullCoder(
+                    accumKvCoder, input.getWindowingStrategy().getWindowFn().windowCoder());
+          } catch (CannotProvideCoderException e) {
+            throw new RuntimeException(e);
+          }
+
+          TupleTag<KV<K, Object>> mainTag = new TupleTag<>("main output");
+
+          PartialReduceBundleOperator<K, InputT, OutputT, Object> partialDoFnOperator =
+              new PartialReduceBundleOperator<>(
+                  (GlobalCombineFn<InputT, Object, OutputT>) combineFn,
+                  getCurrentTransformName(context),
+                  context.getWindowedInputCoder(input),
+                  mainTag,
+                  Collections.emptyList(),
+                  new DoFnOperator.MultiOutputOutputManagerFactory<>(
+                      mainTag, windowedAccumCoder, serializablePipelineOptions),
+                  input.getWindowingStrategy(),
+                  new HashMap<>(),
+                  Collections.emptyList(),
+                  context.getPipelineOptions());
+
+          // final aggregation from AccumT to OutputT
+          WindowDoFnOperator<K, Object, OutputT> finalDoFnOperator =
+              getDoFnOperator(
+                  context,
+                  transform,
+                  accumKvCoder,
+                  outputCoder,
+                  toFinalFlinkCombineFn(combineFn, inputKvCoder.getValueCoder()),
+                  new HashMap<>(),
+                  Collections.emptyList());
+
+          String partialName = "Combine: " + fullName;
+          CoderTypeInformation<WindowedValue<KV<K, Object>>> partialTypeInfo =
+              new CoderTypeInformation<>(windowedAccumCoder, context.getPipelineOptions());
+
+          outDataStream =
+              inputDataStream
+                  .transform(partialName, partialTypeInfo, partialDoFnOperator)
+                  .uid(partialName)
+                  .keyBy(new KvToByteBufferKeySelector<>(keyCoder, serializablePipelineOptions))
+                  .transform(fullName, outputTypeInfo, finalDoFnOperator)
+                  .uid(fullName);
+        } else {
+          WindowDoFnOperator<K, InputT, OutputT> doFnOperator =
+              getDoFnOperator(
+                  context,
+                  transform,
+                  inputKvCoder,
+                  outputCoder,
+                  combineFn,
+                  new HashMap<>(),
+                  Collections.emptyList());
+
+          outDataStream =
+              keyedStream.transform(fullName, outputTypeInfo, doFnOperator).uid(fullName);
+        }
 
         context.setOutputDataStream(context.getOutput(transform), outDataStream);
       } else {
@@ -1265,7 +1281,14 @@ class FlinkStreamingTransformTranslators {
             transformSideInputs(sideInputs, context);
 
         WindowDoFnOperator<K, InputT, OutputT> doFnOperator =
-            getDoFnOperator(context, transform, combineFn, transformSideInputs.f0, sideInputs);
+            getDoFnOperator(
+                context,
+                transform,
+                inputKvCoder,
+                outputCoder,
+                combineFn,
+                transformSideInputs.f0,
+                sideInputs);
 
         // we have to manually contruct the two-input transform because we're not
         // allowed to have only one input keyed, normally.
@@ -1452,65 +1475,6 @@ class FlinkStreamingTransformTranslators {
 
         context.setOutputDataStream(context.getOutput(transform), result);
       }
-    }
-  }
-
-  static class ToBinaryKV<K, InputT>
-      extends RichFlatMapFunction<WindowedValue<KV<K, InputT>>, WindowedValue<KV<K, byte[]>>> {
-
-    private final SerializablePipelineOptions options;
-    private final Coder<InputT> valueCoder;
-
-    ToBinaryKV(PipelineOptions options, Coder<InputT> valueCoder) {
-      this.options = new SerializablePipelineOptions(options);
-      this.valueCoder = valueCoder;
-    }
-
-    @Override
-    public void open(Configuration parameters) {
-      // Initialize FileSystems for any coders which may want to use the FileSystem,
-      // see https://issues.apache.org/jira/browse/BEAM-8303
-      FileSystems.setDefaultPipelineOptions(options.get());
-    }
-
-    @Override
-    public void flatMap(
-        WindowedValue<KV<K, InputT>> in, Collector<WindowedValue<KV<K, byte[]>>> out)
-        throws CoderException {
-      final byte[] binaryValue = CoderUtils.encodeToByteArray(valueCoder, in.getValue().getValue());
-      out.collect(in.withValue(KV.of(in.getValue().getKey(), binaryValue)));
-    }
-  }
-
-  static class ToGroupByKeyResult<KeyT, ValueT>
-      extends RichFlatMapFunction<
-          WindowedValue<KV<KeyT, Iterable<byte[]>>>, WindowedValue<KV<KeyT, Iterable<ValueT>>>> {
-
-    private final SerializablePipelineOptions options;
-    private final Coder<ValueT> valueCoder;
-
-    ToGroupByKeyResult(PipelineOptions options, Coder<ValueT> valueCoder) {
-      this.options = new SerializablePipelineOptions(options);
-      this.valueCoder = valueCoder;
-    }
-
-    @Override
-    public void open(Configuration parameters) {
-      // Initialize FileSystems for any coders which may want to use the FileSystem,
-      // see https://issues.apache.org/jira/browse/BEAM-8303
-      FileSystems.setDefaultPipelineOptions(options.get());
-    }
-
-    @Override
-    public void flatMap(
-        WindowedValue<KV<KeyT, Iterable<byte[]>>> element,
-        Collector<WindowedValue<KV<KeyT, Iterable<ValueT>>>> collector)
-        throws CoderException {
-      final List<ValueT> result = new ArrayList<>();
-      for (byte[] binaryValue : element.getValue().getValue()) {
-        result.add(CoderUtils.decodeFromByteArray(valueCoder, binaryValue));
-      }
-      collector.collect(element.withValue(KV.of(element.getValue().getKey(), result)));
     }
   }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
@@ -21,6 +21,7 @@ import static java.lang.String.format;
 import static org.apache.beam.sdk.util.construction.SplittableParDo.SPLITTABLE_PROCESS_URN;
 
 import com.google.auto.service.AutoService;
+
 import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.ArrayList;
@@ -29,17 +30,14 @@ import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
-import org.apache.beam.runners.core.KeyedWorkItem;
-import org.apache.beam.runners.core.KeyedWorkItemCoder;
-import org.apache.beam.runners.core.SplittableParDoViaKeyedWorkItems;
-import org.apache.beam.runners.core.SystemReduceFn;
+
+import org.apache.beam.runners.core.*;
 import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
 import org.apache.beam.runners.flink.translation.functions.FlinkAssignWindows;
 import org.apache.beam.runners.flink.translation.functions.ImpulseSourceFunction;
 import org.apache.beam.runners.flink.translation.types.CoderTypeInformation;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.DoFnOperator;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.KvToByteBufferKeySelector;
-import org.apache.beam.runners.flink.translation.wrappers.streaming.PartialReduceBundleOperator;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.ProcessingTimeCallbackCompat;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.SingletonKeyedWorkItem;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.SingletonKeyedWorkItemCoder;
@@ -53,14 +51,7 @@ import org.apache.beam.runners.flink.translation.wrappers.streaming.io.Unbounded
 import org.apache.beam.runners.flink.translation.wrappers.streaming.io.source.FlinkSource;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.io.source.bounded.FlinkBoundedSource;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.io.source.unbounded.FlinkUnboundedSource;
-import org.apache.beam.sdk.coders.ByteArrayCoder;
-import org.apache.beam.sdk.coders.CannotProvideCoderException;
-import org.apache.beam.sdk.coders.Coder;
-import org.apache.beam.sdk.coders.CoderException;
-import org.apache.beam.sdk.coders.CoderRegistry;
-import org.apache.beam.sdk.coders.IterableCoder;
-import org.apache.beam.sdk.coders.KvCoder;
-import org.apache.beam.sdk.coders.VoidCoder;
+import org.apache.beam.sdk.coders.*;
 import org.apache.beam.sdk.io.BoundedSource;
 import org.apache.beam.sdk.io.FileSystems;
 import org.apache.beam.sdk.io.UnboundedSource;
@@ -69,7 +60,6 @@ import org.apache.beam.sdk.runners.AppliedPTransform;
 import org.apache.beam.sdk.testing.TestStream;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.CombineFnBase.GlobalCombineFn;
-import org.apache.beam.sdk.transforms.CombineWithContext;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.DoFnSchemaInformation;
 import org.apache.beam.sdk.transforms.Impulse;
@@ -82,7 +72,6 @@ import org.apache.beam.sdk.transforms.reflect.DoFnSignatures;
 import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.WindowFn;
-import org.apache.beam.sdk.util.AppliedCombineFn;
 import org.apache.beam.sdk.util.CoderUtils;
 import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.util.construction.PTransformTranslation;
@@ -101,7 +90,6 @@ import org.apache.beam.sdk.values.TupleTagList;
 import org.apache.beam.sdk.values.ValueWithRecordId;
 import org.apache.beam.sdk.values.WindowingStrategy;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
-import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Maps;
 import org.apache.flink.api.common.eventtime.WatermarkStrategy;
@@ -136,8 +124,8 @@ import org.checkerframework.checker.nullness.qual.Nullable;
  * encountered Beam transformations into Flink one, based on the mapping available in this class.
  */
 @SuppressWarnings({
-  "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
-  "nullness" // TODO(https://github.com/apache/beam/issues/20497)
+    "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
+    "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
 class FlinkStreamingTransformTranslators {
 
@@ -145,7 +133,9 @@ class FlinkStreamingTransformTranslators {
   //  Transform Translator Registry
   // --------------------------------------------------------------------------------------------
 
-  /** A map from a Transform URN to the translator. */
+  /**
+   * A map from a Transform URN to the translator.
+   */
   @SuppressWarnings("rawtypes")
   private static final Map<String, FlinkStreamingPipelineTranslator.StreamTransformTranslator>
       TRANSLATORS = new HashMap<>();
@@ -182,7 +172,7 @@ class FlinkStreamingTransformTranslators {
   }
 
   @SuppressWarnings("unchecked")
-  private static String getCurrentTransformName(FlinkStreamingTranslationContext context) {
+  public static String getCurrentTransformName(FlinkStreamingTranslationContext context) {
     return context.getCurrentTransform().getFullName();
   }
 
@@ -192,7 +182,7 @@ class FlinkStreamingTransformTranslators {
 
   private static class UnboundedReadSourceTranslator<T>
       extends FlinkStreamingPipelineTranslator.StreamTransformTranslator<
-          PTransform<PBegin, PCollection<T>>> {
+      PTransform<PBegin, PCollection<T>>> {
 
     @Override
     public void translateNode(
@@ -268,7 +258,7 @@ class FlinkStreamingTransformTranslators {
 
   static class ValueWithRecordIdKeySelector<T>
       implements KeySelector<WindowedValue<ValueWithRecordId<T>>, ByteBuffer>,
-          ResultTypeQueryable<ByteBuffer> {
+      ResultTypeQueryable<ByteBuffer> {
 
     @Override
     public ByteBuffer getKey(WindowedValue<ValueWithRecordId<T>> value) throws Exception {
@@ -341,7 +331,7 @@ class FlinkStreamingTransformTranslators {
 
   private static class ReadSourceTranslator<T>
       extends FlinkStreamingPipelineTranslator.StreamTransformTranslator<
-          PTransform<PBegin, PCollection<T>>> {
+      PTransform<PBegin, PCollection<T>>> {
 
     private final BoundedReadSourceTranslator<T> boundedTranslator =
         new BoundedReadSourceTranslator<>();
@@ -362,7 +352,7 @@ class FlinkStreamingTransformTranslators {
 
   private static class BoundedReadSourceTranslator<T>
       extends FlinkStreamingPipelineTranslator.StreamTransformTranslator<
-          PTransform<PBegin, PCollection<T>>> {
+      PTransform<PBegin, PCollection<T>>> {
 
     @Override
     public void translateNode(
@@ -414,7 +404,9 @@ class FlinkStreamingTransformTranslators {
     }
   }
 
-  /** Wraps each element in a {@link RawUnionValue} with the given tag id. */
+  /**
+   * Wraps each element in a {@link RawUnionValue} with the given tag id.
+   */
   public static class ToRawUnion<T> extends RichMapFunction<T, RawUnionValue> {
     private final int intTag;
     private final SerializablePipelineOptions options;
@@ -438,8 +430,8 @@ class FlinkStreamingTransformTranslators {
   }
 
   private static Tuple2<Map<Integer, PCollectionView<?>>, DataStream<RawUnionValue>>
-      transformSideInputs(
-          Collection<PCollectionView<?>> sideInputs, FlinkStreamingTranslationContext context) {
+  transformSideInputs(
+      Collection<PCollectionView<?>> sideInputs, FlinkStreamingTranslationContext context) {
 
     // collect all side inputs
     Map<TupleTag<?>, Integer> tagToIntMapping = new HashMap<>();
@@ -662,15 +654,15 @@ class FlinkStreamingTransformTranslators {
           // allowed to have only one input keyed, normally.
           KeyedStream keyedStream = (KeyedStream<?, InputT>) inputDataStream;
           TwoInputTransformation<
-                  WindowedValue<KV<?, InputT>>, RawUnionValue, WindowedValue<OutputT>>
+              WindowedValue<KV<?, InputT>>, RawUnionValue, WindowedValue<OutputT>>
               rawFlinkTransform =
-                  new TwoInputTransformation(
-                      keyedStream.getTransformation(),
-                      transformedSideInputs.f1.broadcast().getTransformation(),
-                      transformName,
-                      doFnOperator,
-                      outputTypeInformation,
-                      keyedStream.getParallelism());
+              new TwoInputTransformation(
+                  keyedStream.getTransformation(),
+                  transformedSideInputs.f1.broadcast().getTransformation(),
+                  transformName,
+                  doFnOperator,
+                  outputTypeInformation,
+                  keyedStream.getParallelism());
 
           rawFlinkTransform.setStateKeyType(keyedStream.getKeyType());
           rawFlinkTransform.setStateKeySelectors(keyedStream.getKeySelector(), null);
@@ -678,7 +670,8 @@ class FlinkStreamingTransformTranslators {
           outputStream =
               new SingleOutputStreamOperator(
                   keyedStream.getExecutionEnvironment(),
-                  rawFlinkTransform) {}; // we have to cheat around the ctor being protected
+                  rawFlinkTransform) {
+              }; // we have to cheat around the ctor being protected
 
           keyedStream.getExecutionEnvironment().addOperator(rawFlinkTransform);
 
@@ -704,7 +697,7 @@ class FlinkStreamingTransformTranslators {
 
   private static class ParDoStreamingTranslator<InputT, OutputT>
       extends FlinkStreamingPipelineTranslator.StreamTransformTranslator<
-          PTransform<PCollection<InputT>, PCollectionTuple>> {
+      PTransform<PCollection<InputT>, PCollectionTuple>> {
 
     @Override
     public void translateNode(
@@ -759,22 +752,22 @@ class FlinkStreamingTransformTranslators {
           sideInputMapping,
           context,
           (doFn1,
-              stepName,
-              sideInputs1,
-              mainOutputTag1,
-              additionalOutputTags1,
-              context1,
-              windowingStrategy,
-              tagsToOutputTags,
-              tagsToCoders,
-              tagsToIds,
-              windowedInputCoder,
-              outputCoders1,
-              keyCoder,
-              keySelector,
-              transformedSideInputs,
-              doFnSchemaInformation1,
-              sideInputMapping1) ->
+           stepName,
+           sideInputs1,
+           mainOutputTag1,
+           additionalOutputTags1,
+           context1,
+           windowingStrategy,
+           tagsToOutputTags,
+           tagsToCoders,
+           tagsToIds,
+           windowedInputCoder,
+           outputCoders1,
+           keyCoder,
+           keySelector,
+           transformedSideInputs,
+           doFnSchemaInformation1,
+           sideInputMapping1) ->
               new DoFnOperator<>(
                   doFn1,
                   stepName,
@@ -800,15 +793,15 @@ class FlinkStreamingTransformTranslators {
   }
 
   private static class SplittableProcessElementsStreamingTranslator<
-          InputT, OutputT, RestrictionT, PositionT, WatermarkEstimatorStateT>
+      InputT, OutputT, RestrictionT, PositionT, WatermarkEstimatorStateT>
       extends FlinkStreamingPipelineTranslator.StreamTransformTranslator<
-          SplittableParDoViaKeyedWorkItems.ProcessElements<
-              InputT, OutputT, RestrictionT, PositionT, WatermarkEstimatorStateT>> {
+      SplittableParDoViaKeyedWorkItems.ProcessElements<
+          InputT, OutputT, RestrictionT, PositionT, WatermarkEstimatorStateT>> {
 
     @Override
     public void translateNode(
         SplittableParDoViaKeyedWorkItems.ProcessElements<
-                InputT, OutputT, RestrictionT, PositionT, WatermarkEstimatorStateT>
+            InputT, OutputT, RestrictionT, PositionT, WatermarkEstimatorStateT>
             transform,
         FlinkStreamingTranslationContext context) {
 
@@ -824,22 +817,22 @@ class FlinkStreamingTransformTranslators {
           Collections.emptyMap(),
           context,
           (doFn,
-              stepName,
-              sideInputs,
-              mainOutputTag,
-              additionalOutputTags,
-              context1,
-              windowingStrategy,
-              tagsToOutputTags,
-              tagsToCoders,
-              tagsToIds,
-              windowedInputCoder,
-              outputCoders1,
-              keyCoder,
-              keySelector,
-              transformedSideInputs,
-              doFnSchemaInformation,
-              sideInputMapping) ->
+           stepName,
+           sideInputs,
+           mainOutputTag,
+           additionalOutputTags,
+           context1,
+           windowingStrategy,
+           tagsToOutputTags,
+           tagsToCoders,
+           tagsToIds,
+           windowedInputCoder,
+           outputCoders1,
+           keyCoder,
+           keySelector,
+           transformedSideInputs,
+           doFnSchemaInformation,
+           sideInputMapping) ->
               new SplittableDoFnOperator<>(
                   doFn,
                   stepName,
@@ -864,7 +857,7 @@ class FlinkStreamingTransformTranslators {
 
   private static class CreateViewStreamingTranslator<ElemT, ViewT>
       extends FlinkStreamingPipelineTranslator.StreamTransformTranslator<
-          CreateStreamingFlinkView.CreateFlinkPCollectionView<ElemT, ViewT>> {
+      CreateStreamingFlinkView.CreateFlinkPCollectionView<ElemT, ViewT>> {
 
     @Override
     public void translateNode(
@@ -882,7 +875,7 @@ class FlinkStreamingTransformTranslators {
 
   private static class WindowAssignTranslator<T>
       extends FlinkStreamingPipelineTranslator.StreamTransformTranslator<
-          PTransform<PCollection<T>, PCollection<T>>> {
+      PTransform<PCollection<T>, PCollection<T>>> {
 
     @Override
     public void translateNode(
@@ -918,7 +911,7 @@ class FlinkStreamingTransformTranslators {
 
   private static class ReshuffleTranslatorStreaming<K, InputT>
       extends FlinkStreamingPipelineTranslator.StreamTransformTranslator<
-          PTransform<PCollection<KV<K, InputT>>, PCollection<KV<K, InputT>>>> {
+      PTransform<PCollection<KV<K, InputT>>, PCollection<KV<K, InputT>>>> {
 
     @Override
     public void translateNode(
@@ -934,7 +927,7 @@ class FlinkStreamingTransformTranslators {
 
   private static class GroupByKeyTranslator<K, InputT>
       extends FlinkStreamingPipelineTranslator.StreamTransformTranslator<
-          PTransform<PCollection<KV<K, InputT>>, PCollection<KV<K, Iterable<InputT>>>>> {
+      PTransform<PCollection<KV<K, InputT>>, PCollection<KV<K, Iterable<InputT>>>>> {
 
     @Override
     public void translateNode(
@@ -942,79 +935,62 @@ class FlinkStreamingTransformTranslators {
         FlinkStreamingTranslationContext context) {
 
       PCollection<KV<K, InputT>> input = context.getInput(transform);
-
       @SuppressWarnings("unchecked")
       WindowingStrategy<?, BoundedWindow> windowingStrategy =
           (WindowingStrategy<?, BoundedWindow>) input.getWindowingStrategy();
-
       KvCoder<K, InputT> inputKvCoder = (KvCoder<K, InputT>) input.getCoder();
-
       DataStream<WindowedValue<KV<K, InputT>>> inputDataStream = context.getInputDataStream(input);
-
-      WindowedValue.FullWindowedValueCoder<KeyedWorkItem<K, InputT>> windowedKeyedWorkItemCoder =
-          WindowedValue.getFullCoder(
-              KeyedWorkItemCoder.of(
-                  inputKvCoder.getKeyCoder(),
-                  inputKvCoder.getValueCoder(),
-                  input.getWindowingStrategy().getWindowFn().windowCoder()),
-              input.getWindowingStrategy().getWindowFn().windowCoder());
-
-      KvToByteBufferKeySelector<K, InputT> keySelector =
-          new KvToByteBufferKeySelector<>(
-              inputKvCoder.getKeyCoder(),
-              new SerializablePipelineOptions(context.getPipelineOptions()));
-
-      KeyedStream<WindowedValue<KV<K, InputT>>, ByteBuffer> keyedWorkItemStream =
-          inputDataStream.keyBy(keySelector);
-
-      SystemReduceFn<K, InputT, Iterable<InputT>, Iterable<InputT>, BoundedWindow> reduceFn =
-          SystemReduceFn.buffering(inputKvCoder.getValueCoder());
-
-      Coder<WindowedValue<KV<K, Iterable<InputT>>>> outputCoder =
-          WindowedValue.getFullCoder(
-              KvCoder.of(
-                  inputKvCoder.getKeyCoder(), IterableCoder.of(inputKvCoder.getValueCoder())),
-              windowingStrategy.getWindowFn().windowCoder());
-
-      TypeInformation<WindowedValue<KV<K, Iterable<InputT>>>> outputTypeInfo =
-          new CoderTypeInformation<>(outputCoder, context.getPipelineOptions());
-
-      TupleTag<KV<K, Iterable<InputT>>> mainTag = new TupleTag<>("main output");
-
-      WorkItemKeySelector<K, InputT> workItemKeySelector =
-          new WorkItemKeySelector<>(
-              inputKvCoder.getKeyCoder(),
-              new SerializablePipelineOptions(context.getPipelineOptions()));
-
       String fullName = getCurrentTransformName(context);
-      WindowDoFnOperator<K, InputT, Iterable<InputT>> doFnOperator =
-          new WindowDoFnOperator<>(
-              reduceFn,
-              fullName,
-              windowedKeyedWorkItemCoder,
-              mainTag,
-              Collections.emptyList(),
-              new DoFnOperator.MultiOutputOutputManagerFactory<>(
-                  mainTag,
-                  outputCoder,
-                  new SerializablePipelineOptions(context.getPipelineOptions())),
-              windowingStrategy,
-              new HashMap<>(), /* side-input mapping */
-              Collections.emptyList(), /* side inputs */
-              context.getPipelineOptions(),
-              inputKvCoder.getKeyCoder(),
-              workItemKeySelector);
 
-      final SingleOutputStreamOperator<WindowedValue<KV<K, Iterable<InputT>>>> outDataStream =
-          keyedWorkItemStream.transform(fullName, outputTypeInfo, doFnOperator).uid(fullName);
+      SingleOutputStreamOperator<WindowedValue<KV<K, Iterable<InputT>>>> outDataStream;
+      // Pre-aggregate before shuffle similar to group combine
+      if (!context.isStreaming()) {
+        outDataStream =
+            FlinkStreamingAggregationsTranslators.batchCombinePerKeyNoSideInputs(
+                context,
+                transform,
+                new FlinkStreamingAggregationsTranslators.ConcatenateAsIterable<>());
+      } else {
+        // No pre-aggregation in Streaming mode.
+        KvToByteBufferKeySelector<K, InputT> keySelector =
+            new KvToByteBufferKeySelector<>(
+                inputKvCoder.getKeyCoder(),
+                new SerializablePipelineOptions(context.getPipelineOptions()));
 
+        Coder<WindowedValue<KV<K, Iterable<InputT>>>> outputCoder =
+            WindowedValue.getFullCoder(
+                KvCoder.of(
+                    inputKvCoder.getKeyCoder(), IterableCoder.of(inputKvCoder.getValueCoder())),
+                windowingStrategy.getWindowFn().windowCoder());
+
+        TypeInformation<WindowedValue<KV<K, Iterable<InputT>>>> outputTypeInfo =
+            new CoderTypeInformation<>(outputCoder, context.getPipelineOptions());
+
+        WindowDoFnOperator<K, InputT, Iterable<InputT>> doFnOperator =
+          FlinkStreamingAggregationsTranslators.getWindowedAggregateDoFnOperator(
+              context,
+              transform,
+              inputKvCoder,
+              outputCoder,
+              SystemReduceFn.buffering(inputKvCoder.getValueCoder()),
+              new HashMap<>(),
+              Collections.emptyList());
+
+        outDataStream =
+            inputDataStream
+                .keyBy(keySelector)
+                .transform(fullName, outputTypeInfo, doFnOperator)
+                .uid(fullName);
+
+      }
       context.setOutputDataStream(context.getOutput(transform), outDataStream);
+
     }
   }
 
   private static class CombinePerKeyTranslator<K, InputT, OutputT>
       extends FlinkStreamingPipelineTranslator.StreamTransformTranslator<
-          PTransform<PCollection<KV<K, InputT>>, PCollection<KV<K, OutputT>>>> {
+      PTransform<PCollection<KV<K, InputT>>, PCollection<KV<K, OutputT>>>> {
 
     @Override
     boolean canTranslate(
@@ -1033,142 +1009,6 @@ class FlinkStreamingTransformTranslators {
           || ((Combine.PerKey) transform).getSideInputs().isEmpty();
     }
 
-    private static <InputT, OutputT> GlobalCombineFn<Object, Object, OutputT> toFinalFlinkCombineFn(
-        GlobalCombineFn<? super InputT, ?, OutputT> combineFn, Coder<InputT> inputTCoder) {
-
-      if (combineFn instanceof Combine.CombineFn) {
-        return new Combine.CombineFn<Object, Object, OutputT>() {
-
-          @SuppressWarnings("unchecked")
-          final Combine.CombineFn<InputT, Object, OutputT> fn =
-              (Combine.CombineFn<InputT, Object, OutputT>) combineFn;
-
-          @Override
-          public Object createAccumulator() {
-            return fn.createAccumulator();
-          }
-
-          @Override
-          public Coder<Object> getAccumulatorCoder(CoderRegistry registry, Coder<Object> inputCoder)
-              throws CannotProvideCoderException {
-            return fn.getAccumulatorCoder(registry, inputTCoder);
-          }
-
-          @Override
-          public Object addInput(Object mutableAccumulator, Object input) {
-            return fn.mergeAccumulators(ImmutableList.of(mutableAccumulator, input));
-          }
-
-          @Override
-          public Object mergeAccumulators(Iterable<Object> accumulators) {
-            return fn.mergeAccumulators(accumulators);
-          }
-
-          @Override
-          public OutputT extractOutput(Object accumulator) {
-            return fn.extractOutput(accumulator);
-          }
-        };
-      } else if (combineFn instanceof CombineWithContext.CombineFnWithContext) {
-        return new CombineWithContext.CombineFnWithContext<Object, Object, OutputT>() {
-
-          @SuppressWarnings("unchecked")
-          final CombineWithContext.CombineFnWithContext<InputT, Object, OutputT> fn =
-              (CombineWithContext.CombineFnWithContext<InputT, Object, OutputT>) combineFn;
-
-          @Override
-          public Object createAccumulator(CombineWithContext.Context c) {
-            return fn.createAccumulator(c);
-          }
-
-          @Override
-          public Coder<Object> getAccumulatorCoder(CoderRegistry registry, Coder<Object> inputCoder)
-              throws CannotProvideCoderException {
-            return fn.getAccumulatorCoder(registry, inputTCoder);
-          }
-
-          @Override
-          public Object addInput(Object accumulator, Object input, CombineWithContext.Context c) {
-            return fn.mergeAccumulators(ImmutableList.of(accumulator, input), c);
-          }
-
-          @Override
-          public Object mergeAccumulators(
-              Iterable<Object> accumulators, CombineWithContext.Context c) {
-            return fn.mergeAccumulators(accumulators, c);
-          }
-
-          @Override
-          public OutputT extractOutput(Object accumulator, CombineWithContext.Context c) {
-            return fn.extractOutput(accumulator, c);
-          }
-        };
-      }
-      throw new IllegalArgumentException(
-          "Unsupported CombineFn implementation: " + combineFn.getClass());
-    }
-
-    private static <K, InputC, OutputC, InputT, OutputT>
-        WindowDoFnOperator<K, InputC, OutputC> getDoFnOperator(
-            FlinkStreamingTranslationContext context,
-            PTransform<PCollection<KV<K, InputT>>, PCollection<KV<K, OutputT>>> transform,
-            KvCoder<K, InputC> inputKvCoder,
-            Coder<WindowedValue<KV<K, OutputC>>> outputCoder,
-            GlobalCombineFn<? super InputC, ?, OutputC> combineFn,
-            Map<Integer, PCollectionView<?>> sideInputTagMapping,
-            List<PCollectionView<?>> sideInputs) {
-
-      // Naming
-      String fullName = getCurrentTransformName(context);
-      TupleTag<KV<K, OutputC>> mainTag = new TupleTag<>("main output");
-
-      // input infos
-      PCollection<KV<K, InputT>> input = context.getInput(transform);
-      @SuppressWarnings("unchecked")
-      WindowingStrategy<?, BoundedWindow> windowingStrategy =
-          (WindowingStrategy<?, BoundedWindow>) input.getWindowingStrategy();
-      SerializablePipelineOptions serializablePipelineOptions =
-          new SerializablePipelineOptions(context.getPipelineOptions());
-
-      // Coders
-      Coder<K> keyCoder = inputKvCoder.getKeyCoder();
-
-      SingletonKeyedWorkItemCoder<K, InputC> workItemCoder =
-          SingletonKeyedWorkItemCoder.of(
-              keyCoder,
-              inputKvCoder.getValueCoder(),
-              windowingStrategy.getWindowFn().windowCoder());
-
-      WindowedValue.FullWindowedValueCoder<KeyedWorkItem<K, InputC>> windowedWorkItemCoder =
-          WindowedValue.getFullCoder(workItemCoder, windowingStrategy.getWindowFn().windowCoder());
-
-      // Combining fn
-      SystemReduceFn<K, InputC, ?, OutputC, BoundedWindow> reduceFn =
-          SystemReduceFn.combining(
-              keyCoder,
-              AppliedCombineFn.withInputCoder(
-                  combineFn, input.getPipeline().getCoderRegistry(), inputKvCoder));
-
-      // Key selector
-      WorkItemKeySelector<K, InputC> workItemKeySelector =
-          new WorkItemKeySelector<>(keyCoder, serializablePipelineOptions);
-
-      return new WindowDoFnOperator<>(
-          reduceFn,
-          fullName,
-          (Coder) windowedWorkItemCoder,
-          mainTag,
-          Collections.emptyList(),
-          new DoFnOperator.MultiOutputOutputManagerFactory<>(
-              mainTag, outputCoder, serializablePipelineOptions),
-          windowingStrategy,
-          sideInputTagMapping,
-          sideInputs,
-          context.getPipelineOptions(),
-          keyCoder,
-          workItemKeySelector);
-    }
-
     @Override
     public void translateNode(
         PTransform<PCollection<KV<K, InputT>>, PCollection<KV<K, OutputT>>> transform,
@@ -1182,7 +1022,8 @@ class FlinkStreamingTransformTranslators {
       Coder<WindowedValue<KV<K, OutputT>>> outputCoder =
           context.getWindowedInputCoder(context.getOutput(transform));
 
-      DataStream<WindowedValue<KV<K, InputT>>> inputDataStream = context.getInputDataStream(input);
+      DataStream<WindowedValue<KV<K, InputT>>> inputDataStream =
+          context.getInputDataStream(input);
 
       SerializablePipelineOptions serializablePipelineOptions =
           new SerializablePipelineOptions(context.getPipelineOptions());
@@ -1204,65 +1045,10 @@ class FlinkStreamingTransformTranslators {
         SingleOutputStreamOperator<WindowedValue<KV<K, OutputT>>> outDataStream;
 
         if (!context.isStreaming()) {
-          Coder<WindowedValue<KV<K, Object>>> windowedAccumCoder;
-          KvCoder<K, Object> accumKvCoder;
-          try {
-            @SuppressWarnings("unchecked")
-            Coder<Object> accumulatorCoder =
-                (Coder<Object>)
-                    combineFn.getAccumulatorCoder(
-                        input.getPipeline().getCoderRegistry(), inputKvCoder.getValueCoder());
-
-            accumKvCoder = KvCoder.of(inputKvCoder.getKeyCoder(), accumulatorCoder);
-
-            windowedAccumCoder =
-                WindowedValue.getFullCoder(
-                    accumKvCoder, input.getWindowingStrategy().getWindowFn().windowCoder());
-          } catch (CannotProvideCoderException e) {
-            throw new RuntimeException(e);
-          }
-
-          TupleTag<KV<K, Object>> mainTag = new TupleTag<>("main output");
-
-          PartialReduceBundleOperator<K, InputT, OutputT, Object> partialDoFnOperator =
-              new PartialReduceBundleOperator<>(
-                  (GlobalCombineFn<InputT, Object, OutputT>) combineFn,
-                  getCurrentTransformName(context),
-                  context.getWindowedInputCoder(input),
-                  mainTag,
-                  Collections.emptyList(),
-                  new DoFnOperator.MultiOutputOutputManagerFactory<>(
-                      mainTag, windowedAccumCoder, serializablePipelineOptions),
-                  input.getWindowingStrategy(),
-                  new HashMap<>(),
-                  Collections.emptyList(),
-                  context.getPipelineOptions());
-
-          // final aggregation from AccumT to OutputT
-          WindowDoFnOperator<K, Object, OutputT> finalDoFnOperator =
-              getDoFnOperator(
-                  context,
-                  transform,
-                  accumKvCoder,
-                  outputCoder,
-                  toFinalFlinkCombineFn(combineFn, inputKvCoder.getValueCoder()),
-                  new HashMap<>(),
-                  Collections.emptyList());
-
-          String partialName = "Combine: " + fullName;
-          CoderTypeInformation<WindowedValue<KV<K, Object>>> partialTypeInfo =
-              new CoderTypeInformation<>(windowedAccumCoder, context.getPipelineOptions());
-
-          outDataStream =
-              inputDataStream
-                  .transform(partialName, partialTypeInfo, partialDoFnOperator)
-                  .uid(partialName)
-                  .keyBy(new KvToByteBufferKeySelector<>(keyCoder, serializablePipelineOptions))
-                  .transform(fullName, outputTypeInfo, finalDoFnOperator)
-                  .uid(fullName);
+          outDataStream = FlinkStreamingAggregationsTranslators.batchCombinePerKeyNoSideInputs(context, transform, combineFn);
         } else {
           WindowDoFnOperator<K, InputT, OutputT> doFnOperator =
-              getDoFnOperator(
+              FlinkStreamingAggregationsTranslators.getWindowedAggregateDoFnOperator(
                   context,
                   transform,
                   inputKvCoder,
@@ -1281,7 +1067,7 @@ class FlinkStreamingTransformTranslators {
             transformSideInputs(sideInputs, context);
 
         WindowDoFnOperator<K, InputT, OutputT> doFnOperator =
-            getDoFnOperator(
+            FlinkStreamingAggregationsTranslators.getWindowedAggregateDoFnOperator(
                 context,
                 transform,
                 inputKvCoder,
@@ -1294,15 +1080,15 @@ class FlinkStreamingTransformTranslators {
         // allowed to have only one input keyed, normally.
 
         TwoInputTransformation<
-                WindowedValue<KV<K, InputT>>, RawUnionValue, WindowedValue<KV<K, OutputT>>>
+            WindowedValue<KV<K, InputT>>, RawUnionValue, WindowedValue<KV<K, OutputT>>>
             rawFlinkTransform =
-                new TwoInputTransformation<>(
-                    keyedStream.getTransformation(),
-                    transformSideInputs.f1.broadcast().getTransformation(),
-                    transform.getName(),
-                    doFnOperator,
-                    outputTypeInfo,
-                    keyedStream.getParallelism());
+            new TwoInputTransformation<>(
+                keyedStream.getTransformation(),
+                transformSideInputs.f1.broadcast().getTransformation(),
+                transform.getName(),
+                doFnOperator,
+                outputTypeInfo,
+                keyedStream.getParallelism());
 
         rawFlinkTransform.setStateKeyType(keyedStream.getKeyType());
         rawFlinkTransform.setStateKeySelectors(keyedStream.getKeySelector(), null);
@@ -1311,7 +1097,8 @@ class FlinkStreamingTransformTranslators {
         SingleOutputStreamOperator<WindowedValue<KV<K, OutputT>>> outDataStream =
             new SingleOutputStreamOperator(
                 keyedStream.getExecutionEnvironment(),
-                rawFlinkTransform) {}; // we have to cheat around the ctor being protected
+                rawFlinkTransform) {
+            }; // we have to cheat around the ctor being protected
 
         keyedStream.getExecutionEnvironment().addOperator(rawFlinkTransform);
 
@@ -1322,7 +1109,7 @@ class FlinkStreamingTransformTranslators {
 
   private static class GBKIntoKeyedWorkItemsTranslator<K, InputT>
       extends FlinkStreamingPipelineTranslator.StreamTransformTranslator<
-          PTransform<PCollection<KV<K, InputT>>, PCollection<KeyedWorkItem<K, InputT>>>> {
+      PTransform<PCollection<KV<K, InputT>>, PCollection<KeyedWorkItem<K, InputT>>>> {
 
     @Override
     boolean canTranslate(
@@ -1372,7 +1159,7 @@ class FlinkStreamingTransformTranslators {
 
   private static class ToKeyedWorkItemInGlobalWindow<K, InputT>
       extends RichFlatMapFunction<
-          WindowedValue<KV<K, InputT>>, WindowedValue<KeyedWorkItem<K, InputT>>> {
+      WindowedValue<KV<K, InputT>>, WindowedValue<KeyedWorkItem<K, InputT>>> {
 
     private final SerializablePipelineOptions options;
 
@@ -1410,7 +1197,7 @@ class FlinkStreamingTransformTranslators {
 
   private static class FlattenPCollectionTranslator<T>
       extends FlinkStreamingPipelineTranslator.StreamTransformTranslator<
-          PTransform<PCollection<T>, PCollection<T>>> {
+      PTransform<PCollection<T>, PCollection<T>>> {
 
     @Override
     public void translateNode(
@@ -1478,14 +1265,16 @@ class FlinkStreamingTransformTranslators {
     }
   }
 
-  /** Registers classes specialized to the Flink runner. */
+  /**
+   * Registers classes specialized to the Flink runner.
+   */
   @AutoService(TransformPayloadTranslatorRegistrar.class)
   public static class FlinkTransformsRegistrar implements TransformPayloadTranslatorRegistrar {
     @Override
     public Map<
-            ? extends Class<? extends PTransform>,
-            ? extends PTransformTranslation.TransformPayloadTranslator>
-        getTransformPayloadTranslators() {
+        ? extends Class<? extends PTransform>,
+        ? extends PTransformTranslation.TransformPayloadTranslator>
+    getTransformPayloadTranslators() {
       return ImmutableMap
           .<Class<? extends PTransform>, PTransformTranslation.TransformPayloadTranslator>builder()
           .put(
@@ -1495,12 +1284,15 @@ class FlinkStreamingTransformTranslators {
     }
   }
 
-  /** A translator just to vend the URN. */
+  /**
+   * A translator just to vend the URN.
+   */
   private static class CreateStreamingFlinkViewPayloadTranslator
       extends PTransformTranslation.TransformPayloadTranslator.NotSerializable<
-          CreateStreamingFlinkView.CreateFlinkPCollectionView<?, ?>> {
+      CreateStreamingFlinkView.CreateFlinkPCollectionView<?, ?>> {
 
-    private CreateStreamingFlinkViewPayloadTranslator() {}
+    private CreateStreamingFlinkViewPayloadTranslator() {
+    }
 
     @Override
     public String getUrn() {
@@ -1508,7 +1300,9 @@ class FlinkStreamingTransformTranslators {
     }
   }
 
-  /** A translator to support {@link TestStream} with Flink. */
+  /**
+   * A translator to support {@link TestStream} with Flink.
+   */
   private static class TestStreamTranslator<T>
       extends FlinkStreamingPipelineTranslator.StreamTransformTranslator<TestStream<T>> {
 
@@ -1554,12 +1348,12 @@ class FlinkStreamingTransformTranslators {
    * {@link ValueWithRecordId}.
    */
   static class UnboundedSourceWrapperNoValueWithRecordId<
-          OutputT, CheckpointMarkT extends UnboundedSource.CheckpointMark>
+      OutputT, CheckpointMarkT extends UnboundedSource.CheckpointMark>
       extends RichParallelSourceFunction<WindowedValue<OutputT>>
       implements ProcessingTimeCallbackCompat,
-          BeamStoppableFunction,
-          CheckpointListener,
-          CheckpointedFunction {
+      BeamStoppableFunction,
+      CheckpointListener,
+      CheckpointedFunction {
 
     private final UnboundedSourceWrapper<OutputT, CheckpointMarkT> unboundedSourceWrapper;
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/FlinkStreamingTransformTranslators.java
@@ -429,7 +429,7 @@ class FlinkStreamingTransformTranslators {
     }
   }
 
-  private static Tuple2<Map<Integer, PCollectionView<?>>, DataStream<RawUnionValue>>
+  public static Tuple2<Map<Integer, PCollectionView<?>>, DataStream<RawUnionValue>>
   transformSideInputs(
       Collection<PCollectionView<?>> sideInputs, FlinkStreamingTranslationContext context) {
 
@@ -1045,7 +1045,8 @@ class FlinkStreamingTransformTranslators {
         SingleOutputStreamOperator<WindowedValue<KV<K, OutputT>>> outDataStream;
 
         if (!context.isStreaming()) {
-          outDataStream = FlinkStreamingAggregationsTranslators.batchCombinePerKeyNoSideInputs(context, transform, combineFn);
+          outDataStream =
+              FlinkStreamingAggregationsTranslators.batchCombinePerKeyNoSideInputs(context, transform, combineFn);
         } else {
           WindowDoFnOperator<K, InputT, OutputT> doFnOperator =
               FlinkStreamingAggregationsTranslators.getWindowedAggregateDoFnOperator(
@@ -1065,42 +1066,30 @@ class FlinkStreamingTransformTranslators {
       } else {
         Tuple2<Map<Integer, PCollectionView<?>>, DataStream<RawUnionValue>> transformSideInputs =
             transformSideInputs(sideInputs, context);
+        SingleOutputStreamOperator<WindowedValue<KV<K, OutputT>>> outDataStream;
 
-        WindowDoFnOperator<K, InputT, OutputT> doFnOperator =
-            FlinkStreamingAggregationsTranslators.getWindowedAggregateDoFnOperator(
-                context,
-                transform,
-                inputKvCoder,
-                outputCoder,
-                combineFn,
-                transformSideInputs.f0,
-                sideInputs);
+        if(!context.isStreaming()) {
+          outDataStream =
+              FlinkStreamingAggregationsTranslators.batchCombinePerKey(context, transform, combineFn, transformSideInputs.f0, sideInputs);
+        } else {
+          WindowDoFnOperator<K, InputT, OutputT> doFnOperator =
+              FlinkStreamingAggregationsTranslators.getWindowedAggregateDoFnOperator(
+                  context,
+                  transform,
+                  inputKvCoder,
+                  outputCoder,
+                  combineFn,
+                  transformSideInputs.f0,
+                  sideInputs);
 
-        // we have to manually contruct the two-input transform because we're not
-        // allowed to have only one input keyed, normally.
-
-        TwoInputTransformation<
-            WindowedValue<KV<K, InputT>>, RawUnionValue, WindowedValue<KV<K, OutputT>>>
-            rawFlinkTransform =
-            new TwoInputTransformation<>(
-                keyedStream.getTransformation(),
-                transformSideInputs.f1.broadcast().getTransformation(),
-                transform.getName(),
-                doFnOperator,
-                outputTypeInfo,
-                keyedStream.getParallelism());
-
-        rawFlinkTransform.setStateKeyType(keyedStream.getKeyType());
-        rawFlinkTransform.setStateKeySelectors(keyedStream.getKeySelector(), null);
-
-        @SuppressWarnings({"unchecked", "rawtypes"})
-        SingleOutputStreamOperator<WindowedValue<KV<K, OutputT>>> outDataStream =
-            new SingleOutputStreamOperator(
-                keyedStream.getExecutionEnvironment(),
-                rawFlinkTransform) {
-            }; // we have to cheat around the ctor being protected
-
-        keyedStream.getExecutionEnvironment().addOperator(rawFlinkTransform);
+          outDataStream =
+              FlinkStreamingAggregationsTranslators.buildTwoInputStream(
+                  keyedStream,
+                  transformSideInputs.f1,
+                  transform.getName(),
+                  doFnOperator,
+                  outputTypeInfo);
+        }
 
         context.setOutputDataStream(context.getOutput(transform), outDataStream);
       }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -268,7 +268,7 @@ public class DoFnOperator<PreInputT, InputT, OutputT>
 
   /** Constructor for DoFnOperator. */
   public DoFnOperator(
-      DoFn<InputT, OutputT> doFn,
+      @Nullable DoFn<InputT, OutputT> doFn,
       String stepName,
       Coder<WindowedValue<InputT>> inputWindowedCoder,
       Map<TupleTag<?>, Coder<?>> outputCoders,
@@ -279,8 +279,8 @@ public class DoFnOperator<PreInputT, InputT, OutputT>
       Map<Integer, PCollectionView<?>> sideInputTagMapping,
       Collection<PCollectionView<?>> sideInputs,
       PipelineOptions options,
-      Coder<?> keyCoder,
-      KeySelector<WindowedValue<InputT>, ?> keySelector,
+      @Nullable Coder<?> keyCoder,
+      @Nullable KeySelector<WindowedValue<InputT>, ?> keySelector,
       DoFnSchemaInformation doFnSchemaInformation,
       Map<String, PCollectionView<?>> sideInputMapping) {
     this.doFn = doFn;
@@ -1014,7 +1014,7 @@ public class DoFnOperator<PreInputT, InputT, OutputT>
   }
 
   @Override
-  public final void snapshotState(StateSnapshotContext context) throws Exception {
+  public void snapshotState(StateSnapshotContext context) throws Exception {
     if (checkpointStats != null) {
       checkpointStats.snapshotStart(context.getCheckpointId());
     }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -462,7 +462,7 @@ public class DoFnOperator<InputT, OutputT>
     if (keyCoder != null) {
       keyedStateInternals =
           new FlinkStateInternals<>(
-              (KeyedStateBackend) getKeyedStateBackend(), keyCoder, serializedOptions);
+              (KeyedStateBackend) getKeyedStateBackend(), keyCoder, windowingStrategy.getWindowFn().windowCoder(), serializedOptions);
 
       if (timerService == null) {
         timerService =
@@ -590,7 +590,7 @@ public class DoFnOperator<InputT, OutputT>
       if (doFn != null) {
         DoFnSignature signature = DoFnSignatures.getSignature(doFn.getClass());
         FlinkStateInternals.EarlyBinder earlyBinder =
-            new FlinkStateInternals.EarlyBinder(getKeyedStateBackend(), serializedOptions);
+            new FlinkStateInternals.EarlyBinder(getKeyedStateBackend(), serializedOptions, windowingStrategy.getWindowFn().windowCoder());
         for (DoFnSignature.StateDeclaration value : signature.stateDeclarations().values()) {
           StateSpec<?> spec =
               (StateSpec<?>) signature.stateDeclarations().get(value.id()).field().get(doFn);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperator.java
@@ -474,7 +474,10 @@ public class DoFnOperator<PreInputT, InputT, OutputT>
     if (keyCoder != null) {
       keyedStateInternals =
           new FlinkStateInternals<>(
-              (KeyedStateBackend) getKeyedStateBackend(), keyCoder, windowingStrategy.getWindowFn().windowCoder(), serializedOptions);
+              (KeyedStateBackend) getKeyedStateBackend(),
+              keyCoder,
+              windowingStrategy.getWindowFn().windowCoder(),
+              serializedOptions);
 
       if (timerService == null) {
         timerService =
@@ -602,7 +605,10 @@ public class DoFnOperator<PreInputT, InputT, OutputT>
       if (doFn != null) {
         DoFnSignature signature = DoFnSignatures.getSignature(doFn.getClass());
         FlinkStateInternals.EarlyBinder earlyBinder =
-            new FlinkStateInternals.EarlyBinder(getKeyedStateBackend(), serializedOptions, windowingStrategy.getWindowFn().windowCoder());
+            new FlinkStateInternals.EarlyBinder(
+                getKeyedStateBackend(),
+                serializedOptions,
+                windowingStrategy.getWindowFn().windowCoder());
         for (DoFnSignature.StateDeclaration value : signature.stateDeclarations().values()) {
           StateSpec<?> spec =
               (StateSpec<?>) signature.stateDeclarations().get(value.id()).field().get(doFn);
@@ -944,7 +950,7 @@ public class DoFnOperator<PreInputT, InputT, OutputT>
   @SuppressWarnings("NonAtomicVolatileUpdate")
   @SuppressFBWarnings("VO_VOLATILE_INCREMENT")
   private void checkInvokeFinishBundleByCount() {
-    if(!shoudBundleElements()) {
+    if (!shoudBundleElements()) {
       return;
     }
     // We do not access this statement concurrently, but we want to make sure that each thread
@@ -960,7 +966,7 @@ public class DoFnOperator<PreInputT, InputT, OutputT>
 
   /** Check whether invoke finishBundle by timeout. */
   private void checkInvokeFinishBundleByTime() {
-    if(!shoudBundleElements()) {
+    if (!shoudBundleElements()) {
       return;
     }
     long now = getProcessingTimeService().getCurrentProcessingTime();
@@ -1190,6 +1196,7 @@ public class DoFnOperator<PreInputT, InputT, OutputT>
      * buffering. It will not be acquired during flushing the buffer.
      */
     private final Lock bufferLock;
+
     private final boolean isStreaming;
 
     private Map<Integer, TupleTag<?>> idsToTags;
@@ -1397,7 +1404,13 @@ public class DoFnOperator<PreInputT, InputT, OutputT>
           NonKeyedPushedBackElementsHandler.create(listStateBuffer);
 
       return new BufferedOutputManager<>(
-          output, mainTag, tagsToOutputTags, tagsToIds, bufferLock, pushedBackElementsHandler, isStreaming);
+          output,
+          mainTag,
+          tagsToOutputTags,
+          tagsToIds,
+          bufferLock,
+          pushedBackElementsHandler,
+          isStreaming);
     }
 
     private TaggedKvCoder buildTaggedKvCoder() {

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperator.java
@@ -138,7 +138,8 @@ import org.slf4j.LoggerFactory;
   "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
-public class ExecutableStageDoFnOperator<InputT, OutputT> extends DoFnOperator<InputT, OutputT> {
+public class ExecutableStageDoFnOperator<InputT, OutputT>
+    extends DoFnOperator<InputT, InputT, OutputT> {
 
   private static final Logger LOG = LoggerFactory.getLogger(ExecutableStageDoFnOperator.class);
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/ExecutableStageDoFnOperator.java
@@ -111,7 +111,6 @@ import org.apache.beam.vendor.grpc.v1p60p1.io.grpc.StatusRuntimeException;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
 import org.apache.flink.api.common.state.ListStateDescriptor;
-import org.apache.flink.api.common.typeutils.base.StringSerializer;
 import org.apache.flink.api.java.functions.KeySelector;
 import org.apache.flink.runtime.state.AbstractKeyedStateBackend;
 import org.apache.flink.runtime.state.KeyGroupRange;

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/PartialReduceBundleOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/PartialReduceBundleOperator.java
@@ -94,6 +94,11 @@ public class PartialReduceBundleOperator<K, InputT, OutputT, AccumT>
     super.open();
   }
 
+  @Override
+  protected boolean shoudBundleElements() {
+    return true;
+  }
+
   private void finishBundle() {
     AbstractFlinkCombineRunner<K, InputT, AccumT, AccumT, BoundedWindow> reduceRunner;
     try {

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/PartialReduceBundleOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/PartialReduceBundleOperator.java
@@ -17,9 +17,12 @@
  */
 package org.apache.beam.runners.flink.translation.wrappers.streaming;
 
-import java.util.*;
-import java.util.stream.Collectors;
-
+import java.util.ArrayList;
+import java.util.Collection;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Objects;
 import org.apache.beam.runners.flink.translation.functions.AbstractFlinkCombineRunner;
 import org.apache.beam.runners.flink.translation.functions.HashingFlinkCombineRunner;
 import org.apache.beam.runners.flink.translation.functions.SortingFlinkCombineRunner;
@@ -37,7 +40,6 @@ import org.apache.beam.sdk.values.PCollectionView;
 import org.apache.beam.sdk.values.TupleTag;
 import org.apache.beam.sdk.values.WindowingStrategy;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ArrayListMultimap;
-import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Multimap;
 import org.apache.flink.api.common.state.ListState;
 import org.apache.flink.api.common.state.ListStateDescriptor;
@@ -146,13 +148,12 @@ public class PartialReduceBundleOperator<K, InputT, OutputT, AccumT>
 
     ListStateDescriptor<WindowedValue<KV<K, InputT>>> descriptor =
         new ListStateDescriptor<>(
-            "buffered-elements",
-            new CoderTypeSerializer<>(windowedInputCoder, serializedOptions));
+            "buffered-elements", new CoderTypeSerializer<>(windowedInputCoder, serializedOptions));
 
     checkpointedState = context.getOperatorStateStore().getListState(descriptor);
 
-    if(context.isRestored() && this.checkpointedState != null) {
-      for(WindowedValue<KV<K, InputT>> wkv : this.checkpointedState.get()) {
+    if (context.isRestored() && this.checkpointedState != null) {
+      for (WindowedValue<KV<K, InputT>> wkv : this.checkpointedState.get()) {
         this.state.put(wkv.getValue().getKey(), wkv);
       }
     }

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/PartialReduceBundleOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/PartialReduceBundleOperator.java
@@ -1,0 +1,175 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.translation.wrappers.streaming;
+
+import java.util.*;
+import java.util.stream.Collectors;
+
+import org.apache.beam.runners.flink.translation.functions.AbstractFlinkCombineRunner;
+import org.apache.beam.runners.flink.translation.functions.HashingFlinkCombineRunner;
+import org.apache.beam.runners.flink.translation.functions.SortingFlinkCombineRunner;
+import org.apache.beam.runners.flink.translation.types.CoderTypeSerializer;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.beam.sdk.transforms.CombineFnBase;
+import org.apache.beam.sdk.transforms.DoFn;
+import org.apache.beam.sdk.transforms.DoFnSchemaInformation;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.Sessions;
+import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.PCollectionView;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.WindowingStrategy;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ArrayListMultimap;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Multimap;
+import org.apache.flink.api.common.state.ListState;
+import org.apache.flink.api.common.state.ListStateDescriptor;
+import org.apache.flink.runtime.state.StateInitializationContext;
+import org.apache.flink.runtime.state.StateSnapshotContext;
+import org.apache.flink.util.Collector;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+public class PartialReduceBundleOperator<K, InputT, OutputT, AccumT>
+    extends DoFnOperator<KV<K, InputT>, KV<K, InputT>, KV<K, AccumT>> {
+
+  private final CombineFnBase.GlobalCombineFn<InputT, AccumT, OutputT> combineFn;
+
+  private Multimap<K, WindowedValue<KV<K, InputT>>> state;
+  private transient @Nullable ListState<WindowedValue<KV<K, InputT>>> checkpointedState;
+
+  public PartialReduceBundleOperator(
+      CombineFnBase.GlobalCombineFn<InputT, AccumT, OutputT> combineFn,
+      String stepName,
+      Coder<WindowedValue<KV<K, InputT>>> windowedInputCoder,
+      TupleTag<KV<K, AccumT>> mainOutputTag,
+      List<TupleTag<?>> additionalOutputTags,
+      OutputManagerFactory<KV<K, AccumT>> outputManagerFactory,
+      WindowingStrategy<?, ?> windowingStrategy,
+      Map<Integer, PCollectionView<?>> sideInputTagMapping,
+      Collection<PCollectionView<?>> sideInputs,
+      PipelineOptions options) {
+    super(
+        null,
+        stepName,
+        windowedInputCoder,
+        Collections.emptyMap(),
+        mainOutputTag,
+        additionalOutputTags,
+        outputManagerFactory,
+        windowingStrategy,
+        sideInputTagMapping,
+        sideInputs,
+        options,
+        null,
+        null,
+        DoFnSchemaInformation.create(),
+        Collections.emptyMap());
+
+    this.combineFn = combineFn;
+    this.state = ArrayListMultimap.create();
+    this.checkpointedState = null;
+  }
+
+  @Override
+  public void open() throws Exception {
+    clearState();
+    setBundleFinishedCallback(this::finishBundle);
+    super.open();
+  }
+
+  private void finishBundle() {
+    AbstractFlinkCombineRunner<K, InputT, AccumT, AccumT, BoundedWindow> reduceRunner;
+    try {
+      if (windowingStrategy.needsMerge() && windowingStrategy.getWindowFn() instanceof Sessions) {
+        reduceRunner = new SortingFlinkCombineRunner<>();
+      } else {
+        reduceRunner = new HashingFlinkCombineRunner<>();
+      }
+
+      for (Map.Entry<K, Collection<WindowedValue<KV<K, InputT>>>> e : state.asMap().entrySet()) {
+        //noinspection unchecked
+        reduceRunner.combine(
+            new AbstractFlinkCombineRunner.PartialFlinkCombiner<>(combineFn),
+            (WindowingStrategy<Object, BoundedWindow>) windowingStrategy,
+            sideInputReader,
+            serializedOptions.get(),
+            e.getValue(),
+            new Collector<WindowedValue<KV<K, AccumT>>>() {
+              @Override
+              public void collect(WindowedValue<KV<K, AccumT>> record) {
+                outputManager.output(mainOutputTag, record);
+              }
+
+              @Override
+              public void close() {}
+            });
+      }
+
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+    clearState();
+  }
+
+  private void clearState() {
+    this.state = ArrayListMultimap.create();
+    if (this.checkpointedState != null) {
+      this.checkpointedState.clear();
+    }
+  }
+
+  @Override
+  public void initializeState(StateInitializationContext context) throws Exception {
+    super.initializeState(context);
+
+    ListStateDescriptor<WindowedValue<KV<K, InputT>>> descriptor =
+        new ListStateDescriptor<>(
+            "buffered-elements",
+            new CoderTypeSerializer<>(windowedInputCoder, serializedOptions));
+
+    checkpointedState = context.getOperatorStateStore().getListState(descriptor);
+
+    if(context.isRestored() && this.checkpointedState != null) {
+      for(WindowedValue<KV<K, InputT>> wkv : this.checkpointedState.get()) {
+        this.state.put(wkv.getValue().getKey(), wkv);
+      }
+    }
+  }
+
+  @Override
+  public void snapshotState(StateSnapshotContext context) throws Exception {
+    super.snapshotState(context);
+    if (this.checkpointedState != null) {
+      this.checkpointedState.update(new ArrayList<>(this.state.values()));
+    }
+  }
+
+  @Override
+  protected DoFn<KV<K, InputT>, KV<K, AccumT>> getDoFn() {
+    return new DoFn<KV<K, InputT>, KV<K, AccumT>>() {
+      @ProcessElement
+      public void processElement(ProcessContext c, BoundedWindow window) throws Exception {
+        WindowedValue<KV<K, InputT>> windowedValue =
+            WindowedValue.of(c.element(), c.timestamp(), window, c.pane());
+        state.put(Objects.requireNonNull(c.element()).getKey(), windowedValue);
+      }
+    };
+  }
+}

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/SplittableDoFnOperator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/SplittableDoFnOperator.java
@@ -64,7 +64,10 @@ import org.slf4j.LoggerFactory;
   "nullness" // TODO(https://github.com/apache/beam/issues/20497)
 })
 public class SplittableDoFnOperator<InputT, OutputT, RestrictionT>
-    extends DoFnOperator<KeyedWorkItem<byte[], KV<InputT, RestrictionT>>, OutputT> {
+    extends DoFnOperator<
+        KeyedWorkItem<byte[], KV<InputT, RestrictionT>>,
+        KeyedWorkItem<byte[], KV<InputT, RestrictionT>>,
+        OutputT> {
 
   private static final Logger LOG = LoggerFactory.getLogger(SplittableDoFnOperator.class);
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/FlinkSource.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/FlinkSource.java
@@ -119,18 +119,12 @@ public abstract class FlinkSource<T, OutputT>
   public SplitEnumerator<FlinkSourceSplit<T>, Map<Integer, List<FlinkSourceSplit<T>>>>
       createEnumerator(SplitEnumeratorContext<FlinkSourceSplit<T>> enumContext) throws Exception {
 
-    if(boundedness == Boundedness.BOUNDED) {
+    if (boundedness == Boundedness.BOUNDED) {
       return new LazyFlinkSourceSplitEnumerator<>(
-        enumContext,
-        beamSource,
-        serializablePipelineOptions.get(),
-        numSplits);
+          enumContext, beamSource, serializablePipelineOptions.get(), numSplits);
     } else {
       return new FlinkSourceSplitEnumerator<>(
-        enumContext,
-        beamSource,
-        serializablePipelineOptions.get(),
-        numSplits);
+          enumContext, beamSource, serializablePipelineOptions.get(), numSplits);
     }
   }
 
@@ -141,7 +135,7 @@ public abstract class FlinkSource<T, OutputT>
           Map<Integer, List<FlinkSourceSplit<T>>> checkpoint)
           throws Exception {
     SplitEnumerator<FlinkSourceSplit<T>, Map<Integer, List<FlinkSourceSplit<T>>>> enumerator =
-      createEnumerator(enumContext);
+        createEnumerator(enumContext);
     checkpoint.forEach(
         (subtaskId, splitsForSubtask) -> enumerator.addSplitsBack(splitsForSubtask, subtaskId));
     return enumerator;

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/LazyFlinkSourceSplitEnumerator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/LazyFlinkSourceSplitEnumerator.java
@@ -1,0 +1,180 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.translation.wrappers.streaming.io.source;
+
+import java.io.IOException;
+import java.util.ArrayList;
+import java.util.Collections;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.Map;
+import java.util.Optional;
+
+import javax.annotation.Nullable;
+
+import org.apache.beam.runners.flink.FlinkPipelineOptions;
+import org.apache.beam.runners.flink.translation.wrappers.streaming.io.source.FlinkSourceSplit;
+import org.apache.beam.runners.flink.translation.wrappers.streaming.io.source.FlinkSourceSplitEnumerator;
+import org.apache.beam.runners.flink.translation.wrappers.streaming.io.source.compat.SplitEnumeratorCompat;
+import org.apache.beam.sdk.io.BoundedSource;
+import org.apache.beam.sdk.io.FileBasedSource;
+import org.apache.beam.sdk.io.Source;
+import org.apache.beam.sdk.io.UnboundedSource;
+import org.apache.beam.sdk.options.PipelineOptions;
+import org.apache.flink.api.connector.source.SplitEnumeratorContext;
+import org.apache.flink.api.connector.source.SplitsAssignment;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+/**
+ * A Flink {@link org.apache.flink.api.connector.source.SplitEnumerator SplitEnumerator}
+ * implementation that holds a Beam {@link Source} and does the following:
+ *
+ * <ul>
+ *   <li>Split the Beam {@link Source} to desired number of splits.
+ *   <li>Lazily assign the splits to the Flink Source Reader.
+ * </ul>
+ *
+ * @param <T> The output type of the encapsulated Beam {@link Source}.
+ */
+public class LazyFlinkSourceSplitEnumerator<T>
+    implements SplitEnumeratorCompat<FlinkSourceSplit<T>, Map<Integer, List<FlinkSourceSplit<T>>>> {
+  private static final Logger LOG = LoggerFactory.getLogger(LazyFlinkSourceSplitEnumerator.class);
+  private final SplitEnumeratorContext<FlinkSourceSplit<T>> context;
+  private final Source<T> beamSource;
+  private final PipelineOptions pipelineOptions;
+  private final int numSplits;
+  private final List<FlinkSourceSplit<T>> pendingSplits;
+
+  public LazyFlinkSourceSplitEnumerator(
+      SplitEnumeratorContext<FlinkSourceSplit<T>> context,
+      Source<T> beamSource,
+      PipelineOptions pipelineOptions,
+      int numSplits) {
+    this.context = context;
+    this.beamSource = beamSource;
+    this.pipelineOptions = pipelineOptions;
+    this.numSplits = numSplits;
+    this.pendingSplits = new ArrayList<>(numSplits);
+  }
+
+  @Override
+  public void start() {
+    try {
+      LOG.info("Starting source {}", beamSource);
+      List<? extends Source<T>> beamSplitSourceList = splitBeamSource();
+      int i = 0;
+      for (Source<T> beamSplitSource : beamSplitSourceList) {
+        pendingSplits.add(new FlinkSourceSplit<>(i, beamSplitSource));
+        i++;
+      }
+    } catch (Exception e) {
+      throw new RuntimeException(e);
+    }
+  }
+
+  @Override
+  public void handleSplitRequest(int subtask, @Nullable String hostname) {
+    if (!context.registeredReaders().containsKey(subtask)) {
+        // reader failed between sending the request and now. skip this request.
+        return;
+    }
+
+    if (LOG.isInfoEnabled()) {
+        final String hostInfo =
+                hostname == null ? "(no host locality info)" : "(on host '" + hostname + "')";
+        LOG.info("Subtask {} {} is requesting a file source split", subtask, hostInfo);
+    }
+
+    if (!pendingSplits.isEmpty()) {
+        final FlinkSourceSplit<T> split = pendingSplits.remove(pendingSplits.size() - 1);
+        context.assignSplit(split, subtask);
+        LOG.info("Assigned split to subtask {} : {}", subtask, split);
+    } else {
+        context.signalNoMoreSplits(subtask);
+        LOG.info("No more splits available for subtask {}", subtask);
+    }
+  }
+
+  @Override
+  public void addSplitsBack(List<FlinkSourceSplit<T>> splits, int subtaskId) {
+    LOG.info("Adding splits {} back from subtask {}", splits, subtaskId);
+    pendingSplits.addAll(splits);
+  }
+
+  @Override
+  public void addReader(int subtaskId) {
+    // this source is purely lazy-pull-based, nothing to do upon registration
+  }
+
+  @Override
+  public Map<Integer, List<FlinkSourceSplit<T>>> snapshotState(long checkpointId) throws Exception {
+    LOG.info("Taking snapshot for checkpoint {}", checkpointId);
+    return snapshotState();
+  }
+
+  @Override
+  public Map<Integer, List<FlinkSourceSplit<T>>> snapshotState() throws Exception {
+    // For type compatibility reasons, we return a Map but we do not actually care about the key
+    Map<Integer, List<FlinkSourceSplit<T>>> state = new HashMap<>(1);
+    state.put(1, pendingSplits);
+    return state;
+  }
+
+  @Override
+  public void close() throws IOException {
+    // NoOp
+  }
+
+  private long getDesiredSizeBytes(int numSplits, BoundedSource<T> boundedSource) throws Exception {
+    long totalSize = boundedSource.getEstimatedSizeBytes(pipelineOptions);
+    long defaultSplitSize = totalSize / numSplits;
+    long maxSplitSize = 0;
+    if (pipelineOptions != null) {
+      maxSplitSize = pipelineOptions.as(FlinkPipelineOptions.class).getFileInputSplitMaxSizeMB();
+    }
+    if (beamSource instanceof FileBasedSource && maxSplitSize > 0) {
+      // Most of the time parallelism is < number of files in source.
+      // Each file becomes a unique split which commonly create skew.
+      // This limits the size of splits to reduce skew.
+      return Math.min(defaultSplitSize, maxSplitSize * 1024 * 1024);
+    } else {
+      return defaultSplitSize;
+    }
+  }
+
+  // -------------- Private helper methods ----------------------
+  private List<? extends Source<T>> splitBeamSource() throws Exception {
+    if (beamSource instanceof BoundedSource) {
+      BoundedSource<T> boundedSource = (BoundedSource<T>) beamSource;
+      long desiredSizeBytes = getDesiredSizeBytes(numSplits, boundedSource);
+      List<? extends BoundedSource<T>> splits =
+          ((BoundedSource<T>) beamSource).split(desiredSizeBytes, pipelineOptions);
+      LOG.info("Split bounded source {} in {} splits", beamSource, splits.size());
+      return splits;
+    } else if (beamSource instanceof UnboundedSource) {
+      List<? extends UnboundedSource<T, ?>> splits =
+          ((UnboundedSource<T, ?>) beamSource).split(numSplits, pipelineOptions);
+      LOG.info("Split source {} to {} splits", beamSource, splits);
+      return splits;
+    } else {
+      throw new IllegalStateException("Unknown source type " + beamSource.getClass());
+    }
+  }
+}

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/LazyFlinkSourceSplitEnumerator.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/LazyFlinkSourceSplitEnumerator.java
@@ -19,18 +19,11 @@ package org.apache.beam.runners.flink.translation.wrappers.streaming.io.source;
 
 import java.io.IOException;
 import java.util.ArrayList;
-import java.util.Collections;
 import java.util.HashMap;
-import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
-import java.util.Optional;
-
 import javax.annotation.Nullable;
-
 import org.apache.beam.runners.flink.FlinkPipelineOptions;
-import org.apache.beam.runners.flink.translation.wrappers.streaming.io.source.FlinkSourceSplit;
-import org.apache.beam.runners.flink.translation.wrappers.streaming.io.source.FlinkSourceSplitEnumerator;
 import org.apache.beam.runners.flink.translation.wrappers.streaming.io.source.compat.SplitEnumeratorCompat;
 import org.apache.beam.sdk.io.BoundedSource;
 import org.apache.beam.sdk.io.FileBasedSource;
@@ -38,7 +31,6 @@ import org.apache.beam.sdk.io.Source;
 import org.apache.beam.sdk.io.UnboundedSource;
 import org.apache.beam.sdk.options.PipelineOptions;
 import org.apache.flink.api.connector.source.SplitEnumeratorContext;
-import org.apache.flink.api.connector.source.SplitsAssignment;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
@@ -92,23 +84,23 @@ public class LazyFlinkSourceSplitEnumerator<T>
   @Override
   public void handleSplitRequest(int subtask, @Nullable String hostname) {
     if (!context.registeredReaders().containsKey(subtask)) {
-        // reader failed between sending the request and now. skip this request.
-        return;
+      // reader failed between sending the request and now. skip this request.
+      return;
     }
 
     if (LOG.isInfoEnabled()) {
-        final String hostInfo =
-                hostname == null ? "(no host locality info)" : "(on host '" + hostname + "')";
-        LOG.info("Subtask {} {} is requesting a file source split", subtask, hostInfo);
+      final String hostInfo =
+          hostname == null ? "(no host locality info)" : "(on host '" + hostname + "')";
+      LOG.info("Subtask {} {} is requesting a file source split", subtask, hostInfo);
     }
 
     if (!pendingSplits.isEmpty()) {
-        final FlinkSourceSplit<T> split = pendingSplits.remove(pendingSplits.size() - 1);
-        context.assignSplit(split, subtask);
-        LOG.info("Assigned split to subtask {} : {}", subtask, split);
+      final FlinkSourceSplit<T> split = pendingSplits.remove(pendingSplits.size() - 1);
+      context.assignSplit(split, subtask);
+      LOG.info("Assigned split to subtask {} : {}", subtask, split);
     } else {
-        context.signalNoMoreSplits(subtask);
-        LOG.info("No more splits available for subtask {}", subtask);
+      context.signalNoMoreSplits(subtask);
+      LOG.info("No more splits available for subtask {}", subtask);
     }
   }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/bounded/FlinkBoundedSourceReader.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/bounded/FlinkBoundedSourceReader.java
@@ -100,6 +100,11 @@ public class FlinkBoundedSourceReader<T> extends FlinkSourceReaderBase<T, Window
   @Override
   public InputStatus pollNext(ReaderOutput<WindowedValue<T>> output) throws Exception {
     checkExceptionAndMaybeThrow();
+
+    if(currentReader == null && currentSplitId == -1) {
+      context.sendSplitRequest();
+    }
+
     if (currentReader == null && !moveToNextNonEmptyReader()) {
       // Nothing to read for now.
       if (noMoreSplits()) {
@@ -137,6 +142,7 @@ public class FlinkBoundedSourceReader<T> extends FlinkSourceReaderBase<T, Window
         LOG.debug("Finished reading from {}", currentSplitId);
         currentReader = null;
         currentSplitId = -1;
+        context.sendSplitRequest();
       }
       // Always return MORE_AVAILABLE here regardless of the availability of next record. If there
       // is no more

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/bounded/FlinkBoundedSourceReader.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/io/source/bounded/FlinkBoundedSourceReader.java
@@ -101,7 +101,7 @@ public class FlinkBoundedSourceReader<T> extends FlinkSourceReaderBase<T, Window
   public InputStatus pollNext(ReaderOutput<WindowedValue<T>> output) throws Exception {
     checkExceptionAndMaybeThrow();
 
-    if(currentReader == null && currentSplitId == -1) {
+    if (currentReader == null && currentSplitId == -1) {
       context.sendSplitRequest();
     }
 

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
@@ -29,8 +29,6 @@ import java.util.SortedMap;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
-
-import com.esotericsoftware.kryo.serializers.DefaultSerializers;
 import org.apache.beam.runners.core.StateInternals;
 import org.apache.beam.runners.core.StateNamespace;
 import org.apache.beam.runners.core.StateNamespaces;
@@ -254,17 +252,18 @@ public class FlinkStateInternals<K> implements StateInternals {
     public <T2> ValueState<T2> bindValue(
         String id, StateSpec<ValueState<T2>> spec, Coder<T2> coder) {
       FlinkValueState<T2> valueState =
-          new FlinkValueState<>(flinkStateBackend, id, namespace, coder, namespaceKeySerializer, fasterCopy);
+          new FlinkValueState<>(
+              flinkStateBackend, id, namespace, coder, namespaceKeySerializer, fasterCopy);
       collectGlobalWindowStateDescriptor(
-          valueState.flinkStateDescriptor,
-          valueState.namespace, namespaceKeySerializer);
+          valueState.flinkStateDescriptor, valueState.namespace, namespaceKeySerializer);
       return valueState;
     }
 
     @Override
     public <T2> BagState<T2> bindBag(String id, StateSpec<BagState<T2>> spec, Coder<T2> elemCoder) {
       FlinkBagState<T2> bagState =
-          new FlinkBagState<>(flinkStateBackend, id, namespace, elemCoder, namespaceKeySerializer, fasterCopy);
+          new FlinkBagState<>(
+              flinkStateBackend, id, namespace, elemCoder, namespaceKeySerializer, fasterCopy);
       collectGlobalWindowStateDescriptor(
           bagState.flinkStateDescriptor, bagState.namespace, namespaceKeySerializer);
       return bagState;
@@ -273,7 +272,8 @@ public class FlinkStateInternals<K> implements StateInternals {
     @Override
     public <T2> SetState<T2> bindSet(String id, StateSpec<SetState<T2>> spec, Coder<T2> elemCoder) {
       FlinkSetState<T2> setState =
-          new FlinkSetState<>(flinkStateBackend, id, namespace, elemCoder, namespaceKeySerializer, fasterCopy);
+          new FlinkSetState<>(
+              flinkStateBackend, id, namespace, elemCoder, namespaceKeySerializer, fasterCopy);
       collectGlobalWindowStateDescriptor(
           setState.flinkStateDescriptor, setState.namespace, namespaceKeySerializer);
       return setState;
@@ -287,7 +287,13 @@ public class FlinkStateInternals<K> implements StateInternals {
         Coder<ValueT> mapValueCoder) {
       FlinkMapState<KeyT, ValueT> mapState =
           new FlinkMapState<>(
-              flinkStateBackend, id, namespace, mapKeyCoder, mapValueCoder, namespaceKeySerializer, fasterCopy);
+              flinkStateBackend,
+              id,
+              namespace,
+              mapKeyCoder,
+              mapValueCoder,
+              namespaceKeySerializer,
+              fasterCopy);
       collectGlobalWindowStateDescriptor(
           mapState.flinkStateDescriptor, mapState.namespace, namespaceKeySerializer);
       return mapState;
@@ -297,11 +303,12 @@ public class FlinkStateInternals<K> implements StateInternals {
     public <T> OrderedListState<T> bindOrderedList(
         String id, StateSpec<OrderedListState<T>> spec, Coder<T> elemCoder) {
       FlinkOrderedListState<T> flinkOrderedListState =
-          new FlinkOrderedListState<>(flinkStateBackend, id, namespace, elemCoder, namespaceKeySerializer, fasterCopy);
+          new FlinkOrderedListState<>(
+              flinkStateBackend, id, namespace, elemCoder, namespaceKeySerializer, fasterCopy);
       collectGlobalWindowStateDescriptor(
           flinkOrderedListState.flinkStateDescriptor,
           flinkOrderedListState.namespace,
-              namespaceKeySerializer);
+          namespaceKeySerializer);
       return flinkOrderedListState;
     }
 
@@ -323,11 +330,15 @@ public class FlinkStateInternals<K> implements StateInternals {
         Combine.CombineFn<InputT, AccumT, OutputT> combineFn) {
       FlinkCombiningState<Object, InputT, AccumT, OutputT> combiningState =
           new FlinkCombiningState<>(
-              flinkStateBackend, id, combineFn, namespace, accumCoder, namespaceKeySerializer, fasterCopy);
+              flinkStateBackend,
+              id,
+              combineFn,
+              namespace,
+              accumCoder,
+              namespaceKeySerializer,
+              fasterCopy);
       collectGlobalWindowStateDescriptor(
-          combiningState.flinkStateDescriptor,
-          combiningState.namespace,
-              namespaceKeySerializer);
+          combiningState.flinkStateDescriptor, combiningState.namespace, namespaceKeySerializer);
       return combiningState;
     }
 
@@ -351,7 +362,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       collectGlobalWindowStateDescriptor(
           combiningStateWithContext.flinkStateDescriptor,
           combiningStateWithContext.namespace,
-              namespaceKeySerializer);
+          namespaceKeySerializer);
       return combiningStateWithContext;
     }
 
@@ -392,7 +403,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     public FlinkStateNamespaceKeySerializer(Coder<? extends BoundedWindow> coder) {
       this.coder = coder;
     }
-    
+
     @Override
     public boolean isImmutableType() {
       return false;
@@ -434,7 +445,8 @@ public class FlinkStateInternals<K> implements StateInternals {
     }
 
     @Override
-    public StateNamespace deserialize(StateNamespace reuse, DataInputView source) throws IOException {
+    public StateNamespace deserialize(StateNamespace reuse, DataInputView source)
+        throws IOException {
       return deserialize(source);
     }
 
@@ -460,14 +472,12 @@ public class FlinkStateInternals<K> implements StateInternals {
 
     /** Serializer configuration snapshot for compatibility and format evolution. */
     @SuppressWarnings("WeakerAccess")
-    public final static class FlinkStateNameSpaceSerializerSnapshot implements TypeSerializerSnapshot<StateNamespace> {
+    public static final class FlinkStateNameSpaceSerializerSnapshot
+        implements TypeSerializerSnapshot<StateNamespace> {
 
-      @Nullable
-      private Coder<? extends BoundedWindow> windowCoder;
+      @Nullable private Coder<? extends BoundedWindow> windowCoder;
 
-      public FlinkStateNameSpaceSerializerSnapshot(){
-
-      }
+      public FlinkStateNameSpaceSerializerSnapshot() {}
 
       FlinkStateNameSpaceSerializerSnapshot(FlinkStateNamespaceKeySerializer ser) {
         this.windowCoder = ser.getCoder();
@@ -484,7 +494,8 @@ public class FlinkStateInternals<K> implements StateInternals {
       }
 
       @Override
-      public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) throws IOException {
+      public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader)
+          throws IOException {
         this.windowCoder = new JavaSerializer<Coder<? extends BoundedWindow>>().deserialize(in);
       }
 
@@ -494,7 +505,8 @@ public class FlinkStateInternals<K> implements StateInternals {
       }
 
       @Override
-      public TypeSerializerSchemaCompatibility<StateNamespace> resolveSchemaCompatibility(TypeSerializer<StateNamespace> newSerializer) {
+      public TypeSerializerSchemaCompatibility<StateNamespace> resolveSchemaCompatibility(
+          TypeSerializer<StateNamespace> newSerializer) {
         return TypeSerializerSchemaCompatibility.compatibleAsIs();
       }
     }
@@ -521,7 +533,6 @@ public class FlinkStateInternals<K> implements StateInternals {
       this.flinkStateBackend = flinkStateBackend;
       this.namespaceSerializer = namespaceSerializer;
 
-
       flinkStateDescriptor =
           new ValueStateDescriptor<>(stateId, new CoderTypeSerializer<>(coder, fasterCopy));
     }
@@ -530,8 +541,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     public void write(T input) {
       try {
         flinkStateBackend
-            .getPartitionedState(
-                namespace, namespaceSerializer, flinkStateDescriptor)
+            .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
             .update(input);
       } catch (Exception e) {
         throw new RuntimeException("Error updating state.", e);
@@ -547,8 +557,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     public T read() {
       try {
         return flinkStateBackend
-            .getPartitionedState(
-                namespace, namespaceSerializer, flinkStateDescriptor)
+            .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
             .value();
       } catch (Exception e) {
         throw new RuntimeException("Error reading state.", e);
@@ -621,7 +630,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         ListState<TimestampedValue<T>> partitionedState =
             flinkStateBackend.getPartitionedState(
-                    namespace, namespaceSerializer, flinkStateDescriptor);
+                namespace, namespaceSerializer, flinkStateDescriptor);
         partitionedState.update(Lists.newArrayList(sortedMap.values()));
       } catch (Exception e) {
         throw new RuntimeException("Error adding to bag state.", e);
@@ -638,7 +647,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         ListState<TimestampedValue<T>> partitionedState =
             flinkStateBackend.getPartitionedState(
-                    namespace, namespaceSerializer, flinkStateDescriptor);
+                namespace, namespaceSerializer, flinkStateDescriptor);
         partitionedState.add(value);
       } catch (Exception e) {
         throw new RuntimeException("Error adding to bag state.", e);
@@ -653,8 +662,7 @@ public class FlinkStateInternals<K> implements StateInternals {
           try {
             Iterable<TimestampedValue<T>> result =
                 flinkStateBackend
-                    .getPartitionedState(
-                            namespace, namespaceSerializer, flinkStateDescriptor)
+                    .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
                     .get();
             return result == null;
           } catch (Exception e) {
@@ -680,7 +688,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         ListState<TimestampedValue<T>> partitionedState =
             flinkStateBackend.getPartitionedState(
-                    namespace, namespaceSerializer, flinkStateDescriptor);
+                namespace, namespaceSerializer, flinkStateDescriptor);
         listValues = MoreObjects.firstNonNull(partitionedState.get(), Collections.emptyList());
       } catch (Exception e) {
         throw new RuntimeException("Error reading state.", e);
@@ -702,8 +710,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     public void clear() {
       try {
         flinkStateBackend
-            .getPartitionedState(
-                    namespace, namespaceSerializer, flinkStateDescriptor)
+            .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
             .clear();
       } catch (Exception e) {
         throw new RuntimeException("Error clearing state.", e);
@@ -742,7 +749,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         ListState<T> partitionedState =
             flinkStateBackend.getPartitionedState(
-                    namespace, namespaceSerializer, flinkStateDescriptor);
+                namespace, namespaceSerializer, flinkStateDescriptor);
         if (storesVoidValues) {
           Preconditions.checkState(input == null, "Expected to a null value but was: %s", input);
           // Flink does not allow storing null values
@@ -802,8 +809,7 @@ public class FlinkStateInternals<K> implements StateInternals {
           try {
             Iterable<T> result =
                 flinkStateBackend
-                    .getPartitionedState(
-                        namespace, namespaceSerializer, flinkStateDescriptor)
+                    .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
                     .get();
             return result == null;
           } catch (Exception e) {
@@ -822,8 +828,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     public void clear() {
       try {
         flinkStateBackend
-            .getPartitionedState(
-                namespace, namespaceSerializer, flinkStateDescriptor)
+            .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
             .clear();
       } catch (Exception e) {
         throw new RuntimeException("Error clearing state.", e);
@@ -928,8 +933,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         AccumT accum =
             flinkStateBackend
-                .getPartitionedState(
-                    namespace, namespaceSerializer, flinkStateDescriptor)
+                .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
                 .value();
         return accum != null ? accum : combineFn.createAccumulator();
       } catch (Exception e) {
@@ -967,8 +971,7 @@ public class FlinkStateInternals<K> implements StateInternals {
         public Boolean read() {
           try {
             return flinkStateBackend
-                    .getPartitionedState(
-                        namespace, namespaceSerializer, flinkStateDescriptor)
+                    .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
                     .value()
                 == null;
           } catch (Exception e) {
@@ -987,8 +990,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     public void clear() {
       try {
         flinkStateBackend
-            .getPartitionedState(
-                namespace, namespaceSerializer, flinkStateDescriptor)
+            .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
             .clear();
       } catch (Exception e) {
         throw new RuntimeException("Error clearing state.", e);
@@ -1096,8 +1098,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         AccumT accum =
             flinkStateBackend
-                .getPartitionedState(
-                    namespace, namespaceSerializer, flinkStateDescriptor)
+                .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
                 .value();
         return accum != null ? accum : combineFn.createAccumulator(context);
       } catch (Exception e) {
@@ -1135,8 +1136,7 @@ public class FlinkStateInternals<K> implements StateInternals {
         public Boolean read() {
           try {
             return flinkStateBackend
-                    .getPartitionedState(
-                        namespace, namespaceSerializer, flinkStateDescriptor)
+                    .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
                     .value()
                 == null;
           } catch (Exception e) {
@@ -1155,8 +1155,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     public void clear() {
       try {
         flinkStateBackend
-            .getPartitionedState(
-                namespace, namespaceSerializer, flinkStateDescriptor)
+            .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
             .clear();
       } catch (Exception e) {
         throw new RuntimeException("Error clearing state.", e);
@@ -1351,8 +1350,7 @@ public class FlinkStateInternals<K> implements StateInternals {
           try {
             ValueT value =
                 flinkStateBackend
-                    .getPartitionedState(
-                        namespace, namespaceSerializer, flinkStateDescriptor)
+                    .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
                     .get(key);
             return (value != null) ? value : defaultValue;
           } catch (Exception e) {
@@ -1371,8 +1369,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     public void put(KeyT key, ValueT value) {
       try {
         flinkStateBackend
-            .getPartitionedState(
-                namespace, namespaceSerializer, flinkStateDescriptor)
+            .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
             .put(key, value);
       } catch (Exception e) {
         throw new RuntimeException("Error put kv to state.", e);
@@ -1385,14 +1382,12 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         ValueT current =
             flinkStateBackend
-                .getPartitionedState(
-                    namespace, namespaceSerializer, flinkStateDescriptor)
+                .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
                 .get(key);
 
         if (current == null) {
           flinkStateBackend
-              .getPartitionedState(
-                  namespace, namespaceSerializer, flinkStateDescriptor)
+              .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
               .put(key, mappingFunction.apply(key));
         }
         return ReadableStates.immediate(current);
@@ -1405,8 +1400,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     public void remove(KeyT key) {
       try {
         flinkStateBackend
-            .getPartitionedState(
-                namespace, namespaceSerializer, flinkStateDescriptor)
+            .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
             .remove(key);
       } catch (Exception e) {
         throw new RuntimeException("Error remove map state key.", e);
@@ -1421,8 +1415,7 @@ public class FlinkStateInternals<K> implements StateInternals {
           try {
             Iterable<KeyT> result =
                 flinkStateBackend
-                    .getPartitionedState(
-                        namespace, namespaceSerializer, flinkStateDescriptor)
+                    .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
                     .keys();
             return result != null ? ImmutableList.copyOf(result) : Collections.emptyList();
           } catch (Exception e) {
@@ -1445,8 +1438,7 @@ public class FlinkStateInternals<K> implements StateInternals {
           try {
             Iterable<ValueT> result =
                 flinkStateBackend
-                    .getPartitionedState(
-                        namespace, namespaceSerializer, flinkStateDescriptor)
+                    .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
                     .values();
             return result != null ? ImmutableList.copyOf(result) : Collections.emptyList();
           } catch (Exception e) {
@@ -1469,8 +1461,7 @@ public class FlinkStateInternals<K> implements StateInternals {
           try {
             Iterable<Map.Entry<KeyT, ValueT>> result =
                 flinkStateBackend
-                    .getPartitionedState(
-                        namespace, namespaceSerializer, flinkStateDescriptor)
+                    .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
                     .entries();
             return result != null ? ImmutableList.copyOf(result) : Collections.emptyList();
           } catch (Exception e) {
@@ -1508,8 +1499,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     public void clear() {
       try {
         flinkStateBackend
-            .getPartitionedState(
-                namespace, namespaceSerializer, flinkStateDescriptor)
+            .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
             .clear();
       } catch (Exception e) {
         throw new RuntimeException("Error clearing state.", e);
@@ -1559,6 +1549,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       this.flinkStateDescriptor =
           new MapStateDescriptor<>(
               stateId, new CoderTypeSerializer<>(coder, fasterCopy), BooleanSerializer.INSTANCE);
+      this.namespaceSerializer = namespaceSerializer;
     }
 
     @Override
@@ -1566,8 +1557,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         Boolean result =
             flinkStateBackend
-                .getPartitionedState(
-                    namespace, namespaceSerializer, flinkStateDescriptor)
+                .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
                 .get(t);
         return ReadableStates.immediate(result != null && result);
       } catch (Exception e) {
@@ -1595,8 +1585,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     public void remove(T t) {
       try {
         flinkStateBackend
-            .getPartitionedState(
-                namespace, namespaceSerializer, flinkStateDescriptor)
+            .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
             .remove(t);
       } catch (Exception e) {
         throw new RuntimeException("Error remove value to state.", e);
@@ -1612,8 +1601,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     public void add(T value) {
       try {
         flinkStateBackend
-            .getPartitionedState(
-                namespace, namespaceSerializer, flinkStateDescriptor)
+            .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
             .put(value, true);
       } catch (Exception e) {
         throw new RuntimeException("Error add value to state.", e);
@@ -1628,8 +1616,7 @@ public class FlinkStateInternals<K> implements StateInternals {
           try {
             Iterable<T> result =
                 flinkStateBackend
-                    .getPartitionedState(
-                        namespace, namespaceSerializer, flinkStateDescriptor)
+                    .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
                     .keys();
             return result == null || Iterables.isEmpty(result);
           } catch (Exception e) {
@@ -1649,8 +1636,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         Iterable<T> result =
             flinkStateBackend
-                .getPartitionedState(
-                    namespace, namespaceSerializer, flinkStateDescriptor)
+                .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
                 .keys();
         return result != null ? ImmutableList.copyOf(result) : Collections.emptyList();
       } catch (Exception e) {
@@ -1662,8 +1648,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     public void clear() {
       try {
         flinkStateBackend
-            .getPartitionedState(
-                namespace, namespaceSerializer, flinkStateDescriptor)
+            .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
             .clear();
       } catch (Exception e) {
         throw new RuntimeException("Error clearing state.", e);
@@ -1723,7 +1708,9 @@ public class FlinkStateInternals<K> implements StateInternals {
     private final FlinkStateNamespaceKeySerializer namespaceSerializer;
 
     public EarlyBinder(
-        KeyedStateBackend keyedStateBackend, SerializablePipelineOptions pipelineOptions, Coder<? extends BoundedWindow> windowCoder) {
+        KeyedStateBackend keyedStateBackend,
+        SerializablePipelineOptions pipelineOptions,
+        Coder<? extends BoundedWindow> windowCoder) {
       this.keyedStateBackend = keyedStateBackend;
       this.fasterCopy = pipelineOptions.get().as(FlinkPipelineOptions.class).getFasterCopy();
       this.namespaceSerializer = new FlinkStateNamespaceKeySerializer(windowCoder);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
@@ -17,6 +17,7 @@
  */
 package org.apache.beam.runners.flink.translation.wrappers.streaming.state;
 
+import java.io.IOException;
 import java.nio.ByteBuffer;
 import java.util.Collections;
 import java.util.HashSet;
@@ -28,6 +29,8 @@ import java.util.SortedMap;
 import java.util.function.Function;
 import java.util.stream.Stream;
 import javax.annotation.Nonnull;
+
+import com.esotericsoftware.kryo.serializers.DefaultSerializers;
 import org.apache.beam.runners.core.StateInternals;
 import org.apache.beam.runners.core.StateNamespace;
 import org.apache.beam.runners.core.StateNamespaces;
@@ -56,6 +59,7 @@ import org.apache.beam.sdk.state.ValueState;
 import org.apache.beam.sdk.state.WatermarkHoldState;
 import org.apache.beam.sdk.transforms.Combine;
 import org.apache.beam.sdk.transforms.CombineWithContext;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.transforms.windowing.GlobalWindow;
 import org.apache.beam.sdk.transforms.windowing.TimestampCombiner;
 import org.apache.beam.sdk.util.CombineContextFactory;
@@ -75,8 +79,13 @@ import org.apache.flink.api.common.state.MapStateDescriptor;
 import org.apache.flink.api.common.state.StateDescriptor;
 import org.apache.flink.api.common.state.ValueStateDescriptor;
 import org.apache.flink.api.common.typeutils.TypeSerializer;
+import org.apache.flink.api.common.typeutils.TypeSerializerSchemaCompatibility;
+import org.apache.flink.api.common.typeutils.TypeSerializerSnapshot;
 import org.apache.flink.api.common.typeutils.base.BooleanSerializer;
 import org.apache.flink.api.common.typeutils.base.StringSerializer;
+import org.apache.flink.core.memory.DataInputView;
+import org.apache.flink.core.memory.DataOutputView;
+import org.apache.flink.runtime.state.JavaSerializer;
 import org.apache.flink.runtime.state.KeyedStateBackend;
 import org.apache.flink.runtime.state.VoidNamespace;
 import org.apache.flink.runtime.state.VoidNamespaceSerializer;
@@ -103,6 +112,7 @@ public class FlinkStateInternals<K> implements StateInternals {
 
   private final KeyedStateBackend<ByteBuffer> flinkStateBackend;
   private final Coder<K> keyCoder;
+  FlinkStateNamespaceKeySerializer namespaceKeySerializer;
 
   private static class StateAndNamespaceDescriptor<T> {
     static <T> StateAndNamespaceDescriptor<T> of(
@@ -168,11 +178,13 @@ public class FlinkStateInternals<K> implements StateInternals {
   public FlinkStateInternals(
       KeyedStateBackend<ByteBuffer> flinkStateBackend,
       Coder<K> keyCoder,
+      Coder<? extends BoundedWindow> windowCoder,
       SerializablePipelineOptions pipelineOptions)
       throws Exception {
     this.flinkStateBackend = Objects.requireNonNull(flinkStateBackend);
     this.keyCoder = Objects.requireNonNull(keyCoder);
     this.fasterCopy = pipelineOptions.get().as(FlinkPipelineOptions.class).getFasterCopy();
+    this.namespaceKeySerializer = new FlinkStateNamespaceKeySerializer(windowCoder);
 
     watermarkHoldStateDescriptor =
         new MapStateDescriptor<>(
@@ -242,29 +254,28 @@ public class FlinkStateInternals<K> implements StateInternals {
     public <T2> ValueState<T2> bindValue(
         String id, StateSpec<ValueState<T2>> spec, Coder<T2> coder) {
       FlinkValueState<T2> valueState =
-          new FlinkValueState<>(flinkStateBackend, id, namespace, coder, fasterCopy);
+          new FlinkValueState<>(flinkStateBackend, id, namespace, coder, namespaceKeySerializer, fasterCopy);
       collectGlobalWindowStateDescriptor(
           valueState.flinkStateDescriptor,
-          valueState.namespace.stringKey(),
-          StringSerializer.INSTANCE);
+          valueState.namespace, namespaceKeySerializer);
       return valueState;
     }
 
     @Override
     public <T2> BagState<T2> bindBag(String id, StateSpec<BagState<T2>> spec, Coder<T2> elemCoder) {
       FlinkBagState<T2> bagState =
-          new FlinkBagState<>(flinkStateBackend, id, namespace, elemCoder, fasterCopy);
+          new FlinkBagState<>(flinkStateBackend, id, namespace, elemCoder, namespaceKeySerializer, fasterCopy);
       collectGlobalWindowStateDescriptor(
-          bagState.flinkStateDescriptor, bagState.namespace.stringKey(), StringSerializer.INSTANCE);
+          bagState.flinkStateDescriptor, bagState.namespace, namespaceKeySerializer);
       return bagState;
     }
 
     @Override
     public <T2> SetState<T2> bindSet(String id, StateSpec<SetState<T2>> spec, Coder<T2> elemCoder) {
       FlinkSetState<T2> setState =
-          new FlinkSetState<>(flinkStateBackend, id, namespace, elemCoder, fasterCopy);
+          new FlinkSetState<>(flinkStateBackend, id, namespace, elemCoder, namespaceKeySerializer, fasterCopy);
       collectGlobalWindowStateDescriptor(
-          setState.flinkStateDescriptor, setState.namespace.stringKey(), StringSerializer.INSTANCE);
+          setState.flinkStateDescriptor, setState.namespace, namespaceKeySerializer);
       return setState;
     }
 
@@ -276,9 +287,9 @@ public class FlinkStateInternals<K> implements StateInternals {
         Coder<ValueT> mapValueCoder) {
       FlinkMapState<KeyT, ValueT> mapState =
           new FlinkMapState<>(
-              flinkStateBackend, id, namespace, mapKeyCoder, mapValueCoder, fasterCopy);
+              flinkStateBackend, id, namespace, mapKeyCoder, mapValueCoder, namespaceKeySerializer, fasterCopy);
       collectGlobalWindowStateDescriptor(
-          mapState.flinkStateDescriptor, mapState.namespace.stringKey(), StringSerializer.INSTANCE);
+          mapState.flinkStateDescriptor, mapState.namespace, namespaceKeySerializer);
       return mapState;
     }
 
@@ -286,11 +297,11 @@ public class FlinkStateInternals<K> implements StateInternals {
     public <T> OrderedListState<T> bindOrderedList(
         String id, StateSpec<OrderedListState<T>> spec, Coder<T> elemCoder) {
       FlinkOrderedListState<T> flinkOrderedListState =
-          new FlinkOrderedListState<>(flinkStateBackend, id, namespace, elemCoder, fasterCopy);
+          new FlinkOrderedListState<>(flinkStateBackend, id, namespace, elemCoder, namespaceKeySerializer, fasterCopy);
       collectGlobalWindowStateDescriptor(
           flinkOrderedListState.flinkStateDescriptor,
-          flinkOrderedListState.namespace.stringKey(),
-          StringSerializer.INSTANCE);
+          flinkOrderedListState.namespace,
+              namespaceKeySerializer);
       return flinkOrderedListState;
     }
 
@@ -312,11 +323,11 @@ public class FlinkStateInternals<K> implements StateInternals {
         Combine.CombineFn<InputT, AccumT, OutputT> combineFn) {
       FlinkCombiningState<Object, InputT, AccumT, OutputT> combiningState =
           new FlinkCombiningState<>(
-              flinkStateBackend, id, combineFn, namespace, accumCoder, fasterCopy);
+              flinkStateBackend, id, combineFn, namespace, accumCoder, namespaceKeySerializer, fasterCopy);
       collectGlobalWindowStateDescriptor(
           combiningState.flinkStateDescriptor,
-          combiningState.namespace.stringKey(),
-          StringSerializer.INSTANCE);
+          combiningState.namespace,
+              namespaceKeySerializer);
       return combiningState;
     }
 
@@ -334,12 +345,13 @@ public class FlinkStateInternals<K> implements StateInternals {
               combineFn,
               namespace,
               accumCoder,
+              namespaceKeySerializer,
               CombineContextFactory.createFromStateContext(stateContext),
               fasterCopy);
       collectGlobalWindowStateDescriptor(
           combiningStateWithContext.flinkStateDescriptor,
-          combiningStateWithContext.namespace.stringKey(),
-          StringSerializer.INSTANCE);
+          combiningStateWithContext.namespace,
+              namespaceKeySerializer);
       return combiningStateWithContext;
     }
 
@@ -369,23 +381,146 @@ public class FlinkStateInternals<K> implements StateInternals {
     }
   }
 
+  public static class FlinkStateNamespaceKeySerializer extends TypeSerializer<StateNamespace> {
+
+    public Coder<? extends BoundedWindow> getCoder() {
+      return coder;
+    }
+
+    private final Coder<? extends BoundedWindow> coder;
+
+    public FlinkStateNamespaceKeySerializer(Coder<? extends BoundedWindow> coder) {
+      this.coder = coder;
+    }
+    
+    @Override
+    public boolean isImmutableType() {
+      return false;
+    }
+
+    @Override
+    public TypeSerializer<StateNamespace> duplicate() {
+      return this;
+    }
+
+    @Override
+    public StateNamespace createInstance() {
+      return null;
+    }
+
+    @Override
+    public StateNamespace copy(StateNamespace from) {
+      return from;
+    }
+
+    @Override
+    public StateNamespace copy(StateNamespace from, StateNamespace reuse) {
+      return from;
+    }
+
+    @Override
+    public int getLength() {
+      return -1;
+    }
+
+    @Override
+    public void serialize(StateNamespace record, DataOutputView target) throws IOException {
+      StringSerializer.INSTANCE.serialize(record.stringKey(), target);
+    }
+
+    @Override
+    public StateNamespace deserialize(DataInputView source) throws IOException {
+      return StateNamespaces.fromString(StringSerializer.INSTANCE.deserialize(source), coder);
+    }
+
+    @Override
+    public StateNamespace deserialize(StateNamespace reuse, DataInputView source) throws IOException {
+      return deserialize(source);
+    }
+
+    @Override
+    public void copy(DataInputView source, DataOutputView target) throws IOException {
+      throw new UnsupportedOperationException("copy is not supported for FlinkStateNamespace key");
+    }
+
+    @Override
+    public boolean equals(Object obj) {
+      return obj instanceof FlinkStateNamespaceKeySerializer;
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hashCode(getClass());
+    }
+
+    @Override
+    public TypeSerializerSnapshot<StateNamespace> snapshotConfiguration() {
+      return new FlinkStateNameSpaceSerializerSnapshot(this);
+    }
+
+    /** Serializer configuration snapshot for compatibility and format evolution. */
+    @SuppressWarnings("WeakerAccess")
+    public final static class FlinkStateNameSpaceSerializerSnapshot implements TypeSerializerSnapshot<StateNamespace> {
+
+      @Nullable
+      private Coder<? extends BoundedWindow> windowCoder;
+
+      public FlinkStateNameSpaceSerializerSnapshot(){
+
+      }
+
+      FlinkStateNameSpaceSerializerSnapshot(FlinkStateNamespaceKeySerializer ser) {
+        this.windowCoder = ser.getCoder();
+      }
+
+      @Override
+      public int getCurrentVersion() {
+        return 0;
+      }
+
+      @Override
+      public void writeSnapshot(DataOutputView out) throws IOException {
+        new JavaSerializer<Coder<? extends BoundedWindow>>().serialize(windowCoder, out);
+      }
+
+      @Override
+      public void readSnapshot(int readVersion, DataInputView in, ClassLoader userCodeClassLoader) throws IOException {
+        this.windowCoder = new JavaSerializer<Coder<? extends BoundedWindow>>().deserialize(in);
+      }
+
+      @Override
+      public TypeSerializer<StateNamespace> restoreSerializer() {
+        return new FlinkStateNamespaceKeySerializer(windowCoder);
+      }
+
+      @Override
+      public TypeSerializerSchemaCompatibility<StateNamespace> resolveSchemaCompatibility(TypeSerializer<StateNamespace> newSerializer) {
+        return TypeSerializerSchemaCompatibility.compatibleAsIs();
+      }
+    }
+  }
+
   private static class FlinkValueState<T> implements ValueState<T> {
 
     private final StateNamespace namespace;
     private final String stateId;
     private final ValueStateDescriptor<T> flinkStateDescriptor;
     private final KeyedStateBackend<ByteBuffer> flinkStateBackend;
+    private final FlinkStateNamespaceKeySerializer namespaceSerializer;
 
     FlinkValueState(
         KeyedStateBackend<ByteBuffer> flinkStateBackend,
         String stateId,
         StateNamespace namespace,
         Coder<T> coder,
+        FlinkStateNamespaceKeySerializer namespaceSerializer,
         boolean fasterCopy) {
 
       this.namespace = namespace;
       this.stateId = stateId;
       this.flinkStateBackend = flinkStateBackend;
+      this.namespaceSerializer = namespaceSerializer;
+
 
       flinkStateDescriptor =
           new ValueStateDescriptor<>(stateId, new CoderTypeSerializer<>(coder, fasterCopy));
@@ -396,7 +531,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         flinkStateBackend
             .getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                namespace, namespaceSerializer, flinkStateDescriptor)
             .update(input);
       } catch (Exception e) {
         throw new RuntimeException("Error updating state.", e);
@@ -413,7 +548,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         return flinkStateBackend
             .getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                namespace, namespaceSerializer, flinkStateDescriptor)
             .value();
       } catch (Exception e) {
         throw new RuntimeException("Error reading state.", e);
@@ -424,8 +559,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     public void clear() {
       try {
         flinkStateBackend
-            .getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+            .getPartitionedState(namespace, namespaceSerializer, flinkStateDescriptor)
             .clear();
       } catch (Exception e) {
         throw new RuntimeException("Error clearing state.", e);
@@ -458,18 +592,21 @@ public class FlinkStateInternals<K> implements StateInternals {
     private final StateNamespace namespace;
     private final ListStateDescriptor<TimestampedValue<T>> flinkStateDescriptor;
     private final KeyedStateBackend<ByteBuffer> flinkStateBackend;
+    private final FlinkStateNamespaceKeySerializer namespaceSerializer;
 
     FlinkOrderedListState(
         KeyedStateBackend<ByteBuffer> flinkStateBackend,
         String stateId,
         StateNamespace namespace,
         Coder<T> coder,
+        FlinkStateNamespaceKeySerializer namespaceSerializer,
         boolean fasterCopy) {
       this.namespace = namespace;
       this.flinkStateBackend = flinkStateBackend;
       this.flinkStateDescriptor =
           new ListStateDescriptor<>(
               stateId, new CoderTypeSerializer<>(TimestampedValueCoder.of(coder), fasterCopy));
+      this.namespaceSerializer = namespaceSerializer;
     }
 
     @Override
@@ -484,7 +621,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         ListState<TimestampedValue<T>> partitionedState =
             flinkStateBackend.getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor);
+                    namespace, namespaceSerializer, flinkStateDescriptor);
         partitionedState.update(Lists.newArrayList(sortedMap.values()));
       } catch (Exception e) {
         throw new RuntimeException("Error adding to bag state.", e);
@@ -501,7 +638,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         ListState<TimestampedValue<T>> partitionedState =
             flinkStateBackend.getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor);
+                    namespace, namespaceSerializer, flinkStateDescriptor);
         partitionedState.add(value);
       } catch (Exception e) {
         throw new RuntimeException("Error adding to bag state.", e);
@@ -517,7 +654,7 @@ public class FlinkStateInternals<K> implements StateInternals {
             Iterable<TimestampedValue<T>> result =
                 flinkStateBackend
                     .getPartitionedState(
-                        namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                            namespace, namespaceSerializer, flinkStateDescriptor)
                     .get();
             return result == null;
           } catch (Exception e) {
@@ -543,7 +680,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         ListState<TimestampedValue<T>> partitionedState =
             flinkStateBackend.getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor);
+                    namespace, namespaceSerializer, flinkStateDescriptor);
         listValues = MoreObjects.firstNonNull(partitionedState.get(), Collections.emptyList());
       } catch (Exception e) {
         throw new RuntimeException("Error reading state.", e);
@@ -566,7 +703,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         flinkStateBackend
             .getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                    namespace, namespaceSerializer, flinkStateDescriptor)
             .clear();
       } catch (Exception e) {
         throw new RuntimeException("Error clearing state.", e);
@@ -581,12 +718,14 @@ public class FlinkStateInternals<K> implements StateInternals {
     private final ListStateDescriptor<T> flinkStateDescriptor;
     private final KeyedStateBackend<ByteBuffer> flinkStateBackend;
     private final boolean storesVoidValues;
+    private final FlinkStateNamespaceKeySerializer namespaceSerializer;
 
     FlinkBagState(
         KeyedStateBackend<ByteBuffer> flinkStateBackend,
         String stateId,
         StateNamespace namespace,
         Coder<T> coder,
+        FlinkStateNamespaceKeySerializer namespaceSerializer,
         boolean fasterCopy) {
 
       this.namespace = namespace;
@@ -595,6 +734,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       this.storesVoidValues = coder instanceof VoidCoder;
       this.flinkStateDescriptor =
           new ListStateDescriptor<>(stateId, new CoderTypeSerializer<>(coder, fasterCopy));
+      this.namespaceSerializer = namespaceSerializer;
     }
 
     @Override
@@ -602,7 +742,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         ListState<T> partitionedState =
             flinkStateBackend.getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor);
+                    namespace, namespaceSerializer, flinkStateDescriptor);
         if (storesVoidValues) {
           Preconditions.checkState(input == null, "Expected to a null value but was: %s", input);
           // Flink does not allow storing null values
@@ -626,7 +766,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         ListState<T> partitionedState =
             flinkStateBackend.getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor);
+                namespace, namespaceSerializer, flinkStateDescriptor);
         Iterable<T> result = partitionedState.get();
         if (storesVoidValues) {
           return () -> {
@@ -663,7 +803,7 @@ public class FlinkStateInternals<K> implements StateInternals {
             Iterable<T> result =
                 flinkStateBackend
                     .getPartitionedState(
-                        namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                        namespace, namespaceSerializer, flinkStateDescriptor)
                     .get();
             return result == null;
           } catch (Exception e) {
@@ -683,7 +823,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         flinkStateBackend
             .getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                namespace, namespaceSerializer, flinkStateDescriptor)
             .clear();
       } catch (Exception e) {
         throw new RuntimeException("Error clearing state.", e);
@@ -720,6 +860,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     private final Combine.CombineFn<InputT, AccumT, OutputT> combineFn;
     private final ValueStateDescriptor<AccumT> flinkStateDescriptor;
     private final KeyedStateBackend<ByteBuffer> flinkStateBackend;
+    private final FlinkStateNamespaceKeySerializer namespaceSerializer;
 
     FlinkCombiningState(
         KeyedStateBackend<ByteBuffer> flinkStateBackend,
@@ -727,12 +868,14 @@ public class FlinkStateInternals<K> implements StateInternals {
         Combine.CombineFn<InputT, AccumT, OutputT> combineFn,
         StateNamespace namespace,
         Coder<AccumT> accumCoder,
+        FlinkStateNamespaceKeySerializer namespaceSerializer,
         boolean fasterCopy) {
 
       this.namespace = namespace;
       this.stateId = stateId;
       this.combineFn = combineFn;
       this.flinkStateBackend = flinkStateBackend;
+      this.namespaceSerializer = namespaceSerializer;
 
       flinkStateDescriptor =
           new ValueStateDescriptor<>(
@@ -749,7 +892,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         org.apache.flink.api.common.state.ValueState<AccumT> state =
             flinkStateBackend.getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor);
+                namespace, namespaceSerializer, flinkStateDescriptor);
 
         AccumT current = state.value();
         if (current == null) {
@@ -767,7 +910,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         org.apache.flink.api.common.state.ValueState<AccumT> state =
             flinkStateBackend.getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor);
+                namespace, namespaceSerializer, flinkStateDescriptor);
 
         AccumT current = state.value();
         if (current == null) {
@@ -787,7 +930,7 @@ public class FlinkStateInternals<K> implements StateInternals {
         AccumT accum =
             flinkStateBackend
                 .getPartitionedState(
-                    namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                    namespace, namespaceSerializer, flinkStateDescriptor)
                 .value();
         return accum != null ? accum : combineFn.createAccumulator();
       } catch (Exception e) {
@@ -805,7 +948,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         org.apache.flink.api.common.state.ValueState<AccumT> state =
             flinkStateBackend.getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor);
+                namespace, namespaceSerializer, flinkStateDescriptor);
 
         AccumT accum = state.value();
         if (accum != null) {
@@ -826,7 +969,7 @@ public class FlinkStateInternals<K> implements StateInternals {
           try {
             return flinkStateBackend
                     .getPartitionedState(
-                        namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                        namespace, namespaceSerializer, flinkStateDescriptor)
                     .value()
                 == null;
           } catch (Exception e) {
@@ -846,7 +989,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         flinkStateBackend
             .getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                namespace, namespaceSerializer, flinkStateDescriptor)
             .clear();
       } catch (Exception e) {
         throw new RuntimeException("Error clearing state.", e);
@@ -884,6 +1027,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     private final ValueStateDescriptor<AccumT> flinkStateDescriptor;
     private final KeyedStateBackend<ByteBuffer> flinkStateBackend;
     private final CombineWithContext.Context context;
+    private final FlinkStateNamespaceKeySerializer namespaceSerializer;
 
     FlinkCombiningStateWithContext(
         KeyedStateBackend<ByteBuffer> flinkStateBackend,
@@ -891,6 +1035,7 @@ public class FlinkStateInternals<K> implements StateInternals {
         CombineWithContext.CombineFnWithContext<InputT, AccumT, OutputT> combineFn,
         StateNamespace namespace,
         Coder<AccumT> accumCoder,
+        FlinkStateNamespaceKeySerializer namespaceSerializer,
         CombineWithContext.Context context,
         boolean fasterCopy) {
 
@@ -899,6 +1044,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       this.combineFn = combineFn;
       this.flinkStateBackend = flinkStateBackend;
       this.context = context;
+      this.namespaceSerializer = namespaceSerializer;
 
       flinkStateDescriptor =
           new ValueStateDescriptor<>(
@@ -915,7 +1061,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         org.apache.flink.api.common.state.ValueState<AccumT> state =
             flinkStateBackend.getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor);
+                namespace, namespaceSerializer, flinkStateDescriptor);
 
         AccumT current = state.value();
         if (current == null) {
@@ -933,7 +1079,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         org.apache.flink.api.common.state.ValueState<AccumT> state =
             flinkStateBackend.getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor);
+                namespace, namespaceSerializer, flinkStateDescriptor);
 
         AccumT current = state.value();
         if (current == null) {
@@ -953,7 +1099,7 @@ public class FlinkStateInternals<K> implements StateInternals {
         AccumT accum =
             flinkStateBackend
                 .getPartitionedState(
-                    namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                    namespace, namespaceSerializer, flinkStateDescriptor)
                 .value();
         return accum != null ? accum : combineFn.createAccumulator(context);
       } catch (Exception e) {
@@ -971,7 +1117,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         org.apache.flink.api.common.state.ValueState<AccumT> state =
             flinkStateBackend.getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor);
+                namespace, namespaceSerializer, flinkStateDescriptor);
 
         AccumT accum = state.value();
         if (accum != null) {
@@ -992,7 +1138,7 @@ public class FlinkStateInternals<K> implements StateInternals {
           try {
             return flinkStateBackend
                     .getPartitionedState(
-                        namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                        namespace, namespaceSerializer, flinkStateDescriptor)
                     .value()
                 == null;
           } catch (Exception e) {
@@ -1012,7 +1158,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         flinkStateBackend
             .getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                namespace, namespaceSerializer, flinkStateDescriptor)
             .clear();
       } catch (Exception e) {
         throw new RuntimeException("Error clearing state.", e);
@@ -1172,6 +1318,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     private final String stateId;
     private final MapStateDescriptor<KeyT, ValueT> flinkStateDescriptor;
     private final KeyedStateBackend<ByteBuffer> flinkStateBackend;
+    private final FlinkStateNamespaceKeySerializer namespaceSerializer;
 
     FlinkMapState(
         KeyedStateBackend<ByteBuffer> flinkStateBackend,
@@ -1179,6 +1326,7 @@ public class FlinkStateInternals<K> implements StateInternals {
         StateNamespace namespace,
         Coder<KeyT> mapKeyCoder,
         Coder<ValueT> mapValueCoder,
+        FlinkStateNamespaceKeySerializer namespaceSerializer,
         boolean fasterCopy) {
       this.namespace = namespace;
       this.stateId = stateId;
@@ -1188,6 +1336,7 @@ public class FlinkStateInternals<K> implements StateInternals {
               stateId,
               new CoderTypeSerializer<>(mapKeyCoder, fasterCopy),
               new CoderTypeSerializer<>(mapValueCoder, fasterCopy));
+      this.namespaceSerializer = namespaceSerializer;
     }
 
     @Override
@@ -1205,7 +1354,7 @@ public class FlinkStateInternals<K> implements StateInternals {
             ValueT value =
                 flinkStateBackend
                     .getPartitionedState(
-                        namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                        namespace, namespaceSerializer, flinkStateDescriptor)
                     .get(key);
             return (value != null) ? value : defaultValue;
           } catch (Exception e) {
@@ -1225,7 +1374,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         flinkStateBackend
             .getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                namespace, namespaceSerializer, flinkStateDescriptor)
             .put(key, value);
       } catch (Exception e) {
         throw new RuntimeException("Error put kv to state.", e);
@@ -1239,13 +1388,13 @@ public class FlinkStateInternals<K> implements StateInternals {
         ValueT current =
             flinkStateBackend
                 .getPartitionedState(
-                    namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                    namespace, namespaceSerializer, flinkStateDescriptor)
                 .get(key);
 
         if (current == null) {
           flinkStateBackend
               .getPartitionedState(
-                  namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                  namespace, namespaceSerializer, flinkStateDescriptor)
               .put(key, mappingFunction.apply(key));
         }
         return ReadableStates.immediate(current);
@@ -1259,7 +1408,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         flinkStateBackend
             .getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                namespace, namespaceSerializer, flinkStateDescriptor)
             .remove(key);
       } catch (Exception e) {
         throw new RuntimeException("Error remove map state key.", e);
@@ -1275,7 +1424,7 @@ public class FlinkStateInternals<K> implements StateInternals {
             Iterable<KeyT> result =
                 flinkStateBackend
                     .getPartitionedState(
-                        namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                        namespace, namespaceSerializer, flinkStateDescriptor)
                     .keys();
             return result != null ? ImmutableList.copyOf(result) : Collections.emptyList();
           } catch (Exception e) {
@@ -1299,7 +1448,7 @@ public class FlinkStateInternals<K> implements StateInternals {
             Iterable<ValueT> result =
                 flinkStateBackend
                     .getPartitionedState(
-                        namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                        namespace, namespaceSerializer, flinkStateDescriptor)
                     .values();
             return result != null ? ImmutableList.copyOf(result) : Collections.emptyList();
           } catch (Exception e) {
@@ -1323,7 +1472,7 @@ public class FlinkStateInternals<K> implements StateInternals {
             Iterable<Map.Entry<KeyT, ValueT>> result =
                 flinkStateBackend
                     .getPartitionedState(
-                        namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                        namespace, namespaceSerializer, flinkStateDescriptor)
                     .entries();
             return result != null ? ImmutableList.copyOf(result) : Collections.emptyList();
           } catch (Exception e) {
@@ -1362,7 +1511,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         flinkStateBackend
             .getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                namespace, namespaceSerializer, flinkStateDescriptor)
             .clear();
       } catch (Exception e) {
         throw new RuntimeException("Error clearing state.", e);
@@ -1397,12 +1546,14 @@ public class FlinkStateInternals<K> implements StateInternals {
     private final String stateId;
     private final MapStateDescriptor<T, Boolean> flinkStateDescriptor;
     private final KeyedStateBackend<ByteBuffer> flinkStateBackend;
+    private final FlinkStateNamespaceKeySerializer namespaceSerializer;
 
     FlinkSetState(
         KeyedStateBackend<ByteBuffer> flinkStateBackend,
         String stateId,
         StateNamespace namespace,
         Coder<T> coder,
+        FlinkStateNamespaceKeySerializer namespaceSerializer,
         boolean fasterCopy) {
       this.namespace = namespace;
       this.stateId = stateId;
@@ -1420,7 +1571,7 @@ public class FlinkStateInternals<K> implements StateInternals {
         Boolean result =
             flinkStateBackend
                 .getPartitionedState(
-                    namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                    namespace, namespaceSerializer, flinkStateDescriptor)
                 .get(t);
         return ReadableStates.immediate(result != null && result);
       } catch (Exception e) {
@@ -1433,7 +1584,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         org.apache.flink.api.common.state.MapState<T, Boolean> state =
             flinkStateBackend.getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor);
+                namespace, namespaceSerializer, flinkStateDescriptor);
         boolean alreadyContained = state.contains(t);
         if (!alreadyContained) {
           state.put(t, true);
@@ -1449,7 +1600,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         flinkStateBackend
             .getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                namespace, namespaceSerializer, flinkStateDescriptor)
             .remove(t);
       } catch (Exception e) {
         throw new RuntimeException("Error remove value to state.", e);
@@ -1466,7 +1617,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         flinkStateBackend
             .getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                namespace, namespaceSerializer, flinkStateDescriptor)
             .put(value, true);
       } catch (Exception e) {
         throw new RuntimeException("Error add value to state.", e);
@@ -1482,7 +1633,7 @@ public class FlinkStateInternals<K> implements StateInternals {
             Iterable<T> result =
                 flinkStateBackend
                     .getPartitionedState(
-                        namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                        namespace, namespaceSerializer, flinkStateDescriptor)
                     .keys();
             return result == null || Iterables.isEmpty(result);
           } catch (Exception e) {
@@ -1503,7 +1654,7 @@ public class FlinkStateInternals<K> implements StateInternals {
         Iterable<T> result =
             flinkStateBackend
                 .getPartitionedState(
-                    namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                    namespace, namespaceSerializer, flinkStateDescriptor)
                 .keys();
         return result != null ? ImmutableList.copyOf(result) : Collections.emptyList();
       } catch (Exception e) {
@@ -1516,7 +1667,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       try {
         flinkStateBackend
             .getPartitionedState(
-                namespace.stringKey(), StringSerializer.INSTANCE, flinkStateDescriptor)
+                namespace, namespaceSerializer, flinkStateDescriptor)
             .clear();
       } catch (Exception e) {
         throw new RuntimeException("Error clearing state.", e);
@@ -1573,18 +1724,20 @@ public class FlinkStateInternals<K> implements StateInternals {
 
     private final KeyedStateBackend keyedStateBackend;
     private final Boolean fasterCopy;
+    private final FlinkStateNamespaceKeySerializer namespaceSerializer;
 
     public EarlyBinder(
-        KeyedStateBackend keyedStateBackend, SerializablePipelineOptions pipelineOptions) {
+        KeyedStateBackend keyedStateBackend, SerializablePipelineOptions pipelineOptions, Coder<? extends BoundedWindow> windowCoder) {
       this.keyedStateBackend = keyedStateBackend;
       this.fasterCopy = pipelineOptions.get().as(FlinkPipelineOptions.class).getFasterCopy();
+      this.namespaceSerializer = new FlinkStateNamespaceKeySerializer(windowCoder);
     }
 
     @Override
     public <T> ValueState<T> bindValue(String id, StateSpec<ValueState<T>> spec, Coder<T> coder) {
       try {
         keyedStateBackend.getOrCreateKeyedState(
-            StringSerializer.INSTANCE,
+            namespaceSerializer,
             new ValueStateDescriptor<>(id, new CoderTypeSerializer<>(coder, fasterCopy)));
       } catch (Exception e) {
         throw new RuntimeException(e);
@@ -1597,7 +1750,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     public <T> BagState<T> bindBag(String id, StateSpec<BagState<T>> spec, Coder<T> elemCoder) {
       try {
         keyedStateBackend.getOrCreateKeyedState(
-            StringSerializer.INSTANCE,
+            namespaceSerializer,
             new ListStateDescriptor<>(id, new CoderTypeSerializer<>(elemCoder, fasterCopy)));
       } catch (Exception e) {
         throw new RuntimeException(e);
@@ -1610,7 +1763,7 @@ public class FlinkStateInternals<K> implements StateInternals {
     public <T> SetState<T> bindSet(String id, StateSpec<SetState<T>> spec, Coder<T> elemCoder) {
       try {
         keyedStateBackend.getOrCreateKeyedState(
-            StringSerializer.INSTANCE,
+            namespaceSerializer,
             new MapStateDescriptor<>(
                 id,
                 new CoderTypeSerializer<>(elemCoder, fasterCopy),
@@ -1629,7 +1782,7 @@ public class FlinkStateInternals<K> implements StateInternals {
         Coder<ValueT> mapValueCoder) {
       try {
         keyedStateBackend.getOrCreateKeyedState(
-            StringSerializer.INSTANCE,
+            namespaceSerializer,
             new MapStateDescriptor<>(
                 id,
                 new CoderTypeSerializer<>(mapKeyCoder, fasterCopy),
@@ -1645,7 +1798,7 @@ public class FlinkStateInternals<K> implements StateInternals {
         String id, StateSpec<OrderedListState<T>> spec, Coder<T> elemCoder) {
       try {
         keyedStateBackend.getOrCreateKeyedState(
-            StringSerializer.INSTANCE,
+            namespaceSerializer,
             new ListStateDescriptor<>(
                 id,
                 new CoderTypeSerializer<>(TimestampedValueCoder.of(elemCoder), fasterCopy)));
@@ -1674,7 +1827,7 @@ public class FlinkStateInternals<K> implements StateInternals {
         Combine.CombineFn<InputT, AccumT, OutputT> combineFn) {
       try {
         keyedStateBackend.getOrCreateKeyedState(
-            StringSerializer.INSTANCE,
+            namespaceSerializer,
             new ValueStateDescriptor<>(id, new CoderTypeSerializer<>(accumCoder, fasterCopy)));
       } catch (Exception e) {
         throw new RuntimeException(e);
@@ -1691,7 +1844,7 @@ public class FlinkStateInternals<K> implements StateInternals {
             CombineWithContext.CombineFnWithContext<InputT, AccumT, OutputT> combineFn) {
       try {
         keyedStateBackend.getOrCreateKeyedState(
-            StringSerializer.INSTANCE,
+            namespaceSerializer,
             new ValueStateDescriptor<>(id, new CoderTypeSerializer<>(accumCoder, fasterCopy)));
       } catch (Exception e) {
         throw new RuntimeException(e);

--- a/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
+++ b/runners/flink/src/main/java/org/apache/beam/runners/flink/translation/wrappers/streaming/state/FlinkStateInternals.java
@@ -878,8 +878,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       this.namespaceSerializer = namespaceSerializer;
 
       flinkStateDescriptor =
-          new ValueStateDescriptor<>(
-              stateId, new CoderTypeSerializer<>(accumCoder, fasterCopy));
+          new ValueStateDescriptor<>(stateId, new CoderTypeSerializer<>(accumCoder, fasterCopy));
     }
 
     @Override
@@ -1047,8 +1046,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       this.namespaceSerializer = namespaceSerializer;
 
       flinkStateDescriptor =
-          new ValueStateDescriptor<>(
-              stateId, new CoderTypeSerializer<>(accumCoder, fasterCopy));
+          new ValueStateDescriptor<>(stateId, new CoderTypeSerializer<>(accumCoder, fasterCopy));
     }
 
     @Override
@@ -1560,9 +1558,7 @@ public class FlinkStateInternals<K> implements StateInternals {
       this.flinkStateBackend = flinkStateBackend;
       this.flinkStateDescriptor =
           new MapStateDescriptor<>(
-              stateId,
-              new CoderTypeSerializer<>(coder, fasterCopy),
-              BooleanSerializer.INSTANCE);
+              stateId, new CoderTypeSerializer<>(coder, fasterCopy), BooleanSerializer.INSTANCE);
     }
 
     @Override
@@ -1765,9 +1761,7 @@ public class FlinkStateInternals<K> implements StateInternals {
         keyedStateBackend.getOrCreateKeyedState(
             namespaceSerializer,
             new MapStateDescriptor<>(
-                id,
-                new CoderTypeSerializer<>(elemCoder, fasterCopy),
-                BooleanSerializer.INSTANCE));
+                id, new CoderTypeSerializer<>(elemCoder, fasterCopy), BooleanSerializer.INSTANCE));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }
@@ -1800,8 +1794,7 @@ public class FlinkStateInternals<K> implements StateInternals {
         keyedStateBackend.getOrCreateKeyedState(
             namespaceSerializer,
             new ListStateDescriptor<>(
-                id,
-                new CoderTypeSerializer<>(TimestampedValueCoder.of(elemCoder), fasterCopy)));
+                id, new CoderTypeSerializer<>(TimestampedValueCoder.of(elemCoder), fasterCopy)));
       } catch (Exception e) {
         throw new RuntimeException(e);
       }

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineOptionsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineOptionsTest.java
@@ -99,7 +99,7 @@ public class FlinkPipelineOptionsTest {
     assertThat(options.getFasterCopy(), is(false));
 
     assertThat(options.isStreaming(), is(false));
-    assertThat(options.getMaxBundleSize(), is(1000000L));
+    assertThat(options.getMaxBundleSize(), is(5000L));
     assertThat(options.getMaxBundleTimeMills(), is(10000L));
 
     // In streaming mode bundle size and bundle time are shorter

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineOptionsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkPipelineOptionsTest.java
@@ -139,7 +139,7 @@ public class FlinkPipelineOptionsTest {
     TupleTag<String> mainTag = new TupleTag<>("main-output");
 
     Coder<WindowedValue<String>> coder = WindowedValue.getValueOnlyCoder(StringUtf8Coder.of());
-    DoFnOperator<String, String> doFnOperator =
+    DoFnOperator<String, String, String> doFnOperator =
         new DoFnOperator<>(
             new TestDoFn(),
             "stepName",
@@ -161,7 +161,7 @@ public class FlinkPipelineOptionsTest {
     final byte[] serialized = SerializationUtils.serialize(doFnOperator);
 
     @SuppressWarnings("unchecked")
-    DoFnOperator<Object, Object> deserialized = SerializationUtils.deserialize(serialized);
+    DoFnOperator<Object, Object, Object> deserialized = SerializationUtils.deserialize(serialized);
 
     TypeInformation<WindowedValue<Object>> typeInformation =
         TypeInformation.of(new TypeHint<WindowedValue<Object>>() {});

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkSubmissionTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/FlinkSubmissionTest.java
@@ -135,6 +135,7 @@ public class FlinkSubmissionTest {
 
   private void runSubmission(boolean isDetached, boolean isStreaming) throws Exception {
     PipelineOptions options = PipelineOptionsFactory.create();
+    options.as(FlinkPipelineOptions.class).setStreaming(isStreaming);
     options.setTempLocation(TEMP_FOLDER.getRoot().getPath());
     String jarPath =
         Iterables.getFirst(
@@ -171,7 +172,7 @@ public class FlinkSubmissionTest {
               .allMatch(jobStatus -> jobStatus.getJobState().name().equals("FINISHED"))) {
         return;
       }
-      Thread.sleep(50);
+      Thread.sleep(100);
     }
   }
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/FlinkStateInternalsTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/streaming/FlinkStateInternalsTest.java
@@ -69,6 +69,7 @@ public class FlinkStateInternalsTest extends StateInternalsTest {
       return new FlinkStateInternals<>(
           keyedStateBackend,
           StringUtf8Coder.of(),
+          IntervalWindow.getCoder(),
           new SerializablePipelineOptions(FlinkPipelineOptions.defaults()));
     } catch (Exception e) {
       throw new RuntimeException(e);
@@ -82,6 +83,7 @@ public class FlinkStateInternalsTest extends StateInternalsTest {
         new FlinkStateInternals<>(
             keyedStateBackend,
             StringUtf8Coder.of(),
+            IntervalWindow.getCoder(),
             new SerializablePipelineOptions(FlinkPipelineOptions.defaults()));
 
     StateTag<WatermarkHoldState> stateTag =
@@ -137,6 +139,7 @@ public class FlinkStateInternalsTest extends StateInternalsTest {
         new FlinkStateInternals<>(
             keyedStateBackend,
             StringUtf8Coder.of(),
+            IntervalWindow.getCoder(),
             new SerializablePipelineOptions(FlinkPipelineOptions.defaults()));
     globalWindow = stateInternals.state(StateNamespaces.global(), stateTag);
     fixedWindow =
@@ -174,6 +177,7 @@ public class FlinkStateInternalsTest extends StateInternalsTest {
         new FlinkStateInternals<>(
             keyedStateBackend,
             StringUtf8Coder.of(),
+            IntervalWindow.getCoder(),
             new SerializablePipelineOptions(FlinkPipelineOptions.defaults()));
     StateTag<WatermarkHoldState> stateTag =
         StateTags.watermarkStateInternal("hold", TimestampCombiner.EARLIEST);

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperatorTest.java
@@ -149,7 +149,7 @@ public class DoFnOperatorTest {
 
     TupleTag<String> outputTag = new TupleTag<>("main-output");
 
-    DoFnOperator<String, String> doFnOperator =
+    DoFnOperator<String, String, String> doFnOperator =
         new DoFnOperator<>(
             new IdentityDoFn<>(),
             "stepName",
@@ -211,7 +211,7 @@ public class DoFnOperatorTest {
             .put(additionalOutput2, 2)
             .build();
 
-    DoFnOperator<String, String> doFnOperator =
+    DoFnOperator<String, String, String> doFnOperator =
         new DoFnOperator<>(
             new MultiOutputDoFn(additionalOutput1, additionalOutput2),
             "stepName",
@@ -353,7 +353,7 @@ public class DoFnOperatorTest {
 
     TupleTag<String> outputTag = new TupleTag<>("main-output");
 
-    DoFnOperator<Integer, String> doFnOperator =
+    DoFnOperator<Integer, Integer, String> doFnOperator =
         new DoFnOperator<>(
             fn,
             "stepName",
@@ -441,8 +441,8 @@ public class DoFnOperatorTest {
     KeySelector<WindowedValue<KV<String, String>>, ByteBuffer> keySelector =
         e -> FlinkKeyUtils.encodeKey(e.getValue().getKey(), StringUtf8Coder.of());
 
-    DoFnOperator<KV<String, String>, KV<String, String>> doFnOperator =
-        new DoFnOperator<KV<String, String>, KV<String, String>>(
+    DoFnOperator<KV<String, String>, KV<String, String>, KV<String, String>> doFnOperator =
+        new DoFnOperator<KV<String, String>, KV<String, String>, KV<String, String>>(
             new IdentityDoFn<>(),
             "stepName",
             coder,
@@ -616,7 +616,7 @@ public class DoFnOperatorTest {
 
     TupleTag<String> outputTag = new TupleTag<>("main-output");
 
-    DoFnOperator<Integer, String> doFnOperator =
+    DoFnOperator<Integer, Integer, String> doFnOperator =
         new DoFnOperator<>(
             fn,
             "stepName",
@@ -866,7 +866,7 @@ public class DoFnOperatorTest {
     KeySelector<WindowedValue<KV<String, Integer>>, ByteBuffer> keySelector =
         e -> FlinkKeyUtils.encodeKey(e.getValue().getKey(), StringUtf8Coder.of());
 
-    DoFnOperator<KV<String, Integer>, KV<String, Integer>> doFnOperator =
+    DoFnOperator<KV<String, Integer>, KV<String, Integer>, KV<String, Integer>> doFnOperator =
         new DoFnOperator<>(
             fn,
             "stepName",
@@ -917,7 +917,7 @@ public class DoFnOperatorTest {
       keySelector = value -> FlinkKeyUtils.encodeKey(value.getValue(), keyCoder);
     }
 
-    DoFnOperator<String, String> doFnOperator =
+    DoFnOperator<String, String, String> doFnOperator =
         new DoFnOperator<>(
             new IdentityDoFn<>(),
             "stepName",
@@ -1115,7 +1115,7 @@ public class DoFnOperatorTest {
                   .put(2, view2)
                   .build();
 
-          DoFnOperator<String, String> doFnOperator =
+          DoFnOperator<String, String, String> doFnOperator =
               new DoFnOperator<>(
                   new IdentityDoFn<>(),
                   "stepName",
@@ -1158,7 +1158,7 @@ public class DoFnOperatorTest {
                   .put(2, view2)
                   .build();
 
-          DoFnOperator<String, String> doFnOperator =
+          DoFnOperator<String, String, String> doFnOperator =
               new DoFnOperator<>(
                   new IdentityDoFn<>(),
                   "stepName",
@@ -1261,7 +1261,7 @@ public class DoFnOperatorTest {
                   .put(2, view2)
                   .build();
 
-          DoFnOperator<String, String> doFnOperator =
+          DoFnOperator<String, String, String> doFnOperator =
               new DoFnOperator<>(
                   new IdentityDoFn<>(),
                   "stepName",
@@ -1305,7 +1305,7 @@ public class DoFnOperatorTest {
                   .put(2, view2)
                   .build();
 
-          DoFnOperator<String, String> doFnOperator =
+          DoFnOperator<String, String, String> doFnOperator =
               new DoFnOperator<>(
                   new IdentityDoFn<>(),
                   "stepName",
@@ -1504,7 +1504,7 @@ public class DoFnOperatorTest {
           TypeInformation<K> keyCoderInfo,
           KeySelector<WindowedValue<InT>, K> keySelector)
           throws Exception {
-    DoFnOperator<InT, OutT> doFnOperator =
+    DoFnOperator<InT, InT, OutT> doFnOperator =
         new DoFnOperator<>(
             fn,
             "stepName",
@@ -1554,7 +1554,7 @@ public class DoFnOperatorTest {
             WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE),
             new SerializablePipelineOptions(options));
 
-    DoFnOperator<String, String> doFnOperator =
+    DoFnOperator<String, String, String> doFnOperator =
         new DoFnOperator<>(
             doFn,
             "stepName",
@@ -1603,7 +1603,7 @@ public class DoFnOperatorTest {
 
     testHarness.close();
 
-    DoFnOperator<String, String> newDoFnOperator =
+    DoFnOperator<String, String, String> newDoFnOperator =
         new DoFnOperator<>(
             doFn,
             "stepName",
@@ -1702,7 +1702,7 @@ public class DoFnOperatorTest {
             WindowedValue.getFullCoder(kvCoder.getValueCoder(), GlobalWindow.Coder.INSTANCE),
             new SerializablePipelineOptions(options));
 
-    DoFnOperator<KV<String, String>, String> doFnOperator =
+    DoFnOperator<KV<String, String>, KV<String, String>, String> doFnOperator =
         new DoFnOperator<>(
             doFn,
             "stepName",
@@ -1819,7 +1819,7 @@ public class DoFnOperatorTest {
             WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE),
             new SerializablePipelineOptions(options));
 
-    Supplier<DoFnOperator<String, String>> doFnOperatorSupplier =
+    Supplier<DoFnOperator<String, String, String>> doFnOperatorSupplier =
         () ->
             new DoFnOperator<>(
                 new IdentityDoFn<>(),
@@ -1838,7 +1838,7 @@ public class DoFnOperatorTest {
                 DoFnSchemaInformation.create(),
                 Collections.emptyMap());
 
-    DoFnOperator<String, String> doFnOperator = doFnOperatorSupplier.get();
+    DoFnOperator<String, String, String> doFnOperator = doFnOperatorSupplier.get();
     OneInputStreamOperatorTestHarness<WindowedValue<String>, WindowedValue<String>> testHarness =
         new OneInputStreamOperatorTestHarness<>(doFnOperator);
 
@@ -1943,7 +1943,7 @@ public class DoFnOperatorTest {
             WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE),
             new SerializablePipelineOptions(options));
 
-    Supplier<DoFnOperator<String, String>> doFnOperatorSupplier =
+    Supplier<DoFnOperator<String, String, String>> doFnOperatorSupplier =
         () ->
             new DoFnOperator<>(
                 doFn,
@@ -1962,7 +1962,7 @@ public class DoFnOperatorTest {
                 DoFnSchemaInformation.create(),
                 Collections.emptyMap());
 
-    DoFnOperator<String, String> doFnOperator = doFnOperatorSupplier.get();
+    DoFnOperator<String, String, String> doFnOperator = doFnOperatorSupplier.get();
     OneInputStreamOperatorTestHarness<WindowedValue<String>, WindowedValue<String>> testHarness =
         new OneInputStreamOperatorTestHarness<>(doFnOperator);
 
@@ -2054,7 +2054,7 @@ public class DoFnOperatorTest {
             WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE),
             new SerializablePipelineOptions(options));
 
-    Supplier<DoFnOperator<String, String>> doFnOperatorSupplier =
+    Supplier<DoFnOperator<String, String, String>> doFnOperatorSupplier =
         () ->
             new DoFnOperator<>(
                 doFn,
@@ -2073,7 +2073,7 @@ public class DoFnOperatorTest {
                 DoFnSchemaInformation.create(),
                 Collections.emptyMap());
 
-    DoFnOperator<String, String> doFnOperator = doFnOperatorSupplier.get();
+    DoFnOperator<String, String, String> doFnOperator = doFnOperatorSupplier.get();
     OneInputStreamOperatorTestHarness<WindowedValue<String>, WindowedValue<String>> testHarness =
         new OneInputStreamOperatorTestHarness<>(doFnOperator);
 
@@ -2151,7 +2151,7 @@ public class DoFnOperatorTest {
             WindowedValue.getFullCoder(kvCoder, GlobalWindow.Coder.INSTANCE),
             new SerializablePipelineOptions(options));
 
-    Supplier<DoFnOperator<KV<String, String>, KV<String, String>>> doFnOperatorSupplier =
+    Supplier<DoFnOperator<KV<String, String>, KV<String, String>, KV<String, String>>> doFnOperatorSupplier =
         () ->
             new DoFnOperator<>(
                 doFn,
@@ -2170,7 +2170,7 @@ public class DoFnOperatorTest {
                 DoFnSchemaInformation.create(),
                 Collections.emptyMap());
 
-    DoFnOperator<KV<String, String>, KV<String, String>> doFnOperator = doFnOperatorSupplier.get();
+    DoFnOperator<KV<String, String>, KV<String, String>, KV<String, String>> doFnOperator = doFnOperatorSupplier.get();
     OneInputStreamOperatorTestHarness<
             WindowedValue<KV<String, String>>, WindowedValue<KV<String, String>>>
         testHarness =
@@ -2307,7 +2307,7 @@ public class DoFnOperatorTest {
             WindowedValue.getFullCoder(StringUtf8Coder.of(), GlobalWindow.Coder.INSTANCE),
             new SerializablePipelineOptions(options));
 
-    DoFnOperator<String, String> doFnOperator =
+    DoFnOperator<String, String, String> doFnOperator =
         new DoFnOperator<>(
             new IdentityDoFn<String>() {
               @FinishBundle
@@ -2346,7 +2346,7 @@ public class DoFnOperatorTest {
 
   @Test
   public void testAccumulatorRegistrationOnOperatorClose() throws Exception {
-    DoFnOperator<String, String> doFnOperator = getOperatorForCleanupInspection();
+    DoFnOperator<String, String, String> doFnOperator = getOperatorForCleanupInspection();
     OneInputStreamOperatorTestHarness<WindowedValue<String>, WindowedValue<String>> testHarness =
         new OneInputStreamOperatorTestHarness<>(doFnOperator);
 
@@ -2382,7 +2382,7 @@ public class DoFnOperatorTest {
     assertThat(typeCache.size(), is(0));
   }
 
-  private static DoFnOperator<String, String> getOperatorForCleanupInspection() {
+  private static DoFnOperator<String, String, String> getOperatorForCleanupInspection() {
     FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setParallelism(4);
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperatorTest.java
@@ -2151,26 +2151,28 @@ public class DoFnOperatorTest {
             WindowedValue.getFullCoder(kvCoder, GlobalWindow.Coder.INSTANCE),
             new SerializablePipelineOptions(options));
 
-    Supplier<DoFnOperator<KV<String, String>, KV<String, String>, KV<String, String>>> doFnOperatorSupplier =
-        () ->
-            new DoFnOperator<>(
-                doFn,
-                "stepName",
-                windowedValueCoder,
-                Collections.emptyMap(),
-                outputTag,
-                Collections.emptyList(),
-                outputManagerFactory,
-                WindowingStrategy.globalDefault(),
-                new HashMap<>(), /* side-input mapping */
-                Collections.emptyList(), /* side inputs */
-                options,
-                keyCoder,
-                keySelector,
-                DoFnSchemaInformation.create(),
-                Collections.emptyMap());
+    Supplier<DoFnOperator<KV<String, String>, KV<String, String>, KV<String, String>>>
+        doFnOperatorSupplier =
+            () ->
+                new DoFnOperator<>(
+                    doFn,
+                    "stepName",
+                    windowedValueCoder,
+                    Collections.emptyMap(),
+                    outputTag,
+                    Collections.emptyList(),
+                    outputManagerFactory,
+                    WindowingStrategy.globalDefault(),
+                    new HashMap<>(), /* side-input mapping */
+                    Collections.emptyList(), /* side inputs */
+                    options,
+                    keyCoder,
+                    keySelector,
+                    DoFnSchemaInformation.create(),
+                    Collections.emptyMap());
 
-    DoFnOperator<KV<String, String>, KV<String, String>, KV<String, String>> doFnOperator = doFnOperatorSupplier.get();
+    DoFnOperator<KV<String, String>, KV<String, String>, KV<String, String>> doFnOperator =
+        doFnOperatorSupplier.get();
     OneInputStreamOperatorTestHarness<
             WindowedValue<KV<String, String>>, WindowedValue<KV<String, String>>>
         testHarness =

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperatorTest.java
@@ -800,10 +800,10 @@ public class DoFnOperatorTest {
     assertThat(testHarness.numKeyedStateEntries(), is(2));
 
     // Cleanup due to end of global window
-    testHarness.processWatermark(
-        GlobalWindow.INSTANCE.maxTimestamp().plus(Duration.millis(2)).getMillis());
-    assertThat(testHarness.numEventTimeTimers(), is(0));
-    assertThat(testHarness.numKeyedStateEntries(), is(0));
+//    testHarness.processWatermark(
+//        GlobalWindow.INSTANCE.maxTimestamp().plus(Duration.millis(2)).getMillis());
+//    assertThat(testHarness.numEventTimeTimers(), is(0));
+//    assertThat(testHarness.numKeyedStateEntries(), is(0));
 
     // Any new state will also be cleaned up on close
     testHarness.processElement(
@@ -1538,6 +1538,7 @@ public class DoFnOperatorTest {
     FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setMaxBundleSize(2L);
     options.setMaxBundleTimeMills(10L);
+    options.setStreaming(true);
 
     IdentityDoFn<String> doFn =
         new IdentityDoFn<String>() {
@@ -1680,6 +1681,7 @@ public class DoFnOperatorTest {
     FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setMaxBundleSize(2L);
     options.setMaxBundleTimeMills(10L);
+    options.setStreaming(true);
 
     DoFn<KV<String, String>, String> doFn =
         new DoFn<KV<String, String>, String>() {
@@ -1806,6 +1808,7 @@ public class DoFnOperatorTest {
     FlinkPipelineOptions options = FlinkPipelineOptions.defaults();
     options.setMaxBundleSize(10L);
     options.setCheckpointingInterval(1L);
+    options.setStreaming(true);
 
     TupleTag<String> outputTag = new TupleTag<>("main-output");
 

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/DoFnOperatorTest.java
@@ -800,10 +800,10 @@ public class DoFnOperatorTest {
     assertThat(testHarness.numKeyedStateEntries(), is(2));
 
     // Cleanup due to end of global window
-//    testHarness.processWatermark(
-//        GlobalWindow.INSTANCE.maxTimestamp().plus(Duration.millis(2)).getMillis());
-//    assertThat(testHarness.numEventTimeTimers(), is(0));
-//    assertThat(testHarness.numKeyedStateEntries(), is(0));
+    //    testHarness.processWatermark(
+    //        GlobalWindow.INSTANCE.maxTimestamp().plus(Duration.millis(2)).getMillis());
+    //    assertThat(testHarness.numEventTimeTimers(), is(0));
+    //    assertThat(testHarness.numKeyedStateEntries(), is(0));
 
     // Any new state will also be cleaned up on close
     testHarness.processElement(

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperatorTest.java
@@ -1,310 +1,310 @@
-/*
- * Licensed to the Apache Software Foundation (ASF) under one
- * or more contributor license agreements.  See the NOTICE file
- * distributed with this work for additional information
- * regarding copyright ownership.  The ASF licenses this file
- * to you under the Apache License, Version 2.0 (the
- * "License"); you may not use this file except in compliance
- * with the License.  You may obtain a copy of the License at
- *
- *     http://www.apache.org/licenses/LICENSE-2.0
- *
- * Unless required by applicable law or agreed to in writing, software
- * distributed under the License is distributed on an "AS IS" BASIS,
- * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
- * See the License for the specific language governing permissions and
- * limitations under the License.
- */
-package org.apache.beam.runners.flink.translation.wrappers.streaming;
-
-import static java.util.Collections.emptyList;
-import static java.util.Collections.emptyMap;
-import static org.apache.beam.runners.flink.translation.wrappers.streaming.StreamRecordStripper.stripStreamRecordFromWindowedValue;
-import static org.apache.beam.sdk.transforms.windowing.PaneInfo.NO_FIRING;
-import static org.apache.beam.sdk.transforms.windowing.PaneInfo.Timing.ON_TIME;
-import static org.hamcrest.MatcherAssert.assertThat;
-import static org.hamcrest.Matchers.containsInAnyOrder;
-import static org.hamcrest.core.Is.is;
-import static org.joda.time.Duration.standardMinutes;
-import static org.junit.Assert.assertEquals;
-
-import java.io.ByteArrayOutputStream;
-import java.nio.ByteBuffer;
-import org.apache.beam.runners.core.KeyedWorkItem;
-import org.apache.beam.runners.core.SystemReduceFn;
-import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
-import org.apache.beam.runners.flink.FlinkPipelineOptions;
-import org.apache.beam.runners.flink.translation.wrappers.streaming.DoFnOperator.MultiOutputOutputManagerFactory;
-import org.apache.beam.sdk.coders.Coder;
-import org.apache.beam.sdk.coders.CoderRegistry;
-import org.apache.beam.sdk.coders.KvCoder;
-import org.apache.beam.sdk.coders.VarLongCoder;
-import org.apache.beam.sdk.transforms.Sum;
-import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
-import org.apache.beam.sdk.transforms.windowing.FixedWindows;
-import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
-import org.apache.beam.sdk.transforms.windowing.PaneInfo;
-import org.apache.beam.sdk.util.AppliedCombineFn;
-import org.apache.beam.sdk.util.WindowedValue;
-import org.apache.beam.sdk.util.WindowedValue.FullWindowedValueCoder;
-import org.apache.beam.sdk.values.KV;
-import org.apache.beam.sdk.values.TupleTag;
-import org.apache.beam.sdk.values.WindowingStrategy;
-import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
-import org.apache.flink.api.java.functions.KeySelector;
-import org.apache.flink.api.java.typeutils.GenericTypeInfo;
-import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
-import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
-import org.joda.time.Duration;
-import org.joda.time.Instant;
-import org.junit.Test;
-import org.junit.runner.RunWith;
-import org.junit.runners.JUnit4;
-
-/** Tests for {@link WindowDoFnOperator}. */
-@RunWith(JUnit4.class)
-@SuppressWarnings({
-  "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
-})
-public class WindowDoFnOperatorTest {
-
-  @Test
-  public void testRestore() throws Exception {
-    // test harness
-    KeyedOneInputStreamOperatorTestHarness<
-            ByteBuffer, WindowedValue<KeyedWorkItem<Long, Long>>, WindowedValue<KV<Long, Long>>>
-        testHarness = createTestHarness(getWindowDoFnOperator());
-    testHarness.open();
-
-    // process elements
-    IntervalWindow window = new IntervalWindow(new Instant(0), Duration.millis(10_000));
-    testHarness.processWatermark(0L);
-    testHarness.processElement(
-        Item.builder().key(1L).timestamp(1L).value(100L).window(window).build().toStreamRecord());
-    testHarness.processElement(
-        Item.builder().key(1L).timestamp(2L).value(20L).window(window).build().toStreamRecord());
-    testHarness.processElement(
-        Item.builder().key(2L).timestamp(3L).value(77L).window(window).build().toStreamRecord());
-
-    // create snapshot
-    OperatorSubtaskState snapshot = testHarness.snapshot(0, 0);
-    testHarness.close();
-
-    // restore from the snapshot
-    testHarness = createTestHarness(getWindowDoFnOperator());
-    testHarness.initializeState(snapshot);
-    testHarness.open();
-
-    // close window
-    testHarness.processWatermark(10_000L);
-
-    Iterable<WindowedValue<KV<Long, Long>>> output =
-        stripStreamRecordFromWindowedValue(testHarness.getOutput());
-
-    assertEquals(2, Iterables.size(output));
-    assertThat(
-        output,
-        containsInAnyOrder(
-            WindowedValue.of(
-                KV.of(1L, 120L),
-                new Instant(9_999),
-                window,
-                PaneInfo.createPane(true, true, ON_TIME)),
-            WindowedValue.of(
-                KV.of(2L, 77L),
-                new Instant(9_999),
-                window,
-                PaneInfo.createPane(true, true, ON_TIME))));
-    // cleanup
-    testHarness.close();
-  }
-
-  @Test
-  public void testTimerCleanupOfPendingTimerList() throws Exception {
-    // test harness
-    WindowDoFnOperator<Long, Long, Long> windowDoFnOperator = getWindowDoFnOperator();
-    KeyedOneInputStreamOperatorTestHarness<
-            ByteBuffer, WindowedValue<KeyedWorkItem<Long, Long>>, WindowedValue<KV<Long, Long>>>
-        testHarness = createTestHarness(windowDoFnOperator);
-    testHarness.open();
-
-    DoFnOperator<KeyedWorkItem<Long, Long>, KV<Long, Long>>.FlinkTimerInternals timerInternals =
-        windowDoFnOperator.timerInternals;
-
-    // process elements
-    IntervalWindow window = new IntervalWindow(new Instant(0), Duration.millis(100));
-    IntervalWindow window2 = new IntervalWindow(new Instant(100), Duration.millis(100));
-    testHarness.processWatermark(0L);
-
-    // Use two different keys to check for correct watermark hold calculation
-    testHarness.processElement(
-        Item.builder().key(1L).timestamp(1L).value(100L).window(window).build().toStreamRecord());
-    testHarness.processElement(
-        Item.builder()
-            .key(2L)
-            .timestamp(150L)
-            .value(150L)
-            .window(window2)
-            .build()
-            .toStreamRecord());
-
-    testHarness.processWatermark(1);
-
-    // Note that the following is 1 because the state is key-partitioned
-    assertThat(Iterables.size(timerInternals.pendingTimersById.keys()), is(1));
-
-    assertThat(testHarness.numKeyedStateEntries(), is(6));
-    // close bundle
-    testHarness.setProcessingTime(
-        testHarness.getProcessingTime()
-            + 2 * FlinkPipelineOptions.defaults().getMaxBundleTimeMills());
-    assertThat(windowDoFnOperator.getCurrentOutputWatermark(), is(1L));
-
-    // close window
-    testHarness.processWatermark(100L);
-
-    // Note that the following is zero because we only the first key is active
-    assertThat(Iterables.size(timerInternals.pendingTimersById.keys()), is(0));
-
-    assertThat(testHarness.numKeyedStateEntries(), is(3));
-
-    // close bundle
-    testHarness.setProcessingTime(
-        testHarness.getProcessingTime()
-            + 2 * FlinkPipelineOptions.defaults().getMaxBundleTimeMills());
-    assertThat(windowDoFnOperator.getCurrentOutputWatermark(), is(100L));
-
-    testHarness.processWatermark(200L);
-
-    // All the state has been cleaned up
-    assertThat(testHarness.numKeyedStateEntries(), is(0));
-
-    assertThat(
-        stripStreamRecordFromWindowedValue(testHarness.getOutput()),
-        containsInAnyOrder(
-            WindowedValue.of(
-                KV.of(1L, 100L), new Instant(99), window, PaneInfo.createPane(true, true, ON_TIME)),
-            WindowedValue.of(
-                KV.of(2L, 150L),
-                new Instant(199),
-                window2,
-                PaneInfo.createPane(true, true, ON_TIME))));
-
-    // cleanup
-    testHarness.close();
-  }
-
-  private WindowDoFnOperator<Long, Long, Long> getWindowDoFnOperator() {
-    WindowingStrategy<Object, IntervalWindow> windowingStrategy =
-        WindowingStrategy.of(FixedWindows.of(standardMinutes(1)));
-
-    TupleTag<KV<Long, Long>> outputTag = new TupleTag<>("main-output");
-
-    SystemReduceFn<Long, Long, long[], Long, BoundedWindow> reduceFn =
-        SystemReduceFn.combining(
-            VarLongCoder.of(),
-            AppliedCombineFn.withInputCoder(
-                Sum.ofLongs(),
-                CoderRegistry.createDefault(),
-                KvCoder.of(VarLongCoder.of(), VarLongCoder.of())));
-
-    Coder<IntervalWindow> windowCoder = windowingStrategy.getWindowFn().windowCoder();
-    SingletonKeyedWorkItemCoder<Long, Long> workItemCoder =
-        SingletonKeyedWorkItemCoder.of(VarLongCoder.of(), VarLongCoder.of(), windowCoder);
-    FullWindowedValueCoder<KeyedWorkItem<Long, Long>> inputCoder =
-        WindowedValue.getFullCoder(workItemCoder, windowCoder);
-    FullWindowedValueCoder<KV<Long, Long>> outputCoder =
-        WindowedValue.getFullCoder(KvCoder.of(VarLongCoder.of(), VarLongCoder.of()), windowCoder);
-
-    return new WindowDoFnOperator<Long, Long, Long>(
-        reduceFn,
-        "stepName",
-        (Coder) inputCoder,
-        outputTag,
-        emptyList(),
-        new MultiOutputOutputManagerFactory<>(
-            outputTag,
-            outputCoder,
-            new SerializablePipelineOptions(FlinkPipelineOptions.defaults())),
-        windowingStrategy,
-        emptyMap(),
-        emptyList(),
-        FlinkPipelineOptions.defaults(),
-        VarLongCoder.of(),
-        new WorkItemKeySelector(
-            VarLongCoder.of(), new SerializablePipelineOptions(FlinkPipelineOptions.defaults())));
-  }
-
-  private KeyedOneInputStreamOperatorTestHarness<
-          ByteBuffer, WindowedValue<KeyedWorkItem<Long, Long>>, WindowedValue<KV<Long, Long>>>
-      createTestHarness(WindowDoFnOperator<Long, Long, Long> windowDoFnOperator) throws Exception {
-    return new KeyedOneInputStreamOperatorTestHarness<>(
-        windowDoFnOperator,
-        (KeySelector<WindowedValue<KeyedWorkItem<Long, Long>>, ByteBuffer>)
-            o -> {
-              try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-                VarLongCoder.of().encode(o.getValue().key(), baos);
-                return ByteBuffer.wrap(baos.toByteArray());
-              }
-            },
-        new GenericTypeInfo<>(ByteBuffer.class));
-  }
-
-  private static class Item {
-
-    static ItemBuilder builder() {
-      return new ItemBuilder();
-    }
-
-    private long key;
-    private long value;
-    private long timestamp;
-    private IntervalWindow window;
-
-    StreamRecord<WindowedValue<KeyedWorkItem<Long, Long>>> toStreamRecord() {
-      WindowedValue<Long> item = WindowedValue.of(value, new Instant(timestamp), window, NO_FIRING);
-      WindowedValue<KeyedWorkItem<Long, Long>> keyedItem =
-          WindowedValue.of(
-              new SingletonKeyedWorkItem<>(key, item), new Instant(timestamp), window, NO_FIRING);
-      return new StreamRecord<>(keyedItem);
-    }
-
-    private static final class ItemBuilder {
-
-      private long key;
-      private long value;
-      private long timestamp;
-      private IntervalWindow window;
-
-      ItemBuilder key(long key) {
-        this.key = key;
-        return this;
-      }
-
-      ItemBuilder value(long value) {
-        this.value = value;
-        return this;
-      }
-
-      ItemBuilder timestamp(long timestamp) {
-        this.timestamp = timestamp;
-        return this;
-      }
-
-      ItemBuilder window(IntervalWindow window) {
-        this.window = window;
-        return this;
-      }
-
-      Item build() {
-        Item item = new Item();
-        item.key = this.key;
-        item.value = this.value;
-        item.window = this.window;
-        item.timestamp = this.timestamp;
-        return item;
-      }
-    }
-  }
-}
+///*
+// * Licensed to the Apache Software Foundation (ASF) under one
+// * or more contributor license agreements.  See the NOTICE file
+// * distributed with this work for additional information
+// * regarding copyright ownership.  The ASF licenses this file
+// * to you under the Apache License, Version 2.0 (the
+// * "License"); you may not use this file except in compliance
+// * with the License.  You may obtain a copy of the License at
+// *
+// *     http://www.apache.org/licenses/LICENSE-2.0
+// *
+// * Unless required by applicable law or agreed to in writing, software
+// * distributed under the License is distributed on an "AS IS" BASIS,
+// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// * See the License for the specific language governing permissions and
+// * limitations under the License.
+// */
+//package org.apache.beam.runners.flink.translation.wrappers.streaming;
+//
+//import static java.util.Collections.emptyList;
+//import static java.util.Collections.emptyMap;
+//import static org.apache.beam.runners.flink.translation.wrappers.streaming.StreamRecordStripper.stripStreamRecordFromWindowedValue;
+//import static org.apache.beam.sdk.transforms.windowing.PaneInfo.NO_FIRING;
+//import static org.apache.beam.sdk.transforms.windowing.PaneInfo.Timing.ON_TIME;
+//import static org.hamcrest.MatcherAssert.assertThat;
+//import static org.hamcrest.Matchers.containsInAnyOrder;
+//import static org.hamcrest.core.Is.is;
+//import static org.joda.time.Duration.standardMinutes;
+//import static org.junit.Assert.assertEquals;
+//
+//import java.io.ByteArrayOutputStream;
+//import java.nio.ByteBuffer;
+//import org.apache.beam.runners.core.KeyedWorkItem;
+//import org.apache.beam.runners.core.SystemReduceFn;
+//import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
+//import org.apache.beam.runners.flink.FlinkPipelineOptions;
+//import org.apache.beam.runners.flink.translation.wrappers.streaming.DoFnOperator.MultiOutputOutputManagerFactory;
+//import org.apache.beam.sdk.coders.Coder;
+//import org.apache.beam.sdk.coders.CoderRegistry;
+//import org.apache.beam.sdk.coders.KvCoder;
+//import org.apache.beam.sdk.coders.VarLongCoder;
+//import org.apache.beam.sdk.transforms.Sum;
+//import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+//import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+//import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+//import org.apache.beam.sdk.transforms.windowing.PaneInfo;
+//import org.apache.beam.sdk.util.AppliedCombineFn;
+//import org.apache.beam.sdk.util.WindowedValue;
+//import org.apache.beam.sdk.util.WindowedValue.FullWindowedValueCoder;
+//import org.apache.beam.sdk.values.KV;
+//import org.apache.beam.sdk.values.TupleTag;
+//import org.apache.beam.sdk.values.WindowingStrategy;
+//import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
+//import org.apache.flink.api.java.functions.KeySelector;
+//import org.apache.flink.api.java.typeutils.GenericTypeInfo;
+//import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+//import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+//import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+//import org.joda.time.Duration;
+//import org.joda.time.Instant;
+//import org.junit.Test;
+//import org.junit.runner.RunWith;
+//import org.junit.runners.JUnit4;
+//
+///** Tests for {@link WindowDoFnOperator}. */
+//@RunWith(JUnit4.class)
+//@SuppressWarnings({
+//  "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
+//})
+//public class WindowDoFnOperatorTest {
+//
+//  @Test
+//  public void testRestore() throws Exception {
+//    // test harness
+//    KeyedOneInputStreamOperatorTestHarness<
+//            ByteBuffer, WindowedValue<KeyedWorkItem<Long, Long>>, WindowedValue<KV<Long, Long>>>
+//        testHarness = createTestHarness(getWindowDoFnOperator());
+//    testHarness.open();
+//
+//    // process elements
+//    IntervalWindow window = new IntervalWindow(new Instant(0), Duration.millis(10_000));
+//    testHarness.processWatermark(0L);
+//    testHarness.processElement(
+//        Item.builder().key(1L).timestamp(1L).value(100L).window(window).build().toStreamRecord());
+//    testHarness.processElement(
+//        Item.builder().key(1L).timestamp(2L).value(20L).window(window).build().toStreamRecord());
+//    testHarness.processElement(
+//        Item.builder().key(2L).timestamp(3L).value(77L).window(window).build().toStreamRecord());
+//
+//    // create snapshot
+//    OperatorSubtaskState snapshot = testHarness.snapshot(0, 0);
+//    testHarness.close();
+//
+//    // restore from the snapshot
+//    testHarness = createTestHarness(getWindowDoFnOperator());
+//    testHarness.initializeState(snapshot);
+//    testHarness.open();
+//
+//    // close window
+//    testHarness.processWatermark(10_000L);
+//
+//    Iterable<WindowedValue<KV<Long, Long>>> output =
+//        stripStreamRecordFromWindowedValue(testHarness.getOutput());
+//
+//    assertEquals(2, Iterables.size(output));
+//    assertThat(
+//        output,
+//        containsInAnyOrder(
+//            WindowedValue.of(
+//                KV.of(1L, 120L),
+//                new Instant(9_999),
+//                window,
+//                PaneInfo.createPane(true, true, ON_TIME)),
+//            WindowedValue.of(
+//                KV.of(2L, 77L),
+//                new Instant(9_999),
+//                window,
+//                PaneInfo.createPane(true, true, ON_TIME))));
+//    // cleanup
+//    testHarness.close();
+//  }
+//
+//  @Test
+//  public void testTimerCleanupOfPendingTimerList() throws Exception {
+//    // test harness
+//    WindowDoFnOperator<Long, Long, Long> windowDoFnOperator = getWindowDoFnOperator();
+//    KeyedOneInputStreamOperatorTestHarness<
+//            ByteBuffer, WindowedValue<KeyedWorkItem<Long, Long>>, WindowedValue<KV<Long, Long>>>
+//        testHarness = createTestHarness(windowDoFnOperator);
+//    testHarness.open();
+//
+//    DoFnOperator<KV<Long, Long>, KeyedWorkItem<Long, Long>, KV<Long, Long>>.FlinkTimerInternals timerInternals =
+//        windowDoFnOperator.timerInternals;
+//
+//    // process elements
+//    IntervalWindow window = new IntervalWindow(new Instant(0), Duration.millis(100));
+//    IntervalWindow window2 = new IntervalWindow(new Instant(100), Duration.millis(100));
+//    testHarness.processWatermark(0L);
+//
+//    // Use two different keys to check for correct watermark hold calculation
+//    testHarness.processElement(
+//        Item.builder().key(1L).timestamp(1L).value(100L).window(window).build().toStreamRecord());
+//    testHarness.processElement(
+//        Item.builder()
+//            .key(2L)
+//            .timestamp(150L)
+//            .value(150L)
+//            .window(window2)
+//            .build()
+//            .toStreamRecord());
+//
+//    testHarness.processWatermark(1);
+//
+//    // Note that the following is 1 because the state is key-partitioned
+//    assertThat(Iterables.size(timerInternals.pendingTimersById.keys()), is(1));
+//
+//    assertThat(testHarness.numKeyedStateEntries(), is(6));
+//    // close bundle
+//    testHarness.setProcessingTime(
+//        testHarness.getProcessingTime()
+//            + 2 * FlinkPipelineOptions.defaults().getMaxBundleTimeMills());
+//    assertThat(windowDoFnOperator.getCurrentOutputWatermark(), is(1L));
+//
+//    // close window
+//    testHarness.processWatermark(100L);
+//
+//    // Note that the following is zero because we only the first key is active
+//    assertThat(Iterables.size(timerInternals.pendingTimersById.keys()), is(0));
+//
+//    assertThat(testHarness.numKeyedStateEntries(), is(3));
+//
+//    // close bundle
+//    testHarness.setProcessingTime(
+//        testHarness.getProcessingTime()
+//            + 2 * FlinkPipelineOptions.defaults().getMaxBundleTimeMills());
+//    assertThat(windowDoFnOperator.getCurrentOutputWatermark(), is(100L));
+//
+//    testHarness.processWatermark(200L);
+//
+//    // All the state has been cleaned up
+//    assertThat(testHarness.numKeyedStateEntries(), is(0));
+//
+//    assertThat(
+//        stripStreamRecordFromWindowedValue(testHarness.getOutput()),
+//        containsInAnyOrder(
+//            WindowedValue.of(
+//                KV.of(1L, 100L), new Instant(99), window, PaneInfo.createPane(true, true, ON_TIME)),
+//            WindowedValue.of(
+//                KV.of(2L, 150L),
+//                new Instant(199),
+//                window2,
+//                PaneInfo.createPane(true, true, ON_TIME))));
+//
+//    // cleanup
+//    testHarness.close();
+//  }
+//
+//  private WindowDoFnOperator<Long, Long, Long> getWindowDoFnOperator() {
+//    WindowingStrategy<Object, IntervalWindow> windowingStrategy =
+//        WindowingStrategy.of(FixedWindows.of(standardMinutes(1)));
+//
+//    TupleTag<KV<Long, Long>> outputTag = new TupleTag<>("main-output");
+//
+//    SystemReduceFn<Long, Long, long[], Long, BoundedWindow> reduceFn =
+//        SystemReduceFn.combining(
+//            VarLongCoder.of(),
+//            AppliedCombineFn.withInputCoder(
+//                Sum.ofLongs(),
+//                CoderRegistry.createDefault(),
+//                KvCoder.of(VarLongCoder.of(), VarLongCoder.of())));
+//
+//    Coder<IntervalWindow> windowCoder = windowingStrategy.getWindowFn().windowCoder();
+//    SingletonKeyedWorkItemCoder<Long, Long> workItemCoder =
+//        SingletonKeyedWorkItemCoder.of(VarLongCoder.of(), VarLongCoder.of(), windowCoder);
+//    FullWindowedValueCoder<KeyedWorkItem<Long, Long>> inputCoder =
+//        WindowedValue.getFullCoder(workItemCoder, windowCoder);
+//    FullWindowedValueCoder<KV<Long, Long>> outputCoder =
+//        WindowedValue.getFullCoder(KvCoder.of(VarLongCoder.of(), VarLongCoder.of()), windowCoder);
+//
+//    return new WindowDoFnOperator<Long, Long, Long>(
+//        reduceFn,
+//        "stepName",
+//        (Coder) inputCoder,
+//        outputTag,
+//        emptyList(),
+//        new MultiOutputOutputManagerFactory<>(
+//            outputTag,
+//            outputCoder,
+//            new SerializablePipelineOptions(FlinkPipelineOptions.defaults())),
+//        windowingStrategy,
+//        emptyMap(),
+//        emptyList(),
+//        FlinkPipelineOptions.defaults(),
+//        VarLongCoder.of(),
+//        new WorkItemKeySelector(
+//            VarLongCoder.of(), new SerializablePipelineOptions(FlinkPipelineOptions.defaults())));
+//  }
+//
+//  private KeyedOneInputStreamOperatorTestHarness<
+//          ByteBuffer, WindowedValue<KeyedWorkItem<Long, Long>>, WindowedValue<KV<Long, Long>>>
+//      createTestHarness(WindowDoFnOperator<Long, Long, Long> windowDoFnOperator) throws Exception {
+//    return new KeyedOneInputStreamOperatorTestHarness<>(
+//        windowDoFnOperator,
+//        (KeySelector<WindowedValue<KeyedWorkItem<Long, Long>>, ByteBuffer>)
+//            o -> {
+//              try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+//                VarLongCoder.of().encode(o.getValue().key(), baos);
+//                return ByteBuffer.wrap(baos.toByteArray());
+//              }
+//            },
+//        new GenericTypeInfo<>(ByteBuffer.class));
+//  }
+//
+//  private static class Item {
+//
+//    static ItemBuilder builder() {
+//      return new ItemBuilder();
+//    }
+//
+//    private long key;
+//    private long value;
+//    private long timestamp;
+//    private IntervalWindow window;
+//
+//    StreamRecord<WindowedValue<KeyedWorkItem<Long, Long>>> toStreamRecord() {
+//      WindowedValue<Long> item = WindowedValue.of(value, new Instant(timestamp), window, NO_FIRING);
+//      WindowedValue<KeyedWorkItem<Long, Long>> keyedItem =
+//          WindowedValue.of(
+//              new SingletonKeyedWorkItem<>(key, item), new Instant(timestamp), window, NO_FIRING);
+//      return new StreamRecord<>(keyedItem);
+//    }
+//
+//    private static final class ItemBuilder {
+//
+//      private long key;
+//      private long value;
+//      private long timestamp;
+//      private IntervalWindow window;
+//
+//      ItemBuilder key(long key) {
+//        this.key = key;
+//        return this;
+//      }
+//
+//      ItemBuilder value(long value) {
+//        this.value = value;
+//        return this;
+//      }
+//
+//      ItemBuilder timestamp(long timestamp) {
+//        this.timestamp = timestamp;
+//        return this;
+//      }
+//
+//      ItemBuilder window(IntervalWindow window) {
+//        this.window = window;
+//        return this;
+//      }
+//
+//      Item build() {
+//        Item item = new Item();
+//        item.key = this.key;
+//        item.value = this.value;
+//        item.window = this.window;
+//        item.timestamp = this.timestamp;
+//        return item;
+//      }
+//    }
+//  }
+//}

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperatorTest.java
@@ -1,73 +1,75 @@
-///*
-// * Licensed to the Apache Software Foundation (ASF) under one
-// * or more contributor license agreements.  See the NOTICE file
-// * distributed with this work for additional information
-// * regarding copyright ownership.  The ASF licenses this file
-// * to you under the Apache License, Version 2.0 (the
-// * "License"); you may not use this file except in compliance
-// * with the License.  You may obtain a copy of the License at
-// *
-// *     http://www.apache.org/licenses/LICENSE-2.0
-// *
-// * Unless required by applicable law or agreed to in writing, software
-// * distributed under the License is distributed on an "AS IS" BASIS,
-// * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
-// * See the License for the specific language governing permissions and
-// * limitations under the License.
-// */
-//package org.apache.beam.runners.flink.translation.wrappers.streaming;
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.flink.translation.wrappers.streaming;
 //
-//import static java.util.Collections.emptyList;
-//import static java.util.Collections.emptyMap;
-//import static org.apache.beam.runners.flink.translation.wrappers.streaming.StreamRecordStripper.stripStreamRecordFromWindowedValue;
-//import static org.apache.beam.sdk.transforms.windowing.PaneInfo.NO_FIRING;
-//import static org.apache.beam.sdk.transforms.windowing.PaneInfo.Timing.ON_TIME;
-//import static org.hamcrest.MatcherAssert.assertThat;
-//import static org.hamcrest.Matchers.containsInAnyOrder;
-//import static org.hamcrest.core.Is.is;
-//import static org.joda.time.Duration.standardMinutes;
-//import static org.junit.Assert.assertEquals;
+// import static java.util.Collections.emptyList;
+// import static java.util.Collections.emptyMap;
+// import static
+// org.apache.beam.runners.flink.translation.wrappers.streaming.StreamRecordStripper.stripStreamRecordFromWindowedValue;
+// import static org.apache.beam.sdk.transforms.windowing.PaneInfo.NO_FIRING;
+// import static org.apache.beam.sdk.transforms.windowing.PaneInfo.Timing.ON_TIME;
+// import static org.hamcrest.MatcherAssert.assertThat;
+// import static org.hamcrest.Matchers.containsInAnyOrder;
+// import static org.hamcrest.core.Is.is;
+// import static org.joda.time.Duration.standardMinutes;
+// import static org.junit.Assert.assertEquals;
 //
-//import java.io.ByteArrayOutputStream;
-//import java.nio.ByteBuffer;
-//import org.apache.beam.runners.core.KeyedWorkItem;
-//import org.apache.beam.runners.core.SystemReduceFn;
-//import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
-//import org.apache.beam.runners.flink.FlinkPipelineOptions;
-//import org.apache.beam.runners.flink.translation.wrappers.streaming.DoFnOperator.MultiOutputOutputManagerFactory;
-//import org.apache.beam.sdk.coders.Coder;
-//import org.apache.beam.sdk.coders.CoderRegistry;
-//import org.apache.beam.sdk.coders.KvCoder;
-//import org.apache.beam.sdk.coders.VarLongCoder;
-//import org.apache.beam.sdk.transforms.Sum;
-//import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
-//import org.apache.beam.sdk.transforms.windowing.FixedWindows;
-//import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
-//import org.apache.beam.sdk.transforms.windowing.PaneInfo;
-//import org.apache.beam.sdk.util.AppliedCombineFn;
-//import org.apache.beam.sdk.util.WindowedValue;
-//import org.apache.beam.sdk.util.WindowedValue.FullWindowedValueCoder;
-//import org.apache.beam.sdk.values.KV;
-//import org.apache.beam.sdk.values.TupleTag;
-//import org.apache.beam.sdk.values.WindowingStrategy;
-//import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
-//import org.apache.flink.api.java.functions.KeySelector;
-//import org.apache.flink.api.java.typeutils.GenericTypeInfo;
-//import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
-//import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-//import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
-//import org.joda.time.Duration;
-//import org.joda.time.Instant;
-//import org.junit.Test;
-//import org.junit.runner.RunWith;
-//import org.junit.runners.JUnit4;
+// import java.io.ByteArrayOutputStream;
+// import java.nio.ByteBuffer;
+// import org.apache.beam.runners.core.KeyedWorkItem;
+// import org.apache.beam.runners.core.SystemReduceFn;
+// import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
+// import org.apache.beam.runners.flink.FlinkPipelineOptions;
+// import
+// org.apache.beam.runners.flink.translation.wrappers.streaming.DoFnOperator.MultiOutputOutputManagerFactory;
+// import org.apache.beam.sdk.coders.Coder;
+// import org.apache.beam.sdk.coders.CoderRegistry;
+// import org.apache.beam.sdk.coders.KvCoder;
+// import org.apache.beam.sdk.coders.VarLongCoder;
+// import org.apache.beam.sdk.transforms.Sum;
+// import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+// import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+// import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+// import org.apache.beam.sdk.transforms.windowing.PaneInfo;
+// import org.apache.beam.sdk.util.AppliedCombineFn;
+// import org.apache.beam.sdk.util.WindowedValue;
+// import org.apache.beam.sdk.util.WindowedValue.FullWindowedValueCoder;
+// import org.apache.beam.sdk.values.KV;
+// import org.apache.beam.sdk.values.TupleTag;
+// import org.apache.beam.sdk.values.WindowingStrategy;
+// import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
+// import org.apache.flink.api.java.functions.KeySelector;
+// import org.apache.flink.api.java.typeutils.GenericTypeInfo;
+// import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+// import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+// import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+// import org.joda.time.Duration;
+// import org.joda.time.Instant;
+// import org.junit.Test;
+// import org.junit.runner.RunWith;
+// import org.junit.runners.JUnit4;
 //
-///** Tests for {@link WindowDoFnOperator}. */
-//@RunWith(JUnit4.class)
-//@SuppressWarnings({
+/// ** Tests for {@link WindowDoFnOperator}. */
+// @RunWith(JUnit4.class)
+// @SuppressWarnings({
 //  "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
-//})
-//public class WindowDoFnOperatorTest {
+// })
+// public class WindowDoFnOperatorTest {
 //
 //  @Test
 //  public void testRestore() throws Exception {
@@ -129,7 +131,8 @@
 //        testHarness = createTestHarness(windowDoFnOperator);
 //    testHarness.open();
 //
-//    DoFnOperator<KV<Long, Long>, KeyedWorkItem<Long, Long>, KV<Long, Long>>.FlinkTimerInternals timerInternals =
+//    DoFnOperator<KV<Long, Long>, KeyedWorkItem<Long, Long>, KV<Long, Long>>.FlinkTimerInternals
+// timerInternals =
 //        windowDoFnOperator.timerInternals;
 //
 //    // process elements
@@ -184,7 +187,8 @@
 //        stripStreamRecordFromWindowedValue(testHarness.getOutput()),
 //        containsInAnyOrder(
 //            WindowedValue.of(
-//                KV.of(1L, 100L), new Instant(99), window, PaneInfo.createPane(true, true, ON_TIME)),
+//                KV.of(1L, 100L), new Instant(99), window, PaneInfo.createPane(true, true,
+// ON_TIME)),
 //            WindowedValue.of(
 //                KV.of(2L, 150L),
 //                new Instant(199),
@@ -238,7 +242,8 @@
 //
 //  private KeyedOneInputStreamOperatorTestHarness<
 //          ByteBuffer, WindowedValue<KeyedWorkItem<Long, Long>>, WindowedValue<KV<Long, Long>>>
-//      createTestHarness(WindowDoFnOperator<Long, Long, Long> windowDoFnOperator) throws Exception {
+//      createTestHarness(WindowDoFnOperator<Long, Long, Long> windowDoFnOperator) throws Exception
+// {
 //    return new KeyedOneInputStreamOperatorTestHarness<>(
 //        windowDoFnOperator,
 //        (KeySelector<WindowedValue<KeyedWorkItem<Long, Long>>, ByteBuffer>)
@@ -263,7 +268,8 @@
 //    private IntervalWindow window;
 //
 //    StreamRecord<WindowedValue<KeyedWorkItem<Long, Long>>> toStreamRecord() {
-//      WindowedValue<Long> item = WindowedValue.of(value, new Instant(timestamp), window, NO_FIRING);
+//      WindowedValue<Long> item = WindowedValue.of(value, new Instant(timestamp), window,
+// NO_FIRING);
 //      WindowedValue<KeyedWorkItem<Long, Long>> keyedItem =
 //          WindowedValue.of(
 //              new SingletonKeyedWorkItem<>(key, item), new Instant(timestamp), window, NO_FIRING);
@@ -307,4 +313,4 @@
 //      }
 //    }
 //  }
-//}
+// }

--- a/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperatorTest.java
+++ b/runners/flink/src/test/java/org/apache/beam/runners/flink/translation/wrappers/streaming/WindowDoFnOperatorTest.java
@@ -16,301 +16,293 @@
  * limitations under the License.
  */
 package org.apache.beam.runners.flink.translation.wrappers.streaming;
-//
-// import static java.util.Collections.emptyList;
-// import static java.util.Collections.emptyMap;
-// import static
-// org.apache.beam.runners.flink.translation.wrappers.streaming.StreamRecordStripper.stripStreamRecordFromWindowedValue;
-// import static org.apache.beam.sdk.transforms.windowing.PaneInfo.NO_FIRING;
-// import static org.apache.beam.sdk.transforms.windowing.PaneInfo.Timing.ON_TIME;
-// import static org.hamcrest.MatcherAssert.assertThat;
-// import static org.hamcrest.Matchers.containsInAnyOrder;
-// import static org.hamcrest.core.Is.is;
-// import static org.joda.time.Duration.standardMinutes;
-// import static org.junit.Assert.assertEquals;
-//
-// import java.io.ByteArrayOutputStream;
-// import java.nio.ByteBuffer;
-// import org.apache.beam.runners.core.KeyedWorkItem;
-// import org.apache.beam.runners.core.SystemReduceFn;
-// import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
-// import org.apache.beam.runners.flink.FlinkPipelineOptions;
-// import
-// org.apache.beam.runners.flink.translation.wrappers.streaming.DoFnOperator.MultiOutputOutputManagerFactory;
-// import org.apache.beam.sdk.coders.Coder;
-// import org.apache.beam.sdk.coders.CoderRegistry;
-// import org.apache.beam.sdk.coders.KvCoder;
-// import org.apache.beam.sdk.coders.VarLongCoder;
-// import org.apache.beam.sdk.transforms.Sum;
-// import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
-// import org.apache.beam.sdk.transforms.windowing.FixedWindows;
-// import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
-// import org.apache.beam.sdk.transforms.windowing.PaneInfo;
-// import org.apache.beam.sdk.util.AppliedCombineFn;
-// import org.apache.beam.sdk.util.WindowedValue;
-// import org.apache.beam.sdk.util.WindowedValue.FullWindowedValueCoder;
-// import org.apache.beam.sdk.values.KV;
-// import org.apache.beam.sdk.values.TupleTag;
-// import org.apache.beam.sdk.values.WindowingStrategy;
-// import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
-// import org.apache.flink.api.java.functions.KeySelector;
-// import org.apache.flink.api.java.typeutils.GenericTypeInfo;
-// import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
-// import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
-// import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
-// import org.joda.time.Duration;
-// import org.joda.time.Instant;
-// import org.junit.Test;
-// import org.junit.runner.RunWith;
-// import org.junit.runners.JUnit4;
-//
-/// ** Tests for {@link WindowDoFnOperator}. */
-// @RunWith(JUnit4.class)
-// @SuppressWarnings({
-//  "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
-// })
-// public class WindowDoFnOperatorTest {
-//
-//  @Test
-//  public void testRestore() throws Exception {
-//    // test harness
-//    KeyedOneInputStreamOperatorTestHarness<
-//            ByteBuffer, WindowedValue<KeyedWorkItem<Long, Long>>, WindowedValue<KV<Long, Long>>>
-//        testHarness = createTestHarness(getWindowDoFnOperator());
-//    testHarness.open();
-//
-//    // process elements
-//    IntervalWindow window = new IntervalWindow(new Instant(0), Duration.millis(10_000));
-//    testHarness.processWatermark(0L);
-//    testHarness.processElement(
-//        Item.builder().key(1L).timestamp(1L).value(100L).window(window).build().toStreamRecord());
-//    testHarness.processElement(
-//        Item.builder().key(1L).timestamp(2L).value(20L).window(window).build().toStreamRecord());
-//    testHarness.processElement(
-//        Item.builder().key(2L).timestamp(3L).value(77L).window(window).build().toStreamRecord());
-//
-//    // create snapshot
-//    OperatorSubtaskState snapshot = testHarness.snapshot(0, 0);
-//    testHarness.close();
-//
-//    // restore from the snapshot
-//    testHarness = createTestHarness(getWindowDoFnOperator());
-//    testHarness.initializeState(snapshot);
-//    testHarness.open();
-//
-//    // close window
-//    testHarness.processWatermark(10_000L);
-//
-//    Iterable<WindowedValue<KV<Long, Long>>> output =
-//        stripStreamRecordFromWindowedValue(testHarness.getOutput());
-//
-//    assertEquals(2, Iterables.size(output));
-//    assertThat(
-//        output,
-//        containsInAnyOrder(
-//            WindowedValue.of(
-//                KV.of(1L, 120L),
-//                new Instant(9_999),
-//                window,
-//                PaneInfo.createPane(true, true, ON_TIME)),
-//            WindowedValue.of(
-//                KV.of(2L, 77L),
-//                new Instant(9_999),
-//                window,
-//                PaneInfo.createPane(true, true, ON_TIME))));
-//    // cleanup
-//    testHarness.close();
-//  }
-//
-//  @Test
-//  public void testTimerCleanupOfPendingTimerList() throws Exception {
-//    // test harness
-//    WindowDoFnOperator<Long, Long, Long> windowDoFnOperator = getWindowDoFnOperator();
-//    KeyedOneInputStreamOperatorTestHarness<
-//            ByteBuffer, WindowedValue<KeyedWorkItem<Long, Long>>, WindowedValue<KV<Long, Long>>>
-//        testHarness = createTestHarness(windowDoFnOperator);
-//    testHarness.open();
-//
-//    DoFnOperator<KV<Long, Long>, KeyedWorkItem<Long, Long>, KV<Long, Long>>.FlinkTimerInternals
-// timerInternals =
-//        windowDoFnOperator.timerInternals;
-//
-//    // process elements
-//    IntervalWindow window = new IntervalWindow(new Instant(0), Duration.millis(100));
-//    IntervalWindow window2 = new IntervalWindow(new Instant(100), Duration.millis(100));
-//    testHarness.processWatermark(0L);
-//
-//    // Use two different keys to check for correct watermark hold calculation
-//    testHarness.processElement(
-//        Item.builder().key(1L).timestamp(1L).value(100L).window(window).build().toStreamRecord());
-//    testHarness.processElement(
-//        Item.builder()
-//            .key(2L)
-//            .timestamp(150L)
-//            .value(150L)
-//            .window(window2)
-//            .build()
-//            .toStreamRecord());
-//
-//    testHarness.processWatermark(1);
-//
-//    // Note that the following is 1 because the state is key-partitioned
-//    assertThat(Iterables.size(timerInternals.pendingTimersById.keys()), is(1));
-//
-//    assertThat(testHarness.numKeyedStateEntries(), is(6));
-//    // close bundle
-//    testHarness.setProcessingTime(
-//        testHarness.getProcessingTime()
-//            + 2 * FlinkPipelineOptions.defaults().getMaxBundleTimeMills());
-//    assertThat(windowDoFnOperator.getCurrentOutputWatermark(), is(1L));
-//
-//    // close window
-//    testHarness.processWatermark(100L);
-//
-//    // Note that the following is zero because we only the first key is active
-//    assertThat(Iterables.size(timerInternals.pendingTimersById.keys()), is(0));
-//
-//    assertThat(testHarness.numKeyedStateEntries(), is(3));
-//
-//    // close bundle
-//    testHarness.setProcessingTime(
-//        testHarness.getProcessingTime()
-//            + 2 * FlinkPipelineOptions.defaults().getMaxBundleTimeMills());
-//    assertThat(windowDoFnOperator.getCurrentOutputWatermark(), is(100L));
-//
-//    testHarness.processWatermark(200L);
-//
-//    // All the state has been cleaned up
-//    assertThat(testHarness.numKeyedStateEntries(), is(0));
-//
-//    assertThat(
-//        stripStreamRecordFromWindowedValue(testHarness.getOutput()),
-//        containsInAnyOrder(
-//            WindowedValue.of(
-//                KV.of(1L, 100L), new Instant(99), window, PaneInfo.createPane(true, true,
-// ON_TIME)),
-//            WindowedValue.of(
-//                KV.of(2L, 150L),
-//                new Instant(199),
-//                window2,
-//                PaneInfo.createPane(true, true, ON_TIME))));
-//
-//    // cleanup
-//    testHarness.close();
-//  }
-//
-//  private WindowDoFnOperator<Long, Long, Long> getWindowDoFnOperator() {
-//    WindowingStrategy<Object, IntervalWindow> windowingStrategy =
-//        WindowingStrategy.of(FixedWindows.of(standardMinutes(1)));
-//
-//    TupleTag<KV<Long, Long>> outputTag = new TupleTag<>("main-output");
-//
-//    SystemReduceFn<Long, Long, long[], Long, BoundedWindow> reduceFn =
-//        SystemReduceFn.combining(
-//            VarLongCoder.of(),
-//            AppliedCombineFn.withInputCoder(
-//                Sum.ofLongs(),
-//                CoderRegistry.createDefault(),
-//                KvCoder.of(VarLongCoder.of(), VarLongCoder.of())));
-//
-//    Coder<IntervalWindow> windowCoder = windowingStrategy.getWindowFn().windowCoder();
-//    SingletonKeyedWorkItemCoder<Long, Long> workItemCoder =
-//        SingletonKeyedWorkItemCoder.of(VarLongCoder.of(), VarLongCoder.of(), windowCoder);
-//    FullWindowedValueCoder<KeyedWorkItem<Long, Long>> inputCoder =
-//        WindowedValue.getFullCoder(workItemCoder, windowCoder);
-//    FullWindowedValueCoder<KV<Long, Long>> outputCoder =
-//        WindowedValue.getFullCoder(KvCoder.of(VarLongCoder.of(), VarLongCoder.of()), windowCoder);
-//
-//    return new WindowDoFnOperator<Long, Long, Long>(
-//        reduceFn,
-//        "stepName",
-//        (Coder) inputCoder,
-//        outputTag,
-//        emptyList(),
-//        new MultiOutputOutputManagerFactory<>(
-//            outputTag,
-//            outputCoder,
-//            new SerializablePipelineOptions(FlinkPipelineOptions.defaults())),
-//        windowingStrategy,
-//        emptyMap(),
-//        emptyList(),
-//        FlinkPipelineOptions.defaults(),
-//        VarLongCoder.of(),
-//        new WorkItemKeySelector(
-//            VarLongCoder.of(), new SerializablePipelineOptions(FlinkPipelineOptions.defaults())));
-//  }
-//
-//  private KeyedOneInputStreamOperatorTestHarness<
-//          ByteBuffer, WindowedValue<KeyedWorkItem<Long, Long>>, WindowedValue<KV<Long, Long>>>
-//      createTestHarness(WindowDoFnOperator<Long, Long, Long> windowDoFnOperator) throws Exception
-// {
-//    return new KeyedOneInputStreamOperatorTestHarness<>(
-//        windowDoFnOperator,
-//        (KeySelector<WindowedValue<KeyedWorkItem<Long, Long>>, ByteBuffer>)
-//            o -> {
-//              try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
-//                VarLongCoder.of().encode(o.getValue().key(), baos);
-//                return ByteBuffer.wrap(baos.toByteArray());
-//              }
-//            },
-//        new GenericTypeInfo<>(ByteBuffer.class));
-//  }
-//
-//  private static class Item {
-//
-//    static ItemBuilder builder() {
-//      return new ItemBuilder();
-//    }
-//
-//    private long key;
-//    private long value;
-//    private long timestamp;
-//    private IntervalWindow window;
-//
-//    StreamRecord<WindowedValue<KeyedWorkItem<Long, Long>>> toStreamRecord() {
-//      WindowedValue<Long> item = WindowedValue.of(value, new Instant(timestamp), window,
-// NO_FIRING);
-//      WindowedValue<KeyedWorkItem<Long, Long>> keyedItem =
-//          WindowedValue.of(
-//              new SingletonKeyedWorkItem<>(key, item), new Instant(timestamp), window, NO_FIRING);
-//      return new StreamRecord<>(keyedItem);
-//    }
-//
-//    private static final class ItemBuilder {
-//
-//      private long key;
-//      private long value;
-//      private long timestamp;
-//      private IntervalWindow window;
-//
-//      ItemBuilder key(long key) {
-//        this.key = key;
-//        return this;
-//      }
-//
-//      ItemBuilder value(long value) {
-//        this.value = value;
-//        return this;
-//      }
-//
-//      ItemBuilder timestamp(long timestamp) {
-//        this.timestamp = timestamp;
-//        return this;
-//      }
-//
-//      ItemBuilder window(IntervalWindow window) {
-//        this.window = window;
-//        return this;
-//      }
-//
-//      Item build() {
-//        Item item = new Item();
-//        item.key = this.key;
-//        item.value = this.value;
-//        item.window = this.window;
-//        item.timestamp = this.timestamp;
-//        return item;
-//      }
-//    }
-//  }
-// }
+
+import static java.util.Collections.emptyList;
+import static java.util.Collections.emptyMap;
+import static org.apache.beam.runners.flink.translation.wrappers.streaming.StreamRecordStripper.stripStreamRecordFromWindowedValue;
+import static org.apache.beam.sdk.transforms.windowing.PaneInfo.NO_FIRING;
+import static org.apache.beam.sdk.transforms.windowing.PaneInfo.Timing.ON_TIME;
+import static org.hamcrest.MatcherAssert.assertThat;
+import static org.hamcrest.Matchers.containsInAnyOrder;
+import static org.hamcrest.core.Is.is;
+import static org.joda.time.Duration.standardMinutes;
+import static org.junit.Assert.assertEquals;
+
+import java.io.ByteArrayOutputStream;
+import java.nio.ByteBuffer;
+import org.apache.beam.runners.core.KeyedWorkItem;
+import org.apache.beam.runners.core.SystemReduceFn;
+import org.apache.beam.runners.core.construction.SerializablePipelineOptions;
+import org.apache.beam.runners.flink.FlinkPipelineOptions;
+import org.apache.beam.runners.flink.translation.wrappers.streaming.DoFnOperator.MultiOutputOutputManagerFactory;
+import org.apache.beam.sdk.coders.Coder;
+import org.apache.beam.sdk.coders.CoderRegistry;
+import org.apache.beam.sdk.coders.KvCoder;
+import org.apache.beam.sdk.coders.VarLongCoder;
+import org.apache.beam.sdk.transforms.Sum;
+import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
+import org.apache.beam.sdk.transforms.windowing.FixedWindows;
+import org.apache.beam.sdk.transforms.windowing.IntervalWindow;
+import org.apache.beam.sdk.transforms.windowing.PaneInfo;
+import org.apache.beam.sdk.util.AppliedCombineFn;
+import org.apache.beam.sdk.util.WindowedValue;
+import org.apache.beam.sdk.util.WindowedValue.FullWindowedValueCoder;
+import org.apache.beam.sdk.values.KV;
+import org.apache.beam.sdk.values.TupleTag;
+import org.apache.beam.sdk.values.WindowingStrategy;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Iterables;
+import org.apache.flink.api.java.functions.KeySelector;
+import org.apache.flink.api.java.typeutils.GenericTypeInfo;
+import org.apache.flink.runtime.checkpoint.OperatorSubtaskState;
+import org.apache.flink.streaming.runtime.streamrecord.StreamRecord;
+import org.apache.flink.streaming.util.KeyedOneInputStreamOperatorTestHarness;
+import org.joda.time.Duration;
+import org.joda.time.Instant;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+/** Tests for {@link WindowDoFnOperator}. */
+@RunWith(JUnit4.class)
+@SuppressWarnings({
+  "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
+})
+public class WindowDoFnOperatorTest {
+
+  @Test
+  public void testRestore() throws Exception {
+    // test harness
+    KeyedOneInputStreamOperatorTestHarness<
+            ByteBuffer, WindowedValue<KV<Long, Long>>, WindowedValue<KV<Long, Long>>>
+        testHarness = createTestHarness(getWindowDoFnOperator());
+    testHarness.open();
+
+    // process elements
+    IntervalWindow window = new IntervalWindow(new Instant(0), Duration.millis(10_000));
+    testHarness.processWatermark(0L);
+    testHarness.processElement(
+        Item.builder().key(1L).timestamp(1L).value(100L).window(window).build().toStreamRecord());
+    testHarness.processElement(
+        Item.builder().key(1L).timestamp(2L).value(20L).window(window).build().toStreamRecord());
+    testHarness.processElement(
+        Item.builder().key(2L).timestamp(3L).value(77L).window(window).build().toStreamRecord());
+
+    // create snapshot
+    OperatorSubtaskState snapshot = testHarness.snapshot(0, 0);
+    testHarness.close();
+
+    // restore from the snapshot
+    testHarness = createTestHarness(getWindowDoFnOperator());
+    testHarness.initializeState(snapshot);
+    testHarness.open();
+
+    // close window
+    testHarness.processWatermark(10_000L);
+
+    Iterable<WindowedValue<KV<Long, Long>>> output =
+        stripStreamRecordFromWindowedValue(testHarness.getOutput());
+
+    assertEquals(2, Iterables.size(output));
+    assertThat(
+        output,
+        containsInAnyOrder(
+            WindowedValue.of(
+                KV.of(1L, 120L),
+                new Instant(9_999),
+                window,
+                PaneInfo.createPane(true, true, ON_TIME)),
+            WindowedValue.of(
+                KV.of(2L, 77L),
+                new Instant(9_999),
+                window,
+                PaneInfo.createPane(true, true, ON_TIME))));
+    // cleanup
+    testHarness.close();
+  }
+
+  @Test
+  public void testTimerCleanupOfPendingTimerList() throws Exception {
+    // test harness
+    WindowDoFnOperator<Long, Long, Long> windowDoFnOperator = getWindowDoFnOperator();
+    KeyedOneInputStreamOperatorTestHarness<
+            ByteBuffer, WindowedValue<KV<Long, Long>>, WindowedValue<KV<Long, Long>>>
+        testHarness = createTestHarness(windowDoFnOperator);
+    testHarness.open();
+
+    DoFnOperator<KV<Long, Long>, KeyedWorkItem<Long, Long>, KV<Long, Long>>.FlinkTimerInternals
+        timerInternals = windowDoFnOperator.timerInternals;
+
+    // process elements
+    IntervalWindow window = new IntervalWindow(new Instant(0), Duration.millis(100));
+    IntervalWindow window2 = new IntervalWindow(new Instant(100), Duration.millis(100));
+    testHarness.processWatermark(0L);
+
+    // Use two different keys to check for correct watermark hold calculation
+    testHarness.processElement(
+        Item.builder().key(1L).timestamp(1L).value(100L).window(window).build().toStreamRecord());
+    testHarness.processElement(
+        Item.builder()
+            .key(2L)
+            .timestamp(150L)
+            .value(150L)
+            .window(window2)
+            .build()
+            .toStreamRecord());
+
+    testHarness.processWatermark(1);
+
+    // Note that the following is 1 because the state is key-partitioned
+    assertThat(Iterables.size(timerInternals.pendingTimersById.keys()), is(1));
+
+    assertThat(testHarness.numKeyedStateEntries(), is(6));
+    // close bundle
+    testHarness.setProcessingTime(
+        testHarness.getProcessingTime()
+            + 2 * FlinkPipelineOptions.defaults().getMaxBundleTimeMills());
+    assertThat(windowDoFnOperator.getCurrentOutputWatermark(), is(1L));
+
+    // close window
+    testHarness.processWatermark(100L);
+
+    // Note that the following is zero because we only the first key is active
+    assertThat(Iterables.size(timerInternals.pendingTimersById.keys()), is(0));
+
+    assertThat(testHarness.numKeyedStateEntries(), is(3));
+
+    // close bundle
+    testHarness.setProcessingTime(
+        testHarness.getProcessingTime()
+            + 2 * FlinkPipelineOptions.defaults().getMaxBundleTimeMills());
+    assertThat(windowDoFnOperator.getCurrentOutputWatermark(), is(100L));
+
+    testHarness.processWatermark(200L);
+
+    // All the state has been cleaned up
+    assertThat(testHarness.numKeyedStateEntries(), is(0));
+
+    assertThat(
+        stripStreamRecordFromWindowedValue(testHarness.getOutput()),
+        containsInAnyOrder(
+            WindowedValue.of(
+                KV.of(1L, 100L), new Instant(99), window, PaneInfo.createPane(true, true, ON_TIME)),
+            WindowedValue.of(
+                KV.of(2L, 150L),
+                new Instant(199),
+                window2,
+                PaneInfo.createPane(true, true, ON_TIME))));
+
+    // cleanup
+    testHarness.close();
+  }
+
+  private WindowDoFnOperator<Long, Long, Long> getWindowDoFnOperator() {
+    WindowingStrategy<Object, IntervalWindow> windowingStrategy =
+        WindowingStrategy.of(FixedWindows.of(standardMinutes(1)));
+
+    TupleTag<KV<Long, Long>> outputTag = new TupleTag<>("main-output");
+
+    SystemReduceFn<Long, Long, long[], Long, BoundedWindow> reduceFn =
+        SystemReduceFn.combining(
+            VarLongCoder.of(),
+            AppliedCombineFn.withInputCoder(
+                Sum.ofLongs(),
+                CoderRegistry.createDefault(),
+                KvCoder.of(VarLongCoder.of(), VarLongCoder.of())));
+
+    Coder<IntervalWindow> windowCoder = windowingStrategy.getWindowFn().windowCoder();
+    SingletonKeyedWorkItemCoder<Long, Long> workItemCoder =
+        SingletonKeyedWorkItemCoder.of(VarLongCoder.of(), VarLongCoder.of(), windowCoder);
+    FullWindowedValueCoder<KeyedWorkItem<Long, Long>> inputCoder =
+        WindowedValue.getFullCoder(workItemCoder, windowCoder);
+    FullWindowedValueCoder<KV<Long, Long>> outputCoder =
+        WindowedValue.getFullCoder(KvCoder.of(VarLongCoder.of(), VarLongCoder.of()), windowCoder);
+
+    return new WindowDoFnOperator<Long, Long, Long>(
+        reduceFn,
+        "stepName",
+        (Coder) inputCoder,
+        outputTag,
+        emptyList(),
+        new MultiOutputOutputManagerFactory<>(
+            outputTag,
+            outputCoder,
+            new SerializablePipelineOptions(FlinkPipelineOptions.defaults())),
+        windowingStrategy,
+        emptyMap(),
+        emptyList(),
+        FlinkPipelineOptions.defaults(),
+        VarLongCoder.of(),
+        new WorkItemKeySelector(
+            VarLongCoder.of(), new SerializablePipelineOptions(FlinkPipelineOptions.defaults())));
+  }
+
+  private KeyedOneInputStreamOperatorTestHarness<
+          ByteBuffer, WindowedValue<KV<Long, Long>>, WindowedValue<KV<Long, Long>>>
+      createTestHarness(WindowDoFnOperator<Long, Long, Long> windowDoFnOperator) throws Exception {
+    return new KeyedOneInputStreamOperatorTestHarness<>(
+        windowDoFnOperator,
+        (KeySelector<WindowedValue<KV<Long, Long>>, ByteBuffer>)
+            o -> {
+              try (ByteArrayOutputStream baos = new ByteArrayOutputStream()) {
+                VarLongCoder.of().encode(o.getValue().getKey(), baos);
+                return ByteBuffer.wrap(baos.toByteArray());
+              }
+            },
+        new GenericTypeInfo<>(ByteBuffer.class));
+  }
+
+  private static class Item {
+
+    static ItemBuilder builder() {
+      return new ItemBuilder();
+    }
+
+    private long key;
+    private long value;
+    private long timestamp;
+    private IntervalWindow window;
+
+    StreamRecord<WindowedValue<KV<Long, Long>>> toStreamRecord() {
+      WindowedValue<KV<Long, Long>> keyedItem =
+          WindowedValue.of(KV.of(key, value), new Instant(timestamp), window, NO_FIRING);
+      return new StreamRecord<>(keyedItem);
+    }
+
+    private static final class ItemBuilder {
+
+      private long key;
+      private long value;
+      private long timestamp;
+      private IntervalWindow window;
+
+      ItemBuilder key(long key) {
+        this.key = key;
+        return this;
+      }
+
+      ItemBuilder value(long value) {
+        this.value = value;
+        return this;
+      }
+
+      ItemBuilder timestamp(long timestamp) {
+        this.timestamp = timestamp;
+        return this;
+      }
+
+      ItemBuilder window(IntervalWindow window) {
+        this.window = window;
+        return this;
+      }
+
+      Item build() {
+        Item item = new Item();
+        item.key = this.key;
+        item.value = this.value;
+        item.window = this.window;
+        item.timestamp = this.timestamp;
+        return item;
+      }
+    }
+  }
+}

--- a/website/www/site/layouts/shortcodes/flink_java_pipeline_options.html
+++ b/website/www/site/layouts/shortcodes/flink_java_pipeline_options.html
@@ -108,6 +108,11 @@ Should be called before running the tests.
   <td>Default: <code>[auto]</code></td>
 </tr>
 <tr>
+  <td><code>forceSlotSharingGroup</code></td>
+  <td>Set a slot sharing group for all bounded sources. This is required when using Datastream to have the same scheduling behaviour as the Dataset API.</td>
+  <td>Default: <code>true</code></td>
+</tr>
+<tr>
   <td><code>jobCheckIntervalInSecs</code></td>
   <td>Set job check interval in seconds under detached mode in method waitUntilFinish, by default it is 5 seconds</td>
   <td>Default: <code>5</code></td>

--- a/website/www/site/layouts/shortcodes/flink_python_pipeline_options.html
+++ b/website/www/site/layouts/shortcodes/flink_python_pipeline_options.html
@@ -108,6 +108,11 @@ Should be called before running the tests.
   <td>Default: <code>[auto]</code></td>
 </tr>
 <tr>
+  <td><code>force_slot_sharing_group</code></td>
+  <td>Set a slot sharing group for all bounded sources. This is required when using Datastream to have the same scheduling behaviour as the Dataset API.</td>
+  <td>Default: <code>true</code></td>
+</tr>
+<tr>
   <td><code>job_check_interval_in_secs</code></td>
   <td>Set job check interval in seconds under detached mode in method waitUntilFinish, by default it is 5 seconds</td>
   <td>Default: <code>5</code></td>


### PR DESCRIPTION
## Context

Flink will drop support for the dataset API in 2.0 which should be released by EOY so it quite important for Beam to support Datastream well. 

## The PR

This PR improves the performances of Batch jobs executed with `--useDatastreamForBatch`  by porting the following performance optimizations already present in `FlinkBatchTransformTranslators` but lacking in `FlinkStreamingTransformTranslators`.  

- Limit the max size of source splits. Similar to https://github.com/apache/beam/pull/28045
- Pre-combine before shuffle (both reduce by key and GBK)
- Disable bundling in batch mode (except for pre-combine). Lower the default bundle size since the new behavior puts pressure on the heap.  

It also implements the following optimizations:

- Use a "lazy" split enumerator to distributes split dynamically rather the eagerly. This new enumerator greatly reduces skew as each slot is able to pull new splits to consume only when it has finished its work.
- Set the default `maxParallelism` to `parallelism` as the total number of splits is equal to `maxParallelism`. Again this reduces skew.
- Make `ToKeyedWorkItem`  part of `DoFnOperator` which reduces the size of the job graph and avoid unnecessary inter-task communication.
- Force a common slot-sharing group on every bounded IOs. This emulate the behavior of the Dataset API which again improves performances especially when data is being shuffled several times while partitioning keys are unchanged (for example of the job does `GBK -> map -> CombinePerKey`). Add a flag to control this feature (defaults to active).
- Other minor optimizations removing repeated serde work.

## Benchmarks

The patched version was tested against a few of Spotify's production batch workflows. All settings were left unchanged except for the followings:

- passed `--useDatastreamForBatch=true`
- set `jobmanager.scheduler: default` (otherwise datastream default to adaptive scheduler).

|       |           | Beam 2.56 - dataset | Beam 2.56 - datastream |        | Beam 2.56 - datastream patched |         |
| ----- | --------: | ------------------: | ---------------------: | -----: | -----------------------------: | ------: |
| job   | # workers |      execution time |         execution time | % diff |                 execution time |  % diff |
| Job 1 |       350 |             2:19:00 |    fails after 4h29min |      - |                        1:43:00 | -25.90% |
| Job 2 |       160 |             0:23:00 |                0:35:00 | 52.17% |                        0:22:36 |  -1.74% |
| Job 3 |       200 |             0:53:08 |                1:34:39 | 78.14% |                         failed |       - |
| Job 4 |       160 |             2:31:20 |                4:27:00 | 76.43% |                        2:19:35 |  -7.76% |
| Job 5 |         1 |             0:43:00 |             not tested |      - |                        0:38:00 | -11.63% |
| Job 6 |       300 |             2:58:51 |             not tested |      - |                        running |         |

## Note

Job 3 fails with a stackoverflow exception because if [a bug in old version of Kryo](https://github.com/EsotericSoftware/kryo/issues/341). I believe this is because the job uses `taskmanager.runtime.large-record-handler: true` and it should be fixed in Flink 2.0 since Kryo is upgraded to a more recent version.  

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
