### PR TITLE
fix JDBC providers

### DIFF
--- a/sdks/python/apache_beam/yaml/standard_io.yaml
+++ b/sdks/python/apache_beam/yaml/standard_io.yaml
@@ -235,21 +235,21 @@
       'WriteToSqlServer': 'WriteToJdbc'
     defaults:
       'ReadFromMySql':
-        jdbcType: 'mysql'
+        jdbc_type: 'mysql'
       'WriteToMySql':
-        jdbcType: 'mysql'
+        jdbc_type: 'mysql'
       'ReadFromPostgres':
-        jdbcType: 'postgres'
+        jdbc_type: 'postgres'
       'WriteToPostgres':
-        jdbcType: 'postgres'
+        jdbc_type: 'postgres'
       'ReadFromOracle':
-        jdbcType: 'oracle'
+        jdbc_type: 'oracle'
       'WriteToOracle':
-        jdbcType: 'oracle'
+        jdbc_type: 'oracle'
       'ReadFromSqlServer':
-        jdbcType: 'mssql'
+        jdbc_type: 'mssql'
       'WriteToSqlServer':
-        jdbcType: 'mssql'
+        jdbc_type: 'mssql'
     underlying_provider:
       type: beamJar
       transforms:

--- a/sdks/python/apache_beam/yaml/tests/map.yaml
+++ b/sdks/python/apache_beam/yaml/tests/map.yaml
@@ -42,6 +42,6 @@ pipelines:
 
         - type: AssertEqual
           config:
-            element
+            elements:
               - {element: 100, named_field: 100, literal_int: 10, literal_float: 1.5, literal_str: "abc"}
               - {element: 200, named_field: 200, literal_int: 10, literal_float: 1.5, literal_str: "abc"}

--- a/sdks/python/apache_beam/yaml/tests/map.yaml
+++ b/sdks/python/apache_beam/yaml/tests/map.yaml
@@ -42,6 +42,6 @@ pipelines:
 
         - type: AssertEqual
           config:
-            elements:
+            element
               - {element: 100, named_field: 100, literal_int: 10, literal_float: 1.5, literal_str: "abc"}
               - {element: 200, named_field: 200, literal_int: 10, literal_float: 1.5, literal_str: "abc"}


### PR DESCRIPTION
Refactor standard_io.yaml to use snake_case for JDBC providers.

There was a change to the naming convention used by the cross-language service here: https://github.com/apache/beam/pull/31374/
which also migrated most of the YAML provider definitions to use the new format. Unfortunately, JDBC providers that inherit the top-level JDBC Provider (MySQL, Postgres, Oracle and Sql Server) were missed. This causes YAML pipelines who use these transforms to fail when the `jdbc_type` (formerly `jdbcType`) config parameter is parsed during expansion.

This PR refactors these transform config parameters to use the new snake_case naming convention.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
