### PR TITLE
Highmem22 runners

### DIFF
--- a/.github/gh-actions-self-hosted-runners/arc/config/arc_autoscaler.tpl
+++ b/.github/gh-actions-self-hosted-runners/arc/config/arc_autoscaler.tpl
@@ -39,4 +39,7 @@ spec:
     scaleDownThreshold: '0.25'
     scaleUpFactor: '2'
     scaleDownFactor: '0.5'
+  - type: TotalNumberOfQueuedAndInProgressWorkflowRuns
+    repositoryNames:
+    - beam
   %{~ endif ~}

--- a/.github/gh-actions-self-hosted-runners/arc/environments/beam.env
+++ b/.github/gh-actions-self-hosted-runners/arc/environments/beam.env
@@ -81,5 +81,22 @@ additional_runner_pools = [{
     labels = ["self-hosted", "ubuntu-20.04", "highmem"]
     enable_selector = true
     enable_taint = true
+},
+{
+    name = "highmem-runner-22"
+    machine_type = "c3-highmem-22"
+    runner_image = "us-central1-docker.pkg.dev/apache-beam-testing/beam-github-actions/beam-arc-runner:3063b55757509dad1c14751c9f2aa5905826d9a0"
+    min_node_count = "0"
+    max_node_count = "2"
+    min_replicas = "0"
+    max_replicas = "2"
+    webhook_scaling = false
+    requests = {
+        cpu = "7.5"
+        memory = "100Gi"
+    }
+    labels = ["self-hosted", "ubuntu-20.04", "highmem22"]
+    enable_selector = true
+    enable_taint = true
 }]
 #state_bucket_name = "beam-arc-state"

--- a/.github/workflows/beam_PostCommit_Python_Examples_Flink.yml
+++ b/.github/workflows/beam_PostCommit_Python_Examples_Flink.yml
@@ -55,7 +55,7 @@ jobs:
       github.event_name == 'workflow_dispatch' ||
       github.event_name == 'pull_request_target' ||
       startsWith(github.event.comment.body, 'Run Python Examples_Flink')
-    runs-on: [self-hosted, ubuntu-20.04, highmem]
+    runs-on: [self-hosted, ubuntu-20.04, highmem22]
     timeout-minutes: 240
     name: ${{ matrix.job_name }} (${{ matrix.job_phrase }} ${{ matrix.python_version }})
     strategy:


### PR DESCRIPTION
- Adds a new runner named `highmem22` based on `c3-highmem-22` node
- Adds `TotalNumberOfQueuedAndInProgressWorkflowRuns` to the runner autscaler metrics list. This will allow to scale from zero as `PercentageRunnersBusy` cannot do that. This metrics is only considered if number of runners is zero and allows to start the scaling. 
- Moves `PostCommit_Python_Examples_Flink` to `highmem22`

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
