### PR TITLE
[Managed Iceberg] Make manifest file writes and commits more efficient

### DIFF
--- a/.github/trigger_files/IO_Iceberg_Integration_Tests.json
+++ b/.github/trigger_files/IO_Iceberg_Integration_Tests.json
@@ -1,4 +1,4 @@
 {
     "comment": "Modify this file in a trivial way to cause this test suite to run",
-    "modification": 2
+    "modification": 3
 }

--- a/CHANGES.md
+++ b/CHANGES.md
@@ -107,6 +107,7 @@
 * Significantly improved performance of Kafka IO reads that enable [commitOffsetsInFinalize](https://beam.apache.org/releases/javadoc/current/org/apache/beam/sdk/io/kafka/KafkaIO.Read.html#commitOffsetsInFinalize--) by removing the data reshuffle from SDF implementation.  ([#31682](https://github.com/apache/beam/pull/31682)).
 * Added support for dynamic writing in MqttIO (Java) ([#19376](https://github.com/apache/beam/issues/19376))
 * Optimized Spark Runner parDo transform evaluator (Java) ([#32537](https://github.com/apache/beam/issues/32537))
+* [Managed Iceberg] More efficient manifest file writes/commits ([#32666](https://github.com/apache/beam/issues/32666))
 
 ## Breaking Changes
 

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/AppendFilesToTables.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/AppendFilesToTables.java
@@ -118,6 +118,7 @@ class AppendFilesToTables
         committedDataFileRecordCount.update(dataFile.recordCount());
         numFiles++;
       }
+      // this commit will create a ManifestFile. we don't need to manually create one.
       update.commit();
       dataFilesCommitted.inc(numFiles);
 

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/AppendFilesToTables.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/AppendFilesToTables.java
@@ -20,6 +20,7 @@ package org.apache.beam.sdk.io.iceberg;
 import org.apache.beam.sdk.coders.KvCoder;
 import org.apache.beam.sdk.coders.StringUtf8Coder;
 import org.apache.beam.sdk.metrics.Counter;
+import org.apache.beam.sdk.metrics.Distribution;
 import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.GroupByKey;
@@ -31,6 +32,7 @@ import org.apache.beam.sdk.transforms.windowing.BoundedWindow;
 import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.iceberg.AppendFiles;
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.Snapshot;
 import org.apache.iceberg.Table;
 import org.apache.iceberg.catalog.Catalog;
@@ -73,6 +75,12 @@ class AppendFilesToTables
       extends DoFn<KV<String, Iterable<FileWriteResult>>, KV<String, SnapshotInfo>> {
     private final Counter snapshotsCreated =
         Metrics.counter(AppendFilesToTables.class, "snapshotsCreated");
+    private final Counter dataFilesCommitted =
+        Metrics.counter(AppendFilesToTables.class, "dataFilesCommitted");
+    private final Distribution committedDataFileByteSize =
+        Metrics.distribution(RecordWriter.class, "committedDataFileByteSize");
+    private final Distribution committedDataFileRecordCount =
+        Metrics.distribution(RecordWriter.class, "committedDataFileRecordCount");
 
     private final IcebergCatalogConfig catalogConfig;
 
@@ -94,18 +102,27 @@ class AppendFilesToTables
         @Element KV<String, Iterable<FileWriteResult>> element,
         OutputReceiver<KV<String, SnapshotInfo>> out,
         BoundedWindow window) {
-      if (!element.getValue().iterator().hasNext()) {
+      String tableStringIdentifier = element.getKey();
+      Iterable<FileWriteResult> fileWriteResults = element.getValue();
+      if (!fileWriteResults.iterator().hasNext()) {
         return;
       }
 
       Table table = getCatalog().loadTable(TableIdentifier.parse(element.getKey()));
       AppendFiles update = table.newAppend();
-      for (FileWriteResult writtenFile : element.getValue()) {
-        update.appendManifest(writtenFile.getManifestFile());
+      long numFiles = 0;
+      for (FileWriteResult result : fileWriteResults) {
+        DataFile dataFile = result.getDataFile(table.spec());
+        update.appendFile(dataFile);
+        committedDataFileByteSize.update(dataFile.fileSizeInBytes());
+        committedDataFileRecordCount.update(dataFile.recordCount());
+        numFiles++;
       }
       update.commit();
+      dataFilesCommitted.inc(numFiles);
+
       Snapshot snapshot = table.currentSnapshot();
-      LOG.info("Created new snapshot for table '{}': {}", element.getKey(), snapshot);
+      LOG.info("Created new snapshot for table '{}': {}", tableStringIdentifier, snapshot);
       snapshotsCreated.inc();
       out.outputWithTimestamp(
           KV.of(element.getKey(), SnapshotInfo.fromSnapshot(snapshot)), window.maxTimestamp());

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergIO.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/IcebergIO.java
@@ -318,7 +318,7 @@ public class IcebergIO {
      * org.apache.iceberg.Snapshot} is produced.
      *
      * <p>Roughly every triggeringFrequency duration, records are written to data files and appended
-     * to the respective table. Each append operation created a new table snapshot.
+     * to the respective table. Each append operation creates a new table snapshot.
      *
      * <p>Generally speaking, increasing this duration will result in fewer, larger data files and
      * fewer snapshots.

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/RecordWriter.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/RecordWriter.java
@@ -19,7 +19,6 @@ package org.apache.beam.sdk.io.iceberg;
 
 import java.io.IOException;
 import org.apache.beam.sdk.metrics.Counter;
-import org.apache.beam.sdk.metrics.Distribution;
 import org.apache.beam.sdk.metrics.Metrics;
 import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
@@ -38,9 +37,8 @@ import org.slf4j.LoggerFactory;
 class RecordWriter {
   private static final Logger LOG = LoggerFactory.getLogger(RecordWriter.class);
   private final Counter activeIcebergWriters =
-      Metrics.counter(RecordWriterManager.class, "activeIcebergWriters");
-  private final Distribution dataFileByteSize =
-      Metrics.distribution(RecordWriter.class, "dataFileByteSize");
+      Metrics.counter(RecordWriter.class, "activeIcebergWriters");
+  private final Counter dataFilesWritten = Metrics.counter(RecordWriter.class, "dataFilesWritten");
   private final DataWriter<Record> icebergDataWriter;
   private final Table table;
   private final String absoluteFilename;
@@ -128,7 +126,7 @@ class RecordWriter {
         dataFile.recordCount(),
         dataFile.fileSizeInBytes(),
         absoluteFilename);
-    dataFileByteSize.update(dataFile.fileSizeInBytes());
+    dataFilesWritten.inc();
   }
 
   public long bytesWritten() {

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/SerializableDataFile.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/SerializableDataFile.java
@@ -1,0 +1,203 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.iceberg;
+
+import com.google.auto.value.AutoValue;
+import java.nio.ByteBuffer;
+import java.util.HashMap;
+import java.util.List;
+import java.util.Map;
+import org.apache.beam.sdk.schemas.AutoValueSchema;
+import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
+import org.apache.iceberg.DataFile;
+import org.apache.iceberg.DataFiles;
+import org.apache.iceberg.FileFormat;
+import org.apache.iceberg.Metrics;
+import org.apache.iceberg.PartitionKey;
+import org.apache.iceberg.PartitionSpec;
+import org.checkerframework.checker.nullness.qual.Nullable;
+
+/**
+ * Serializable version of an Iceberg {@link DataFile}.
+ *
+ * <p>{@link DataFile} is not serializable and Iceberg doesn't offer an easy way to encode/decode
+ * it. This class is an identical version that can be used as a PCollection element type. {@link
+ * #createDataFile(PartitionSpec)} can be used to reconstruct the original {@link DataFile}.
+ */
+@DefaultSchema(AutoValueSchema.class)
+@AutoValue
+abstract class SerializableDataFile {
+  public static Builder builder() {
+    return new AutoValue_SerializableDataFile.Builder();
+  }
+
+  abstract String getPath();
+
+  abstract String getFileFormat();
+
+  abstract long getRecordCount();
+
+  abstract long getFileSizeInBytes();
+
+  abstract String getPartitionPath();
+
+  abstract int getPartitionSpecId();
+
+  abstract @Nullable ByteBuffer getKeyMetadata();
+
+  abstract @Nullable List<Long> getSplitOffsets();
+
+  abstract @Nullable Map<Integer, Long> getColumnSizes();
+
+  abstract @Nullable Map<Integer, Long> getValueCounts();
+
+  abstract @Nullable Map<Integer, Long> getNullValueCounts();
+
+  abstract @Nullable Map<Integer, Long> getNanValueCounts();
+
+  abstract @Nullable Map<Integer, byte[]> getLowerBounds();
+
+  abstract @Nullable Map<Integer, byte[]> getUpperBounds();
+
+  @AutoValue.Builder
+  abstract static class Builder {
+    abstract Builder setPath(String path);
+
+    abstract Builder setFileFormat(String fileFormat);
+
+    abstract Builder setRecordCount(long recordCount);
+
+    abstract Builder setFileSizeInBytes(long fileSizeInBytes);
+
+    abstract Builder setPartitionPath(String partitionPath);
+
+    abstract Builder setPartitionSpecId(int partitionSpec);
+
+    abstract Builder setKeyMetadata(ByteBuffer keyMetadata);
+
+    abstract Builder setSplitOffsets(List<Long> splitOffsets);
+
+    abstract Builder setColumnSizes(Map<Integer, Long> columnSizes);
+
+    abstract Builder setValueCounts(Map<Integer, Long> valueCounts);
+
+    abstract Builder setNullValueCounts(Map<Integer, Long> nullValueCounts);
+
+    abstract Builder setNanValueCounts(Map<Integer, Long> nanValueCounts);
+
+    abstract Builder setLowerBounds(Map<Integer, byte[]> lowerBounds);
+
+    abstract Builder setUpperBounds(Map<Integer, byte[]> upperBounds);
+
+    abstract SerializableDataFile build();
+  }
+
+  /**
+   * Create a {@link SerializableDataFile} from a {@link DataFile} and its associated {@link
+   * PartitionKey}.
+   */
+  static SerializableDataFile from(DataFile f, PartitionKey key) {
+    SerializableDataFile.Builder builder =
+        SerializableDataFile.builder()
+            .setPath(f.path().toString())
+            .setFileFormat(f.format().toString())
+            .setRecordCount(f.recordCount())
+            .setFileSizeInBytes(f.fileSizeInBytes())
+            .setPartitionPath(key.toPath())
+            .setPartitionSpecId(f.specId())
+            .setKeyMetadata(f.keyMetadata())
+            .setSplitOffsets(f.splitOffsets())
+            .setColumnSizes(f.columnSizes())
+            .setValueCounts(f.valueCounts())
+            .setNullValueCounts(f.nullValueCounts())
+            .setNanValueCounts(f.nanValueCounts());
+
+    // ByteBuddyUtils has trouble converting Map value type ByteBuffer
+    // to byte[] and back to ByteBuffer, so we perform this conversion manually
+    // here.
+    if (f.lowerBounds() != null) {
+      Map<Integer, byte[]> lowerBounds = new HashMap<>(f.lowerBounds().size());
+      for (Map.Entry<Integer, ByteBuffer> e : f.lowerBounds().entrySet()) {
+        lowerBounds.put(e.getKey(), e.getValue().array());
+      }
+      builder = builder.setLowerBounds(lowerBounds);
+    }
+    if (f.upperBounds() != null) {
+      Map<Integer, byte[]> upperBounds = new HashMap<>(f.upperBounds().size());
+      for (Map.Entry<Integer, ByteBuffer> e : f.upperBounds().entrySet()) {
+        upperBounds.put(e.getKey(), e.getValue().array());
+      }
+      builder = builder.setUpperBounds(upperBounds);
+    }
+    return builder.build();
+  }
+
+  /**
+   * Reconstructs the original {@link DataFile} from this {@link SerializableDataFile}.
+   *
+   * <p>We require an input {@link PartitionSpec} as well because there's no easy way to reconstruct
+   * it from Beam-compatible types.
+   */
+  @SuppressWarnings("nullness")
+  DataFile createDataFile(PartitionSpec partitionSpec) {
+    Preconditions.checkState(
+        partitionSpec.specId() == getPartitionSpecId(),
+        "Invalid partition spec id '%s'. This DataFile was originally created with spec id '%s'.",
+        partitionSpec.specId(),
+        getPartitionSpecId());
+
+    // ByteBuddyUtils has trouble converting Map value type ByteBuffer
+    // to byte[] and back to ByteBuffer, so we perform this conversion manually
+    // here.
+    Map<Integer, ByteBuffer> lowerBounds = null;
+    Map<Integer, ByteBuffer> upperBounds = null;
+    if (getLowerBounds() != null) {
+      lowerBounds = new HashMap<>(getLowerBounds().size());
+      for (Map.Entry<Integer, byte[]> e : getLowerBounds().entrySet()) {
+        lowerBounds.put(e.getKey(), ByteBuffer.wrap(e.getValue()));
+      }
+    }
+    if (getUpperBounds() != null) {
+      upperBounds = new HashMap<>(getUpperBounds().size());
+      for (Map.Entry<Integer, byte[]> e : getUpperBounds().entrySet()) {
+        upperBounds.put(e.getKey(), ByteBuffer.wrap(e.getValue()));
+      }
+    }
+
+    Metrics dataFileMetrics =
+        new Metrics(
+            getRecordCount(),
+            getColumnSizes(),
+            getValueCounts(),
+            getNullValueCounts(),
+            getNanValueCounts(),
+            lowerBounds,
+            upperBounds);
+
+    return DataFiles.builder(partitionSpec)
+        .withFormat(FileFormat.fromString(getFileFormat()))
+        .withPath(getPath())
+        .withPartitionPath(getPartitionPath())
+        .withEncryptionKeyMetadata(getKeyMetadata())
+        .withFileSizeInBytes(getFileSizeInBytes())
+        .withMetrics(dataFileMetrics)
+        .withSplitOffsets(getSplitOffsets())
+        .build();
+  }
+}

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/SerializableDataFile.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/SerializableDataFile.java
@@ -36,9 +36,12 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 /**
  * Serializable version of an Iceberg {@link DataFile}.
  *
- * <p>{@link DataFile} is not serializable and Iceberg doesn't offer an easy way to encode/decode
- * it. This class is an identical version that can be used as a PCollection element type. {@link
- * #createDataFile(PartitionSpec)} can be used to reconstruct the original {@link DataFile}.
+ * <p>{@link DataFile} is not serializable and the Iceberg API doesn't offer an easy way to
+ * encode/decode it. This class is an identical version that can be used as a PCollection element
+ * type.
+ *
+ * <p>Use {@link #from(DataFile, PartitionKey)} to create a {@link SerializableDataFile} and {@link
+ * #createDataFile(PartitionSpec)} to reconstruct the original {@link DataFile}.
  */
 @DefaultSchema(AutoValueSchema.class)
 @AutoValue

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/WriteGroupedRowsToFiles.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/WriteGroupedRowsToFiles.java
@@ -18,7 +18,6 @@
 package org.apache.beam.sdk.io.iceberg;
 
 import java.util.List;
-import java.util.UUID;
 import org.apache.beam.sdk.transforms.DoFn;
 import org.apache.beam.sdk.transforms.PTransform;
 import org.apache.beam.sdk.transforms.ParDo;
@@ -30,7 +29,6 @@ import org.apache.beam.sdk.values.KV;
 import org.apache.beam.sdk.values.PCollection;
 import org.apache.beam.sdk.values.Row;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
-import org.apache.iceberg.ManifestFile;
 import org.apache.iceberg.catalog.Catalog;
 import org.checkerframework.checker.nullness.qual.MonotonicNonNull;
 
@@ -42,11 +40,15 @@ class WriteGroupedRowsToFiles
 
   private final DynamicDestinations dynamicDestinations;
   private final IcebergCatalogConfig catalogConfig;
+  private final String filePrefix;
 
   WriteGroupedRowsToFiles(
-      IcebergCatalogConfig catalogConfig, DynamicDestinations dynamicDestinations) {
+      IcebergCatalogConfig catalogConfig,
+      DynamicDestinations dynamicDestinations,
+      String filePrefix) {
     this.catalogConfig = catalogConfig;
     this.dynamicDestinations = dynamicDestinations;
+    this.filePrefix = filePrefix;
   }
 
   @Override
@@ -55,7 +57,7 @@ class WriteGroupedRowsToFiles
     return input.apply(
         ParDo.of(
             new WriteGroupedRowsToFilesDoFn(
-                catalogConfig, dynamicDestinations, DEFAULT_MAX_BYTES_PER_FILE)));
+                catalogConfig, dynamicDestinations, DEFAULT_MAX_BYTES_PER_FILE, filePrefix)));
   }
 
   private static class WriteGroupedRowsToFilesDoFn
@@ -70,10 +72,11 @@ class WriteGroupedRowsToFiles
     WriteGroupedRowsToFilesDoFn(
         IcebergCatalogConfig catalogConfig,
         DynamicDestinations dynamicDestinations,
-        long maxFileSize) {
+        long maxFileSize,
+        String filePrefix) {
       this.catalogConfig = catalogConfig;
       this.dynamicDestinations = dynamicDestinations;
-      this.filePrefix = UUID.randomUUID().toString();
+      this.filePrefix = filePrefix;
       this.maxFileSize = maxFileSize;
     }
 
@@ -105,13 +108,13 @@ class WriteGroupedRowsToFiles
         }
       }
 
-      List<ManifestFile> manifestFiles =
-          Preconditions.checkNotNull(writer.getManifestFiles().get(windowedDestination));
-      for (ManifestFile manifestFile : manifestFiles) {
+      List<SerializableDataFile> serializableDataFiles =
+          Preconditions.checkNotNull(writer.getSerializableDataFiles().get(windowedDestination));
+      for (SerializableDataFile dataFile : serializableDataFiles) {
         c.output(
             FileWriteResult.builder()
                 .setTableIdentifier(destination.getTableIdentifier())
-                .setManifestFile(manifestFile)
+                .setSerializableDataFile(dataFile)
                 .build());
       }
     }

--- a/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/WriteToDestinations.java
+++ b/sdks/java/io/iceberg/src/main/java/org/apache/beam/sdk/io/iceberg/WriteToDestinations.java
@@ -60,7 +60,7 @@ class WriteToDestinations extends PTransform<PCollection<KV<String, Row>>, Icebe
     this.dynamicDestinations = dynamicDestinations;
     this.catalogConfig = catalogConfig;
     this.triggeringFrequency = triggeringFrequency;
-    // single unique prefix per pipeline
+    // single unique prefix per write transform
     this.filePrefix = UUID.randomUUID().toString();
   }
 

--- a/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/RecordWriterManagerTest.java
+++ b/sdks/java/io/iceberg/src/test/java/org/apache/beam/sdk/io/iceberg/RecordWriterManagerTest.java
@@ -33,6 +33,7 @@ import org.apache.beam.sdk.util.WindowedValue;
 import org.apache.beam.sdk.values.Row;
 import org.apache.commons.lang3.RandomStringUtils;
 import org.apache.hadoop.conf.Configuration;
+import org.apache.iceberg.DataFile;
 import org.apache.iceberg.FileFormat;
 import org.apache.iceberg.PartitionKey;
 import org.apache.iceberg.PartitionSpec;
@@ -266,5 +267,43 @@ public class RecordWriterManagerTest {
     assertEquals(1, writerManager.openWriters);
 
     assertThrows(IllegalStateException.class, writerManager::getSerializableDataFiles);
+  }
+
+  @Test
+  public void testSerializableDataFileRoundTripEquality() throws IOException {
+    PartitionKey partitionKey = new PartitionKey(PARTITION_SPEC, ICEBERG_SCHEMA);
+
+    Row row = Row.withSchema(BEAM_SCHEMA).addValues(1, "abcdef", true).build();
+    Row row2 = Row.withSchema(BEAM_SCHEMA).addValues(2, "abcxyz", true).build();
+    // same partition for both records (name_trunc=abc, bool=true)
+    partitionKey.partition(IcebergUtils.beamRowToIcebergRecord(ICEBERG_SCHEMA, row));
+
+    RecordWriter writer =
+        new RecordWriter(catalog, windowedDestination.getValue(), "test_file_name", partitionKey);
+    writer.write(IcebergUtils.beamRowToIcebergRecord(ICEBERG_SCHEMA, row));
+    writer.write(IcebergUtils.beamRowToIcebergRecord(ICEBERG_SCHEMA, row2));
+
+    writer.close();
+    DataFile datafile = writer.getDataFile();
+    assertEquals(2L, datafile.recordCount());
+
+    DataFile roundTripDataFile =
+        SerializableDataFile.from(datafile, partitionKey).createDataFile(PARTITION_SPEC);
+    // DataFile doesn't implement a .equals() method. Check equality manually
+    assertEquals(datafile.path(), roundTripDataFile.path());
+    assertEquals(datafile.format(), roundTripDataFile.format());
+    assertEquals(datafile.recordCount(), roundTripDataFile.recordCount());
+    assertEquals(datafile.partition(), roundTripDataFile.partition());
+    assertEquals(datafile.specId(), roundTripDataFile.specId());
+    assertEquals(datafile.keyMetadata(), roundTripDataFile.keyMetadata());
+    assertEquals(datafile.splitOffsets(), roundTripDataFile.splitOffsets());
+    assertEquals(datafile.columnSizes(), roundTripDataFile.columnSizes());
+    assertEquals(datafile.valueCounts(), roundTripDataFile.valueCounts());
+    assertEquals(datafile.nullValueCounts(), roundTripDataFile.nullValueCounts());
+    assertEquals(datafile.nanValueCounts(), roundTripDataFile.nanValueCounts());
+    assertEquals(datafile.equalityFieldIds(), roundTripDataFile.equalityFieldIds());
+    assertEquals(datafile.fileSequenceNumber(), roundTripDataFile.fileSequenceNumber());
+    assertEquals(datafile.dataSequenceNumber(), roundTripDataFile.dataSequenceNumber());
+    assertEquals(datafile.pos(), roundTripDataFile.pos());
   }
 }


### PR DESCRIPTION
When writing to Iceberg, we need to write just one manifest file per snapshot.

However, we are currently writing one manifest file per bundle (or one per GIB batch for streaming writes), which is a lot more frequent than needed. In medium/large streaming jobs, we can end up with thousands of extra manifest files. For an Iceberg table, the effect of this inefficiency is felt in two ways:
- Writing more files than necessary
- During query planning, having to open and read more files than necessary 


Solution:
Continue writing bundles/batches to **data files**, but stop writing manifest files at that frequency. Instead, group data files by destination then write and commit just one manifest file per destination. Essentially, the number of manifest files should be 1-1 with snapshots/commits (currently, it's roughly 1-1 with data files).