### PR TITLE
`@JsonIgnore` causes emulator endpoint to be missing in DoFn's

### DIFF
--- a/sdks/java/io/google-cloud-platform/build.gradle
+++ b/sdks/java/io/google-cloud-platform/build.gradle
@@ -115,7 +115,6 @@ dependencies {
   implementation library.java.http_client
   implementation library.java.hamcrest
   implementation library.java.http_core
-  implementation library.java.jackson_annotations
   implementation library.java.jackson_core
   implementation library.java.jackson_databind
   implementation library.java.jackson_datatype_joda

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryOptions.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryOptions.java
@@ -17,7 +17,6 @@
  */
 package org.apache.beam.sdk.io.gcp.bigquery;
 
-import com.fasterxml.jackson.annotation.JsonIgnore;
 import java.util.Map;
 import org.apache.beam.sdk.extensions.gcp.options.GcpOptions;
 import org.apache.beam.sdk.options.ApplicationNameOptions;
@@ -225,7 +224,6 @@ public interface BigQueryOptions
   void setJobLabelsMap(Map<String, String> value);
 
   /** BQ endpoint to use. If unspecified, uses the default endpoint. */
-  @JsonIgnore
   @Hidden
   @Description("The URL for the BigQuery API.")
   String getBigQueryEndpoint();


### PR DESCRIPTION
Unfortunately, `BigQueryIO` continues to refer to pipeline option post graph construction time, for example during `@FinishBundle` in `UpdateSchemaDestination`, and `@JsonIgnore` prevents endpoint URL to be serialized, and the whole thing doesn't work. This fixes that.