### PR TITLE
[Dataflow Streaming] Use separate heartbeat streams based on job settings

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowStreamingPipelineOptions.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/options/DataflowStreamingPipelineOptions.java
@@ -132,10 +132,9 @@ public interface DataflowStreamingPipelineOptions extends PipelineOptions {
 
   @Description(
       "If true, separate streaming rpcs will be used for heartbeats instead of sharing streams with state reads.")
-  @Default.Boolean(false)
-  boolean getUseSeparateWindmillHeartbeatStreams();
+  Boolean getUseSeparateWindmillHeartbeatStreams();
 
-  void setUseSeparateWindmillHeartbeatStreams(boolean value);
+  void setUseSeparateWindmillHeartbeatStreams(Boolean value);
 
   @Description("The number of streams to use for GetData requests.")
   @Default.Integer(1)

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/config/FakeGlobalConfigHandle.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/config/FakeGlobalConfigHandle.java
@@ -1,0 +1,52 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.streaming.config;
+
+import java.util.function.Consumer;
+import javax.annotation.Nonnull;
+import javax.annotation.concurrent.ThreadSafe;
+import org.apache.beam.sdk.annotations.Internal;
+
+@Internal
+@ThreadSafe
+/*
+ *  Fake StreamingGlobalConfigHandle used for Tests. Allows setting fake configs.
+ */
+public class FakeGlobalConfigHandle implements StreamingGlobalConfigHandle {
+
+  private final StreamingGlobalConfigHandleImpl globalConfigHandle;
+
+  public FakeGlobalConfigHandle(StreamingGlobalConfig config) {
+    this.globalConfigHandle = new StreamingGlobalConfigHandleImpl();
+    this.globalConfigHandle.setConfig(config);
+  }
+
+  @Override
+  public StreamingGlobalConfig getConfig() {
+    return globalConfigHandle.getConfig();
+  }
+
+  public void setConfig(StreamingGlobalConfig config) {
+    globalConfigHandle.setConfig(config);
+  }
+
+  @Override
+  public void registerConfigObserver(@Nonnull Consumer<StreamingGlobalConfig> callback) {
+    globalConfigHandle.registerConfigObserver(callback);
+  }
+}

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/refresh/StreamPoolHeartbeatSender.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/refresh/StreamPoolHeartbeatSender.java
@@ -51,23 +51,24 @@ public final class StreamPoolHeartbeatSender implements HeartbeatSender {
    * Creates StreamPoolHeartbeatSender that switches between the passed in stream pools depending on
    * global config.
    *
-   * @param heartbeatStreamPool stream to use when using separate streams for heartbeat is enabled.
+   * @param dedicatedHeartbeatPool stream to use when using separate streams for heartbeat is
+   *     enabled.
    * @param getDataPool stream to use when using separate streams for heartbeat is disabled.
    */
   public static StreamPoolHeartbeatSender Create(
-      @Nonnull WindmillStreamPool<WindmillStream.GetDataStream> heartbeatStreamPool,
+      @Nonnull WindmillStreamPool<WindmillStream.GetDataStream> dedicatedHeartbeatPool,
       @Nonnull WindmillStreamPool<WindmillStream.GetDataStream> getDataPool,
       @Nonnull StreamingGlobalConfigHandle configHandle) {
     // Use getDataPool as the default, settings callback will
     // switch to the separate pool if enabled before processing any elements are processed.
-    StreamPoolHeartbeatSender heartbeatSender = new StreamPoolHeartbeatSender(heartbeatStreamPool);
+    StreamPoolHeartbeatSender heartbeatSender = new StreamPoolHeartbeatSender(getDataPool);
     configHandle.registerConfigObserver(
         streamingGlobalConfig ->
             heartbeatSender.heartbeatStreamPool.set(
                 streamingGlobalConfig
                         .userWorkerJobSettings()
                         .getUseSeparateWindmillHeartbeatStreams()
-                    ? heartbeatStreamPool
+                    ? dedicatedHeartbeatPool
                     : getDataPool));
     return heartbeatSender;
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/refresh/StreamPoolHeartbeatSender.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/work/refresh/StreamPoolHeartbeatSender.java
@@ -17,6 +17,9 @@
  */
 package org.apache.beam.runners.dataflow.worker.windmill.work.refresh;
 
+import java.util.concurrent.atomic.AtomicReference;
+import javax.annotation.Nonnull;
+import org.apache.beam.runners.dataflow.worker.streaming.config.StreamingGlobalConfigHandle;
 import org.apache.beam.runners.dataflow.worker.windmill.client.CloseableStream;
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStream;
 import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStreamPool;
@@ -27,19 +30,52 @@ import org.slf4j.LoggerFactory;
 /** StreamingEngine stream pool based implementation of {@link HeartbeatSender}. */
 @Internal
 public final class StreamPoolHeartbeatSender implements HeartbeatSender {
+
   private static final Logger LOG = LoggerFactory.getLogger(StreamPoolHeartbeatSender.class);
 
-  private final WindmillStreamPool<WindmillStream.GetDataStream> heartbeatStreamPool;
+  @Nonnull
+  private final AtomicReference<WindmillStreamPool<WindmillStream.GetDataStream>>
+      heartbeatStreamPool = new AtomicReference<>();
 
-  public StreamPoolHeartbeatSender(
+  private StreamPoolHeartbeatSender(
       WindmillStreamPool<WindmillStream.GetDataStream> heartbeatStreamPool) {
-    this.heartbeatStreamPool = heartbeatStreamPool;
+    this.heartbeatStreamPool.set(heartbeatStreamPool);
+  }
+
+  public static StreamPoolHeartbeatSender Create(
+      @Nonnull WindmillStreamPool<WindmillStream.GetDataStream> heartbeatStreamPool) {
+    return new StreamPoolHeartbeatSender(heartbeatStreamPool);
+  }
+
+  /**
+   * Creates StreamPoolHeartbeatSender that switches between the passed in stream pools depending on
+   * global config.
+   *
+   * @param heartbeatStreamPool stream to use when using separate streams for heartbeat is enabled.
+   * @param getDataPool stream to use when using separate streams for heartbeat is disabled.
+   */
+  public static StreamPoolHeartbeatSender Create(
+      @Nonnull WindmillStreamPool<WindmillStream.GetDataStream> heartbeatStreamPool,
+      @Nonnull WindmillStreamPool<WindmillStream.GetDataStream> getDataPool,
+      @Nonnull StreamingGlobalConfigHandle configHandle) {
+    // Use getDataPool as the default, settings callback will
+    // switch to the separate pool if enabled before processing any elements are processed.
+    StreamPoolHeartbeatSender heartbeatSender = new StreamPoolHeartbeatSender(heartbeatStreamPool);
+    configHandle.registerConfigObserver(
+        streamingGlobalConfig ->
+            heartbeatSender.heartbeatStreamPool.set(
+                streamingGlobalConfig
+                        .userWorkerJobSettings()
+                        .getUseSeparateWindmillHeartbeatStreams()
+                    ? heartbeatStreamPool
+                    : getDataPool));
+    return heartbeatSender;
   }
 
   @Override
   public void sendHeartbeats(Heartbeats heartbeats) {
     try (CloseableStream<WindmillStream.GetDataStream> closeableStream =
-        heartbeatStreamPool.getCloseableStream()) {
+        heartbeatStreamPool.get().getCloseableStream()) {
       closeableStream.stream().refreshActiveWork(heartbeats.heartbeatRequests().asMap());
     } catch (Exception e) {
       LOG.warn("Error occurred sending heartbeats=[{}].", heartbeats, e);

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/work/refresh/StreamPoolHeartbeatSenderTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/work/refresh/StreamPoolHeartbeatSenderTest.java
@@ -1,0 +1,113 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.windmill.work.refresh;
+
+import static org.junit.Assert.assertEquals;
+
+import java.util.Optional;
+import org.apache.beam.runners.dataflow.worker.FakeWindmillServer;
+import org.apache.beam.runners.dataflow.worker.streaming.config.FixedGlobalConfigHandle;
+import org.apache.beam.runners.dataflow.worker.streaming.config.StreamingGlobalConfig;
+import org.apache.beam.runners.dataflow.worker.windmill.Windmill.HeartbeatRequest;
+import org.apache.beam.runners.dataflow.worker.windmill.Windmill.UserWorkerRunnerV1Settings;
+import org.apache.beam.runners.dataflow.worker.windmill.client.WindmillStreamPool;
+import org.joda.time.Duration;
+import org.junit.Test;
+import org.junit.rules.ErrorCollector;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class StreamPoolHeartbeatSenderTest {
+
+  @Test
+  public void sendsHeartbeatsOnStream() {
+    FakeWindmillServer server = new FakeWindmillServer(new ErrorCollector(), c -> Optional.empty());
+    StreamPoolHeartbeatSender heartbeatSender =
+        StreamPoolHeartbeatSender.Create(
+            WindmillStreamPool.create(1, Duration.standardSeconds(10), server::getDataStream));
+    Heartbeats.Builder heartbeatsBuilder = Heartbeats.builder();
+    heartbeatsBuilder
+        .heartbeatRequestsBuilder()
+        .put("key", HeartbeatRequest.newBuilder().setWorkToken(123).build());
+    heartbeatSender.sendHeartbeats(heartbeatsBuilder.build());
+    assertEquals(1, server.getGetDataRequests().size());
+  }
+
+  @Test
+  public void sendsHeartbeatsOnDedicatedStream() {
+    FakeWindmillServer dedicatedServer =
+        new FakeWindmillServer(new ErrorCollector(), c -> Optional.empty());
+    FakeWindmillServer getDataServer =
+        new FakeWindmillServer(new ErrorCollector(), c -> Optional.empty());
+
+    FixedGlobalConfigHandle configHandle =
+        new FixedGlobalConfigHandle(
+            StreamingGlobalConfig.builder()
+                .setUserWorkerJobSettings(
+                    UserWorkerRunnerV1Settings.newBuilder()
+                        .setUseSeparateWindmillHeartbeatStreams(true)
+                        .build())
+                .build());
+    StreamPoolHeartbeatSender heartbeatSender =
+        StreamPoolHeartbeatSender.Create(
+            WindmillStreamPool.create(
+                1, Duration.standardSeconds(10), dedicatedServer::getDataStream),
+            WindmillStreamPool.create(
+                1, Duration.standardSeconds(10), getDataServer::getDataStream),
+            configHandle);
+    Heartbeats.Builder heartbeatsBuilder = Heartbeats.builder();
+    heartbeatsBuilder
+        .heartbeatRequestsBuilder()
+        .put("key", HeartbeatRequest.newBuilder().setWorkToken(123).build());
+    heartbeatSender.sendHeartbeats(heartbeatsBuilder.build());
+    assertEquals(1, dedicatedServer.getGetDataRequests().size());
+    assertEquals(0, getDataServer.getGetDataRequests().size());
+  }
+
+  @Test
+  public void sendsHeartbeatsOnGetDataStream() {
+    FakeWindmillServer dedicatedServer =
+        new FakeWindmillServer(new ErrorCollector(), c -> Optional.empty());
+    FakeWindmillServer getDataServer =
+        new FakeWindmillServer(new ErrorCollector(), c -> Optional.empty());
+
+    FixedGlobalConfigHandle configHandle =
+        new FixedGlobalConfigHandle(
+            StreamingGlobalConfig.builder()
+                .setUserWorkerJobSettings(
+                    UserWorkerRunnerV1Settings.newBuilder()
+                        .setUseSeparateWindmillHeartbeatStreams(false)
+                        .build())
+                .build());
+    StreamPoolHeartbeatSender heartbeatSender =
+        StreamPoolHeartbeatSender.Create(
+            WindmillStreamPool.create(
+                1, Duration.standardSeconds(10), dedicatedServer::getDataStream),
+            WindmillStreamPool.create(
+                1, Duration.standardSeconds(10), getDataServer::getDataStream),
+            configHandle);
+    Heartbeats.Builder heartbeatsBuilder = Heartbeats.builder();
+    heartbeatsBuilder
+        .heartbeatRequestsBuilder()
+        .put("key", HeartbeatRequest.newBuilder().setWorkToken(123).build());
+    heartbeatSender.sendHeartbeats(heartbeatsBuilder.build());
+    assertEquals(0, dedicatedServer.getGetDataRequests().size());
+    assertEquals(1, getDataServer.getGetDataRequests().size());
+  }
+}


### PR DESCRIPTION
The logic is guarded behind an experiment `streaming_engine_use_job_settings_for_heartbeat_pool`. The experiment will be removed once backend changes are rollback safe. 