### PR TITLE
Remove antlr from dependency from java-core pom

### DIFF
--- a/runners/direct-java/build.gradle
+++ b/runners/direct-java/build.gradle
@@ -22,12 +22,12 @@ plugins { id 'org.apache.beam.module' }
 // Shade away runner execution utilities till because this causes ServiceLoader conflicts with
 // TransformPayloadTranslatorRegistrar amongst other runners. This only happens in the DirectRunner
 // because it is likely to appear on the classpath of another runner.
-def dependOnProjects = [
-                        ":runners:core-java",
-                        ":runners:local-java",
-                        ":runners:java-fn-execution",
-                        ":sdks:java:core",
-                        ]
+def dependOnProjectsAndConfigs = [
+        ":runners:core-java":null,
+        ":runners:local-java":null,
+        ":runners:java-fn-execution":null,
+        ":sdks:java:core":"shadow",
+]
 
 applyJavaNature(
         automaticModuleName: 'org.apache.beam.runners.direct',
@@ -36,8 +36,8 @@ applyJavaNature(
         ],
         shadowClosure: {
           dependencies {
-            dependOnProjects.each {
-              include(project(path: it, configuration: "shadow"))
+            dependOnProjectsAndConfigs.each {
+              include(project(path: it.key, configuration: "shadow"))
             }
           }
         },
@@ -63,8 +63,10 @@ configurations {
 dependencies {
   shadow library.java.vendored_guava_32_1_2_jre
   shadow project(path: ":model:pipeline", configuration: "shadow")
-  dependOnProjects.each {
-    implementation project(it)
+  dependOnProjectsAndConfigs.each {
+    // For projects producing shadowjar, use the packaged jar as dependency to
+    // handle redirected packages from it
+    implementation project(path: it.key, configuration: it.value)
   }
   shadow library.java.vendored_grpc_1_60_1
   shadow library.java.joda_time

--- a/sdks/java/core/build.gradle
+++ b/sdks/java/core/build.gradle
@@ -81,7 +81,6 @@ dependencies {
   shadow library.java.vendored_grpc_1_60_1
   shadow library.java.vendored_guava_32_1_2_jre
   shadow library.java.byte_buddy
-  shadow library.java.antlr_runtime
   shadow library.java.commons_compress
   shadow library.java.commons_lang3
   testImplementation library.java.mockito_inline


### PR DESCRIPTION
Alternative fix of #32696

We already vendored and repackaged antlr runtime into the jar. It was intended to avoid dependency version conflict if user using different antlr versions. However, beam java core still declares it as a dependency.

Before:

java core pom has antlr4-runtime dependency, e.g. in https://repo1.maven.org/maven2/org/apache/beam/beam-sdks-java-core/2.60.0/beam-sdks-java-core-2.60.0.pom

```
<dependency>
<groupId>org.antlr</groupId>
<artifactId>antlr4-runtime</artifactId>
<version>4.7</version>
<scope>compile</scope>
```

after:

ran `./gradlew :sdks:java:core:publishToMavenLocal -Ppublishing` and checked that antlr-runtime is no longer a dependency of beam java core in generated pom.

Also checked the jar still repackaged antlr runtime in `org/apache/beam/repackaged/core/org/antlr/v4/runtime`


**Please** add a meaningful description for your change here

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
