### PR TITLE
[WIP] Enable CDC configuration for cross language StorageWrite API usage

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProviderTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProviderTest.java
@@ -56,6 +56,7 @@ import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.PCollectionRowTuple;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.sdk.values.TypeDescriptors;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -230,7 +231,7 @@ public class BigQueryStorageWriteApiSchemaTransformProviderTest {
     BigQueryStorageWriteApiSchemaTransformConfiguration config =
         BigQueryStorageWriteApiSchemaTransformConfiguration.builder()
             .setTable(tableSpec)
-            .setUseCDCWritesWithTablePrimaryKey(List.of("name"))
+            .setUseCDCWritesWithPrimaryKey(ImmutableList.of("name"))
             .build();
 
     Schema cdcInfoSchema =
@@ -243,7 +244,7 @@ public class BigQueryStorageWriteApiSchemaTransformProviderTest {
             .addRowField("record", SCHEMA)
             .addRowField("cdc_info", cdcInfoSchema)
             .build();
-    
+
     List<Row> rowsDuplicated =
         Stream.concat(ROWS.stream(), ROWS.stream()).collect(Collectors.toList());
     List<Row> rowsWithCDC =
@@ -285,7 +286,7 @@ public class BigQueryStorageWriteApiSchemaTransformProviderTest {
     BigQueryStorageWriteApiSchemaTransformConfiguration config =
         BigQueryStorageWriteApiSchemaTransformConfiguration.builder()
             .setTable(dynamic)
-            .setUseCDCWritesWithTablePrimaryKey(List.of("name"))
+            .setUseCDCWritesWithPrimaryKey(ImmutableList.of("name"))
             .build();
 
     String baseTableSpec = "project:dataset.dynamic_write_";
@@ -301,7 +302,7 @@ public class BigQueryStorageWriteApiSchemaTransformProviderTest {
             .addRowField("record", SCHEMA)
             .addRowField("cdc_info", cdcInfoSchema)
             .build();
-    
+
     List<Row> rowsDuplicated =
         Stream.concat(ROWS.stream(), ROWS.stream()).collect(Collectors.toList());
     List<Row> rowsWithDestinationsAndCDC =

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProviderTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigquery/providers/BigQueryStorageWriteApiSchemaTransformProviderTest.java
@@ -257,7 +257,8 @@ public class BigQueryStorageWriteApiSchemaTransformProviderTest {
                           "cdc_info",
                           Row.withSchema(cdcInfoSchema)
                               .withFieldValue("mutation_info", "UPSERT")
-                              .withFieldValue("change_sequence_number", "AAA/" + idx))
+                              .withFieldValue("change_sequence_number", "AAA/" + idx)
+                              .build())
                       .withFieldValue("record", row)
                       .build();
                 })
@@ -316,7 +317,8 @@ public class BigQueryStorageWriteApiSchemaTransformProviderTest {
                           "cdc_info",
                           Row.withSchema(cdcInfoSchema)
                               .withFieldValue("mutation_info", "UPSERT")
-                              .withFieldValue("change_sequence_number", "AAA/" + idx))
+                              .withFieldValue("change_sequence_number", "AAA/" + idx)
+                              .build())
                       .withFieldValue("record", row)
                       .build();
                 })


### PR DESCRIPTION
This change enables the configuration of CDC usage for the `BigQueryStorageWriteApiSchemaTransformProvider`. 

By setting `configuration.setUseCDCWritesWithPrimaryKey(List.of("col1", "col2"))` on the provider's config, the transform creation will create a `BigQuery.Write<Row>` transform that will configure the right row mutation information by checking for a Row schema like: 
```
{
  cdc_info:{
    mutation_type: "..."              // can be UPSERT or DELETE
    change_sequence_number: "..."     // used for custom insert ordering
  }
  record:{...}                        // actual data to be inserted
}
```

The implementation also enables the possibility of setting a dynamic destination alongside with CDC usage by using this Row schema: 
```
{
  cdc_info:{
    mutation_type: "..."              // can be UPSERT or DELETE
    change_sequence_number: "..."     // used for custom insert ordering
  }
  destination: "..."                  // destination table for the data
  record:{...}                        // actual data to be inserted
}
```
**Note:** In case of using dynamic destination and CDC is only supported when all the destination share the same primary key columns.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
