### PR TITLE
[java] BQ: use logical type in avro schema factory on write

### DIFF
--- a/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
+++ b/sdks/java/io/google-cloud-platform/src/main/java/org/apache/beam/sdk/io/gcp/bigquery/BigQueryIO.java
@@ -626,9 +626,6 @@ public class BigQueryIO {
   static final SerializableFunction<org.apache.avro.Schema, DatumWriter<GenericRecord>>
       GENERIC_DATUM_WRITER_FACTORY = schema -> new GenericDatumWriter<>();
 
-  private static final SerializableFunction<TableSchema, org.apache.avro.Schema>
-      DEFAULT_AVRO_SCHEMA_FACTORY = BigQueryAvroUtils::toGenericAvroSchema;
-
   /**
    * @deprecated Use {@link #read(SerializableFunction)} or {@link #readTableRows} instead. {@link
    *     #readTableRows()} does exactly the same as {@link #read}, however {@link
@@ -3625,7 +3622,8 @@ public class BigQueryIO {
                 hasSchema,
                 "A schema must be provided if an avroFormatFunction "
                     + "is set but no avroSchemaFactory is defined.");
-            avroSchemaFactory = DEFAULT_AVRO_SCHEMA_FACTORY;
+            avroSchemaFactory =
+                (tableSchema) -> BigQueryUtils.toGenericAvroSchema(tableSchema, true);
           }
           rowWriterFactory = avroRowWriterFactory.prepare(dynamicDestinations, avroSchemaFactory);
         } else if (formatFunction != null) {
@@ -3857,7 +3855,8 @@ public class BigQueryIO {
                   (RowWriterFactory.AvroRowWriterFactory<T, GenericRecord, DestinationT>)
                       rowWriterFactory;
           SerializableFunction<@Nullable TableSchema, org.apache.avro.Schema> avroSchemaFactory =
-              Optional.ofNullable(getAvroSchemaFactory()).orElse(DEFAULT_AVRO_SCHEMA_FACTORY);
+              Optional.ofNullable(getAvroSchemaFactory())
+                  .orElse(ts -> BigQueryAvroUtils.toGenericAvroSchema(ts, true));
 
           storageApiDynamicDestinations =
               new StorageApiDynamicDestinationsGenericRecord<>(


### PR DESCRIPTION
when writing to BQ with avro, if the table schema contains `DATE`, `TIME`, `TIMESTAMP` columns, the default schema factory should create avro fields with matching logical type.

There is still an issue with `DATETIME`: `BigQueryAvroUtils::toGenericAvroSchema` favors generating schema for the reading side and generates an avro field with `string(datetime)` type. This can't be used on write (expecting `long(local-timestamp-millis)` or `long(local-timestamp-micros)`).

See note in [doc](https://cloud.google.com/bigquery/docs/loading-data-cloud-storage-avro#logical_types)
> When exporting to Avro from BigQuery, DATETIME is exported as a STRING with a custom logical time that is not recognized as a DATETIME upon importing back into BigQuery.