### PR TITLE
Fix exception sampling logic

### DIFF
--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -24,7 +24,6 @@ For internal use only; no backwards-compatibility guarantees.
 
 import collections
 import copy
-import cython
 import logging
 import sys
 import threading
@@ -70,6 +69,11 @@ from apache_beam.utils.timestamp import Timestamp
 from apache_beam.utils.windowed_value import HomogeneousWindowedBatch
 from apache_beam.utils.windowed_value import WindowedBatch
 from apache_beam.utils.windowed_value import WindowedValue
+
+try:
+  import cython
+except ImportError:
+  globals()['cython'] = type('fake_cython', (), {'annotation_typing': lambda x: (lambda x : x)})
 
 if TYPE_CHECKING:
   from apache_beam.runners.worker.bundle_processor import ExecutionContext

--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -1504,8 +1504,7 @@ class DoFnRunner:
       return []
 
   def _maybe_sample_exception(
-      self, exc_info: Tuple,
-      windowed_value: Optional[WindowedValue]) -> None:
+      self, exc_info: Tuple, windowed_value: Optional[WindowedValue]) -> None:
 
     if self.execution_context is None:
       return

--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -1608,7 +1608,7 @@ class DoFnRunner:
     _, _, tb = exc_info
 
     new_exn = new_exn.with_traceback(tb)
-    self._maybe_sample_exception(exc_info, windowed_value)
+    self._maybe_sample_exception(new_exn, windowed_value)
     _LOGGER.exception(new_exn)
     raise new_exn
 

--- a/sdks/python/apache_beam/runners/common.py
+++ b/sdks/python/apache_beam/runners/common.py
@@ -24,6 +24,7 @@ For internal use only; no backwards-compatibility guarantees.
 
 import collections
 import copy
+import cython
 import logging
 import sys
 import threading
@@ -1503,6 +1504,8 @@ class DoFnRunner:
       self._reraise_augmented(exn, windowed_value)
       return []
 
+  # Ignore type annotations to allow subclasses of BaseException
+  @cython.annotation_typing(False)
   def _maybe_sample_exception(
       self, exn: BaseException,
       windowed_value: Optional[WindowedValue]) -> None:


### PR DESCRIPTION
Right now, PreCommit Python is persistently red - https://github.com/apache/beam/actions/workflows/beam_PreCommit_Python.yml?query=event%3Aschedule

When this goes red, we see the following errors:

```
Traceback (most recent call last): |  
  | File "apache_beam/runners/common.py", line 1501, in apache_beam.runners.common.DoFnRunner.process |  
  | return self.do_fn_invoker.invoke_process(windowed_value) |  
  | File "apache_beam/runners/common.py", line 689, in apache_beam.runners.common.SimpleInvoker.invoke_process |  
  | self.output_handler.handle_process_outputs( |  
  | File "apache_beam/runners/common.py", line 1687, in apache_beam.runners.common._OutputHandler.handle_process_outputs |  
  | self._write_value_to_tag(tag, windowed_value, watermark_estimator) |  
  | File "apache_beam/runners/common.py", line 1800, in apache_beam.runners.common._OutputHandler._write_value_to_tag |  
  | self.main_receivers.receive(windowed_value) |  
  | File "apache_beam/runners/worker/operations.py", line 263, in apache_beam.runners.worker.operations.SingletonElementConsumerSet.receive |  
  | self.consumer.process(windowed_value) |  
  | File "apache_beam/runners/worker/operations.py", line 950, in apache_beam.runners.worker.operations.DoOperation.process |  
  | with self.scoped_process_state: |  
  | File "apache_beam/runners/worker/operations.py", line 951, in apache_beam.runners.worker.operations.DoOperation.process |  
  | delayed_applications = self.dofn_runner.process(o) |  
  | File "apache_beam/runners/common.py", line 1503, in apache_beam.runners.common.DoFnRunner.process |  
  | self._reraise_augmented(exn, windowed_value) |  
  | File "apache_beam/runners/common.py", line 1611, in apache_beam.runners.common.DoFnRunner._reraise_augmented |  
  | self._maybe_sample_exception(exc_info, windowed_value) |  
  | TypeError: Argument 'exn' has incorrect type (expected BaseException, got tuple) |  
```

This is because we pass `sys.exc_info()`, which returns a tuple, into a class expecting just the exception. This fixes that problem (though not the PreCommit yet)

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
