### PR TITLE
[KafkaIO] Decouple consumer threads from harness threads

### DIFF
--- a/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/ConcurrentConsumer.java
+++ b/sdks/java/io/kafka/src/main/java/org/apache/beam/sdk/io/kafka/ConcurrentConsumer.java
@@ -1,0 +1,231 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one
+ * or more contributor license agreements.  See the NOTICE file
+ * distributed with this work for additional information
+ * regarding copyright ownership.  The ASF licenses this file
+ * to you under the Apache License, Version 2.0 (the
+ * "License"); you may not use this file except in compliance
+ * with the License.  You may obtain a copy of the License at
+ *
+ *     http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package org.apache.beam.sdk.io.kafka;
+
+import static org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Preconditions.checkState;
+
+import java.time.Duration;
+import java.util.Collections;
+import java.util.List;
+import java.util.Map;
+import java.util.Set;
+import java.util.concurrent.ConcurrentHashMap;
+import java.util.concurrent.Phaser;
+import java.util.function.Supplier;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.base.Suppliers;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.AtomicLongMap;
+import org.apache.kafka.clients.consumer.Consumer;
+import org.apache.kafka.clients.consumer.ConsumerRecord;
+import org.apache.kafka.clients.consumer.ConsumerRecords;
+import org.apache.kafka.clients.consumer.OffsetAndTimestamp;
+import org.apache.kafka.common.Metric;
+import org.apache.kafka.common.MetricName;
+import org.apache.kafka.common.TopicPartition;
+import org.apache.kafka.common.errors.WakeupException;
+import org.checkerframework.checker.nullness.qual.Nullable;
+import org.slf4j.Logger;
+import org.slf4j.LoggerFactory;
+
+final class ConcurrentConsumer<K, V> implements AutoCloseable {
+  private static final Logger LOG = LoggerFactory.getLogger(ConcurrentConsumer.class);
+
+  private final ConsumerPhaser phaser;
+  private final Consumer<K, V> consumer;
+  private final Duration pollDuration;
+  private final AtomicLongMap<TopicPartition> times;
+  private final AtomicLongMap<TopicPartition> positions;
+  private final Supplier<Metric> recordsLagMax;
+  private final Map<TopicPartition, Supplier<Metric>> partitionRecordsLag;
+  private ConsumerRecords<K, V> pollResult;
+  private Map<TopicPartition, OffsetAndTimestamp> offsetsForTimesResult;
+
+  private final class ConsumerPhaser extends Phaser {
+    @Override
+    protected boolean onAdvance(final int phase, final int registeredParties) {
+      try {
+        final Map<TopicPartition, Long> positionsView = positions.asMap();
+        final Set<TopicPartition> prevAssignment = consumer.assignment();
+        final Set<TopicPartition> nextAssignment = positionsView.keySet();
+
+        if (!times.isEmpty()) {
+          offsetsForTimesResult = consumer.offsetsForTimes(times.asMap());
+          times.clear();
+        }
+
+        if (!prevAssignment.equals(nextAssignment)) {
+          consumer.assign(nextAssignment);
+        }
+
+        positionsView.forEach(
+            (tp, o) -> {
+              if (o == Long.MIN_VALUE) {
+                consumer.pause(Collections.singleton(tp));
+              } else if (!prevAssignment.contains(tp)) {
+                consumer.seek(tp, o);
+              }
+            });
+
+        if (consumer.paused().size() != nextAssignment.size()) {
+          pollResult = consumer.poll(pollDuration.toMillis());
+        }
+
+        nextAssignment.forEach(tp -> positions.put(tp, consumer.position(tp)));
+        return false;
+      } catch (WakeupException e) {
+        if (!this.isTerminated()) {
+          LOG.error("Unexpected wakeup while running", e);
+        }
+      } catch (Exception e) {
+        LOG.error("Exception while reading from Kafka", e);
+      }
+      return true;
+    }
+  }
+
+  ConcurrentConsumer(final Consumer<K, V> consumer, final Duration pollDuration) {
+    this.phaser = new ConsumerPhaser();
+    this.consumer = consumer;
+    this.pollDuration = pollDuration;
+    this.times = AtomicLongMap.create();
+    this.positions = AtomicLongMap.create();
+    this.recordsLagMax =
+        Suppliers.memoize(
+            () ->
+                this.consumer.metrics().values().stream()
+                    .filter(
+                        m ->
+                            "consumer-fetch-manager-metrics".equals(m.metricName().group())
+                                && "records-lag-max".equals(m.metricName().name())
+                                && !m.metricName().tags().containsKey("topic")
+                                && !m.metricName().tags().containsKey("partition"))
+                    .findAny()
+                    .get());
+    this.partitionRecordsLag = new ConcurrentHashMap<>();
+    this.pollResult = ConsumerRecords.empty();
+    this.offsetsForTimesResult = Collections.emptyMap();
+  }
+
+  @Override
+  public void close() {
+    this.phaser.forceTermination();
+    try {
+      this.consumer.wakeup();
+      this.consumer.close();
+    } catch (Exception e) {
+      LOG.error("Exception while closing Kafka consumer", e);
+    }
+    this.times.clear();
+    this.positions.clear();
+    this.pollResult = ConsumerRecords.empty();
+    this.offsetsForTimesResult = Collections.emptyMap();
+  }
+
+  boolean isClosed() {
+    return this.phaser.isTerminated();
+  }
+
+  Map<MetricName, ? extends Metric> metrics() {
+    return this.consumer.metrics();
+  }
+
+  long currentLagOrMaxLag(final TopicPartition topicPartition) {
+    final Supplier<Metric> metric =
+        this.partitionRecordsLag.getOrDefault(topicPartition, this.recordsLagMax);
+    try {
+      return ((Number) metric.get().metricValue()).longValue();
+    } catch (Exception e) {
+      return 0;
+    }
+  }
+
+  long position(final TopicPartition topicPartition) {
+    return this.positions.get(topicPartition) & Long.MAX_VALUE;
+  }
+
+  long initialOffsetForPartition(final TopicPartition topicPartition) {
+    // Offsets start at 0 and there is no position to advance to beyond Long.MAX_VALUE.
+    // The sign bit indicates that an assignment is paused.
+    checkState(this.phaser.register() >= 0);
+    this.positions.put(topicPartition, Long.MIN_VALUE);
+
+    // Synchronize and throw if the consumer was terminated in between.
+    checkState(this.phaser.arriveAndAwaitAdvance() >= 0);
+
+    // Removal will revoke the assignment when the phase advances.
+    final long result = this.positions.remove(topicPartition);
+
+    // Synchronize and ignore the consumer status since the result is already known.
+    this.phaser.arriveAndDeregister();
+
+    // Since Long.MIN_VALUE only has the sign bit set, this will return 0 as a default value if no
+    // position could be determined.
+    return result & Long.MAX_VALUE;
+  }
+
+  @Nullable
+  OffsetAndTimestamp initialOffsetForTime(final TopicPartition topicPartition, final long time) {
+    // Request the offset closest to the provided time.
+    checkState(this.phaser.register() >= 0);
+    this.times.put(topicPartition, time);
+
+    // Synchronize and throw if the consumer was terminated in between.
+    checkState(this.phaser.arriveAndAwaitAdvance() >= 0);
+    final Map<TopicPartition, OffsetAndTimestamp> result = this.offsetsForTimesResult;
+
+    // Synchronize and ignore the consumer status since the result is already known.
+    this.phaser.arriveAndDeregister();
+
+    return result.get(topicPartition);
+  }
+
+  void assignAndSeek(final TopicPartition topicPartition, final long offset) {
+    checkState(this.phaser.register() >= 0);
+
+    this.positions.put(topicPartition, offset);
+    this.partitionRecordsLag.computeIfAbsent(
+        topicPartition,
+        k ->
+            Suppliers.memoize(
+                () ->
+                    this.consumer.metrics().values().stream()
+                        .filter(
+                            m ->
+                                "consumer-fetch-manager-metrics".equals(m.metricName().group())
+                                    && "records-lag-max".equals(m.metricName().name())
+                                    && k.topic()
+                                        .replace('.', '_')
+                                        .equals(m.metricName().tags().get("topic"))
+                                    && Integer.toString(k.partition())
+                                        .equals(m.metricName().tags().get("partition")))
+                        .findAny()
+                        .get()));
+  }
+
+  List<ConsumerRecord<K, V>> poll(final TopicPartition topicPartition) {
+    checkState(this.phaser.arriveAndAwaitAdvance() >= 0);
+
+    return this.pollResult.records(topicPartition);
+  }
+
+  void unassign(final TopicPartition topicPartition) {
+    this.positions.remove(topicPartition);
+    this.partitionRecordsLag.remove(topicPartition);
+
+    this.phaser.arriveAndDeregister();
+  }
+}

--- a/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/ReadFromKafkaDoFnTest.java
+++ b/sdks/java/io/kafka/src/test/java/org/apache/beam/sdk/io/kafka/ReadFromKafkaDoFnTest.java
@@ -412,14 +412,14 @@ public class ReadFromKafkaDoFnTest {
 
   @Before
   public void setUp() throws Exception {
-    dofnInstance.setup();
-    exceptionDofnInstance.setup();
-    dofnInstanceWithBrokenSeek.setup();
+    dofnInstance.setup(PipelineOptionsFactory.create());
+    exceptionDofnInstance.setup(PipelineOptionsFactory.create());
+    dofnInstanceWithBrokenSeek.setup(PipelineOptionsFactory.create());
     consumer.reset();
   }
 
   @Test
-  public void testInitialRestrictionWhenHasStartOffset() throws Exception {
+  public void testInitialRestrictionWhenHasStartOffset() throws Throwable {
     long expectedStartOffset = 10L;
     consumer.setStartOffsetForTime(15L, Instant.now());
     consumer.setCurrentPos(5L);
@@ -431,7 +431,7 @@ public class ReadFromKafkaDoFnTest {
   }
 
   @Test
-  public void testInitialRestrictionWhenHasStopOffset() throws Exception {
+  public void testInitialRestrictionWhenHasStopOffset() throws Throwable {
     long expectedStartOffset = 10L;
     long expectedStopOffset = 20L;
     consumer.setStartOffsetForTime(15L, Instant.now());
@@ -450,7 +450,7 @@ public class ReadFromKafkaDoFnTest {
   }
 
   @Test
-  public void testInitialRestrictionWhenHasStartTime() throws Exception {
+  public void testInitialRestrictionWhenHasStartTime() throws Throwable {
     long expectedStartOffset = 10L;
     Instant startReadTime = Instant.now();
     consumer.setStartOffsetForTime(expectedStartOffset, startReadTime);
@@ -463,7 +463,7 @@ public class ReadFromKafkaDoFnTest {
   }
 
   @Test
-  public void testInitialRestrictionWhenHasStopTime() throws Exception {
+  public void testInitialRestrictionWhenHasStopTime() throws Throwable {
     long expectedStartOffset = 10L;
     Instant startReadTime = Instant.now();
     long expectedStopOffset = 100L;
@@ -479,7 +479,7 @@ public class ReadFromKafkaDoFnTest {
   }
 
   @Test
-  public void testInitialRestrictionWithConsumerPosition() throws Exception {
+  public void testInitialRestrictionWithConsumerPosition() throws Throwable {
     long expectedStartOffset = 5L;
     consumer.setCurrentPos(5L);
     OffsetRange result =
@@ -489,7 +489,7 @@ public class ReadFromKafkaDoFnTest {
   }
 
   @Test
-  public void testInitialRestrictionWithException() throws Exception {
+  public void testInitialRestrictionWithException() throws Throwable {
     thrown.expect(KafkaException.class);
     thrown.expectMessage("PositionException");
 
@@ -498,7 +498,7 @@ public class ReadFromKafkaDoFnTest {
   }
 
   @Test
-  public void testProcessElement() throws Exception {
+  public void testProcessElement() throws Throwable {
     MockMultiOutputReceiver receiver = new MockMultiOutputReceiver();
     consumer.setNumOfRecordsPerPoll(3L);
     long startOffset = 5L;
@@ -514,7 +514,7 @@ public class ReadFromKafkaDoFnTest {
   }
 
   @Test
-  public void testProcessElementWithEarlierOffset() throws Exception {
+  public void testProcessElementWithEarlierOffset() throws Throwable {
     MockMultiOutputReceiver receiver = new MockMultiOutputReceiver();
     consumerWithBrokenSeek.setNumOfRecordsPerPoll(6L);
     consumerWithBrokenSeek.setCurrentPos(0L);
@@ -532,7 +532,7 @@ public class ReadFromKafkaDoFnTest {
   }
 
   @Test
-  public void testRawSizeMetric() throws Exception {
+  public void testRawSizeMetric() throws Throwable {
     final int numElements = 1000;
     final int recordSize = 8; // The size of key and value is defined in SimpleMockKafkaConsumer.
     MetricsContainerImpl container = new MetricsContainerImpl("any");
@@ -558,7 +558,7 @@ public class ReadFromKafkaDoFnTest {
   }
 
   @Test
-  public void testProcessElementWithEmptyPoll() throws Exception {
+  public void testProcessElementWithEmptyPoll() throws Throwable {
     MockMultiOutputReceiver receiver = new MockMultiOutputReceiver();
     consumer.setNumOfRecordsPerPoll(-1);
     OffsetRangeTracker tracker = new OffsetRangeTracker(new OffsetRange(0L, Long.MAX_VALUE));
@@ -573,7 +573,7 @@ public class ReadFromKafkaDoFnTest {
   }
 
   @Test
-  public void testProcessElementWhenTopicPartitionIsRemoved() throws Exception {
+  public void testProcessElementWhenTopicPartitionIsRemoved() throws Throwable {
     MockMultiOutputReceiver receiver = new MockMultiOutputReceiver();
     consumer.setRemoved();
     consumer.setNumOfRecordsPerPoll(-1);
@@ -600,7 +600,7 @@ public class ReadFromKafkaDoFnTest {
   }
 
   @Test
-  public void testProcessElementWhenTopicPartitionIsStopped() throws Exception {
+  public void testProcessElementWhenTopicPartitionIsStopped() throws Throwable {
     MockMultiOutputReceiver receiver = new MockMultiOutputReceiver();
     ReadFromKafkaDoFn<String, String> instance =
         ReadFromKafkaDoFn.create(
@@ -616,7 +616,7 @@ public class ReadFromKafkaDoFnTest {
                     })
                 .build(),
             RECORDS);
-    instance.setup();
+    instance.setup(PipelineOptionsFactory.create());
     consumer.setNumOfRecordsPerPoll(10);
     OffsetRangeTracker tracker = new OffsetRangeTracker(new OffsetRange(0L, Long.MAX_VALUE));
     ProcessContinuation result =
@@ -630,7 +630,7 @@ public class ReadFromKafkaDoFnTest {
   }
 
   @Test
-  public void testProcessElementWithException() throws Exception {
+  public void testProcessElementWithException() throws Throwable {
     thrown.expect(KafkaException.class);
     thrown.expectMessage("SeekException");
 
@@ -646,7 +646,7 @@ public class ReadFromKafkaDoFnTest {
 
   @Test
   public void testProcessElementWithDeserializationExceptionDefaultRecordHandler()
-      throws Exception {
+      throws Throwable {
     thrown.expect(SerializationException.class);
     thrown.expectMessage("Intentional serialization exception");
 
@@ -658,7 +658,7 @@ public class ReadFromKafkaDoFnTest {
     ReadFromKafkaDoFn<String, String> dofnInstance =
         ReadFromKafkaDoFn.create(makeFailingReadSourceDescriptor(consumer), RECORDS);
 
-    dofnInstance.setup();
+    dofnInstance.setup(PipelineOptionsFactory.create());
 
     dofnInstance.processElement(
         KafkaSourceDescriptor.of(topicPartition, null, null, null, null, null),
@@ -672,7 +672,7 @@ public class ReadFromKafkaDoFnTest {
 
   @Test
   public void testProcessElementWithDeserializationExceptionRecordingRecordHandler()
-      throws Exception {
+      throws Throwable {
     MockMultiOutputReceiver receiver = new MockMultiOutputReceiver();
     OffsetRangeTracker tracker = new OffsetRangeTracker(new OffsetRange(0L, 1L));
 
@@ -687,7 +687,7 @@ public class ReadFromKafkaDoFnTest {
 
     ReadFromKafkaDoFn<String, String> dofnInstance = ReadFromKafkaDoFn.create(descriptors, RECORDS);
 
-    dofnInstance.setup();
+    dofnInstance.setup(PipelineOptionsFactory.create());
 
     dofnInstance.processElement(
         KafkaSourceDescriptor.of(topicPartition, null, null, null, null, null),
@@ -719,12 +719,12 @@ public class ReadFromKafkaDoFnTest {
     ReadSourceDescriptors<String, String> descriptors = makeReadSourceDescriptor(consumer);
     // default poll timeout = 1 scond
     ReadFromKafkaDoFn<String, String> dofnInstance = ReadFromKafkaDoFn.create(descriptors, RECORDS);
-    Assert.assertEquals(2L, dofnInstance.consumerPollingTimeout);
+    Assert.assertEquals(Duration.ofSeconds(2L), dofnInstance.consumerPollingTimeout);
     // updated timeout = 5 seconds
     descriptors = descriptors.withConsumerPollingTimeout(5L);
     ReadFromKafkaDoFn<String, String> dofnInstanceNew =
         ReadFromKafkaDoFn.create(descriptors, RECORDS);
-    Assert.assertEquals(5L, dofnInstanceNew.consumerPollingTimeout);
+    Assert.assertEquals(Duration.ofSeconds(5L), dofnInstanceNew.consumerPollingTimeout);
   }
 
   private BoundednessVisitor testBoundedness(


### PR DESCRIPTION
Allows a Kafka consumer to be used for bundled assignments. By decoupling consumers from splits and running them in separate threads the harness thread should be blocked less by the creation of network connections or outstanding polls. The consumer thread may prefetch a batch of records while the harness thread is processing the current record batch. Multiplexing assigned `TopicPartition`s onto a single consumer may improve utilization of the network connection. A follow up PR may introduce consumer pools for cases where a single consumer would become a bottleneck.

These changes to KafkaIO's SDF should meet or exceed the throughput performance of the unbounded source implementation. Attached are the throughput and backlog bytes graphs, shown on the left is KafkaIO's unbounded source on Dataflow (legacy) and shown on the right is KafkaIO's SDF with these changes on Dataflow (portability). The input is produced in GCP by a n2d-standard-16 machine at a rate of ~110 MiB/s to a topic with 500 partitions in a cluster hosted on Google Cloud Managed Service for Apache Kafka. The pipelines use a pool of up to 8 n2d-standard-2 machines each and the pipeline on the left was intentionally configured to not quite catch up with its backlog. It's possible that applying these changes to the unbounded source implementation may result in a slight uplift to throughput performance there as well.

![results](https://github.com/user-attachments/assets/a2f1d42d-a24c-4fbd-a34a-c1156e1f65b2)

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
