### PR TITLE
Reduce setDefaultPipelineOptions call on creating TestPipelineOptions

### DIFF
--- a/.github/trigger_files/beam_PostCommit_Java_PVR_Spark_Batch.json
+++ b/.github/trigger_files/beam_PostCommit_Java_PVR_Spark_Batch.json
@@ -1,4 +1,4 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run",
-  "modification": 0
+  "modification": 1
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystems.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/io/FileSystems.java
@@ -565,11 +565,13 @@ public class FileSystems {
    *
    * <p>It will be used in {@link FileSystemRegistrar FileSystemRegistrars} for all schemes.
    *
-   * <p>This is expected only to be used by runners after {@code Pipeline.run}, or in tests.
+   * <p>Outside of workers where Beam FileSystem API is used (e.g. test methods, user code executed
+   * during pipeline submission), consider use {@link #registerFileSystemsOnce} if initialize
+   * FIleSystem of supported schema is the main goal.
    */
   @Internal
   public static void setDefaultPipelineOptions(PipelineOptions options) {
-    checkNotNull(options, "options");
+    checkNotNull(options, "options cannot be null");
     long id = options.getOptionsId();
     int nextRevision = options.revision();
 
@@ -590,6 +592,23 @@ public class FileSystems {
         SCHEME_TO_FILESYSTEM.set(verifySchemesAreUnique(options, registrars));
         return;
       }
+    }
+  }
+
+  /**
+   * Register file systems once if never done before.
+   *
+   * <p>This method executes {@link #setDefaultPipelineOptions} only if it has never been run,
+   * otherwise it returns immediately.
+   *
+   * <p>It is internally used by test setup to avoid repeated filesystem registrations (involves
+   * expensive ServiceLoader calls) when there are multiple pipeline and PipelineOptions object
+   * initialized, which is commonly seen in test execution.
+   */
+  @Internal
+  public static synchronized void registerFileSystemsOnce(PipelineOptions options) {
+    if (FILESYSTEM_REVISION.get() == null) {
+      setDefaultPipelineOptions(options);
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipeline.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipeline.java
@@ -373,7 +373,7 @@ public class TestPipeline extends Pipeline implements TestRule {
       }
       newOptions.setStableUniqueNames(CheckEnabled.ERROR);
 
-      FileSystems.setDefaultPipelineOptions(options);
+      FileSystems.registerFileSystemsOnce(options);
       return run(newOptions);
     } catch (IOException e) {
       throw new RuntimeException(
@@ -515,7 +515,7 @@ public class TestPipeline extends Pipeline implements TestRule {
       }
       options.setStableUniqueNames(CheckEnabled.ERROR);
 
-      FileSystems.setDefaultPipelineOptions(options);
+      FileSystems.registerFileSystemsOnce(options);
       return options;
     } catch (IOException e) {
       throw new RuntimeException(


### PR DESCRIPTION
Fix #30512

## Problem statement

Random tests in this test suite failing due to tmp file get deleted half way, likely a racing condition.

## Investigation

This is a longstanding and tricky issue, see earlier investigation in

https://github.com/apache/beam/issues/30512#issuecomment-2402923733

as the validate runner test set adds//enables more tests, the test becomes increasingly flaky.

### setDefaultPipelineOptions

In TestPipeline scenario, it is found that setDefaultPipelineOptions is called at least twice

1. When TestPipelineOptions object is created: https://github.com/apache/beam/blob/4cf99ea31aa2f3b4e8fa0da479939bbe92bd46dd/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipeline.java#L518

2. Right before pipeline runs : https://github.com/apache/beam/blob/4cf99ea31aa2f3b4e8fa0da479939bbe92bd46dd/sdks/java/core/src/main/java/org/apache/beam/sdk/PipelineRunner.java#L47

Note that if "options.revision" does not change, the second call should usually be skipped. However there are multiple place modifying pipeline options before submit (amending some options). Checked that in the first call, revision=2; in the second call, revision=4. Therefore both run resulted in rebuild the map.

If run by "runWithAddidionalArgument", there is a third call: 
https://github.com/apache/beam/blob/4cf99ea31aa2f3b4e8fa0da479939bbe92bd46dd/sdks/java/core/src/main/java/org/apache/beam/sdk/testing/TestPipeline.java#L376

The first run is even triggered when the test is filtered by a wildcard, where junit still runs `@Rule TestPipelineOptions options = TestPipelineOption.create()`

## Assumptions of what happened

### Assumption 1

Spark runner first put jars in a temp directory (`/temp/.../userFiles/...`), load jars into class loader (https://github.com/apache/beam/issues/30512#issuecomment-2402962813), and after pipeline run delete these files (likely in a async way, there is "shutdown hook called..." appeared in log)

At the same time in tests, setDefaultPipelineOptions are called, invoking ServiceLoader, looking for registered services in the classloader. For PortableSparkRunner tests. It causes racing condition when class loader still has jars entry from previous test that has been deleted.

### Assumption 2

Executing the tests locally (on macOS) there are other intermittent test failure, but now FileNotFoundException has a hint (Too many files open). It could also be that ServiceLoader is opening lots of files if running frequently.

Nevertheless, both observation agrees with excessive call to `setDefaultPipelineOptions` in test pipeline submission time.

## Solution

This PR reduces call to `setDefaultPipelineOptions` in two places in TestPipeline.java. This reduces `setDefaultPipelineOptions` call by at least half.

## Risk

There is potential risk of FileSystem stored PipelineOptions is out of sync **between TestPipelineOptions.create and testPipeline.run()**. I would argue this is of less concern because

* TestPipeline / TestPipelineOptions are meant by tests, this change does not affect dev and prod settings.

* Under current setting out-of-sync can already happen. Consider the following code

```
p1 = TestPipeline.create()
// at this moment, FileSystem's option are set to p1's
p2 = TestPipeline.create()
// at this moment, FileSystem's option are set to p2's. Any operation on P1 involving FileSystem will use P2's option
```

Under the current implementation of using a Static map for PipelineOption initalized FileSystem, whenever there are multiple pipelines, it can always be out-of-sync.

**Please** add a meaningful description for your change here


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
