### PR TITLE
Fix RowCoderGenerator to use the encodingPositions when encoding and decoding the bit set representing null fields.

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/coders/RowCoder.java
@@ -25,6 +25,7 @@ import org.apache.beam.sdk.schemas.SchemaCoder;
 import org.apache.beam.sdk.transforms.SerializableFunctions;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TypeDescriptors;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
 import org.checkerframework.checker.nullness.qual.Nullable;
 
 /** A sub-class of SchemaCoder that can only encode {@link Row} instances. */
@@ -35,7 +36,12 @@ public class RowCoder extends SchemaCoder<Row> {
 
   /** Override encoding positions for the given schema. */
   public static void overrideEncodingPositions(UUID uuid, Map<String, Integer> encodingPositions) {
-    SchemaCoder.overrideEncodingPositions(uuid, encodingPositions);
+    RowCoderGenerator.overrideEncodingPositions(uuid, encodingPositions);
+  }
+
+  @VisibleForTesting
+  static void clearGeneratedRowCoders() {
+    RowCoderGenerator.clearRowCoderCache();
   }
 
   private RowCoder(Schema schema) {

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaCoder.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaCoder.java
@@ -164,7 +164,10 @@ public class SchemaCoder<T> extends CustomCoder<T> {
   }
 
   // Sets the schema id, and then recursively ensures that all schemas have ids set.
-  private static void setSchemaIds(Schema schema) {
+  private static void setSchemaIds(@Nullable Schema schema) {
+    if (schema == null) {
+      return;
+    }
     if (schema.getUUID() == null) {
       schema.setUUID(UUID.randomUUID());
     }
@@ -187,7 +190,7 @@ public class SchemaCoder<T> extends CustomCoder<T> {
         return;
 
       case ARRAY:
-      case ITERABLE:;
+      case ITERABLE:
         setSchemaIds(fieldType.getCollectionElementType());
         return;
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/RowCoderTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/coders/RowCoderTest.java
@@ -22,10 +22,12 @@ import static org.junit.Assert.assertEquals;
 import java.io.ByteArrayInputStream;
 import java.io.ByteArrayOutputStream;
 import java.math.BigDecimal;
+import java.nio.charset.StandardCharsets;
 import java.util.Arrays;
 import java.util.Collections;
 import java.util.List;
 import java.util.Map;
+import java.util.UUID;
 import org.apache.beam.sdk.coders.Coder.NonDeterministicException;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
@@ -37,6 +39,7 @@ import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
+import org.checkerframework.checker.nullness.qual.NonNull;
 import org.joda.time.DateTime;
 import org.joda.time.DateTimeZone;
 import org.junit.Assume;
@@ -62,7 +65,7 @@ public class RowCoderTest {
             .build();
 
     DateTime dateTime =
-        new DateTime().withDate(1979, 03, 14).withTime(1, 2, 3, 4).withZone(DateTimeZone.UTC);
+        new DateTime().withDate(1979, 3, 14).withTime(1, 2, 3, 4).withZone(DateTimeZone.UTC);
     Row row =
         Row.withSchema(schema)
             .addValues(
@@ -219,12 +222,14 @@ public class RowCoderTest {
     }
 
     @Override
-    public Value toBaseType(String input) {
+    @NonNull
+    public Value toBaseType(@NonNull String input) {
       return enumeration.valueOf(input);
     }
 
     @Override
-    public String toInputType(Value base) {
+    @NonNull
+    public String toInputType(@NonNull Value base) {
       return enumeration.toString(base);
     }
   }
@@ -397,6 +402,129 @@ public class RowCoderTest {
 
     ByteArrayOutputStream os = new ByteArrayOutputStream();
     RowCoder.of(schema1).encode(row, os);
+    Row decoded = RowCoder.of(schema2).decode(new ByteArrayInputStream(os.toByteArray()));
+    assertEquals(expected, decoded);
+  }
+
+  @Test
+  public void testEncodingPositionReorderFieldsWithNulls() throws Exception {
+    Schema schema1 =
+        Schema.builder()
+            .addNullableField("f_int32", FieldType.INT32)
+            .addNullableField("f_string", FieldType.STRING)
+            .build();
+    Schema schema2 =
+        Schema.builder()
+            .addNullableField("f_string", FieldType.STRING)
+            .addNullableField("f_int32", FieldType.INT32)
+            .build();
+    schema2.setEncodingPositions(ImmutableMap.of("f_int32", 0, "f_string", 1));
+    Row schema1row =
+        Row.withSchema(schema1)
+            .withFieldValue("f_int32", null)
+            .withFieldValue("f_string", "hello world!")
+            .build();
+
+    Row schema2row =
+        Row.withSchema(schema2)
+            .withFieldValue("f_int32", null)
+            .withFieldValue("f_string", "hello world!")
+            .build();
+
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    RowCoder.of(schema1).encode(schema1row, os);
+    Row schema1to2decoded = RowCoder.of(schema2).decode(new ByteArrayInputStream(os.toByteArray()));
+    assertEquals(schema2row, schema1to2decoded);
+
+    os.reset();
+    RowCoder.of(schema2).encode(schema2row, os);
+    Row schema2to1decoded = RowCoder.of(schema1).decode(new ByteArrayInputStream(os.toByteArray()));
+    assertEquals(schema1row, schema2to1decoded);
+  }
+
+  @Test
+  public void testEncodingPositionReorderViaStaticOverride() throws Exception {
+    Schema schema1 =
+        Schema.builder()
+            .addNullableField("failsafeTableRowPayload", FieldType.STRING)
+            .addByteArrayField("payload")
+            .addNullableField("timestamp", FieldType.INT32)
+            .addNullableField("unknownFieldsPayload", FieldType.STRING)
+            .build();
+    UUID uuid = UUID.randomUUID();
+    schema1.setUUID(uuid);
+
+    Row row =
+        Row.withSchema(schema1)
+            .addValues("", "hello world!".getBytes(StandardCharsets.UTF_8), 1, "")
+            .build();
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    RowCoder.of(schema1).encode(row, os);
+    // Pretend that we are restarting and want to recover from persisted state with a compatible
+    // schema using the
+    // overridden encoding positions.
+    RowCoder.clearGeneratedRowCoders();
+    RowCoder.overrideEncodingPositions(
+        uuid,
+        ImmutableMap.of(
+            "failsafeTableRowPayload", 0, "payload", 1, "timestamp", 2, "unknownFieldsPayload", 3));
+
+    Schema schema2 =
+        Schema.builder()
+            .addByteArrayField("payload")
+            .addNullableField("timestamp", FieldType.INT32)
+            .addNullableField("unknownFieldsPayload", FieldType.STRING)
+            .addNullableField("failsafeTableRowPayload", FieldType.STRING)
+            .build();
+    schema2.setUUID(uuid);
+
+    Row expected =
+        Row.withSchema(schema2)
+            .addValues("hello world!".getBytes(StandardCharsets.UTF_8), 1, "", "")
+            .build();
+    Row decoded = RowCoder.of(schema2).decode(new ByteArrayInputStream(os.toByteArray()));
+    assertEquals(expected, decoded);
+  }
+
+  @Test
+  public void testEncodingPositionReorderViaStaticOverrideWithNulls() throws Exception {
+    Schema schema1 =
+        Schema.builder()
+            .addNullableField("failsafeTableRowPayload", FieldType.BYTES)
+            .addByteArrayField("payload")
+            .addNullableField("timestamp", FieldType.INT32)
+            .addNullableField("unknownFieldsPayload", FieldType.BYTES)
+            .build();
+    UUID uuid = UUID.randomUUID();
+    schema1.setUUID(uuid);
+
+    Row row =
+        Row.withSchema(schema1)
+            .addValues(null, "hello world!".getBytes(StandardCharsets.UTF_8), 1, null)
+            .build();
+    ByteArrayOutputStream os = new ByteArrayOutputStream();
+    RowCoder.of(schema1).encode(row, os);
+    // Pretend that we are restarting and want to recover from persisted state with a compatible
+    // schema using the overridden encoding positions.
+    RowCoder.clearGeneratedRowCoders();
+    RowCoder.overrideEncodingPositions(
+        uuid,
+        ImmutableMap.of(
+            "failsafeTableRowPayload", 0, "payload", 1, "timestamp", 2, "unknownFieldsPayload", 3));
+
+    Schema schema2 =
+        Schema.builder()
+            .addByteArrayField("payload")
+            .addNullableField("timestamp", FieldType.INT32)
+            .addNullableField("unknownFieldsPayload", FieldType.BYTES)
+            .addNullableField("failsafeTableRowPayload", FieldType.BYTES)
+            .build();
+    schema2.setUUID(uuid);
+
+    Row expected =
+        Row.withSchema(schema2)
+            .addValues("hello world!".getBytes(StandardCharsets.UTF_8), 1, null, null)
+            .build();
     Row decoded = RowCoder.of(schema2).decode(new ByteArrayInputStream(os.toByteArray()));
     assertEquals(expected, decoded);
   }


### PR DESCRIPTION
Add tests that fail without the change covering encoding and decoding

Also add tests that cover the static position overrides which was not tested previously.

Some other cleanup to help debug other possible encoding positions issues in the future:
- ensure that only a single RowCoder is created for a given UUID by using synchronization when generating coders
- add some logging if encoding position overrides arrive after a RowCoder has already been generated for the UUID

fixes #32388 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
