### PR TITLE
Support poisioning instruction ids to prevent the FnApi data stream from blocking on failed instructions

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/fn/data/BeamFnDataGrpcMultiplexerTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/fn/data/BeamFnDataGrpcMultiplexerTest.java
@@ -280,6 +280,7 @@ public class BeamFnDataGrpcMultiplexerTest {
             DESCRIPTOR,
             OutboundObserverFactory.clientDirect(),
             inboundObserver -> TestStreams.withOnNext(outboundValues::add).build());
+    final AtomicBoolean closed = new AtomicBoolean();
     multiplexer.registerConsumer(
         DATA_INSTRUCTION_ID,
         new CloseableFnDataReceiver<BeamFnApi.Elements>() {
@@ -290,7 +291,7 @@ public class BeamFnDataGrpcMultiplexerTest {
 
           @Override
           public void close() throws Exception {
-            fail("Unexpected call");
+            closed.set(true);
           }
 
           @Override
@@ -320,6 +321,7 @@ public class BeamFnDataGrpcMultiplexerTest {
         dataInboundValues,
         Matchers.contains(
             BeamFnApi.Elements.newBuilder().addData(data.setTransformId("A").build()).build()));
+    assertTrue(closed.get());
   }
 
   @Test

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
@@ -64,7 +64,6 @@ import org.apache.beam.model.fnexecution.v1.BeamFnApi.ProcessBundleRequest.Cache
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.ProcessBundleResponse;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.StateRequest;
 import org.apache.beam.model.fnexecution.v1.BeamFnApi.StateResponse;
-import org.apache.beam.model.pipeline.v1.Endpoints;
 import org.apache.beam.model.pipeline.v1.Endpoints.ApiServiceDescriptor;
 import org.apache.beam.model.pipeline.v1.RunnerApi;
 import org.apache.beam.model.pipeline.v1.RunnerApi.Coder;
@@ -93,6 +92,7 @@ import org.apache.beam.sdk.util.construction.Timer;
 import org.apache.beam.vendor.grpc.v1p60p1.com.google.protobuf.ByteString;
 import org.apache.beam.vendor.grpc.v1p60p1.com.google.protobuf.TextFormat;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.annotations.VisibleForTesting;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.cache.CacheBuilder;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.cache.CacheLoader;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.cache.LoadingCache;
@@ -108,20 +108,19 @@ import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
 
 /**
- * Processes {@link BeamFnApi.ProcessBundleRequest}s and {@link
- * BeamFnApi.ProcessBundleSplitRequest}s.
+ * Processes {@link ProcessBundleRequest}s and {@link BeamFnApi.ProcessBundleSplitRequest}s.
  *
  * <p>{@link BeamFnApi.ProcessBundleSplitRequest}s use a {@link BundleProcessorCache cache} to
  * find/create a {@link BundleProcessor}. The creation of a {@link BundleProcessor} uses the
- * associated {@link BeamFnApi.ProcessBundleDescriptor} definition; creating runners for each {@link
+ * associated {@link ProcessBundleDescriptor} definition; creating runners for each {@link
  * RunnerApi.FunctionSpec}; wiring them together based upon the {@code input} and {@code output} map
  * definitions. The {@link BundleProcessor} executes the DAG based graph by starting all runners in
  * reverse topological order, and finishing all runners in forward topological order.
  *
  * <p>{@link BeamFnApi.ProcessBundleSplitRequest}s finds an {@code active} {@link BundleProcessor}
- * associated with a currently processing {@link BeamFnApi.ProcessBundleRequest} and uses it to
- * perform a split request. See <a href="https://s.apache.org/beam-breaking-fusion">breaking the
- * fusion barrier</a> for further details.
+ * associated with a currently processing {@link ProcessBundleRequest} and uses it to perform a
+ * split request. See <a href="https://s.apache.org/beam-breaking-fusion">breaking the fusion
+ * barrier</a> for further details.
  */
 @SuppressWarnings({
   "rawtypes", // TODO(https://github.com/apache/beam/issues/20447)
@@ -153,7 +152,7 @@ public class ProcessBundleHandler {
   }
 
   private final PipelineOptions options;
-  private final Function<String, BeamFnApi.ProcessBundleDescriptor> fnApiRegistry;
+  private final Function<String, ProcessBundleDescriptor> fnApiRegistry;
   private final BeamFnDataClient beamFnDataClient;
   private final BeamFnStateGrpcClientCache beamFnStateGrpcClientCache;
   private final FinalizeBundleHandler finalizeBundleHandler;
@@ -170,7 +169,7 @@ public class ProcessBundleHandler {
   public ProcessBundleHandler(
       PipelineOptions options,
       Set<String> runnerCapabilities,
-      Function<String, BeamFnApi.ProcessBundleDescriptor> fnApiRegistry,
+      Function<String, ProcessBundleDescriptor> fnApiRegistry,
       BeamFnDataClient beamFnDataClient,
       BeamFnStateGrpcClientCache beamFnStateGrpcClientCache,
       FinalizeBundleHandler finalizeBundleHandler,
@@ -197,7 +196,7 @@ public class ProcessBundleHandler {
   ProcessBundleHandler(
       PipelineOptions options,
       Set<String> runnerCapabilities,
-      Function<String, BeamFnApi.ProcessBundleDescriptor> fnApiRegistry,
+      Function<String, ProcessBundleDescriptor> fnApiRegistry,
       BeamFnDataClient beamFnDataClient,
       BeamFnStateGrpcClientCache beamFnStateGrpcClientCache,
       FinalizeBundleHandler finalizeBundleHandler,
@@ -216,7 +215,7 @@ public class ProcessBundleHandler {
     this.runnerCapabilities = runnerCapabilities;
     this.runnerAcceptsShortIds =
         runnerCapabilities.contains(
-            BeamUrns.getUrn(RunnerApi.StandardRunnerProtocols.Enum.MONITORING_INFO_SHORT_IDS));
+            BeamUrns.getUrn(StandardRunnerProtocols.Enum.MONITORING_INFO_SHORT_IDS));
     this.executionStateSampler = executionStateSampler;
     this.urnToPTransformRunnerFactoryMap = urnToPTransformRunnerFactoryMap;
     this.defaultPTransformRunnerFactory =
@@ -232,7 +231,7 @@ public class ProcessBundleHandler {
       String pTransformId,
       PTransform pTransform,
       Supplier<String> processBundleInstructionId,
-      Supplier<List<BeamFnApi.ProcessBundleRequest.CacheToken>> cacheTokens,
+      Supplier<List<CacheToken>> cacheTokens,
       Supplier<Cache<?, ?>> bundleCache,
       ProcessBundleDescriptor processBundleDescriptor,
       SetMultimap<String, String> pCollectionIdsToConsumingPTransforms,
@@ -242,7 +241,7 @@ public class ProcessBundleHandler {
       PTransformFunctionRegistry finishFunctionRegistry,
       Consumer<ThrowingRunnable> addResetFunction,
       Consumer<ThrowingRunnable> addTearDownFunction,
-      BiConsumer<Endpoints.ApiServiceDescriptor, DataEndpoint<?>> addDataEndpoint,
+      BiConsumer<ApiServiceDescriptor, DataEndpoint<?>> addDataEndpoint,
       Consumer<TimerEndpoint<?>> addTimerEndpoint,
       Consumer<BundleProgressReporter> addBundleProgressReporter,
       BundleSplitListener splitListener,
@@ -499,28 +498,29 @@ public class ProcessBundleHandler {
    * Processes a bundle, running the start(), process(), and finish() functions. This function is
    * required to be reentrant.
    */
-  public BeamFnApi.InstructionResponse.Builder processBundle(BeamFnApi.InstructionRequest request)
+  public BeamFnApi.InstructionResponse.Builder processBundle(InstructionRequest request)
       throws Exception {
-    BeamFnApi.ProcessBundleResponse.Builder response = BeamFnApi.ProcessBundleResponse.newBuilder();
-
-    BundleProcessor bundleProcessor =
-        bundleProcessorCache.get(
-            request,
-            () -> {
-              try {
-                return createBundleProcessor(
-                    request.getProcessBundle().getProcessBundleDescriptorId(),
-                    request.getProcessBundle());
-              } catch (IOException e) {
-                throw new RuntimeException(e);
-              }
-            });
+    @Nullable BundleProcessor bundleProcessor = null;
     try {
+      bundleProcessor =
+          Preconditions.checkNotNull(
+              bundleProcessorCache.get(
+                  request,
+                  () -> {
+                    try {
+                      return createBundleProcessor(
+                          request.getProcessBundle().getProcessBundleDescriptorId(),
+                          request.getProcessBundle());
+                    } catch (IOException e) {
+                      throw new RuntimeException(e);
+                    }
+                  }));
+
       PTransformFunctionRegistry startFunctionRegistry = bundleProcessor.getStartFunctionRegistry();
       PTransformFunctionRegistry finishFunctionRegistry =
           bundleProcessor.getFinishFunctionRegistry();
       ExecutionStateTracker stateTracker = bundleProcessor.getStateTracker();
-
+      ProcessBundleResponse.Builder response = ProcessBundleResponse.newBuilder();
       try (HandleStateCallsForBundle beamFnStateClient = bundleProcessor.getBeamFnStateClient()) {
         stateTracker.start(request.getInstructionId());
         try {
@@ -596,12 +596,17 @@ public class ProcessBundleHandler {
           request.getProcessBundle().getProcessBundleDescriptorId(), bundleProcessor);
       return BeamFnApi.InstructionResponse.newBuilder().setProcessBundle(response);
     } catch (Exception e) {
-      // Make sure we clean up from the active set of bundle processors.
       LOG.debug(
-          "Discard bundleProcessor for {} after exception: {}",
+          "Error processing bundle {} with bundleProcessor for {} after exception: {}",
+          request.getInstructionId(),
           request.getProcessBundle().getProcessBundleDescriptorId(),
           e.getMessage());
-      bundleProcessorCache.discard(bundleProcessor);
+      if (bundleProcessor != null) {
+        // Make sure we clean up from the active set of bundle processors.
+        bundleProcessorCache.discard(bundleProcessor);
+      }
+      // Ensure that if more data arrives for the instruction it is discarded.
+      beamFnDataClient.poisonInstructionId(request.getInstructionId());
       throw e;
     }
   }
@@ -643,7 +648,7 @@ public class ProcessBundleHandler {
     }
   }
 
-  public BeamFnApi.InstructionResponse.Builder progress(BeamFnApi.InstructionRequest request)
+  public BeamFnApi.InstructionResponse.Builder progress(InstructionRequest request)
       throws Exception {
     BundleProcessor bundleProcessor =
         bundleProcessorCache.find(request.getProcessBundleProgress().getInstructionId());
@@ -727,7 +732,7 @@ public class ProcessBundleHandler {
   }
 
   /** Splits an active bundle. */
-  public BeamFnApi.InstructionResponse.Builder trySplit(BeamFnApi.InstructionRequest request) {
+  public BeamFnApi.InstructionResponse.Builder trySplit(InstructionRequest request) {
     BundleProcessor bundleProcessor =
         bundleProcessorCache.find(request.getProcessBundleSplit().getInstructionId());
     BeamFnApi.ProcessBundleSplitResponse.Builder response =
@@ -772,8 +777,8 @@ public class ProcessBundleHandler {
   }
 
   private BundleProcessor createBundleProcessor(
-      String bundleId, BeamFnApi.ProcessBundleRequest processBundleRequest) throws IOException {
-    BeamFnApi.ProcessBundleDescriptor bundleDescriptor = fnApiRegistry.apply(bundleId);
+      String bundleId, ProcessBundleRequest processBundleRequest) throws IOException {
+    ProcessBundleDescriptor bundleDescriptor = fnApiRegistry.apply(bundleId);
 
     SetMultimap<String, String> pCollectionIdsToConsumingPTransforms = HashMultimap.create();
     BundleProgressReporter.InMemory bundleProgressReporterAndRegistrar =
@@ -799,8 +804,7 @@ public class ProcessBundleHandler {
     List<ThrowingRunnable> tearDownFunctions = new ArrayList<>();
 
     // Build a multimap of PCollection ids to PTransform ids which consume said PCollections
-    for (Map.Entry<String, RunnerApi.PTransform> entry :
-        bundleDescriptor.getTransformsMap().entrySet()) {
+    for (Map.Entry<String, PTransform> entry : bundleDescriptor.getTransformsMap().entrySet()) {
       for (String pCollectionId : entry.getValue().getInputsMap().values()) {
         pCollectionIdsToConsumingPTransforms.put(pCollectionId, entry.getKey());
       }
@@ -848,8 +852,7 @@ public class ProcessBundleHandler {
             runnerCapabilities);
 
     // Create a BeamFnStateClient
-    for (Map.Entry<String, RunnerApi.PTransform> entry :
-        bundleDescriptor.getTransformsMap().entrySet()) {
+    for (Map.Entry<String, PTransform> entry : bundleDescriptor.getTransformsMap().entrySet()) {
 
       // Skip anything which isn't a root.
       // Also force data output transforms to be unconditionally instantiated (see BEAM-10450).
@@ -1090,7 +1093,7 @@ public class ProcessBundleHandler {
 
     abstract HandleStateCallsForBundle getBeamFnStateClient();
 
-    abstract List<Endpoints.ApiServiceDescriptor> getInboundEndpointApiServiceDescriptors();
+    abstract List<ApiServiceDescriptor> getInboundEndpointApiServiceDescriptors();
 
     abstract List<DataEndpoint<?>> getInboundDataEndpoints();
 
@@ -1117,7 +1120,7 @@ public class ProcessBundleHandler {
     synchronized Cache<Object, Object> getBundleCache() {
       if (this.bundleCache == null) {
         this.bundleCache =
-            new Caches.ClearableCache<>(
+            new ClearableCache<>(
                 Caches.subCache(getProcessWideCache(), "Bundle", this.instructionId));
       }
       return this.bundleCache;
@@ -1264,7 +1267,7 @@ public class ProcessBundleHandler {
     }
 
     @Override
-    public CompletableFuture<StateResponse> handle(BeamFnApi.StateRequest.Builder requestBuilder) {
+    public CompletableFuture<StateResponse> handle(StateRequest.Builder requestBuilder) {
       throw new IllegalStateException(
           String.format(
               "State API calls are unsupported because the "

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/data/BeamFnDataClient.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/data/BeamFnDataClient.java
@@ -55,9 +55,18 @@ public interface BeamFnDataClient {
    * successfully.
    *
    * <p>It is expected that if a bundle fails during processing then the failure will become visible
-   * to the {@link BeamFnDataClient} during a future {@link FnDataReceiver#accept} invocation.
+   * to the {@link BeamFnDataClient} during a future {@link FnDataReceiver#accept} invocation or via
+   * a call to {@link #poisonInstructionId}.
    */
   void unregisterReceiver(String instructionId, List<ApiServiceDescriptor> apiServiceDescriptors);
+
+  /**
+   * Poisons the instruction id, indicating that future data arriving for it should be discarded.
+   * Unregisters the receiver if was registered.
+   *
+   * @param instructionId
+   */
+  void poisonInstructionId(String instructionId);
 
   /**
    * Creates a {@link BeamFnDataOutboundAggregator} for buffering and sending outbound data and

--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/data/BeamFnDataGrpcClient.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/data/BeamFnDataGrpcClient.java
@@ -83,6 +83,14 @@ public class BeamFnDataGrpcClient implements BeamFnDataClient {
   }
 
   @Override
+  public void poisonInstructionId(String instructionId) {
+    LOG.debug("Poisoning instruction {}", instructionId);
+    for (BeamFnDataGrpcMultiplexer client : multiplexerCache.values()) {
+      client.poisonInstructionId(instructionId);
+    }
+  }
+
+  @Override
   public BeamFnDataOutboundAggregator createOutboundAggregator(
       ApiServiceDescriptor apiServiceDescriptor,
       Supplier<String> processBundleRequestIdSupplier,

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/PTransformRunnerFactoryTestContext.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/PTransformRunnerFactoryTestContext.java
@@ -92,6 +92,11 @@ public abstract class PTransformRunnerFactoryTestContext
                   boolean collectElementsIfNoFlushes) {
                 throw new UnsupportedOperationException("Unexpected call during test.");
               }
+
+              @Override
+              public void poisonInstructionId(String instructionId) {
+                throw new UnsupportedOperationException("Unexpected call during test.");
+              }
             })
         .beamFnStateClient(
             new BeamFnStateClient() {

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/ProcessBundleHandlerTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/control/ProcessBundleHandlerTest.java
@@ -1516,6 +1516,7 @@ public class ProcessBundleHandlerTest {
 
     // Ensure that we unregister during successful processing
     verify(beamFnDataClient).registerReceiver(eq("instructionId"), any(), any());
+    verify(beamFnDataClient).poisonInstructionId(eq("instructionId"));
     verifyNoMoreInteractions(beamFnDataClient);
   }
 


### PR DESCRIPTION
Previously it could occur that an instruction id was observed on the control stream but due to exception it would never register a handler and the data stream would be forever blocked trying to multiplex elements to it's queue.

Fixes #32714

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
