### PR TITLE
Add Flush Interval to default Buffered Logger 

### DIFF
--- a/sdks/go/container/tools/buffered_logging.go
+++ b/sdks/go/container/tools/buffered_logging.go
@@ -18,13 +18,15 @@ package tools
 import (
 	"context"
 	"log"
-	"math"
 	"os"
 	"strings"
 	"time"
 )
 
-const initialLogSize int = 255
+const (
+	initialLogSize       int           = 255
+	defaultFlushInterval time.Duration = 15 * time.Second
+)
 
 // BufferedLogger is a wrapper around the FnAPI logging client meant to be used
 // in place of stdout and stderr in bootloader subprocesses. Not intended for
@@ -41,7 +43,7 @@ type BufferedLogger struct {
 
 // NewBufferedLogger returns a new BufferedLogger type by reference.
 func NewBufferedLogger(logger *Logger) *BufferedLogger {
-	return &BufferedLogger{logger: logger, lastFlush: time.Now(), flushInterval: time.Duration(math.MaxInt64), periodicFlushContext: context.Background(), now: time.Now}
+	return &BufferedLogger{logger: logger, lastFlush: time.Now(), flushInterval: defaultFlushInterval, periodicFlushContext: context.Background(), now: time.Now}
 }
 
 // NewBufferedLoggerWithFlushInterval returns a new BufferedLogger type by reference. This type will

--- a/sdks/python/container/boot.go
+++ b/sdks/python/container/boot.go
@@ -73,8 +73,6 @@ const (
 	workerPoolIdEnv   = "BEAM_PYTHON_WORKER_POOL_ID"
 
 	standardArtifactFileTypeUrn = "beam:artifact:type:file:v1"
-
-	loggerFlushInterval time.Duration = 15 * time.Second
 )
 
 func main() {
@@ -280,8 +278,7 @@ func launchSDKProcess() error {
 		go func(workerId string) {
 			defer wg.Done()
 
-			bufLogger := tools.NewBufferedLoggerWithFlushInterval(context.Background(), logger, loggerFlushInterval)
-			errorCount := 0
+			bufLogger := tools.NewBufferedLogger(logger)
 			for {
 				childPids.mu.Lock()
 				if childPids.canceled {

--- a/sdks/python/container/boot.go
+++ b/sdks/python/container/boot.go
@@ -279,6 +279,7 @@ func launchSDKProcess() error {
 			defer wg.Done()
 
 			bufLogger := tools.NewBufferedLogger(logger)
+			errorCount := 0
 			for {
 				childPids.mu.Lock()
 				if childPids.canceled {

--- a/sdks/python/container/boot.go
+++ b/sdks/python/container/boot.go
@@ -73,6 +73,8 @@ const (
 	workerPoolIdEnv   = "BEAM_PYTHON_WORKER_POOL_ID"
 
 	standardArtifactFileTypeUrn = "beam:artifact:type:file:v1"
+
+	loggerFlushInterval time.Duration = 15 * time.Second
 )
 
 func main() {
@@ -278,7 +280,7 @@ func launchSDKProcess() error {
 		go func(workerId string) {
 			defer wg.Done()
 
-			bufLogger := tools.NewBufferedLogger(logger)
+			bufLogger := tools.NewBufferedLoggerWithFlushInterval(context.Background(), logger, loggerFlushInterval)
 			errorCount := 0
 			for {
 				childPids.mu.Lock()


### PR DESCRIPTION
Adds a default flush interval of 15 seconds to the BufferedLogger type to avoid logs being held until the job ends. 

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
