### PR TITLE
Revert "Update pyproject.toml by using grpcio-tools==1.65.5"

### DIFF
--- a/sdks/python/pyproject.toml
+++ b/sdks/python/pyproject.toml
@@ -21,7 +21,7 @@
 requires = [
     "setuptools",
     "wheel>=0.36.0",
-    "grpcio-tools==1.65.5",
+    "grpcio-tools==1.62.1",
     "mypy-protobuf==3.5.0",
     # Avoid https://github.com/pypa/virtualenv/issues/2006
     "distlib==0.3.7",


### PR DESCRIPTION
Reverts apache/beam#32773

No need to do this. This is only needed when installing the Python build system. If we use `python -m build --sdist` to install the Beam package, the build system should be created with another Python env, which should not impact the Beam dependencies. 