### PR TITLE
Fix BQ storage stream split

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryStorageStreamSource.java
@@ -347,7 +347,7 @@ class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
       // Because superclass cannot have preconditions around these variables, cannot use
       // @RequiresNonNull
       Preconditions.checkStateNotNull(responseStream);
-      BigQueryServerStream<ReadRowsResponse> responseStream = this.responseStream;
+      final BigQueryServerStream<ReadRowsResponse> responseStream = this.responseStream;
       totalSplitCalls.inc();
       LOG.debug(
           "Received BigQuery Storage API split request for stream {} at fraction {}.",
@@ -433,9 +433,9 @@ class BigQueryStorageStreamSource<T> extends BoundedSource<T> {
 
         // Cancels the parent stream before replacing it with the primary stream.
         responseStream.cancel();
-        source = source.fromExisting(splitResponse.getPrimaryStream());
-        responseStream = newResponseStream;
-        responseIterator = newResponseIterator;
+        this.source = source.fromExisting(splitResponse.getPrimaryStream());
+        this.responseStream = newResponseStream;
+        this.responseIterator = newResponseIterator;
         reader.resetBuffer();
       }
 


### PR DESCRIPTION
A variable shadowing was introduced  [here](https://github.com/apache/beam/commit/4e8d7fbf7dfef6bcef9d7f01ce986c93f26ed958#diff-c3aff238bc5d7e190d1f7b4d80ce30ef24a42613a36034d6047b1decf2a285e8R306), preventing modification of the stream reader source after splitting.

I don't know the implication of this bug.