### PR TITLE
Fix the snapshot publishing script

### DIFF
--- a/sdks/python/scripts/run_snapshot_publish.sh
+++ b/sdks/python/scripts/run_snapshot_publish.sh
@@ -30,8 +30,10 @@ DEP_SNAPSHOT_FILE_NAME="beam-py-requirements-$time.txt"
 # and located under Gradle build directory.
 cd $WORKSPACE/sdks/python/build
 
-# Rename the file to be apache-beam-{VERSION}-{datetime}.tar.gz
-for file in "apache-beam-$VERSION*.tar.gz"; do
+# Rename the file to be apache_beam-{VERSION}-{datetime}.tar.gz
+# Notice that the distribution name of beam has been normalized as "apache_beam"
+# since setuptools 69.3.0.
+for file in "apache_beam-$VERSION*.tar.gz"; do
   mv $file $SNAPSHOT
 done
 

--- a/sdks/python/scripts/run_snapshot_publish.sh
+++ b/sdks/python/scripts/run_snapshot_publish.sh
@@ -30,10 +30,10 @@ DEP_SNAPSHOT_FILE_NAME="beam-py-requirements-$time.txt"
 # and located under Gradle build directory.
 cd $WORKSPACE/sdks/python/build
 
-# Rename the file to be apache_beam-{VERSION}-{datetime}.tar.gz
-# Notice that the distribution name of beam has been normalized as "apache_beam"
-# since setuptools 69.3.0.
-for file in "apache_beam-$VERSION*.tar.gz"; do
+# Rename the file to be apache-beam-{VERSION}-{datetime}.tar.gz
+# Notice that the distribution name of beam can be "apache-beam" with
+# setuptools<69.3.0 or "apache_beam" with setuptools>=69.3.0.
+for file in "apache[-_]beam-$VERSION*.tar.gz"; do
   mv $file $SNAPSHOT
 done
 


### PR DESCRIPTION
Since setuptools 69.3.0,  the distribution name of a package has been normalized according to https://packaging.python.org/en/latest/specifications/binary-distribution-format/#escaping-and-unicode to support PEP 625 (https://github.com/pypa/setuptools/commit/b0135f5097f32a27b7a14e2c6296ba14bcb4e10b). 

In our case, the source and  binary distribution name would be changed from `apache-beam` to `apache_beam`.

This PR is to fix the script for publishing python snapshot so that the file can be published to gcs.

fixes #32729

related thread: #30955