### PR TITLE
[GCSIO] Fix internal unit test failure

### DIFF
--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -975,6 +975,11 @@ class GoogleCloudOptions(PipelineOptions):
   # Log warning if soft delete policy is enabled in a gcs bucket
   # that is specified in an argument.
   def _warn_if_soft_delete_policy_enabled(self, arg_name):
+    # skip the check if it is in dry-run mode because the later step requires
+    # internet connection to access GCS
+    if self.view_as(TestOptions).dry_run:
+      return
+
     gcs_path = getattr(self, arg_name, None)
     try:
       from apache_beam.io.gcp import gcsio
@@ -1023,8 +1028,7 @@ class GoogleCloudOptions(PipelineOptions):
   def validate(self, validator):
     errors = []
     if validator.is_service_runner():
-      if not self.view_as(TestOptions).dry_run:
-        errors.extend(self._handle_temp_and_staging_locations(validator))
+      errors.extend(self._handle_temp_and_staging_locations(validator))
       errors.extend(validator.validate_cloud_options(self))
 
     if self.view_as(DebugOptions).dataflow_job_file:

--- a/sdks/python/apache_beam/options/pipeline_options.py
+++ b/sdks/python/apache_beam/options/pipeline_options.py
@@ -1023,7 +1023,8 @@ class GoogleCloudOptions(PipelineOptions):
   def validate(self, validator):
     errors = []
     if validator.is_service_runner():
-      errors.extend(self._handle_temp_and_staging_locations(validator))
+      if not self.view_as(TestOptions).dry_run:
+        errors.extend(self._handle_temp_and_staging_locations(validator))
       errors.extend(validator.validate_cloud_options(self))
 
     if self.view_as(DebugOptions).dataflow_job_file:

--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -45,7 +45,7 @@ from apache_beam.transforms.display_test import DisplayDataItemMatcher
 _LOGGER = logging.getLogger(__name__)
 
 try:
-  import apache_beam.io.gcp.gcsio # pylint: disable=unused-import
+  import apache_beam.io.gcp.gcsio  # pylint: disable=unused-import
   has_gcsio = True
 except ImportError:
   has_gcsio = False

--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -719,8 +719,10 @@ class PipelineOptionsTest(unittest.TestCase):
         '--temp_location=gs://beam/tmp'
     ])
     validator = PipelineOptionsValidator(options, runner)
-    errors = options._handle_temp_and_staging_locations(validator)
-    self.assertEqual(errors, [])
+    with mock.patch('apache_beam.io.gcp.gcsio.GcsIO.is_soft_delete_enabled',
+                    return_value=False):
+      errors = options._handle_temp_and_staging_locations(validator)
+      self.assertEqual(errors, [])
     self.assertEqual(
         options.get_all_options()['staging_location'], "gs://beam/stg")
     self.assertEqual(
@@ -734,8 +736,10 @@ class PipelineOptionsTest(unittest.TestCase):
         '--temp_location=gs://beam/tmp'
     ])
     validator = PipelineOptionsValidator(options, runner)
-    errors = options._handle_temp_and_staging_locations(validator)
-    self.assertEqual(errors, [])
+    with mock.patch('apache_beam.io.gcp.gcsio.GcsIO.is_soft_delete_enabled',
+                    return_value=False):
+      errors = options._handle_temp_and_staging_locations(validator)
+      self.assertEqual(errors, [])
     self.assertEqual(
         options.get_all_options()['staging_location'], "gs://beam/tmp")
     self.assertEqual(
@@ -749,8 +753,10 @@ class PipelineOptionsTest(unittest.TestCase):
         '--temp_location=badGSpath'
     ])
     validator = PipelineOptionsValidator(options, runner)
-    errors = options._handle_temp_and_staging_locations(validator)
-    self.assertEqual(errors, [])
+    with mock.patch('apache_beam.io.gcp.gcsio.GcsIO.is_soft_delete_enabled',
+                    return_value=False):
+      errors = options._handle_temp_and_staging_locations(validator)
+      self.assertEqual(errors, [])
     self.assertEqual(
         options.get_all_options()['staging_location'], "gs://beam/stg")
     self.assertEqual(
@@ -764,8 +770,10 @@ class PipelineOptionsTest(unittest.TestCase):
         '--temp_location=badGSpath'
     ])
     validator = PipelineOptionsValidator(options, runner)
-    errors = options._handle_temp_and_staging_locations(validator)
-    self.assertEqual(errors, [])
+    with mock.patch('apache_beam.io.gcp.gcsio.GcsIO.is_soft_delete_enabled',
+                    return_value=False):
+      errors = options._handle_temp_and_staging_locations(validator)
+      self.assertEqual(errors, [])
     self.assertEqual(
         options.get_all_options()['staging_location'], "gs://default/bucket")
     self.assertEqual(
@@ -779,8 +787,10 @@ class PipelineOptionsTest(unittest.TestCase):
         '--temp_location=badGSpath'
     ])
     validator = PipelineOptionsValidator(options, runner)
-    errors = options._handle_temp_and_staging_locations(validator)
-    self.assertEqual(len(errors), 2, errors)
+    with mock.patch('apache_beam.io.gcp.gcsio.GcsIO.is_soft_delete_enabled',
+                    return_value=False):
+      errors = options._handle_temp_and_staging_locations(validator)
+      self.assertEqual(len(errors), 2, errors)
     self.assertIn(
         'Invalid GCS path (badGSpath), given for the option: temp_location.',
         errors,

--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -33,6 +33,7 @@ from apache_beam.options.pipeline_options import DebugOptions
 from apache_beam.options.pipeline_options import GoogleCloudOptions
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import ProfilingOptions
+from apache_beam.options.pipeline_options import TestOptions
 from apache_beam.options.pipeline_options import TypeOptions
 from apache_beam.options.pipeline_options import WorkerOptions
 from apache_beam.options.pipeline_options import _BeamArgumentParser
@@ -718,11 +719,10 @@ class PipelineOptionsTest(unittest.TestCase):
         '--staging_location=gs://beam/stg',
         '--temp_location=gs://beam/tmp'
     ])
+    options.view_as(TestOptions).dry_run = True
     validator = PipelineOptionsValidator(options, runner)
-    with mock.patch('apache_beam.io.gcp.gcsio.GcsIO.is_soft_delete_enabled',
-                    return_value=False):
-      errors = options._handle_temp_and_staging_locations(validator)
-      self.assertEqual(errors, [])
+    errors = options._handle_temp_and_staging_locations(validator)
+    self.assertEqual(errors, [])
     self.assertEqual(
         options.get_all_options()['staging_location'], "gs://beam/stg")
     self.assertEqual(
@@ -735,11 +735,10 @@ class PipelineOptionsTest(unittest.TestCase):
         '--staging_location=badGSpath',
         '--temp_location=gs://beam/tmp'
     ])
+    options.view_as(TestOptions).dry_run = True
     validator = PipelineOptionsValidator(options, runner)
-    with mock.patch('apache_beam.io.gcp.gcsio.GcsIO.is_soft_delete_enabled',
-                    return_value=False):
-      errors = options._handle_temp_and_staging_locations(validator)
-      self.assertEqual(errors, [])
+    errors = options._handle_temp_and_staging_locations(validator)
+    self.assertEqual(errors, [])
     self.assertEqual(
         options.get_all_options()['staging_location'], "gs://beam/tmp")
     self.assertEqual(
@@ -752,11 +751,10 @@ class PipelineOptionsTest(unittest.TestCase):
         '--staging_location=gs://beam/stg',
         '--temp_location=badGSpath'
     ])
+    options.view_as(TestOptions).dry_run = True
     validator = PipelineOptionsValidator(options, runner)
-    with mock.patch('apache_beam.io.gcp.gcsio.GcsIO.is_soft_delete_enabled',
-                    return_value=False):
-      errors = options._handle_temp_and_staging_locations(validator)
-      self.assertEqual(errors, [])
+    errors = options._handle_temp_and_staging_locations(validator)
+    self.assertEqual(errors, [])
     self.assertEqual(
         options.get_all_options()['staging_location'], "gs://beam/stg")
     self.assertEqual(
@@ -769,11 +767,10 @@ class PipelineOptionsTest(unittest.TestCase):
         '--staging_location=badGSpath',
         '--temp_location=badGSpath'
     ])
+    options.view_as(TestOptions).dry_run = True
     validator = PipelineOptionsValidator(options, runner)
-    with mock.patch('apache_beam.io.gcp.gcsio.GcsIO.is_soft_delete_enabled',
-                    return_value=False):
-      errors = options._handle_temp_and_staging_locations(validator)
-      self.assertEqual(errors, [])
+    errors = options._handle_temp_and_staging_locations(validator)
+    self.assertEqual(errors, [])
     self.assertEqual(
         options.get_all_options()['staging_location'], "gs://default/bucket")
     self.assertEqual(
@@ -786,11 +783,10 @@ class PipelineOptionsTest(unittest.TestCase):
         '--staging_location=badGSpath',
         '--temp_location=badGSpath'
     ])
+    options.view_as(TestOptions).dry_run = True
     validator = PipelineOptionsValidator(options, runner)
-    with mock.patch('apache_beam.io.gcp.gcsio.GcsIO.is_soft_delete_enabled',
-                    return_value=False):
-      errors = options._handle_temp_and_staging_locations(validator)
-      self.assertEqual(len(errors), 2, errors)
+    errors = options._handle_temp_and_staging_locations(validator)
+    self.assertEqual(len(errors), 2, errors)
     self.assertIn(
         'Invalid GCS path (badGSpath), given for the option: temp_location.',
         errors,

--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -33,7 +33,6 @@ from apache_beam.options.pipeline_options import DebugOptions
 from apache_beam.options.pipeline_options import GoogleCloudOptions
 from apache_beam.options.pipeline_options import PipelineOptions
 from apache_beam.options.pipeline_options import ProfilingOptions
-from apache_beam.options.pipeline_options import TestOptions
 from apache_beam.options.pipeline_options import TypeOptions
 from apache_beam.options.pipeline_options import WorkerOptions
 from apache_beam.options.pipeline_options import _BeamArgumentParser
@@ -44,6 +43,12 @@ from apache_beam.transforms.display import DisplayData
 from apache_beam.transforms.display_test import DisplayDataItemMatcher
 
 _LOGGER = logging.getLogger(__name__)
+
+try:
+  import apache_beam.io.gcp.gcsio
+  has_gcsio = True
+except ImportError:
+  has_gcsio = False
 
 
 # Mock runners to use for validations.
@@ -712,6 +717,16 @@ class PipelineOptionsTest(unittest.TestCase):
         "the dest and the flag name to the map "
         "_FLAG_THAT_SETS_FALSE_VALUE in PipelineOptions.py")
 
+  def _check_errors(self, options, validator, expected):
+    if has_gcsio:
+      with mock.patch('apache_beam.io.gcp.gcsio.GcsIO.is_soft_delete_enabled',
+                      return_value=False):
+        errors = options._handle_temp_and_staging_locations(validator)
+        self.assertEqual(errors, expected)
+    else:
+      errors = options._handle_temp_and_staging_locations(validator)
+      self.assertEqual(errors, expected)
+
   def test_validation_good_stg_good_temp(self):
     runner = MockRunners.DataflowRunner()
     options = GoogleCloudOptions([
@@ -719,10 +734,8 @@ class PipelineOptionsTest(unittest.TestCase):
         '--staging_location=gs://beam/stg',
         '--temp_location=gs://beam/tmp'
     ])
-    options.view_as(TestOptions).dry_run = True
     validator = PipelineOptionsValidator(options, runner)
-    errors = options._handle_temp_and_staging_locations(validator)
-    self.assertEqual(errors, [])
+    self._check_errors(options, validator, [])
     self.assertEqual(
         options.get_all_options()['staging_location'], "gs://beam/stg")
     self.assertEqual(
@@ -735,10 +748,8 @@ class PipelineOptionsTest(unittest.TestCase):
         '--staging_location=badGSpath',
         '--temp_location=gs://beam/tmp'
     ])
-    options.view_as(TestOptions).dry_run = True
     validator = PipelineOptionsValidator(options, runner)
-    errors = options._handle_temp_and_staging_locations(validator)
-    self.assertEqual(errors, [])
+    self._check_errors(options, validator, [])
     self.assertEqual(
         options.get_all_options()['staging_location'], "gs://beam/tmp")
     self.assertEqual(
@@ -751,10 +762,8 @@ class PipelineOptionsTest(unittest.TestCase):
         '--staging_location=gs://beam/stg',
         '--temp_location=badGSpath'
     ])
-    options.view_as(TestOptions).dry_run = True
     validator = PipelineOptionsValidator(options, runner)
-    errors = options._handle_temp_and_staging_locations(validator)
-    self.assertEqual(errors, [])
+    self._check_errors(options, validator, [])
     self.assertEqual(
         options.get_all_options()['staging_location'], "gs://beam/stg")
     self.assertEqual(
@@ -767,10 +776,8 @@ class PipelineOptionsTest(unittest.TestCase):
         '--staging_location=badGSpath',
         '--temp_location=badGSpath'
     ])
-    options.view_as(TestOptions).dry_run = True
     validator = PipelineOptionsValidator(options, runner)
-    errors = options._handle_temp_and_staging_locations(validator)
-    self.assertEqual(errors, [])
+    self._check_errors(options, validator, [])
     self.assertEqual(
         options.get_all_options()['staging_location'], "gs://default/bucket")
     self.assertEqual(
@@ -783,18 +790,16 @@ class PipelineOptionsTest(unittest.TestCase):
         '--staging_location=badGSpath',
         '--temp_location=badGSpath'
     ])
-    options.view_as(TestOptions).dry_run = True
     validator = PipelineOptionsValidator(options, runner)
-    errors = options._handle_temp_and_staging_locations(validator)
-    self.assertEqual(len(errors), 2, errors)
-    self.assertIn(
-        'Invalid GCS path (badGSpath), given for the option: temp_location.',
-        errors,
-        errors)
-    self.assertIn(
-        'Invalid GCS path (badGSpath), given for the option: staging_location.',
-        errors,
-        errors)
+    self._check_errors(
+        options,
+        validator,
+        [
+          'Invalid GCS path (badGSpath), given for the option: ' \
+            'temp_location.',
+          'Invalid GCS path (badGSpath), given for the option: ' \
+            'staging_location.'
+        ])
 
 
 if __name__ == '__main__':

--- a/sdks/python/apache_beam/options/pipeline_options_test.py
+++ b/sdks/python/apache_beam/options/pipeline_options_test.py
@@ -45,7 +45,7 @@ from apache_beam.transforms.display_test import DisplayDataItemMatcher
 _LOGGER = logging.getLogger(__name__)
 
 try:
-  import apache_beam.io.gcp.gcsio
+  import apache_beam.io.gcp.gcsio # pylint: disable=unused-import
   has_gcsio = True
 except ImportError:
   has_gcsio = False


### PR DESCRIPTION
Skip or mock the check of `is_soft_delete_enabled`, because it requires a networck connection to access GCS.