### PR TITLE
Fix ParDo#with_exception_handling(timeout) with custom thread class and thread scoped storage in state sampler.

### DIFF
--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -2797,7 +2797,7 @@ class DeadLettersTest(unittest.TestCase):
       _, _ = (
           (p | beam.Create([1,2,3])) | beam.ParDo(CounterDoFn())
           .with_exception_handling(
-            use_subprocess=self.use_subprocess, timeout=1))
+            use_subprocess=self.use_subprocess, timeout=20))
     results = p.result
     metric_results = results.metrics().query(
         MetricsFilter().with_name("recordsCounter"))

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -2780,6 +2780,31 @@ class DeadLettersTest(unittest.TestCase):
                     ('slow', 'TimeoutError()')]),
           label='CheckBad')
 
+  def test_increment_counter(self):
+    # Counters are not currently supported for
+    # ParDo#with_exception_handling(use_subprocess=True).
+    if (self.use_subprocess):
+      return
+
+    class CounterDoFn(beam.DoFn):
+      def __init__(self):
+        self.records_counter = Metrics.counter(self.__class__, 'recordsCounter')
+
+      def process(self, element):
+        self.records_counter.inc()
+
+    with TestPipeline() as p:
+      _, _ = (
+          (p | beam.Create([1,2,3])) | beam.ParDo(CounterDoFn())
+          .with_exception_handling(
+            use_subprocess=self.use_subprocess, timeout=1))
+    results = p.result
+    metric_results = results.metrics().query(
+        MetricsFilter().with_name("recordsCounter"))
+    records_counter = metric_results['counters'][0]
+    self.assertEqual(records_counter.key.metric.name, 'recordsCounter')
+    self.assertEqual(records_counter.result, 3)
+
   def test_lifecycle(self):
     die = type(self).die
 

--- a/sdks/python/apache_beam/utils/threads.py
+++ b/sdks/python/apache_beam/utils/threads.py
@@ -1,0 +1,35 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+import threading
+
+
+class ParentAwareThread(threading.Thread):
+  """
+  A thread subclass that is aware of its parent thread.
+  
+  This is useful in scenarios where work is executed in a child thread
+  (e.g. ParDo#with_exception_handling(timeout)) and the child thread requires
+  access to parent thread scoped state variables (e.g. state sampler).
+
+  Attributes:
+    parent_thread_id (int): The identifier of the parent thread that created
+      this thread instance.
+  """
+  def __init__(self, *args, **kwargs):
+    super().__init__(*args, **kwargs)
+    self.parent_thread_id = threading.current_thread().ident

--- a/sdks/python/apache_beam/utils/threads_test.py
+++ b/sdks/python/apache_beam/utils/threads_test.py
@@ -1,0 +1,39 @@
+#
+# Licensed to the Apache Software Foundation (ASF) under one or more
+# contributor license agreements.  See the NOTICE file distributed with
+# this work for additional information regarding copyright ownership.
+# The ASF licenses this file to You under the Apache License, Version 2.0
+# (the "License"); you may not use this file except in compliance with
+# the License.  You may obtain a copy of the License at
+#
+#    http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+#
+
+"""Unit tests for thread utilities."""
+
+import unittest
+import threading
+
+from apache_beam.utils.threads import ParentAwareThread
+
+
+class ParentAwareThreadTest(unittest.TestCase):
+  def test_child_tread_can_access_parent_thread_id(self):
+    expected_parent_thread_id = threading.get_ident()
+    actual_parent_thread_id = None
+
+    def get_parent_thread_id():
+      nonlocal actual_parent_thread_id
+      actual_parent_thread_id = threading.current_thread().parent_thread_id
+
+    thread = ParentAwareThread(target=get_parent_thread_id)
+    thread.start()
+    thread.join()
+
+    self.assertEqual(expected_parent_thread_id, actual_parent_thread_id)


### PR DESCRIPTION
Create and use ParentAwareThread in Pardo#with_exception_handling(timeout)

- ParDo#with_exception_handling(timeout) executes the DoFn in a new thread [1]
- Incrimenting a counter invokes tries to access the state sampler that was declared in the main thread local storage from the child thread [2]
- Since the child thread does not have access to the state sampler from the main thread the get_current_tracker method fails silently [3] and the counter isnt actually incremented

This change
- Creates a new ParentAwareThread class that stores the ID of its parent thread
- Refactors state samplers to be stored in a non thread-local dictionary where each thread's state sampler is keyed by thread id
- When a ParentAwareThread increments a counter it retrieves the state sampler set by its parent thread

[1] https://github.com/apache/beam/blob/1eddbdca4c5efe4bfccc11af29624f9689ea2997/sdks/python/apache_beam/transforms/core.py#L2599
[2] https://github.com/apache/beam/blob/1eddbdca4c5efe4bfccc11af29624f9689ea2997/sdks/python/apache_beam/runners/worker/statesampler.py#L43
[3] https://github.com/apache/beam/blob/1eddbdca4c5efe4bfccc11af29624f9689ea2997/sdks/python/apache_beam/runners/worker/statesampler.py#L54 


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
