### PR TITLE
[#32498][prism] Add split / progress back off + catch-up.

### DIFF
--- a/sdks/go/pkg/beam/runners/prism/internal/preprocess_test.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/preprocess_test.go
@@ -134,7 +134,11 @@ func Test_preprocessor_preProcessGraph(t *testing.T) {
 			}})
 
 			gotStages := pre.preProcessGraph(test.input, nil)
-			if diff := cmp.Diff(test.wantStages, gotStages, cmp.AllowUnexported(stage{}, link{}), cmpopts.EquateEmpty()); diff != "" {
+			if diff := cmp.Diff(test.wantStages, gotStages,
+				cmp.AllowUnexported(stage{}, link{}),
+				cmpopts.EquateEmpty(),
+				cmpopts.IgnoreFields(stage{}, "baseProgTick"),
+			); diff != "" {
 				t.Errorf("preProcessGraph(%q) stages diff (-want,+got)\n%v", test.name, diff)
 			}
 

--- a/sdks/go/pkg/beam/runners/prism/internal/stage.go
+++ b/sdks/go/pkg/beam/runners/prism/internal/stage.go
@@ -84,7 +84,7 @@ type stage struct {
 
 // The minimum and maximum durations between each ProgressBundleRequest and split evaluation.
 const (
-	minimumProgTick = 10 * time.Millisecond
+	minimumProgTick = 100 * time.Millisecond
 	maximumProgTick = 30 * time.Second
 )
 
@@ -266,7 +266,7 @@ progress:
 	}
 	// If we never received any progress ticks, we may have too long a time, shrink it for new runs instead.
 	if !ticked {
-		newTick := clampTick(baseTick / 2)
+		newTick := clampTick(baseTick - minimumProgTick)
 		// If it's otherwise unchanged, apply the new duration.
 		s.baseProgTick.CompareAndSwap(baseTick, newTick)
 	}


### PR DESCRIPTION
Prism splits too aggressively in low latency scenarios, which for textio can cause splitting to single byte inputs most of which don't output anything.

While it would be nice to make this configurable, that is more plumbing than I'd like to do right now. Instead we add some per stage back off and catchup.

* Give each stage an atomic progress interval value for its "ticks".
* If no progress has been made in the interval (via no PCollections element count or channel index changes), split.
* If we successfully split, back off the interval for all instances of the stage.
   * This back off is clamped to a 30 second interval maximum.
   * Back off is multiplicative (by a factor of 4).
   * New bundles for this stage use that value.
   * Reduces noisy per bundle log printouts by splitting less.
* If bundles begin to complete without having any progress ticks, reduce the interval to catch up.
   * This catch up is clamped to a minimum interval of 100 milliseconds.
   * The catch up is additive (where we subtract the minimum interval from the current value).
   * This allows us to get to a clear "rate" per stage, where it should settle on getting at least one progress tick.

The stages are all independant, so different stages will get different progress intervals over time. If bundles are always making progress, splitting behavior is unchanged (biased to not split).

This allows for larger latencies to first input, while not hampering separation harness tests, or otherwise overdoing it.

There still remains the same bad case, of time between elements being larger than 2* maximumProgressInterval, but to resolve that likely requires a bit more global state awareness, and not splitting when maximum parallelism has been reached. But that would be a different change.

Fixes #32498.

Tested against the Wordcount example with tightened minimal timings, and sleeps. Once this is in the following command should be able to validate that it's fixed the issue for the higher latency cases.

```
go run github.com/apache/beam/sdks/v2/go/examples/wordcount@master --input "gs://apache-beam-samples/shakespeare/kinglear.txt" --output counts
head -n 30 count
```

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
