### PR TITLE
Revert "Bump org.sonarqube from 3.0 to 6.0.0.5145"

### DIFF
--- a/build.gradle.kts
+++ b/build.gradle.kts
@@ -23,7 +23,7 @@ plugins {
   // Enable gradle-based release management
   id("net.researchgate.release") version "2.8.1"
   id("org.apache.beam.module")
-  id("org.sonarqube") version "6.0.0.5145"
+  id("org.sonarqube") version "3.0"
 }
 
 /*************************************************************************************************/


### PR DESCRIPTION
Reverts apache/beam#33174 - this is not important and is causing test failures (e.g. https://github.com/apache/beam/actions/runs/11977749343/job/33396321957?pr=33192), it looks like there might be compat issues with Java 21