### PR TITLE
Update Playground and other location usage of Go  to use latest released version by default.

### DIFF
--- a/playground/README.md
+++ b/playground/README.md
@@ -41,7 +41,7 @@ build, test, and deploy the frontend and backend services.
 > - buf
 > - sbt
 
-1. Install Go 1.20+
+1. Install Go 1.23+
 
     **Ubuntu 22.04 and newer:**
     ```shell

--- a/playground/backend/containers/go/build.gradle
+++ b/playground/backend/containers/go/build.gradle
@@ -88,7 +88,7 @@ docker {
    buildArgs(
          ['BASE_IMAGE'   : project.rootProject.hasProperty(["base-image"]) ?
                project.rootProject["base-image"] :
-               "golang:1.20-bullseye",
+               "golang:1-bullseye",
           'SDK_TAG'      : project.rootProject.hasProperty(["sdk-tag"]) ?
                 project.rootProject["sdk-tag"] : project.rootProject.sdk_version,
           'SDK_TAG_LOCAL': project.rootProject.sdk_version,

--- a/playground/backend/containers/java/Dockerfile
+++ b/playground/backend/containers/java/Dockerfile
@@ -16,7 +16,7 @@
 # limitations under the License.
 ###############################################################################
 ARG BEAM_VERSION=2.44.0
-FROM golang:1.20-bullseye AS build
+FROM golang:1-bullseye AS build
 ARG BEAM_VERSION
 ARG GIT_COMMIT="<unknown>"
 ARG GIT_TIMESTAMP="0"

--- a/playground/backend/containers/python/Dockerfile
+++ b/playground/backend/containers/python/Dockerfile
@@ -15,7 +15,7 @@
 #  See the License for the specific language governing permissions and
 # limitations under the License.
 ###############################################################################
-ARG GO_BASE_IMAGE=golang:1.20-bullseye
+ARG GO_BASE_IMAGE=golang:1-bullseye
 ARG SDK_TAG
 ARG BASE_IMAGE=apache/beam_python3.10_sdk:$SDK_TAG
 FROM $GO_BASE_IMAGE AS build

--- a/playground/backend/containers/python/build.gradle
+++ b/playground/backend/containers/python/build.gradle
@@ -75,7 +75,7 @@ docker {
    buildArgs(
          ['GO_BASE_IMAGE': project.rootProject.hasProperty(["go-base-image"]) ?
                project.rootProject["go-base-image"] :
-               "golang:1.20-bullseye",
+               "golang:1-bullseye",
           'SDK_TAG'      : project.rootProject.hasProperty(["sdk-tag"]) ?
                 project.rootProject["sdk-tag"] : default_beam_version,
           'GIT_COMMIT'   : getGitCommitHash(),

--- a/playground/backend/containers/router/Dockerfile
+++ b/playground/backend/containers/router/Dockerfile
@@ -16,7 +16,7 @@
 # limitations under the License.
 ###############################################################################
 #Dokerfile to set up the Beam Go SDK
-ARG BASE_IMAGE=golang:1.20-bullseye
+ARG BASE_IMAGE=golang:1-bullseye
 #Two-stage assembly
 FROM $BASE_IMAGE AS build
 ARG GIT_COMMIT="<unknown>"

--- a/playground/backend/containers/router/build.gradle
+++ b/playground/backend/containers/router/build.gradle
@@ -70,7 +70,7 @@ docker {
    tags containerImageTags()
    buildArgs(['BASE_IMAGE'   : project.rootProject.hasProperty(["base-image"]) ?
          project.rootProject["base-image"] :
-         "golang:1.20-bullseye",
+         "golang:1-bullseye",
               'GIT_COMMIT'   : getGitCommitHash(),
               'GIT_TIMESTAMP': getGitCommitTimestamp()])
 }

--- a/playground/backend/containers/scio/Dockerfile
+++ b/playground/backend/containers/scio/Dockerfile
@@ -16,7 +16,7 @@
 # limitations under the License.
 ###############################################################################
 ARG BASE_IMAGE=openjdk:11
-FROM golang:1.20-bullseye AS build
+FROM golang:1-bullseye AS build
 ARG GIT_COMMIT="<unknown>"
 ARG GIT_TIMESTAMP="0"
 

--- a/playground/backend/playground_functions/Dockerfile
+++ b/playground/backend/playground_functions/Dockerfile
@@ -18,7 +18,7 @@
 
 # This Dockerfile is only for local testing
 
-FROM golang:1.20-alpine as build
+FROM golang:1-alpine as build
 
 COPY . /app
 WORKDIR /app/playground_functions

--- a/playground/infrastructure/cloudbuild/playground_ci_examples.sh
+++ b/playground/infrastructure/cloudbuild/playground_ci_examples.sh
@@ -84,7 +84,7 @@ export STEP=CI
 export SDK_CONFIG="$BEAM_ROOT_DIR/playground/sdks.yaml"
 export BEAM_EXAMPLE_CATEGORIES="$BEAM_ROOT_DIR/playground/categories.yaml"
 export GRADLE_VERSION=7.5.1
-export GO_VERSION=1.20 
+export GO_VERSION=1.23
 
 LogOutput "Installing python java8 and dependencies"
 apt-get update > /dev/null

--- a/release/go-licenses/Dockerfile
+++ b/release/go-licenses/Dockerfile
@@ -16,7 +16,7 @@
 # limitations under the License.
 ###############################################################################
 
-FROM golang:1.20-bookworm
+FROM golang:1-bookworm
 
 WORKDIR /usr/src/app
 COPY go.mod ./


### PR DESCRIPTION
Where possible stop being specific about which Go image version to use, or which Go version to download.

* As of Go 1.21+, modules are built using their version of the Go language toolchain.
* The playground should be using the latest version of Go anyway, when updated.

Also including the go-licences image because it's not used for specific builds, but it does need to run on any of our go code to produce the container license manifests.

Fixes #32441  (In particular, it's required to fix the Playground CI Nightly build).

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
