### PR TITLE
[prism] Dev prism builds for python  and Python Direct Runner fallbacks. 

### DIFF
--- a/sdks/python/apache_beam/runners/direct/direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner.py
@@ -66,7 +66,6 @@ class SwitchingDirectRunner(PipelineRunner):
   which supports streaming execution and certain primitives not yet
   implemented in the FnApiRunner.
   """
-
   def is_fnapi_compatible(self):
     return BundleBasedDirectRunner.is_fnapi_compatible()
 
@@ -79,7 +78,6 @@ class SwitchingDirectRunner(PipelineRunner):
 
     class _FnApiRunnerSupportVisitor(PipelineVisitor):
       """Visitor determining if a Pipeline can be run on the FnApiRunner."""
-
       def accept(self, pipeline):
         self.supported_by_fnapi_runner = True
         pipeline.visit(self)
@@ -114,7 +112,6 @@ class SwitchingDirectRunner(PipelineRunner):
 
     class _PrismRunnerSupportVisitor(PipelineVisitor):
       """Visitor determining if a Pipeline can be run on the PrismRunner."""
-
       def accept(self, pipeline):
         self.supported_by_prism_runner = True
         pipeline.visit(self)
@@ -190,7 +187,6 @@ V = typing.TypeVar('V')
 @typehints.with_output_types(typing.Tuple[K, typing.Iterable[V]])
 class _GroupByKeyOnly(PTransform):
   """A group by key transform, ignoring windows."""
-
   def infer_output_type(self, input_type):
     key_type, value_type = trivial_inference.key_value_types(input_type)
     return typehints.KV[key_type, typehints.Iterable[value_type]]
@@ -204,7 +200,6 @@ class _GroupByKeyOnly(PTransform):
 @typehints.with_output_types(typing.Tuple[K, typing.Iterable[V]])
 class _GroupAlsoByWindow(ParDo):
   """The GroupAlsoByWindow transform."""
-
   def __init__(self, windowing):
     super().__init__(_GroupAlsoByWindowDoFn(windowing))
     self.windowing = windowing
@@ -279,7 +274,6 @@ class _StreamingGroupAlsoByWindow(_GroupAlsoByWindow):
 @typehints.with_output_types(typing.Tuple[K, typing.Iterable[V]])
 class _GroupByKey(PTransform):
   """The DirectRunner GroupByKey implementation."""
-
   def expand(self, pcoll):
     # Imported here to avoid circular dependencies.
     # pylint: disable=wrong-import-order, wrong-import-position
@@ -342,7 +336,6 @@ def _get_transform_overrides(pipeline_options):
   from apache_beam.runners.direct.sdf_direct_runner import SplittableParDoOverride
 
   class CombinePerKeyOverride(PTransformOverride):
-
     def matches(self, applied_ptransform):
       if isinstance(applied_ptransform.transform, CombinePerKey):
         return applied_ptransform.inputs[0].windowing.is_default()
@@ -360,7 +353,6 @@ def _get_transform_overrides(pipeline_options):
         return transform
 
   class StreamingGroupByKeyOverride(PTransformOverride):
-
     def matches(self, applied_ptransform):
       # Note: we match the exact class, since we replace it with a subclass.
       return applied_ptransform.transform.__class__ == _GroupByKeyOnly
@@ -372,7 +364,6 @@ def _get_transform_overrides(pipeline_options):
       return transform
 
   class StreamingGroupAlsoByWindowOverride(PTransformOverride):
-
     def matches(self, applied_ptransform):
       # Note: we match the exact class, since we replace it with a subclass.
       transform = applied_ptransform.transform
@@ -389,7 +380,6 @@ def _get_transform_overrides(pipeline_options):
       return transform
 
   class TestStreamOverride(PTransformOverride):
-
     def matches(self, applied_ptransform):
       from apache_beam.testing.test_stream import TestStream
       self.applied_ptransform = applied_ptransform
@@ -405,7 +395,6 @@ def _get_transform_overrides(pipeline_options):
 
     This replaces the Beam implementation as a primitive.
     """
-
     def matches(self, applied_ptransform):
       # Imported here to avoid circular dependencies.
       # pylint: disable=wrong-import-order, wrong-import-position
@@ -447,7 +436,6 @@ def _get_transform_overrides(pipeline_options):
 
 
 class _DirectReadFromPubSub(PTransform):
-
   def __init__(self, source):
     self._source = source
 
@@ -523,7 +511,6 @@ def _get_pubsub_transform_overrides(pipeline_options):
   from apache_beam.pipeline import PTransformOverride
 
   class ReadFromPubSubOverride(PTransformOverride):
-
     def matches(self, applied_ptransform):
       return isinstance(
           applied_ptransform.transform, beam_pubsub.ReadFromPubSub)
@@ -537,7 +524,6 @@ def _get_pubsub_transform_overrides(pipeline_options):
       return _DirectReadFromPubSub(applied_ptransform.transform._source)
 
   class WriteToPubSubOverride(PTransformOverride):
-
     def matches(self, applied_ptransform):
       return isinstance(applied_ptransform.transform, beam_pubsub.WriteToPubSub)
 
@@ -554,7 +540,6 @@ def _get_pubsub_transform_overrides(pipeline_options):
 
 class BundleBasedDirectRunner(PipelineRunner):
   """Executes a single pipeline on the local machine."""
-
   @staticmethod
   def is_fnapi_compatible():
     return False
@@ -577,7 +562,6 @@ class BundleBasedDirectRunner(PipelineRunner):
 
     class VerifyNoCrossLanguageTransforms(PipelineVisitor):
       """Visitor determining whether a Pipeline uses a TestStream."""
-
       def visit_transform(self, applied_ptransform):
         if isinstance(applied_ptransform.transform, ExternalTransform):
           raise RuntimeError(
@@ -591,7 +575,6 @@ class BundleBasedDirectRunner(PipelineRunner):
     # If the TestStream I/O is used, use a mock test clock.
     class TestStreamUsageVisitor(PipelineVisitor):
       """Visitor determining whether a Pipeline uses a TestStream."""
-
       def __init__(self):
         self.uses_test_stream = False
 
@@ -642,7 +625,6 @@ DirectRunner = SwitchingDirectRunner
 
 class DirectPipelineResult(PipelineResult):
   """A DirectPipelineResult provides access to info about a pipeline."""
-
   def __init__(self, executor, evaluation_context):
     super().__init__(PipelineState.RUNNING)
     self._executor = executor

--- a/sdks/python/apache_beam/runners/direct/direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner.py
@@ -119,6 +119,9 @@ class SwitchingDirectRunner(PipelineRunner):
 
       def visit_transform(self, applied_ptransform):
         transform = applied_ptransform.transform
+        # Python SDK assumes the direct runner TestStream implementation is being used.
+        if isinstance(transform, TestStream):
+          self.supported_by_prism_runner = False
         if isinstance(transform, beam.ParDo):
           dofn = transform.dofn
           # It's uncertain if the Prism Runner supports execution of CombineFns

--- a/sdks/python/apache_beam/runners/direct/direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner.py
@@ -66,6 +66,7 @@ class SwitchingDirectRunner(PipelineRunner):
   which supports streaming execution and certain primitives not yet
   implemented in the FnApiRunner.
   """
+
   def is_fnapi_compatible(self):
     return BundleBasedDirectRunner.is_fnapi_compatible()
 
@@ -78,6 +79,7 @@ class SwitchingDirectRunner(PipelineRunner):
 
     class _FnApiRunnerSupportVisitor(PipelineVisitor):
       """Visitor determining if a Pipeline can be run on the FnApiRunner."""
+
       def accept(self, pipeline):
         self.supported_by_fnapi_runner = True
         pipeline.visit(self)
@@ -112,6 +114,7 @@ class SwitchingDirectRunner(PipelineRunner):
 
     class _PrismRunnerSupportVisitor(PipelineVisitor):
       """Visitor determining if a Pipeline can be run on the PrismRunner."""
+
       def accept(self, pipeline):
         self.supported_by_prism_runner = True
         pipeline.visit(self)
@@ -143,21 +146,22 @@ class SwitchingDirectRunner(PipelineRunner):
           beam_provision_api_pb2.ProvisionInfo(
               pipeline_options=encoded_options))
       runner = fn_runner.FnApiRunner(provision_info=provision_info)
-    elif  _PrismRunnerSupportVisitor().accept(pipeline):
+    elif _PrismRunnerSupportVisitor().accept(pipeline):
       _LOGGER.info('Running pipeline with PrismRunner.')
       from apache_beam.runners.portability import prism_runner
       runner = prism_runner.PrismRunner()
       tryingPrism = True
     else:
       runner = BundleBasedDirectRunner()
-    
+
     if tryingPrism:
-      try: 
+      try:
         pr = runner.run_pipeline(pipeline, options)
-        # This is non-blocking, so if the state is *already* finished, something 
+        # This is non-blocking, so if the state is *already* finished, something
         # probably failed on job submission.
         if pr.state.is_terminal() and pr.state != PipelineState.DONE:
-          _LOGGER.info('Pipeline failed on PrismRunner, falling back toDirectRunner.')
+          _LOGGER.info(
+              'Pipeline failed on PrismRunner, falling back toDirectRunner.')
           runner = BundleBasedDirectRunner()
         else:
           return pr
@@ -180,6 +184,7 @@ V = typing.TypeVar('V')
 @typehints.with_output_types(typing.Tuple[K, typing.Iterable[V]])
 class _GroupByKeyOnly(PTransform):
   """A group by key transform, ignoring windows."""
+
   def infer_output_type(self, input_type):
     key_type, value_type = trivial_inference.key_value_types(input_type)
     return typehints.KV[key_type, typehints.Iterable[value_type]]
@@ -193,6 +198,7 @@ class _GroupByKeyOnly(PTransform):
 @typehints.with_output_types(typing.Tuple[K, typing.Iterable[V]])
 class _GroupAlsoByWindow(ParDo):
   """The GroupAlsoByWindow transform."""
+
   def __init__(self, windowing):
     super().__init__(_GroupAlsoByWindowDoFn(windowing))
     self.windowing = windowing
@@ -267,6 +273,7 @@ class _StreamingGroupAlsoByWindow(_GroupAlsoByWindow):
 @typehints.with_output_types(typing.Tuple[K, typing.Iterable[V]])
 class _GroupByKey(PTransform):
   """The DirectRunner GroupByKey implementation."""
+
   def expand(self, pcoll):
     # Imported here to avoid circular dependencies.
     # pylint: disable=wrong-import-order, wrong-import-position
@@ -329,6 +336,7 @@ def _get_transform_overrides(pipeline_options):
   from apache_beam.runners.direct.sdf_direct_runner import SplittableParDoOverride
 
   class CombinePerKeyOverride(PTransformOverride):
+
     def matches(self, applied_ptransform):
       if isinstance(applied_ptransform.transform, CombinePerKey):
         return applied_ptransform.inputs[0].windowing.is_default()
@@ -346,6 +354,7 @@ def _get_transform_overrides(pipeline_options):
         return transform
 
   class StreamingGroupByKeyOverride(PTransformOverride):
+
     def matches(self, applied_ptransform):
       # Note: we match the exact class, since we replace it with a subclass.
       return applied_ptransform.transform.__class__ == _GroupByKeyOnly
@@ -357,6 +366,7 @@ def _get_transform_overrides(pipeline_options):
       return transform
 
   class StreamingGroupAlsoByWindowOverride(PTransformOverride):
+
     def matches(self, applied_ptransform):
       # Note: we match the exact class, since we replace it with a subclass.
       transform = applied_ptransform.transform
@@ -373,6 +383,7 @@ def _get_transform_overrides(pipeline_options):
       return transform
 
   class TestStreamOverride(PTransformOverride):
+
     def matches(self, applied_ptransform):
       from apache_beam.testing.test_stream import TestStream
       self.applied_ptransform = applied_ptransform
@@ -388,6 +399,7 @@ def _get_transform_overrides(pipeline_options):
 
     This replaces the Beam implementation as a primitive.
     """
+
     def matches(self, applied_ptransform):
       # Imported here to avoid circular dependencies.
       # pylint: disable=wrong-import-order, wrong-import-position
@@ -429,6 +441,7 @@ def _get_transform_overrides(pipeline_options):
 
 
 class _DirectReadFromPubSub(PTransform):
+
   def __init__(self, source):
     self._source = source
 
@@ -504,6 +517,7 @@ def _get_pubsub_transform_overrides(pipeline_options):
   from apache_beam.pipeline import PTransformOverride
 
   class ReadFromPubSubOverride(PTransformOverride):
+
     def matches(self, applied_ptransform):
       return isinstance(
           applied_ptransform.transform, beam_pubsub.ReadFromPubSub)
@@ -517,6 +531,7 @@ def _get_pubsub_transform_overrides(pipeline_options):
       return _DirectReadFromPubSub(applied_ptransform.transform._source)
 
   class WriteToPubSubOverride(PTransformOverride):
+
     def matches(self, applied_ptransform):
       return isinstance(applied_ptransform.transform, beam_pubsub.WriteToPubSub)
 
@@ -533,6 +548,7 @@ def _get_pubsub_transform_overrides(pipeline_options):
 
 class BundleBasedDirectRunner(PipelineRunner):
   """Executes a single pipeline on the local machine."""
+
   @staticmethod
   def is_fnapi_compatible():
     return False
@@ -555,6 +571,7 @@ class BundleBasedDirectRunner(PipelineRunner):
 
     class VerifyNoCrossLanguageTransforms(PipelineVisitor):
       """Visitor determining whether a Pipeline uses a TestStream."""
+
       def visit_transform(self, applied_ptransform):
         if isinstance(applied_ptransform.transform, ExternalTransform):
           raise RuntimeError(
@@ -568,6 +585,7 @@ class BundleBasedDirectRunner(PipelineRunner):
     # If the TestStream I/O is used, use a mock test clock.
     class TestStreamUsageVisitor(PipelineVisitor):
       """Visitor determining whether a Pipeline uses a TestStream."""
+
       def __init__(self):
         self.uses_test_stream = False
 
@@ -618,6 +636,7 @@ DirectRunner = SwitchingDirectRunner
 
 class DirectPipelineResult(PipelineResult):
   """A DirectPipelineResult provides access to info about a pipeline."""
+
   def __init__(self, executor, evaluation_context):
     super().__init__(PipelineState.RUNNING)
     self._executor = executor

--- a/sdks/python/apache_beam/runners/direct/direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner.py
@@ -154,12 +154,16 @@ class SwitchingDirectRunner(PipelineRunner):
     if tryingPrism:
       try: 
         pr = runner.run_pipeline(pipeline, options)
+        # This is non-blocking, so if the state is *already* finished, something 
+        # probably failed on job submission.
         if pr.state.is_terminal() and pr.state != PipelineState.DONE:
           _LOGGER.info('Pipeline failed on PrismRunner, falling back toDirectRunner.')
           runner = BundleBasedDirectRunner()
         else:
           return pr
       except Exception as e:
+        # If prism fails in Preparing the portable job, then the PortableRunner
+        # code raises an exception. Catch it, log it, and use the Direct runner instead.
         _LOGGER.info('Exception with PrismRunner:\n %s\n' % (e))
         _LOGGER.info('Falling back to DirectRunner')
         runner = BundleBasedDirectRunner()

--- a/sdks/python/apache_beam/runners/direct/direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner.py
@@ -132,6 +132,12 @@ class SwitchingDirectRunner(PipelineRunner):
             if any(isinstance(arg, ArgumentPlaceholder)
                    for arg in args_to_check):
               self.supported_by_prism_runner = False
+          if userstate.is_stateful_dofn(dofn):
+            # https://github.com/apache/beam/issues/32786 - Remove once Real time clock is used.
+            _, timer_specs = userstate.get_dofn_specs(dofn)
+            for timer in timer_specs:
+              if timer.time_domain == TimeDomain.REAL_TIME:
+                self.supported_by_prism_runner = False
 
     tryingPrism = False
     # Check whether all transforms used in the pipeline are supported by the

--- a/sdks/python/apache_beam/runners/direct/direct_runner.py
+++ b/sdks/python/apache_beam/runners/direct/direct_runner.py
@@ -119,7 +119,8 @@ class SwitchingDirectRunner(PipelineRunner):
 
       def visit_transform(self, applied_ptransform):
         transform = applied_ptransform.transform
-        # Python SDK assumes the direct runner TestStream implementation is being used.
+        # Python SDK assumes the direct runner TestStream implementation is
+        # being used.
         if isinstance(transform, TestStream):
           self.supported_by_prism_runner = False
         if isinstance(transform, beam.ParDo):
@@ -133,7 +134,8 @@ class SwitchingDirectRunner(PipelineRunner):
                    for arg in args_to_check):
               self.supported_by_prism_runner = False
           if userstate.is_stateful_dofn(dofn):
-            # https://github.com/apache/beam/issues/32786 - Remove once Real time clock is used.
+            # https://github.com/apache/beam/issues/32786 -
+            # Remove once Real time clock is used.
             _, timer_specs = userstate.get_dofn_specs(dofn)
             for timer in timer_specs:
               if timer.time_domain == TimeDomain.REAL_TIME:
@@ -173,7 +175,8 @@ class SwitchingDirectRunner(PipelineRunner):
           return pr
       except Exception as e:
         # If prism fails in Preparing the portable job, then the PortableRunner
-        # code raises an exception. Catch it, log it, and use the Direct runner instead.
+        # code raises an exception. Catch it, log it, and use the Direct runner
+        # instead.
         _LOGGER.info('Exception with PrismRunner:\n %s\n' % (e))
         _LOGGER.info('Falling back to DirectRunner')
         runner = BundleBasedDirectRunner()

--- a/sdks/python/apache_beam/runners/portability/prism_runner.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner.py
@@ -56,6 +56,7 @@ class PrismRunner(portable_runner.PortableRunner):
   """A runner for launching jobs on Prism, automatically downloading and
   starting a Prism instance if needed.
   """
+
   def default_environment(
       self,
       options: pipeline_options.PipelineOptions) -> environments.Environment:
@@ -197,7 +198,7 @@ class PrismJobServer(job_server.SubprocessJobServer):
           root_tag, platform.system(), platform.machine())
 
     if '.dev' not in self._version:
-      # Not a development version, so construct the production download URL 
+      # Not a development version, so construct the production download URL
       return self.construct_download_url(
           self._version, platform.system(), platform.machine())
 
@@ -207,12 +208,14 @@ class PrismJobServer(job_server.SubprocessJobServer):
     PRISMPKG = "github.com/apache/beam/sdks/v2/go/cmd/prism"
 
     process = subprocess.run(["go", "install", PRISMPKG],
-        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=envdict)
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.STDOUT,
+                             env=envdict)
     if process.returncode == 0:
       # Successfully installed
       return '%s/prism' % (self.BIN_CACHE)
-      
-    # We failed to build for some reason. 
+
+    # We failed to build for some reason.
     output = process.stdout.decode("utf-8")
     if "not in a module" not in output and "no required module provides" not in output:
       # This branch handles two classes of failures:
@@ -226,21 +229,25 @@ class PrismJobServer(job_server.SubprocessJobServer):
           'Likely Go is not installed, or a local change to Prism did not compile.\n'
           'Please install Go (see https://go.dev/doc/install) to enable automatic local builds.\n'
           'Alternatively provide an alternate version with the '
-          '--prism_beam_version_override flag.\nCaptured output:\n %s' % (self._version, output))
-    
-    # Go is installed and claims we're not in a Go module that has access to the Prism package. 
+          '--prism_beam_version_override flag.\nCaptured output:\n %s' %
+          (self._version, output))
+
+    # Go is installed and claims we're not in a Go module that has access to the Prism package.
     # Fallback to using the @latest version of prism, which works everywhere.
     process = subprocess.run(["go", "install", PRISMPKG + "@latest"],
-        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=envdict)
+                             stdout=subprocess.PIPE,
+                             stderr=subprocess.STDOUT,
+                             env=envdict)
 
     if process.returncode == 0:
       return '%s/prism' % (self.BIN_CACHE)
-    
+
     output = process.stdout.decode("utf-8")
     raise ValueError(
         'We were unable to execute the subprocess "%s" to automatically build prism. \n'
         'Alternatively provide an alternate version with the '
-        '--prism_beam_version_override flag.\nCaptured output:\n %s' % (process.args, output))
+        '--prism_beam_version_override flag.\nCaptured output:\n %s' %
+        (process.args, output))
 
   def subprocess_cmd_and_endpoint(
       self) -> typing.Tuple[typing.List[typing.Any], str]:

--- a/sdks/python/apache_beam/runners/portability/prism_runner.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner.py
@@ -27,6 +27,7 @@ import os
 import platform
 import shutil
 import stat
+import subprocess
 import typing
 import urllib
 import zipfile
@@ -167,37 +168,79 @@ class PrismJobServer(job_server.SubprocessJobServer):
 
   def path_to_binary(self) -> str:
     if self._path is not None:
-      if not os.path.exists(self._path):
-        url = urllib.parse.urlparse(self._path)
-        if not url.scheme:
-          raise ValueError(
-              'Unable to parse binary URL "%s". If using a full URL, make '
-              'sure the scheme is specified. If using a local file xpath, '
-              'make sure the file exists; you may have to first build prism '
-              'using `go build `.' % (self._path))
+      # The path is overidden, check various cases.
+      if os.path.exists(self._path):
+        # The path is local and exists, use directly.
+        return self.bin_path
 
-        # We have a URL, see if we need to construct a valid file name.
-        if self._path.startswith(GITHUB_DOWNLOAD_PREFIX):
-          # If this URL starts with the download prefix, let it through.
-          return self._path
-        # The only other valid option is a github release page.
-        if not self._path.startswith(GITHUB_TAG_PREFIX):
-          raise ValueError(
-              'Provided --prism_location URL is not an Apache Beam Github '
-              'Release page URL or download URL: %s' % (self._path))
-        # Get the root tag for this URL
-        root_tag = os.path.basename(os.path.normpath(self._path))
-        return self.construct_download_url(
-            root_tag, platform.system(), platform.machine())
-      return self._path
-    else:
-      if '.dev' in self._version:
+      # Check if the path is a URL.
+      url = urllib.parse.urlparse(self._path)
+      if not url.scheme:
         raise ValueError(
-            'Unable to derive URL for dev versions "%s". Please provide an '
-            'alternate version to derive the release URL with the '
-            '--prism_beam_version_override flag.' % (self._version))
+            'Unable to parse binary URL "%s". If using a full URL, make '
+            'sure the scheme is specified. If using a local file xpath, '
+            'make sure the file exists; you may have to first build prism '
+            'using `go build `.' % (self._path))
+
+      # We have a URL, see if we need to construct a valid file name.
+      if self._path.startswith(GITHUB_DOWNLOAD_PREFIX):
+        # If this URL starts with the download prefix, let it through.
+        return self._path
+      # The only other valid option is a github release page.
+      if not self._path.startswith(GITHUB_TAG_PREFIX):
+        raise ValueError(
+            'Provided --prism_location URL is not an Apache Beam Github '
+            'Release page URL or download URL: %s' % (self._path))
+      # Get the root tag for this URL
+      root_tag = os.path.basename(os.path.normpath(self._path))
+      return self.construct_download_url(
+          root_tag, platform.system(), platform.machine())
+
+    if '.dev' not in self._version:
+      # Not a development version, so construct the production download URL 
       return self.construct_download_url(
           self._version, platform.system(), platform.machine())
+
+    # This is a development version! Assume Go is installed.
+    # Set the install directory to the cache location.
+    envdict = dict(os.environ) | {"GOBIN": self.BIN_CACHE}
+    PRISMPKG = "github.com/apache/beam/sdks/v2/go/cmd/prism"
+
+    process = subprocess.run(["go", "install", PRISMPKG],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=envdict)
+    if process.returncode == 0:
+      # Successfully installed
+      return '%s/prism' % (self.BIN_CACHE)
+      
+    # We failed to build for some reason. 
+    output = process.stdout.decode("utf-8")
+    if "not in a module" not in output and "no required module provides" not in output:
+      # This branch handles two classes of failures:
+      # 1. Go isn't installed, so it needs to be installed by the Beam SDK developer.
+      # 2. Go is installed, and they are building in a local version of Prism,
+      #    but there was a compile error, that the developer should address.
+      # Either way, the @latest fallback either would fail, or hide the error, so fail now.
+      _LOGGER.info(output)
+      raise ValueError(
+          'Unable to install a local of Prism: "%s";\n'
+          'Likely Go is not installed, or a local change to Prism did not compile.\n'
+          'Please install Go (see https://go.dev/doc/install) to enable automatic local builds.\n'
+          'Alternatively provide an alternate version with the '
+          '--prism_beam_version_override flag.\nCaptured output:\n %s' % (self._version, output))
+    
+    # Go is installed and claims we're not in a Go module that has access to the Prism package. 
+    # Fallback to using the @latest version of prism, which works everywhere.
+    process = subprocess.run(["go", "install", PRISMPKG + "@latest"],
+        stdout=subprocess.PIPE, stderr=subprocess.STDOUT, env=envdict)
+
+    if process.returncode == 0:
+      return '%s/prism' % (self.BIN_CACHE)
+    
+    output = process.stdout.decode("utf-8")
+    raise ValueError(
+        'We were unable to execute the subprocess "%s" to automatically build prism. \n'
+        'Alternatively provide an alternate version with the '
+        '--prism_beam_version_override flag.\nCaptured output:\n %s' % (process.args, output))
 
   def subprocess_cmd_and_endpoint(
       self) -> typing.Tuple[typing.List[typing.Any], str]:

--- a/sdks/python/apache_beam/runners/portability/prism_runner.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner.py
@@ -171,7 +171,7 @@ class PrismJobServer(job_server.SubprocessJobServer):
       # The path is overidden, check various cases.
       if os.path.exists(self._path):
         # The path is local and exists, use directly.
-        return self.bin_path
+        return self._path
 
       # Check if the path is a URL.
       url = urllib.parse.urlparse(self._path)
@@ -203,7 +203,7 @@ class PrismJobServer(job_server.SubprocessJobServer):
 
     # This is a development version! Assume Go is installed.
     # Set the install directory to the cache location.
-    envdict = dict(os.environ) | {"GOBIN": self.BIN_CACHE}
+    envdict = {**os.environ, "GOBIN": self.BIN_CACHE} 
     PRISMPKG = "github.com/apache/beam/sdks/v2/go/cmd/prism"
 
     process = subprocess.run(["go", "install", PRISMPKG],

--- a/sdks/python/apache_beam/runners/portability/prism_runner.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner.py
@@ -203,7 +203,7 @@ class PrismJobServer(job_server.SubprocessJobServer):
 
     # This is a development version! Assume Go is installed.
     # Set the install directory to the cache location.
-    envdict = {**os.environ, "GOBIN": self.BIN_CACHE} 
+    envdict = {**os.environ, "GOBIN": self.BIN_CACHE}
     PRISMPKG = "github.com/apache/beam/sdks/v2/go/cmd/prism"
 
     process = subprocess.run(["go", "install", PRISMPKG],

--- a/sdks/python/apache_beam/runners/portability/prism_runner.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner.py
@@ -56,7 +56,6 @@ class PrismRunner(portable_runner.PortableRunner):
   """A runner for launching jobs on Prism, automatically downloading and
   starting a Prism instance if needed.
   """
-
   def default_environment(
       self,
       options: pipeline_options.PipelineOptions) -> environments.Environment:
@@ -229,11 +228,11 @@ class PrismJobServer(job_server.SubprocessJobServer):
           'Likely Go is not installed, or a local change to Prism did not compile.\n'
           'Please install Go (see https://go.dev/doc/install) to enable automatic local builds.\n'
           'Alternatively provide a binary with the --prism_location flag.'
-          '\nCaptured output:\n %s' %
-          (self._version, output))
+          '\nCaptured output:\n %s' % (self._version, output))
 
     # Go is installed and claims we're not in a Go module that has access to the Prism package.
-    # Fallback to using the @latest version of prism, which works everywhere.
+
+  # Fallback to using the @latest version of prism, which works everywhere.
     process = subprocess.run(["go", "install", PRISMPKG + "@latest"],
                              stdout=subprocess.PIPE,
                              stderr=subprocess.STDOUT,
@@ -246,8 +245,7 @@ class PrismJobServer(job_server.SubprocessJobServer):
     raise ValueError(
         'We were unable to execute the subprocess "%s" to automatically build prism. \n'
         'Alternatively provide an alternate binary with the --prism_location flag.'
-        '\nCaptured output:\n %s' %
-        (process.args, output))
+        '\nCaptured output:\n %s' % (process.args, output))
 
   def subprocess_cmd_and_endpoint(
       self) -> typing.Tuple[typing.List[typing.Any], str]:

--- a/sdks/python/apache_beam/runners/portability/prism_runner.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner.py
@@ -209,42 +209,50 @@ class PrismJobServer(job_server.SubprocessJobServer):
     process = subprocess.run(["go", "install", PRISMPKG],
                              stdout=subprocess.PIPE,
                              stderr=subprocess.STDOUT,
-                             env=envdict)
+                             env=envdict,
+                             check=False)
     if process.returncode == 0:
       # Successfully installed
       return '%s/prism' % (self.BIN_CACHE)
 
     # We failed to build for some reason.
     output = process.stdout.decode("utf-8")
-    if "not in a module" not in output and "no required module provides" not in output:
+    if ("not in a module" not in output) and (
+        "no required module provides" not in output):
       # This branch handles two classes of failures:
-      # 1. Go isn't installed, so it needs to be installed by the Beam SDK developer.
+      # 1. Go isn't installed, so it needs to be installed by the Beam SDK
+      #   developer.
       # 2. Go is installed, and they are building in a local version of Prism,
       #    but there was a compile error that the developer should address.
-      # Either way, the @latest fallback either would fail, or hide the error, so fail now.
+      # Either way, the @latest fallback either would fail, or hide the error,
+      # so fail now.
       _LOGGER.info(output)
       raise ValueError(
           'Unable to install a local of Prism: "%s";\n'
-          'Likely Go is not installed, or a local change to Prism did not compile.\n'
-          'Please install Go (see https://go.dev/doc/install) to enable automatic local builds.\n'
+          'Likely Go is not installed, or a local change to Prism did not '
+          'compile.\nPlease install Go (see https://go.dev/doc/install) to '
+          'enable automatic local builds.\n'
           'Alternatively provide a binary with the --prism_location flag.'
           '\nCaptured output:\n %s' % (self._version, output))
 
-    # Go is installed and claims we're not in a Go module that has access to the Prism package.
+    # Go is installed and claims we're not in a Go module that has access to
+    # the Prism package.
 
-  # Fallback to using the @latest version of prism, which works everywhere.
+    # Fallback to using the @latest version of prism, which works everywhere.
     process = subprocess.run(["go", "install", PRISMPKG + "@latest"],
                              stdout=subprocess.PIPE,
                              stderr=subprocess.STDOUT,
-                             env=envdict)
+                             env=envdict,
+                             check=False)
 
     if process.returncode == 0:
       return '%s/prism' % (self.BIN_CACHE)
 
     output = process.stdout.decode("utf-8")
     raise ValueError(
-        'We were unable to execute the subprocess "%s" to automatically build prism. \n'
-        'Alternatively provide an alternate binary with the --prism_location flag.'
+        'We were unable to execute the subprocess "%s" to automatically '
+        'build prism.\nAlternatively provide an alternate binary with the '
+        '--prism_location flag.'
         '\nCaptured output:\n %s' % (process.args, output))
 
   def subprocess_cmd_and_endpoint(

--- a/sdks/python/apache_beam/runners/portability/prism_runner.py
+++ b/sdks/python/apache_beam/runners/portability/prism_runner.py
@@ -221,15 +221,15 @@ class PrismJobServer(job_server.SubprocessJobServer):
       # This branch handles two classes of failures:
       # 1. Go isn't installed, so it needs to be installed by the Beam SDK developer.
       # 2. Go is installed, and they are building in a local version of Prism,
-      #    but there was a compile error, that the developer should address.
+      #    but there was a compile error that the developer should address.
       # Either way, the @latest fallback either would fail, or hide the error, so fail now.
       _LOGGER.info(output)
       raise ValueError(
           'Unable to install a local of Prism: "%s";\n'
           'Likely Go is not installed, or a local change to Prism did not compile.\n'
           'Please install Go (see https://go.dev/doc/install) to enable automatic local builds.\n'
-          'Alternatively provide an alternate version with the '
-          '--prism_beam_version_override flag.\nCaptured output:\n %s' %
+          'Alternatively provide a binary with the --prism_location flag.'
+          '\nCaptured output:\n %s' %
           (self._version, output))
 
     # Go is installed and claims we're not in a Go module that has access to the Prism package.
@@ -245,8 +245,8 @@ class PrismJobServer(job_server.SubprocessJobServer):
     output = process.stdout.decode("utf-8")
     raise ValueError(
         'We were unable to execute the subprocess "%s" to automatically build prism. \n'
-        'Alternatively provide an alternate version with the '
-        '--prism_beam_version_override flag.\nCaptured output:\n %s' %
+        'Alternatively provide an alternate binary with the --prism_location flag.'
+        '\nCaptured output:\n %s' %
         (process.args, output))
 
   def subprocess_cmd_and_endpoint(


### PR DESCRIPTION
This change does two tasks:

* Enables Python SDK developers to have prism automatically build and run locally using local changes to Prism when using PrismRunner.
* Sets Prism to be attempted to be used in the Python DirectRunner in some circumstances.

The main change is to the prism_runner behavior when the SDK reports a `.dev` version.
In that case:
* Try to `go install github.com/apache/beam/sdks/v2/go/cmd/prism` to the binary cache directory.
* If that doesn't succeed, inspect the output for module errors 
  * If there are no *module* errors, then the local version of prism couldn't compile, OR go isn't installed. Either way, this is a developer addressable error.
  * If there are module errors, then those modules don't have access to a version of Beam Go, so instead install the latest released version of prism. 
    * This can be avoided by having a go.work file set up to direct Beam to a local version of the beam repo. This will be documented in a forthcoming SDK Development guide.
 
Arguably independently, is Attempt To Use Prism in the direct runner.
* This currently only happens if we can't use the FnAPI runner.
* If Prism fails on receiving the job, on job submission, then fallback to the DirectRunner instead.
 
Other changes are a refactor to reverse a few if blocks and return earlier, improving readability and reducing indentations.

Part of #32564

Fixes #32877.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
