### PR TITLE
[yaml] Add Beam YAML Examples

### DIFF
--- a/sdks/python/apache_beam/yaml/examples/io/test_aggregation_using_sql.yaml
+++ b/sdks/python/apache_beam/yaml/examples/io/test_aggregation_using_sql.yaml
@@ -1,0 +1,63 @@
+# coding=utf-8
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This examples reads from a public file stored on Google Cloud. This
+# requires authenticating with Google Cloud, or setting the file in
+#`ReadFromText` to a local file.
+#
+# To set up Application Default Credentials,
+# see https://cloud.google.com/docs/authentication/external/set-up-adc for more
+# information
+#
+# The following example reads mock transaction data from resources/products.csv
+# then performs a MapToFields in order to rename the imput data names
+# then uses a Combine with sql to run some aggregations
+pipeline:
+  transforms:
+    - type: ReadFromCsv
+      name: ReadInputFile
+      config:
+        path: gs://apache-beam-samples/beam-yaml-blog/products.csv
+    - type: MapToFields
+      name: MapToFields
+      input: ReadInputFile
+      config:
+        language: sql
+        fields:
+          id: "transaction_id"
+          prod_name: "product_name"
+          category_name: "category"
+          price: "price"
+    - type: Combine
+      name: Combines
+      input: MapToFields
+      config:
+        language: sql
+        group_by: category_name
+        combine:
+          num_sold: count
+          revenue: sum
+    - type: WriteToCsv
+      name: WriteOutputFile
+      input: Combines
+      config:
+        path: output
+        
+# Expected:
+#  Row(category_name='Apparel', num_sold=1, revenue=109.99)
+#  Row(category_name='Kitchen', num_sold=1, revenue=29.99)
+#  Row(category_name='Electronics', num_sold=3, revenue=369.97)

--- a/sdks/python/apache_beam/yaml/examples/io/test_aggregation_using_sqlstatement.yaml
+++ b/sdks/python/apache_beam/yaml/examples/io/test_aggregation_using_sqlstatement.yaml
@@ -1,0 +1,49 @@
+# coding=utf-8
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This examples reads from a public file stored on Google Cloud. This
+# requires authenticating with Google Cloud, or setting the file in
+#`ReadFromText` to a local file.
+#
+# To set up Application Default Credentials,
+# see https://cloud.google.com/docs/authentication/external/set-up-adc for more
+# information
+#
+# The following example reads data from a Mysql database
+# then load the results back to a Postgre database
+pipeline:
+  transforms:
+    - type: ReadFromCsv
+      name: ReadInputFile
+      config:
+        path: gs://apache-beam-samples/beam-yaml-blog/products.csv
+        delimiter: ","
+    - type: Sql
+      name: SqlCommand 
+      config:
+        query: "select category, count(*) as num_sold, sum(price) as revenue, max(price) as max_price from PCOLLECTION group by category"
+      input: ReadInputFile
+    - type: WriteToCsv
+      name: WriteOutputFile
+      input: SqlCommand
+      config:
+        path: output.csv
+        
+# Expected:
+#  Row(category='Apparel', num_sold=1, revenue=109.99, max_price=109.99)
+#  Row(category='Kitchen', num_sold=1, revenue=29.99, max_price=29.99)
+#  Row(category='Electronics', num_sold=3, revenue=369.97, max_price=249.99)

--- a/sdks/python/apache_beam/yaml/examples/io/test_read_mysql_write_postgres.yaml
+++ b/sdks/python/apache_beam/yaml/examples/io/test_read_mysql_write_postgres.yaml
@@ -1,0 +1,48 @@
+# coding=utf-8
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This examples reads from a public file stored on Google Cloud. This
+# requires authenticating with Google Cloud, or setting the file in
+#`ReadFromText` to a local file.
+#
+# To set up Application Default Credentials,
+# see https://cloud.google.com/docs/authentication/external/set-up-adc for more
+# information
+#
+# The following example reads data from a Mysql database
+# then load the results back to a Postgre database
+pipeline:
+  transforms:
+    - type: ReadFromJdbc
+      name: ReadFromMysql
+      config:
+        driver_class_name: 'com.mysql.cj.jdbc.Driver'
+        jdbc_url: 'jdbc:mysql://database_ip:3306/database_name'
+        username: 'username'
+        password: 'password'
+        read_query: 'select * from table;'
+        driver_jars: 'mysql-connector-j-9.0.0.jar'
+    - type: WriteToJdbc
+      name: WriteToJdbc
+      input: ReadFromMysql
+      config:
+        driver_class_name: 'org.postgresql.Driver'
+        jdbc_url: 'jdbc:postgresql://database_ip:5432/database_name'
+        username: 'username'
+        password: 'password'
+        table: 'table_name'
+        driver_jars: 'postgresql-42.7.4.jar'

--- a/sdks/python/apache_beam/yaml/examples/test_aggregation_using_sql.yaml
+++ b/sdks/python/apache_beam/yaml/examples/test_aggregation_using_sql.yaml
@@ -1,0 +1,63 @@
+# coding=utf-8
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This examples reads from a public file stored on Google Cloud. This
+# requires authenticating with Google Cloud, or setting the file in
+#`ReadFromText` to a local file.
+#
+# To set up Application Default Credentials,
+# see https://cloud.google.com/docs/authentication/external/set-up-adc for more
+# information
+#
+# The following example reads mock transaction data from resources/products.csv
+# then performs a MapToFields in order to rename the imput data names
+# then uses a Combine with sql to run some aggregations
+pipeline:
+  transforms:
+    - type: ReadFromCsv
+      name: ReadInputFile
+      config:
+        path: gs://apache-beam-samples/beam-yaml-blog/products.csv
+    - type: MapToFields
+      name: MapToFields
+      input: ReadInputFile
+      config:
+        language: sql
+        fields:
+          id: "transaction_id"
+          prod_name: "product_name"
+          category_name: "category"
+          price: "price"
+    - type: Combine
+      name: Combines
+      input: MapToFields
+      config:
+        language: sql
+        group_by: category_name
+        combine:
+          num_sold: count
+          revenue: sum
+    - type: WriteToCsv
+      name: WriteOutputFile
+      input: Combines
+      config:
+        path: output
+        
+# Expected:
+#  Row(category_name='Apparel', num_sold=1, revenue=109.99)
+#  Row(category_name='Kitchen', num_sold=1, revenue=29.99)
+#  Row(category_name='Electronics', num_sold=3, revenue=369.97)

--- a/sdks/python/apache_beam/yaml/examples/test_aggregation_using_sqlstatement.yaml
+++ b/sdks/python/apache_beam/yaml/examples/test_aggregation_using_sqlstatement.yaml
@@ -1,0 +1,49 @@
+# coding=utf-8
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This examples reads from a public file stored on Google Cloud. This
+# requires authenticating with Google Cloud, or setting the file in
+#`ReadFromText` to a local file.
+#
+# To set up Application Default Credentials,
+# see https://cloud.google.com/docs/authentication/external/set-up-adc for more
+# information
+#
+# The following example reads data from a Mysql database
+# then load the results back to a Postgre database
+pipeline:
+  transforms:
+    - type: ReadFromCsv
+      name: ReadInputFile
+      config:
+        path: gs://apache-beam-samples/beam-yaml-blog/products.csv
+        delimiter: ","
+    - type: Sql
+      name: SqlCommand 
+      config:
+        query: "select category, count(*) as num_sold, sum(price) as revenue, max(price) as max_price from PCOLLECTION group by category"
+      input: ReadInputFile
+    - type: WriteToCsv
+      name: WriteOutputFile
+      input: SqlCommand
+      config:
+        path: output.csv
+        
+# Expected:
+#  Row(category='Apparel', num_sold=1, revenue=109.99, max_price=109.99)
+#  Row(category='Kitchen', num_sold=1, revenue=29.99, max_price=29.99)
+#  Row(category='Electronics', num_sold=3, revenue=369.97, max_price=249.99)

--- a/sdks/python/apache_beam/yaml/examples/test_read_mysql_write_postgres.yaml
+++ b/sdks/python/apache_beam/yaml/examples/test_read_mysql_write_postgres.yaml
@@ -33,13 +33,10 @@ pipeline:
         username: 'username'
         password: 'password'
         query: 'select * from table;'
-    - type: WriteToJdbc
-      name: WriteToJdbc
+    - type: WriteToPostgres
       input: ReadFromMysql
       config:
-        driver_class_name: 'org.postgresql.Driver'
-        jdbc_url: 'jdbc:postgresql://database_ip:5432/database_name'
+        url: 'jdbc:postgresql://database_ip:5432/database_name'
         username: 'username'
         password: 'password'
         table: 'table_name'
-        driver_jars: 'postgresql-42.7.4.jar'

--- a/sdks/python/apache_beam/yaml/examples/test_read_mysql_write_postgres.yaml
+++ b/sdks/python/apache_beam/yaml/examples/test_read_mysql_write_postgres.yaml
@@ -15,13 +15,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# This examples reads from a public file stored on Google Cloud. This
-# requires authenticating with Google Cloud, or setting the file in
-#`ReadFromText` to a local file.
-#
-# To set up Application Default Credentials,
-# see https://cloud.google.com/docs/authentication/external/set-up-adc for more
-# information
 #
 # The following example reads data from a Mysql database
 # then load the results back to a Postgre database

--- a/sdks/python/apache_beam/yaml/examples/test_read_mysql_write_postgres.yaml
+++ b/sdks/python/apache_beam/yaml/examples/test_read_mysql_write_postgres.yaml
@@ -27,15 +27,12 @@
 # then load the results back to a Postgre database
 pipeline:
   transforms:
-    - type: ReadFromJdbc
-      name: ReadFromMysql
+    - type: ReadFromMySql
       config:
-        driver_class_name: 'com.mysql.cj.jdbc.Driver'
-        jdbc_url: 'jdbc:mysql://database_ip:3306/database_name'
+        url: 'jdbc:mysql://database_ip:3306/database_name'
         username: 'username'
         password: 'password'
-        read_query: 'select * from table;'
-        driver_jars: 'mysql-connector-j-9.0.0.jar'
+        query: 'select * from table;'
     - type: WriteToJdbc
       name: WriteToJdbc
       input: ReadFromMysql

--- a/sdks/python/apache_beam/yaml/examples/test_read_mysql_write_postgres.yaml
+++ b/sdks/python/apache_beam/yaml/examples/test_read_mysql_write_postgres.yaml
@@ -1,0 +1,48 @@
+# coding=utf-8
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# This examples reads from a public file stored on Google Cloud. This
+# requires authenticating with Google Cloud, or setting the file in
+#`ReadFromText` to a local file.
+#
+# To set up Application Default Credentials,
+# see https://cloud.google.com/docs/authentication/external/set-up-adc for more
+# information
+#
+# The following example reads data from a Mysql database
+# then load the results back to a Postgre database
+pipeline:
+  transforms:
+    - type: ReadFromJdbc
+      name: ReadFromMysql
+      config:
+        driver_class_name: 'com.mysql.cj.jdbc.Driver'
+        jdbc_url: 'jdbc:mysql://database_ip:3306/database_name'
+        username: 'username'
+        password: 'password'
+        read_query: 'select * from table;'
+        driver_jars: 'mysql-connector-j-9.0.0.jar'
+    - type: WriteToJdbc
+      name: WriteToJdbc
+      input: ReadFromMysql
+      config:
+        driver_class_name: 'org.postgresql.Driver'
+        jdbc_url: 'jdbc:postgresql://database_ip:5432/database_name'
+        username: 'username'
+        password: 'password'
+        table: 'table_name'
+        driver_jars: 'postgresql-42.7.4.jar'

--- a/sdks/python/apache_beam/yaml/examples/test_read_mysql_write_postgres.yaml
+++ b/sdks/python/apache_beam/yaml/examples/test_read_mysql_write_postgres.yaml
@@ -17,7 +17,7 @@
 
 #
 # The following example reads data from a Mysql database
-# then load the results back to a Postgre database
+# then loads the results back to a Postgres database
 pipeline:
   transforms:
     - type: ReadFromMySql


### PR DESCRIPTION
1x Example: MapToFields and Combine using SQL
1x Example: MapToFields using SQL and the SQL type command
1x Example: Using JDBC connection to read (Mysql) and write (Postgre) in a database
