### PR TITLE
fix NPE and other exceptions thrown when work fails to process before work execution

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/ComputationWorkExecutor.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/ComputationWorkExecutor.java
@@ -83,11 +83,11 @@ public abstract class ComputationWorkExecutor {
    * cannot be reused.
    */
   public final void invalidate() {
-    context().invalidateCache();
     try {
+      context().invalidateCache();
       workExecutor().close();
     } catch (Exception e) {
-      LOG.warn("Failed to close map task executor: ", e);
+      LOG.warn("Failed to invalidate ComputationWorkExecutor: ", e);
     }
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/ComputationWorkExecutorTest.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/streaming/ComputationWorkExecutorTest.java
@@ -1,0 +1,71 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.runners.dataflow.worker.streaming;
+
+import static org.junit.Assert.assertTrue;
+import static org.mockito.Mockito.doAnswer;
+import static org.mockito.Mockito.doThrow;
+import static org.mockito.Mockito.mock;
+import static org.mockito.Mockito.verifyNoInteractions;
+
+import java.util.concurrent.atomic.AtomicBoolean;
+import org.apache.beam.runners.core.metrics.ExecutionStateTracker;
+import org.apache.beam.runners.dataflow.worker.DataflowWorkExecutor;
+import org.apache.beam.runners.dataflow.worker.StreamingModeExecutionContext;
+import org.junit.Before;
+import org.junit.Test;
+import org.junit.runner.RunWith;
+import org.junit.runners.JUnit4;
+
+@RunWith(JUnit4.class)
+public class ComputationWorkExecutorTest {
+
+  private final DataflowWorkExecutor dataflowWorkExecutor = mock(DataflowWorkExecutor.class);
+  private final StreamingModeExecutionContext context = mock(StreamingModeExecutionContext.class);
+  private ComputationWorkExecutor computationWorkExecutor;
+
+  @Before
+  public void setUp() {
+    computationWorkExecutor =
+        ComputationWorkExecutor.builder()
+            .setWorkExecutor(dataflowWorkExecutor)
+            .setContext(context)
+            .setExecutionStateTracker(mock(ExecutionStateTracker.class))
+            .build();
+  }
+
+  @Test
+  public void testInvalidate_handlesException() {
+    NullPointerException npe = new NullPointerException("something bad happened");
+    doThrow(npe).when(context).invalidateCache();
+    computationWorkExecutor.invalidate();
+    verifyNoInteractions(dataflowWorkExecutor);
+    AtomicBoolean verifyContextInvalidated = new AtomicBoolean(false);
+    Throwable e = new RuntimeException("something bad happened 2");
+    doThrow(e).when(dataflowWorkExecutor).close();
+    doAnswer(
+            ignored -> {
+              verifyContextInvalidated.set(true);
+              return null;
+            })
+        .when(context)
+        .invalidateCache();
+    computationWorkExecutor.invalidate();
+    assertTrue(verifyContextInvalidated.get());
+  }
+}


### PR DESCRIPTION
StreamingModeExecutionContext requires a call to `start()` in order to work correctly.
If an exception is thrown during work execution before a call to start(), its possible that internal StreamingModeExecutionContext members are `null`.

Fix NPE in calls to `invalidateCache()` made w/o a call to `start()`.
Also prevent ComputationWorkExecutor.invalidate() from crashing the worker.
------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
