### PR TITLE
use direct executor to deflake tests

### DIFF
--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/FanOutStreamingEngineWorkerHarness.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/FanOutStreamingEngineWorkerHarness.java
@@ -68,6 +68,7 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Immuta
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.ImmutableSet;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.collect.Streams;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.net.HostAndPort;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -125,7 +126,8 @@ public final class FanOutStreamingEngineWorkerHarness implements StreamingWorker
       GetWorkBudgetDistributor getWorkBudgetDistributor,
       GrpcDispatcherClient dispatcherClient,
       Function<WindmillStream.CommitWorkStream, WorkCommitter> workCommitterFactory,
-      ThrottlingGetDataMetricTracker getDataMetricTracker) {
+      ThrottlingGetDataMetricTracker getDataMetricTracker,
+      ExecutorService workerMetadataConsumer) {
     this.jobHeader = jobHeader;
     this.getDataMetricTracker = getDataMetricTracker;
     this.started = false;
@@ -138,9 +140,7 @@ public final class FanOutStreamingEngineWorkerHarness implements StreamingWorker
     this.windmillStreamManager =
         Executors.newCachedThreadPool(
             new ThreadFactoryBuilder().setNameFormat(STREAM_MANAGER_THREAD_NAME).build());
-    this.workerMetadataConsumer =
-        Executors.newSingleThreadExecutor(
-            new ThreadFactoryBuilder().setNameFormat(WORKER_METADATA_CONSUMER_THREAD_NAME).build());
+    this.workerMetadataConsumer = workerMetadataConsumer;
     this.getWorkBudgetDistributor = getWorkBudgetDistributor;
     this.totalGetWorkBudget = totalGetWorkBudget;
     this.activeMetadataVersion = Long.MIN_VALUE;
@@ -171,7 +171,11 @@ public final class FanOutStreamingEngineWorkerHarness implements StreamingWorker
         getWorkBudgetDistributor,
         dispatcherClient,
         workCommitterFactory,
-        getDataMetricTracker);
+        getDataMetricTracker,
+        Executors.newSingleThreadExecutor(
+            new ThreadFactoryBuilder()
+                .setNameFormat(WORKER_METADATA_CONSUMER_THREAD_NAME)
+                .build()));
   }
 
   @VisibleForTesting
@@ -195,7 +199,10 @@ public final class FanOutStreamingEngineWorkerHarness implements StreamingWorker
             getWorkBudgetDistributor,
             dispatcherClient,
             workCommitterFactory,
-            getDataMetricTracker);
+            getDataMetricTracker,
+            // Run the workerMetadataConsumer on the direct calling thread to make testing more
+            // deterministic.
+            MoreExecutors.newDirectExecutorService());
     fanOutStreamingEngineWorkProvider.start();
     return fanOutStreamingEngineWorkProvider;
   }

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/FanOutStreamingEngineWorkerHarness.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/streaming/harness/FanOutStreamingEngineWorkerHarness.java
@@ -200,8 +200,11 @@ public final class FanOutStreamingEngineWorkerHarness implements StreamingWorker
             dispatcherClient,
             workCommitterFactory,
             getDataMetricTracker,
-            // Run the workerMetadataConsumer on the direct calling thread to make testing more
-            // deterministic.
+            // Run the workerMetadataConsumer on the direct calling thread to remove waiting and
+            // make unit tests more deterministic as we do not have to worry about network IO being
+            // blocked by the consumeWorkerMetadata() task. Test suites run in different
+            // environments and non-determinism has lead to past flakiness. See
+            // https://github.com/apache/beam/issues/28957.
             MoreExecutors.newDirectExecutorService());
     fanOutStreamingEngineWorkProvider.start();
     return fanOutStreamingEngineWorkProvider;

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/WindmillEndpoints.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/WindmillEndpoints.java
@@ -88,17 +88,23 @@ public abstract class WindmillEndpoints {
             .map(address -> AuthenticatedGcpServiceAddress.create(authenticatingService, address))
             .map(WindmillServiceAddress::create);
 
-    return directEndpointIpV6Address.isPresent()
-        ? directEndpointIpV6Address
-        : tryParseEndpointIntoHostAndPort(endpointProto.getDirectEndpoint())
-            .map(WindmillServiceAddress::create);
+    Optional<WindmillServiceAddress> windmillServiceAddress =
+        directEndpointIpV6Address.isPresent()
+            ? directEndpointIpV6Address
+            : tryParseEndpointIntoHostAndPort(endpointProto.getDirectEndpoint())
+                .map(WindmillServiceAddress::create);
+
+    if (!windmillServiceAddress.isPresent()) {
+      LOG.warn("Endpoint {} could not be parsed into a WindmillServiceAddress.", endpointProto);
+    }
+
+    return windmillServiceAddress;
   }
 
   private static Optional<HostAndPort> tryParseEndpointIntoHostAndPort(String directEndpoint) {
     try {
       return Optional.of(HostAndPort.fromString(directEndpoint));
     } catch (IllegalArgumentException e) {
-      LOG.warn("{} cannot be parsed into a gcpServiceAddress", directEndpoint);
       return Optional.empty();
     }
   }
@@ -113,19 +119,12 @@ public abstract class WindmillEndpoints {
     try {
       directEndpointAddress = Inet6Address.getByName(endpointProto.getDirectEndpoint());
     } catch (UnknownHostException e) {
-      LOG.warn(
-          "Error occurred trying to parse direct_endpoint={} into IPv6 address. Exception={}",
-          endpointProto.getDirectEndpoint(),
-          e.toString());
       return Optional.empty();
     }
 
     // Inet6Address.getByAddress returns either an IPv4 or an IPv6 address depending on the format
     // of the direct_endpoint string.
     if (!(directEndpointAddress instanceof Inet6Address)) {
-      LOG.warn(
-          "{} is not an IPv6 address. Direct endpoints are expected to be in IPv6 format.",
-          endpointProto.getDirectEndpoint());
       return Optional.empty();
     }
 

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDispatcherClient.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/GrpcDispatcherClient.java
@@ -150,6 +150,8 @@ public class GrpcDispatcherClient {
       }
     }
 
+    LOG.info("Windmill Service endpoint initialized after {} seconds.", secondsWaited);
+
     ImmutableList<CloudWindmillMetadataServiceV1Alpha1Stub> windmillMetadataServiceStubs =
         dispatcherStubs.get().windmillMetadataServiceStubs();
 
@@ -190,7 +192,7 @@ public class GrpcDispatcherClient {
 
   public synchronized void consumeWindmillDispatcherEndpoints(
       ImmutableSet<HostAndPort> dispatcherEndpoints) {
-    consumeWindmillDispatcherEndpoints(dispatcherEndpoints, /*forceRecreateStubs=*/ false);
+    consumeWindmillDispatcherEndpoints(dispatcherEndpoints, /* forceRecreateStubs= */ false);
   }
 
   private synchronized void consumeWindmillDispatcherEndpoints(

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/stubs/ChannelCache.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/stubs/ChannelCache.java
@@ -18,6 +18,7 @@
 package org.apache.beam.runners.dataflow.worker.windmill.client.grpc.stubs;
 
 import java.io.PrintWriter;
+import java.util.concurrent.Executor;
 import java.util.concurrent.Executors;
 import java.util.concurrent.TimeUnit;
 import java.util.function.Function;
@@ -31,6 +32,7 @@ import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.cache.CacheLoa
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.cache.LoadingCache;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.cache.RemovalListener;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.cache.RemovalListeners;
+import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.MoreExecutors;
 import org.apache.beam.vendor.guava.v32_1_2_jre.com.google.common.util.concurrent.ThreadFactoryBuilder;
 import org.slf4j.Logger;
 import org.slf4j.LoggerFactory;
@@ -50,14 +52,11 @@ public final class ChannelCache implements StatusDataProvider {
 
   private ChannelCache(
       Function<WindmillServiceAddress, ManagedChannel> channelFactory,
-      RemovalListener<WindmillServiceAddress, ManagedChannel> onChannelRemoved) {
+      RemovalListener<WindmillServiceAddress, ManagedChannel> onChannelRemoved,
+      Executor channelCloser) {
     this.channelCache =
         CacheBuilder.newBuilder()
-            .removalListener(
-                RemovalListeners.asynchronous(
-                    onChannelRemoved,
-                    Executors.newCachedThreadPool(
-                        new ThreadFactoryBuilder().setNameFormat("GrpcChannelCloser").build())))
+            .removalListener(RemovalListeners.asynchronous(onChannelRemoved, channelCloser))
             .build(
                 new CacheLoader<WindmillServiceAddress, ManagedChannel>() {
                   @Override
@@ -72,11 +71,13 @@ public final class ChannelCache implements StatusDataProvider {
     return new ChannelCache(
         channelFactory,
         // Shutdown the channels as they get removed from the cache, so they do not leak.
-        notification -> shutdownChannel(notification.getValue()));
+        notification -> shutdownChannel(notification.getValue()),
+        Executors.newCachedThreadPool(
+            new ThreadFactoryBuilder().setNameFormat("GrpcChannelCloser").build()));
   }
 
   @VisibleForTesting
-  static ChannelCache forTesting(
+  public static ChannelCache forTesting(
       Function<WindmillServiceAddress, ManagedChannel> channelFactory, Runnable onChannelShutdown) {
     return new ChannelCache(
         channelFactory,
@@ -85,7 +86,9 @@ public final class ChannelCache implements StatusDataProvider {
         notification -> {
           shutdownChannel(notification.getValue());
           onChannelShutdown.run();
-        });
+        },
+        // Run the removal on the calling thread for better determinism in tests.
+        MoreExecutors.directExecutor());
   }
 
   private static void shutdownChannel(ManagedChannel channel) {
@@ -108,6 +111,7 @@ public final class ChannelCache implements StatusDataProvider {
 
   public void clear() {
     channelCache.invalidateAll();
+    channelCache.cleanUp();
   }
 
   /**

--- a/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/stubs/ChannelCache.java
+++ b/runners/google-cloud-dataflow-java/worker/src/main/java/org/apache/beam/runners/dataflow/worker/windmill/client/grpc/stubs/ChannelCache.java
@@ -87,7 +87,9 @@ public final class ChannelCache implements StatusDataProvider {
           shutdownChannel(notification.getValue());
           onChannelShutdown.run();
         },
-        // Run the removal on the calling thread for better determinism in tests.
+        // Run the removal synchronously on the calling thread to prevent waiting on asynchronous
+        // tasks to run and make unit tests deterministic. In testing, we verify that things are
+        // removed from the cache.
         MoreExecutors.directExecutor());
   }
 

--- a/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/testing/FakeWindmillStubFactory.java
+++ b/runners/google-cloud-dataflow-java/worker/src/test/java/org/apache/beam/runners/dataflow/worker/windmill/testing/FakeWindmillStubFactory.java
@@ -31,7 +31,7 @@ public final class FakeWindmillStubFactory implements ChannelCachingStubFactory 
   private final ChannelCache channelCache;
 
   public FakeWindmillStubFactory(Supplier<ManagedChannel> channelFactory) {
-    this.channelCache = ChannelCache.create(ignored -> channelFactory.get());
+    this.channelCache = ChannelCache.forTesting(ignored -> channelFactory.get(), () -> {});
   }
 
   @Override


### PR DESCRIPTION
`MoreExecutors.directExecutor()/directExecutorService` runs all tasks on the calling thread (w/o offloading to another thread for async work) and calls to `submit` and `execute` will block until the submitted task returns (i.e `Runnable.run()`).

Use this in test implementations of `ChannelCache` and `FanOutStreamingEngineWorkerHarness` to prevent threads waiting on each other.  The old implementation seems to work locally but in the test runner environment has increased in flakiness.

Flakiness is referenced in https://github.com/apache/beam/issues/28957

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
