### PR TITLE
Pin protobuf version for TF dependency tests

### DIFF
--- a/sdks/python/test-suites/tox/py39/build.gradle
+++ b/sdks/python/test-suites/tox/py39/build.gradle
@@ -149,9 +149,9 @@ postCommitPyDep.dependsOn "testPy39tft-113"
 // postCommitPyDep.dependsOn "testPy39onnx-113"
 
 // Create a test task for each minor version of tensorflow
-toxTask "testPy39tensorflow-213", "py39-tensorflow-213", "${posargs}"
-test.dependsOn "testPy39tensorflow-213"
-postCommitPyDep.dependsOn "testPy39tensorflow-213"
+toxTask "testPy39tensorflow-212", "py39-tensorflow-212", "${posargs}"
+test.dependsOn "testPy39tensorflow-212"
+postCommitPyDep.dependsOn "testPy39tensorflow-212"
 
 // Create a test task for each minor version of transformers
 toxTask "testPy39transformers-428", "py39-transformers-428", "${posargs}"

--- a/sdks/python/test-suites/tox/py39/build.gradle
+++ b/sdks/python/test-suites/tox/py39/build.gradle
@@ -149,9 +149,9 @@ postCommitPyDep.dependsOn "testPy39tft-113"
 // postCommitPyDep.dependsOn "testPy39onnx-113"
 
 // Create a test task for each minor version of tensorflow
-toxTask "testPy39tensorflow-212", "py39-tensorflow-212", "${posargs}"
-test.dependsOn "testPy39tensorflow-212"
-postCommitPyDep.dependsOn "testPy39tensorflow-212"
+toxTask "testPy39tensorflow-213", "py39-tensorflow-213", "${posargs}"
+test.dependsOn "testPy39tensorflow-213"
+postCommitPyDep.dependsOn "testPy39tensorflow-213"
 
 // Create a test task for each minor version of transformers
 toxTask "testPy39transformers-428", "py39-transformers-428", "${posargs}"

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -390,9 +390,11 @@ commands =
 
 [testenv:py39-tensorflow-213]
 deps =
-  212: tensorflow>=2.13rc1,<2.14
-  # Help pip resolve conflict with typing-extensions for old version of TF https://github.com/apache/beam/issues/30852
-  212: pydantic<2.7
+  213: 
+    tensorflow>=2.13rc1,<2.14
+    # Help pip resolve conflict with typing-extensions for old version of TF https://github.com/apache/beam/issues/30852
+    pydantic<2.7
+    protobuf==4.25.5
 extras = test,gcp
 commands =
   # Log tensorflow version for debugging
@@ -419,12 +421,21 @@ commands =
 
 [testenv:py{39,310}-transformers-{428,429,430}]
 deps =
-  428: transformers>=4.28.0,<4.29.0
-  429: transformers>=4.29.0,<4.30.0
-  430: transformers>=4.30.0,<4.31.0
-  torch>=1.9.0,<1.14.0
-  tensorflow==2.13.0
-  protobuf==4.25.5
+  428: 
+    transformers>=4.28.0,<4.29.0
+    torch>=1.9.0,<1.14.0
+    tensorflow==2.12.0
+    protobuf==4.25.5
+  429: 
+    transformers>=4.29.0,<4.30.0
+    torch>=1.9.0,<1.14.0
+    tensorflow==2.12.0
+    protobuf==4.25.5
+  430: 
+    transformers>=4.30.0,<4.31.0
+    torch>=1.9.0,<1.14.0
+    tensorflow==2.12.0
+    protobuf==4.25.5
 extras = test,gcp
 commands =
   # Log transformers and its dependencies version for debugging

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -421,12 +421,9 @@ commands =
 
 [testenv:py{39,310}-transformers-{428,429,430}]
 deps =
-  428: 
-    transformers>=4.28.0,<4.29.0
-  429: 
-    transformers>=4.29.0,<4.30.0
-  430: 
-    transformers>=4.30.0,<4.31.0
+  428: transformers>=4.28.0,<4.29.0
+  429: transformers>=4.29.0,<4.30.0
+  430: transformers>=4.30.0,<4.31.0
   torch>=1.9.0,<1.14.0
   tensorflow==2.12.0
   protobuf==4.25.5

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -390,9 +390,10 @@ commands =
 
 [testenv:py39-tensorflow-213]
 deps =
-  212: tensorflow>=2.13rc1,<2.14
+  212: tensorflow>=2.12rc1,<2.13
   # Help pip resolve conflict with typing-extensions for old version of TF https://github.com/apache/beam/issues/30852
   212: pydantic<2.7
+  212: protobuf==4.25.5
 extras = test,gcp
 commands =
   # Log tensorflow version for debugging
@@ -424,7 +425,7 @@ deps =
   430: transformers>=4.30.0,<4.31.0
   torch>=1.9.0,<1.14.0
   tensorflow==2.12.0
-  protobuf==4.22.1
+  protobuf==4.25.5
 extras = test,gcp
 commands =
   # Log transformers and its dependencies version for debugging

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -388,12 +388,11 @@ commands =
   # Run all ONNX unit tests
   pytest -o junit_suite_name={envname} --junitxml=pytest_{envname}.xml -n 6 -m uses_onnx {posargs}
 
-[testenv:py39-tensorflow-212]
+[testenv:py39-tensorflow-213]
 deps =
-  212: tensorflow>=2.12rc1,<2.13
+  212: tensorflow>=2.13rc1,<2.14
   # Help pip resolve conflict with typing-extensions for old version of TF https://github.com/apache/beam/issues/30852
   212: pydantic<2.7
-  212: protobuf==4.22.5
 extras = test,gcp
 commands =
   # Log tensorflow version for debugging

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -388,12 +388,11 @@ commands =
   # Run all ONNX unit tests
   pytest -o junit_suite_name={envname} --junitxml=pytest_{envname}.xml -n 6 -m uses_onnx {posargs}
 
-[testenv:py39-tensorflow-212]
+[testenv:py39-tensorflow-213]
 deps =
-  212: tensorflow>=2.12rc1,<2.13
+  212: tensorflow>=2.13rc1,<2.14
   # Help pip resolve conflict with typing-extensions for old version of TF https://github.com/apache/beam/issues/30852
   212: pydantic<2.7
-  212: protobuf==4.25.5
 extras = test,gcp
 commands =
   # Log tensorflow version for debugging
@@ -424,7 +423,7 @@ deps =
   429: transformers>=4.29.0,<4.30.0
   430: transformers>=4.30.0,<4.31.0
   torch>=1.9.0,<1.14.0
-  tensorflow==2.12.0
+  tensorflow==2.13.0
   protobuf==4.25.5
 extras = test,gcp
 commands =

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -388,7 +388,7 @@ commands =
   # Run all ONNX unit tests
   pytest -o junit_suite_name={envname} --junitxml=pytest_{envname}.xml -n 6 -m uses_onnx {posargs}
 
-[testenv:py39-tensorflow-213]
+[testenv:py39-tensorflow-212]
 deps =
   212: tensorflow>=2.12rc1,<2.13
   # Help pip resolve conflict with typing-extensions for old version of TF https://github.com/apache/beam/issues/30852

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -393,7 +393,7 @@ deps =
   212: tensorflow>=2.12rc1,<2.13
   # Help pip resolve conflict with typing-extensions for old version of TF https://github.com/apache/beam/issues/30852
   212: pydantic<2.7
-  212: protobuf>=4.0.0,<5.0.0.dev0
+  212: protobuf==4.22.5
 extras = test,gcp
 commands =
   # Log tensorflow version for debugging
@@ -425,7 +425,7 @@ deps =
   430: transformers>=4.30.0,<4.31.0
   torch>=1.9.0,<1.14.0
   tensorflow==2.12.0
-  protobuf>=4.0.0,<5.0.0.dev0
+  protobuf==4.22.1
 extras = test,gcp
 commands =
   # Log transformers and its dependencies version for debugging

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -393,6 +393,7 @@ deps =
   212: tensorflow>=2.12rc1,<2.13
   # Help pip resolve conflict with typing-extensions for old version of TF https://github.com/apache/beam/issues/30852
   212: pydantic<2.7
+  212: protobuf>=4.0.0,<5.0.0.dev0
 extras = test,gcp
 commands =
   # Log tensorflow version for debugging
@@ -424,6 +425,7 @@ deps =
   430: transformers>=4.30.0,<4.31.0
   torch>=1.9.0,<1.14.0
   tensorflow==2.12.0
+  protobuf>=4.0.0,<5.0.0.dev0
 extras = test,gcp
 commands =
   # Log transformers and its dependencies version for debugging

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -436,7 +436,7 @@ deps =
     torch>=1.9.0,<1.14.0
     tensorflow==2.12.0
     protobuf==4.25.5
-extras = test,gcp
+extras = test,gcp,ml_test
 commands =
   # Log transformers and its dependencies version for debugging
   /bin/sh -c "pip freeze | grep -E transformers"

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -388,14 +388,14 @@ commands =
   # Run all ONNX unit tests
   pytest -o junit_suite_name={envname} --junitxml=pytest_{envname}.xml -n 6 -m uses_onnx {posargs}
 
-[testenv:py39-tensorflow-213]
+[testenv:py39-tensorflow-212]
 deps =
   213: 
-    tensorflow>=2.13rc1,<2.14
+    tensorflow>=2.12rc1,<2.13
     # Help pip resolve conflict with typing-extensions for old version of TF https://github.com/apache/beam/issues/30852
     pydantic<2.7
     protobuf==4.25.5
-extras = test,gcp
+extras = test,gcp,ml_test
 commands =
   # Log tensorflow version for debugging
   /bin/sh -c "pip freeze | grep -E tensorflow"

--- a/sdks/python/tox.ini
+++ b/sdks/python/tox.ini
@@ -390,7 +390,7 @@ commands =
 
 [testenv:py39-tensorflow-212]
 deps =
-  213: 
+  212: 
     tensorflow>=2.12rc1,<2.13
     # Help pip resolve conflict with typing-extensions for old version of TF https://github.com/apache/beam/issues/30852
     pydantic<2.7
@@ -423,19 +423,13 @@ commands =
 deps =
   428: 
     transformers>=4.28.0,<4.29.0
-    torch>=1.9.0,<1.14.0
-    tensorflow==2.12.0
-    protobuf==4.25.5
   429: 
     transformers>=4.29.0,<4.30.0
-    torch>=1.9.0,<1.14.0
-    tensorflow==2.12.0
-    protobuf==4.25.5
   430: 
     transformers>=4.30.0,<4.31.0
-    torch>=1.9.0,<1.14.0
-    tensorflow==2.12.0
-    protobuf==4.25.5
+  torch>=1.9.0,<1.14.0
+  tensorflow==2.12.0
+  protobuf==4.25.5
 extras = test,gcp,ml_test
 commands =
   # Log transformers and its dependencies version for debugging


### PR DESCRIPTION
The Tensorflow dependency test running against TensorFlow 2.12 was failing as the test environment was separately installing protobuf 5.x. This ensures that an appropriate protobuf version is installed before installing beam deps. 

Fresh run of the workflow against this branch is running at https://github.com/apache/beam/actions/runs/11258372012 - there are some pandas/numpy failures that are unrelated.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
