### PR TITLE
Added replaceGcsFilesWithLocalFiles

### DIFF
--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -45,6 +45,7 @@ import java.io.IOException;
 import java.io.OutputStreamWriter;
 import java.io.PrintWriter;
 import java.nio.channels.Channels;
+import java.nio.channels.ReadableByteChannel;
 import java.util.ArrayList;
 import java.util.Arrays;
 import java.util.Collections;
@@ -185,6 +186,8 @@ import org.joda.time.DateTimeZone;
 import org.joda.time.format.DateTimeFormat;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.io.ByteStreams;
+import java.io.FileOutputStream;
 
 /**
  * A {@link PipelineRunner} that executes the operations in the pipeline by first translating them
@@ -257,6 +260,81 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
   /** Dataflow service endpoints are expected to match this pattern. */
   static final String ENDPOINT_REGEXP = "https://[\\S]*googleapis\\.com[/]?";
 
+
+  /**
+   * Replaces GCS file paths with local file paths by downloading the GCS files locally.
+   * This is useful when files need to be accessed locally before being staged to Dataflow.
+   *
+   * @param filesToStage List of file paths that may contain GCS paths (gs://) and local paths
+   * @return List of local file paths where any GCS paths have been downloaded locally
+   * @throws RuntimeException if there are errors copying GCS files locally
+   */
+  private List<String> replaceGcsFilesWithLocalFiles(List<String> filesToStage) {
+    List<String> processedFiles = new ArrayList<>();
+    
+    for (String fileToStage : filesToStage) {
+      String localPath;
+      if (fileToStage.contains("=")) {
+        // Handle files with staging name specified
+        String[] components = fileToStage.split("=", 2);
+        String stagingName = components[0];
+        String filePath = components[1];
+        
+        if (filePath.startsWith("gs://")) {
+          try {
+            // Create temp file with exact same name as GCS file
+            String gcsFileName = filePath.substring(filePath.lastIndexOf('/') + 1);
+            File tempDir = Files.createTempDir();
+            tempDir.deleteOnExit();
+            File tempFile = new File(tempDir, gcsFileName);
+            tempFile.deleteOnExit();
+            
+            // Copy GCS file to local temp file
+            ResourceId source = FileSystems.matchNewResource(filePath, false);
+            try (ReadableByteChannel reader = FileSystems.open(source);
+                 FileOutputStream writer = new FileOutputStream(tempFile)) {
+              ByteStreams.copy(Channels.newInputStream(reader), writer);
+            }
+            
+            localPath = stagingName + "=" + tempFile.getAbsolutePath();
+          } catch (IOException e) {
+            throw new RuntimeException("Failed to copy GCS file locally: " + filePath, e);
+          }
+        } else {
+          localPath = fileToStage;
+        }
+      } else {
+        // Handle files without staging name
+        if (fileToStage.startsWith("gs://")) {
+          try {
+            // Create temp file with exact same name as GCS file
+            String gcsFileName = fileToStage.substring(fileToStage.lastIndexOf('/') + 1);
+            File tempDir = Files.createTempDir();
+            tempDir.deleteOnExit();
+            File tempFile = new File(tempDir, gcsFileName);
+            tempFile.deleteOnExit();
+            
+            // Copy GCS file to local temp file
+            ResourceId source = FileSystems.matchNewResource(fileToStage, false);
+            try (ReadableByteChannel reader = FileSystems.open(source);
+                 FileOutputStream writer = new FileOutputStream(tempFile)) {
+              ByteStreams.copy(Channels.newInputStream(reader), writer);
+            }
+            
+            localPath = tempFile.getAbsolutePath();
+          } catch (IOException e) {
+            throw new RuntimeException("Failed to copy GCS file locally: " + fileToStage, e);
+          }
+        } else {
+          localPath = fileToStage;
+        }
+      }
+      processedFiles.add(localPath);
+    }
+    
+    return processedFiles;
+  }
+
   /**
    * Construct a runner from the provided options.
    *
@@ -312,6 +390,8 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
     }
 
     if (dataflowOptions.getFilesToStage() != null) {
+      // Replace GCS file paths with local file paths
+      dataflowOptions.setFilesToStage(replaceGcsFilesWithLocalFiles(dataflowOptions.getFilesToStage()));
       // The user specifically requested these files, so fail now if they do not exist.
       // (automatically detected classpath elements are permitted to not exist, so later
       // staging will not fail on nonexistent files)
@@ -2671,4 +2751,5 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
           .build();
     }
   }
+
 }

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -288,6 +288,8 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
             File tempFile = new File(tempDir, gcsFileName);
             tempFile.deleteOnExit();
 
+            LOG.info("Downloading GCS file {} to local temp file {}", filePath, tempFile.getAbsolutePath());
+
             // Copy GCS file to local temp file
             ResourceId source = FileSystems.matchNewResource(filePath, false);
             try (ReadableByteChannel reader = FileSystems.open(source);
@@ -296,6 +298,7 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
             }
 
             localPath = stagingName + "=" + tempFile.getAbsolutePath();
+            LOG.info("Replaced GCS path {} with local path {}", fileToStage, localPath);
           } catch (IOException e) {
             throw new RuntimeException("Failed to copy GCS file locally: " + filePath, e);
           }
@@ -313,6 +316,8 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
             File tempFile = new File(tempDir, gcsFileName);
             tempFile.deleteOnExit();
 
+            LOG.info("Downloading GCS file {} to local temp file {}", fileToStage, tempFile.getAbsolutePath());
+
             // Copy GCS file to local temp file
             ResourceId source = FileSystems.matchNewResource(fileToStage, false);
             try (ReadableByteChannel reader = FileSystems.open(source);
@@ -321,6 +326,7 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
             }
 
             localPath = tempFile.getAbsolutePath();
+            LOG.info("Replaced GCS path {} with local path {}", fileToStage, localPath);
           } catch (IOException e) {
             throw new RuntimeException("Failed to copy GCS file locally: " + fileToStage, e);
           }

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -288,7 +288,10 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
             File tempFile = new File(tempDir, gcsFileName);
             tempFile.deleteOnExit();
 
-            LOG.info("Downloading GCS file {} to local temp file {}", filePath, tempFile.getAbsolutePath());
+            LOG.info(
+                "Downloading GCS file {} to local temp file {}",
+                filePath,
+                tempFile.getAbsolutePath());
 
             // Copy GCS file to local temp file
             ResourceId source = FileSystems.matchNewResource(filePath, false);
@@ -316,7 +319,10 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
             File tempFile = new File(tempDir, gcsFileName);
             tempFile.deleteOnExit();
 
-            LOG.info("Downloading GCS file {} to local temp file {}", fileToStage, tempFile.getAbsolutePath());
+            LOG.info(
+                "Downloading GCS file {} to local temp file {}",
+                fileToStage,
+                tempFile.getAbsolutePath());
 
             // Copy GCS file to local temp file
             ResourceId source = FileSystems.matchNewResource(fileToStage, false);

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -269,7 +269,7 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
    * @return List of local file paths where any GCS paths have been downloaded locally
    * @throws RuntimeException if there are errors copying GCS files locally
    */
-  private List<String> replaceGcsFilesWithLocalFiles(List<String> filesToStage) {
+  private static List<String> replaceGcsFilesWithLocalFiles(List<String> filesToStage) {
     List<String> processedFiles = new ArrayList<>();
     
     for (String fileToStage : filesToStage) {

--- a/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
+++ b/runners/google-cloud-dataflow-java/src/main/java/org/apache/beam/runners/dataflow/DataflowRunner.java
@@ -268,7 +268,7 @@ public class DataflowRunner extends PipelineRunner<DataflowPipelineJob> {
    * @return List of local file paths where any GCS paths have been downloaded locally
    * @throws RuntimeException if there are errors copying GCS files locally
    */
-  private static List<String> replaceGcsFilesWithLocalFiles(List<String> filesToStage) {
+  public static List<String> replaceGcsFilesWithLocalFiles(List<String> filesToStage) {
     List<String> processedFiles = new ArrayList<>();
 
     for (String fileToStage : filesToStage) {

--- a/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowRunnerTest.java
+++ b/runners/google-cloud-dataflow-java/src/test/java/org/apache/beam/runners/dataflow/DataflowRunnerTest.java
@@ -77,6 +77,7 @@ import java.io.File;
 import java.io.FileNotFoundException;
 import java.io.IOException;
 import java.io.Serializable;
+import java.io.Writer;
 import java.nio.channels.FileChannel;
 import java.nio.charset.StandardCharsets;
 import java.nio.file.Files;
@@ -1153,6 +1154,19 @@ public class DataflowRunnerTest implements Serializable {
     ArgumentCaptor<Job> jobCaptor = ArgumentCaptor.forClass(Job.class);
     Mockito.verify(mockJobs).create(eq(PROJECT_ID), eq(REGION_ID), jobCaptor.capture());
     assertValidJob(jobCaptor.getValue());
+  }
+
+  @Test
+  public void testReplaceGcsFilesWithLocalFilesEmptyList() {
+    List<String> filesToStage = Collections.emptyList();
+    List<String> processedFiles = DataflowRunner.replaceGcsFilesWithLocalFiles(filesToStage);
+    assertTrue(processedFiles.isEmpty());
+  }
+
+  @Test(expected = RuntimeException.class)
+  public void testReplaceGcsFilesWithLocalFilesIOError() {
+    List<String> filesToStage = Collections.singletonList("gs://non-existent-bucket/file.jar");
+    DataflowRunner.replaceGcsFilesWithLocalFiles(filesToStage);
   }
 
   @Test


### PR DESCRIPTION
Fixes #32531

# Improve GCS file handling in DataflowRunner

The proposed changes are only limited to DataflowRunner and are kept simple. When a GCS file is detected in `filesToStage`, we first download this to a local temp file and replace the GCS file with this local temp file.

## Changes
- Added functionality to handle GCS files in `replaceGcsFilesWithLocalFiles()` method
- Files with GCS paths (gs://) are now downloaded to local temp files before being staged
- Maintains original file names when downloading from GCS
- Handles both files with and without staging names specified
- Adds logging for file downloads and replacements

## Notes
- Temp files are created with same names as original GCS files for consistency
- Files are downloaded using FileSystems API for proper GCS integration
- Original functionality for local files is preserved unchanged

## Tests

- Add a simple IT to validate the file is downloaded and staged later with a Dataflow job
<img width="491" alt="image" src="https://github.com/user-attachments/assets/535d14b1-8902-4531-953c-af1426925251">


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
