### PR TITLE
Revert "bump hadoop version"

### DIFF
--- a/CHANGES.md
+++ b/CHANGES.md
@@ -63,7 +63,6 @@
 ## I/Os
 
 * Support for X source added (Java/Python) ([#X](https://github.com/apache/beam/issues/X)).
-* Upgraded the default version of Hadoop dependencies to 3.4.1. Hadoop 2.10.2 is still supported (Java) ([#33011](https://github.com/apache/beam/issues/33011)).
 
 ## New Features / Improvements
 

--- a/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
+++ b/buildSrc/src/main/groovy/org/apache/beam/gradle/BeamModulePlugin.groovy
@@ -614,7 +614,7 @@ class BeamModulePlugin implements Plugin<Project> {
     // [bomupgrader] determined by: io.grpc:grpc-netty, consistent with: google_cloud_platform_libraries_bom
     def grpc_version = "1.67.1"
     def guava_version = "33.1.0-jre"
-    def hadoop_version = "3.4.1"
+    def hadoop_version = "2.10.2"
     def hamcrest_version = "2.1"
     def influxdb_version = "2.19"
     def httpclient_version = "4.5.13"


### PR DESCRIPTION
Fix #33257 , fix #33252

Reverts apache/beam#33011

PreCommit Java HBase IO Direct and PostCommit Java Hadoop Versions are failing due to NoClassDefFoundError.

This is due to the hadoop forward compatibility issue. The original PR changed compiling Beam with Hadoop 3. Likely we still need to compile Beam with Hadoop 2, but can overwrite expansion service jar to use hadoop 3 as an alternative fix