### PR TITLE
Attempt to fix the permred "PostCommit Java IO Performance Tests"

### DIFF
--- a/.github/trigger_files/beam_PostCommit_Java_IO_Performance_Tests.json
+++ b/.github/trigger_files/beam_PostCommit_Java_IO_Performance_Tests.json
@@ -1,4 +1,0 @@
-{
-  "comment": "Modify this file in a trivial way to cause this test suite to run",
-  "modification": 0
-}

--- a/.github/trigger_files/beam_PostCommit_Java_IO_Performance_Tests.json
+++ b/.github/trigger_files/beam_PostCommit_Java_IO_Performance_Tests.json
@@ -1,0 +1,4 @@
+{
+  "comment": "Modify this file in a trivial way to cause this test suite to run",
+  "modification": 0
+}

--- a/.github/workflows/beam_PostCommit_Java_IO_Performance_Tests.yml
+++ b/.github/workflows/beam_PostCommit_Java_IO_Performance_Tests.yml
@@ -93,7 +93,6 @@ jobs:
       with:
         credentials_json: ${{ secrets.GCP_SA_KEY }}
         project_id: ${{ secrets.GCP_PROJECT_ID }}
-        token_format: 'access_token'
     - name: Setup gcloud
       uses: google-github-actions/setup-gcloud@v2
       with:

--- a/.github/workflows/beam_PostCommit_Java_IO_Performance_Tests.yml
+++ b/.github/workflows/beam_PostCommit_Java_IO_Performance_Tests.yml
@@ -89,7 +89,7 @@ jobs:
       with:
         java-version: default
     - name: Authenticate on GCP
-      uses: google-github-actions/auth@v2
+      uses: google-github-actions/auth@v1
       with:
         credentials_json: ${{ secrets.GCP_SA_KEY }}
         project_id: ${{ secrets.GCP_PROJECT_ID }}


### PR DESCRIPTION
The test of `PostCommit Java IO Performance Tests` has been permred:
https://github.com/apache/beam/actions/workflows/beam_PostCommit_Java_IO_Performance_Tests.yml

The error message is as follows.
```
Run google-github-actions/auth@v2
Created credentials file at "/runner/_work/beam/beam/gha-creds-839d6022ed8787fc.json"
Error: google-github-actions/auth failed with: failed to generate Google Cloud OAuth 2.0 Access Token for ahmedabualsaud-test@clouddfe.google.com.iam.gserviceaccount.com: ***
  "error": ***
    "code": 401,
    "message": "Request had invalid authentication credentials. Expected OAuth 2 access token, login cookie or other valid authentication credential. See https://developers.google.com/identity/sign-in/web/devconsole-project.",
    "status": "UNAUTHENTICATED"
  ***
***
```

I noticed that this failed test is calling `auth@v2` while the other tests (i.e. Java Tests and Python Tests) are using `auth@v1`.

https://github.com/apache/beam/blob/9ceb14e23f413ba4b48f0918e30f5a47da04931e/.github/workflows/java_tests.yml#L181
 https://github.com/apache/beam/blob/9ceb14e23f413ba4b48f0918e30f5a47da04931e/.github/workflows/python_tests.yml#L184

So here I am trying to change it to v1 and see if it fixes the problem (#30527).