### PR TITLE
Don't swallow BQ file loads writer errors 

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteBundlesToFiles.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/WriteBundlesToFiles.java
@@ -297,19 +297,15 @@ class WriteBundlesToFiles<DestinationT extends @NonNull Object, ElementT>
     }
 
     for (Map.Entry<DestinationT, BigQueryRowWriter<ElementT>> entry : writers.entrySet()) {
-      try {
-        DestinationT destination = entry.getKey();
-        BigQueryRowWriter<ElementT> writer = entry.getValue();
-        BigQueryRowWriter.Result result = writer.getResult();
-        BoundedWindow window = writerWindows.get(destination);
-        Preconditions.checkStateNotNull(window);
-        c.output(
-            new Result<>(result.resourceId.toString(), result.byteSize, destination),
-            window.maxTimestamp(),
-            window);
-      } catch (Exception e) {
-        exceptionList.add(e);
-      }
+      DestinationT destination = entry.getKey();
+      BigQueryRowWriter<ElementT> writer = entry.getValue();
+      BigQueryRowWriter.Result result = writer.getResult();
+      BoundedWindow window = writerWindows.get(destination);
+      Preconditions.checkStateNotNull(window);
+      c.output(
+          new Result<>(result.resourceId.toString(), result.byteSize, destination),
+          window.maxTimestamp(),
+          window);
     }
     writers.clear();
   }


### PR DESCRIPTION
Investigating an issue that is causing our WriteBundlesToFiles to swallow errors. In the worst case, this can lead to data-loss because we don't retry these errors. This is a potential candidate for where this swallowing might happen. We're also realizing it doesn't make too much sense to put a try-block here