### PR TITLE
fix: workaround BigtableIO.read() recreating the client for every split

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableServiceFactory.java
@@ -95,7 +95,7 @@ class BigtableServiceFactory implements Serializable {
 
     static BigtableServiceEntry create(ConfigId configId, BigtableService service) {
       return new AutoValue_BigtableServiceFactory_BigtableServiceEntry(
-          configId, service, CloseMode.INLINE);
+          configId, service, CloseMode.INLINE, null);
     }
 
     static BigtableServiceEntry create(
@@ -304,6 +304,7 @@ class BigtableServiceFactory implements Serializable {
     private ScheduledExecutorService executor = null;
     private int numOutstanding = 0;
 
+    @SuppressWarnings("FutureReturnValueIgnored")
     synchronized void enqueue(BigtableServiceEntry entry, Duration closeDelay) {
       if (numOutstanding == 0) {
         executor = Executors.newScheduledThreadPool(1);


### PR DESCRIPTION
This is a temporary workaround for BigtableIO.read().
Currently BigtableIO.read() uses the BoundedSource api, which means that its reader is closed per split. Originally a ref count system was added to allow different reader instances to share the same bigtable client. Unfortunately that system proved to be inadequate - in practice the the readers from multiple threads get closed around the same time.

The proper fix for this would be to implement Bigtable.read() as a SplittableDoFn and tie in to the worker lifetime via the Teardown event. However that will be a longer term project. For the short term future, this patch will simply defer the decrementing the refcount by 10 secs, which should prevent the ref count from dropping to zero in between splits.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
