### PR TITLE
Schema inference parameterized types

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/AutoValueSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/AutoValueSchema.java
@@ -19,8 +19,10 @@ package org.apache.beam.sdk.schemas;
 
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.stream.Collectors;
 import org.apache.beam.sdk.schemas.annotations.SchemaIgnore;
 import org.apache.beam.sdk.schemas.utils.AutoValueUtils;
@@ -61,8 +63,9 @@ public class AutoValueSchema extends GetterBasedSchemaProviderV2 {
               .filter(m -> !m.isAnnotationPresent(SchemaIgnore.class))
               .collect(Collectors.toList());
       List<FieldValueTypeInformation> types = Lists.newArrayListWithCapacity(methods.size());
+      Map<Type, Type> boundTypes = ReflectUtils.getAllBoundTypes(typeDescriptor);
       for (int i = 0; i < methods.size(); ++i) {
-        types.add(FieldValueTypeInformation.forGetter(methods.get(i), i));
+        types.add(FieldValueTypeInformation.forGetter(methods.get(i), i, boundTypes));
       }
       types.sort(Comparator.comparing(FieldValueTypeInformation::getNumber));
       validateFieldNumbers(types);
@@ -143,7 +146,8 @@ public class AutoValueSchema extends GetterBasedSchemaProviderV2 {
 
   @Override
   public <T> @Nullable Schema schemaFor(TypeDescriptor<T> typeDescriptor) {
+    Map<Type, Type> boundTypes = ReflectUtils.getAllBoundTypes(typeDescriptor);
     return JavaBeanUtils.schemaFromJavaBeanClass(
-        typeDescriptor, AbstractGetterTypeSupplier.INSTANCE);
+        typeDescriptor, AbstractGetterTypeSupplier.INSTANCE, boundTypes);
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FieldValueTypeInformation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/FieldValueTypeInformation.java
@@ -29,6 +29,7 @@ import java.util.Arrays;
 import java.util.Collections;
 import java.util.Map;
 import java.util.stream.Stream;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.schemas.annotations.SchemaCaseFormat;
 import org.apache.beam.sdk.schemas.annotations.SchemaFieldDescription;
 import org.apache.beam.sdk.schemas.annotations.SchemaFieldName;
@@ -45,6 +46,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
   "nullness", // TODO(https://github.com/apache/beam/issues/20497)
   "rawtypes"
 })
+@Internal
 public abstract class FieldValueTypeInformation implements Serializable {
   /** Optionally returns the field index. */
   public abstract @Nullable Integer getNumber();

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaFieldSchema.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/JavaFieldSchema.java
@@ -21,8 +21,10 @@ import java.lang.reflect.Constructor;
 import java.lang.reflect.Field;
 import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
+import java.lang.reflect.Type;
 import java.util.Comparator;
 import java.util.List;
+import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 import javax.annotation.Nullable;
@@ -62,9 +64,11 @@ public class JavaFieldSchema extends GetterBasedSchemaProviderV2 {
           ReflectUtils.getFields(typeDescriptor.getRawType()).stream()
               .filter(m -> !m.isAnnotationPresent(SchemaIgnore.class))
               .collect(Collectors.toList());
+
       List<FieldValueTypeInformation> types = Lists.newArrayListWithCapacity(fields.size());
+      Map<Type, Type> boundTypes = ReflectUtils.getAllBoundTypes(typeDescriptor);
       for (int i = 0; i < fields.size(); ++i) {
-        types.add(FieldValueTypeInformation.forField(fields.get(i), i));
+        types.add(FieldValueTypeInformation.forField(fields.get(i), i, boundTypes));
       }
       types.sort(Comparator.comparing(FieldValueTypeInformation::getNumber));
       validateFieldNumbers(types);
@@ -111,7 +115,9 @@ public class JavaFieldSchema extends GetterBasedSchemaProviderV2 {
 
   @Override
   public <T> Schema schemaFor(TypeDescriptor<T> typeDescriptor) {
-    return POJOUtils.schemaFromPojoClass(typeDescriptor, JavaFieldTypeSupplier.INSTANCE);
+    Map<Type, Type> boundTypes = ReflectUtils.getAllBoundTypes(typeDescriptor);
+    return POJOUtils.schemaFromPojoClass(
+        typeDescriptor, JavaFieldTypeSupplier.INSTANCE, boundTypes);
   }
 
   @Override

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaProvider.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaProvider.java
@@ -38,8 +38,7 @@ public interface SchemaProvider extends Serializable {
    * Given a type, return a function that converts that type to a {@link Row} object If no schema
    * exists, returns null.
    */
-  @Nullable
-  <T> SerializableFunction<T, Row> toRowFunction(TypeDescriptor<T> typeDescriptor);
+  <T> @Nullable SerializableFunction<T, Row> toRowFunction(TypeDescriptor<T> typeDescriptor);
 
   /**
    * Given a type, returns a function that converts from a {@link Row} object to that type. If no

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaRegistry.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/SchemaRegistry.java
@@ -76,13 +76,12 @@ public class SchemaRegistry {
       providers.put(typeDescriptor, schemaProvider);
     }
 
-    @Override
-    public <T> @Nullable Schema schemaFor(TypeDescriptor<T> typeDescriptor) {
+    private <T> @Nullable SchemaProvider schemaProviderFor(TypeDescriptor<T> typeDescriptor) {
       TypeDescriptor<?> type = typeDescriptor;
       do {
         SchemaProvider schemaProvider = providers.get(type);
         if (schemaProvider != null) {
-          return schemaProvider.schemaFor(type);
+          return schemaProvider;
         }
         Class<?> superClass = type.getRawType().getSuperclass();
         if (superClass == null || superClass.equals(Object.class)) {
@@ -90,40 +89,26 @@ public class SchemaRegistry {
         }
         type = TypeDescriptor.of(superClass);
       } while (true);
+    }
+
+    @Override
+    public <T> @Nullable Schema schemaFor(TypeDescriptor<T> typeDescriptor) {
+      @Nullable SchemaProvider schemaProvider = schemaProviderFor(typeDescriptor);
+      return schemaProvider != null ? schemaProvider.schemaFor(typeDescriptor) : null;
     }
 
     @Override
     public <T> @Nullable SerializableFunction<T, Row> toRowFunction(
         TypeDescriptor<T> typeDescriptor) {
-      TypeDescriptor<?> type = typeDescriptor;
-      do {
-        SchemaProvider schemaProvider = providers.get(type);
-        if (schemaProvider != null) {
-          return (SerializableFunction<T, Row>) schemaProvider.toRowFunction(type);
-        }
-        Class<?> superClass = type.getRawType().getSuperclass();
-        if (superClass == null || superClass.equals(Object.class)) {
-          return null;
-        }
-        type = TypeDescriptor.of(superClass);
-      } while (true);
+      @Nullable SchemaProvider schemaProvider = schemaProviderFor(typeDescriptor);
+      return schemaProvider != null ? schemaProvider.toRowFunction(typeDescriptor) : null;
     }
 
     @Override
     public <T> @Nullable SerializableFunction<Row, T> fromRowFunction(
         TypeDescriptor<T> typeDescriptor) {
-      TypeDescriptor<?> type = typeDescriptor;
-      do {
-        SchemaProvider schemaProvider = providers.get(type);
-        if (schemaProvider != null) {
-          return (SerializableFunction<Row, T>) schemaProvider.fromRowFunction(type);
-        }
-        Class<?> superClass = type.getRawType().getSuperclass();
-        if (superClass == null || superClass.equals(Object.class)) {
-          return null;
-        }
-        type = TypeDescriptor.of(superClass);
-      } while (true);
+      @Nullable SchemaProvider schemaProvider = schemaProviderFor(typeDescriptor);
+      return schemaProvider != null ? schemaProvider.fromRowFunction(typeDescriptor) : null;
     }
   }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/providers/JavaRowUdf.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/transforms/providers/JavaRowUdf.java
@@ -160,7 +160,8 @@ public class JavaRowUdf implements Serializable {
 
     public FunctionAndType(TypeDescriptor<?> outputType, Function<Row, Object> function) {
       this(
-          StaticSchemaInference.fieldFromType(outputType, new EmptyFieldValueTypeSupplier()),
+          StaticSchemaInference.fieldFromType(
+              outputType, new EmptyFieldValueTypeSupplier(), Collections.emptyMap()),
           function);
     }
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AutoValueUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AutoValueUtils.java
@@ -53,6 +53,7 @@ import net.bytebuddy.implementation.bytecode.member.MethodReturn;
 import net.bytebuddy.implementation.bytecode.member.MethodVariableAccess;
 import net.bytebuddy.jar.asm.ClassWriter;
 import net.bytebuddy.matcher.ElementMatchers;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.schemas.FieldValueTypeInformation;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.SchemaUserTypeCreator;
@@ -71,6 +72,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
   "nullness", // TODO(https://github.com/apache/beam/issues/20497)
   "rawtypes"
 })
+@Internal
 public class AutoValueUtils {
   public static TypeDescriptor<?> getBaseAutoValueClass(TypeDescriptor<?> typeDescriptor) {
     // AutoValue extensions may be nested

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AutoValueUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/AutoValueUtils.java
@@ -164,7 +164,6 @@ public class AutoValueUtils {
     // Verify that constructor parameters match (name and type) the inferred schema.
     for (Parameter parameter : constructor.getParameters()) {
       FieldValueTypeInformation type = typeMap.get(parameter.getName());
-      ;
       if (type == null || !type.getRawType().equals(parameter.getType())) {
         valid = false;
         break;

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ByteBuddyUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ByteBuddyUtils.java
@@ -344,19 +344,22 @@ public class ByteBuddyUtils {
 
     @Override
     protected Type convertCollection(TypeDescriptor<?> type) {
-      TypeDescriptor ret = createCollectionType(ReflectUtils.getIterableComponentType(type));
+      TypeDescriptor ret =
+          createCollectionType(ReflectUtils.getIterableComponentType(type, Collections.emptyMap()));
       return returnRawTypes ? ret.getRawType() : ret.getType();
     }
 
     @Override
     protected Type convertList(TypeDescriptor<?> type) {
-      TypeDescriptor ret = createCollectionType(ReflectUtils.getIterableComponentType(type));
+      TypeDescriptor ret =
+          createCollectionType(ReflectUtils.getIterableComponentType(type, Collections.emptyMap()));
       return returnRawTypes ? ret.getRawType() : ret.getType();
     }
 
     @Override
     protected Type convertIterable(TypeDescriptor<?> type) {
-      TypeDescriptor ret = createIterableType(ReflectUtils.getIterableComponentType(type));
+      TypeDescriptor ret =
+          createIterableType(ReflectUtils.getIterableComponentType(type, Collections.emptyMap()));
       return returnRawTypes ? ret.getRawType() : ret.getType();
     }
 
@@ -687,7 +690,8 @@ public class ByteBuddyUtils {
 
     @Override
     protected StackManipulation convertIterable(TypeDescriptor<?> type) {
-      TypeDescriptor componentType = ReflectUtils.getIterableComponentType(type);
+      TypeDescriptor componentType =
+          ReflectUtils.getIterableComponentType(type, Collections.emptyMap());
       Type convertedComponentType = getFactory().createTypeConversion(true).convert(componentType);
 
       final TypeDescriptor finalComponentType = ReflectUtils.boxIfPrimitive(componentType);
@@ -707,7 +711,8 @@ public class ByteBuddyUtils {
 
     @Override
     protected StackManipulation convertCollection(TypeDescriptor<?> type) {
-      TypeDescriptor componentType = ReflectUtils.getIterableComponentType(type);
+      TypeDescriptor componentType =
+          ReflectUtils.getIterableComponentType(type, Collections.emptyMap());
       Type convertedComponentType = getFactory().createTypeConversion(true).convert(componentType);
       final TypeDescriptor finalComponentType = ReflectUtils.boxIfPrimitive(componentType);
       if (!finalComponentType.hasUnresolvedParameters()) {
@@ -726,7 +731,8 @@ public class ByteBuddyUtils {
 
     @Override
     protected StackManipulation convertList(TypeDescriptor<?> type) {
-      TypeDescriptor componentType = ReflectUtils.getIterableComponentType(type);
+      TypeDescriptor componentType =
+          ReflectUtils.getIterableComponentType(type, Collections.emptyMap());
       Type convertedComponentType = getFactory().createTypeConversion(true).convert(componentType);
       final TypeDescriptor finalComponentType = ReflectUtils.boxIfPrimitive(componentType);
       if (!finalComponentType.hasUnresolvedParameters()) {
@@ -745,8 +751,8 @@ public class ByteBuddyUtils {
 
     @Override
     protected StackManipulation convertMap(TypeDescriptor<?> type) {
-      final TypeDescriptor keyType = ReflectUtils.getMapType(type, 0);
-      final TypeDescriptor valueType = ReflectUtils.getMapType(type, 1);
+      final TypeDescriptor keyType = ReflectUtils.getMapType(type, 0, Collections.emptyMap());
+      final TypeDescriptor valueType = ReflectUtils.getMapType(type, 1, Collections.emptyMap());
 
       Type convertedKeyType = getFactory().createTypeConversion(true).convert(keyType);
       Type convertedValueType = getFactory().createTypeConversion(true).convert(valueType);
@@ -1038,8 +1044,9 @@ public class ByteBuddyUtils {
       Type rowElementType =
           getFactory()
               .createTypeConversion(false)
-              .convert(ReflectUtils.getIterableComponentType(type));
-      final TypeDescriptor iterableElementType = ReflectUtils.getIterableComponentType(type);
+              .convert(ReflectUtils.getIterableComponentType(type, Collections.emptyMap()));
+      final TypeDescriptor iterableElementType =
+          ReflectUtils.getIterableComponentType(type, Collections.emptyMap());
       if (!iterableElementType.hasUnresolvedParameters()) {
         ForLoadedType conversionFunction =
             new ForLoadedType(
@@ -1060,8 +1067,9 @@ public class ByteBuddyUtils {
       Type rowElementType =
           getFactory()
               .createTypeConversion(false)
-              .convert(ReflectUtils.getIterableComponentType(type));
-      final TypeDescriptor collectionElementType = ReflectUtils.getIterableComponentType(type);
+              .convert(ReflectUtils.getIterableComponentType(type, Collections.emptyMap()));
+      final TypeDescriptor collectionElementType =
+          ReflectUtils.getIterableComponentType(type, Collections.emptyMap());
 
       if (!collectionElementType.hasUnresolvedParameters()) {
         ForLoadedType conversionFunction =
@@ -1083,8 +1091,9 @@ public class ByteBuddyUtils {
       Type rowElementType =
           getFactory()
               .createTypeConversion(false)
-              .convert(ReflectUtils.getIterableComponentType(type));
-      final TypeDescriptor collectionElementType = ReflectUtils.getIterableComponentType(type);
+              .convert(ReflectUtils.getIterableComponentType(type, Collections.emptyMap()));
+      final TypeDescriptor collectionElementType =
+          ReflectUtils.getIterableComponentType(type, Collections.emptyMap());
 
       StackManipulation readTrasformedValue = readValue;
       if (!collectionElementType.hasUnresolvedParameters()) {
@@ -1113,11 +1122,17 @@ public class ByteBuddyUtils {
     @Override
     protected StackManipulation convertMap(TypeDescriptor<?> type) {
       Type rowKeyType =
-          getFactory().createTypeConversion(false).convert(ReflectUtils.getMapType(type, 0));
-      final TypeDescriptor keyElementType = ReflectUtils.getMapType(type, 0);
+          getFactory()
+              .createTypeConversion(false)
+              .convert(ReflectUtils.getMapType(type, 0, Collections.emptyMap()));
+      final TypeDescriptor keyElementType =
+          ReflectUtils.getMapType(type, 0, Collections.emptyMap());
       Type rowValueType =
-          getFactory().createTypeConversion(false).convert(ReflectUtils.getMapType(type, 1));
-      final TypeDescriptor valueElementType = ReflectUtils.getMapType(type, 1);
+          getFactory()
+              .createTypeConversion(false)
+              .convert(ReflectUtils.getMapType(type, 1, Collections.emptyMap()));
+      final TypeDescriptor valueElementType =
+          ReflectUtils.getMapType(type, 1, Collections.emptyMap());
 
       StackManipulation readTrasformedValue = readValue;
       if (!keyElementType.hasUnresolvedParameters()
@@ -1475,7 +1490,7 @@ public class ByteBuddyUtils {
           Parameter parameter = parameters.get(i);
           ForLoadedType convertedType =
               new ForLoadedType(
-                  (Class) convertType.convert(TypeDescriptor.of(parameter.getType())));
+                  (Class) convertType.convert(TypeDescriptor.of(parameter.getParameterizedType())));
 
           // The instruction to read the parameter. Use the fieldMapping to reorder parameters as
           // necessary.

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ConvertHelpers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ConvertHelpers.java
@@ -22,6 +22,7 @@ import static org.apache.beam.sdk.util.ByteBuddyUtils.getClassLoadingStrategy;
 import java.io.Serializable;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Type;
+import java.util.Collections;
 import java.util.ServiceLoader;
 import net.bytebuddy.ByteBuddy;
 import net.bytebuddy.asm.AsmVisitorWrapper;
@@ -148,7 +149,8 @@ public class ConvertHelpers {
       TypeDescriptor<?> outputTypeDescriptor,
       TypeConversionsFactory typeConversionsFactory) {
     FieldType expectedFieldType =
-        StaticSchemaInference.fieldFromType(outputTypeDescriptor, JavaFieldTypeSupplier.INSTANCE);
+        StaticSchemaInference.fieldFromType(
+            outputTypeDescriptor, JavaFieldTypeSupplier.INSTANCE, Collections.emptyMap());
     if (!expectedFieldType.equals(fieldType)) {
       throw new IllegalArgumentException(
           "Element argument type "

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ConvertHelpers.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ConvertHelpers.java
@@ -37,6 +37,7 @@ import net.bytebuddy.implementation.bytecode.member.MethodReturn;
 import net.bytebuddy.implementation.bytecode.member.MethodVariableAccess;
 import net.bytebuddy.jar.asm.ClassWriter;
 import net.bytebuddy.matcher.ElementMatchers;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.schemas.JavaFieldSchema.JavaFieldTypeSupplier;
 import org.apache.beam.sdk.schemas.NoSuchSchemaException;
 import org.apache.beam.sdk.schemas.Schema;
@@ -57,6 +58,7 @@ import org.slf4j.LoggerFactory;
   "nullness", // TODO(https://github.com/apache/beam/issues/20497)
   "rawtypes"
 })
+@Internal
 public class ConvertHelpers {
   private static class SchemaInformationProviders {
     private static final ServiceLoader<SchemaInformationProvider> INSTANCE =

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtils.java
@@ -43,6 +43,7 @@ import net.bytebuddy.implementation.bytecode.member.MethodReturn;
 import net.bytebuddy.implementation.bytecode.member.MethodVariableAccess;
 import net.bytebuddy.jar.asm.ClassWriter;
 import net.bytebuddy.matcher.ElementMatchers;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.schemas.FieldValueGetter;
 import org.apache.beam.sdk.schemas.FieldValueSetter;
 import org.apache.beam.sdk.schemas.FieldValueTypeInformation;
@@ -62,6 +63,7 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Maps;
   "nullness", // TODO(https://github.com/apache/beam/issues/20497)
   "rawtypes"
 })
+@Internal
 public class JavaBeanUtils {
   /** Create a {@link Schema} for a Java Bean class. */
   public static Schema schemaFromJavaBeanClass(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtils.java
@@ -22,6 +22,7 @@ import static org.apache.beam.sdk.util.ByteBuddyUtils.getClassLoadingStrategy;
 import java.lang.reflect.Constructor;
 import java.lang.reflect.InvocationTargetException;
 import java.lang.reflect.Method;
+import java.lang.reflect.Type;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -64,8 +65,11 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Maps;
 public class JavaBeanUtils {
   /** Create a {@link Schema} for a Java Bean class. */
   public static Schema schemaFromJavaBeanClass(
-      TypeDescriptor<?> typeDescriptor, FieldValueTypeSupplier fieldValueTypeSupplier) {
-    return StaticSchemaInference.schemaFromClass(typeDescriptor, fieldValueTypeSupplier);
+      TypeDescriptor<?> typeDescriptor,
+      FieldValueTypeSupplier fieldValueTypeSupplier,
+      Map<Type, Type> boundTypes) {
+    return StaticSchemaInference.schemaFromClass(
+        typeDescriptor, fieldValueTypeSupplier, boundTypes);
   }
 
   private static final String CONSTRUCTOR_HELP_STRING =

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/POJOUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/POJOUtils.java
@@ -73,8 +73,11 @@ import org.checkerframework.checker.nullness.qual.Nullable;
 public class POJOUtils {
 
   public static Schema schemaFromPojoClass(
-      TypeDescriptor<?> typeDescriptor, FieldValueTypeSupplier fieldValueTypeSupplier) {
-    return StaticSchemaInference.schemaFromClass(typeDescriptor, fieldValueTypeSupplier);
+      TypeDescriptor<?> typeDescriptor,
+      FieldValueTypeSupplier fieldValueTypeSupplier,
+      Map<Type, Type> boundTypes) {
+    return StaticSchemaInference.schemaFromClass(
+        typeDescriptor, fieldValueTypeSupplier, boundTypes);
   }
 
   // Static ByteBuddy instance used by all helpers.
@@ -301,7 +304,7 @@ public class POJOUtils {
             field.getDeclaringClass(),
             typeConversionsFactory
                 .createTypeConversion(false)
-                .convert(TypeDescriptor.of(field.getType())));
+                .convert(TypeDescriptor.of(field.getGenericType())));
     builder =
         implementGetterMethods(builder, field, typeInformation.getName(), typeConversionsFactory);
     try {
@@ -383,7 +386,7 @@ public class POJOUtils {
             field.getDeclaringClass(),
             typeConversionsFactory
                 .createTypeConversion(false)
-                .convert(TypeDescriptor.of(field.getType())));
+                .convert(TypeDescriptor.of(field.getGenericType())));
     builder = implementSetterMethods(builder, field, typeConversionsFactory);
     try {
       return builder
@@ -491,7 +494,7 @@ public class POJOUtils {
                 // Do any conversions necessary.
                 typeConversionsFactory
                     .createSetterConversions(readField)
-                    .convert(TypeDescriptor.of(field.getType())),
+                    .convert(TypeDescriptor.of(field.getGenericType())),
                 // Now update the field and return void.
                 FieldAccess.forField(new ForLoadedField(field)).write(),
                 MethodReturn.VOID);
@@ -546,7 +549,8 @@ public class POJOUtils {
           Field field = fields.get(i);
 
           ForLoadedType convertedType =
-              new ForLoadedType((Class) convertType.convert(TypeDescriptor.of(field.getType())));
+              new ForLoadedType(
+                  (Class) convertType.convert(TypeDescriptor.of(field.getGenericType())));
 
           // The instruction to read the parameter.
           StackManipulation readParameter =
@@ -563,7 +567,7 @@ public class POJOUtils {
                   // Do any conversions necessary.
                   typeConversionsFactory
                       .createSetterConversions(readParameter)
-                      .convert(TypeDescriptor.of(field.getType())),
+                      .convert(TypeDescriptor.of(field.getGenericType())),
                   // Now update the field.
                   FieldAccess.forField(new ForLoadedField(field)).write());
           stackManipulation = new StackManipulation.Compound(stackManipulation, updateField);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/POJOUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/POJOUtils.java
@@ -49,6 +49,7 @@ import net.bytebuddy.implementation.bytecode.member.MethodReturn;
 import net.bytebuddy.implementation.bytecode.member.MethodVariableAccess;
 import net.bytebuddy.jar.asm.ClassWriter;
 import net.bytebuddy.matcher.ElementMatchers;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.schemas.FieldValueGetter;
 import org.apache.beam.sdk.schemas.FieldValueSetter;
 import org.apache.beam.sdk.schemas.FieldValueTypeInformation;
@@ -70,6 +71,7 @@ import org.checkerframework.checker.nullness.qual.Nullable;
   "nullness", // TODO(https://github.com/apache/beam/issues/20497)
   "rawtypes" // TODO(https://github.com/apache/beam/issues/20447)
 })
+@Internal
 public class POJOUtils {
 
   public static Schema schemaFromPojoClass(

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ReflectUtils.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/ReflectUtils.java
@@ -256,6 +256,10 @@ public class ReflectUtils {
         : typeDescriptor;
   }
 
+  /**
+   * If this (or a base class)is a paremeterized type, return a map of all TypeVariable->Type
+   * bindings. This allows us to resolve types in any contained fields or methods.
+   */
   public static <T> Map<Type, Type> getAllBoundTypes(TypeDescriptor<T> typeDescriptor) {
     Map<Type, Type> boundParameters = Maps.newHashMap();
     TypeDescriptor<?> currentType = typeDescriptor;
@@ -266,7 +270,7 @@ public class ReflectUtils {
         Type[] typeArguments = parameterizedType.getActualTypeArguments();
         ;
         if (typeArguments.length != typeVariables.length) {
-          throw new RuntimeException("Unmatching arguments lengths");
+          throw new RuntimeException("Unmatching arguments lengths in type " + typeDescriptor);
         }
         for (int i = 0; i < typeVariables.length; ++i) {
           boundParameters.put(typeVariables[i], typeArguments[i]);

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/StaticSchemaInference.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/StaticSchemaInference.java
@@ -19,7 +19,7 @@ package org.apache.beam.sdk.schemas.utils;
 
 import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkArgument;
 
-import java.lang.reflect.ParameterizedType;
+import java.lang.reflect.Type;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.util.Arrays;
@@ -33,6 +33,7 @@ import org.apache.beam.sdk.schemas.FieldValueTypeInformation;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.logicaltypes.EnumerationType;
+import org.apache.beam.sdk.util.Preconditions;
 import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.joda.time.ReadableInstant;
@@ -85,14 +86,17 @@ public class StaticSchemaInference {
    * public getter methods, or special annotations on the class.
    */
   public static Schema schemaFromClass(
-      TypeDescriptor<?> typeDescriptor, FieldValueTypeSupplier fieldValueTypeSupplier) {
-    return schemaFromClass(typeDescriptor, fieldValueTypeSupplier, new HashMap<>());
+      TypeDescriptor<?> typeDescriptor,
+      FieldValueTypeSupplier fieldValueTypeSupplier,
+      Map<Type, Type> boundTypes) {
+    return schemaFromClass(typeDescriptor, fieldValueTypeSupplier, new HashMap<>(), boundTypes);
   }
 
   private static Schema schemaFromClass(
       TypeDescriptor<?> typeDescriptor,
       FieldValueTypeSupplier fieldValueTypeSupplier,
-      Map<TypeDescriptor<?>, Schema> alreadyVisitedSchemas) {
+      Map<TypeDescriptor<?>, Schema> alreadyVisitedSchemas,
+      Map<Type, Type> boundTypes) {
     if (alreadyVisitedSchemas.containsKey(typeDescriptor)) {
       Schema existingSchema = alreadyVisitedSchemas.get(typeDescriptor);
       if (existingSchema == null) {
@@ -106,7 +110,7 @@ public class StaticSchemaInference {
     Schema.Builder builder = Schema.builder();
     for (FieldValueTypeInformation type : fieldValueTypeSupplier.get(typeDescriptor)) {
       Schema.FieldType fieldType =
-          fieldFromType(type.getType(), fieldValueTypeSupplier, alreadyVisitedSchemas);
+          fieldFromType(type.getType(), fieldValueTypeSupplier, alreadyVisitedSchemas, boundTypes);
       Schema.Field f =
           type.isNullable()
               ? Schema.Field.nullable(type.getName(), fieldType)
@@ -123,15 +127,18 @@ public class StaticSchemaInference {
 
   /** Map a Java field type to a Beam Schema FieldType. */
   public static Schema.FieldType fieldFromType(
-      TypeDescriptor type, FieldValueTypeSupplier fieldValueTypeSupplier) {
-    return fieldFromType(type, fieldValueTypeSupplier, new HashMap<>());
+      TypeDescriptor<?> type,
+      FieldValueTypeSupplier fieldValueTypeSupplier,
+      Map<Type, Type> boundTypes) {
+    return fieldFromType(type, fieldValueTypeSupplier, new HashMap<>(), boundTypes);
   }
 
   // TODO(https://github.com/apache/beam/issues/21567): support type inference for logical types
   private static Schema.FieldType fieldFromType(
       TypeDescriptor type,
       FieldValueTypeSupplier fieldValueTypeSupplier,
-      Map<TypeDescriptor<?>, Schema> alreadyVisitedSchemas) {
+      Map<TypeDescriptor<?>, Schema> alreadyVisitedSchemas,
+      Map<Type, Type> boundTypes) {
     FieldType primitiveType = PRIMITIVE_TYPES.get(type.getRawType());
     if (primitiveType != null) {
       return primitiveType;
@@ -152,27 +159,25 @@ public class StaticSchemaInference {
       } else {
         // Otherwise this is an array type.
         return FieldType.array(
-            fieldFromType(component, fieldValueTypeSupplier, alreadyVisitedSchemas));
+            fieldFromType(component, fieldValueTypeSupplier, alreadyVisitedSchemas, boundTypes));
       }
     } else if (type.isSubtypeOf(TypeDescriptor.of(Map.class))) {
-      TypeDescriptor<Collection<?>> map = type.getSupertype(Map.class);
-      if (map.getType() instanceof ParameterizedType) {
-        ParameterizedType ptype = (ParameterizedType) map.getType();
-        java.lang.reflect.Type[] params = ptype.getActualTypeArguments();
-        checkArgument(params.length == 2);
-        FieldType keyType =
-            fieldFromType(
-                TypeDescriptor.of(params[0]), fieldValueTypeSupplier, alreadyVisitedSchemas);
-        FieldType valueType =
-            fieldFromType(
-                TypeDescriptor.of(params[1]), fieldValueTypeSupplier, alreadyVisitedSchemas);
-        checkArgument(
-            keyType.getTypeName().isPrimitiveType(),
-            "Only primitive types can be map keys. type: " + keyType.getTypeName());
-        return FieldType.map(keyType, valueType);
-      } else {
-        throw new RuntimeException("Cannot infer schema from unparameterized map.");
-      }
+      FieldType keyType =
+          fieldFromType(
+              ReflectUtils.getMapType(type, 0, boundTypes),
+              fieldValueTypeSupplier,
+              alreadyVisitedSchemas,
+              boundTypes);
+      FieldType valueType =
+          fieldFromType(
+              ReflectUtils.getMapType(type, 1, boundTypes),
+              fieldValueTypeSupplier,
+              alreadyVisitedSchemas,
+              boundTypes);
+      checkArgument(
+          keyType.getTypeName().isPrimitiveType(),
+          "Only primitive types can be map keys. type: " + keyType.getTypeName());
+      return FieldType.map(keyType, valueType);
     } else if (type.isSubtypeOf(TypeDescriptor.of(CharSequence.class))) {
       return FieldType.STRING;
     } else if (type.isSubtypeOf(TypeDescriptor.of(ReadableInstant.class))) {
@@ -180,26 +185,22 @@ public class StaticSchemaInference {
     } else if (type.isSubtypeOf(TypeDescriptor.of(ByteBuffer.class))) {
       return FieldType.BYTES;
     } else if (type.isSubtypeOf(TypeDescriptor.of(Iterable.class))) {
-      TypeDescriptor<Iterable<?>> iterable = type.getSupertype(Iterable.class);
-      if (iterable.getType() instanceof ParameterizedType) {
-        ParameterizedType ptype = (ParameterizedType) iterable.getType();
-        java.lang.reflect.Type[] params = ptype.getActualTypeArguments();
-        checkArgument(params.length == 1);
-        // TODO: should this be AbstractCollection?
-        if (type.isSubtypeOf(TypeDescriptor.of(Collection.class))) {
-          return FieldType.array(
-              fieldFromType(
-                  TypeDescriptor.of(params[0]), fieldValueTypeSupplier, alreadyVisitedSchemas));
-        } else {
-          return FieldType.iterable(
-              fieldFromType(
-                  TypeDescriptor.of(params[0]), fieldValueTypeSupplier, alreadyVisitedSchemas));
-        }
+      FieldType elementType =
+          fieldFromType(
+              Preconditions.checkArgumentNotNull(
+                  ReflectUtils.getIterableComponentType(type, boundTypes)),
+              fieldValueTypeSupplier,
+              alreadyVisitedSchemas,
+              boundTypes);
+      // TODO: should this be AbstractCollection?
+      if (type.isSubtypeOf(TypeDescriptor.of(Collection.class))) {
+        return FieldType.array(elementType);
       } else {
-        throw new RuntimeException("Cannot infer schema from unparameterized collection.");
+        return FieldType.iterable(elementType);
       }
     } else {
-      return FieldType.row(schemaFromClass(type, fieldValueTypeSupplier, alreadyVisitedSchemas));
+      return FieldType.row(
+          schemaFromClass(type, fieldValueTypeSupplier, alreadyVisitedSchemas, boundTypes));
     }
   }
 }

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/StaticSchemaInference.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/schemas/utils/StaticSchemaInference.java
@@ -29,6 +29,7 @@ import java.util.List;
 import java.util.Map;
 import java.util.function.Function;
 import java.util.stream.Collectors;
+import org.apache.beam.sdk.annotations.Internal;
 import org.apache.beam.sdk.schemas.FieldValueTypeInformation;
 import org.apache.beam.sdk.schemas.Schema;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
@@ -43,6 +44,7 @@ import org.joda.time.ReadableInstant;
   "nullness", // TODO(https://github.com/apache/beam/issues/20497)
   "rawtypes"
 })
+@Internal
 public class StaticSchemaInference {
   public static List<FieldValueTypeInformation> sortBySchema(
       List<FieldValueTypeInformation> types, Schema schema) {

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AutoValueSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/AutoValueSchemaTest.java
@@ -28,6 +28,7 @@ import com.google.auto.value.extension.memoized.Memoized;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Map;
 import org.apache.beam.sdk.schemas.Schema.Field;
 import org.apache.beam.sdk.schemas.Schema.FieldType;
 import org.apache.beam.sdk.schemas.annotations.DefaultSchema;
@@ -39,6 +40,7 @@ import org.apache.beam.sdk.schemas.annotations.SchemaFieldNumber;
 import org.apache.beam.sdk.schemas.utils.SchemaTestUtils;
 import org.apache.beam.sdk.util.SerializableUtils;
 import org.apache.beam.sdk.values.Row;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.CaseFormat;
 import org.joda.time.DateTime;
 import org.joda.time.Instant;
@@ -885,5 +887,152 @@ public class AutoValueSchemaTest {
     Schema schema = registry.getSchema(SchemaFieldDescriptionSimpleClass.class);
     assertEquals(FIELD_DESCRIPTION_SCHEMA.getField("lng"), schema.getField("lng"));
     assertEquals(FIELD_DESCRIPTION_SCHEMA.getField("str"), schema.getField("str"));
+  }
+
+  @AutoValue
+  @DefaultSchema(AutoValueSchema.class)
+  abstract static class ParameterizedAutoValue<T, V, W, X> {
+    abstract W getValue1();
+
+    abstract T getValue2();
+
+    abstract V getValue3();
+
+    abstract X getValue4();
+  }
+
+  @Test
+  public void testAutoValueWithTypeParameter() throws NoSuchSchemaException {
+    SchemaRegistry registry = SchemaRegistry.createDefault();
+    TypeDescriptor<ParameterizedAutoValue<String, Long, Boolean, SimpleAutoValue>> typeDescriptor =
+        new TypeDescriptor<ParameterizedAutoValue<String, Long, Boolean, SimpleAutoValue>>() {};
+    Schema schema = registry.getSchema(typeDescriptor);
+
+    final Schema expectedSchema =
+        Schema.builder()
+            .addBooleanField("value1")
+            .addStringField("value2")
+            .addInt64Field("value3")
+            .addRowField("value4", SIMPLE_SCHEMA)
+            .build();
+    assertTrue(expectedSchema.equivalent(schema));
+  }
+
+  @DefaultSchema(AutoValueSchema.class)
+  abstract static class ParameterizedAutoValueSubclass<T>
+      extends ParameterizedAutoValue<String, Long, Boolean, SimpleAutoValue> {
+    abstract T getValue5();
+  }
+
+  @Test
+  public void testAutoValueWithInheritedTypeParameter() throws NoSuchSchemaException {
+    SchemaRegistry registry = SchemaRegistry.createDefault();
+    TypeDescriptor<ParameterizedAutoValueSubclass<Short>> typeDescriptor =
+        new TypeDescriptor<ParameterizedAutoValueSubclass<Short>>() {};
+    Schema schema = registry.getSchema(typeDescriptor);
+
+    final Schema expectedSchema =
+        Schema.builder()
+            .addBooleanField("value1")
+            .addStringField("value2")
+            .addInt64Field("value3")
+            .addRowField("value4", SIMPLE_SCHEMA)
+            .addInt16Field("value5")
+            .build();
+    assertTrue(expectedSchema.equivalent(schema));
+  }
+
+  @AutoValue
+  @DefaultSchema(AutoValueSchema.class)
+  abstract static class NestedParameterizedCollectionAutoValue<ElementT, KeyT> {
+    abstract Iterable<ElementT> getNested();
+
+    abstract Map<KeyT, ElementT> getMap();
+  }
+
+  @Test
+  public void testAutoValueWithNestedCollectionTypeParameter() throws NoSuchSchemaException {
+    SchemaRegistry registry = SchemaRegistry.createDefault();
+    TypeDescriptor<
+            NestedParameterizedCollectionAutoValue<
+                ParameterizedAutoValue<String, Long, Boolean, SimpleAutoValue>, String>>
+        typeDescriptor =
+            new TypeDescriptor<
+                NestedParameterizedCollectionAutoValue<
+                    ParameterizedAutoValue<String, Long, Boolean, SimpleAutoValue>, String>>() {};
+    Schema schema = registry.getSchema(typeDescriptor);
+
+    final Schema expectedInnerSchema =
+        Schema.builder()
+            .addBooleanField("value1")
+            .addStringField("value2")
+            .addInt64Field("value3")
+            .addRowField("value4", SIMPLE_SCHEMA)
+            .build();
+    final Schema expectedSchema =
+        Schema.builder()
+            .addIterableField("nested", FieldType.row(expectedInnerSchema))
+            .addMapField("map", FieldType.STRING, FieldType.row(expectedInnerSchema))
+            .build();
+    assertTrue(expectedSchema.equivalent(schema));
+  }
+
+  @Test
+  public void testAutoValueWithDoublyNestedCollectionTypeParameter() throws NoSuchSchemaException {
+    SchemaRegistry registry = SchemaRegistry.createDefault();
+    TypeDescriptor<
+            NestedParameterizedCollectionAutoValue<
+                Iterable<ParameterizedAutoValue<String, Long, Boolean, SimpleAutoValue>>, String>>
+        typeDescriptor =
+            new TypeDescriptor<
+                NestedParameterizedCollectionAutoValue<
+                    Iterable<ParameterizedAutoValue<String, Long, Boolean, SimpleAutoValue>>,
+                    String>>() {};
+    Schema schema = registry.getSchema(typeDescriptor);
+
+    final Schema expectedInnerSchema =
+        Schema.builder()
+            .addBooleanField("value1")
+            .addStringField("value2")
+            .addInt64Field("value3")
+            .addRowField("value4", SIMPLE_SCHEMA)
+            .build();
+    final Schema expectedSchema =
+        Schema.builder()
+            .addIterableField("nested", FieldType.iterable(FieldType.row(expectedInnerSchema)))
+            .addMapField(
+                "map", FieldType.STRING, FieldType.iterable(FieldType.row(expectedInnerSchema)))
+            .build();
+    assertTrue(expectedSchema.equivalent(schema));
+  }
+
+  @AutoValue
+  @DefaultSchema(AutoValueSchema.class)
+  abstract static class NestedParameterizedAutoValue<T> {
+    abstract T getNested();
+  }
+
+  @Test
+  public void testAutoValueWithNestedTypeParameter() throws NoSuchSchemaException {
+    SchemaRegistry registry = SchemaRegistry.createDefault();
+    TypeDescriptor<
+            NestedParameterizedAutoValue<
+                ParameterizedAutoValue<String, Long, Boolean, SimpleAutoValue>>>
+        typeDescriptor =
+            new TypeDescriptor<
+                NestedParameterizedAutoValue<
+                    ParameterizedAutoValue<String, Long, Boolean, SimpleAutoValue>>>() {};
+    Schema schema = registry.getSchema(typeDescriptor);
+
+    final Schema expectedInnerSchema =
+        Schema.builder()
+            .addBooleanField("value1")
+            .addStringField("value2")
+            .addInt64Field("value3")
+            .addRowField("value4", SIMPLE_SCHEMA)
+            .build();
+    final Schema expectedSchema =
+        Schema.builder().addRowField("nested", expectedInnerSchema).build();
+    assertTrue(expectedSchema.equivalent(schema));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JavaBeanSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JavaBeanSchemaTest.java
@@ -628,7 +628,7 @@ public class JavaBeanSchemaTest {
   }
 
   @Test
-  public void testRegisterBeamWithTypeParameter() throws NoSuchSchemaException {
+  public void testBeanWithTypeParameter() throws NoSuchSchemaException {
     SchemaRegistry registry = SchemaRegistry.createDefault();
     TypeDescriptor<TestJavaBeans.SimpleParameterizedBean<String, Long, Boolean, SimpleBean>>
         typeDescriptor =
@@ -647,7 +647,7 @@ public class JavaBeanSchemaTest {
   }
 
   @Test
-  public void testRegisterBeanWithInheritedTypeParameter() throws NoSuchSchemaException {
+  public void testBeanWithInheritedTypeParameter() throws NoSuchSchemaException {
     SchemaRegistry registry = SchemaRegistry.createDefault();
     TypeDescriptor<TestJavaBeans.SimpleParameterizedBeanSubclass<Short>> typeDescriptor =
         new TypeDescriptor<TestJavaBeans.SimpleParameterizedBeanSubclass<Short>>() {};
@@ -661,6 +661,92 @@ public class JavaBeanSchemaTest {
             .addRowField("value4", SIMPLE_BEAN_SCHEMA)
             .addInt16Field("value5")
             .build();
+    assertTrue(expectedSchema.equivalent(schema));
+  }
+
+  @Test
+  public void testBeanWithNestedCollectionTypeParameter() throws NoSuchSchemaException {
+    SchemaRegistry registry = SchemaRegistry.createDefault();
+    TypeDescriptor<
+            TestJavaBeans.NestedParameterizedCollectionBean<
+                TestJavaBeans.SimpleParameterizedBean<String, Long, Boolean, SimpleBean>, String>>
+        typeDescriptor =
+            new TypeDescriptor<
+                TestJavaBeans.NestedParameterizedCollectionBean<
+                    TestJavaBeans.SimpleParameterizedBean<String, Long, Boolean, SimpleBean>,
+                    String>>() {};
+    Schema schema = registry.getSchema(typeDescriptor);
+
+    final Schema expectedInnerSchema =
+        Schema.builder()
+            .addBooleanField("value1")
+            .addStringField("value2")
+            .addInt64Field("value3")
+            .addRowField("value4", SIMPLE_BEAN_SCHEMA)
+            .build();
+    final Schema expectedSchema =
+        Schema.builder()
+            .addIterableField("nested", Schema.FieldType.row(expectedInnerSchema))
+            .addMapField("map", Schema.FieldType.STRING, Schema.FieldType.row(expectedInnerSchema))
+            .build();
+    assertTrue(expectedSchema.equivalent(schema));
+  }
+
+  @Test
+  public void testBeanWithDoublyNestedCollectionTypeParameter() throws NoSuchSchemaException {
+    SchemaRegistry registry = SchemaRegistry.createDefault();
+    TypeDescriptor<
+            TestJavaBeans.NestedParameterizedCollectionBean<
+                Iterable<TestJavaBeans.SimpleParameterizedBean<String, Long, Boolean, SimpleBean>>,
+                String>>
+        typeDescriptor =
+            new TypeDescriptor<
+                TestJavaBeans.NestedParameterizedCollectionBean<
+                    Iterable<
+                        TestJavaBeans.SimpleParameterizedBean<String, Long, Boolean, SimpleBean>>,
+                    String>>() {};
+    Schema schema = registry.getSchema(typeDescriptor);
+
+    final Schema expectedInnerSchema =
+        Schema.builder()
+            .addBooleanField("value1")
+            .addStringField("value2")
+            .addInt64Field("value3")
+            .addRowField("value4", SIMPLE_BEAN_SCHEMA)
+            .build();
+    final Schema expectedSchema =
+        Schema.builder()
+            .addIterableField(
+                "nested", Schema.FieldType.iterable(Schema.FieldType.row(expectedInnerSchema)))
+            .addMapField(
+                "map",
+                Schema.FieldType.STRING,
+                Schema.FieldType.iterable(Schema.FieldType.row(expectedInnerSchema)))
+            .build();
+    assertTrue(expectedSchema.equivalent(schema));
+  }
+
+  @Test
+  public void testBeanWithNestedTypeParameter() throws NoSuchSchemaException {
+    SchemaRegistry registry = SchemaRegistry.createDefault();
+    TypeDescriptor<
+            TestJavaBeans.NestedParameterizedBean<
+                TestJavaBeans.SimpleParameterizedBean<String, Long, Boolean, SimpleBean>>>
+        typeDescriptor =
+            new TypeDescriptor<
+                TestJavaBeans.NestedParameterizedBean<
+                    TestJavaBeans.SimpleParameterizedBean<String, Long, Boolean, SimpleBean>>>() {};
+    Schema schema = registry.getSchema(typeDescriptor);
+
+    final Schema expectedInnerSchema =
+        Schema.builder()
+            .addBooleanField("value1")
+            .addStringField("value2")
+            .addInt64Field("value3")
+            .addRowField("value4", SIMPLE_BEAN_SCHEMA)
+            .build();
+    final Schema expectedSchema =
+        Schema.builder().addRowField("nested", expectedInnerSchema).build();
     assertTrue(expectedSchema.equivalent(schema));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JavaBeanSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JavaBeanSchemaTest.java
@@ -68,6 +68,7 @@ import org.apache.beam.sdk.schemas.utils.TestJavaBeans.SimpleBean;
 import org.apache.beam.sdk.schemas.utils.TestJavaBeans.SimpleBeanWithAnnotations;
 import org.apache.beam.sdk.util.SerializableUtils;
 import org.apache.beam.sdk.values.Row;
+import org.apache.beam.sdk.values.TypeDescriptor;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableList;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableMap;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Lists;
@@ -624,5 +625,42 @@ public class JavaBeanSchemaTest {
     assertEquals(output, row);
     assertEquals(
         registry.getFromRowFunction(BeanWithCaseFormat.class).apply(row), beanWithCaseFormat);
+  }
+
+  @Test
+  public void testRegisterBeamWithTypeParameter() throws NoSuchSchemaException {
+    SchemaRegistry registry = SchemaRegistry.createDefault();
+    TypeDescriptor<TestJavaBeans.SimpleParameterizedBean<String, Long, Boolean, SimpleBean>>
+        typeDescriptor =
+            new TypeDescriptor<
+                TestJavaBeans.SimpleParameterizedBean<String, Long, Boolean, SimpleBean>>() {};
+    Schema schema = registry.getSchema(typeDescriptor);
+
+    final Schema expectedSchema =
+        Schema.builder()
+            .addBooleanField("value1")
+            .addStringField("value2")
+            .addInt64Field("value3")
+            .addRowField("value4", SIMPLE_BEAN_SCHEMA)
+            .build();
+    assertTrue(expectedSchema.equivalent(schema));
+  }
+
+  @Test
+  public void testRegisterBeanWithInheritedTypeParameter() throws NoSuchSchemaException {
+    SchemaRegistry registry = SchemaRegistry.createDefault();
+    TypeDescriptor<TestJavaBeans.SimpleParameterizedBeanSubclass<Short>> typeDescriptor =
+        new TypeDescriptor<TestJavaBeans.SimpleParameterizedBeanSubclass<Short>>() {};
+    Schema schema = registry.getSchema(typeDescriptor);
+
+    final Schema expectedSchema =
+        Schema.builder()
+            .addBooleanField("value1")
+            .addStringField("value2")
+            .addInt64Field("value3")
+            .addRowField("value4", SIMPLE_BEAN_SCHEMA)
+            .addInt16Field("value5")
+            .build();
+    assertTrue(expectedSchema.equivalent(schema));
   }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/JavaBeanUtilsTest.java
@@ -34,6 +34,7 @@ import static org.junit.Assert.assertTrue;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import org.apache.beam.sdk.schemas.FieldValueGetter;
 import org.apache.beam.sdk.schemas.FieldValueSetter;
@@ -65,7 +66,9 @@ public class JavaBeanUtilsTest {
   public void testNullable() {
     Schema schema =
         JavaBeanUtils.schemaFromJavaBeanClass(
-            new TypeDescriptor<NullableBean>() {}, GetterTypeSupplier.INSTANCE);
+            new TypeDescriptor<NullableBean>() {},
+            GetterTypeSupplier.INSTANCE,
+            Collections.emptyMap());
     assertTrue(schema.getField("str").getType().getNullable());
     assertFalse(schema.getField("anInt").getType().getNullable());
   }
@@ -74,7 +77,9 @@ public class JavaBeanUtilsTest {
   public void testSimpleBean() {
     Schema schema =
         JavaBeanUtils.schemaFromJavaBeanClass(
-            new TypeDescriptor<SimpleBean>() {}, GetterTypeSupplier.INSTANCE);
+            new TypeDescriptor<SimpleBean>() {},
+            GetterTypeSupplier.INSTANCE,
+            Collections.emptyMap());
     SchemaTestUtils.assertSchemaEquivalent(SIMPLE_BEAN_SCHEMA, schema);
   }
 
@@ -82,7 +87,9 @@ public class JavaBeanUtilsTest {
   public void testNestedBean() {
     Schema schema =
         JavaBeanUtils.schemaFromJavaBeanClass(
-            new TypeDescriptor<NestedBean>() {}, GetterTypeSupplier.INSTANCE);
+            new TypeDescriptor<NestedBean>() {},
+            GetterTypeSupplier.INSTANCE,
+            Collections.emptyMap());
     SchemaTestUtils.assertSchemaEquivalent(NESTED_BEAN_SCHEMA, schema);
   }
 
@@ -90,7 +97,9 @@ public class JavaBeanUtilsTest {
   public void testPrimitiveArray() {
     Schema schema =
         JavaBeanUtils.schemaFromJavaBeanClass(
-            new TypeDescriptor<PrimitiveArrayBean>() {}, GetterTypeSupplier.INSTANCE);
+            new TypeDescriptor<PrimitiveArrayBean>() {},
+            GetterTypeSupplier.INSTANCE,
+            Collections.emptyMap());
     SchemaTestUtils.assertSchemaEquivalent(PRIMITIVE_ARRAY_BEAN_SCHEMA, schema);
   }
 
@@ -98,7 +107,9 @@ public class JavaBeanUtilsTest {
   public void testNestedArray() {
     Schema schema =
         JavaBeanUtils.schemaFromJavaBeanClass(
-            new TypeDescriptor<NestedArrayBean>() {}, GetterTypeSupplier.INSTANCE);
+            new TypeDescriptor<NestedArrayBean>() {},
+            GetterTypeSupplier.INSTANCE,
+            Collections.emptyMap());
     SchemaTestUtils.assertSchemaEquivalent(NESTED_ARRAY_BEAN_SCHEMA, schema);
   }
 
@@ -106,7 +117,9 @@ public class JavaBeanUtilsTest {
   public void testNestedCollection() {
     Schema schema =
         JavaBeanUtils.schemaFromJavaBeanClass(
-            new TypeDescriptor<NestedCollectionBean>() {}, GetterTypeSupplier.INSTANCE);
+            new TypeDescriptor<NestedCollectionBean>() {},
+            GetterTypeSupplier.INSTANCE,
+            Collections.emptyMap());
     SchemaTestUtils.assertSchemaEquivalent(NESTED_COLLECTION_BEAN_SCHEMA, schema);
   }
 
@@ -114,7 +127,9 @@ public class JavaBeanUtilsTest {
   public void testPrimitiveMap() {
     Schema schema =
         JavaBeanUtils.schemaFromJavaBeanClass(
-            new TypeDescriptor<PrimitiveMapBean>() {}, GetterTypeSupplier.INSTANCE);
+            new TypeDescriptor<PrimitiveMapBean>() {},
+            GetterTypeSupplier.INSTANCE,
+            Collections.emptyMap());
     SchemaTestUtils.assertSchemaEquivalent(PRIMITIVE_MAP_BEAN_SCHEMA, schema);
   }
 
@@ -122,7 +137,9 @@ public class JavaBeanUtilsTest {
   public void testNestedMap() {
     Schema schema =
         JavaBeanUtils.schemaFromJavaBeanClass(
-            new TypeDescriptor<NestedMapBean>() {}, GetterTypeSupplier.INSTANCE);
+            new TypeDescriptor<NestedMapBean>() {},
+            GetterTypeSupplier.INSTANCE,
+            Collections.emptyMap());
     SchemaTestUtils.assertSchemaEquivalent(NESTED_MAP_BEAN_SCHEMA, schema);
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/POJOUtilsTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/POJOUtilsTest.java
@@ -35,6 +35,7 @@ import static org.junit.Assert.assertTrue;
 import java.math.BigDecimal;
 import java.nio.ByteBuffer;
 import java.nio.charset.StandardCharsets;
+import java.util.Collections;
 import java.util.List;
 import org.apache.beam.sdk.schemas.FieldValueGetter;
 import org.apache.beam.sdk.schemas.FieldValueSetter;
@@ -71,7 +72,9 @@ public class POJOUtilsTest {
   public void testNullables() {
     Schema schema =
         POJOUtils.schemaFromPojoClass(
-            new TypeDescriptor<POJOWithNullables>() {}, JavaFieldTypeSupplier.INSTANCE);
+            new TypeDescriptor<POJOWithNullables>() {},
+            JavaFieldTypeSupplier.INSTANCE,
+            Collections.emptyMap());
     assertTrue(schema.getField("str").getType().getNullable());
     assertFalse(schema.getField("anInt").getType().getNullable());
   }
@@ -80,7 +83,9 @@ public class POJOUtilsTest {
   public void testSimplePOJO() {
     Schema schema =
         POJOUtils.schemaFromPojoClass(
-            new TypeDescriptor<SimplePOJO>() {}, JavaFieldTypeSupplier.INSTANCE);
+            new TypeDescriptor<SimplePOJO>() {},
+            JavaFieldTypeSupplier.INSTANCE,
+            Collections.emptyMap());
     assertEquals(SIMPLE_POJO_SCHEMA, schema);
   }
 
@@ -88,7 +93,9 @@ public class POJOUtilsTest {
   public void testNestedPOJO() {
     Schema schema =
         POJOUtils.schemaFromPojoClass(
-            new TypeDescriptor<NestedPOJO>() {}, JavaFieldTypeSupplier.INSTANCE);
+            new TypeDescriptor<NestedPOJO>() {},
+            JavaFieldTypeSupplier.INSTANCE,
+            Collections.emptyMap());
     SchemaTestUtils.assertSchemaEquivalent(NESTED_POJO_SCHEMA, schema);
   }
 
@@ -97,7 +104,8 @@ public class POJOUtilsTest {
     Schema schema =
         POJOUtils.schemaFromPojoClass(
             new TypeDescriptor<TestPOJOs.NestedPOJOWithSimplePOJO>() {},
-            JavaFieldTypeSupplier.INSTANCE);
+            JavaFieldTypeSupplier.INSTANCE,
+            Collections.emptyMap());
     SchemaTestUtils.assertSchemaEquivalent(NESTED_POJO_WITH_SIMPLE_POJO_SCHEMA, schema);
   }
 
@@ -105,7 +113,9 @@ public class POJOUtilsTest {
   public void testPrimitiveArray() {
     Schema schema =
         POJOUtils.schemaFromPojoClass(
-            new TypeDescriptor<PrimitiveArrayPOJO>() {}, JavaFieldTypeSupplier.INSTANCE);
+            new TypeDescriptor<PrimitiveArrayPOJO>() {},
+            JavaFieldTypeSupplier.INSTANCE,
+            Collections.emptyMap());
     SchemaTestUtils.assertSchemaEquivalent(PRIMITIVE_ARRAY_POJO_SCHEMA, schema);
   }
 
@@ -113,7 +123,9 @@ public class POJOUtilsTest {
   public void testNestedArray() {
     Schema schema =
         POJOUtils.schemaFromPojoClass(
-            new TypeDescriptor<NestedArrayPOJO>() {}, JavaFieldTypeSupplier.INSTANCE);
+            new TypeDescriptor<NestedArrayPOJO>() {},
+            JavaFieldTypeSupplier.INSTANCE,
+            Collections.emptyMap());
     SchemaTestUtils.assertSchemaEquivalent(NESTED_ARRAY_POJO_SCHEMA, schema);
   }
 
@@ -121,7 +133,9 @@ public class POJOUtilsTest {
   public void testNestedCollection() {
     Schema schema =
         POJOUtils.schemaFromPojoClass(
-            new TypeDescriptor<NestedCollectionPOJO>() {}, JavaFieldTypeSupplier.INSTANCE);
+            new TypeDescriptor<NestedCollectionPOJO>() {},
+            JavaFieldTypeSupplier.INSTANCE,
+            Collections.emptyMap());
     SchemaTestUtils.assertSchemaEquivalent(NESTED_COLLECTION_POJO_SCHEMA, schema);
   }
 
@@ -129,7 +143,9 @@ public class POJOUtilsTest {
   public void testPrimitiveMap() {
     Schema schema =
         POJOUtils.schemaFromPojoClass(
-            new TypeDescriptor<PrimitiveMapPOJO>() {}, JavaFieldTypeSupplier.INSTANCE);
+            new TypeDescriptor<PrimitiveMapPOJO>() {},
+            JavaFieldTypeSupplier.INSTANCE,
+            Collections.emptyMap());
     SchemaTestUtils.assertSchemaEquivalent(PRIMITIVE_MAP_POJO_SCHEMA, schema);
   }
 
@@ -137,7 +153,9 @@ public class POJOUtilsTest {
   public void testNestedMap() {
     Schema schema =
         POJOUtils.schemaFromPojoClass(
-            new TypeDescriptor<NestedMapPOJO>() {}, JavaFieldTypeSupplier.INSTANCE);
+            new TypeDescriptor<NestedMapPOJO>() {},
+            JavaFieldTypeSupplier.INSTANCE,
+            Collections.emptyMap());
     SchemaTestUtils.assertSchemaEquivalent(NESTED_MAP_POJO_SCHEMA, schema);
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestJavaBeans.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestJavaBeans.java
@@ -1397,4 +1397,60 @@ public class TestJavaBeans {
               Schema.Field.nullable("value", FieldType.FLOAT)
                   .withDescription("This value is the value stored in the object as a float."))
           .build();
+
+  @DefaultSchema(JavaBeanSchema.class)
+  public static class SimpleParameterizedBean<T, V, W, X> {
+    @Nullable private W value1;
+    @Nullable private T value2;
+    @Nullable private V value3;
+    @Nullable private X value4;
+
+    public W getValue1() {
+      return value1;
+    }
+
+    public void setValue1(W value1) {
+      this.value1 = value1;
+    }
+
+    public T getValue2() {
+      return value2;
+    }
+
+    public void setValue2(T value2) {
+      this.value2 = value2;
+    }
+
+    public V getValue3() {
+      return value3;
+    }
+
+    public void setValue3(V value3) {
+      this.value3 = value3;
+    }
+
+    public X getValue4() {
+      return value4;
+    }
+
+    public void setValue4(X value4) {
+      this.value4 = value4;
+    }
+  }
+
+  @DefaultSchema(JavaBeanSchema.class)
+  public static class SimpleParameterizedBeanSubclass<T>
+      extends SimpleParameterizedBean<String, Long, Boolean, SimpleBean> {
+    @Nullable private T value5;
+
+    public SimpleParameterizedBeanSubclass() {}
+
+    public T getValue5() {
+      return value5;
+    }
+
+    public void setValue5(T value5) {
+      this.value5 = value5;
+    }
+  }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestJavaBeans.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestJavaBeans.java
@@ -1453,4 +1453,39 @@ public class TestJavaBeans {
       this.value5 = value5;
     }
   }
+
+  @DefaultSchema(JavaBeanSchema.class)
+  public static class NestedParameterizedCollectionBean<ElementT, KeyT> {
+    private Iterable<ElementT> nested;
+    private Map<KeyT, ElementT> map;
+
+    public Iterable<ElementT> getNested() {
+      return nested;
+    }
+
+    public Map<KeyT, ElementT> getMap() {
+      return map;
+    }
+
+    public void setNested(Iterable<ElementT> nested) {
+      this.nested = nested;
+    }
+
+    public void setMap(Map<KeyT, ElementT> map) {
+      this.map = map;
+    }
+  }
+
+  @DefaultSchema(JavaBeanSchema.class)
+  public static class NestedParameterizedBean<T> {
+    private T nested;
+
+    public T getNested() {
+      return nested;
+    }
+
+    public void setNested(T nested) {
+      this.nested = nested;
+    }
+  }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestPOJOs.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestPOJOs.java
@@ -495,6 +495,125 @@ public class TestPOJOs {
           .addStringField("stringBuilder")
           .build();
 
+  @DefaultSchema(JavaFieldSchema.class)
+  public static class SimpleParameterizedPOJO<T, V, W, X> {
+    public W value1;
+    public T value2;
+    public V value3;
+    public X value4;
+
+    public SimpleParameterizedPOJO() {}
+
+    public SimpleParameterizedPOJO(W value1, T value2, V value3, X value4) {
+      this.value1 = value1;
+      this.value2 = value2;
+      this.value3 = value3;
+      this.value4 = value4;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof SimpleParameterizedPOJO)) {
+        return false;
+      }
+      SimpleParameterizedPOJO<?, ?, ?, ?> that = (SimpleParameterizedPOJO<?, ?, ?, ?>) o;
+      return Objects.equals(value1, that.value1)
+          && Objects.equals(value2, that.value2)
+          && Objects.equals(value3, that.value3)
+          && Objects.equals(value4, that.value4);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(value1, value2, value3, value4);
+    }
+  }
+
+  @DefaultSchema(JavaFieldSchema.class)
+  public static class SimpleParameterizedPOJOSubclass<T>
+      extends SimpleParameterizedPOJO<String, Long, Boolean, SimplePOJO> {
+    public T value5;
+
+    public SimpleParameterizedPOJOSubclass() {}
+
+    public SimpleParameterizedPOJOSubclass(T value5) {
+      this.value5 = value5;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof SimpleParameterizedPOJOSubclass)) {
+        return false;
+      }
+      SimpleParameterizedPOJOSubclass<?> that = (SimpleParameterizedPOJOSubclass<?>) o;
+      return Objects.equals(value5, that.value5);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(value4);
+    }
+  }
+
+  @DefaultSchema(JavaFieldSchema.class)
+  public static class NestedParameterizedCollectionPOJO<ElementT, KeyT> {
+    public Iterable<ElementT> nested;
+    public Map<KeyT, ElementT> map;
+
+    public NestedParameterizedCollectionPOJO(Iterable<ElementT> nested, Map<KeyT, ElementT> map) {
+      this.nested = nested;
+      this.map = map;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof NestedParameterizedCollectionPOJO)) {
+        return false;
+      }
+      NestedParameterizedCollectionPOJO<?, ?> that = (NestedParameterizedCollectionPOJO<?, ?>) o;
+      return Objects.equals(nested, that.nested) && Objects.equals(map, that.map);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(nested, map);
+    }
+  }
+
+  @DefaultSchema(JavaFieldSchema.class)
+  public static class NestedParameterizedPOJO<T> {
+    public T nested;
+
+    public NestedParameterizedPOJO(T nested) {
+      this.nested = nested;
+    }
+
+    @Override
+    public boolean equals(Object o) {
+      if (this == o) {
+        return true;
+      }
+      if (!(o instanceof NestedParameterizedPOJO)) {
+        return false;
+      }
+      NestedParameterizedPOJO<?> that = (NestedParameterizedPOJO<?>) o;
+      return Objects.equals(nested, that.nested);
+    }
+
+    @Override
+    public int hashCode() {
+      return Objects.hash(nested);
+    }
+  }
   /** A POJO containing a nested class. * */
   @DefaultSchema(JavaFieldSchema.class)
   public static class NestedPOJO {
@@ -887,7 +1006,7 @@ public class TestPOJOs {
       if (this == o) {
         return true;
       }
-      if (!(o instanceof PojoWithNestedArray)) {
+      if (!(o instanceof PojoWithIterable)) {
         return false;
       }
       PojoWithIterable that = (PojoWithIterable) o;

--- a/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/schemas/utils/AvroByteBuddyUtils.java
+++ b/sdks/java/extensions/avro/src/main/java/org/apache/beam/sdk/extensions/avro/schemas/utils/AvroByteBuddyUtils.java
@@ -78,8 +78,8 @@ class AvroByteBuddyUtils {
 
     // Generate a method call to create and invoke the SpecificRecord's constructor. .
     MethodCall construct = MethodCall.construct(baseConstructor);
-    for (int i = 0; i < baseConstructor.getParameterTypes().length; ++i) {
-      Class<?> baseType = baseConstructor.getParameterTypes()[i];
+    for (int i = 0; i < baseConstructor.getGenericParameterTypes().length; ++i) {
+      Type baseType = baseConstructor.getGenericParameterTypes()[i];
       construct = construct.with(readAndConvertParameter(baseType, i), baseType);
     }
 
@@ -110,7 +110,7 @@ class AvroByteBuddyUtils {
   }
 
   private static StackManipulation readAndConvertParameter(
-      Class<?> constructorParameterType, int index) {
+      Type constructorParameterType, int index) {
     TypeConversionsFactory typeConversionsFactory = new AvroUtils.AvroTypeConversionFactory();
 
     // The types in the AVRO-generated constructor might be the types returned by Beam's Row class,

--- a/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoByteBuddyUtils.java
+++ b/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoByteBuddyUtils.java
@@ -39,6 +39,7 @@ import java.lang.reflect.Method;
 import java.lang.reflect.Modifier;
 import java.lang.reflect.Type;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.Iterator;
 import java.util.List;
 import java.util.Map;
@@ -1045,7 +1046,8 @@ class ProtoByteBuddyUtils {
     } else {
       Method method = getProtoSetter(methods, field.getName(), field.getType());
       return JavaBeanUtils.createSetter(
-          FieldValueTypeInformation.forSetter(method, protoSetterPrefix(field.getType())),
+          FieldValueTypeInformation.forSetter(
+              method, protoSetterPrefix(field.getType()), Collections.emptyMap()),
           new ProtoTypeConversionsFactory());
     }
   }

--- a/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoMessageSchema.java
+++ b/sdks/java/extensions/protobuf/src/main/java/org/apache/beam/sdk/extensions/protobuf/ProtoMessageSchema.java
@@ -23,6 +23,7 @@ import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Pr
 import com.google.protobuf.DynamicMessage;
 import com.google.protobuf.Message;
 import java.lang.reflect.Method;
+import java.util.Collections;
 import java.util.List;
 import java.util.Map;
 import org.apache.beam.sdk.extensions.protobuf.ProtoByteBuddyUtils.ProtoTypeConversionsFactory;
@@ -72,7 +73,8 @@ public class ProtoMessageSchema extends GetterBasedSchemaProviderV2 {
             Method method = getProtoGetter(methods, oneOfField.getName(), oneOfField.getType());
             oneOfTypes.put(
                 oneOfField.getName(),
-                FieldValueTypeInformation.forGetter(method, i).withName(field.getName()));
+                FieldValueTypeInformation.forGetter(method, i, Collections.emptyMap())
+                    .withName(field.getName()));
           }
           // Add an entry that encapsulates information about all possible getters.
           types.add(
@@ -82,7 +84,9 @@ public class ProtoMessageSchema extends GetterBasedSchemaProviderV2 {
         } else {
           // This is a simple field. Add the getter.
           Method method = getProtoGetter(methods, field.getName(), field.getType());
-          types.add(FieldValueTypeInformation.forGetter(method, i).withName(field.getName()));
+          types.add(
+              FieldValueTypeInformation.forGetter(method, i, Collections.emptyMap())
+                  .withName(field.getName()));
         }
       }
       return types;

--- a/sdks/java/extensions/python/src/main/java/org/apache/beam/sdk/extensions/python/PythonExternalTransform.java
+++ b/sdks/java/extensions/python/src/main/java/org/apache/beam/sdk/extensions/python/PythonExternalTransform.java
@@ -25,6 +25,7 @@ import java.io.Writer;
 import java.nio.charset.StandardCharsets;
 import java.util.ArrayList;
 import java.util.Arrays;
+import java.util.Collections;
 import java.util.HashMap;
 import java.util.List;
 import java.util.Map;
@@ -389,7 +390,8 @@ public class PythonExternalTransform<InputT extends PInput, OutputT extends POut
             fieldName,
             StaticSchemaInference.fieldFromType(
                 TypeDescriptor.of(field.getClass()),
-                JavaFieldSchema.JavaFieldTypeSupplier.INSTANCE));
+                JavaFieldSchema.JavaFieldTypeSupplier.INSTANCE,
+                Collections.emptyMap()));
       }
 
       counter++;

--- a/sdks/java/io/thrift/src/main/java/org/apache/beam/sdk/io/thrift/ThriftSchema.java
+++ b/sdks/java/io/thrift/src/main/java/org/apache/beam/sdk/io/thrift/ThriftSchema.java
@@ -242,10 +242,11 @@ public final class ThriftSchema extends GetterBasedSchemaProviderV2 {
       if (factoryMethods.size() > 1) {
         throw new IllegalStateException("Overloaded factory methods: " + factoryMethods);
       }
-      return FieldValueTypeInformation.forSetter(factoryMethods.get(0), "");
+      return FieldValueTypeInformation.forSetter(factoryMethods.get(0), "", Collections.emptyMap());
     } else {
       try {
-        return FieldValueTypeInformation.forField(type.getDeclaredField(fieldName), 0);
+        return FieldValueTypeInformation.forField(
+            type.getDeclaredField(fieldName), 0, Collections.emptyMap());
       } catch (NoSuchFieldException e) {
         throw new IllegalArgumentException(e);
       }


### PR DESCRIPTION
Beam automatically infers schema for common Java types: POJOs, JavaBean, AutoValue, AVRO, among others. In addition for it's use with schema transforms, this also provides a simple, efficient way of using these types in PCollections without needing to construct a Coder. A frequent complaint has been that this inference did not work in the presence of generic type parameters. E.g. this means that while Beam can handle PCollections of this class:

@DefaultSchema(JavaFieldSchema.class)
class MyType {
   String field1;
}
PCollection<MyType> myTypes = read();

Schema inference would fail for this:

@DefaultSchema(JavaFieldSchema.class)
class MyType\<T\> {
   T field1;
}
PCollection<MyType<String>> myTypes = read();

This PR adds support for generic type parameters to schema inference for common types, addressing the above issue.