### PR TITLE
Remove beam logging in playground for Python

### DIFF
--- a/playground/backend/internal/preparers/python_preparers.go
+++ b/playground/backend/internal/preparers/python_preparers.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	addLogHandlerCode       = ""
+	addLogHandlerCode       = "import logging\nlogging.basicConfig(\n    level=logging.INFO,\n    format=\"%(asctime)s [%(levelname)s] %(message)s\",\n    handlers=[\n        logging.FileHandler(\"logs.log\"),\n    ]\n)\n"
 	oneIndentation          = "  "
 	findWithPipelinePattern = `(\s*)with.+Pipeline.+as (.+):`
 	indentationPattern      = `^(%s){0,1}\w+`

--- a/playground/backend/internal/preparers/python_preparers.go
+++ b/playground/backend/internal/preparers/python_preparers.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	addLogHandlerCode       = "import logging\nlogging.basicConfig(\n    level=logging.INFO,\n    format=\"%(asctime)s [%(levelname)s] %(message)s\",\n    handlers=[\n        logging.FileHandler(\"logs.log\"),\n    ]\n)\n"
+	addLogHandlerCode       = "import logging\nlogging.basicConfig(\n    level=logging.ERROR,\n    format=\"%(asctime)s [%(levelname)s] %(message)s\",\n    handlers=[\n        logging.FileHandler(\"logs.log\"),\n    ]\n)\n"
 	oneIndentation          = "  "
 	findWithPipelinePattern = `(\s*)with.+Pipeline.+as (.+):`
 	indentationPattern      = `^(%s){0,1}\w+`

--- a/playground/backend/internal/preparers/python_preparers.go
+++ b/playground/backend/internal/preparers/python_preparers.go
@@ -26,7 +26,7 @@ import (
 )
 
 const (
-	addLogHandlerCode       = "import logging\nlogging.basicConfig(\n    level=logging.INFO,\n    format=\"%(asctime)s [%(levelname)s] %(message)s\",\n    handlers=[\n        logging.FileHandler(\"logs.log\"),\n    ]\n)\n"
+	addLogHandlerCode       = ""
 	oneIndentation          = "  "
 	findWithPipelinePattern = `(\s*)with.+Pipeline.+as (.+):`
 	indentationPattern      = `^(%s){0,1}\w+`

--- a/playground/backend/internal/preparers/python_preparers_test.go
+++ b/playground/backend/internal/preparers/python_preparers_test.go
@@ -53,7 +53,7 @@ func TestGetPythonPreparers(t *testing.T) {
 }
 
 func Test_addCodeToFile(t *testing.T) {
-	wantCode := "import logging\nlogging.basicConfig(\n    level=logging.INFO,\n    format=\"%(asctime)s [%(levelname)s] %(message)s\",\n    handlers=[\n        logging.FileHandler(\"logs.log\"),\n    ]\n)\n" + pyCode
+	wantCode := "import logging\nlogging.basicConfig(\n    level=logging.ERROR,\n    format=\"%(asctime)s [%(levelname)s] %(message)s\",\n    handlers=[\n        logging.FileHandler(\"logs.log\"),\n    ]\n)\n" + pyCode
 
 	type args struct {
 		args []interface{}

--- a/playground/backend/internal/preparers/python_preparers_test.go
+++ b/playground/backend/internal/preparers/python_preparers_test.go
@@ -53,7 +53,7 @@ func TestGetPythonPreparers(t *testing.T) {
 }
 
 func Test_addCodeToFile(t *testing.T) {
-	wantCode := pyCode
+	wantCode := "import logging\nlogging.basicConfig(\n    level=logging.INFO,\n    format=\"%(asctime)s [%(levelname)s] %(message)s\",\n    handlers=[\n        logging.FileHandler(\"logs.log\"),\n    ]\n)\n" + pyCode
 
 	type args struct {
 		args []interface{}

--- a/playground/backend/internal/preparers/python_preparers_test.go
+++ b/playground/backend/internal/preparers/python_preparers_test.go
@@ -53,7 +53,7 @@ func TestGetPythonPreparers(t *testing.T) {
 }
 
 func Test_addCodeToFile(t *testing.T) {
-	wantCode := "import logging\nlogging.basicConfig(\n    level=logging.INFO,\n    format=\"%(asctime)s [%(levelname)s] %(message)s\",\n    handlers=[\n        logging.FileHandler(\"logs.log\"),\n    ]\n)\n" + pyCode
+	wantCode := pyCode
 
 	type args struct {
 		args []interface{}

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -1465,6 +1465,7 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
   def test_filter_does_not_type_check_using_type_hints_method(self):
     # Filter is expecting an int but instead looks to the 'left' and sees a str
     # incoming.
+
     with self.assertRaises(typehints.TypeCheckError) as e:
       (
           self.p

--- a/sdks/python/apache_beam/transforms/ptransform_test.py
+++ b/sdks/python/apache_beam/transforms/ptransform_test.py
@@ -1465,7 +1465,6 @@ class PTransformTypeCheckTestCase(TypeHintTestCase):
   def test_filter_does_not_type_check_using_type_hints_method(self):
     # Filter is expecting an int but instead looks to the 'left' and sees a str
     # incoming.
-
     with self.assertRaises(typehints.TypeCheckError) as e:
       (
           self.p


### PR DESCRIPTION
I get a lot of complaints about all the logging in Beam playground for python examples. It really drowns out any output that might be coming from the examples.

I attempted to just remove the logging altogether for the python examples here, though I have no way of testing it.

My rationale is that the Beam playground environment doesn't really make sense to have logging for. If something goes wrong with an example, it makes a lot more sense to just copy and paste the example into your local Beam environment and debug it there (and optionally turn on logging in your own environment). 
