### PR TITLE
Changes maxBufferingDuration payload to be taken from millis directly…

### DIFF
--- a/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/GroupIntoBatchesTranslation.java
+++ b/sdks/java/core/src/main/java/org/apache/beam/sdk/util/construction/GroupIntoBatchesTranslation.java
@@ -83,7 +83,7 @@ public class GroupIntoBatchesTranslation {
     return RunnerApi.GroupIntoBatchesPayload.newBuilder()
         .setBatchSize(params.getBatchSize())
         .setBatchSizeBytes(params.getBatchSizeBytes())
-        .setMaxBufferingDurationMillis(params.getMaxBufferingDuration().getStandardSeconds() * 1000)
+        .setMaxBufferingDurationMillis(params.getMaxBufferingDuration().getMillis())
         .build();
   }
 

--- a/sdks/java/core/src/test/java/org/apache/beam/sdk/util/construction/GroupIntoBatchesTranslationTest.java
+++ b/sdks/java/core/src/test/java/org/apache/beam/sdk/util/construction/GroupIntoBatchesTranslationTest.java
@@ -71,6 +71,7 @@ public class GroupIntoBatchesTranslationTest {
             ImmutableSet.of( //
                 gib -> gib, //
                 gib -> gib.withMaxBufferingDuration(Duration.ZERO), //
+                gib -> gib.withMaxBufferingDuration(Duration.millis(200)), //
                 gib -> gib.withMaxBufferingDuration(Duration.standardSeconds(10)));
 
     return Sets.cartesianProduct(
@@ -150,7 +151,7 @@ public class GroupIntoBatchesTranslationTest {
     assertThat(payload.getBatchSize(), equalTo(params.getBatchSize()));
     assertThat(payload.getBatchSizeBytes(), equalTo(params.getBatchSizeBytes()));
     assertThat(
-        payload.getMaxBufferingDurationMillis(),
-        equalTo(params.getMaxBufferingDuration().getStandardSeconds() * 1000));
+        Duration.millis(payload.getMaxBufferingDurationMillis()),
+        equalTo(params.getMaxBufferingDuration()));
   }
 }


### PR DESCRIPTION
Changes GroupIntoBatches payload to compute MaxBufferingDuration via Duration.getMillis() instead of Duration.standardSeconds() * 1000. The latter causes unnecessary truncation. Also adds a test case that fails without this change.

------------------------

Thank you for your contribution! Follow this checklist to help us incorporate your contribution quickly and easily:

 - [ ] Mention the appropriate issue in your description (for example: `addresses #123`), if applicable. This will automatically add a link to the pull request in the issue. If you would like the issue to automatically close on merging the pull request, comment `fixes #<ISSUE NUMBER>` instead.
 - [ ] Update `CHANGES.md` with noteworthy changes.
 - [ ] If this contribution is large, please file an Apache [Individual Contributor License Agreement](https://www.apache.org/licenses/icla.pdf).

See the [Contributor Guide](https://beam.apache.org/contribute) for more tips on [how to make review process smoother](https://github.com/apache/beam/blob/master/CONTRIBUTING.md#make-the-reviewers-job-easier).

To check the build health, please visit [https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md](https://github.com/apache/beam/blob/master/.test-infra/BUILD_STATUS.md)

GitHub Actions Tests Status (on master branch)
------------------------------------------------------------------------------------------------
[![Build python source distribution and wheels](https://github.com/apache/beam/workflows/Build%20python%20source%20distribution%20and%20wheels/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Build+python+source+distribution+and+wheels%22+branch%3Amaster+event%3Aschedule)
[![Python tests](https://github.com/apache/beam/workflows/Python%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Python+Tests%22+branch%3Amaster+event%3Aschedule)
[![Java tests](https://github.com/apache/beam/workflows/Java%20Tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Java+Tests%22+branch%3Amaster+event%3Aschedule)
[![Go tests](https://github.com/apache/beam/workflows/Go%20tests/badge.svg?branch=master&event=schedule)](https://github.com/apache/beam/actions?query=workflow%3A%22Go+tests%22+branch%3Amaster+event%3Aschedule)

See [CI.md](https://github.com/apache/beam/blob/master/CI.md) for more information about GitHub Actions CI or the [workflows README](https://github.com/apache/beam/blob/master/.github/workflows/README.md) to see a list of phrases to trigger workflows.
