### PR TITLE
Enable BuildKit on gradle docker task

### DIFF
--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamDockerPlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamDockerPlugin.groovy
@@ -130,6 +130,7 @@ class BeamDockerPlugin implements Plugin<Project> {
       group = 'Docker'
       description = 'Builds Docker image.'
       dependsOn prepare
+      environment 'DOCKER_BUILDKIT', '1'
     })
 
     Task tag = project.tasks.create('dockerTag', {

--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -152,7 +152,7 @@ def firestoreDb = project.findProperty('firestoreDb') ?: 'firestoredb'
 def dockerImageRoot = project.findProperty('dockerImageRoot') ?: "us.gcr.io/${gcpProject.replaceAll(':', '/')}/java-postcommit-it"
 def dockerJavaImageContainer = "${dockerImageRoot}/java"
 def dockerPythonImageContainer = "${dockerImageRoot}/python"
-def dockerTag = project.findProperty('dockerTag') ?: new Date().format('yyyyMMddHHmmss')
+def dockerTag = new Date().format('yyyyMMddHHmmss')
 ext.dockerJavaImageName = "${dockerJavaImageContainer}:${dockerTag}"
 ext.dockerPythonImageName = "${dockerPythonImageContainer}:${dockerTag}"
 

--- a/runners/google-cloud-dataflow-java/build.gradle
+++ b/runners/google-cloud-dataflow-java/build.gradle
@@ -152,7 +152,7 @@ def firestoreDb = project.findProperty('firestoreDb') ?: 'firestoredb'
 def dockerImageRoot = project.findProperty('dockerImageRoot') ?: "us.gcr.io/${gcpProject.replaceAll(':', '/')}/java-postcommit-it"
 def dockerJavaImageContainer = "${dockerImageRoot}/java"
 def dockerPythonImageContainer = "${dockerImageRoot}/python"
-def dockerTag = new Date().format('yyyyMMddHHmmss')
+def dockerTag = project.findProperty('dockerTag') ?: new Date().format('yyyyMMddHHmmss')
 ext.dockerJavaImageName = "${dockerJavaImageContainer}:${dockerTag}"
 ext.dockerPythonImageName = "${dockerPythonImageContainer}:${dockerTag}"
 


### PR DESCRIPTION
Closes #32819 enabling [BuildKit](https://docs.docker.com/build/buildkit/) via Gradle `:docker` task defined in [buildSrc/src/main/groovy/org/apache/beam/gradle/BeamDockerPlugin.groovy](https://github.com/apache/beam/blob/master/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamDockerPlugin.groovy).

Prior to creating PR, validated via running `:sdks:go:container:docker`, `:sdks:Java:container:java11:docker`, `:sdks:python:container:py311:docker`,  `:runners:google-cloud-dataflow-java:validatesRunnerV2`, and `:runners:google-cloud-dataflow-java:validatesCrossLanguageRunnerPythonUsingPython`. The Dataflow validates runner tests detect errors in the container image build as a result of using BuildKit within an Job execution context.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [x] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - ~Update `CHANGES.md` with noteworthy changes.~
 - ~If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).~

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
