### PR TITLE
Revert "Bump com.pswidersk.terraform-plugin from 1.0.0 to 1.1.1"

### DIFF
--- a/learning/tour-of-beam/terraform/build.gradle.kts
+++ b/learning/tour-of-beam/terraform/build.gradle.kts
@@ -21,7 +21,7 @@ import java.io.ByteArrayOutputStream
 import java.util.regex.Pattern
 
 plugins {
-    id("com.pswidersk.terraform-plugin") version "1.1.1"
+    id("com.pswidersk.terraform-plugin") version "1.0.0"
 }
 
 terraformPlugin {

--- a/playground/terraform/build.gradle.kts
+++ b/playground/terraform/build.gradle.kts
@@ -39,7 +39,7 @@ val licenseText = "#############################################################
         "################################################################################"
 
 plugins {
-    id("com.pswidersk.terraform-plugin") version "1.1.1"
+    id("com.pswidersk.terraform-plugin") version "1.0.0"
 }
 
 terraformPlugin {


### PR DESCRIPTION
Reverts apache/beam#32541

This is causing build failure:

```
A problem occurred configuring project ':playground:terraform'.
> Could not resolve all files for configuration ':playground:terraform:classpath'.
   > Could not resolve com.pswidersk:terraform-gradle-plugin:1.1.1.
     Required by:
         project :playground:terraform > com.pswidersk.terraform-plugin:com.pswidersk.terraform-plugin.gradle.plugin:1.1.1
      > No matching variant of com.pswidersk:terraform-gradle-plugin:1.1.1 was found. The consumer was configured to find a library for use during runtime, compatible with Java 8, packaged as a jar, and its dependencies declared externally, as well as attribute 'org.gradle.plugin.api-version' with value '8.4' but:

```