### PR TITLE
[Java Harness] Improve heap dump support by configuring JVM to dump heap on OOM exceptions

### DIFF
--- a/sdks/java/container/boot.go
+++ b/sdks/java/container/boot.go
@@ -222,6 +222,18 @@ func main() {
 	} else {
 		args = append(args, jammAgentArgs)
 	}
+
+	// If heap dumping is enabled, configure the JVM to dump it on oom events.
+	if pipelineOptions, ok := info.GetPipelineOptions().GetFields()["options"]; ok {
+		if heapDumpOption, ok := pipelineOptions.GetStructValue().GetFields()["enableHeapDumps"]; ok {
+			if heapDumpOption.GetBoolValue() {
+			  args = append(args, "-XX:+HeapDumpOnOutOfMemoryError",
+			                "-Dbeam.fn.heap_dump_dir="+filepath.Join(dir, "heapdumps"),
+			                "-XX:HeapDumpPath="+filepath.Join(dir, "heapdumps", "heap_dump.hprof"))
+			}
+		}
+	}
+
 	// Apply meta options
 	const metaDir = "/opt/apache/beam/options"
 

--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/options/MemoryMonitorOptions.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/options/MemoryMonitorOptions.java
@@ -36,4 +36,25 @@ public interface MemoryMonitorOptions extends PipelineOptions {
   Double getGCThrashingPercentagePerPeriod();
 
   void setGCThrashingPercentagePerPeriod(Double value);
+
+  /**
+   * A remote file system to upload captured heap dumps to. If not provided defaults to
+   * --tempLocation.
+   *
+   * <p>This can be a path of any file system.
+   */
+  @Description("A remote file system to upload captured heap dumps to.")
+  String getRemoteHeapDumpLocation();
+
+  void setRemoteHeapDumpLocation(String value);
+
+  /**
+   * Controls if heap dumps that are copied to remote destination are gzipped compressed. This can
+   * greatly reduce the data copied and speed up the time to copy heap dumps.
+   */
+  @Description("A remote file system to upload captured heap dumps to.")
+  @Default.Boolean(true)
+  boolean getGzipCompressHeapDumps();
+
+  void setGzipCompressHeapDumps(boolean value);
 }

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/status/MemoryMonitorTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/status/MemoryMonitorTest.java
@@ -233,7 +233,8 @@ public class MemoryMonitorTest {
                 .create());
     if (ioLocalTempDir != null) {
       assertTrue(m.canDumpHeap);
-      assertEquals(ioLocalTempDir, m.localDumpFolder.toString());
+      assertEquals(
+          new File(ioLocalTempDir).getCanonicalPath(), m.localDumpFolder.getCanonicalPath());
     } else {
       // If the generic temp directory property isn't set it will be disabled.
       assertFalse(m.canDumpHeap);

--- a/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/status/MemoryMonitorTest.java
+++ b/sdks/java/harness/src/test/java/org/apache/beam/fn/harness/status/MemoryMonitorTest.java
@@ -18,16 +18,22 @@
 package org.apache.beam.fn.harness.status;
 
 import static org.hamcrest.MatcherAssert.assertThat;
+import static org.junit.Assert.assertEquals;
 import static org.junit.Assert.assertFalse;
 import static org.junit.Assert.assertNotNull;
 import static org.junit.Assert.assertTrue;
 
 import java.io.File;
+import java.io.FileInputStream;
 import java.io.IOException;
 import java.util.concurrent.Semaphore;
 import java.util.concurrent.TimeUnit;
 import java.util.concurrent.atomic.AtomicBoolean;
+import java.util.zip.GZIPInputStream;
+import org.apache.beam.sdk.options.PipelineOptionsFactory;
+import org.checkerframework.checker.nullness.qual.Nullable;
 import org.hamcrest.Matchers;
+import org.junit.After;
 import org.junit.Before;
 import org.junit.Rule;
 import org.junit.Test;
@@ -61,21 +67,25 @@ public class MemoryMonitorTest {
 
   private FakeGCStatsProvider provider;
   private File localDumpFolder;
-  private MemoryMonitor monitor;
-  private Thread thread;
 
   @Before
   public void setup() throws IOException {
     provider = new FakeGCStatsProvider();
     localDumpFolder = tempFolder.newFolder();
-    // Update every 10ms, never shutdown VM.
-    monitor = MemoryMonitor.forTest(provider, 10, 0, false, 50.0, null, localDumpFolder);
-    thread = new Thread(monitor);
-    thread.start();
+  }
+
+  @After
+  public void tearDown() {
+    System.clearProperty(MemoryMonitor.LOCAL_HEAPDUMP_DIR_SYSTEM_PROPERTY_NAME);
   }
 
   @Test(timeout = 1000)
   public void detectGCThrashing() throws InterruptedException {
+    // Update every 10ms, never shutdown VM.
+    MemoryMonitor monitor =
+        MemoryMonitor.forTest(provider, 10, 0, false, 50.0, null, localDumpFolder, false);
+    Thread thread = new Thread(monitor);
+    thread.start();
     monitor.waitForRunning();
     monitor.waitForResources("Test1");
     provider.inGCThrashingState.set(true);
@@ -92,38 +102,41 @@ public class MemoryMonitorTest {
     monitor.waitForThrashingState(false);
     assertTrue(s.tryAcquire(100, TimeUnit.MILLISECONDS));
     monitor.waitForResources("Test3");
+    monitor.stop();
+    thread.join();
   }
 
   @Test
   public void heapDumpOnce() throws Exception {
-    File folder = tempFolder.newFolder();
-
-    File dump1 = MemoryMonitor.dumpHeap(folder);
+    MemoryMonitor monitor =
+        MemoryMonitor.forTest(provider, 10, 0, true, 50.0, null, localDumpFolder, false);
+    File dump1 = monitor.dumpHeap();
     assertNotNull(dump1);
     assertTrue(dump1.exists());
-    assertThat(dump1.getParentFile(), Matchers.equalTo(folder));
+    assertThat(dump1.getParentFile(), Matchers.equalTo(localDumpFolder));
   }
 
   @Test
   public void heapDumpTwice() throws Exception {
-    File folder = tempFolder.newFolder();
-
-    File dump1 = MemoryMonitor.dumpHeap(folder);
+    MemoryMonitor monitor =
+        MemoryMonitor.forTest(provider, 10, 0, true, 50.0, null, localDumpFolder, false);
+    File dump1 = monitor.dumpHeap();
     assertNotNull(dump1);
     assertTrue(dump1.exists());
-    assertThat(dump1.getParentFile(), Matchers.equalTo(folder));
+    assertThat(dump1.getParentFile(), Matchers.equalTo(localDumpFolder));
 
-    File dump2 = MemoryMonitor.dumpHeap(folder);
+    File dump2 = monitor.dumpHeap();
     assertNotNull(dump2);
     assertTrue(dump2.exists());
-    assertThat(dump2.getParentFile(), Matchers.equalTo(folder));
+    assertThat(dump2.getParentFile(), Matchers.equalTo(localDumpFolder));
   }
 
   @Test
   public void uploadFile() throws Exception {
     File remoteFolder = tempFolder.newFolder();
-    monitor =
-        MemoryMonitor.forTest(provider, 10, 0, true, 50.0, remoteFolder.getPath(), localDumpFolder);
+    MemoryMonitor monitor =
+        MemoryMonitor.forTest(
+            provider, 10, 0, true, 50.0, remoteFolder.getPath(), localDumpFolder, false);
 
     // Force the monitor to generate a local heap dump
     monitor.dumpHeap();
@@ -138,8 +151,33 @@ public class MemoryMonitorTest {
   }
 
   @Test
+  public void uploadFileGzip() throws Exception {
+    File remoteFolder = tempFolder.newFolder();
+    MemoryMonitor monitor =
+        MemoryMonitor.forTest(
+            provider, 10, 0, true, 50.0, remoteFolder.getPath(), localDumpFolder, true);
+
+    // Force the monitor to generate a local heap dump
+    monitor.dumpHeap();
+
+    // Try to upload the heap dump
+    assertTrue(monitor.tryUploadHeapDumpIfItExists());
+
+    File[] files = remoteFolder.listFiles();
+    assertThat(files, Matchers.arrayWithSize(1));
+    assertThat(files[0].getAbsolutePath(), Matchers.containsString("heap_dump"));
+    assertThat(files[0].getAbsolutePath(), Matchers.containsString("hprof.gz"));
+
+    try (FileInputStream f = new FileInputStream(files[0]);
+        GZIPInputStream g = new GZIPInputStream(f)) {
+      assertThat(g.read(), Matchers.not(Matchers.is(-1)));
+    }
+  }
+
+  @Test
   public void uploadFileDisabled() throws Exception {
-    monitor = MemoryMonitor.forTest(provider, 10, 0, true, 50.0, null, localDumpFolder);
+    MemoryMonitor monitor =
+        MemoryMonitor.forTest(provider, 10, 0, true, 50.0, null, localDumpFolder, false);
 
     // Force the monitor to generate a local heap dump
     monitor.dumpHeap();
@@ -150,8 +188,14 @@ public class MemoryMonitorTest {
 
   @Test
   public void disableMemoryMonitor() throws Exception {
+    // Update every 10ms, never shutdown VM.
+    MemoryMonitor monitor =
+        MemoryMonitor.forTest(provider, 10, 0, false, 50.0, null, localDumpFolder, false);
+    Thread thread = new Thread(monitor);
+    thread.start();
+
     MemoryMonitor disabledMonitor =
-        MemoryMonitor.forTest(provider, 10, 0, true, 100.0, null, localDumpFolder);
+        MemoryMonitor.forTest(provider, 10, 0, true, 100.0, null, localDumpFolder, false);
     Thread disabledMonitorThread = new Thread(disabledMonitor);
     disabledMonitorThread.start();
 
@@ -162,5 +206,116 @@ public class MemoryMonitorTest {
 
     // Enabled monitor thread should still be running.
     assertTrue(thread.isAlive());
+    monitor.stop();
+    thread.join();
+  }
+
+  @Test
+  public void fromOptions_DefaultOff() throws Exception {
+    MemoryMonitor m = MemoryMonitor.fromOptions(PipelineOptionsFactory.fromArgs("").create());
+    assertFalse(m.canDumpHeap);
+  }
+
+  @Test
+  public void fromOptions_NoUploadLocationOff() throws Exception {
+    // No remote location specified.
+    MemoryMonitor m =
+        MemoryMonitor.fromOptions(PipelineOptionsFactory.fromArgs("--enableHeapDumps").create());
+    assertFalse(m.canDumpHeap);
+  }
+
+  @Test
+  public void fromOptions_EnabledAndUploadLocation() throws Exception {
+    @Nullable String ioLocalTempDir = System.getProperty("java.io.tmpdir");
+    MemoryMonitor m =
+        MemoryMonitor.fromOptions(
+            PipelineOptionsFactory.fromArgs("--enableHeapDumps", "--tempLocation=gs://temp/heaps")
+                .create());
+    if (ioLocalTempDir != null) {
+      assertTrue(m.canDumpHeap);
+      assertEquals(ioLocalTempDir, m.localDumpFolder.toString());
+    } else {
+      // If the generic temp directory property isn't set it will be disabled.
+      assertFalse(m.canDumpHeap);
+    }
+  }
+
+  @Test
+  public void fromOptions_EnabledSpecificPropertySetNoRemote() throws Exception {
+    System.setProperty(
+        MemoryMonitor.LOCAL_HEAPDUMP_DIR_SYSTEM_PROPERTY_NAME, localDumpFolder.toString());
+    MemoryMonitor m =
+        MemoryMonitor.fromOptions(PipelineOptionsFactory.fromArgs("--enableHeapDumps").create());
+    assertFalse(m.canDumpHeap);
+  }
+
+  @Test
+  public void fromOptions_SuccessfullyEnabledWithTemp() throws Exception {
+    System.setProperty(
+        MemoryMonitor.LOCAL_HEAPDUMP_DIR_SYSTEM_PROPERTY_NAME, localDumpFolder.toString());
+    MemoryMonitor m =
+        MemoryMonitor.fromOptions(
+            PipelineOptionsFactory.fromArgs("--enableHeapDumps", "--tempLocation=gs://temp/heaps")
+                .create());
+    assertTrue(m.canDumpHeap);
+    assertEquals(localDumpFolder, m.localDumpFolder);
+    assertEquals("gs://temp/heaps", m.uploadFilePath);
+    assertTrue(m.gzipCompress);
+  }
+
+  @Test
+  public void fromOptions_SuccessfullyEnabledWithSpecific() throws Exception {
+    System.setProperty(
+        MemoryMonitor.LOCAL_HEAPDUMP_DIR_SYSTEM_PROPERTY_NAME, localDumpFolder.toString());
+    MemoryMonitor m =
+        MemoryMonitor.fromOptions(
+            PipelineOptionsFactory.fromArgs(
+                    "--enableHeapDumps", "--remoteHeapDumpLocation=gs://temp/heaps")
+                .create());
+    assertTrue(m.canDumpHeap);
+    assertEquals(localDumpFolder, m.localDumpFolder);
+    assertEquals("gs://temp/heaps", m.uploadFilePath);
+    assertTrue(m.gzipCompress);
+  }
+
+  @Test
+  public void fromOptions_SuccessfullyEnabledDisableGzip() throws Exception {
+    System.setProperty(
+        MemoryMonitor.LOCAL_HEAPDUMP_DIR_SYSTEM_PROPERTY_NAME, localDumpFolder.toString());
+    MemoryMonitor m =
+        MemoryMonitor.fromOptions(
+            PipelineOptionsFactory.fromArgs(
+                    "--enableHeapDumps",
+                    "--tempLocation=gs://temp/heaps",
+                    "--gzipCompressHeapDumps=false")
+                .create());
+    assertTrue(m.canDumpHeap);
+    assertEquals(localDumpFolder, m.localDumpFolder);
+    assertEquals("gs://temp/heaps", m.uploadFilePath);
+    assertFalse(m.gzipCompress);
+  }
+
+  @Test
+  public void fromOptions_heapDumpToNonexistentDir() throws Exception {
+    File subfolder = localDumpFolder.toPath().resolve("subfolder_for_dumps").toFile();
+    File remoteFolder = tempFolder.newFolder();
+    System.setProperty(MemoryMonitor.LOCAL_HEAPDUMP_DIR_SYSTEM_PROPERTY_NAME, subfolder.toString());
+    MemoryMonitor m =
+        MemoryMonitor.fromOptions(
+            PipelineOptionsFactory.fromArgs(
+                    "--enableHeapDumps", "--remoteHeapDumpLocation=" + remoteFolder)
+                .create());
+    assertTrue(m.canDumpHeap);
+    assertEquals(subfolder, m.localDumpFolder);
+    assertEquals(remoteFolder.toString(), m.uploadFilePath);
+    assertTrue(m.gzipCompress);
+
+    m.dumpHeap();
+    // Try to upload the heap dump
+    assertTrue(m.tryUploadHeapDumpIfItExists());
+    File[] files = remoteFolder.listFiles();
+    assertThat(files, Matchers.arrayWithSize(1));
+    assertThat(files[0].getAbsolutePath(), Matchers.containsString("heap_dump"));
+    assertThat(files[0].getAbsolutePath(), Matchers.containsString("hprof"));
   }
 }


### PR DESCRIPTION
This configures the boot script to use JVM flags so that it dumps heaps to a directory that the MemoryMonitor will look in.

Other improvements are made to:
- allow configuring remote upload location separately from tempLocation 
- add default-on support to gzip uploads to speed them up

These changes were tested with a manual dataflow test with a pipeline that leaked memory.
I confirmed that files were successfully dumped by the JVM and then uploaded.  Unzipping and loading the hprof files in VisualVM was successful in identifying the objects pinning memory and leading to OOMs.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
