### PR TITLE
Temporarily fix pip check failure on xgboost and grpcio

### DIFF
--- a/.github/workflows/python_tests.yml
+++ b/.github/workflows/python_tests.yml
@@ -113,10 +113,14 @@ jobs:
           python-version: ${{ matrix.params.py_ver }}
       - name: Install tox
         run: pip install tox
-      - name: Run tests basic unix
-        if: startsWith(matrix.os, 'ubuntu') || startsWith(matrix.os, 'macos')
+      - name: Run tests basic linux
+        if: startsWith(matrix.os, 'ubuntu')
         working-directory: ./sdks/python
         run: tox -c tox.ini run -e ${{ matrix.params.tox_env }}
+      - name: Run tests basic macos
+        if: startsWith(matrix.os, 'macos')
+        working-directory: ./sdks/python
+        run: tox -c tox.ini run -e ${{ matrix.params.tox_env }}-macos
       - name: Run tests basic windows
         if: startsWith(matrix.os, 'windows')
         working-directory: ./sdks/python

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -2977,12 +2977,8 @@ class BeamModulePlugin implements Plugin<Project> {
             // TODO: https://github.com/apache/beam/issues/29022
             // pip 23.3 is failing due to Hash mismatch between expected SHA of the packaged and actual SHA.
             // until it is resolved on pip's side, don't use pip's cache.
-            // TODO: https://github.com/apache/beam/issues/32431
-            // Some packages failed on tag check on pip-24.2. We will need to update
-            // them to the latest version (e.g. xgboost) or wait for a new version (e.g. grpcio)
-            // before unpinning pip.
             args '-c', ". ${project.ext.envdir}/bin/activate && " +
-                "pip install --pre --retries 10 pip==24.1 --no-cache-dir && " +
+                "pip install --pre --retries 10 --upgrade pip --no-cache-dir && " +
                 "pip install --pre --retries 10 --upgrade tox --no-cache-dir"
           }
         }

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -2977,8 +2977,12 @@ class BeamModulePlugin implements Plugin<Project> {
             // TODO: https://github.com/apache/beam/issues/29022
             // pip 23.3 is failing due to Hash mismatch between expected SHA of the packaged and actual SHA.
             // until it is resolved on pip's side, don't use pip's cache.
+            // TODO: https://github.com/apache/beam/issues/32431
+            // Some packages failed on tag check on pip-24.2. We will need to update
+            // them to the latest version (e.g. xgboost) or wait for a new version (e.g. grpcio)
+            // before unpinning pip.
             args '-c', ". ${project.ext.envdir}/bin/activate && " +
-                "pip install --pre --retries 10 --upgrade pip --no-cache-dir && " +
+                "pip install --pre --retries 10 pip==24.1 --no-cache-dir && " +
                 "pip install --pre --retries 10 --upgrade tox --no-cache-dir"
           }
         }

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -34,9 +34,7 @@ requires = [
     'pyyaml>=3.12,<7.0.0',
     # also update Jinja2 bounds in test-suites/xlang/build.gradle (look for xlangWrapperValidation task)
     "jinja2>=2.7.1,<4.0.0",
-    'yapf==0.29.0',
-    # TODO: unpin this after resolving blockers in https://github.com/apache/beam/issues/32431
-    "pip<=24.1",
+    'yapf==0.29.0'
 ]
 
 

--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -34,7 +34,9 @@ requires = [
     'pyyaml>=3.12,<7.0.0',
     # also update Jinja2 bounds in test-suites/xlang/build.gradle (look for xlangWrapperValidation task)
     "jinja2>=2.7.1,<4.0.0",
-    'yapf==0.29.0'
+    'yapf==0.29.0',
+    # TODO: unpin this after resolving blockers in https://github.com/apache/beam/issues/32431
+    "pip<=24.1",
 ]
 
 

--- a/sdks/python/setup.py
+++ b/sdks/python/setup.py
@@ -498,7 +498,10 @@ if __name__ == '__main__':
               'tf2onnx',
               'torch',
               'transformers',
-              'xgboost<2.0',  # https://github.com/apache/beam/issues/31252
+              # Comment out xgboost as it is breaking presubmit python ml
+              # tests due to tag check introduced since pip 24.2
+              # https://github.com/apache/beam/issues/31285
+              # 'xgboost<2.0',  # https://github.com/apache/beam/issues/31252
           ],
           'aws': ['boto3>=1.9,<2'],
           'azure': [

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -68,6 +68,21 @@ commands_post =
 commands = false {envname} is misconfigured
 
 [testenv:py{38,39,310,311,312}]
+commands_pre =
+  python --version
+  pip --version
+  pip check
+  bash {toxinidir}/scripts/run_tox_cleanup.sh
+commands =
+  python apache_beam/examples/complete/autocomplete_test.py
+  bash {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"
+
+[testenv:py{38,39,310,311,312}-macos]
+commands_pre =
+  python --version
+  pip --version
+  # pip check
+  bash {toxinidir}/scripts/run_tox_cleanup.sh
 commands =
   python apache_beam/examples/complete/autocomplete_test.py
   bash {toxinidir}/scripts/run_pytest.sh {envname} "{posargs}"

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -59,6 +59,7 @@ install_command = {envbindir}/python {envbindir}/pip install --retries 10 {opts}
 list_dependencies_command = {envbindir}/python {envbindir}/pip freeze
 commands_pre =
   python --version
+  pip install pip==24.1
   pip --version
   pip check
   bash {toxinidir}/scripts/run_tox_cleanup.sh

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -59,7 +59,6 @@ install_command = {envbindir}/python {envbindir}/pip install --retries 10 {opts}
 list_dependencies_command = {envbindir}/python {envbindir}/pip freeze
 commands_pre =
   python --version
-  pip install pip==24.1
   pip --version
   pip check
   bash {toxinidir}/scripts/run_tox_cleanup.sh


### PR DESCRIPTION
Originally, this PR is to pin pip to version 24.1, so that `pip check` would not fail on xgboost-1.7.6 and grpcio-1.66.1.

After some attempts, it seems it is a bit inconvenient to enforce pip version, especially inside the venv set up by tox.
 
Therefore, we decide to make the following changes
1) for xgboost, since we don't have any plan to invest further on it, we are going to remove it from deps.  After that, the xgboost related tests in the ML test suite will be skipped. We can put it back in the future if we decide to support xgboost again (https://github.com/apache/beam/issues/31252) .

2) for grpcio, the failure only occurs on MacOS, so we decide to skip `pip check` on MacOS until https://github.com/grpc/grpc/issues/37660 is fixed.

#fixes #31285