### PR TITLE
Adding Google Storage Requester pays feature to Golang SDK.

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -65,7 +65,7 @@
 * Support for X source added (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
 
 ## New Features / Improvements
-
+* Adding Google Storage Requests Pays feature (Golang)([#30747](https://github.com/apache/beam/issues/30747)).
 * X feature added (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
 
 ## Breaking Changes

--- a/sdks/go/pkg/beam/io/filesystem/gcs/gcs_test.go
+++ b/sdks/go/pkg/beam/io/filesystem/gcs/gcs_test.go
@@ -43,6 +43,15 @@ func TestGCS_FilesystemNew(t *testing.T) {
 }
 
 func TestGCS_direct(t *testing.T) {
+	testGCS_direct(t)
+}
+
+func TestGCS_directSettingBillingProjectID(t *testing.T) {
+	t.Setenv("BILLING_PROJECT_ID", "projectfake")
+	testGCS_direct(t)
+}
+
+func testGCS_direct(t *testing.T) {
 	ctx := context.Background()
 	dirPath := "gs://beamgogcsfilesystemtest"
 	filePath := dirPath + "/file.txt"


### PR DESCRIPTION
Setting UserProject on Google Storage Bucket operations to enable requester pays feature.

Requester pays project ID will come from environment variable named `BILLING_PROJECT_ID`

More information about Google storage requester pays feature here https://cloud.google.com/storage/docs/requester-pays

`fixes #30747 `

