### PR TITLE
Revert "Bump Flink and Spark job server container base imager to tumerin-11"

### DIFF
--- a/.github/trigger_files/beam_PostCommit_Java_PVR_Flink_Batch.json
+++ b/.github/trigger_files/beam_PostCommit_Java_PVR_Flink_Batch.json
@@ -1,4 +1,4 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run",
-  "modification": 2
+  "modification": 1
 }

--- a/.github/trigger_files/beam_PostCommit_Java_PVR_Flink_Docker.json
+++ b/.github/trigger_files/beam_PostCommit_Java_PVR_Flink_Docker.json
@@ -1,4 +1,4 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run",
-  "modification": "1"
+  "https://github.com/apache/beam/pull/31156": "noting that PR #31156 should run this test"
 }

--- a/.github/trigger_files/beam_PostCommit_Java_PVR_Spark3_Streaming.json
+++ b/.github/trigger_files/beam_PostCommit_Java_PVR_Spark3_Streaming.json
@@ -1,4 +1,4 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run",
-  "modification": 3
+  "modification": 1
 }

--- a/.github/trigger_files/beam_PostCommit_Java_PVR_Spark_Batch.json
+++ b/.github/trigger_files/beam_PostCommit_Java_PVR_Spark_Batch.json
@@ -1,4 +1,4 @@
 {
   "comment": "Modify this file in a trivial way to cause this test suite to run",
-  "modification": 4
+  "modification": 1
 }

--- a/.github/trigger_files/beam_PostCommit_XVR_Direct.json
+++ b/.github/trigger_files/beam_PostCommit_XVR_Direct.json
@@ -1,0 +1,4 @@
+{
+    "comment": "Modify this file in a trivial way to cause this test suite to run",
+    "modification": 1
+}

--- a/runners/flink/job-server-container/Dockerfile
+++ b/runners/flink/job-server-container/Dockerfile
@@ -16,7 +16,7 @@
 # limitations under the License.
 ###############################################################################
 
-FROM eclipse-temurin:11
+FROM openjdk:8
 MAINTAINER "Apache Beam <dev@beam.apache.org>"
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libltdl7

--- a/runners/spark/job-server/container/Dockerfile
+++ b/runners/spark/job-server/container/Dockerfile
@@ -16,7 +16,7 @@
 # limitations under the License.
 ###############################################################################
 
-FROM eclipse-temurin:11
+FROM openjdk:8
 MAINTAINER "Apache Beam <dev@beam.apache.org>"
 
 RUN apt-get update && DEBIAN_FRONTEND=noninteractive apt-get install -y libltdl7


### PR DESCRIPTION
Reverts apache/beam#32976

It looks like this may be causing https://github.com/apache/beam/issues/30517 - trying reverting to see