### PR TITLE
Support caching in Apache Beam by using relative co_filename paths.

### DIFF
--- a/sdks/python/apache_beam/internal/pickler_test.py
+++ b/sdks/python/apache_beam/internal/pickler_test.py
@@ -94,6 +94,14 @@ class PicklerTest(unittest.TestCase):
 
     self.assertIsInstance(loads(dumps(rlock_instance)), rlock_type)
 
+  # MOE:begin_strip
+  def test_save_paths(self):
+    f = loads(dumps(lambda x: x))
+    co_filename = f.__code__.co_filename
+    self.assertTrue(co_filename.endswith('pickler_test.py'))
+
+  # MOE:end_strip
+
   @unittest.skipIf(NO_MAPPINGPROXYTYPE, 'test if MappingProxyType introduced')
   def test_dump_and_load_mapping_proxy(self):
     self.assertEqual(


### PR DESCRIPTION
Apache Beam does the following:
- Pickle Python code
- Send the pickled source code to "worker" VMs
- The workers unpickle and execute the code

In the environment that these Beam pipelines execute, the source code is in a temporary directory whose name is random and changes. The source code paths relative to the temporary directory are constant. Using absolute paths prevents pickled code from being cached because the absolute path keeps changing. Using relative paths enables this caching and promises significant resource savings and speed-ups.

Additionally the absolute paths leak information about the directory structure of the machine pickling the source code. When the pickled code is passed across the network to another machine, the absolute paths may no longer be valid when the other machine has a different directory structure.

The reason for using relative paths rather than omitting the path entirely is because Python uses the co_filename attribute to create stack traces.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
