### PR TITLE
Log warning if process function return None

### DIFF
--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -1465,8 +1465,8 @@ def _get_function_body_without_inners(func):
   first_def_line = next(source_lines).strip()
   if first_def_line.startswith("def "):
     last_def_line = first_def_line
-    while not last_def_line.split("#")[0].split("\"\"\"")[0].strip().endswith(
-        ":"):
+    while not (
+        last_def_line.split("#")[0].split("\"\"\"")[0].strip().endswith(":")):
       last_def_line = next(source_lines)
 
     first_line = next(source_lines)

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -1465,7 +1465,8 @@ def _get_function_body_without_inners(func):
   first_def_line = next(source_lines).strip()
   if first_def_line.startswith("def "):
     last_def_line = first_def_line
-    while not last_def_line.split("#")[0].split("\"\"\"")[0].endswith(":"):
+    while not last_def_line.split("#")[0].split("\"\"\"")[0].strip().endswith(
+        ":"):
       last_def_line = next(source_lines)
 
     first_line = next(source_lines)

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -1464,10 +1464,11 @@ def _get_function_body_without_inners(func):
   source_lines = dropwhile(lambda x: x.startswith("@"), source_lines)
   first_def_line = next(source_lines).strip()
   if first_def_line.startswith("def "):
-    last_def_line = first_def_line
-    while not (
-        last_def_line.split("#")[0].split("\"\"\"")[0].strip().endswith(":")):
-      last_def_line = next(source_lines)
+    last_def_line_without_comment = first_def_line.split("#")[0] \
+        .split("\"\"\"")[0]
+    while not last_def_line_without_comment.strip().endswith(":"):
+      last_def_line_without_comment = next(source_lines).split("#")[0] \
+        .split("\"\"\"")[0]
 
     first_line = next(source_lines)
     indentation = len(first_line) - len(first_line.lstrip())

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -1497,15 +1497,26 @@ def _check_fn_use_yield_and_return(fn):
     source_code = _get_function_body_without_inners(fn)
     has_yield = False
     has_return = False
+    return_none_warning = (
+        "No iterator is returned by the process method in %s.",
+        fn.__self__.__class__)
     for line in source_code.split("\n"):
-      if line.lstrip().startswith("yield ") or line.lstrip().startswith(
+      lstripped_line = line.lstrip()
+      if lstripped_line.startswith("yield ") or lstripped_line.startswith(
           "yield("):
         has_yield = True
-      if line.lstrip().startswith("return ") or line.lstrip().startswith(
+      if lstripped_line.startswith("return ") or lstripped_line.startswith(
           "return("):
         has_return = True
+        if lstripped_line.startswith(
+            "return None") or lstripped_line.rstrip() == "return":
+          _LOGGER.warning(return_none_warning)
       if has_yield and has_return:
         return True
+
+    if not has_yield and not has_return:
+      _LOGGER.warning(return_none_warning)
+
     return False
   except Exception as e:
     _LOGGER.debug(str(e))

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -1463,7 +1463,10 @@ def _get_function_body_without_inners(func):
   source_lines = inspect.getsourcelines(func)[0]
   source_lines = dropwhile(lambda x: x.startswith("@"), source_lines)
   def_line = next(source_lines).strip()
-  if def_line.startswith("def ") and def_line.endswith(":"):
+  if def_line.startswith("def "):
+    while next(source_lines).split("#")[0].split("\"\"\"")[0].endswith(":"):
+      continue
+
     first_line = next(source_lines)
     indentation = len(first_line) - len(first_line.lstrip())
     final_lines = [first_line[indentation:]]

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -1462,10 +1462,11 @@ class CallableWrapperPartitionFn(PartitionFn):
 def _get_function_body_without_inners(func):
   source_lines = inspect.getsourcelines(func)[0]
   source_lines = dropwhile(lambda x: x.startswith("@"), source_lines)
-  def_line = next(source_lines).strip()
-  if def_line.startswith("def "):
-    while not def_line.split("#")[0].split("\"\"\"")[0].endswith(":"):
-      def_line = next(source_lines)
+  first_def_line = next(source_lines).strip()
+  if first_def_line.startswith("def "):
+    last_def_line = first_def_line
+    while not last_def_line.split("#")[0].split("\"\"\"")[0].endswith(":"):
+      last_def_line = next(source_lines)
 
     first_line = next(source_lines)
     indentation = len(first_line) - len(first_line.lstrip())
@@ -1490,7 +1491,7 @@ def _get_function_body_without_inners(func):
 
     return "".join(final_lines)
   else:
-    return def_line.rsplit(":")[-1].strip()
+    return first_def_line.rsplit(":")[-1].strip()
 
 
 def _check_fn_use_yield_and_return(fn):

--- a/sdks/python/apache_beam/transforms/core.py
+++ b/sdks/python/apache_beam/transforms/core.py
@@ -1464,8 +1464,8 @@ def _get_function_body_without_inners(func):
   source_lines = dropwhile(lambda x: x.startswith("@"), source_lines)
   def_line = next(source_lines).strip()
   if def_line.startswith("def "):
-    while next(source_lines).split("#")[0].split("\"\"\"")[0].endswith(":"):
-      continue
+    while not def_line.split("#")[0].split("\"\"\"")[0].endswith(":"):
+      def_line = next(source_lines)
 
     first_line = next(source_lines)
     indentation = len(first_line) - len(first_line.lstrip())


### PR DESCRIPTION
fixes #28061
Replicated #28159

Add warning log if implemented process function return None as Expected to notify users in following case:

1. function return explicitly as `return None`
2. function pass `pass`
3. function do not have `return` or `yield`

Fix _get_function_body_without_inners function in corner case if function def is 
```python
def process(param1,  
            param2):
```
The current function will be fail. That will address this comment https://github.com/apache/beam/pull/28159#issuecomment-1695291184

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [x] Update `CHANGES.md` with noteworthy changes.
 - [x] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
