### PR TITLE
ignore overridden setters and getters in JavaBeanSchema

### DIFF
--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JavaBeanSchemaTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/JavaBeanSchemaTest.java
@@ -625,4 +625,11 @@ public class JavaBeanSchemaTest {
     assertEquals(
         registry.getFromRowFunction(BeanWithCaseFormat.class).apply(row), beanWithCaseFormat);
   }
+
+  @Test
+  public void testSimpleBeanWithOverriddenAccessors() throws Exception {
+    SchemaRegistry registry = SchemaRegistry.createDefault();
+    Schema schema = registry.getSchema(TestJavaBeans.SimpleBeanWithOverriddenAccessors.class);
+    SchemaTestUtils.assertSchemaEquivalent(SIMPLE_BEAN_SCHEMA, schema);
+  }
 }

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestJavaBeans.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/schemas/utils/TestJavaBeans.java
@@ -1397,4 +1397,17 @@ public class TestJavaBeans {
               Schema.Field.nullable("value", FieldType.FLOAT)
                   .withDescription("This value is the value stored in the object as a float."))
           .build();
+
+  @DefaultSchema(JavaBeanSchema.class)
+  public static class SimpleBeanWithOverriddenAccessors extends SimpleBean {
+    @Override
+    public String getStr() {
+      return super.getStr();
+    }
+
+    @Override
+    public void setStr(String str) {
+      super.setStr(str);
+    }
+  }
 }


### PR DESCRIPTION
With recent [change](https://github.com/apache/beam/pull/32081/commits/0e7018da8cbeaf6f10a0a9f9c326e52d3d0b348f) to `ReflectUtils.getMethods` which made it so that it now traverses the whole class hierarchy for search of methods to return to make it consistent with the behavior of the `getFields` method,  the schema inference for Java Bean classes will fail (see the test) if that class overrides any of its getters or setters - this PR fixes that by making sure that we only consider the bottommost accessors when calculating the schema 
