### PR TITLE
Avoid holding data elements alive via stack frame gc roots.

### DIFF
--- a/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
+++ b/sdks/java/harness/src/main/java/org/apache/beam/fn/harness/control/ProcessBundleHandler.java
@@ -525,7 +525,9 @@ public class ProcessBundleHandler {
             boolean inputFinished =
                 bundleProcessor
                     .getInboundObserver()
-                    .multiplexElements(request.getProcessBundle().getElements());
+                    .multiplexElements(
+                        request.getProcessBundle().getElements().getDataList().iterator(),
+                        request.getProcessBundle().getElements().getTimersList().iterator());
             if (!inputFinished) {
               throw new RuntimeException(
                   "Elements embedded in ProcessBundleRequest do not contain stream terminators for "


### PR DESCRIPTION
This is accomplished by changing to iterators which throw away elements that have been passed as well as just referring to the inputstream of the element instead of the entire stream. If the ByteString is based upon a ByteBuffer this will allow blocks that have been advanced past to be gc'd.

This isn't done for the inlined elements to process data as that request is kept alive in many other places. I investigated fixing it but it resulted in some complicated code and since inlining is only performed for small-enough inputs it doesn't seem worth it.

![6RZxPD26GxaKR9c](https://github.com/user-attachments/assets/574db261-d9c8-45bd-a43e-afbf494268b2)


------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
