### PR TITLE
Remove nondeterminism from expansion tests

### DIFF
--- a/sdks/python/apache_beam/transforms/external_test.py
+++ b/sdks/python/apache_beam/transforms/external_test.py
@@ -52,6 +52,7 @@ from apache_beam.typehints import typehints
 from apache_beam.typehints.native_type_compatibility import convert_to_beam_type
 from apache_beam.utils import proto_utils
 from apache_beam.utils.subprocess_server import JavaJarServer
+from apache_beam.utils.subprocess_server import SubprocessServer
 
 # Protect against environments where apitools library is not available.
 # pylint: disable=wrong-import-order, wrong-import-position
@@ -718,6 +719,9 @@ class JavaClassLookupPayloadBuilderTest(unittest.TestCase):
 
 
 class JavaJarExpansionServiceTest(unittest.TestCase):
+  def setUp(self):
+    SubprocessServer._cache._live_owners = set()
+
   def test_classpath(self):
     with tempfile.TemporaryDirectory() as temp_dir:
       try:


### PR DESCRIPTION
These depend on https://github.com/apache/beam/blob/47740d07ed9e0824b4975ca4cadece74aae38302/sdks/python/apache_beam/transforms/external.py#L1007 which can lead to errors like:

```
    def test_classpath(self):
      with tempfile.TemporaryDirectory() as temp_dir:
        try:
          # Avoid having to prefix everything in our test strings.
          oldwd = os.getcwd()
          os.chdir(temp_dir)
          # Touch some files for globing.
          with open('a1.jar', 'w') as _:
            pass
    
          service = JavaJarExpansionService(
              'main.jar', classpath=['a*.jar', 'b.jar'])
>         self.assertEqual(
              service._default_args(),
              ['{{PORT}}', '--filesToStage=main.jar,a1.jar,b.jar'])
E             AssertionError: Lists differ: ['{{P[13 chars]lesToStage=main.jar,a1.jar,b.jar', '--alsoStartLoopbackWorker'] != ['{{P[13 chars]lesToStage=main.jar,a1.jar,b.jar']
E             
E             First list contains 1 additional elements.
E             First extra element 2:
E             '--alsoStartLoopbackWorker'
E             
E             - ['{{PORT}}',
E             -  '--filesToStage=main.jar,a1.jar,b.jar',
E             ?                                        ^
E             
E             + ['{{PORT}}', '--filesToStage=main.jar,a1.jar,b.jar']
E             ? ++++++++++++                                       ^
E             
E             -  '--alsoStartLoopbackWorker']
```

and overall flakiness like https://github.com/apache/beam/actions/workflows/beam_PreCommit_Python_Coverage.yml?query=event%3Aschedule

This removes the nondeterminism by clearing the cache.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
