### PR TITLE
Add option to adjust ReadChangeStream API timeout to allow longer timeout for longer checkpoint durations

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
@@ -2114,8 +2114,6 @@ public class BigtableIO {
     private static final Duration DEFAULT_BACKLOG_REPLICATION_ADJUSTMENT =
         Duration.standardSeconds(30);
 
-    private static final Duration DEFAULT_READ_CHANGE_STREAM_TIMEOUT = Duration.standardSeconds(15);
-
     static ReadChangeStream create() {
       BigtableConfig config = BigtableConfig.builder().setValidate(true).build();
       BigtableConfig metadataTableconfig = BigtableConfig.builder().setValidate(true).build();
@@ -2481,21 +2479,13 @@ public class BigtableIO {
         backlogReplicationAdjustment = DEFAULT_BACKLOG_REPLICATION_ADJUSTMENT;
       }
 
-      Duration readChangeStreamTimeout = getReadChangeStreamTimeout();
-      if (readChangeStreamTimeout == null) {
-        readChangeStreamTimeout = DEFAULT_READ_CHANGE_STREAM_TIMEOUT;
-      }
-
       ActionFactory actionFactory = new ActionFactory();
       ChangeStreamMetrics metrics = new ChangeStreamMetrics();
       DaoFactory daoFactory =
           new DaoFactory(
-              bigtableConfig,
-              metadataTableConfig,
-              getTableId(),
-              metadataTableId,
-              changeStreamName,
-              readChangeStreamTimeout);
+              bigtableConfig, metadataTableConfig, getTableId(), metadataTableId, changeStreamName);
+
+      daoFactory.setReadChangeStreamTimeout(getReadChangeStreamTimeout());
 
       // Validate the configuration is correct before creating the pipeline, if required.
       try {
@@ -2610,14 +2600,7 @@ public class BigtableIO {
       tableId = MetadataTableAdminDao.DEFAULT_METADATA_TABLE_NAME;
     }
 
-    DaoFactory daoFactory =
-        new DaoFactory(
-            null,
-            bigtableConfig,
-            null,
-            tableId,
-            null,
-            ReadChangeStream.DEFAULT_READ_CHANGE_STREAM_TIMEOUT);
+    DaoFactory daoFactory = new DaoFactory(null, bigtableConfig, null, tableId, null);
 
     try {
       MetadataTableAdminDao metadataTableAdminDao = daoFactory.getMetadataTableAdminDao();

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
@@ -2360,8 +2360,8 @@ public class BigtableIO {
      * requests.
      *
      * <p>This is useful to override the default of 15s timeout if the checkpoint duration is longer
-     * than 15s. Setting this value to longer than periodic checkpoint duration ensures that
-     * ReadChangeStream will stream until the next checkpoint is initiated.
+     * than 15s. Setting this value to longer (to add some padding) than periodic checkpoint
+     * duration ensures that ReadChangeStream will stream until the next checkpoint is initiated.
      *
      * <p>Optional: defaults to 15 seconds.
      *

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIO.java
@@ -2484,7 +2484,6 @@ public class BigtableIO {
       DaoFactory daoFactory =
           new DaoFactory(
               bigtableConfig, metadataTableConfig, getTableId(), metadataTableId, changeStreamName);
-
       daoFactory.setReadChangeStreamTimeout(getReadChangeStreamTimeout());
 
       // Validate the configuration is correct before creating the pipeline, if required.

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dao/BigtableChangeStreamAccessor.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dao/BigtableChangeStreamAccessor.java
@@ -52,6 +52,7 @@ public class BigtableChangeStreamAccessor implements AutoCloseable {
   // Create one bigtable data/admin client per bigtable config (project/instance/table/app profile)
   private static final ConcurrentHashMap<BigtableConfig, BigtableChangeStreamAccessor>
       bigtableAccessors = new ConcurrentHashMap<>();
+  private static Duration readChangeStreamTimeout = Duration.ofSeconds(15);
 
   private final BigtableDataClient dataClient;
   private final BigtableTableAdminClient tableAdminClient;
@@ -81,6 +82,10 @@ public class BigtableChangeStreamAccessor implements AutoCloseable {
       instanceAdminClient.close();
     }
     bigtableAccessors.remove(bigtableConfig);
+  }
+
+  public static void setReadChangeStreamTimeout(Duration timeout) {
+    readChangeStreamTimeout = timeout;
   }
 
   /**
@@ -204,9 +209,9 @@ public class BigtableChangeStreamAccessor implements AutoCloseable {
         .readChangeStreamSettings()
         .setRetrySettings(
             readChangeStreamRetrySettings
-                .setInitialRpcTimeout(Duration.ofSeconds(15))
-                .setTotalTimeout(Duration.ofSeconds(15))
-                .setMaxRpcTimeout(Duration.ofSeconds(15))
+                .setInitialRpcTimeout(readChangeStreamTimeout)
+                .setTotalTimeout(readChangeStreamTimeout)
+                .setMaxRpcTimeout(readChangeStreamTimeout)
                 .setMaxAttempts(10)
                 .build());
 

--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dao/DaoFactory.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigtable/changestreams/dao/DaoFactory.java
@@ -47,7 +47,7 @@ public class DaoFactory implements Serializable, AutoCloseable {
   private final String metadataTableId;
   private final String changeStreamName;
 
-  @Nullable private Duration readChangeStreamTimeout;
+  private @Nullable Duration readChangeStreamTimeout;
 
   public DaoFactory(
       BigtableConfig changeStreamConfig,

--- a/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
+++ b/sdks/java/io/google-cloud-platform/src/test/java/org/apache/beam/sdk/io/gcp/bigtable/BigtableIOTest.java
@@ -2053,6 +2053,7 @@ public class BigtableIOTest {
             .withMetadataTableAppProfileId("metadata-app-profile")
             .withStartTime(startTime)
             .withBacklogReplicationAdjustment(Duration.standardMinutes(1))
+            .withReadChangeStreamTimeout(Duration.standardMinutes(1))
             .withCreateOrUpdateMetadataTable(false)
             .withExistingPipelineOptions(BigtableIO.ExistingPipelineOptions.FAIL_IF_EXISTS);
     assertEquals("project", readChangeStream.getBigtableConfig().getProjectId().get());
@@ -2071,6 +2072,7 @@ public class BigtableIOTest {
     assertEquals("change-stream-name", readChangeStream.getChangeStreamName());
     assertEquals(startTime, readChangeStream.getStartTime());
     assertEquals(Duration.standardMinutes(1), readChangeStream.getBacklogReplicationAdjustment());
+    assertEquals(Duration.standardMinutes(1), readChangeStream.getReadChangeStreamTimeout());
     assertEquals(false, readChangeStream.getCreateOrUpdateMetadataTable());
     assertEquals(
         BigtableIO.ExistingPipelineOptions.FAIL_IF_EXISTS,


### PR DESCRIPTION
This is useful if the runner's checkpoint duration is longer than 15s which is the default we set for ReadChangeStream API. If the runner's checkpoint duration is longer than 15s, the ReadChangeStream request will get deadline exceeded error before the runner initiated. This will cause the run to fail and return to the previous checkpoint.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
