### PR TITLE
Pin debezium test container version

### DIFF
--- a/sdks/go/test/integration/io/xlang/debezium/debezium_test.go
+++ b/sdks/go/test/integration/io/xlang/debezium/debezium_test.go
@@ -34,7 +34,9 @@ import (
 )
 
 const (
-	debeziumImage = "debezium/example-postgres:latest"
+	// TODO(https://github.com/apache/beam/issues/32937): use latest tag once a
+	// container exists again
+	debeziumImage = "debezium/example-postgres:3.0.0.final"
 	debeziumPort  = "5432/tcp"
 	maxRetries    = 5
 )

--- a/sdks/go/test/integration/io/xlang/debezium/debezium_test.go
+++ b/sdks/go/test/integration/io/xlang/debezium/debezium_test.go
@@ -36,7 +36,7 @@ import (
 const (
 	// TODO(https://github.com/apache/beam/issues/32937): use latest tag once a
 	// container exists again
-	debeziumImage = "debezium/example-postgres:3.0.0.final"
+	debeziumImage = "debezium/example-postgres:3.0.0.Final"
 	debeziumPort  = "5432/tcp"
 	maxRetries    = 5
 )

--- a/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumIOPostgresSqlConnectorIT.java
+++ b/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumIOPostgresSqlConnectorIT.java
@@ -56,7 +56,7 @@ public class DebeziumIOPostgresSqlConnectorIT {
   @ClassRule
   public static final PostgreSQLContainer<?> POSTGRES_SQL_CONTAINER =
       // TODO(https://github.com/apache/beam/issues/32937): use latest tag once
-	  // a container exists again
+      // a container exists again
       new PostgreSQLContainer<>(
               DockerImageName.parse("debezium/example-postgres:3.0.0.Final")
                   .asCompatibleSubstituteFor("postgres"))

--- a/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumIOPostgresSqlConnectorIT.java
+++ b/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumIOPostgresSqlConnectorIT.java
@@ -55,8 +55,10 @@ public class DebeziumIOPostgresSqlConnectorIT {
    */
   @ClassRule
   public static final PostgreSQLContainer<?> POSTGRES_SQL_CONTAINER =
+      // TODO(https://github.com/apache/beam/issues/32937): use latest tag once
+	  // a container exists again
       new PostgreSQLContainer<>(
-              DockerImageName.parse("debezium/example-postgres:latest")
+              DockerImageName.parse("debezium/example-postgres:3.0.0.final")
                   .asCompatibleSubstituteFor("postgres"))
           .withPassword("dbz")
           .withUsername("debezium")

--- a/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumIOPostgresSqlConnectorIT.java
+++ b/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumIOPostgresSqlConnectorIT.java
@@ -58,7 +58,7 @@ public class DebeziumIOPostgresSqlConnectorIT {
       // TODO(https://github.com/apache/beam/issues/32937): use latest tag once
 	  // a container exists again
       new PostgreSQLContainer<>(
-              DockerImageName.parse("debezium/example-postgres:3.0.0.final")
+              DockerImageName.parse("debezium/example-postgres:3.0.0.Final")
                   .asCompatibleSubstituteFor("postgres"))
           .withPassword("dbz")
           .withUsername("debezium")

--- a/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumReadSchemaTransformTest.java
+++ b/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumReadSchemaTransformTest.java
@@ -45,8 +45,10 @@ public class DebeziumReadSchemaTransformTest {
 
   @ClassRule
   public static final PostgreSQLContainer<?> POSTGRES_SQL_CONTAINER =
+      // TODO(https://github.com/apache/beam/issues/32937): use latest tag once
+	    // a container exists again
       new PostgreSQLContainer<>(
-              DockerImageName.parse("debezium/example-postgres:latest")
+              DockerImageName.parse("debezium/example-postgres:3.0.0.final")
                   .asCompatibleSubstituteFor("postgres"))
           .withPassword("dbz")
           .withUsername("debezium")

--- a/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumReadSchemaTransformTest.java
+++ b/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumReadSchemaTransformTest.java
@@ -46,7 +46,7 @@ public class DebeziumReadSchemaTransformTest {
   @ClassRule
   public static final PostgreSQLContainer<?> POSTGRES_SQL_CONTAINER =
       // TODO(https://github.com/apache/beam/issues/32937): use latest tag once
-	    // a container exists again
+      // a container exists again
       new PostgreSQLContainer<>(
               DockerImageName.parse("debezium/example-postgres:3.0.0.Final")
                   .asCompatibleSubstituteFor("postgres"))

--- a/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumReadSchemaTransformTest.java
+++ b/sdks/java/io/debezium/src/test/java/org/apache/beam/io/debezium/DebeziumReadSchemaTransformTest.java
@@ -48,7 +48,7 @@ public class DebeziumReadSchemaTransformTest {
       // TODO(https://github.com/apache/beam/issues/32937): use latest tag once
 	    // a container exists again
       new PostgreSQLContainer<>(
-              DockerImageName.parse("debezium/example-postgres:3.0.0.final")
+              DockerImageName.parse("debezium/example-postgres:3.0.0.Final")
                   .asCompatibleSubstituteFor("postgres"))
           .withPassword("dbz")
           .withUsername("debezium")

--- a/sdks/python/apache_beam/io/external/xlang_debeziumio_it_test.py
+++ b/sdks/python/apache_beam/io/external/xlang_debeziumio_it_test.py
@@ -102,12 +102,13 @@ class CrossLanguageDebeziumIOTest(unittest.TestCase):
 
 # Creating a container with testcontainers sometimes raises ReadTimeout
 # error. In java there are 2 retries set by default.
-
+# TODO(https://github.com/apache/beam/issues/32937): use latest tag once a 
+# container exists again
   def start_db_container(self, retries):
     for i in range(retries):
       try:
         self.db = PostgresContainer(
-            'debezium/example-postgres:latest',
+            'debezium/example-postgres:3.0.0.final',
             user=self.username,
             password=self.password,
             dbname=self.database)

--- a/sdks/python/apache_beam/io/external/xlang_debeziumio_it_test.py
+++ b/sdks/python/apache_beam/io/external/xlang_debeziumio_it_test.py
@@ -102,8 +102,9 @@ class CrossLanguageDebeziumIOTest(unittest.TestCase):
 
 # Creating a container with testcontainers sometimes raises ReadTimeout
 # error. In java there are 2 retries set by default.
-# TODO(https://github.com/apache/beam/issues/32937): use latest tag once a 
+# TODO(https://github.com/apache/beam/issues/32937): use latest tag once a
 # container exists again
+
   def start_db_container(self, retries):
     for i in range(retries):
       try:

--- a/sdks/python/apache_beam/io/external/xlang_debeziumio_it_test.py
+++ b/sdks/python/apache_beam/io/external/xlang_debeziumio_it_test.py
@@ -108,7 +108,7 @@ class CrossLanguageDebeziumIOTest(unittest.TestCase):
     for i in range(retries):
       try:
         self.db = PostgresContainer(
-            'debezium/example-postgres:3.0.0.final',
+            'debezium/example-postgres:3.0.0.Final',
             user=self.username,
             password=self.password,
             dbname=self.database)


### PR DESCRIPTION
Pins the `debezium/example-postgres` container to version `3.0.0.Final` as there currently isn't a `latest` tagged container and this is causing workflows to fail.

Fixes #32936

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
